### PR TITLE
fix: anywidget ESM rendering — correct MIME types and iframe CSP

### DIFF
--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -1042,6 +1042,50 @@ pub fn format_widget_summary(
             format!("{name} {short_id}\u{2026}: {val}")
         }
 
+        // Anywidget — detect via _anywidget_id or model_module == "anywidget".
+        // Extract the class name from _anywidget_id (e.g., "altair.jupyter.jupyter_chart.JupyterChart")
+        // and fingerprint chart types from state keys.
+        "Any" if entry.model_module == "anywidget" => {
+            let widget_name = entry
+                .state
+                .get("_anywidget_id")
+                .and_then(|v| v.as_str())
+                .and_then(|id| id.rsplit('.').next())
+                .unwrap_or("Anywidget");
+
+            // Fingerprint: if state has "spec" with an actual dict (not a $blob sentinel),
+            // try to identify the chart type via viz summarization.
+            if let Some(spec) = entry.state.get("spec") {
+                // Skip $blob sentinels — the spec was blob-stored and we don't have
+                // the content here. Just report it as a chart widget.
+                let is_blob_sentinel = spec
+                    .as_object()
+                    .is_some_and(|obj| obj.contains_key("$blob"));
+
+                if !is_blob_sentinel {
+                    if let Some(summary) =
+                        repr_llm::summarize_viz("application/vnd.vegalite.v5+json", spec)
+                    {
+                        return format!("{widget_name} {short_id}\u{2026}: {summary}");
+                    }
+                    // spec exists but summarizer didn't match — check for title
+                    let title = spec.get("title").and_then(|v| v.as_str()).or_else(|| {
+                        spec.get("title")
+                            .and_then(|v| v.get("text"))
+                            .and_then(|v| v.as_str())
+                    });
+                    if let Some(title) = title {
+                        return format!("{widget_name} {short_id}\u{2026}: \"{title}\"");
+                    }
+                }
+
+                // Has spec (inline or blob) — it's a chart widget
+                return format!("{widget_name} {short_id}\u{2026} (chart)");
+            }
+
+            format!("{widget_name} {short_id}\u{2026}")
+        }
+
         // Fallback — show description or value if available
         _ => match entry.state.get("description").and_then(|v| v.as_str()) {
             Some(d) if !d.is_empty() => format!("{name} {short_id}\u{2026}: {d:?}"),

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -75,8 +75,24 @@ impl BlobStore {
         let hash = hex::encode(Sha256::digest(data));
         let (shard_dir, blob_path, meta_path) = self.paths(&hash);
 
-        // Fast path: both files already present — nothing to do.
+        // Fast path: both files already present.
+        // If the caller provides a different media_type than what's stored,
+        // update the metadata sidecar (e.g., blob was first stored as
+        // application/json but is now text/javascript for anywidget _esm).
         if blob_path.exists() && meta_path.exists() {
+            if let Ok(existing_meta_json) = tokio::fs::read_to_string(&meta_path).await {
+                if let Ok(existing_meta) = serde_json::from_str::<BlobMeta>(&existing_meta_json) {
+                    if existing_meta.media_type != media_type {
+                        let updated = BlobMeta {
+                            media_type: media_type.to_string(),
+                            ..existing_meta
+                        };
+                        if let Ok(json) = serde_json::to_string(&updated) {
+                            tokio::fs::write(&meta_path, json).await.ok();
+                        }
+                    }
+                }
+            }
             return Ok(hash);
         }
 
@@ -294,9 +310,11 @@ mod tests {
         let hash2 = store.put(data, "application/octet-stream").await.unwrap();
         // Same bytes = same hash (media type doesn't affect hash)
         assert_eq!(hash1, hash2);
-        // Metadata keeps the first media type (idempotent — didn't overwrite)
+        // Metadata updates to the latest media type (e.g., content first
+        // stored as application/json then re-stored as text/javascript
+        // for anywidget _esm).
         let meta = store.get_meta(&hash1).await.unwrap().unwrap();
-        assert_eq!(meta.media_type, "text/plain");
+        assert_eq!(meta.media_type, "application/octet-stream");
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -182,19 +182,31 @@ async fn blob_store_large_state_values(
 
         if size > COMM_STATE_BLOB_THRESHOLD {
             // Serialize and store in blob store.
-            let json_bytes = match serde_json::to_vec(value) {
-                Ok(b) => b,
-                Err(e) => {
-                    log::warn!(
-                        "[kernel-manager] Failed to serialize comm state key '{}': {}",
-                        key,
-                        e
-                    );
-                    modified.insert(key.clone(), value.clone());
-                    continue;
+            // Use the raw string bytes for strings (preserves content type for
+            // _esm JavaScript, _css stylesheets, etc.) and JSON for structured values.
+            let (blob_bytes, media_type) = match value {
+                serde_json::Value::String(s) => {
+                    let mime = match key.as_str() {
+                        "_esm" => "text/javascript",
+                        "_css" => "text/css",
+                        _ => "text/plain",
+                    };
+                    (s.as_bytes().to_vec(), mime)
                 }
+                _ => match serde_json::to_vec(value) {
+                    Ok(b) => (b, "application/json"),
+                    Err(e) => {
+                        log::warn!(
+                            "[kernel-manager] Failed to serialize comm state key '{}': {}",
+                            key,
+                            e
+                        );
+                        modified.insert(key.clone(), value.clone());
+                        continue;
+                    }
+                },
             };
-            match blob_store.put(&json_bytes, "application/json").await {
+            match blob_store.put(&blob_bytes, media_type).await {
                 Ok(hash) => {
                     modified.insert(key.clone(), serde_json::json!({"$blob": hash}));
                 }

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -39,7 +39,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline' https:; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https: http://127.0.0.1:*; style-src 'unsafe-inline' https: http://127.0.0.1:*; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
   <style>
     :root {
       --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};


### PR DESCRIPTION
Follow-up to #1571. With large comm state values blob-stored, anywidget's `_esm` JavaScript needs to load from the blob server. Three fixes:

**1. Correct MIME types for blob-stored comm state**

| Key | Before | After |
|-----|--------|-------|
| `_esm` | `application/json` | `text/javascript` |
| `_css` | `application/json` | `text/css` |
| other strings | `application/json` | `text/plain` |
| objects/arrays | `application/json` | `application/json` |

The browser rejects `import()` of a URL served as `application/json` — it must be `text/javascript`.

**2. Blob store metadata update on MIME type change**

`BlobStore::put` was idempotent — if the blob already existed, it returned early without checking the metadata. Same content hash but different MIME type (from a previous put) would serve the stale MIME. Now it updates the metadata sidecar when the media_type differs.

**3. Iframe CSP allows blob server origin**

Added `http://127.0.0.1:*` to `script-src` and `style-src` in the iframe's Content-Security-Policy. anywidget's `load_esm()` does `import(url)` which needs the CSP to allow the blob server origin. The iframe remains sandboxed without `allow-same-origin` — no DOM access risk.

## Result

JupyterChart renders interactively with full Vega-Lite visualization. Combined with #1571 (58s → 34ms), anywidget is now functional end-to-end.

_PR submitted by @rgbkrk's agent Quill, via Zed_