### PR TITLE
fix(runtimed): eliminate double-bootout race during nightly upgrade

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -924,7 +924,11 @@ where
     }
 
     if exit_code != Some(0) {
-        let error = format!("Daemon upgrade failed with code {:?}", exit_code);
+        let code_str = match exit_code {
+            Some(code) => format!("exit code {code}"),
+            None => "signal".to_string(),
+        };
+        let error = format!("Daemon upgrade failed ({code_str})");
         log::error!("[startup] {}", error);
         on_progress(DaemonProgress::Failed {
             error: error.clone(),

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -625,6 +625,20 @@ pub fn launchd_stop() -> Result<(), String> {
 /// "not found" errors), then bootstraps fresh from the plist.
 #[cfg(target_os = "macos")]
 pub fn launchd_start() -> Result<(), String> {
+    // Clear any stale registration — launchd_stop() already treats "not found"
+    // as Ok, so ? propagates only unexpected failures.
+    launchd_stop()?;
+
+    launchd_bootstrap_only()
+}
+
+/// Bootstrap the daemon's launchd service without stopping first.
+///
+/// Use this when the caller has already stopped the service and only needs
+/// to bootstrap. Avoids the double-bootout race that can occur when
+/// `launchd_start()` is called after an explicit `launchd_stop()`.
+#[cfg(target_os = "macos")]
+pub fn launchd_bootstrap_only() -> Result<(), String> {
     let plist = launchd_plist_path()?;
     if !plist.exists() {
         return Err(format!("launchd plist not found at {}", plist.display()));
@@ -633,12 +647,6 @@ pub fn launchd_start() -> Result<(), String> {
     let uid = launchd_uid()?;
     let domain = format!("gui/{uid}");
 
-    // Clear any stale registration — launchd_stop() already treats "not found"
-    // as Ok, so ? propagates only unexpected failures.
-    launchd_stop()?;
-
-    // launchd_bootstrap retries with backoff if launchd needs time to
-    // clean up after the bootout above.
     launchd_bootstrap(&plist, &domain)
 }
 
@@ -722,8 +730,8 @@ pub fn launchd_ensure_loaded() -> Result<bool, String> {
 /// recent `bootout`.
 #[cfg(target_os = "macos")]
 fn launchd_bootstrap(plist: &Path, domain: &str) -> Result<(), String> {
-    // First attempt immediate, then backoff. Total max wait ~3.7s.
-    let delays_ms: &[u64] = &[0, 200, 500, 1000, 2000];
+    // First attempt immediate, then backoff. Total max wait ~7.7s.
+    let delays_ms: &[u64] = &[0, 200, 500, 1000, 2000, 4000];
     let mut last_err = String::new();
 
     for (attempt, &delay_ms) in delays_ms.iter().enumerate() {

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -363,9 +363,11 @@ impl ServiceManager {
             }
         }
 
-        // Bootstrap only — self.stop() above already did the bootout.
-        // Using launchd_start() here would cause a double-bootout race that
-        // puts launchd into a transient error-5 state.
+        // Bootstrap only. The stop() call above is best-effort and may have
+        // already performed the launchd bootout, but upgrade intentionally does
+        // not issue another bootout here. Using launchd_start() would add a
+        // second bootout attempt and can put launchd into a transient error-5
+        // state.
         #[cfg(target_os = "macos")]
         runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -363,9 +363,11 @@ impl ServiceManager {
             }
         }
 
-        // Use launchd_start() which always does bootout+bootstrap
+        // Bootstrap only — self.stop() above already did the bootout.
+        // Using launchd_start() here would cause a double-bootout race that
+        // puts launchd into a transient error-5 state.
         #[cfg(target_os = "macos")]
-        runt_workspace::launchd_start().map_err(ServiceError::StartFailed)?;
+        runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
 
         #[cfg(not(target_os = "macos"))]
         self.start()?;


### PR DESCRIPTION
## Summary

- **Fix double-bootout race**: The upgrade path called `launchctl bootout` twice in rapid succession — once via `self.stop()` and again inside `launchd_start()`. This put launchd into a transient error-5 (I/O error) state that outlasted the retry window, causing `launchctl bootstrap` to fail and leaving the daemon down after upgrade. Added `launchd_bootstrap_only()` for callers that have already stopped the service, and use it in `upgrade()`.
- **Fix raw `Some(1)` in error message**: The upgrade failure UI showed "Daemon upgrade failed with code Some(1)" — Rust `Option` debug format leaking to users. Now shows "Daemon upgrade failed (exit code 1)".
- **Extend retry backoff**: Increased `launchd_bootstrap()` retry ceiling from ~3.7s to ~7.7s as defense-in-depth for edge cases where launchd takes longer to recover.

## Test plan

- [ ] Trigger a nightly auto-upgrade with an active notebook session and verify daemon restarts successfully
- [ ] Verify `runt-nightly daemon doctor` reports healthy state after upgrade
- [ ] Confirm error messages show "exit code N" instead of "Some(N)" if upgrade fails
- [ ] `cargo check -p runt-workspace -p runtimed-client -p notebook` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)