### PR TITLE
fix(runtimed): update RuntimeStateDoc on interrupt to clear CRDT queue

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -607,6 +607,9 @@ pub enum RuntimeAgentResponse {
     /// History search result.
     HistoryResult { entries: Vec<HistoryEntry> },
 
+    /// Interrupt acknowledged. Contains the list of cleared queue entries.
+    InterruptAcknowledged { cleared: Vec<QueueEntry> },
+
     /// Generic success.
     Ok,
 

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -2978,7 +2978,8 @@ impl RoomKernel {
     }
 
     /// Interrupt the currently executing cell and clear the execution queue.
-    pub async fn interrupt(&mut self) -> Result<()> {
+    /// Returns the list of cleared queue entries (for state_doc cleanup).
+    pub async fn interrupt(&mut self) -> Result<Vec<QueueEntry>> {
         let connection_info = self
             .connection_info
             .as_ref()
@@ -2992,6 +2993,23 @@ impl RoomKernel {
 
         info!("[kernel-manager] Sent interrupt_request");
 
+        // Wait for the kernel to acknowledge the interrupt so we know SIGINT
+        // landed before we clear state. Use a timeout — if the kernel is
+        // completely hung it may never reply.
+        match tokio::time::timeout(std::time::Duration::from_secs(5), control.read()).await {
+            Ok(Ok(_reply)) => {
+                info!("[kernel-manager] Received interrupt_reply");
+            }
+            Ok(Err(e)) => {
+                warn!("[kernel-manager] Error receiving interrupt_reply: {}", e);
+                // Proceed with queue clearing anyway — the signal was sent
+            }
+            Err(_) => {
+                warn!("[kernel-manager] Timed out waiting for interrupt_reply (5s)");
+                // Proceed with queue clearing anyway — the signal was sent
+            }
+        }
+
         // Clear the execution queue - interrupt semantically means "stop all pending work"
         let cleared = self.clear_queue();
         if !cleared.is_empty() {
@@ -3001,7 +3019,7 @@ impl RoomKernel {
             );
         }
 
-        Ok(())
+        Ok(cleared)
     }
 
     /// Send a comm message to the kernel (for widget interactions).

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4918,6 +4918,11 @@ async fn handle_notebook_request(
                         .await;
                         NotebookResponse::InterruptSent {}
                     }
+                    Ok(
+                        notebook_protocol::protocol::RuntimeAgentResponse::Error { error },
+                    ) => NotebookResponse::Error {
+                        error: format!("Agent interrupt error: {}", error),
+                    },
                     Ok(_) => {
                         // Legacy Ok response — still update state_doc with empty cleared list
                         apply_interrupt_to_state_doc(&room.state_doc, &room.state_changed_tx, &[])

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4903,9 +4903,11 @@ async fn handle_notebook_request(
                 )
                 .await
                 {
-                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::InterruptAcknowledged {
-                        cleared,
-                    }) => {
+                    Ok(
+                        notebook_protocol::protocol::RuntimeAgentResponse::InterruptAcknowledged {
+                            cleared,
+                        },
+                    ) => {
                         // Update RuntimeStateDoc: clear CRDT queue, mark cleared
                         // executions as errored so the frontend reflects the interrupt.
                         apply_interrupt_to_state_doc(
@@ -4918,12 +4920,8 @@ async fn handle_notebook_request(
                     }
                     Ok(_) => {
                         // Legacy Ok response — still update state_doc with empty cleared list
-                        apply_interrupt_to_state_doc(
-                            &room.state_doc,
-                            &room.state_changed_tx,
-                            &[],
-                        )
-                        .await;
+                        apply_interrupt_to_state_doc(&room.state_doc, &room.state_changed_tx, &[])
+                            .await;
                         NotebookResponse::InterruptSent {}
                     }
                     Err(e) => NotebookResponse::Error {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -728,6 +728,55 @@ pub(crate) async fn apply_cell_error_to_state_doc(
     }
 }
 
+/// Handle interrupt: clear queued executions in state_doc and mark them as
+/// errored using fork+merge. The currently-executing cell is left alone —
+/// the kernel will send an `execute_reply` with error status for it, which
+/// the normal IOPub handler will process.
+pub(crate) async fn apply_interrupt_to_state_doc(
+    room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
+    room_state_changed_tx: &broadcast::Sender<()>,
+    cleared: &[notebook_protocol::protocol::QueueEntry],
+) {
+    // Fork state_doc so mutations compose with any concurrent writes.
+    let mut fork = {
+        let mut sd = room_state_doc.write().await;
+        let mut f = sd.fork();
+        f.set_actor("runtimed:state:interrupt");
+        f
+    };
+
+    // Read the currently-executing entry from the CRDT (it stays — the
+    // kernel will send an execute_reply for it via the normal IOPub path).
+    let state = fork.read_state();
+    let exec = state.queue.executing.as_ref().map(|e| DocQueueEntry {
+        cell_id: e.cell_id.clone(),
+        execution_id: e.execution_id.clone(),
+    });
+
+    // Clear the queued entries, keeping only the executing one.
+    fork.set_queue(exec.as_ref(), &[]);
+
+    // Mark cleared executions as errored on the fork
+    for entry in cleared {
+        fork.set_execution_done(&entry.execution_id, false);
+    }
+
+    // Merge fork back — concurrent state_doc writes compose via CRDT
+    {
+        let mut sd = room_state_doc.write().await;
+        match catch_automerge_panic("interrupt-state-merge", || sd.merge(&mut fork)) {
+            Ok(Ok(_)) => {
+                let _ = room_state_changed_tx.send(());
+            }
+            Ok(Err(_)) => {}
+            Err(e) => {
+                warn!("{}", e);
+                sd.rebuild_from_save();
+            }
+        }
+    }
+}
+
 /// Handle KernelDied: set error status, clear queue, mark all executions
 /// as errored using fork+merge. Returns env_source for presence update.
 pub(crate) async fn apply_kernel_died_to_state_doc(
@@ -4846,7 +4895,6 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::InterruptExecution {} => {
-            // Agent path: send RPC via sync connection
             let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
             if has_runtime_agent {
                 match send_runtime_agent_request(
@@ -4855,7 +4903,29 @@ async fn handle_notebook_request(
                 )
                 .await
                 {
-                    Ok(_) => NotebookResponse::InterruptSent {},
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::InterruptAcknowledged {
+                        cleared,
+                    }) => {
+                        // Update RuntimeStateDoc: clear CRDT queue, mark cleared
+                        // executions as errored so the frontend reflects the interrupt.
+                        apply_interrupt_to_state_doc(
+                            &room.state_doc,
+                            &room.state_changed_tx,
+                            &cleared,
+                        )
+                        .await;
+                        NotebookResponse::InterruptSent {}
+                    }
+                    Ok(_) => {
+                        // Legacy Ok response — still update state_doc with empty cleared list
+                        apply_interrupt_to_state_doc(
+                            &room.state_doc,
+                            &room.state_changed_tx,
+                            &[],
+                        )
+                        .await;
+                        NotebookResponse::InterruptSent {}
+                    }
                     Err(e) => NotebookResponse::Error {
                         error: format!("Agent interrupt error: {}", e),
                     },

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4918,11 +4918,11 @@ async fn handle_notebook_request(
                         .await;
                         NotebookResponse::InterruptSent {}
                     }
-                    Ok(
-                        notebook_protocol::protocol::RuntimeAgentResponse::Error { error },
-                    ) => NotebookResponse::Error {
-                        error: format!("Agent interrupt error: {}", error),
-                    },
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
+                        NotebookResponse::Error {
+                            error: format!("Agent interrupt error: {}", error),
+                        }
+                    }
                     Ok(_) => {
                         // Legacy Ok response — still update state_doc with empty cleared list
                         apply_interrupt_to_state_doc(&room.state_doc, &room.state_changed_tx, &[])

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -465,7 +465,7 @@ async fn handle_runtime_agent_request(
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.interrupt().await {
-                    Ok(()) => RuntimeAgentResponse::Ok,
+                    Ok(_cleared) => RuntimeAgentResponse::Ok,
                     Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to interrupt: {}", e),
                     },

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -465,7 +465,7 @@ async fn handle_runtime_agent_request(
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.interrupt().await {
-                    Ok(_cleared) => RuntimeAgentResponse::Ok,
+                    Ok(cleared) => RuntimeAgentResponse::InterruptAcknowledged { cleared },
                     Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to interrupt: {}", e),
                     },

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1885,9 +1885,7 @@ class TestKernelLifecycle:
 
         # Now execute a NEW cell — it should work immediately, not hang
         verify_id = await session.create_cell("1 + 1")
-        verify_result = await asyncio.wait_for(
-            session.execute_cell(verify_id), timeout=10
-        )
+        verify_result = await asyncio.wait_for(session.execute_cell(verify_id), timeout=10)
         assert verify_result.success, f"Post-interrupt cell should succeed: {verify_result}"
 
     async def test_async_shutdown_kernel(self, session):

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1857,10 +1857,38 @@ class TestKernelLifecycle:
         reason="Flaky on CI: daemon relay 30s timeout can expire on slow runners",
         strict=False,
     )
-    async def test_async_kernel_interrupt(self, session):
-        """Can interrupt a running kernel."""
+    async def test_interrupt_clears_queue_and_unblocks(self, session):
+        """Interrupt clears the CRDT queue and allows new cells to execute (#1583)."""
         await async_start_kernel_with_retry(session)
-        await session.interrupt()  # Should not raise
+
+        # Create a cell that blocks for a long time
+        blocking_id = await session.create_cell("import time; time.sleep(60)")
+        # Create a cell that will be queued behind the blocking cell
+        queued_id = await session.create_cell("queued = True")
+
+        # Execute both — blocking cell runs first, queued cell waits
+        blocking_task = asyncio.create_task(session.execute_cell(blocking_id))
+        await asyncio.sleep(0.5)  # Let blocking cell start
+        queued_task = asyncio.create_task(session.execute_cell(queued_id))
+        await asyncio.sleep(0.5)  # Let queue settle
+
+        # Interrupt — should clear the queue and send SIGINT
+        await session.interrupt()
+
+        # The blocking cell should fail with KeyboardInterrupt
+        blocking_result = await asyncio.wait_for(blocking_task, timeout=10)
+        assert not blocking_result.success, "Interrupted cell should report failure"
+
+        # The queued cell should also fail (cleared from queue, never ran)
+        queued_result = await asyncio.wait_for(queued_task, timeout=5)
+        assert not queued_result.success, "Cleared queued cell should report failure"
+
+        # Now execute a NEW cell — it should work immediately, not hang
+        verify_id = await session.create_cell("1 + 1")
+        verify_result = await asyncio.wait_for(
+            session.execute_cell(verify_id), timeout=10
+        )
+        assert verify_result.success, f"Post-interrupt cell should succeed: {verify_result}"
 
     async def test_async_shutdown_kernel(self, session):
         """Can shutdown the kernel."""


### PR DESCRIPTION
## Summary

Fixes #1583 — a single interrupt now properly clears the CRDT execution queue and unblocks subsequent cell execution.

**Three gaps caused the bug:**

1. **`kernel_manager::interrupt()` was fire-and-forget** — sent `InterruptRequest` over ZMQ but never waited for `InterruptReply`. Now waits with a 5s timeout so the SIGINT lands before state is cleared.

2. **RuntimeStateDoc was never updated after interrupt** — the shutdown handler properly called `sd.set_queue(None, &[])`, but the interrupt handler just returned `InterruptSent {}` with no CRDT update. Added `apply_interrupt_to_state_doc()` (modeled on `apply_cell_error_to_state_doc()`) that fork+merges the RuntimeStateDoc to clear the queue.

3. **Cleared queue entries were never marked as done** — cells drained from the local queue were left in "queued" state in RuntimeStateDoc indefinitely. Now each cleared entry gets `set_execution_done(id, false)`.

## Changes

- `kernel_manager.rs`: `interrupt()` waits for `InterruptReply` (5s timeout), returns `Vec<QueueEntry>`
- `protocol.rs`: New `RuntimeAgentResponse::InterruptAcknowledged { cleared }` variant
- `runtime_agent.rs`: Returns cleared entries via `InterruptAcknowledged`
- `notebook_sync_server.rs`: New `apply_interrupt_to_state_doc()` + wired into interrupt handler
- `test_daemon_integration.py`: Comprehensive test — interrupt during execution clears queue, post-interrupt cell succeeds

## Test plan

- [ ] Run integration test: `cargo xtask integration test_interrupt_clears_queue_and_unblocks`
- [ ] Manual: open notebook, run `time.sleep(60)`, interrupt, execute another cell — should work immediately
- [ ] Verify no regression: `cargo xtask integration`