### PR TITLE
docs: update agent and contributing docs for recent architecture changes

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -20,7 +20,7 @@ paths:
 
 4. **Local-first editing, synced execution.** Cell mutations happen instantly in the WASM Automerge peer. Execution always runs against the synced document. Source edits debounce at 20ms; `flushSync()` fires before execute/save.
 
-5. **Binary separation via manifests.** Cell outputs are content-addressed blobs with manifest references. The CRDT stores only 64-char SHA-256 hashes. Large outputs never block document sync.
+5. **Binary separation via blob store.** Cell outputs use inline manifest Maps in the CRDT with `ContentRef` entries pointing to the blob store. MIME types and sizes are readable directly from the CRDT without any blob fetch. Large binary content (>1KB) goes to the content-addressed blob store; small content is inlined.
 
 6. **Daemon manages runtime resources.** Clients request kernel launch; they never spawn kernels directly. Environment selection, tool availability, and lifecycle are the daemon's responsibility.
 
@@ -43,7 +43,7 @@ The Tauri app crate (`crates/notebook/`) is glue -- it wires Tauri commands to d
 | Cell source (`Text` CRDT) | Frontend WASM | Local-first, character-level merge |
 | Cell position, type, metadata | Frontend WASM | User-initiated via UI |
 | Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
-| Cell outputs (manifest hashes) | Daemon | Kernel IOPub -> blob store -> hash in doc |
+| Cell outputs (inline manifests) | Daemon | Kernel IOPub -> blob store -> inline manifest Maps in RuntimeStateDoc |
 | Execution count | Daemon | Set on `execute_input` from kernel |
 | Widget state | Daemon (via `CommState`) | Kernel `comm_open`/`comm_msg` |
 | RuntimeStateDoc (kernel status, queue, executions, env, trust) | Daemon | Separate per-notebook Automerge doc synced via frame `0x05` |
