### PR TITLE
feat(wasm): selective MIME resolution via priority list

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SyncableHandle } from "runtimed";
-import { SyncEngine } from "runtimed";
+import { DEFAULT_MIME_PRIORITY, SyncEngine } from "runtimed";
 import { concatMap, from, switchMap } from "rxjs";
 import {
   needsPlugin,
@@ -184,6 +184,7 @@ export function useAutomergeNotebook() {
 
     handleRef.current?.free();
     handleRef.current = handle;
+    handle.set_mime_priority(DEFAULT_MIME_PRIORITY);
     setNotebookHandle(handle);
 
     setIsLoading(true);

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -87,6 +87,24 @@ export async function resolveOutput(
       return resolved;
     } catch (e) {
       logger.warn("[materialize-cells] Failed to resolve manifest:", e);
+      // Fallback: try resolving with just text/plain if available
+      if (
+        (output.output_type === "display_data" ||
+          output.output_type === "execute_result") &&
+        output.data["text/plain"]
+      ) {
+        try {
+          const fallback = {
+            ...output,
+            data: { "text/plain": output.data["text/plain"] },
+          } as typeof output;
+          const resolved = await resolveManifest(fallback, blobPort);
+          cache.set(key, resolved);
+          return resolved;
+        } catch {
+          // text/plain fallback also failed
+        }
+      }
       return null;
     }
   }

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -99,7 +99,8 @@ export async function resolveOutput(
             data: { "text/plain": output.data["text/plain"] },
           } as typeof output;
           const resolved = await resolveManifest(fallback, blobPort);
-          cache.set(key, resolved);
+          // Don't cache the fallback — leave the original key as a cache miss
+          // so the next materialization retries the rich MIME type.
           return resolved;
         } catch {
           // text/plain fallback also failed

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -477,6 +477,12 @@ export class NotebookHandle {
      */
     set_metadata_value(key: string, value: any): void;
     /**
+     * Set the MIME type priority list for output selection.
+     * Types earlier in the list are preferred when narrowing output data bundles.
+     * If empty, all MIME types are returned (backward compatible).
+     */
+    set_mime_priority(priority: any): void;
+    /**
      * Set Pixi channels.
      * Accepts a JSON array string (e.g. `'["conda-forge"]'`).
      */
@@ -632,6 +638,7 @@ export interface InitOutput {
     readonly notebookhandle_set_metadata: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_set_metadata_snapshot_value: (a: number, b: number, c: number) => void;
     readonly notebookhandle_set_metadata_value: (a: number, b: number, c: number, d: number, e: number) => void;
+    readonly notebookhandle_set_mime_priority: (a: number, b: number) => void;
     readonly notebookhandle_set_pixi_channels: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_set_pixi_python: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_set_uv_prerelease: (a: number, b: number, c: number, d: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -1568,6 +1568,15 @@ export class NotebookHandle {
         }
     }
     /**
+     * Set the MIME type priority list for output selection.
+     * Types earlier in the list are preferred when narrowing output data bundles.
+     * If empty, all MIME types are returned (backward compatible).
+     * @param {any} priority
+     */
+    set_mime_priority(priority) {
+        wasm.notebookhandle_set_mime_priority(this.__wbg_ptr, addHeapObject(priority));
+    }
+    /**
      * Set Pixi channels.
      * Accepts a JSON array string (e.g. `'["conda-forge"]'`).
      * @param {string} channels_json

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de5d0f319f202e7cbc21b57e0d5a5e21f7d58f42c67873547e4f2d0f166a44c9
-size 1617956
+oid sha256:01f8778c6512cca62ada935d18008d46c2d4c998cfc75e1172fd272fdafc57f8
+size 1622059

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01f8778c6512cca62ada935d18008d46c2d4c998cfc75e1172fd272fdafc57f8
-size 1622059
+oid sha256:e889057bec1793c3a3d68c41b72721f88d2e4a4928da6b2f1b5e368b43946b4e
+size 1622915

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -80,6 +80,7 @@ export const notebookhandle_set_conda_python: (a: number, b: number, c: number, 
 export const notebookhandle_set_metadata: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_set_metadata_snapshot_value: (a: number, b: number, c: number) => void;
 export const notebookhandle_set_metadata_value: (a: number, b: number, c: number, d: number, e: number) => void;
+export const notebookhandle_set_mime_priority: (a: number, b: number) => void;
 export const notebookhandle_set_pixi_channels: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_set_pixi_python: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_set_uv_prerelease: (a: number, b: number, c: number, d: number) => void;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -28,6 +28,39 @@ use wasm_bindgen::prelude::*;
 /// Using `serialize_maps_as_objects(true)` ensures all maps become plain
 /// JS Objects, matching what `JSON.parse()` would produce. The returned
 /// `JsValue` can be any JS type (object, array, scalar) depending on input.
+/// Check if a MIME type represents binary content (images, audio, video).
+///
+/// Binary MIME refs resolve to blob URLs (no fetch needed), so they're
+/// cheap to include in narrowed output bundles. Only text blob refs
+/// are expensive (HTTP roundtrip to the blob server).
+fn is_binary_mime(mime: &str) -> bool {
+    if mime.starts_with("image/") {
+        // SVG is XML text, not binary
+        return !mime.ends_with("+xml");
+    }
+    if mime.starts_with("audio/") || mime.starts_with("video/") {
+        return true;
+    }
+    // application/* is binary by default, with carve-outs for text-like formats
+    if let Some(subtype) = mime.strip_prefix("application/") {
+        let is_text = subtype == "json"
+            || subtype == "javascript"
+            || subtype == "ecmascript"
+            || subtype == "xml"
+            || subtype == "xhtml+xml"
+            || subtype == "mathml+xml"
+            || subtype == "sql"
+            || subtype == "graphql"
+            || subtype == "x-latex"
+            || subtype == "x-tex"
+            || subtype.ends_with("+json")
+            || subtype.ends_with(".json")
+            || subtype.ends_with("+xml");
+        return !is_text;
+    }
+    false
+}
+
 fn serialize_to_js<T: Serialize>(value: &T) -> Result<JsValue, serde_wasm_bindgen::Error> {
     let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
     value.serialize(&serializer)
@@ -463,8 +496,11 @@ impl NotebookHandle {
         }
     }
 
-    /// Narrow an output manifest's data bundle to the winning MIME type.
-    /// Includes text/plain alongside the winner as a fallback candidate.
+    /// Narrow an output manifest's data bundle to the winning MIME type,
+    /// plus all binary MIME refs (cheap — just URL construction, no fetch)
+    /// and text/plain as a fallback candidate.
+    ///
+    /// Only expensive text blob refs for non-winning types are dropped.
     /// Returns the manifest unchanged if mime_priority is empty or output_type
     /// is not display_data/execute_result.
     fn narrow_output_data(&self, mut output: serde_json::Value) -> serde_json::Value {
@@ -488,14 +524,9 @@ impl NotebookHandle {
 
             if let Some(winner_mime) = winner {
                 let mut narrowed = serde_json::Map::new();
-                // Always include the winner
-                if let Some(val) = data.get(winner_mime) {
-                    narrowed.insert(winner_mime.to_string(), val.clone());
-                }
-                // Include text/plain as fallback if it exists and isn't already the winner
-                if winner_mime != "text/plain" {
-                    if let Some(plain) = data.get("text/plain") {
-                        narrowed.insert("text/plain".to_string(), plain.clone());
+                for (mime, val) in data {
+                    if mime == winner_mime || mime == "text/plain" || is_binary_mime(mime) {
+                        narrowed.insert(mime.clone(), val.clone());
                     }
                 }
                 output["data"] = serde_json::Value::Object(narrowed);

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -179,6 +179,10 @@ pub struct NotebookHandle {
     /// Avoids re-serializing the metadata snapshot on every
     /// `get_metadata_fingerprint()` call (~30/sec during streaming).
     metadata_fingerprint_cache: Option<String>,
+    /// MIME type priority list for output selection.
+    /// Types earlier in the list are preferred when narrowing output data bundles.
+    /// If empty, all MIME types are returned (backward compatible).
+    mime_priority: Vec<String>,
 }
 
 /// A cell snapshot returned to JavaScript.
@@ -277,6 +281,7 @@ impl NotebookHandle {
             pool_doc: PoolDoc::new_empty(),
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
+            mime_priority: Vec::new(),
         }
     }
 
@@ -294,6 +299,7 @@ impl NotebookHandle {
             pool_doc: PoolDoc::new_empty(),
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
+            mime_priority: Vec::new(),
         }
     }
 
@@ -325,6 +331,7 @@ impl NotebookHandle {
             pool_doc: PoolDoc::new_empty(),
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
+            mime_priority: Vec::new(),
         })
     }
 
@@ -386,7 +393,10 @@ impl NotebookHandle {
             if let Some(eid) = self.doc.get_execution_id(&cell.id) {
                 let outputs = self.state_doc.get_outputs(&eid);
                 if !outputs.is_empty() {
-                    cell.outputs = outputs;
+                    cell.outputs = outputs
+                        .into_iter()
+                        .map(|o| self.narrow_output_data(o))
+                        .collect();
                 }
             }
         }
@@ -429,7 +439,11 @@ impl NotebookHandle {
                 if out.is_empty() {
                     None
                 } else {
-                    Some(out)
+                    Some(
+                        out.into_iter()
+                            .map(|o| self.narrow_output_data(o))
+                            .collect::<Vec<_>>(),
+                    )
                 }
             }
             None => None,
@@ -438,6 +452,56 @@ impl NotebookHandle {
             Some(outputs) => serialize_to_js(&outputs).unwrap_or(JsValue::UNDEFINED),
             None => JsValue::UNDEFINED,
         }
+    }
+
+    /// Set the MIME type priority list for output selection.
+    /// Types earlier in the list are preferred when narrowing output data bundles.
+    /// If empty, all MIME types are returned (backward compatible).
+    pub fn set_mime_priority(&mut self, priority: JsValue) {
+        if let Ok(p) = serde_wasm_bindgen::from_value::<Vec<String>>(priority) {
+            self.mime_priority = p;
+        }
+    }
+
+    /// Narrow an output manifest's data bundle to the winning MIME type.
+    /// Includes text/plain alongside the winner as a fallback candidate.
+    /// Returns the manifest unchanged if mime_priority is empty or output_type
+    /// is not display_data/execute_result.
+    fn narrow_output_data(&self, mut output: serde_json::Value) -> serde_json::Value {
+        if self.mime_priority.is_empty() {
+            return output;
+        }
+        let output_type = output.get("output_type").and_then(|v| v.as_str());
+        if !matches!(output_type, Some("display_data" | "execute_result")) {
+            return output;
+        }
+        if let Some(data) = output.get("data").and_then(|d| d.as_object()) {
+            let keys: Vec<&str> = data.keys().map(|k| k.as_str()).collect();
+            // Find the winning MIME type from priority list
+            let winner = self
+                .mime_priority
+                .iter()
+                .find(|p| keys.contains(&p.as_str()))
+                .map(|s| s.as_str())
+                // Fallback: first available key
+                .or_else(|| keys.first().copied());
+
+            if let Some(winner_mime) = winner {
+                let mut narrowed = serde_json::Map::new();
+                // Always include the winner
+                if let Some(val) = data.get(winner_mime) {
+                    narrowed.insert(winner_mime.to_string(), val.clone());
+                }
+                // Include text/plain as fallback if it exists and isn't already the winner
+                if winner_mime != "text/plain" {
+                    if let Some(plain) = data.get("text/plain") {
+                        narrowed.insert("text/plain".to_string(), plain.clone());
+                    }
+                }
+                output["data"] = serde_json::Value::Object(narrowed);
+            }
+        }
+        output
     }
 
     /// Get a cell's execution count.

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -100,6 +100,9 @@ export type {
   NotebookResponse,
 } from "./request-types";
 
+// MIME priority
+export { DEFAULT_MIME_PRIORITY } from "./mime-priority";
+
 // Testing
 export { DirectTransport } from "./direct-transport";
 export type { ServerHandle } from "./direct-transport";

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -1,0 +1,51 @@
+/**
+ * Default MIME type display priority for notebook outputs.
+ *
+ * Used by the WASM layer to select which MIME type to resolve when an
+ * output bundle contains multiple representations. Higher priority
+ * (earlier in the array) wins.
+ */
+export const DEFAULT_MIME_PRIORITY = [
+  // Rich formats first
+  "application/vnd.jupyter.widget-view+json",
+  "application/vnd.plotly.v1+json",
+  "application/vnd.vegalite.v6+json",
+  "application/vnd.vegalite.v6.json",
+  "application/vnd.vegalite.v5+json",
+  "application/vnd.vegalite.v5.json",
+  "application/vnd.vegalite.v4+json",
+  "application/vnd.vegalite.v3+json",
+  "application/vnd.vega.v6+json",
+  "application/vnd.vega.v6.json",
+  "application/vnd.vega.v5+json",
+  "application/vnd.vega.v5.json",
+  "application/vnd.vega.v4+json",
+  "application/geo+json",
+  // HTML, PDF, markdown, and LaTeX
+  "text/html",
+  "application/pdf",
+  "text/markdown",
+  "text/latex",
+  "application/javascript",
+  // Images
+  "image/svg+xml",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  // Audio
+  "audio/wav",
+  "audio/mpeg",
+  "audio/ogg",
+  "audio/flac",
+  "audio/webm",
+  // Video
+  "video/mp4",
+  "video/webm",
+  "video/ogg",
+  // Structured data
+  "application/json",
+  // Plain text (fallback)
+  "text/plain",
+] as const;


### PR DESCRIPTION
WASM selects the winning MIME type, JS resolves only that. Outputs go from N blob fetches to 1-2 per output.

## What

`NotebookHandle` accepts a MIME priority list at init via `set_mime_priority()`. When returning outputs, it narrows `display_data`/`execute_result` data bundles to:

- The winning MIME type (first priority match)
- All binary MIME refs (images, audio, video — just URL construction, zero fetch cost)
- `text/plain` as a fallback candidate

Stream and error outputs pass through unchanged. The resolution pipeline (`resolveManifest` / `resolveDataBundle`) is unchanged — it just gets smaller bundles.

## Why

A typical Altair output has 4 MIME types. We were fetching blobs for all of them, then `selectMimeType` picked the winner and discarded the rest. Binary refs are cheap (URL construction), but text blob refs are real HTTP roundtrips to the blob server.

## Changes

- `packages/runtimed/src/mime-priority.ts` — canonical `DEFAULT_MIME_PRIORITY` in the transport-agnostic library (future UIs get it for free)
- `crates/runtimed-wasm/src/lib.rs` — `set_mime_priority()`, `narrow_output_data()` with `is_binary_mime()` applied in `get_cell_outputs` and `get_cells_json`
- `apps/notebook/src/hooks/useAutomergeNotebook.ts` — calls `set_mime_priority` at WASM init
- `apps/notebook/src/lib/materialize-cells.ts` — `text/plain` fallback in `resolveOutput` when the winner fails (not cached, so next pass retries the rich MIME)
- WASM artifacts rebuilt

## Known limitation

WASM narrowing uses `DEFAULT_MIME_PRIORITY` at init, which means non-default text MIME types are dropped before `MediaRouter` runs. The `MediaProvider`/`MediaRouter` custom priority override path isn't used for notebook outputs today — it's leftover API surface. If custom priority overrides become a real feature, the fix is to pass the same priority to both WASM and `MediaRouter`.

## Backward compatible

When `mime_priority` is empty (no `set_mime_priority` call), all MIME types are returned — existing behavior preserved.

_PR submitted by @rgbkrk's agent Quill, via Zed_