### PR TITLE
feat(mcp): selective manifest resolution — only fetch what the LLM needs

### DIFF
--- a/apps/mcp-app/src/mcp-app.ts
+++ b/apps/mcp-app/src/mcp-app.ts
@@ -1,4 +1,8 @@
-import { App, applyDocumentTheme, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  applyDocumentTheme,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const root = document.getElementById("root")!;
@@ -11,7 +15,7 @@ interface CellOutput {
   text?: string;
   ename?: string;
   evalue?: string;
-  traceback?: string[];
+  traceback?: string[] | string;
   data?: Record<string, string>;
 }
 
@@ -40,25 +44,71 @@ function renderOutput(output: CellOutput): HTMLElement {
 
   if (output.output_type === "stream") {
     const pre = document.createElement("div");
-    pre.className = "stream" + (output.name === "stderr" ? " stream-stderr" : "");
-    pre.textContent = stripAnsi(output.text || "");
+    pre.className =
+      "stream" + (output.name === "stderr" ? " stream-stderr" : "");
+    const text = output.text || "";
+    if (text.startsWith("http://") || text.startsWith("https://")) {
+      pre.textContent = "Loading…";
+      fetch(text)
+        .then((r) => r.text())
+        .then((t) => {
+          pre.textContent = stripAnsi(t);
+        })
+        .catch(() => {
+          pre.textContent = text;
+        });
+    } else {
+      pre.textContent = stripAnsi(text);
+    }
     el.appendChild(pre);
   } else if (output.output_type === "error") {
     const pre = document.createElement("div");
     pre.className = "error-output";
-    const parts: string[] = [];
-    if (output.ename) parts.push(`${output.ename}: ${output.evalue || ""}`);
-    if (output.traceback?.length) parts.push(output.traceback.map(stripAnsi).join("\n"));
-    pre.textContent = parts.join("\n\n");
+    const header = output.ename
+      ? `${output.ename}: ${output.evalue || ""}`
+      : "";
+    const tb = output.traceback;
+    if (
+      typeof tb === "string" &&
+      (tb.startsWith("http://") || tb.startsWith("https://"))
+    ) {
+      pre.textContent = header || "Loading…";
+      fetch(tb)
+        .then((r) => r.json())
+        .then((lines: string[]) => {
+          const parts: string[] = [];
+          if (header) parts.push(header);
+          if (Array.isArray(lines) && lines.length)
+            parts.push(lines.map(stripAnsi).join("\n"));
+          pre.textContent = parts.join("\n\n");
+        })
+        .catch(() => {
+          pre.textContent = header || tb;
+        });
+    } else {
+      const parts: string[] = [];
+      if (header) parts.push(header);
+      if (Array.isArray(tb) && tb.length)
+        parts.push(tb.map(stripAnsi).join("\n"));
+      pre.textContent = parts.join("\n\n");
+    }
     el.appendChild(pre);
-  } else if (output.output_type === "display_data" || output.output_type === "execute_result") {
+  } else if (
+    output.output_type === "display_data" ||
+    output.output_type === "execute_result"
+  ) {
     const data = output.data || {};
-    const imgMime = ["image/png", "image/jpeg", "image/gif", "image/webp"].find(m => data[m]);
+    const imgMime = ["image/png", "image/jpeg", "image/gif", "image/webp"].find(
+      (m) => data[m],
+    );
     if (imgMime) {
       const img = document.createElement("img");
       img.className = "image-output";
       const raw = data[imgMime];
-      img.src = raw.startsWith("data:") || raw.startsWith("http") ? raw : `data:${imgMime};base64,${raw}`;
+      img.src =
+        raw.startsWith("data:") || raw.startsWith("http")
+          ? raw
+          : `data:${imgMime};base64,${raw}`;
       if (data["text/plain"]) img.alt = data["text/plain"];
       el.appendChild(img);
     } else if (data["text/html"]) {
@@ -85,7 +135,9 @@ function renderOutput(output: CellOutput): HTMLElement {
         try {
           const h = frame.contentDocument?.documentElement?.scrollHeight;
           if (h) frame.style.height = `${h + 2}px`;
-        } catch { /* cross-origin, ignore */ }
+        } catch {
+          /* cross-origin, ignore */
+        }
       });
       el.appendChild(frame);
     } else if (data["application/json"]) {
@@ -93,7 +145,8 @@ function renderOutput(output: CellOutput): HTMLElement {
       pre.className = "display-text";
       const jsonData = data["application/json"];
       try {
-        const obj = typeof jsonData === "string" ? JSON.parse(jsonData) : jsonData;
+        const obj =
+          typeof jsonData === "string" ? JSON.parse(jsonData) : jsonData;
         pre.textContent = JSON.stringify(obj, null, 2);
       } catch {
         pre.textContent = String(jsonData);
@@ -150,15 +203,17 @@ function render(data: NteractContent) {
   }
 
   // Check if any cell has actual outputs to display
-  const hasOutputs = cells.some(c => c.outputs?.length > 0);
+  const hasOutputs = cells.some((c) => c.outputs?.length > 0);
   if (!hasOutputs) {
     // Cells exist but no outputs (e.g., import statements, assignments).
     // Show a minimal status indicator instead of the noisy "No output" box.
     const status = cells[0]?.status;
     if (status === "error") {
-      root.innerHTML = '<div class="status-indicator status-error">✗ Error</div>';
+      root.innerHTML =
+        '<div class="status-indicator status-error">✗ Error</div>';
     } else if (status === "running") {
-      root.innerHTML = '<div class="status-indicator status-running">◐ Running…</div>';
+      root.innerHTML =
+        '<div class="status-indicator status-running">◐ Running…</div>';
     }
     // For "idle" with no outputs, show nothing — clean and quiet.
     return;

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -152,7 +152,7 @@ pub async fn execute_and_wait(
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = if !output_manifests.is_empty() {
-        output_resolver::resolve_cell_outputs(
+        output_resolver::resolve_cell_outputs_for_llm(
             &output_manifests,
             blob_base_url,
             blob_store_path,
@@ -160,7 +160,7 @@ pub async fn execute_and_wait(
         )
         .await
     } else if let Some(cell_snapshot) = handle.get_cell(cell_id) {
-        output_resolver::resolve_cell_outputs(
+        output_resolver::resolve_cell_outputs_for_llm(
             &cell_snapshot.outputs,
             blob_base_url,
             blob_store_path,

--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -15,9 +15,11 @@ static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 /// MIME types to try for text output, in priority order.
-/// text/llm+plain is a custom MIME for LLM-friendly representations.
+/// Matches the `CONTENT_PRIORITY` order in `output_resolver.rs` with
+/// `application/json` appended as a formatting-layer fallback.
 const TEXT_MIME_PRIORITY: &[&str] = &[
     "text/llm+plain",
+    "text/latex",
     "text/markdown",
     "text/plain",
     "application/json",

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -3,8 +3,13 @@
 //! Tools that produce cell output (execute_cell, create_cell, set_cell, etc.)
 //! return both text content (for LLM consumption) and structured JSON that
 //! the output.html renderer can display.
+//!
+//! The manifest-based functions (`cell_structured_content_from_manifests`,
+//! `manifest_output_to_structured`) read inline content directly from
+//! ContentRef entries and emit blob URLs for blob-stored content. Zero blob
+//! fetches — structured content is always compact.
 
-use runtimed_client::resolved_output::{DataValue, Output, ResolvedCell};
+use runtimed_client::output_resolver;
 use serde_json::{json, Value};
 
 /// Check if a MIME type is a visualization spec (Plotly, Vega-Lite, Vega).
@@ -17,89 +22,98 @@ fn is_viz_mime(mime: &str) -> bool {
             && (mime.ends_with("+json") || mime.ends_with(".json")))
 }
 
-/// Return a blob URL for the given MIME type, or None to skip the entry.
-fn blob_url_or_skip(output: &Output, mime: &str) -> Option<Value> {
-    output
-        .blob_urls
-        .as_ref()
-        .and_then(|urls| urls.get(mime))
-        .map(|url| Value::String(url.clone()))
-}
-
-/// Build the structuredContent JSON for a resolved cell.
-pub fn cell_structured_content(cell: &ResolvedCell, status: &str) -> Value {
+/// Build structuredContent JSON directly from manifest Values and blob URLs.
+///
+/// Unlike [`cell_structured_content`] which requires fully-resolved outputs,
+/// this function reads inline content directly from ContentRef entries and
+/// emits blob URLs for anything stored in the blob store. Zero blob fetches.
+pub fn cell_structured_content_from_manifests(
+    cell_id: &str,
+    cell_type: &str,
+    source: &str,
+    output_manifests: &[serde_json::Value],
+    execution_count: Option<i64>,
+    status: &str,
+    blob_base_url: &Option<String>,
+) -> Value {
     json!({
         "cell": {
-            "cell_id": cell.id,
-            "source": cell.source,
-            "outputs": cell.outputs.iter().map(output_to_structured).collect::<Vec<_>>(),
-            "execution_count": cell.execution_count,
+            "cell_id": cell_id,
+            "source": source,
+            "cell_type": cell_type,
+            "outputs": output_manifests.iter().map(|m| manifest_output_to_structured(m, blob_base_url)).collect::<Vec<_>>(),
+            "execution_count": execution_count,
             "status": status,
         }
     })
 }
 
-/// Convert a resolved Output to the JSON structure expected by the output renderer.
-fn output_to_structured(output: &Output) -> Value {
-    match output.output_type.as_str() {
+/// Convert a single output manifest Value to structured JSON for the output renderer.
+///
+/// Reads inline content directly from ContentRef entries and emits blob URLs
+/// for blob-stored content. No blob fetches are performed.
+fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String>) -> Value {
+    let output_type = manifest
+        .get("output_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    match output_type {
         "stream" => {
+            let name = manifest.get("name").cloned().unwrap_or(Value::Null);
+            // text is a ContentRef: {"inline": "..."} or {"blob": "hash", "size": N}
+            let text = manifest
+                .get("text")
+                .and_then(|cr| resolve_text_content_ref(cr, blob_base_url))
+                .unwrap_or(Value::Null);
             json!({
                 "output_type": "stream",
-                "name": output.name,
-                "text": output.text,
+                "name": name,
+                "text": text,
             })
         }
         "error" => {
             json!({
                 "output_type": "error",
-                "ename": output.ename,
-                "evalue": output.evalue,
-                "traceback": output.traceback,
+                "ename": manifest.get("ename").cloned().unwrap_or(Value::Null),
+                "evalue": manifest.get("evalue").cloned().unwrap_or(Value::Null),
+                "traceback": manifest.get("traceback").cloned().unwrap_or(Value::Null),
             })
         }
         "display_data" | "execute_result" => {
             let mut data = serde_json::Map::new();
 
-            if let Some(ref output_data) = output.data {
-                // Check if the output has a raster image that the MCP app can
-                // render directly (png/jpeg/gif/webp via blob URL). When true,
-                // we can safely skip text/html (which is often a massive base64
-                // data URI for audio, or redundant chart HTML that duplicates
-                // the image).
-                let has_renderable_image = output_data.keys().any(|m| {
+            if let Some(data_map) = manifest.get("data").and_then(|v| v.as_object()) {
+                // Check for renderable raster images to skip redundant text/html
+                let has_renderable_image = data_map.keys().any(|m| {
                     matches!(
                         m.as_str(),
                         "image/png" | "image/jpeg" | "image/gif" | "image/webp"
                     )
                 });
 
-                for (mime, value) in output_data {
-                    // Skip text/llm+plain — it's for LLM consumption, not the widget
-                    if mime == "text/llm+plain" {
-                        continue;
-                    }
-
-                    // Skip text/html when the MCP app can render a raster image
-                    // instead. This avoids sending large base64 data URIs (audio
-                    // HTML embeds) or redundant chart HTML alongside the image.
+                for (mime, content_ref) in data_map {
+                    // Skip text/html when a raster image exists — avoids large
+                    // base64 data URIs or redundant chart HTML.
                     if mime == "text/html" && has_renderable_image {
                         continue;
                     }
-
-                    // Skip viz JSON specs — the MCP app doesn't render them, and
-                    // they're large (tens of KB). The app uses text/html or image
-                    // fallbacks for display.
                     if is_viz_mime(mime) {
                         continue;
                     }
 
-                    let json_value = match value {
-                        DataValue::Binary(_) => {
-                            // For binary data, use blob URL if available
-                            blob_url_or_skip(output, mime)
-                        }
-                        DataValue::Json(v) => Some(v.clone()),
-                        DataValue::Text(s) => Some(Value::String(s.clone())),
+                    let meta = output_resolver::content_ref_meta(content_ref);
+
+                    let json_value = if meta.is_inline {
+                        // Inline content — extract the value directly
+                        content_ref.get("inline").cloned()
+                    } else if let Some(hash) = meta.blob_hash {
+                        // Blob-stored content — emit blob URL
+                        blob_base_url
+                            .as_ref()
+                            .map(|base| Value::String(format!("{}/blob/{}", base, hash)))
+                    } else {
+                        None
                     };
 
                     if let Some(jv) = json_value {
@@ -109,16 +123,230 @@ fn output_to_structured(output: &Output) -> Value {
             }
 
             let mut result = json!({
-                "output_type": output.output_type,
+                "output_type": output_type,
                 "data": data,
             });
 
-            if let Some(count) = output.execution_count {
+            if let Some(count) = manifest.get("execution_count").and_then(|v| v.as_i64()) {
                 result["execution_count"] = json!(count);
             }
 
             result
         }
-        _ => json!({"output_type": output.output_type}),
+        _ => json!({"output_type": output_type}),
+    }
+}
+
+/// Resolve a text ContentRef to a JSON value (inline text or blob URL).
+fn resolve_text_content_ref(content_ref: &Value, blob_base_url: &Option<String>) -> Option<Value> {
+    let meta = output_resolver::content_ref_meta(content_ref);
+    if meta.is_inline {
+        content_ref.get("inline").cloned()
+    } else if let Some(hash) = meta.blob_hash {
+        blob_base_url
+            .as_ref()
+            .map(|base| Value::String(format!("{}/blob/{}", base, hash)))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn inline_ref(content: &str) -> serde_json::Value {
+        json!({"inline": content})
+    }
+
+    fn blob_ref(hash: &str, size: u64) -> serde_json::Value {
+        json!({"blob": hash, "size": size})
+    }
+
+    #[test]
+    fn structured_inline_content_passes_through() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": inline_ref("hello"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert_eq!(data["text/plain"], "hello");
+    }
+
+    #[test]
+    fn structured_blob_becomes_url() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "image/png": blob_ref("abc123", 50_000),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert_eq!(data["image/png"], "http://localhost:9999/blob/abc123");
+    }
+
+    #[test]
+    fn structured_no_blob_base_url_omits_blobs() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "image/png": blob_ref("abc123", 50_000),
+                "text/plain": inline_ref("fallback"),
+            },
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        let data = result["data"].as_object().unwrap();
+        // Blob entry not included (no base URL to construct from)
+        assert!(!data.contains_key("image/png"));
+        // Inline entry still present
+        assert_eq!(data["text/plain"], "fallback");
+    }
+
+    #[test]
+    fn structured_viz_mime_skipped() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.plotly.v1+json": inline_ref("{\"data\": []}"),
+                "text/plain": inline_ref("Figure()"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert!(!data.contains_key("application/vnd.plotly.v1+json"));
+        assert_eq!(data["text/plain"], "Figure()");
+    }
+
+    #[test]
+    fn structured_html_skipped_when_raster_image_exists() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/html": inline_ref("<img src='data:...' />"),
+                "image/png": blob_ref("img_hash", 40_000),
+                "text/plain": inline_ref("<Figure>"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert!(!data.contains_key("text/html"));
+        assert_eq!(data["image/png"], "http://localhost:9999/blob/img_hash");
+    }
+
+    #[test]
+    fn structured_html_included_without_raster_image() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/html": inline_ref("<b>bold</b>"),
+                "text/plain": inline_ref("bold"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert_eq!(data["text/html"], "<b>bold</b>");
+    }
+
+    #[test]
+    fn structured_llm_plain_included_as_fallback() {
+        // text/llm+plain should NOT be filtered out in structured content
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/llm+plain": inline_ref("Summary of output"),
+                "image/png": blob_ref("img", 10_000),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"].as_object().unwrap();
+        assert_eq!(data["text/llm+plain"], "Summary of output");
+    }
+
+    #[test]
+    fn structured_stream_inline() {
+        let manifest = json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": inline_ref("hello"),
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        assert_eq!(result["output_type"], "stream");
+        assert_eq!(result["name"], "stdout");
+        assert_eq!(result["text"], "hello");
+    }
+
+    #[test]
+    fn structured_stream_blob_text() {
+        let manifest = json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": blob_ref("stream_hash", 5_000),
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        assert_eq!(result["text"], "http://localhost:9999/blob/stream_hash");
+    }
+
+    #[test]
+    fn structured_error_passthrough() {
+        let manifest = json!({
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "bad",
+            "traceback": ["line 1", "line 2"],
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        assert_eq!(result["output_type"], "error");
+        assert_eq!(result["ename"], "ValueError");
+        assert_eq!(result["traceback"][0], "line 1");
+    }
+
+    #[test]
+    fn structured_execute_result_has_count() {
+        let manifest = json!({
+            "output_type": "execute_result",
+            "data": {
+                "text/plain": inline_ref("42"),
+            },
+            "execution_count": 7,
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        assert_eq!(result["execution_count"], 7);
+    }
+
+    #[test]
+    fn cell_structured_content_wrapper() {
+        let manifests = vec![json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": inline_ref("output"),
+        })];
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = cell_structured_content_from_manifests(
+            "cell-123",
+            "code",
+            "print('hello')",
+            &manifests,
+            Some(3),
+            "done",
+            &blob_base,
+        );
+        assert_eq!(result["cell"]["cell_id"], "cell-123");
+        assert_eq!(result["cell"]["cell_type"], "code");
+        assert_eq!(result["cell"]["source"], "print('hello')");
+        assert_eq!(result["cell"]["execution_count"], 3);
+        assert_eq!(result["cell"]["status"], "done");
+        assert_eq!(result["cell"]["outputs"].as_array().unwrap().len(), 1);
     }
 }

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -73,11 +73,34 @@ fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String
             })
         }
         "error" => {
+            // traceback is a ContentRef (inline JSON string or blob), not a
+            // raw string[]. Resolve it: parse inline JSON → array, or fall
+            // back to a blob URL for rare oversized tracebacks.
+            let traceback = manifest
+                .get("traceback")
+                .and_then(|cr| {
+                    // Inline ContentRef: the value is a JSON-stringified array
+                    // e.g. {"inline": "[\"line1\", \"line2\"]"}
+                    if let Some(inline) = cr.get("inline").and_then(|v| v.as_str()) {
+                        serde_json::from_str::<Value>(inline).ok()
+                    } else if let Some(hash) = cr.get("blob").and_then(|v| v.as_str()) {
+                        // Blob-stored traceback — return URL for renderer to fetch
+                        blob_base_url
+                            .as_ref()
+                            .map(|base| Value::String(format!("{}/blob/{}", base, hash)))
+                    } else if cr.is_array() {
+                        // Legacy: already a plain JSON array
+                        Some(cr.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(Value::Null);
             json!({
                 "output_type": "error",
                 "ename": manifest.get("ename").cloned().unwrap_or(Value::Null),
                 "evalue": manifest.get("evalue").cloned().unwrap_or(Value::Null),
-                "traceback": manifest.get("traceback").cloned().unwrap_or(Value::Null),
+                "traceback": traceback,
             })
         }
         "display_data" | "execute_result" => {
@@ -299,17 +322,56 @@ mod tests {
     }
 
     #[test]
-    fn structured_error_passthrough() {
+    fn structured_error_inline_traceback_parsed() {
+        // Daemon stores traceback as ContentRef with JSON-stringified array
         let manifest = json!({
             "output_type": "error",
             "ename": "ValueError",
             "evalue": "bad",
-            "traceback": ["line 1", "line 2"],
+            "traceback": inline_ref(r#"["line 1", "line 2"]"#),
         });
         let result = manifest_output_to_structured(&manifest, &None);
         assert_eq!(result["output_type"], "error");
         assert_eq!(result["ename"], "ValueError");
-        assert_eq!(result["traceback"][0], "line 1");
+        // Traceback should be a parsed JSON array, not the raw ContentRef
+        let tb = result["traceback"]
+            .as_array()
+            .expect("traceback should be an array");
+        assert_eq!(tb.len(), 2);
+        assert_eq!(tb[0], "line 1");
+        assert_eq!(tb[1], "line 2");
+    }
+
+    #[test]
+    fn structured_error_blob_traceback_becomes_url() {
+        let manifest = json!({
+            "output_type": "error",
+            "ename": "RecursionError",
+            "evalue": "maximum recursion depth exceeded",
+            "traceback": blob_ref("tb_hash_123", 8_000),
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        assert_eq!(
+            result["traceback"],
+            "http://localhost:9999/blob/tb_hash_123"
+        );
+    }
+
+    #[test]
+    fn structured_error_legacy_traceback_array() {
+        // Legacy outputs may have a plain JSON array (not a ContentRef)
+        let manifest = json!({
+            "output_type": "error",
+            "ename": "TypeError",
+            "evalue": "oops",
+            "traceback": ["line 1", "line 2"],
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        let tb = result["traceback"]
+            .as_array()
+            .expect("legacy array should pass through");
+        assert_eq!(tb.len(), 2);
     }
 
     #[test]

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -197,7 +197,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert_eq!(data["text/plain"], "hello");
     }
 
@@ -211,7 +213,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert_eq!(data["image/png"], "http://localhost:9999/blob/abc123");
     }
 
@@ -225,7 +229,9 @@ mod tests {
             },
         });
         let result = manifest_output_to_structured(&manifest, &None);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         // Blob entry not included (no base URL to construct from)
         assert!(!data.contains_key("image/png"));
         // Inline entry still present
@@ -243,7 +249,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert!(!data.contains_key("application/vnd.plotly.v1+json"));
         assert_eq!(data["text/plain"], "Figure()");
     }
@@ -260,7 +268,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert!(!data.contains_key("text/html"));
         assert_eq!(data["image/png"], "http://localhost:9999/blob/img_hash");
     }
@@ -276,7 +286,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert_eq!(data["text/html"], "<b>bold</b>");
     }
 
@@ -292,7 +304,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"].as_object().unwrap();
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
         assert_eq!(data["text/llm+plain"], "Summary of output");
     }
 
@@ -409,6 +423,12 @@ mod tests {
         assert_eq!(result["cell"]["source"], "print('hello')");
         assert_eq!(result["cell"]["execution_count"], 3);
         assert_eq!(result["cell"]["status"], "done");
-        assert_eq!(result["cell"]["outputs"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            result["cell"]["outputs"]
+                .as_array()
+                .expect("outputs should be an array")
+                .len(),
+            1
+        );
     }
 }

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -197,9 +197,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert_eq!(data["text/plain"], "hello");
     }
 
@@ -213,9 +213,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert_eq!(data["image/png"], "http://localhost:9999/blob/abc123");
     }
 
@@ -229,9 +229,9 @@ mod tests {
             },
         });
         let result = manifest_output_to_structured(&manifest, &None);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         // Blob entry not included (no base URL to construct from)
         assert!(!data.contains_key("image/png"));
         // Inline entry still present
@@ -249,9 +249,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert!(!data.contains_key("application/vnd.plotly.v1+json"));
         assert_eq!(data["text/plain"], "Figure()");
     }
@@ -268,9 +268,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert!(!data.contains_key("text/html"));
         assert_eq!(data["image/png"], "http://localhost:9999/blob/img_hash");
     }
@@ -286,9 +286,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert_eq!(data["text/html"], "<b>bold</b>");
     }
 
@@ -304,9 +304,9 @@ mod tests {
         });
         let blob_base = Some("http://localhost:9999".to_string());
         let result = manifest_output_to_structured(&manifest, &blob_base);
-        let data = result["data"]
-            .as_object()
-            .expect("data should be an object");
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
         assert_eq!(data["text/llm+plain"], "Summary of output");
     }
 
@@ -348,9 +348,9 @@ mod tests {
         assert_eq!(result["output_type"], "error");
         assert_eq!(result["ename"], "ValueError");
         // Traceback should be a parsed JSON array, not the raw ContentRef
-        let tb = result["traceback"]
-            .as_array()
-            .expect("traceback should be an array");
+        let Some(tb) = result["traceback"].as_array() else {
+            panic!("traceback should be an array");
+        };
         assert_eq!(tb.len(), 2);
         assert_eq!(tb[0], "line 1");
         assert_eq!(tb[1], "line 2");
@@ -382,9 +382,9 @@ mod tests {
             "traceback": ["line 1", "line 2"],
         });
         let result = manifest_output_to_structured(&manifest, &None);
-        let tb = result["traceback"]
-            .as_array()
-            .expect("legacy array should pass through");
+        let Some(tb) = result["traceback"].as_array() else {
+            panic!("legacy array should pass through");
+        };
         assert_eq!(tb.len(), 2);
     }
 
@@ -423,12 +423,9 @@ mod tests {
         assert_eq!(result["cell"]["source"], "print('hello')");
         assert_eq!(result["cell"]["execution_count"], 3);
         assert_eq!(result["cell"]["status"], "done");
-        assert_eq!(
-            result["cell"]["outputs"]
-                .as_array()
-                .expect("outputs should be an array")
-                .len(),
-            1
-        );
+        let Some(outputs) = result["cell"]["outputs"].as_array() else {
+            panic!("outputs should be an array");
+        };
+        assert_eq!(outputs.len(), 1);
     }
 }

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -74,7 +74,7 @@ pub async fn get_cell(
 
     // Resolve outputs (with widget state synthesis)
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
-    let outputs = output_resolver::resolve_cell_outputs(
+    let outputs = output_resolver::resolve_cell_outputs_for_llm(
         &cell.outputs,
         &server.blob_base_url,
         &server.blob_store_path,
@@ -173,7 +173,7 @@ pub async fn get_all_cells(
 
                 // Resolve outputs through the output resolver so that
                 // text/llm+plain is synthesized and viz specs are summarized.
-                let resolved = output_resolver::resolve_cell_outputs(
+                let resolved = output_resolver::resolve_cell_outputs_for_llm(
                     &cell.outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
@@ -210,7 +210,7 @@ pub async fn get_all_cells(
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec = cell_ec_map.get(&cell.id).map(String::as_str);
-                let outputs = output_resolver::resolve_cell_outputs(
+                let outputs = output_resolver::resolve_cell_outputs_for_llm(
                     &cell.outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
@@ -253,7 +253,7 @@ pub async fn get_all_cells(
                     preview_chars,
                 );
                 if include_outputs && !cell.outputs.is_empty() {
-                    let outputs = output_resolver::resolve_cell_outputs(
+                    let outputs = output_resolver::resolve_cell_outputs_for_llm(
                         &cell.outputs,
                         &server.blob_base_url,
                         &server.blob_store_path,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -402,39 +402,27 @@ pub async fn build_execution_result(
     let mut items = vec![Content::text(header)];
     items.extend(crate::formatting::outputs_to_content_items(&result.outputs));
 
-    // Build structured content for MCP Apps widget.
-    // Only send structured content when there are outputs to render.
+    // Build structured content directly from manifest Values + blob URLs.
+    // No blob fetches — inline ContentRefs pass through, blobs become URLs.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let structured_content = if let Some(snap) = cell_snapshot {
         if snap.outputs.is_empty() {
             None
         } else {
-            let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
-            let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
-                &snap.outputs,
-                &server.blob_base_url,
-                &server.blob_store_path,
-                comms.as_ref(),
-            )
-            .await;
             let ec_str = cell_read::get_cell_execution_count_from_runtime(handle, &snap.id);
             let ec: Option<i64> = if ec_str.is_empty() {
                 None
             } else {
                 ec_str.parse().ok()
             };
-            let resolved = runtimed_client::resolved_output::ResolvedCell {
-                id: snap.id,
-                cell_type: snap.cell_type,
-                position: snap.position,
-                source: snap.source,
-                execution_count: ec,
-                outputs,
-                metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
-            };
-            Some(crate::structured::cell_structured_content(
-                &resolved,
+            Some(crate::structured::cell_structured_content_from_manifests(
+                &snap.id,
+                &snap.cell_type,
+                &snap.source,
+                &snap.outputs,
+                ec,
                 &result.status,
+                &server.blob_base_url,
             ))
         }
     } else {

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -1330,8 +1330,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // text/plain resolved
         assert!(matches!(data.get("text/plain"), Some(DataValue::Text(s)) if s == "hello world"));
@@ -1347,8 +1347,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // text/latex should be resolved (it's higher priority than text/plain)
         assert!(matches!(data.get("text/latex"), Some(DataValue::Text(s)) if s == "$E=mc^2$"));
@@ -1365,8 +1365,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         assert!(
             matches!(data.get("text/llm+plain"), Some(DataValue::Text(s)) if s == "Author's summary")
@@ -1383,8 +1383,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // text/plain is resolved (it's the content)
         assert!(data.contains_key("text/plain"));
@@ -1407,8 +1407,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // No text/llm+plain synthesized — text/plain is under/at threshold
         assert!(!data.contains_key("text/llm+plain"));
@@ -1424,8 +1424,8 @@ mod tests {
         let blob_base = Some("http://localhost:9999".to_string());
         let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // No image data resolved
         assert!(!data.contains_key("image/png"));
@@ -1447,7 +1447,10 @@ mod tests {
         let output = resolve_output_for_llm(&manifest, &None, &None, None).await;
         // Empty data map still produces an output, just with empty data
         assert!(output.is_some());
-        let data = output.unwrap().data.unwrap();
+        let data = output
+            .expect("should produce output")
+            .data
+            .expect("should have data");
         assert!(data.is_empty());
     }
 
@@ -1460,7 +1463,7 @@ mod tests {
         });
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
+            .expect("resolve should succeed");
         assert_eq!(output.output_type, "stream");
         assert_eq!(output.text.as_deref(), Some("hello from stdout"));
     }
@@ -1475,10 +1478,17 @@ mod tests {
         });
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
+            .expect("resolve should succeed");
         assert_eq!(output.output_type, "error");
         assert_eq!(output.ename.as_deref(), Some("ValueError"));
-        assert_eq!(output.traceback.as_ref().unwrap().len(), 2);
+        assert_eq!(
+            output
+                .traceback
+                .as_ref()
+                .expect("should have traceback")
+                .len(),
+            2
+        );
     }
 
     #[tokio::test]
@@ -1486,7 +1496,7 @@ mod tests {
         let manifest = make_execute_result_manifest(json!({"text/plain": inline_ref("42")}), 5);
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
+            .expect("resolve should succeed");
         assert_eq!(output.output_type, "execute_result");
         assert_eq!(output.execution_count, Some(5));
     }
@@ -1500,8 +1510,8 @@ mod tests {
         }));
         let output = resolve_output_for_llm(&manifest, &None, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         // text/latex resolution failed → fell through to text/plain
         assert!(!data.contains_key("text/latex"));
@@ -1519,8 +1529,8 @@ mod tests {
         let blob_base = Some("http://localhost:9999".to_string());
         let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
             .await
-            .unwrap();
-        let data = output.data.unwrap();
+            .expect("resolve should succeed");
+        let data = output.data.expect("output should have data");
 
         assert!(!data.contains_key("text/html"));
         let llm = match data.get("text/llm+plain") {
@@ -1550,7 +1560,10 @@ mod tests {
         assert_eq!(outputs[0].output_type, "stream");
         assert_eq!(outputs[1].output_type, "display_data");
         // The display_data should only have text/plain, not image/png
-        let data = outputs[1].data.as_ref().unwrap();
+        let data = outputs[1]
+            .data
+            .as_ref()
+            .expect("display_data should have data");
         assert!(data.contains_key("text/plain"));
         assert!(!data.contains_key("image/png"));
     }

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -1249,11 +1249,11 @@ mod tests {
         // '€' is 3 bytes (U+20AC). Put it right at the cut boundary.
         // side_bytes=5, so we need text > 10 bytes total.
         let text = "ab€€€€cd"; // 2 + 4*3 + 2 = 16 bytes
-        let result = truncate_head_tail(&text, 5);
+        let result = truncate_head_tail(text, 5);
         // Should find a valid char boundary, not panic
         assert!(result.contains("[... truncated"));
         // Verify the result is valid UTF-8 (it is, since it's a String)
-        assert!(result.len() > 0);
+        assert!(!result.is_empty());
     }
 
     #[test]
@@ -1328,10 +1328,12 @@ mod tests {
             "text/plain": inline_ref("hello world"),
             "image/png": blob_ref("abc123", 50_000),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // text/plain resolved
         assert!(matches!(data.get("text/plain"), Some(DataValue::Text(s)) if s == "hello world"));
@@ -1345,10 +1347,12 @@ mod tests {
             "text/latex": inline_ref("$E=mc^2$"),
             "text/plain": inline_ref("E=mc^2"),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // text/latex should be resolved (it's higher priority than text/plain)
         assert!(matches!(data.get("text/latex"), Some(DataValue::Text(s)) if s == "$E=mc^2$"));
@@ -1363,10 +1367,12 @@ mod tests {
             "text/plain": inline_ref("raw repr"),
             "image/png": blob_ref("img123", 100_000),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         assert!(
             matches!(data.get("text/llm+plain"), Some(DataValue::Text(s)) if s == "Author's summary")
@@ -1381,10 +1387,12 @@ mod tests {
         let manifest = make_display_manifest(json!({
             "text/plain": inline_ref(&large_text),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // text/plain is resolved (it's the content)
         assert!(data.contains_key("text/plain"));
@@ -1405,10 +1413,12 @@ mod tests {
         let manifest = make_display_manifest(json!({
             "text/plain": inline_ref(&text),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // No text/llm+plain synthesized — text/plain is under/at threshold
         assert!(!data.contains_key("text/llm+plain"));
@@ -1422,10 +1432,12 @@ mod tests {
             "image/svg+xml": blob_ref("svg456", 12_000),
         }));
         let blob_base = Some("http://localhost:9999".to_string());
-        let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &blob_base, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // No image data resolved
         assert!(!data.contains_key("image/png"));
@@ -1446,11 +1458,12 @@ mod tests {
         let manifest = make_display_manifest(json!({}));
         let output = resolve_output_for_llm(&manifest, &None, &None, None).await;
         // Empty data map still produces an output, just with empty data
-        assert!(output.is_some());
-        let data = output
-            .expect("should produce output")
-            .data
-            .expect("should have data");
+        let Some(output) = output else {
+            panic!("should produce output");
+        };
+        let Some(data) = output.data else {
+            panic!("should have data");
+        };
         assert!(data.is_empty());
     }
 
@@ -1461,9 +1474,9 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hello from stdout"),
         });
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
         assert_eq!(output.output_type, "stream");
         assert_eq!(output.text.as_deref(), Some("hello from stdout"));
     }
@@ -1476,27 +1489,23 @@ mod tests {
             "evalue": "bad value",
             "traceback": ["line 1", "line 2"],
         });
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
         assert_eq!(output.output_type, "error");
         assert_eq!(output.ename.as_deref(), Some("ValueError"));
-        assert_eq!(
-            output
-                .traceback
-                .as_ref()
-                .expect("should have traceback")
-                .len(),
-            2
-        );
+        let Some(ref traceback) = output.traceback else {
+            panic!("should have traceback");
+        };
+        assert_eq!(traceback.len(), 2);
     }
 
     #[tokio::test]
     async fn llm_execute_result_has_execution_count() {
         let manifest = make_execute_result_manifest(json!({"text/plain": inline_ref("42")}), 5);
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
         assert_eq!(output.output_type, "execute_result");
         assert_eq!(output.execution_count, Some(5));
     }
@@ -1508,10 +1517,12 @@ mod tests {
             "text/latex": blob_ref("latex_hash", 5000),
             "text/plain": inline_ref("fallback plain"),
         }));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         // text/latex resolution failed → fell through to text/plain
         assert!(!data.contains_key("text/latex"));
@@ -1527,10 +1538,12 @@ mod tests {
             "text/html": blob_ref("html_hash", 8_000),
         }));
         let blob_base = Some("http://localhost:9999".to_string());
-        let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
-            .await
-            .expect("resolve should succeed");
-        let data = output.data.expect("output should have data");
+        let Some(output) = resolve_output_for_llm(&manifest, &blob_base, &None, None).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
 
         assert!(!data.contains_key("text/html"));
         let llm = match data.get("text/llm+plain") {
@@ -1560,10 +1573,9 @@ mod tests {
         assert_eq!(outputs[0].output_type, "stream");
         assert_eq!(outputs[1].output_type, "display_data");
         // The display_data should only have text/plain, not image/png
-        let data = outputs[1]
-            .data
-            .as_ref()
-            .expect("display_data should have data");
+        let Some(ref data) = outputs[1].data else {
+            panic!("display_data should have data");
+        };
         assert!(data.contains_key("text/plain"));
         assert!(!data.contains_key("image/png"));
     }

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -19,6 +19,25 @@ use crate::resolved_output::{DataValue, Output};
 /// MIME type for Jupyter widget view references.
 const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
 
+/// Priority order for selecting the best text MIME type for LLM consumption.
+///
+/// Walk this list against the manifest's MIME keys; resolve the first match.
+/// `text/llm+plain` is either author-provided or synthesized by us when no
+/// direct text type exists (viz specs, widget state, binary-only outputs) or
+/// when the best text type was too large and got summarized.
+pub const CONTENT_PRIORITY: &[&str] = &[
+    "text/llm+plain",
+    "text/latex",
+    "text/markdown",
+    "text/plain",
+];
+
+/// When `text/plain` exceeds this size, synthesize a truncated `text/llm+plain`.
+const LLM_TEXT_MAX_SIZE: usize = 4 * 1024;
+
+/// Bytes to keep from head and tail when truncating into `text/llm+plain`.
+const LLM_TEXT_SIDE_SIZE: usize = 2 * 1024;
+
 /// Classification of a MIME type for output data.
 ///
 /// This is the canonical Rust implementation of MIME classification.
@@ -33,6 +52,51 @@ pub enum MimeKind {
     Binary,
     /// JSON data: application/json, *+json
     Json,
+}
+
+/// Metadata extracted from a ContentRef Value without resolving content.
+///
+/// Enables inspection of manifest entries (MIME type, size, blob hash) without
+/// any I/O. After #1558 inlined manifests into the RuntimeStateDoc, this is
+/// all we need to decide what to fetch for LLM consumption.
+pub struct ContentRefMeta<'a> {
+    /// True if the content is inlined in the CRDT (< 1KB).
+    pub is_inline: bool,
+    /// Content size in bytes. For inline refs this is the string length;
+    /// for blob refs it comes from the `size` field written at storage time.
+    pub size: u64,
+    /// Blob hash, if the content is stored in the blob store.
+    pub blob_hash: Option<&'a str>,
+}
+
+/// Extract metadata from a ContentRef Value without resolving the content.
+///
+/// Works with both `{"inline": "..."}` and `{"blob": "hash", "size": N}` shapes.
+pub fn content_ref_meta(content_ref: &Value) -> ContentRefMeta<'_> {
+    if let Some(inline) = content_ref.get("inline") {
+        let size = inline.as_str().map(|s| s.len() as u64).unwrap_or(0);
+        ContentRefMeta {
+            is_inline: true,
+            size,
+            blob_hash: None,
+        }
+    } else if let Some(blob_hash) = content_ref.get("blob").and_then(|v| v.as_str()) {
+        let size = content_ref
+            .get("size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        ContentRefMeta {
+            is_inline: false,
+            size,
+            blob_hash: Some(blob_hash),
+        }
+    } else {
+        ContentRefMeta {
+            is_inline: false,
+            size: 0,
+            blob_hash: None,
+        }
+    }
 }
 
 /// Classify a MIME type into Text, Binary, or Json.
@@ -417,6 +481,263 @@ pub async fn resolve_cell_outputs(
         }
     }
     outputs
+}
+
+// ── LLM-selective resolution ────────────────────────────────────────
+//
+// These functions resolve only what the MCP LLM text path needs from
+// output manifests. Instead of fetching every blob, they walk
+// CONTENT_PRIORITY to find the single best text MIME, resolve just that,
+// and synthesize `text/llm+plain` from manifest metadata when no direct
+// text representation exists.
+
+/// Resolve all outputs for a cell, fetching only what the LLM text path needs.
+///
+/// Drop-in replacement for [`resolve_cell_outputs`] in MCP tool handlers.
+/// Streams and errors are resolved normally (text-only, cheap). For
+/// `display_data`/`execute_result`, only the highest-priority text MIME
+/// is resolved; everything else is described from manifest metadata.
+pub async fn resolve_cell_outputs_for_llm(
+    raw_outputs: &[serde_json::Value],
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
+) -> Vec<Output> {
+    let mut outputs = Vec::with_capacity(raw_outputs.len());
+    for manifest in raw_outputs {
+        if let Some(output) =
+            resolve_output_for_llm(manifest, blob_base_url, blob_store_path, comms).await
+        {
+            outputs.push(output);
+        }
+    }
+    outputs
+}
+
+/// Resolve a single output manifest for LLM consumption.
+///
+/// Streams and errors pass through the normal resolver (text-only, cheap).
+/// Display data / execute results use [`resolve_display_for_llm`] which
+/// only fetches the highest-priority text MIME type.
+pub async fn resolve_output_for_llm(
+    manifest: &serde_json::Value,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
+) -> Option<Output> {
+    let output_type = manifest.get("output_type")?.as_str()?;
+
+    match output_type {
+        // Stream and error are text-only — resolve as normal.
+        "stream" => {
+            let name = manifest.get("name")?.as_str()?;
+            let text_ref = manifest.get("text")?;
+            let text = resolve_text_ref(text_ref, blob_base_url, blob_store_path).await?;
+            Some(Output::stream(name, &text))
+        }
+        "error" => {
+            let ename = manifest.get("ename")?.as_str()?.to_string();
+            let evalue = manifest.get("evalue")?.as_str()?.to_string();
+            let traceback_val = manifest.get("traceback")?;
+            let traceback = if let Some(arr) = traceback_val.as_array() {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            } else {
+                let tb_str =
+                    resolve_text_ref(traceback_val, blob_base_url, blob_store_path).await?;
+                serde_json::from_str::<Vec<String>>(&tb_str).ok()?
+            };
+            Some(Output::error(&ename, &evalue, traceback))
+        }
+        "display_data" | "execute_result" => {
+            resolve_display_for_llm(output_type, manifest, blob_base_url, blob_store_path, comms)
+                .await
+        }
+        _ => None,
+    }
+}
+
+/// Selectively resolve a display_data or execute_result manifest for LLM use.
+///
+/// 1. Walk [`CONTENT_PRIORITY`] against the manifest's MIME keys.
+/// 2. If a priority MIME exists, resolve just that one ContentRef.
+///    - If `text/plain` and too large, synthesize a truncated `text/llm+plain`.
+/// 3. If no priority MIME exists, synthesize `text/llm+plain`:
+///    - Resolve viz JSON specs for `summarize_viz`.
+///    - Resolve widget JSON for widget state summaries.
+///    - Describe binary/heavy-text MIMEs from ContentRef metadata (no fetch).
+/// 4. Return an Output with only the resolved/synthesized entries.
+async fn resolve_display_for_llm(
+    output_type: &str,
+    manifest: &serde_json::Value,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
+) -> Option<Output> {
+    let data_map = manifest.get("data")?.as_object()?;
+
+    let mut output_data: HashMap<String, DataValue> = HashMap::new();
+
+    // Phase 1: Try to resolve the highest-priority text MIME that exists.
+    let mut found_priority = false;
+    for &mime in CONTENT_PRIORITY {
+        let Some(content_ref) = data_map.get(mime) else {
+            continue;
+        };
+        let Some(content) =
+            resolve_content_ref(content_ref, blob_base_url, blob_store_path, Some(mime)).await
+        else {
+            continue; // Resolution failed, try next priority.
+        };
+
+        // For text/plain: if too large, synthesize truncated text/llm+plain.
+        if mime == "text/plain" {
+            if let DataValue::Text(ref text) = content {
+                if text.len() > LLM_TEXT_MAX_SIZE {
+                    let truncated = truncate_head_tail(text, LLM_TEXT_SIDE_SIZE);
+                    output_data.insert("text/llm+plain".to_string(), DataValue::Text(truncated));
+                }
+            }
+        }
+
+        output_data.insert(mime.to_string(), content);
+        found_priority = true;
+        break;
+    }
+
+    // Phase 2: No priority MIME found — synthesize text/llm+plain from metadata.
+    if !found_priority {
+        // 2a: Resolve JSON types for viz summarization.
+        for (mime, content_ref) in data_map {
+            if mime_kind(mime) == MimeKind::Json {
+                if let Some(content) =
+                    resolve_content_ref(content_ref, blob_base_url, blob_store_path, Some(mime))
+                        .await
+                {
+                    output_data.insert(mime.to_string(), content);
+                }
+            }
+        }
+        synthesize_llm_plain_for_viz(&mut output_data);
+
+        // 2b: Widget synthesis (if viz didn't produce text/llm+plain).
+        if !output_data.contains_key("text/llm+plain") {
+            if let Some(widget_ref) = data_map.get(WIDGET_VIEW_MIME) {
+                if !output_data.contains_key(WIDGET_VIEW_MIME) {
+                    if let Some(content) = resolve_content_ref(
+                        widget_ref,
+                        blob_base_url,
+                        blob_store_path,
+                        Some(WIDGET_VIEW_MIME),
+                    )
+                    .await
+                    {
+                        output_data.insert(WIDGET_VIEW_MIME.to_string(), content);
+                    }
+                }
+                if let Some(comms) = comms {
+                    synthesize_llm_plain_for_widgets(&mut output_data, comms);
+                }
+            }
+        }
+
+        // 2c: Large JSON summary (if still no text/llm+plain).
+        if !output_data.contains_key("text/llm+plain") {
+            if let Some(DataValue::Json(ref val)) = output_data.get("application/json") {
+                if let Some(summary) = repr_llm::summarize_json(val) {
+                    output_data.insert("text/llm+plain".to_string(), DataValue::Text(summary));
+                }
+            }
+        }
+
+        // 2d: Describe remaining MIMEs from manifest metadata (no fetches).
+        if !output_data.contains_key("text/llm+plain") {
+            let mut descriptions: Vec<String> = Vec::new();
+
+            for (mime, content_ref) in data_map {
+                // Skip JSON (already resolved above) and widget view.
+                if mime_kind(mime) == MimeKind::Json || mime == WIDGET_VIEW_MIME {
+                    continue;
+                }
+
+                let meta = content_ref_meta(content_ref);
+                let label = mime_label(mime);
+                let kb = meta.size / 1024;
+                let mut desc = format!("{label} output ({mime}, {kb} KB)");
+
+                // Append blob URL so the LLM can fetch if it wants.
+                if let Some(hash) = meta.blob_hash {
+                    if let Some(base_url) = blob_base_url {
+                        desc.push_str(&format!("\n{}/blob/{}", base_url, hash));
+                    }
+                }
+                descriptions.push(desc);
+            }
+
+            if !descriptions.is_empty() {
+                output_data.insert(
+                    "text/llm+plain".to_string(),
+                    DataValue::Text(descriptions.join("\n")),
+                );
+            }
+        }
+    }
+
+    // Build the output.
+    if output_type == "execute_result" {
+        let execution_count = manifest.get("execution_count").and_then(|v| v.as_i64())?;
+        Some(Output::execute_result(output_data, execution_count))
+    } else {
+        Some(Output::display_data(output_data))
+    }
+}
+
+/// Truncate text keeping head and tail, since errors and results tend to
+/// appear at the bottom while context (imports, setup) is at the top.
+fn truncate_head_tail(text: &str, side_bytes: usize) -> String {
+    if text.len() <= side_bytes * 2 {
+        return text.to_string();
+    }
+
+    // Find char boundary at or before the head limit.
+    let mut head_end = side_bytes;
+    while head_end > 0 && !text.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+
+    // Find char boundary at or after the tail start.
+    let mut tail_start = text.len() - side_bytes;
+    while tail_start < text.len() && !text.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+
+    let omitted = tail_start - head_end;
+    format!(
+        "{}\n[... truncated {} bytes ...]\n{}",
+        &text[..head_end],
+        omitted,
+        &text[tail_start..],
+    )
+}
+
+/// Human-readable label for a MIME type in synthesis descriptions.
+fn mime_label(mime: &str) -> &str {
+    if mime == "image/svg+xml" {
+        "SVG image"
+    } else if mime.starts_with("image/") {
+        "Image"
+    } else if mime.starts_with("audio/") {
+        "Audio"
+    } else if mime.starts_with("video/") {
+        "Video"
+    } else if mime == "text/html" {
+        "HTML"
+    } else if mime == "text/latex" {
+        "LaTeX"
+    } else {
+        "Content"
+    }
 }
 
 /// Synthesize `text/llm+plain` from visualization specs (Plotly, Vega-Lite, Vega).
@@ -833,5 +1154,404 @@ fn truncate_str(s: &str, max: usize) -> String {
     } else {
         let truncated: String = s.chars().take(max).collect();
         format!("{truncated}\u{2026}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── content_ref_meta ────────────────────────────────────────
+
+    #[test]
+    fn content_ref_meta_inline() {
+        let cr = json!({"inline": "hello world"});
+        let meta = content_ref_meta(&cr);
+        assert!(meta.is_inline);
+        assert_eq!(meta.size, 11);
+        assert!(meta.blob_hash.is_none());
+    }
+
+    #[test]
+    fn content_ref_meta_blob() {
+        let cr = json!({"blob": "abc123def456", "size": 50_000});
+        let meta = content_ref_meta(&cr);
+        assert!(!meta.is_inline);
+        assert_eq!(meta.size, 50_000);
+        assert_eq!(meta.blob_hash, Some("abc123def456"));
+    }
+
+    #[test]
+    fn content_ref_meta_blob_missing_size() {
+        let cr = json!({"blob": "abc123"});
+        let meta = content_ref_meta(&cr);
+        assert!(!meta.is_inline);
+        assert_eq!(meta.size, 0);
+        assert_eq!(meta.blob_hash, Some("abc123"));
+    }
+
+    #[test]
+    fn content_ref_meta_malformed() {
+        let cr = json!({"unexpected": true});
+        let meta = content_ref_meta(&cr);
+        assert!(!meta.is_inline);
+        assert_eq!(meta.size, 0);
+        assert!(meta.blob_hash.is_none());
+    }
+
+    #[test]
+    fn content_ref_meta_raw_string_legacy() {
+        // Legacy outputs are plain strings, not ContentRef objects
+        let cr = json!("some raw text");
+        let meta = content_ref_meta(&cr);
+        assert!(!meta.is_inline);
+        assert_eq!(meta.size, 0);
+        assert!(meta.blob_hash.is_none());
+    }
+
+    // ── truncate_head_tail ──────────────────────────────────────
+
+    #[test]
+    fn truncate_short_text_unchanged() {
+        let text = "short";
+        assert_eq!(truncate_head_tail(text, 100), "short");
+    }
+
+    #[test]
+    fn truncate_exactly_at_boundary() {
+        // 2 * side_bytes = total, should NOT truncate
+        let text = "a".repeat(200);
+        assert_eq!(truncate_head_tail(&text, 100), text);
+    }
+
+    #[test]
+    fn truncate_one_over_boundary() {
+        // 201 bytes, side=100 → head 100 + tail 100, middle 1 byte truncated
+        let text = "a".repeat(201);
+        let result = truncate_head_tail(&text, 100);
+        assert!(result.contains("[... truncated 1 bytes ...]"));
+        assert!(result.starts_with(&"a".repeat(100)));
+        assert!(result.ends_with(&"a".repeat(100)));
+    }
+
+    #[test]
+    fn truncate_large_text() {
+        let text = format!("HEAD{}{}", "x".repeat(10_000), "TAIL");
+        let result = truncate_head_tail(&text, 10);
+        assert!(result.starts_with("HEAD"));
+        assert!(result.ends_with("TAIL"));
+        assert!(result.contains("[... truncated"));
+    }
+
+    #[test]
+    fn truncate_multibyte_unicode_boundary() {
+        // '€' is 3 bytes (U+20AC). Put it right at the cut boundary.
+        // side_bytes=5, so we need text > 10 bytes total.
+        let text = "ab€€€€cd"; // 2 + 4*3 + 2 = 16 bytes
+        let result = truncate_head_tail(&text, 5);
+        // Should find a valid char boundary, not panic
+        assert!(result.contains("[... truncated"));
+        // Verify the result is valid UTF-8 (it is, since it's a String)
+        assert!(result.len() > 0);
+    }
+
+    #[test]
+    fn truncate_preserves_head_and_tail_content() {
+        let head = "ERROR at line 1\n";
+        let middle = "x".repeat(10_000);
+        let tail = "\nTraceback: something failed";
+        let text = format!("{head}{middle}{tail}");
+        let result = truncate_head_tail(&text, 100);
+        // Head content preserved
+        assert!(result.starts_with("ERROR at line 1"));
+        // Tail content preserved
+        assert!(result.ends_with("something failed"));
+    }
+
+    // ── mime_label ──────────────────────────────────────────────
+
+    #[test]
+    fn mime_labels() {
+        assert_eq!(mime_label("image/svg+xml"), "SVG image");
+        assert_eq!(mime_label("image/png"), "Image");
+        assert_eq!(mime_label("image/jpeg"), "Image");
+        assert_eq!(mime_label("audio/wav"), "Audio");
+        assert_eq!(mime_label("audio/mpeg"), "Audio");
+        assert_eq!(mime_label("video/mp4"), "Video");
+        assert_eq!(mime_label("text/html"), "HTML");
+        assert_eq!(mime_label("text/latex"), "LaTeX");
+        assert_eq!(mime_label("application/octet-stream"), "Content");
+    }
+
+    // ── CONTENT_PRIORITY constant ───────────────────────────────
+
+    #[test]
+    fn content_priority_order() {
+        assert_eq!(CONTENT_PRIORITY[0], "text/llm+plain");
+        assert_eq!(CONTENT_PRIORITY[1], "text/latex");
+        assert_eq!(CONTENT_PRIORITY[2], "text/markdown");
+        assert_eq!(CONTENT_PRIORITY[3], "text/plain");
+    }
+
+    // ── resolve_display_for_llm (async) ─────────────────────────
+
+    /// Helper to build a display_data manifest with inline data entries.
+    fn make_display_manifest(data: serde_json::Value) -> serde_json::Value {
+        json!({
+            "output_type": "display_data",
+            "data": data,
+        })
+    }
+
+    fn make_execute_result_manifest(data: serde_json::Value, ec: i64) -> serde_json::Value {
+        json!({
+            "output_type": "execute_result",
+            "data": data,
+            "execution_count": ec,
+        })
+    }
+
+    /// Helper: inline ContentRef
+    fn inline_ref(content: &str) -> serde_json::Value {
+        json!({"inline": content})
+    }
+
+    /// Helper: blob ContentRef (won't resolve without a blob store)
+    fn blob_ref(hash: &str, size: u64) -> serde_json::Value {
+        json!({"blob": hash, "size": size})
+    }
+
+    #[tokio::test]
+    async fn llm_resolves_text_plain_only() {
+        let manifest = make_display_manifest(json!({
+            "text/plain": inline_ref("hello world"),
+            "image/png": blob_ref("abc123", 50_000),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // text/plain resolved
+        assert!(matches!(data.get("text/plain"), Some(DataValue::Text(s)) if s == "hello world"));
+        // image/png NOT resolved (no blob store, but more importantly: not attempted)
+        assert!(!data.contains_key("image/png"));
+    }
+
+    #[tokio::test]
+    async fn llm_latex_wins_over_plain() {
+        let manifest = make_display_manifest(json!({
+            "text/latex": inline_ref("$E=mc^2$"),
+            "text/plain": inline_ref("E=mc^2"),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // text/latex should be resolved (it's higher priority than text/plain)
+        assert!(matches!(data.get("text/latex"), Some(DataValue::Text(s)) if s == "$E=mc^2$"));
+        // text/plain should NOT be resolved (lower priority, not needed)
+        assert!(!data.contains_key("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn llm_author_provided_llm_plain_wins() {
+        let manifest = make_display_manifest(json!({
+            "text/llm+plain": inline_ref("Author's summary"),
+            "text/plain": inline_ref("raw repr"),
+            "image/png": blob_ref("img123", 100_000),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        assert!(
+            matches!(data.get("text/llm+plain"), Some(DataValue::Text(s)) if s == "Author's summary")
+        );
+        assert!(!data.contains_key("text/plain"));
+        assert!(!data.contains_key("image/png"));
+    }
+
+    #[tokio::test]
+    async fn llm_large_text_plain_gets_truncated() {
+        let large_text = format!("START{}{}", "x".repeat(10_000), "END");
+        let manifest = make_display_manifest(json!({
+            "text/plain": inline_ref(&large_text),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // text/plain is resolved (it's the content)
+        assert!(data.contains_key("text/plain"));
+        // text/llm+plain is synthesized as truncated version
+        let llm = match data.get("text/llm+plain") {
+            Some(DataValue::Text(s)) => s.clone(),
+            _ => panic!("expected text/llm+plain"),
+        };
+        assert!(llm.contains("[... truncated"));
+        assert!(llm.starts_with("START"));
+        assert!(llm.ends_with("END"));
+    }
+
+    #[tokio::test]
+    async fn llm_text_plain_under_threshold_not_truncated() {
+        // 4096 bytes exactly = LLM_TEXT_MAX_SIZE, should NOT truncate (> threshold, not >=)
+        let text = "a".repeat(4096);
+        let manifest = make_display_manifest(json!({
+            "text/plain": inline_ref(&text),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // No text/llm+plain synthesized — text/plain is under/at threshold
+        assert!(!data.contains_key("text/llm+plain"));
+        assert!(matches!(data.get("text/plain"), Some(DataValue::Text(s)) if s.len() == 4096));
+    }
+
+    #[tokio::test]
+    async fn llm_no_text_mime_binary_only_described() {
+        let manifest = make_display_manifest(json!({
+            "image/png": blob_ref("png123", 45_000),
+            "image/svg+xml": blob_ref("svg456", 12_000),
+        }));
+        let blob_base = Some("http://localhost:9999".to_string());
+        let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // No image data resolved
+        assert!(!data.contains_key("image/png"));
+        assert!(!data.contains_key("image/svg+xml"));
+
+        // text/llm+plain synthesized from metadata
+        let llm = match data.get("text/llm+plain") {
+            Some(DataValue::Text(s)) => s.clone(),
+            _ => panic!("expected text/llm+plain synthesis"),
+        };
+        assert!(llm.contains("image/png"));
+        assert!(llm.contains("45 KB") || llm.contains("43 KB")); // 45000/1024 ≈ 43
+        assert!(llm.contains("http://localhost:9999/blob/png123"));
+    }
+
+    #[tokio::test]
+    async fn llm_empty_data_map() {
+        let manifest = make_display_manifest(json!({}));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None).await;
+        // Empty data map still produces an output, just with empty data
+        assert!(output.is_some());
+        let data = output.unwrap().data.unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn llm_stream_resolves_normally() {
+        let manifest = json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": inline_ref("hello from stdout"),
+        });
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        assert_eq!(output.output_type, "stream");
+        assert_eq!(output.text.as_deref(), Some("hello from stdout"));
+    }
+
+    #[tokio::test]
+    async fn llm_error_resolves_normally() {
+        let manifest = json!({
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "bad value",
+            "traceback": ["line 1", "line 2"],
+        });
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        assert_eq!(output.output_type, "error");
+        assert_eq!(output.ename.as_deref(), Some("ValueError"));
+        assert_eq!(output.traceback.as_ref().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn llm_execute_result_has_execution_count() {
+        let manifest = make_execute_result_manifest(json!({"text/plain": inline_ref("42")}), 5);
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        assert_eq!(output.output_type, "execute_result");
+        assert_eq!(output.execution_count, Some(5));
+    }
+
+    #[tokio::test]
+    async fn llm_blob_text_plain_falls_through_on_failure() {
+        // text/latex is a blob that can't resolve (no store), text/plain is inline
+        let manifest = make_display_manifest(json!({
+            "text/latex": blob_ref("latex_hash", 5000),
+            "text/plain": inline_ref("fallback plain"),
+        }));
+        let output = resolve_output_for_llm(&manifest, &None, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        // text/latex resolution failed → fell through to text/plain
+        assert!(!data.contains_key("text/latex"));
+        assert!(
+            matches!(data.get("text/plain"), Some(DataValue::Text(s)) if s == "fallback plain")
+        );
+    }
+
+    #[tokio::test]
+    async fn llm_only_html_gets_described() {
+        // text/html is NOT in CONTENT_PRIORITY — should be described, not resolved
+        let manifest = make_display_manifest(json!({
+            "text/html": blob_ref("html_hash", 8_000),
+        }));
+        let blob_base = Some("http://localhost:9999".to_string());
+        let output = resolve_output_for_llm(&manifest, &blob_base, &None, None)
+            .await
+            .unwrap();
+        let data = output.data.unwrap();
+
+        assert!(!data.contains_key("text/html"));
+        let llm = match data.get("text/llm+plain") {
+            Some(DataValue::Text(s)) => s.clone(),
+            _ => panic!("expected text/llm+plain for HTML-only output"),
+        };
+        assert!(llm.contains("HTML"));
+        assert!(llm.contains("text/html"));
+        assert!(llm.contains("http://localhost:9999/blob/html_hash"));
+    }
+
+    #[tokio::test]
+    async fn llm_resolve_cell_outputs_for_llm_mixed() {
+        let manifests = vec![
+            json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": inline_ref("print output"),
+            }),
+            make_display_manifest(json!({
+                "text/plain": inline_ref("<Figure>"),
+                "image/png": blob_ref("fig_png", 80_000),
+            })),
+        ];
+        let outputs = resolve_cell_outputs_for_llm(&manifests, &None, &None, None).await;
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].output_type, "stream");
+        assert_eq!(outputs[1].output_type, "display_data");
+        // The display_data should only have text/plain, not image/png
+        let data = outputs[1].data.as_ref().unwrap();
+        assert!(data.contains_key("text/plain"));
+        assert!(!data.contains_key("image/png"));
     }
 }


### PR DESCRIPTION
MCP tool handlers (`get_cell`, `execute_cell`, `get_all_cells`) previously resolved ALL content refs from output manifests — fetching 50KB SVGs, 200KB PNGs, megabyte audio blobs — to produce a text summary and discard the data.

After #1558 inlined manifests into RuntimeStateDoc, MIME types and sizes are in ContentRef metadata without touching the blob store. This exploits that.

## Two priority orders, each yielding one result

**LLM text** (`resolve_cell_outputs_for_llm`):
- Walk `[text/llm+plain, text/latex, text/markdown, text/plain]`, resolve the first match
- If none exist, synthesize `text/llm+plain` from manifest metadata: viz JSON summaries, widget state, or MIME+size+blob-URL descriptions for binary/heavy-text (no blob fetch)
- Large `text/plain` (>4KB) gets head+tail truncation into `text/llm+plain`

**Structured content** (`cell_structured_content_from_manifests`):
- Build structured JSON directly from manifest Values
- Inline ContentRefs (<1KB) pass through, blob ContentRefs become URLs
- Zero blob fetches — keeps `structuredContent` compact since Claude Code reads it into context

## Changes

| File | What |
|------|------|
| `output_resolver.rs` | `ContentRefMeta`, `content_ref_meta()`, `CONTENT_PRIORITY`, `resolve_cell_outputs_for_llm()`, `resolve_display_for_llm()`, `truncate_head_tail()` |
| `formatting.rs` | Add `text/latex` to `TEXT_MIME_PRIORITY` |
| `structured.rs` | `cell_structured_content_from_manifests()`, `manifest_output_to_structured()` — replaces old full-resolution path |
| `cell_read.rs` | Switch 4 call sites to `resolve_cell_outputs_for_llm` |
| `execution.rs` | Switch 2 call sites to `resolve_cell_outputs_for_llm` |
| `tools/mod.rs` | `build_execution_result` uses manifest-based structured builder instead of second full resolution |

## Before/After

**matplotlib plot** (`text/plain` + `image/png` + `image/svg+xml`):
- Before: fetch PNG blob (~50KB), SVG blob (~10KB), resolve text/plain, synthesize text/llm+plain describing all three
- After: resolve just `text/plain` (inline, <1KB). Zero blob fetches.

**Audio output** (500KB WAV):
- Before: fetch entire WAV blob, resolve HTML embed, synthesize description
- After: no blob fetch. `text/llm+plain`: "Audio output (audio/wav, 488 KB)" + blob URL

Full `resolve_cell_outputs` stays for Python bindings and other consumers.

_PR submitted by @rgbkrk's agent Quill, via Zed_