### PR TITLE
refactor(notebook-doc): unify MIME classification into shared crate

### DIFF
--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -7,6 +7,10 @@ import type { JupyterOutput } from "../types";
  * from Jupyter's base64 wire format). The blob HTTP server serves them
  * with the correct Content-Type, so the frontend can use blob URLs
  * directly (e.g., `<img src="http://...">`) instead of base64 data URIs.
+ *
+ * **This is a TypeScript port of the canonical Rust implementation in
+ * `crates/notebook-doc/src/mime.rs` (`is_binary_mime` / `mime_kind`).
+ * Keep them in sync — see AGENTS.md § "The `is_binary_mime` Contract".**
  */
 export function isBinaryMime(mime: string): boolean {
   if (mime.startsWith("image/")) {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e889057bec1793c3a3d68c41b72721f88d2e4a4928da6b2f1b5e368b43946b4e
-size 1622915
+oid sha256:9ba5551d45c0b4b3e32f978c8f896fc14a0dee09ae007fe867bd11aa2fa4ac17
+size 1622972

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -37,6 +37,7 @@
 pub mod diff;
 pub mod frame_types;
 pub mod metadata;
+pub mod mime;
 pub mod pep723;
 pub mod pool_state;
 pub mod presence;

--- a/crates/notebook-doc/src/mime.rs
+++ b/crates/notebook-doc/src/mime.rs
@@ -1,0 +1,197 @@
+//! Canonical MIME type classification for notebook outputs.
+//!
+//! This is the single source of truth for MIME classification in the Rust
+//! codebase. The three-way [`MimeKind`] enum and [`mime_kind`] classifier
+//! determine how output data is stored, transferred, and displayed.
+//!
+//! ## Keeping copies in sync
+//!
+//! A TypeScript copy of this logic lives in
+//! `apps/notebook/src/lib/manifest-resolution.ts` (`isBinaryMime`).
+//! Any changes here **must** be mirrored there — see the `is_binary_mime`
+//! contract in `AGENTS.md` for the full list of locations.
+
+/// Three-way classification of a MIME type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MimeKind {
+    /// UTF-8 text: `text/*`, `image/svg+xml`, `application/javascript`, etc.
+    Text,
+    /// Raw binary bytes: `image/png`, `audio/*`, `video/*`, etc.
+    Binary,
+    /// JSON data: `application/json`, `*+json`, `*.json`.
+    Json,
+}
+
+/// Classify a MIME type into [`MimeKind::Text`], [`MimeKind::Binary`], or
+/// [`MimeKind::Json`].
+///
+/// The rules, in evaluation order:
+///
+/// 1. `application/json` → Json
+/// 2. `application/*+json` or `application/*.json` → Json
+/// 3. `image/*` → Binary, **except** `image/*+xml` (e.g. SVG) → Text
+/// 4. `audio/*`, `video/*` → Binary
+/// 5. `application/*` → Binary by default, with carve-outs for text-like
+///    subtypes (`javascript`, `ecmascript`, `xml`, `xhtml+xml`, `mathml+xml`,
+///    `sql`, `graphql`, `x-latex`, `x-tex`, and any `+xml` suffix)
+/// 6. Everything else (`text/*`, unknown) → Text
+pub fn mime_kind(mime: &str) -> MimeKind {
+    // JSON types
+    if mime == "application/json" {
+        return MimeKind::Json;
+    }
+    if let Some(subtype) = mime.strip_prefix("application/") {
+        if subtype.ends_with("+json") || subtype.ends_with(".json") {
+            return MimeKind::Json;
+        }
+    }
+
+    // Binary images (but NOT SVG — that's XML text)
+    if mime.starts_with("image/") {
+        return if mime.ends_with("+xml") {
+            MimeKind::Text
+        } else {
+            MimeKind::Binary
+        };
+    }
+
+    // Audio/video are always binary
+    if mime.starts_with("audio/") || mime.starts_with("video/") {
+        return MimeKind::Binary;
+    }
+
+    // application/* is binary by default, with carve-outs for text-like formats
+    if let Some(subtype) = mime.strip_prefix("application/") {
+        let is_text = subtype == "javascript"
+            || subtype == "ecmascript"
+            || subtype == "xml"
+            || subtype == "xhtml+xml"
+            || subtype == "mathml+xml"
+            || subtype == "sql"
+            || subtype == "graphql"
+            || subtype == "x-latex"
+            || subtype == "x-tex"
+            || subtype.ends_with("+xml");
+        return if is_text {
+            MimeKind::Text
+        } else {
+            MimeKind::Binary
+        };
+    }
+
+    // Everything else (text/*, unknown) is text
+    MimeKind::Text
+}
+
+/// Returns `true` when the MIME type represents raw binary data.
+///
+/// This is a convenience wrapper around [`mime_kind`].
+#[inline]
+pub fn is_binary_mime(mime: &str) -> bool {
+    matches!(mime_kind(mime), MimeKind::Binary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_png_is_binary() {
+        assert_eq!(mime_kind("image/png"), MimeKind::Binary);
+    }
+
+    #[test]
+    fn svg_is_text() {
+        assert_eq!(mime_kind("image/svg+xml"), MimeKind::Text);
+    }
+
+    #[test]
+    fn audio_wav_is_binary() {
+        assert_eq!(mime_kind("audio/wav"), MimeKind::Binary);
+    }
+
+    #[test]
+    fn video_mp4_is_binary() {
+        assert_eq!(mime_kind("video/mp4"), MimeKind::Binary);
+    }
+
+    #[test]
+    fn text_plain_is_text() {
+        assert_eq!(mime_kind("text/plain"), MimeKind::Text);
+    }
+
+    #[test]
+    fn text_html_is_text() {
+        assert_eq!(mime_kind("text/html"), MimeKind::Text);
+    }
+
+    #[test]
+    fn application_json_is_json() {
+        assert_eq!(mime_kind("application/json"), MimeKind::Json);
+    }
+
+    #[test]
+    fn plotly_json_is_json() {
+        assert_eq!(mime_kind("application/vnd.plotly.v1+json"), MimeKind::Json);
+    }
+
+    #[test]
+    fn vegalite_json_is_json() {
+        assert_eq!(
+            mime_kind("application/vnd.vegalite.v5+json"),
+            MimeKind::Json
+        );
+    }
+
+    #[test]
+    fn application_javascript_is_text() {
+        assert_eq!(mime_kind("application/javascript"), MimeKind::Text);
+    }
+
+    #[test]
+    fn application_pdf_is_binary() {
+        assert_eq!(mime_kind("application/pdf"), MimeKind::Binary);
+    }
+
+    #[test]
+    fn geo_json_is_json() {
+        assert_eq!(mime_kind("application/geo+json"), MimeKind::Json);
+    }
+
+    #[test]
+    fn application_xml_is_text() {
+        assert_eq!(mime_kind("application/xml"), MimeKind::Text);
+    }
+
+    #[test]
+    fn application_octet_stream_is_binary() {
+        assert_eq!(mime_kind("application/octet-stream"), MimeKind::Binary);
+    }
+
+    #[test]
+    fn is_binary_mime_convenience() {
+        assert!(is_binary_mime("image/png"));
+        assert!(!is_binary_mime("text/plain"));
+        assert!(!is_binary_mime("application/json"));
+    }
+
+    #[test]
+    fn application_text_like_carveouts() {
+        // All the text-like application/* subtypes
+        assert_eq!(mime_kind("application/ecmascript"), MimeKind::Text);
+        assert_eq!(mime_kind("application/xhtml+xml"), MimeKind::Text);
+        assert_eq!(mime_kind("application/mathml+xml"), MimeKind::Text);
+        assert_eq!(mime_kind("application/sql"), MimeKind::Text);
+        assert_eq!(mime_kind("application/graphql"), MimeKind::Text);
+        assert_eq!(mime_kind("application/x-latex"), MimeKind::Text);
+        assert_eq!(mime_kind("application/x-tex"), MimeKind::Text);
+    }
+
+    #[test]
+    fn dot_json_suffix_is_json() {
+        assert_eq!(
+            mime_kind("application/vnd.dataresource.json"),
+            MimeKind::Json
+        );
+    }
+}

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -16,6 +16,8 @@ use serde_json::Value;
 
 use crate::resolved_output::{DataValue, Output};
 
+pub use notebook_doc::mime::{mime_kind, MimeKind};
+
 /// MIME type for Jupyter widget view references.
 const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
 
@@ -37,22 +39,6 @@ const LLM_TEXT_MAX_SIZE: usize = 4 * 1024;
 
 /// Bytes to keep from head and tail when truncating into `text/llm+plain`.
 const LLM_TEXT_SIDE_SIZE: usize = 2 * 1024;
-
-/// Classification of a MIME type for output data.
-///
-/// This is the canonical Rust implementation of MIME classification.
-/// Must stay in sync with:
-/// - `crates/runtimed/src/output_store.rs` — `is_binary_mime()`
-/// - `apps/notebook/src/lib/manifest-resolution.ts` — `isBinaryMime()`
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MimeKind {
-    /// UTF-8 text: text/*, image/svg+xml, application/javascript, etc.
-    Text,
-    /// Raw binary bytes: image/png, audio/*, video/*, etc.
-    Binary,
-    /// JSON data: application/json, *+json
-    Json,
-}
 
 /// Metadata extracted from a ContentRef Value without resolving content.
 ///
@@ -97,55 +83,6 @@ pub fn content_ref_meta(content_ref: &Value) -> ContentRefMeta<'_> {
             blob_hash: None,
         }
     }
