### PR TITLE
chore: bump to 2.1.1, update README for runt CLI, fix prewarm syntax error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6210,7 +6210,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6352,7 +6352,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "kernel-env",
  "log",

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ Download the latest release from [GitHub Releases](https://github.com/nteract/de
 
 The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
 
-The Python bindings are available on PyPI:
-
-```bash
-pip install runtimed
-```
+The `runt` CLI and `runtimed` Python bindings ship with the app and stay up to date automatically. For nightly builds, use `runt-nightly` instead.
 
 ## What's in here
 
@@ -23,7 +19,7 @@ pip install runtimed
 | `nteract` | Desktop notebook editor (Tauri + React) |
 | `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
-| `runtimed` (PyPI) | Python bindings for the daemon |
+| `runtimed` (Python) | Python bindings for the daemon (ships with the app) |
 ## MCP Server
 
 The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents get 27 tools for working with notebooks — executing code, reading and writing cells, managing dependencies, and collaborating in real-time alongside humans in the desktop app.
@@ -55,13 +51,7 @@ claude mcp add nteract-nightly -- runt-nightly mcp
 }
 ```
 
-#### Via PyPI (convenience wrapper)
-
-If `runt` isn't on your PATH, the `nteract` PyPI package can find it in the app bundle:
-
-```bash
-claude mcp add nteract -- uvx nteract
-```
+The `runt` CLI ships with the desktop app. Use `runt` (stable) or `runt-nightly` directly — no PyPI install needed.
 
 ## Usage
 

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -293,7 +293,7 @@ import zmq
             script.push('\n');
             script.push_str("for module_name in ");
             script.push_str(&modules_json);
-            script.push_str("]:\n");
+            script.push_str(":\n");
             script.push_str("    try:\n");
             script.push_str("        __import__(module_name)\n");
             script.push_str("    except Exception:\n");

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.1.0"
+version = "2.1.1"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- **README**: Replace `pip install runtimed` and `uvx nteract` guidance with `runt`/`runt-nightly` CLI — ships with the desktop app, stays up to date automatically
- **Version bump**: 2.1.0 → 2.1.1 across all 8 release-tracked files (Cargo.toml × 5, tauri.conf.json, pyproject.toml × 2)
- **Bug fix** (`crates/runtimed/src/daemon.rs`): Fix double-bracket syntax error in prewarm import script generation — `serde_json::to_string` already produces `[...]`, but an extra `]` was appended, causing a Python `SyntaxError` that broke all prewarm imports (matplotlib, ipywidgets, etc.)

## Test plan

- [x] `cargo check` passes (Cargo.lock updated)
- [x] `cargo xtask lint` passes
- [ ] Verify prewarm works after daemon rebuild — packages should no longer show "Invalid or unavailable package"