@@ -69,7 +69,7 @@ Key files: `crates/notebook-doc/src/runtime_state.rs`, `apps/notebook/src/lib/ru
 Jupyter kernels send binary data as base64-encoded strings on the wire. The daemon **base64-decodes binary MIME types before storing** so the blob store holds actual binary bytes.
 
 **Text MIME types** (`text/*`, `application/json`, `image/svg+xml`, anything `+json`/`+xml`):
-- Stored as UTF-8 string bytes (or inlined in manifest if < 8KB)
+- Stored as UTF-8 string bytes (or inlined in manifest if < 1KB)
 - Resolved via `read_to_string()` / `response.text()`
 
 **Binary MIME types** (`image/png`, `image/jpeg`, `audio/*`, `video/*`, most `application/*`):
@@ -82,13 +82,11 @@ Jupyter kernels send binary data as base64-encoded strings on the wire. The daem
 
 ### The `is_binary_mime` Contract
 
-Three implementations **MUST stay in sync**. Update all three when changing MIME classification:
+One canonical Rust implementation in `notebook-doc::mime` is the single source of truth for MIME classification. All Rust crates (`runtimed`, `runtimed-client`, `runtimed-wasm`) use this module — the old per-crate copies have been deleted. WASM now owns MIME classification end-to-end — it resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly, so the frontend never needs to classify MIMEs itself.
 
-| Location | Language | Function |
-|----------|----------|----------|
-| `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
-| `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
+| Location | Function |
+|----------|----------|
+| `crates/notebook-doc/src/mime.rs` | `is_binary_mime()`, `mime_kind()`, `MimeKind` |
 
 Classification rules:
 - `image/*` -> binary, **EXCEPT** `image/svg+xml`
@@ -107,7 +105,7 @@ Classification rules:
 
 | Consumer | Binary MIME | Text MIME |
 |----------|------------|-----------|
-| **Frontend** (`manifest-resolution.ts`) | Returns `http://` blob URL | `response.text()` -> string |
+| **Frontend** (WASM `ContentRef` resolution) | Resolves `ContentRef` to `Blob` variant -> `http://` blob URL | Resolves to `Inline` (string) or `Url` variant |
 | **Python** (`output_resolver.rs`) | `fs::read()` -> raw `bytes` | `read_to_string()` -> string |
 | **.ipynb save** (`output_store.rs`) | `resolve_binary_as_base64()` | `resolve()` -> UTF-8 string |
 
@@ -115,9 +113,7 @@ Classification rules:
 
 Content-addressed storage at `~/.cache/runt/blobs/`, sharded by first 2 hex chars. Each blob has a `.meta` sidecar with `{media_type, size, created_at}`. Blobs are ephemeral -- derived from notebook content, regenerated from `.ipynb` on daemon restart.
 
-**Two-tier indirection:**
-1. Cell outputs list -> manifest hashes (64-char hex strings in `doc.cells[id].outputs`)
-2. Manifest (JSON in blob store) -> `ContentRef` per MIME type: `{"inline": "<data>"}` for <=8KB text, `{"blob": "<hash>", "size": N}` for large text or ANY binary
+**One-hop indirection:** Manifests are inline Automerge Maps in RuntimeStateDoc (not stored in the blob store). Each manifest contains `ContentRef` entries per MIME type: `{"inline": "<data>"}` for <=1KB text, `{"blob": "<hash>", "size": N}` for content >1KB or ANY binary. The CRDT points directly to content blobs — no manifest blob hop. MIME types and sizes are readable directly from the CRDT.
 
 HTTP server at `127.0.0.1:<dynamic-port>` serves `GET /blob/{hash}` with correct `Content-Type` and `Cache-Control: immutable`.
 
@@ -161,14 +157,15 @@ Never pass code directly in execution requests. The correct flow: write to the C
 |------|------|
 | `crates/notebook-doc/src/lib.rs` | `NotebookDoc` -- Automerge schema, cell CRUD, output writes |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset` -- structural diff from Automerge patches |
+| `crates/notebook-doc/src/mime.rs` | Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`) |
 | `crates/notebook-protocol/src/protocol.rs` | Wire types: requests, responses, broadcasts |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync infrastructure, per-cell accessors |
 | `crates/runtimed/src/notebook_sync_server.rs` | `NotebookRoom`, room lifecycle, autosave, re-keying |
 | `crates/runtimed/src/kernel_manager.rs` | Kernel lifecycle, execution queue, IOPub routing |
-| `crates/runtimed/src/output_store.rs` | Manifest creation/resolution, `is_binary_mime()`, `ContentRef` |
+| `crates/runtimed/src/output_store.rs` | Manifest creation/resolution, `ContentRef` |
 | `crates/runtimed/src/blob_store.rs` | Content-addressed storage |
 | `crates/runtimed/src/blob_server.rs` | HTTP server for blob retrieval |
-| `crates/runtimed-client/src/output_resolver.rs` | Shared Rust resolution, `mime_kind()` |
-| `apps/notebook/src/lib/manifest-resolution.ts` | Frontend resolution, `isBinaryMime()` |
+| `crates/runtimed-client/src/output_resolver.rs` | Shared Rust resolution |
+| `apps/notebook/src/lib/manifest-resolution.ts` | Frontend resolution (WASM resolves `ContentRef` directly) |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM -> React conversion |
 | `apps/notebook/src/lib/notebook-cells.ts` | Split cell store, per-cell subscriptions |

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -120,13 +120,12 @@ After WASM `receive_frame()` demuxes frames, broadcasts and presence are dispatc
 
 ## Output Storage
 
-Two-tier blob manifest system. When daemon receives kernel output:
-1. Convert to nbformat JSON, create manifest (`output_store.rs`)
-2. Each MIME type -> `ContentRef`: `Inline` for < 8KB, `Blob { hash, size }` for >= 8KB
-3. Binary content stored in blob store (SHA-256 hashes, `~/.cache/runt/blobs/`)
-4. Manifest stored in blob store -> 64-char hex hash
-5. Automerge doc stores only the manifest hash in `cell.outputs[]`
-6. Clients resolve from daemon's HTTP blob server (`GET /blob/{hash}`)
+Inline manifest system with blob offload for large payloads. When daemon receives kernel output:
+1. Convert to nbformat JSON, create output manifest as an **inline Automerge Map** in RuntimeStateDoc (`output_store.rs`)
+2. Each MIME type → `ContentRef`: `Inline` for ≤ 1KB, `Blob { hash, size }` for > 1KB
+3. Large content stored in blob store (SHA-256 hashes, `~/.cache/runt/blobs/`)
+4. MIME types and small payloads are readable directly from the CRDT without any blob fetch
+5. Clients resolve large blobs from daemon's HTTP blob server (`GET /blob/{hash}`)
 
 ## RuntimeStateDoc (Shipped)
 

--- a/.claude/rules/widget-development.md
+++ b/.claude/rules/widget-development.md
@@ -18,7 +18,7 @@ Widgets run inside a security-isolated iframe. The parent window owns the Widget
 
 Widget state lives in the **RuntimeStateDoc** CRDT (`doc.comms/` Automerge map). Each comm entry tracks target_name, model_module, model_name, state (as native Automerge map), outputs, and seq.
 
-- **Daemon:** Writes comm state on `comm_open`/`comm_msg(update)`/`comm_close` from kernel IOPub. State updates go through a 16ms coalescing writer to avoid overwhelming CRDT sync.
+- **Daemon:** Writes comm state on `comm_open`/`comm_msg(update)`/`comm_close` from kernel IOPub. State updates go through a 16ms coalescing writer to avoid overwhelming CRDT sync. Large comm state values (>1KB serialized JSON) are stored in the blob store with a `$blob` sentinel in the CRDT, following the same pattern as binary widget buffers and output ContentRefs. This prevents expensive recursive CRDT expansion of large JSON objects (e.g., Vega-Lite specs embedded in JupyterChart state).
 - **Frontend:** `WidgetStore` in `widget-store.ts` -- per-model subscriptions, IPY_MODEL_ reference resolution, custom message buffering. Populated by a CRDT watcher in `useDaemonKernel.ts` that diffs `runtimeState.comms` and synthesizes Jupyter comm messages.
 - **Frontend → Kernel:** Built-in widget state updates write to RuntimeStateDoc via `getCrdtCommWriter()`. The runtime agent diffs comm state on each sync and forwards deltas to the kernel.
 

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -16,21 +16,17 @@ When changing the wire handshake or typed frame semantics, also inspect:
 
 ## MIME classification contract
 
-Keep these implementations in sync when changing text-vs-binary rules:
-
-- `crates/runtimed/src/output_store.rs`
-- `crates/runtimed-client/src/output_resolver.rs`
-- `apps/notebook/src/lib/manifest-resolution.ts`
+Single canonical Rust implementation in `crates/notebook-doc/src/mime.rs` (`is_binary_mime()`, `mime_kind()`, `MimeKind` enum). All Rust crates use this module. The old per-crate copies in `runtimed/src/output_store.rs`, `runtimed-client/src/output_resolver.rs`, and the TypeScript `isBinaryMime()` in `manifest-resolution.ts` have been deleted — WASM owns MIME classification end-to-end.
 
 Important rule: `image/svg+xml` is text, not binary.
 
 ## Output pipeline
 
-The daemon stores manifests and blobs; the CRDT stores only manifest hashes. Frontend and Python consumers resolve through the manifest layer rather than treating output payloads as inline notebook state.
+The daemon stores content in the blob store; output manifests are inline Automerge Maps in RuntimeStateDoc. MIME types and sizes are readable directly from the CRDT without any blob fetch. Frontend and Python consumers resolve ContentRefs through the manifest layer — Inline for ≤1KB, Blob for >1KB.
 
 ## Common pitfalls
 
 - Storing base64 text for binary blobs instead of raw bytes
 - Reading binary blobs as UTF-8 strings
-- Forgetting to update both frontend and Python MIME classification paths
+- Adding MIME classification outside `crates/notebook-doc/src/mime.rs` — there is one canonical implementation
 - Changing sync reply or retry behavior without testing failed-delivery cases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 | `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
 | `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
 | `notebook` | Tauri desktop app — main GUI, bundles daemon+CLI as sidecars |
-| `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723 |
+| `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723, MIME classification |
 | `notebook-protocol` | Wire types — requests, responses, broadcasts |
 | `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
 | `runt` | CLI — daemon management, kernel control, notebook launching, MCP server |
@@ -308,7 +308,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 | `runt-workspace` | Per-worktree daemon isolation, socket path management |
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
-| `repr-llm` | LLM-friendly text summaries of visualization specs (`text/llm+plain` synthesis) |
+| `repr-llm` | LLM-friendly text summaries of visualization specs incl. GeoJSON (`text/llm+plain` synthesis) |
 | `mcp-supervisor` | nteract-dev — MCP supervisor proxy, daemon/vite lifecycle management |
 | `xtask` | Build system orchestration |
 
@@ -442,21 +442,21 @@ This is why `NotebookDoc::bootstrap()` only writes `schema_version` (a scalar). 
 
 ### The `is_binary_mime` Contract
 
-Three implementations **must stay in sync** — if you change MIME classification, update all three:
+One canonical Rust implementation in `notebook-doc::mime` is the single source of truth for MIME classification. It exports `is_binary_mime()`, `mime_kind()`, and the `MimeKind` enum. All Rust crates (`runtimed`, `runtimed-client`, `runtimed-wasm`) use this module — the old per-crate copies have been deleted.
 
-| Location | Language | Function |
-|----------|----------|----------|
-| `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
-| `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
+On the TypeScript side, `isBinaryMime()` has been deleted from `manifest-resolution.ts`. **WASM now owns MIME classification end-to-end** — it resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly, so the frontend never needs to classify MIMEs itself.
 
-The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/*`, `video/*` → binary. `application/*` → binary by default (EXCEPT json, javascript, xml, and `+json`/`+xml` suffixes). `text/*` → always text.
+| Location | Function |
+|----------|----------|
+| `crates/notebook-doc/src/mime.rs` | `is_binary_mime()`, `mime_kind()`, `MimeKind` |
+
+The classification rules: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/*`, `video/*` → binary. `application/*` → binary by default (EXCEPT json, javascript, xml, and `+json`/`+xml` suffixes). `text/*` → always text.
 
 ### Crate Boundaries
 
 | Crate | Owns | Modify when |
 |-------|------|-------------|
-| `notebook-doc` | Automerge schema, cell CRUD, output writes, `CellChangeset` | Changing document schema or cell operations |
+| `notebook-doc` | Automerge schema, cell CRUD, output writes, MIME classification, `CellChangeset` | Changing document schema or cell operations |
 | `notebook-protocol` | Wire types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`) | Adding request/response/broadcast types |
 | `notebook-sync` | `DocHandle`, sync infrastructure, per-cell accessors for Python | Changing Python client sync behavior |
 
@@ -467,7 +467,7 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 | Cell source | Frontend WASM | Local-first, character-level merge |
 | Cell position, type, metadata | Frontend WASM | User-initiated via UI |
 | Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
-| Cell outputs (manifest hashes) | Runtime agent subprocess | Kernel IOPub → blob store → hash in RuntimeStateDoc |
+| Cell outputs (inline manifests) | Runtime agent subprocess | Kernel IOPub → blob store → inline manifest Maps in RuntimeStateDoc |
 | Execution count | Runtime agent subprocess | Set on `execute_input` from kernel |
 | Execution queue (source, seq, status) | Coordinator writes `queued`, runtime agent transitions to `running`/`done` | CRDT-driven execution — no RPC for cell execution |
 | RuntimeStateDoc (kernel, queue, executions, env, trust) | Runtime agent + Coordinator | Separate Automerge doc, frame type `0x05` |
@@ -480,9 +480,9 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 
 ### Renderer Plugins (Isolated Iframe)
 
-Heavy output renderers (markdown, plotly, vega, leaflet) are loaded as **on-demand CJS plugins** — not bundled into the core IIFE. Each plugin has its own Vite virtual module (`virtual:renderer-plugin/{name}`) for code splitting. The iframe's CJS loader provides React via a custom `require` shim — no window globals. See `contributing/iframe-isolation.md` § Renderer Plugins for the full architecture and step-by-step guide to adding new plugins.
+Heavy output renderers (markdown, plotly, vega, leaflet) are loaded as **on-demand CJS plugins** — not bundled into the core IIFE. Plugins are identified by **MIME types directly** — MIME types flow from CRDT outputs to the loading boundary without translation. Each plugin has its own Vite virtual module (`virtual:renderer-plugin/{name}`) for code splitting. The iframe's CJS loader provides React via a custom `require` shim — no window globals. `text/latex` is rendered via KaTeX inside the markdown renderer plugin. See `contributing/iframe-isolation.md` § Renderer Plugins for the full architecture and step-by-step guide to adding new plugins.
 
-**Key files:** `src/isolated-renderer/index.tsx` (registry + loader), `src/isolated-renderer/*-renderer.tsx` (plugins), `apps/notebook/vite-plugin-isolated-renderer.ts` (build), `src/components/isolated/iframe-libraries.ts` (on-demand loading).
+**Key files:** `src/isolated-renderer/index.tsx` (registry + loader), `src/isolated-renderer/*-renderer.tsx` (plugins), `apps/notebook/vite-plugin-isolated-renderer.ts` (build), `src/components/isolated/iframe-libraries.ts` (single MIME→plugin mapping layer: `PLUGIN_MIME_TYPES`, `needsPlugin`, `loadPluginForMime`).
 
 ### Cell List Stable DOM Order (Iframe Reload Prevention)
 

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -88,7 +88,7 @@ The blob store uses content-addressed storage at `~/.cache/runt/blobs/`. Each bl
 Jupyter kernels send binary data (images) as base64-encoded strings on the wire. The daemon **base64-decodes binary MIME types before storing** so the blob store holds actual binary bytes (real PNG, JPEG, etc.), not base64 text. This classification is determined by `is_binary_mime()`.
 
 **Text MIME types** (`text/*`, `application/json`, `image/svg+xml`, anything `+json`/`+xml`):
-- Stored as UTF-8 string bytes (or inlined in the manifest if < 8KB)
+- Stored as UTF-8 string bytes (or inlined in the manifest if ≤ 1KB)
 - Resolved via `read_to_string()` / `response.text()`
 
 **Binary MIME types** (`image/png`, `image/jpeg`, `audio/*`, `video/*`, most `application/*`):
@@ -102,13 +102,11 @@ Jupyter kernels send binary data (images) as base64-encoded strings on the wire.
 
 #### The `is_binary_mime` Contract
 
-Three implementations **must stay in sync** — if you change the classification, update all three:
+One canonical Rust implementation in `notebook-doc::mime` is the single source of truth. All Rust crates use this module — the old per-crate copies have been deleted. On the TypeScript side, `isBinaryMime()` has been deleted from `manifest-resolution.ts`. WASM now owns MIME classification end-to-end — it resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly.
 
-| Location | Language | Function |
-|----------|----------|----------|
-| `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
-| `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
+| Location | Function |
+|----------|----------|
+| `crates/notebook-doc/src/mime.rs` | `is_binary_mime()`, `mime_kind()`, `MimeKind` |
 
 The rule:
 - `image/*` → binary, **EXCEPT** `image/svg+xml` (plain XML text)
@@ -127,24 +125,25 @@ The rule:
 
 1. Kernel produces output → daemon's `kernel_manager.rs` converts to nbformat JSON
 2. `output_store.rs` creates manifest:
-   - Text MIME → `ContentRef::from_data()` (inline if < 8KB, blob if larger)
+   - Text MIME → `ContentRef::from_data()` (inline if ≤ 1KB, blob if larger)
    - Binary MIME → base64-decode → `ContentRef::from_binary()` (always blob)
-3. Manifest JSON stored in blob store → hash goes into Automerge CRDT
+3. Manifest is written as an inline Automerge Map in RuntimeStateDoc — MIME types and sizes are readable from the CRDT without blob fetch
 
 Resolution varies by consumer:
 
 | Consumer | Binary MIME | Text MIME |
 |----------|------------|-----------|
-| **Frontend** (`manifest-resolution.ts`) | Returns `http://` blob URL | `response.text()` → string |
+| **Frontend** (WASM resolves `ContentRef` → `Inline`/`Url`/`Blob` variants) | Returns `http://` blob URL | Inline string or `response.text()` → string |
 | **Python** (`output_resolver.rs`) | `fs::read()` → base64-encode | `read_to_string()` → string |
 | **.ipynb save** (`output_store.rs`) | `resolve_binary_as_base64()` | `resolve()` → UTF-8 string |
 
 Key files:
-- `crates/runtimed/src/output_store.rs` — Manifest creation/resolution, `is_binary_mime()`, `ContentRef`
+- `crates/notebook-doc/src/mime.rs` — Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`)
+- `crates/runtimed/src/output_store.rs` — Manifest creation/resolution, `ContentRef`
 - `crates/runtimed/src/blob_store.rs` — Content-addressed storage with atomic writes
 - `crates/runtimed/src/blob_server.rs` — HTTP server (`GET /blob/{hash}`, serves raw bytes with correct `Content-Type`)
-- `crates/runtimed-client/src/output_resolver.rs` — Shared Rust manifest resolution, `mime_kind()`, Python/MCP consumers
-- `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution, `isBinaryMime()`, `resolveContentRef()`
+- `crates/runtimed-client/src/output_resolver.rs` — Shared Rust manifest resolution, Python/MCP consumers
+- `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution (`isBinaryMime()` deleted, WASM resolves `ContentRef` directly)
 - `apps/notebook/src/lib/materialize-cells.ts` — Assembles cells with resolved outputs
 
 ### 6. Process-Isolated Kernel Execution
@@ -271,7 +270,8 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
 - `crates/runtimed/src/kernel_manager.rs` — `RoomKernel`: kernel process lifecycle, execution queue, IOPub output routing
 - `crates/runtimed/src/comm_state.rs` — Widget comm state + Output widget capture routing
-- `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `is_binary_mime()`, `ContentRef`
+- `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `ContentRef`
+- `crates/notebook-doc/src/mime.rs` — Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`)
 - `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon
 - `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
 - `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -209,8 +209,8 @@ declare module "virtual:renderer-plugin/my-renderer" {
 ```
 
 4. **Register the MIME type** in `src/components/isolated/iframe-libraries.ts`:
-   - Add to `MIME_PLUGINS` map (or handle in `pluginForMime()` for regex patterns)
-   - Add the import case in `loadPlugin()`
+   - Add to `PLUGIN_MIME_TYPES` map
+   - Add the import case in `loadPluginForMime()`
 
 5. **Remove from core bundle** in `src/isolated-renderer/index.tsx`:
    - Remove the component import

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -304,16 +304,15 @@ All dispatch is synchronous and in-process — no serialization or Tauri event l
 
 ## Output Storage
 
-Cell outputs use a two-tier blob manifest system rather than inline data. When the daemon receives output from a kernel:
+Cell outputs use inline manifests with blob offload for large payloads. When the daemon receives output from a kernel:
 
-1. The output is converted to nbformat JSON, then a **manifest** is created (`output_store.rs`)
-2. Each MIME type's content becomes a `ContentRef`: `Inline` for < 8KB, `Blob { hash, size }` for ≥ 8KB
+1. The output is converted to nbformat JSON, then a **manifest** is created as an inline Automerge Map in RuntimeStateDoc (`output_store.rs`)
+2. Each MIME type's content becomes a `ContentRef`: `Inline` for ≤ 1KB, `Blob { hash, size }` for > 1KB
 3. Large binary content (images, plots) is stored in a content-addressed **blob store** (`blob_store.rs`, SHA-256 hashes, `~/.cache/runt/blobs/`)
-4. The manifest itself is stored in the blob store → produces a 64-char hex manifest hash
-5. The Automerge doc stores only the manifest hash in `cell.outputs[]`
-6. Clients resolve manifests and blobs from the daemon's HTTP blob server (`GET /blob/{hash}` on a dynamic port)
+4. MIME types and small payloads are readable directly from the CRDT without any blob fetch
+5. Clients resolve large blobs from the daemon's HTTP blob server (`GET /blob/{hash}` on a dynamic port)
 
-This keeps the CRDT small: a cell with 50 outputs adds ~3.2KB to the doc (50 × 64 bytes), regardless of output content size.
+This keeps the CRDT efficient: manifests are structured Maps with compact ContentRef entries. MIME type metadata is always available without touching the blob store.
 
 Stream outputs (stdout/stderr) are special: text is fed through a terminal emulator (`stream_terminals`) for carriage return and ANSI escape handling before manifest creation. `upsert_stream_output` updates in-place when consecutive stream outputs arrive.
 


### PR DESCRIPTION
Reflect #1558–#1571 across `AGENTS.md`, `.claude/rules/`, `.codex/skills/`, and `contributing/`.

**is_binary_mime contract**: Single Rust impl in `notebook-doc::mime`. TS `isBinaryMime()` deleted — WASM owns classification end-to-end.

**Output manifests**: Inline Automerge Maps in RuntimeStateDoc, not blob-stored hashes. ContentRef threshold 8KB → 1KB.

**Renderer plugins**: MIME types as direct identifiers (`renderer-plugins.ts` deleted). `text/latex` via KaTeX in markdown plugin.

**Widget state**: `$blob` sentinel for large comm state values (>1KB).

**Crate descriptions**: `notebook-doc` gains MIME classification, `repr-llm` gains GeoJSON.

_PR submitted by @rgbkrk's agent Quill, via Zed_