-}
-
-/// Classify a MIME type into Text, Binary, or Json.
-pub fn mime_kind(mime: &str) -> MimeKind {
-    // JSON types
-    if mime == "application/json" {
-        return MimeKind::Json;
-    }
-    if let Some(subtype) = mime.strip_prefix("application/") {
-        if subtype.ends_with("+json") || subtype.ends_with(".json") {
-            return MimeKind::Json;
-        }
-    }
-
-    // Binary images (but NOT SVG — that's XML text)
-    if mime.starts_with("image/") {
-        return if mime.ends_with("+xml") {
-            MimeKind::Text
-        } else {
-            MimeKind::Binary
-        };
-    }
-
-    // Audio/video are always binary
-    if mime.starts_with("audio/") || mime.starts_with("video/") {
-        return MimeKind::Binary;
-    }
-
-    // application/* is binary by default, with carve-outs for text-like formats
-    if let Some(subtype) = mime.strip_prefix("application/") {
-        let is_text = subtype == "javascript"
-            || subtype == "ecmascript"
-            || subtype == "xml"
-            || subtype == "xhtml+xml"
-            || subtype == "mathml+xml"
-            || subtype == "sql"
-            || subtype == "graphql"
-            || subtype == "x-latex"
-            || subtype == "x-tex"
-            || subtype.ends_with("+xml");
-        return if is_text {
-            MimeKind::Text
-        } else {
-            MimeKind::Binary
-        };
-    }
-
-    // Everything else (text/*, unknown) is text
-    MimeKind::Text
 }
 
 /// Resolve a structured output manifest Value to an Output.

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -10,6 +10,7 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::Prop;
 use notebook_doc::diff::{diff_cells, CellChangeset};
