### PR TITLE
feat(frontend): text/latex renderer via iframe plugin

### DIFF
--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -35,6 +35,8 @@ function normalize(m: { code: string; css?: string }): PluginModule {
 const PLUGIN_MIME_TYPES: Record<string, () => Promise<PluginModule>> = {
   "text/markdown": () =>
     import("virtual:renderer-plugin/markdown").then(normalize),
+  "text/latex": () =>
+    import("virtual:renderer-plugin/markdown").then(normalize),
   "application/vnd.plotly.v1+json": () =>
     import("virtual:renderer-plugin/plotly").then(normalize),
   "application/geo+json": () =>
@@ -42,8 +44,7 @@ const PLUGIN_MIME_TYPES: Record<string, () => Promise<PluginModule>> = {
 };
 
 /** Lazy loader for all Vega/Vega-Lite MIME variants. */
-const loadVega = () =>
-  import("virtual:renderer-plugin/vega").then(normalize);
+const loadVega = () => import("virtual:renderer-plugin/vega").then(normalize);
 
 /**
  * Check whether a MIME type requires a renderer plugin.
@@ -64,7 +65,8 @@ function loadPluginForMime(mime: string): Promise<PluginModule> | undefined {
   const cached = pluginCache.get(mime);
   if (cached) return cached;
 
-  const loader = PLUGIN_MIME_TYPES[mime] ?? (isVegaMimeType(mime) ? loadVega : undefined);
+  const loader =
+    PLUGIN_MIME_TYPES[mime] ?? (isVegaMimeType(mime) ? loadVega : undefined);
   if (!loader) return undefined;
 
   const promise = loader();

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -22,9 +22,7 @@ const SvgOutput = lazy(() =>
 const JsonOutput = lazy(() =>
   import("./json-output").then((m) => ({ default: m.JsonOutput })),
 );
-const MathOutput = lazy(() =>
-  import("./math-output").then((m) => ({ default: m.MathOutput })),
-);
+
 const AudioOutput = lazy(() =>
   import("./audio-output").then((m) => ({ default: m.AudioOutput })),
 );
@@ -349,11 +347,6 @@ export function MediaRouter({
       return <MarkdownOutput content={String(content)} className={className} />;
     }
 
-    // LaTeX math (KaTeX, rendered in-DOM — safe static HTML)
-    if (mimeType === "text/latex") {
-      return <MathOutput content={String(content)} className={className} />;
-    }
-
     // HTML (only renders when in iframe)
     if (mimeType === "text/html") {
       return <HtmlOutput content={String(content)} className={className} />;
@@ -408,9 +401,7 @@ export function MediaRouter({
 
     // JavaScript (only in iframe)
     if (mimeType === "application/javascript") {
-      return (
-        <JavaScriptOutput code={String(content)} className={className} />
-      );
+      return <JavaScriptOutput code={String(content)} className={className} />;
     }
 
     // JSON and structured data (but not custom +json types without a renderer)

--- a/src/components/outputs/safe-mime-types.ts
+++ b/src/components/outputs/safe-mime-types.ts
@@ -8,8 +8,6 @@
 const MAIN_DOM_SAFE_TYPES = new Set([
   // Plain text with ANSI — no script risk
   "text/plain",
-  // LaTeX — KaTeX renders safe static HTML
-  "text/latex",
   // Raster images — <img> tags, no script risk
   "image/png",
   "image/jpeg",

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -290,9 +290,7 @@ function IsolatedRendererApp() {
         const batchPayload = payload as { outputs: RenderPayload[] };
         const entries: OutputEntry[] = (batchPayload.outputs ?? []).map(
           (p, i) => ({
-            id: p.cellId
-              ? `${p.cellId}-${p.outputIndex ?? i}`
-              : `output-${i}`,
+            id: p.cellId ? `${p.cellId}-${p.outputIndex ?? i}` : `output-${i}`,
             payload: p,
           }),
         );
@@ -468,29 +466,6 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
   // Plain text / ANSI
   if (mimeType === "text/plain") {
     return <AnsiOutput>{String(content)}</AnsiOutput>;
-  }
-
-  // Unknown text/* types — render with a MIME type label for distinction
-  if (mimeType.startsWith("text/")) {
-    return (
-      <div>
-        <span
-          style={{
-            display: "inline-block",
-            marginBottom: "4px",
-            padding: "1px 6px",
-            fontSize: "10px",
-            fontFamily: "monospace",
-            color: "var(--text-secondary)",
-            background: "var(--bg-secondary)",
-            borderRadius: "4px",
-          }}
-        >
-          {mimeType}
-        </span>
-        <AnsiOutput>{String(content)}</AnsiOutput>
-      </div>
-    );
   }
 
   // Fallback: render as plain text

--- a/src/isolated-renderer/markdown-renderer.tsx
+++ b/src/isolated-renderer/markdown-renderer.tsx
@@ -9,6 +9,7 @@
  */
 
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
+import { MathOutput } from "@/components/outputs/math-output";
 
 interface RendererProps {
   data: unknown;
@@ -20,6 +21,10 @@ function MarkdownRenderer({ data }: RendererProps) {
   return <MarkdownOutput content={String(data)} />;
 }
 
+function LatexRenderer({ data }: RendererProps) {
+  return <MathOutput content={String(data)} />;
+}
+
 export function install(ctx: {
   register: (
     mimeTypes: string[],
@@ -27,4 +32,5 @@ export function install(ctx: {
   ) => void;
 }) {
   ctx.register(["text/markdown"], MarkdownRenderer);
+  ctx.register(["text/latex"], LatexRenderer);
 }


### PR DESCRIPTION
`text/latex` outputs now render as proper math via KaTeX in the iframe, using the markdown renderer plugin (shared KaTeX bundle).

## Changes

- `markdown-renderer.tsx` — registers `LatexRenderer` for `text/latex` alongside `text/markdown`
- `iframe-libraries.ts` — maps `text/latex` to the markdown plugin
- Removed `text/latex` from `MAIN_DOM_SAFE_TYPES` — KaTeX with `trust: true` can inject URLs via `\href`/`\url`, so it needs iframe isolation
- Removed hardcoded `text/latex` handler from core IIFE and `MediaRouter`
- Removed the `text/*` badge fallback from iframe `OutputRenderer` — it was masking missing renderers by showing raw text with a MIME label

## Why plugin-only, not core IIFE

KaTeX is ~300KB. Hardcoding it in the core IIFE would bloat every iframe. The markdown plugin already bundles KaTeX (via `rehype-katex`), so registering `text/latex` there shares the bundle with zero duplication.

## Security

`katex.render()` with `trust: true` writes to the DOM via innerHTML and allows `\href`, `\url`, `\includegraphics` which can embed arbitrary URLs. Not safe for the main DOM — requires iframe sandbox.

_PR submitted by @rgbkrk's agent Quill, via Zed_