### PR TITLE
docs: document iframe Content Security Policy

### DIFF
--- a/.claude/rules/iframe-isolation.md
+++ b/.claude/rules/iframe-isolation.md
@@ -33,6 +33,12 @@ allow-popups, allow-popups-to-escape-sandbox, allow-modals
 
 No `allow-same-origin`. Ever.
 
+### Content Security Policy
+
+The iframe HTML includes a `<meta>` CSP as defense-in-depth. `script-src` and `style-src` allow `http://127.0.0.1:*` for anywidget ESM/CSS served from the daemon's blob store. This is safe because the sandbox lacks `allow-same-origin` — loaded scripts still can't access the parent DOM, Tauri APIs, or storage. See `contributing/iframe-isolation.md` § Content Security Policy for the full policy.
+
+**Key file:** `src/components/isolated/frame-html.ts` — `generateFrameHtml()`.
+
 ### Source Validation
 
 The iframe's message handler validates `event.source !== window.parent` to reject messages from other windows/iframes.
@@ -86,6 +92,7 @@ The JSON-RPC widget methods include:
 ## Code Review Checklist
 
 - No `allow-same-origin` added to sandbox attributes
+- CSP not weakened — no new origins in `script-src`/`style-src` beyond `127.0.0.1:*` and `https:`
 - Source validation intact (`event.source !== window.parent`)
 - Message whitelist updated if new types added (`frame-bridge.ts`)
 - Tests updated for new message types

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -64,6 +64,29 @@ it("sandbox does NOT include allow-same-origin", () => {
 });
 ```
 
+### Content Security Policy
+
+The iframe HTML includes a `<meta>` CSP as defense-in-depth alongside the sandbox:
+
+```
+default-src 'self' blob: data:;
+script-src  'unsafe-inline' 'unsafe-eval' blob: https: http://127.0.0.1:*;
+style-src   'unsafe-inline' https: http://127.0.0.1:*;
+img-src     * data: blob:;
+font-src    * data:;
+media-src   * data: blob:;
+object-src  * data: blob:;
+connect-src *;
+```
+
+**Why `http://127.0.0.1:*`:** Anywidget ESM modules (`_esm`) and CSS (`_css`) are served from the daemon's blob store HTTP server on a dynamic localhost port. Without this exception, the browser rejects `import()` of blob-served JavaScript with a MIME type violation. This is safe because:
+
+1. The iframe is sandboxed **without `allow-same-origin`** — it cannot read cookies, localStorage, or access the parent DOM regardless of what scripts load.
+2. The blob server is read-only and content-addressed — it serves immutable blobs with correct `Content-Type` headers.
+3. `https:` is allowed for CDN-hosted widget assets (e.g., anywidget ESM from unpkg/jsdelivr).
+
+**Key file:** `src/components/isolated/frame-html.ts` — `generateFrameHtml()`.
+
 ### Source Validation
 
 The iframe's message handler validates that messages come from the parent window:
@@ -286,6 +309,7 @@ JSON-RPC widget methods are defined separately in `rpc-methods.ts`.
 When reviewing changes to iframe isolation code:
 
 - [ ] **No `allow-same-origin`** added to sandbox attributes
+- [ ] **CSP not weakened** — no new origins in `script-src`/`style-src` beyond `127.0.0.1:*` and `https:`
 - [ ] **Source validation intact** (`event.source !== window.parent`)
 - [ ] **Message whitelist updated** if new types added (frame-bridge.ts)
 - [ ] **Tests updated** for any new message types


### PR DESCRIPTION
The iframe's `<meta>` CSP is a real security layer (defense-in-depth alongside the sandbox) but wasn't documented anywhere. Documents:

- Full CSP policy breakdown
- Why `http://127.0.0.1:*` is in `script-src`/`style-src` (anywidget ESM/CSS from blob store, added in #1572)
- Why it's safe (sandbox lacks `allow-same-origin`)
- CSP added to both code review checklists

_PR submitted by @rgbkrk's agent Quill, via Zed_