+use notebook_doc::mime::is_binary_mime;
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
 use notebook_doc::runtime_state::{diff_execution_outputs, RuntimeState, RuntimeStateDoc};
@@ -28,38 +29,6 @@ use wasm_bindgen::prelude::*;
 /// Using `serialize_maps_as_objects(true)` ensures all maps become plain
 /// JS Objects, matching what `JSON.parse()` would produce. The returned
 /// `JsValue` can be any JS type (object, array, scalar) depending on input.
-/// Check if a MIME type represents binary content (images, audio, video).
-///
-/// Binary MIME refs resolve to blob URLs (no fetch needed), so they're
-/// cheap to include in narrowed output bundles. Only text blob refs
-/// are expensive (HTTP roundtrip to the blob server).
-fn is_binary_mime(mime: &str) -> bool {
-    if mime.starts_with("image/") {
-        // SVG is XML text, not binary
-        return !mime.ends_with("+xml");
-    }
-    if mime.starts_with("audio/") || mime.starts_with("video/") {
-        return true;
-    }
-    // application/* is binary by default, with carve-outs for text-like formats
-    if let Some(subtype) = mime.strip_prefix("application/") {
-        let is_text = subtype == "json"
-            || subtype == "javascript"
-            || subtype == "ecmascript"
-            || subtype == "xml"
-            || subtype == "xhtml+xml"
-            || subtype == "mathml+xml"
-            || subtype == "sql"
-            || subtype == "graphql"
-            || subtype == "x-latex"
-            || subtype == "x-tex"
-            || subtype.ends_with("+json")
-            || subtype.ends_with(".json")
-            || subtype.ends_with("+xml");
-        return !is_text;
-    }
-    false
-}
 
 fn serialize_to_js<T: Serialize>(value: &T) -> Result<JsValue, serde_wasm_bindgen::Error> {
     let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -50,6 +50,8 @@ use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use notebook_doc::mime::is_binary_mime;
+
 use crate::blob_store::BlobStore;
 
 /// Default inlining threshold: 1 KB.
@@ -662,44 +664,6 @@ fn value_to_string(value: &Value) -> String {
         Value::String(s) => s.clone(),
         _ => serde_json::to_string(value).unwrap_or_default(),
     }
-}
-
-/// Check if a MIME type represents binary content.
-///
-/// Binary MIME types are base64-encoded on the Jupyter wire protocol.
-/// We decode them to raw bytes before storing in the blob store so that:
-/// - The blob store holds actual binary content (33% smaller than base64)
-/// - The HTTP blob server serves correct Content-Type with real bytes
-/// - Future binary formats (Arrow IPC, Parquet) work without changes
-fn is_binary_mime(mime: &str) -> bool {
-    if mime.starts_with("image/") {
-        // SVG is plain XML text in Jupyter, not base64-encoded binary.
-        return !mime.ends_with("+xml");
-    }
-    if mime.starts_with("audio/") || mime.starts_with("video/") {
-        return true;
-    }
-
-    // application/* is binary by default, with carve-outs for text-like formats.
-    if let Some(subtype) = mime.strip_prefix("application/") {
-        // Text-like application types that should NOT be treated as binary
-        let is_text = subtype == "json"
-            || subtype == "javascript"
-            || subtype == "ecmascript"
-            || subtype == "xml"
-            || subtype == "xhtml+xml"
-            || subtype == "mathml+xml"
-            || subtype == "sql"
-            || subtype == "graphql"
-            || subtype == "x-latex"
-            || subtype == "x-tex"
-            || subtype.ends_with("+json")
-            || subtype.ends_with(".json")
-            || subtype.ends_with("+xml");
-        return !is_text;
-    }
-
-    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Unify the three Rust copies of `is_binary_mime` / `mime_kind` into `notebook-doc::mime` — one implementation, used everywhere.

## Before

Three private copies that had to stay in sync manually (called out in AGENTS.md as a high-risk invariant):

| Location | Function |
|----------|----------|
| `runtimed/src/output_store.rs` | `is_binary_mime()` |
| `runtimed-client/src/output_resolver.rs` | `mime_kind()` + `MimeKind` |
| `runtimed-wasm/src/lib.rs` | `is_binary_mime()` |

## After

One canonical module in `notebook-doc::mime`:

- `MimeKind` enum (`Text`, `Binary`, `Json`)
- `mime_kind(mime) -> MimeKind` — the three-way classifier
- `is_binary_mime(mime) -> bool` — convenience wrapper

All three consumers now import from `notebook-doc`. The TypeScript copy in `manifest-resolution.ts` must stay (no Rust FFI from the renderer) but has a cross-reference comment pointing at the canonical source.

17 tests cover the classification logic.

_PR submitted by @rgbkrk's agent Quill, via Zed_