### PR TITLE
feat(wasm): resolve ContentRefs to Inline/Url/Blob variants

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -109,6 +109,9 @@ export function useAutomergeNotebook() {
     if (blobPort === null) {
       blobPort = await refreshBlobPort();
     }
+    if (blobPort !== null) {
+      handle.set_blob_port(blobPort);
+    }
     const newCells = await cellSnapshotsToNotebookCells(
       snapshots,
       blobPort,
@@ -185,6 +188,10 @@ export function useAutomergeNotebook() {
     handleRef.current?.free();
     handleRef.current = handle;
     handle.set_mime_priority(DEFAULT_MIME_PRIORITY);
+    const initialBlobPort = getBlobPort();
+    if (initialBlobPort !== null) {
+      handle.set_blob_port(initialBlobPort);
+    }
     setNotebookHandle(handle);
 
     setIsLoading(true);

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ContentRef,
-  isBinaryMime,
   isOutputManifest,
   type OutputManifest,
   resolveContentRef,
@@ -56,6 +55,17 @@ describe("isOutputManifest", () => {
       isOutputManifest({
         output_type: "display_data",
         data: { "text/plain": { inline: "hi" } },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for a display_data manifest with url ContentRef", () => {
+    expect(
+      isOutputManifest({
+        output_type: "display_data",
+        data: {
+          "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
+        },
       }),
     ).toBe(true);
   });
@@ -177,11 +187,11 @@ describe("resolveManifestSync", () => {
     });
   });
 
-  it("resolves display_data with binary blob ref to URL", () => {
+  it("resolves display_data with url ref", () => {
     const manifest: OutputManifest = {
       output_type: "display_data",
       data: {
-        "image/png": { blob: "imgblob", size: 5000 },
+        "image/png": { url: `http://127.0.0.1:${blobPort}/blob/imgblob` },
       },
     };
     const output = resolveManifestSync(manifest, blobPort);
@@ -249,50 +259,6 @@ describe("resolveManifestSync", () => {
 });
 
 // ---------------------------------------------------------------------------
-// isBinaryMime
-// ---------------------------------------------------------------------------
-
-describe("isBinaryMime", () => {
-  it("returns true for image types", () => {
-    expect(isBinaryMime("image/png")).toBe(true);
-    expect(isBinaryMime("image/jpeg")).toBe(true);
-    expect(isBinaryMime("image/gif")).toBe(true);
-    expect(isBinaryMime("image/webp")).toBe(true);
-  });
-
-  it("returns false for SVG (plain XML text in Jupyter)", () => {
-    expect(isBinaryMime("image/svg+xml")).toBe(false);
-  });
-
-  it("returns true for audio/video types", () => {
-    expect(isBinaryMime("audio/mpeg")).toBe(true);
-    expect(isBinaryMime("video/mp4")).toBe(true);
-  });
-
-  it("returns true for binary application types", () => {
-    expect(isBinaryMime("application/pdf")).toBe(true);
-    expect(isBinaryMime("application/octet-stream")).toBe(true);
-    expect(isBinaryMime("application/vnd.apache.arrow.stream")).toBe(true);
-    expect(isBinaryMime("application/vnd.apache.parquet")).toBe(true);
-    expect(isBinaryMime("application/wasm")).toBe(true);
-  });
-
-  it("returns false for text-like application types", () => {
-    expect(isBinaryMime("application/json")).toBe(false);
-    expect(isBinaryMime("application/javascript")).toBe(false);
-    expect(isBinaryMime("application/xml")).toBe(false);
-    expect(isBinaryMime("application/vnd.vegalite.v5+json")).toBe(false);
-    expect(isBinaryMime("application/xhtml+xml")).toBe(false);
-  });
-
-  it("returns false for text types", () => {
-    expect(isBinaryMime("text/plain")).toBe(false);
-    expect(isBinaryMime("text/html")).toBe(false);
-    expect(isBinaryMime("text/latex")).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // resolveContentRef
 // ---------------------------------------------------------------------------
 
@@ -312,6 +278,13 @@ describe("resolveContentRef", () => {
     expect(result).toBe("");
   });
 
+  it("returns url ref directly without fetching", async () => {
+    const ref: ContentRef = { url: "http://127.0.0.1:9876/blob/pnghash" };
+    const result = await resolveContentRef(ref, blobPort);
+    expect(result).toBe("http://127.0.0.1:9876/blob/pnghash");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("fetches text blob content from the blob store", async () => {
     const blobHash = "abc123";
     const ref: ContentRef = { blob: blobHash, size: 42 };
@@ -320,28 +293,11 @@ describe("resolveContentRef", () => {
       new Response("fetched content", { status: 200 }),
     );
 
-    // Text MIME type: fetches content as text
     const result = await resolveContentRef(ref, blobPort, "text/plain");
     expect(result).toBe("fetched content");
     expect(mockFetch).toHaveBeenCalledWith(
       `http://127.0.0.1:${blobPort}/blob/${blobHash}`,
     );
-  });
-
-  it("returns blob URL for binary MIME types without fetching", async () => {
-    const ref: ContentRef = { blob: "pnghash", size: 5000 };
-
-    const result = await resolveContentRef(ref, blobPort, "image/png");
-    expect(result).toBe("http://127.0.0.1:9876/blob/pnghash");
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("returns blob URL for application/pdf", async () => {
-    const ref: ContentRef = { blob: "pdfhash", size: 10000 };
-
-    const result = await resolveContentRef(ref, blobPort, "application/pdf");
-    expect(result).toBe("http://127.0.0.1:9876/blob/pdfhash");
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("fetches blob content when no mimeType is provided", async () => {
@@ -363,12 +319,15 @@ describe("resolveContentRef", () => {
     ).rejects.toThrow("Failed to fetch blob deadbeef: 404");
   });
 
-  it("uses the correct port in the URL", async () => {
+  it("uses the correct port in blob fetch URL", async () => {
     const ref: ContentRef = { blob: "hash123", size: 5 };
+    mockFetch.mockResolvedValueOnce(new Response("data", { status: 200 }));
 
-    // Binary MIME: uses port in the URL
-    const result = await resolveContentRef(ref, 5555, "image/jpeg");
-    expect(result).toBe("http://127.0.0.1:5555/blob/hash123");
+    const result = await resolveContentRef(ref, 5555);
+    expect(result).toBe("data");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:5555/blob/hash123",
+    );
   });
 });
 
@@ -434,9 +393,9 @@ describe("resolveDataBundle", () => {
     expect(result["text/plain"]).toBe(jsonString);
   });
 
-  it("resolves binary blob refs to URLs without fetching", async () => {
+  it("resolves url refs without fetching", async () => {
     const data: Record<string, ContentRef> = {
-      "image/png": { blob: "pnghash", size: 100 },
+      "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
     };
 
     const result = await resolveDataBundle(data, blobPort);
@@ -444,10 +403,10 @@ describe("resolveDataBundle", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("handles mixed inline text and binary blob refs", async () => {
+  it("handles mixed inline text and url refs", async () => {
     const data: Record<string, ContentRef> = {
       "text/plain": { inline: "fallback text" },
-      "image/png": { blob: "pnghash", size: 200 },
+      "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
     };
 
     const result = await resolveDataBundle(data, blobPort);
@@ -508,11 +467,11 @@ describe("resolveManifest", () => {
       });
     });
 
-    it("resolves binary blob refs to URLs", async () => {
+    it("resolves url refs directly", async () => {
       const manifest: OutputManifest = {
         output_type: "display_data",
         data: {
-          "image/png": { blob: "pnghash", size: 500 },
+          "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
         },
       };
 

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -698,7 +698,7 @@ describe("cellSnapshotsToNotebookCells", () => {
       },
       {
         output_type: "display_data",
-        data: { "image/png": { blob: "imgblob", size: 500 } },
+        data: { "image/png": { url: "http://127.0.0.1:8765/blob/imgblob" } },
       },
     ];
     const snap = codeSnapshot("c1", "compute()", outputs, "3");

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -1,53 +1,17 @@
 import type { JupyterOutput } from "../types";
 
 /**
- * Check if a MIME type represents binary content.
+ * A content reference — either inlined data, a URL, or a blob-store hash.
  *
- * Binary MIME types are stored as raw bytes in the blob store (decoded
- * from Jupyter's base64 wire format). The blob HTTP server serves them
- * with the correct Content-Type, so the frontend can use blob URLs
- * directly (e.g., `<img src="http://...">`) instead of base64 data URIs.
- *
- * **This is a TypeScript port of the canonical Rust implementation in
- * `crates/notebook-doc/src/mime.rs` (`is_binary_mime` / `mime_kind`).
- * Keep them in sync — see AGENTS.md § "The `is_binary_mime` Contract".**
+ * These variants match the `ResolvedContentRef` shape emitted by WASM:
+ * - `inline`: text content embedded directly
+ * - `url`: a pre-resolved URL (e.g., blob server URL for binary content)
+ * - `blob`: a blob-store hash for text content that needs fetching
  */
-export function isBinaryMime(mime: string): boolean {
-  if (mime.startsWith("image/")) {
-    // SVG is plain XML text in Jupyter, not base64-encoded binary.
-    return !mime.endsWith("+xml");
-  }
-  if (mime.startsWith("audio/") || mime.startsWith("video/")) {
-    return true;
-  }
-
-  // application/* is binary by default, with carve-outs for text-like formats.
-  if (mime.startsWith("application/")) {
-    const subtype = mime.slice("application/".length);
-    const isText =
-      subtype === "json" ||
-      subtype === "javascript" ||
-      subtype === "ecmascript" ||
-      subtype === "xml" ||
-      subtype === "xhtml+xml" ||
-      subtype === "mathml+xml" ||
-      subtype === "sql" ||
-      subtype === "graphql" ||
-      subtype === "x-latex" ||
-      subtype === "x-tex" ||
-      subtype.endsWith("+json") ||
-      subtype.endsWith(".json") ||
-      subtype.endsWith("+xml");
-    return !isText;
-  }
-
-  return false;
-}
-
-/**
- * A content reference — either inlined data or a blob-store hash.
- */
-export type ContentRef = { inline: string } | { blob: string; size: number };
+export type ContentRef =
+  | { inline: string }
+  | { url: string }
+  | { blob: string; size: number };
 
 /**
  * An output manifest with content refs that may need blob-store resolution.
@@ -83,7 +47,7 @@ export type OutputManifest =
  * (i.e., has ContentRef objects rather than already-resolved primitive data).
  *
  * Distinguishes manifests from raw JupyterOutputs by checking whether the
- * data fields contain ContentRef objects (`{ inline }` or `{ blob }`).
+ * data fields contain ContentRef objects (`{ inline }`, `{ url }`, or `{ blob }`).
  */
 export function isOutputManifest(value: unknown): value is OutputManifest {
   if (typeof value !== "object" || value === null) return false;
@@ -107,12 +71,13 @@ export function isOutputManifest(value: unknown): value is OutputManifest {
   }
 }
 
-/** Check if a value is a ContentRef (`{ inline }` or `{ blob, size }`). */
+/** Check if a value is a ContentRef (`{ inline }`, `{ url }`, or `{ blob, size }`). */
 function isContentRef(value: unknown): value is ContentRef {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
   return (
     ("inline" in obj && typeof obj.inline === "string") ||
+    ("url" in obj && typeof obj.url === "string") ||
     ("blob" in obj && typeof obj.blob === "string")
   );
 }
@@ -120,26 +85,22 @@ function isContentRef(value: unknown): value is ContentRef {
 /**
  * Resolve a content reference to its string value.
  *
- * For binary MIME types (images, etc.), blob refs resolve to an HTTP URL
- * pointing at the blob server. The browser fetches the raw bytes directly
- * when rendering (e.g., `<img src="http://...">`) — no base64 round-trip.
- *
- * For text MIME types, blob refs are fetched and returned as strings.
- * Inlined refs always return the embedded string directly.
+ * - `inline` refs return the embedded string directly.
+ * - `url` refs return the pre-resolved URL (e.g., blob server URL for binary content).
+ * - `blob` refs fetch text content from the blob server.
  */
 export async function resolveContentRef(
   ref: ContentRef,
   blobPort: number,
-  mimeType?: string,
+  _mimeType?: string,
 ): Promise<string> {
   if ("inline" in ref) {
     return ref.inline;
   }
-  // Binary blob refs resolve to a URL — the blob server serves raw bytes
-  // with the correct Content-Type. The browser/iframe fetches directly.
-  if (mimeType && isBinaryMime(mimeType)) {
-    return `http://127.0.0.1:${blobPort}/blob/${ref.blob}`;
+  if ("url" in ref) {
+    return ref.url;
   }
+  // Blob ref — fetch text content from blob server
   const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
   if (!response.ok) {
     throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
@@ -149,36 +110,35 @@ export async function resolveContentRef(
 
 /**
  * Resolve a content reference synchronously, returning null if async
- * work (text blob fetch) would be required.
+ * work (blob fetch) would be required.
  *
  * Resolves:
  * - Inline refs → the embedded string
- * - Binary blob refs → blob server URL
+ * - URL refs → the pre-resolved URL
  *
- * Returns null for text blob refs (require HTTP fetch).
+ * Returns null for blob refs (require HTTP fetch).
  */
 function resolveContentRefSync(
   ref: ContentRef,
-  blobPort: number,
-  mimeType?: string,
+  _blobPort: number,
+  _mimeType?: string,
 ): string | null {
   if ("inline" in ref) {
     return ref.inline;
   }
-  // Binary blob refs → URL (no fetch needed)
-  if (mimeType && isBinaryMime(mimeType)) {
-    return `http://127.0.0.1:${blobPort}/blob/${ref.blob}`;
+  if ("url" in ref) {
+    return ref.url;
   }
-  // Text blob ref — needs async fetch
+  // Blob ref — needs async fetch
   return null;
 }
 
 /**
  * Resolve a MIME-type → ContentRef map to a fully hydrated data bundle.
  *
- * Binary MIME types resolve to blob URLs (the browser fetches raw bytes
- * directly from the blob server). JSON MIME types are auto-parsed.
- * Text MIME types are returned as strings.
+ * URL refs (binary content) pass through as URLs for the browser to fetch
+ * directly. JSON MIME types are auto-parsed. Text MIME types are returned
+ * as strings.
  */
 export async function resolveDataBundle(
   data: Record<string, ContentRef>,
@@ -208,7 +168,7 @@ export async function resolveDataBundle(
 }
 
 /**
- * Synchronously resolve a data bundle. Returns null if any text blob
+ * Synchronously resolve a data bundle. Returns null if any blob
  * fetch would be required.
  */
 function resolveDataBundleSync(
@@ -286,9 +246,8 @@ export async function resolveManifest(
 /**
  * Synchronously resolve a manifest into a JupyterOutput.
  *
- * Returns null if any content ref requires an async blob fetch (i.e.,
- * a text blob ref). Inline refs and binary blob refs (which resolve to
- * URLs) are handled synchronously.
+ * Returns null if any content ref requires an async blob fetch.
+ * Inline refs and URL refs are handled synchronously.
  *
  * Use this in the sync materialization path where blob fetches are not
  * available — the async path will pick up unresolved outputs later.

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -393,6 +393,11 @@ export class NotebookHandle {
      */
     set_actor(actor_label: string): void;
     /**
+     * Set the blob server port for resolving binary ContentRefs to URLs.
+     * Call after init and whenever the daemon restarts with a new port.
+     */
+    set_blob_port(port: number): void;
+    /**
      * Replace entire cell metadata (last-write-wins).
      *
      * Accepts metadata as a JSON object string.
@@ -625,6 +630,7 @@ export interface InitOutput {
     readonly notebookhandle_reset_sync_state: (a: number) => void;
     readonly notebookhandle_save: (a: number, b: number) => void;
     readonly notebookhandle_set_actor: (a: number, b: number, c: number) => void;
+    readonly notebookhandle_set_blob_port: (a: number, b: number) => void;
     readonly notebookhandle_set_cell_metadata: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_set_cell_metadata_value: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly notebookhandle_set_cell_outputs_hidden: (a: number, b: number, c: number, d: number, e: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -1266,6 +1266,14 @@ export class NotebookHandle {
         wasm.notebookhandle_set_actor(this.__wbg_ptr, ptr0, len0);
     }
     /**
+     * Set the blob server port for resolving binary ContentRefs to URLs.
+     * Call after init and whenever the daemon restarts with a new port.
+     * @param {number} port
+     */
+    set_blob_port(port) {
+        wasm.notebookhandle_set_blob_port(this.__wbg_ptr, port);
+    }
+    /**
      * Replace entire cell metadata (last-write-wins).
      *
      * Accepts metadata as a JSON object string.

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ba5551d45c0b4b3e32f978c8f896fc14a0dee09ae007fe867bd11aa2fa4ac17
-size 1622972
+oid sha256:4e40c3cf2224a35d464f3fc4456ad05affb7b3d3ef6b8da11a62f24f33199a92
+size 1624921

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -67,6 +67,7 @@ export const notebookhandle_remove_uv_dependency: (a: number, b: number, c: numb
 export const notebookhandle_reset_sync_state: (a: number) => void;
 export const notebookhandle_save: (a: number, b: number) => void;
 export const notebookhandle_set_actor: (a: number, b: number, c: number) => void;
+export const notebookhandle_set_blob_port: (a: number, b: number) => void;
 export const notebookhandle_set_cell_metadata: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_set_cell_metadata_value: (a: number, b: number, c: number, d: number, e: number) => void;
 export const notebookhandle_set_cell_outputs_hidden: (a: number, b: number, c: number, d: number, e: number) => void;

--- a/crates/notebook-doc/src/mime.rs
+++ b/crates/notebook-doc/src/mime.rs
@@ -11,6 +11,8 @@
 //! Any changes here **must** be mirrored there — see the `is_binary_mime`
 //! contract in `AGENTS.md` for the full list of locations.
 
+use serde::{Deserialize, Serialize};
+
 /// Three-way classification of a MIME type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MimeKind {
@@ -89,6 +91,27 @@ pub fn mime_kind(mime: &str) -> MimeKind {
 #[inline]
 pub fn is_binary_mime(mime: &str) -> bool {
     matches!(mime_kind(mime), MimeKind::Binary)
+}
+
+/// A content reference resolved for frontend consumption.
+///
+/// WASM resolves binary blob refs to URLs (the browser fetches raw bytes
+/// directly) and passes through inline content and text blob refs that
+/// need JS-side fetching.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResolvedContentRef {
+    /// Ready to use — inline text content (< 1KB threshold).
+    #[serde(rename_all = "camelCase")]
+    Inline { inline: String },
+    /// Ready to use — browser fetches raw bytes from this URL.
+    /// Used for binary MIME types (images, audio, video).
+    #[serde(rename_all = "camelCase")]
+    Url { url: String },
+    /// Needs JS-side fetch — text blob ref that WASM couldn't resolve
+    /// (requires HTTP fetch to blob server for text content).
+    #[serde(rename_all = "camelCase")]
+    Blob { blob: String, size: u64 },
 }
 
 #[cfg(test)]
@@ -193,5 +216,49 @@ mod tests {
             mime_kind("application/vnd.dataresource.json"),
             MimeKind::Json
         );
+    }
+
+    #[test]
+    fn resolved_content_ref_inline_json() {
+        let r = ResolvedContentRef::Inline {
+            inline: "hello".to_string(),
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json, serde_json::json!({"inline": "hello"}));
+    }
+
+    #[test]
+    fn resolved_content_ref_url_json() {
+        let r = ResolvedContentRef::Url {
+            url: "http://127.0.0.1:8765/blob/abc".to_string(),
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"url": "http://127.0.0.1:8765/blob/abc"})
+        );
+    }
+
+    #[test]
+    fn resolved_content_ref_blob_json() {
+        let r = ResolvedContentRef::Blob {
+            blob: "abc123".to_string(),
+            size: 4200,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json, serde_json::json!({"blob": "abc123", "size": 4200}));
+    }
+
+    #[test]
+    fn resolved_content_ref_roundtrip() {
+        let inline: ResolvedContentRef =
+            serde_json::from_value(serde_json::json!({"inline": "hi"})).unwrap();
+        assert!(matches!(inline, ResolvedContentRef::Inline { .. }));
+        let url: ResolvedContentRef =
+            serde_json::from_value(serde_json::json!({"url": "http://x"})).unwrap();
+        assert!(matches!(url, ResolvedContentRef::Url { .. }));
+        let blob: ResolvedContentRef =
+            serde_json::from_value(serde_json::json!({"blob": "h", "size": 1})).unwrap();
+        assert!(matches!(blob, ResolvedContentRef::Blob { .. }));
     }
 }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -10,7 +10,7 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::Prop;
 use notebook_doc::diff::{diff_cells, CellChangeset};
-use notebook_doc::mime::is_binary_mime;
+use notebook_doc::mime::{is_binary_mime, ResolvedContentRef};
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
 use notebook_doc::runtime_state::{diff_execution_outputs, RuntimeState, RuntimeStateDoc};
@@ -185,6 +185,9 @@ pub struct NotebookHandle {
     /// Types earlier in the list are preferred when narrowing output data bundles.
     /// If empty, all MIME types are returned (backward compatible).
     mime_priority: Vec<String>,
+    /// Blob server port for resolving binary ContentRefs to URLs.
+    /// Set via `set_blob_port()`. When None, binary refs pass through as-is.
+    blob_port: Option<u16>,
 }
 
 /// A cell snapshot returned to JavaScript.
@@ -284,6 +287,7 @@ impl NotebookHandle {
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
             mime_priority: Vec::new(),
+            blob_port: None,
         }
     }
 
@@ -302,6 +306,7 @@ impl NotebookHandle {
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
             mime_priority: Vec::new(),
+            blob_port: None,
         }
     }
 
@@ -334,6 +339,7 @@ impl NotebookHandle {
             pool_sync_state: sync::State::new(),
             metadata_fingerprint_cache: None,
             mime_priority: Vec::new(),
+            blob_port: None,
         })
     }
 
@@ -465,9 +471,19 @@ impl NotebookHandle {
         }
     }
 
+    /// Set the blob server port for resolving binary ContentRefs to URLs.
+    /// Call after init and whenever the daemon restarts with a new port.
+    pub fn set_blob_port(&mut self, port: u16) {
+        self.blob_port = Some(port);
+    }
+
     /// Narrow an output manifest's data bundle to the winning MIME type,
-    /// plus all binary MIME refs (cheap — just URL construction, no fetch)
-    /// and text/plain as a fallback candidate.
+    /// plus all binary MIME refs and text/plain as a fallback candidate.
+    ///
+    /// Resolves ContentRefs into `ResolvedContentRef` variants:
+    /// - Binary MIME types → `Url` (blob server URL, zero fetch cost)
+    /// - Inline refs → `Inline` (embedded text)
+    /// - Text blob refs → `Blob` (needs JS-side HTTP fetch)
     ///
     /// Only expensive text blob refs for non-winning types are dropped.
     /// Returns the manifest unchanged if mime_priority is empty or output_type
@@ -495,13 +511,53 @@ impl NotebookHandle {
                 let mut narrowed = serde_json::Map::new();
                 for (mime, val) in data {
                     if mime == winner_mime || mime == "text/plain" || is_binary_mime(mime) {
-                        narrowed.insert(mime.clone(), val.clone());
+                        let resolved = self.resolve_content_ref(mime, val);
+                        narrowed.insert(mime.clone(), resolved);
                     }
                 }
                 output["data"] = serde_json::Value::Object(narrowed);
             }
         }
         output
+    }
+
+    /// Resolve a ContentRef value into a ResolvedContentRef based on MIME type.
+    ///
+    /// - `{ "inline": "..." }` → `ResolvedContentRef::Inline`
+    /// - Binary MIME + `{ "blob": "hash", "size": N }` → `ResolvedContentRef::Url`
+    ///   (when blob_port is set)
+    /// - Text MIME + `{ "blob": "hash", "size": N }` → `ResolvedContentRef::Blob`
+    fn resolve_content_ref(&self, mime: &str, val: &serde_json::Value) -> serde_json::Value {
+        // Inline refs pass through as Inline variant
+        if let Some(inline) = val.get("inline").and_then(|v| v.as_str()) {
+            return serde_json::to_value(ResolvedContentRef::Inline {
+                inline: inline.to_string(),
+            })
+            .unwrap_or_else(|_| val.clone());
+        }
+
+        // Blob refs: resolve binary to URL, leave text as Blob
+        if let Some(blob_hash) = val.get("blob").and_then(|v| v.as_str()) {
+            let size = val.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+
+            if is_binary_mime(mime) {
+                if let Some(port) = self.blob_port {
+                    return serde_json::to_value(ResolvedContentRef::Url {
+                        url: format!("http://127.0.0.1:{}/blob/{}", port, blob_hash),
+                    })
+                    .unwrap_or_else(|_| val.clone());
+                }
+            }
+
+            return serde_json::to_value(ResolvedContentRef::Blob {
+                blob: blob_hash.to_string(),
+                size,
+            })
+            .unwrap_or_else(|_| val.clone());
+        }
+
+        // Unknown shape — pass through unchanged
+        val.clone()
     }
 
     /// Get a cell's execution count.


### PR DESCRIPTION
WASM resolves ContentRefs into explicit `Inline | Url | Blob` variants. JS pattern-matches on the variant instead of classifying MIME types.

## Before

```
WASM → { "image/png": { blob: "hash", size: 500 } }
JS   → isBinaryMime("image/png") ? constructUrl(hash) : fetch(hash)
```

Three copies of `isBinaryMime` had to stay in sync (Rust daemon, Rust WASM, TypeScript).

## After

```
WASM → { "image/png": { url: "http://127.0.0.1:8765/blob/hash" } }
JS   → ref.url  (done)
```

WASM owns the classification. JS just reads the variant.

## `ResolvedContentRef`

```rust
enum ResolvedContentRef {
    Inline { inline: String },  // text < 1KB, embedded
    Url { url: String },        // binary — browser fetches directly
    Blob { blob: String, size: u64 },  // text blob — JS fetches
}
```

Added to `notebook-doc::mime` alongside the unified `MimeKind` / `is_binary_mime` from #1563.

## Changes

- `crates/notebook-doc/src/mime.rs` — `ResolvedContentRef` enum with serde roundtrip tests
- `crates/runtimed-wasm/src/lib.rs` — `set_blob_port()`, `resolve_content_ref()` in `narrow_output_data`
- `apps/notebook/src/hooks/useAutomergeNotebook.ts` — calls `set_blob_port` at init and on refresh
- `apps/notebook/src/lib/manifest-resolution.ts` — delete `isBinaryMime`, simplify `resolveContentRef` to variant dispatch
- Tests updated

## Blob port lifecycle

`set_blob_port(port)` is called at WASM init and again in `materializeCells` whenever the port is (re)obtained. Daemon restarts that change the port are handled by the existing `refreshBlobPort()` flow — now it also updates the WASM handle.

_PR submitted by @rgbkrk's agent Quill, via Zed_