### PR TITLE
fix(runt-mcp): replace_match context matching + create_notebook dep sync

### DIFF
--- a/crates/runt-mcp/src/editing.rs
+++ b/crates/runt-mcp/src/editing.rs
@@ -7,6 +7,7 @@
 //! Both require exactly one match to succeed.
 
 /// An edit span in the source text (byte offsets).
+#[derive(Debug)]
 pub struct EditSpan {
     pub start: usize,
     pub end: usize,
@@ -48,6 +49,11 @@ impl std::fmt::Display for EditError {
 
 /// Resolve a literal match with optional context disambiguation.
 ///
+/// Finds all occurrences of `match_text`, then filters by `context_before`
+/// and `context_after` proximity. Context strings are searched within a
+/// window around each match (same line + nearby lines), not required to be
+/// immediately adjacent.
+///
 /// Returns the byte span of the unique match, or an error.
 pub fn resolve_match(
     source: &str,
@@ -59,43 +65,79 @@ pub fn resolve_match(
         return Err(EditError::NoMatch("Match text cannot be empty".to_string()));
     }
 
-    // Build a regex that includes optional context
+    // Find all occurrences of the literal match text
     let escaped_match = regex::escape(match_text);
-    let pattern = match (context_before, context_after) {
-        (Some(before), Some(after)) => {
-            format!(
-                "{}{}{}",
-                regex::escape(before),
-                escaped_match,
-                regex::escape(after)
-            )
-        }
-        (Some(before), None) => format!("{}{}", regex::escape(before), escaped_match),
-        (None, Some(after)) => format!("{}{}", escaped_match, regex::escape(after)),
-        (None, None) => escaped_match,
-    };
+    let re =
+        regex::Regex::new(&escaped_match).map_err(|e| EditError::InvalidPattern(e.to_string()))?;
+    let all_matches: Vec<regex::Match> = re.find_iter(source).collect();
 
-    let re = regex::Regex::new(&pattern).map_err(|e| EditError::InvalidPattern(e.to_string()))?;
-    let matches: Vec<regex::Match> = re.find_iter(source).collect();
+    if all_matches.is_empty() {
+        return Err(EditError::NoMatch(format!(
+            "No match found for '{match_text}'"
+        )));
+    }
 
-    match matches.len() {
+    // If no context provided, require exactly one match
+    if context_before.is_none() && context_after.is_none() {
+        return match all_matches.len() {
+            1 => {
+                let m = &all_matches[0];
+                Ok(EditSpan {
+                    start: m.start(),
+                    end: m.end(),
+                })
+            }
+            n => Err(EditError::AmbiguousMatch {
+                count: n,
+                offsets: all_matches.iter().map(|m| m.start()).collect(),
+            }),
+        };
+    }
+
+    // For each match, search for context only in the "gap" between
+    // adjacent matches of the target text. This scopes context to the
+    // region that uniquely belongs to each match occurrence.
+    let filtered: Vec<&regex::Match> = all_matches
+        .iter()
+        .enumerate()
+        .filter(|(i, m)| {
+            if let Some(before) = context_before {
+                let gap_start = if *i > 0 { all_matches[i - 1].end() } else { 0 };
+                let before_text = &source[gap_start..m.start()];
+                if !before_text.contains(before) {
+                    return false;
+                }
+            }
+            if let Some(after) = context_after {
+                let gap_end = if *i + 1 < all_matches.len() {
+                    all_matches[i + 1].start()
+                } else {
+                    source.len()
+                };
+                let after_text = &source[m.end()..gap_end];
+                if !after_text.contains(after) {
+                    return false;
+                }
+            }
+            true
+        })
+        .map(|(_, m)| m)
+        .collect();
+
+    match filtered.len() {
         0 => Err(EditError::NoMatch(format!(
             "No match found for '{match_text}'"
         ))),
         1 => {
-            let m = &matches[0];
-            // Calculate the offset of the actual match within the full pattern
-            let context_before_len = context_before.map(|s| s.len()).unwrap_or(0);
-            let match_start = m.start() + context_before_len;
-            let match_end = match_start + match_text.len();
+            let m = filtered[0];
             Ok(EditSpan {
-                start: match_start,
-                end: match_end,
+                start: m.start(),
+                end: m.end(),
             })
         }
         n => Err(EditError::AmbiguousMatch {
             count: n,
-            offsets: matches.iter().map(|m| m.start()).collect(),
+            offsets: filtered.iter().map(|m| m.start()).collect(),
         }),
     }
 }
@@ -148,4 +190,119 @@ pub fn apply_replacement(source: &str, span: &EditSpan, replacement: &str) -> St
     result.push_str(replacement);
     result.push_str(&source[span.end..]);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── resolve_match: no context ───────────────────────────────
+
+    #[test]
+    fn match_unique_no_context() {
+        let source = "hello world";
+        let span = resolve_match(source, "world", None, None).unwrap();
+        assert_eq!(&source[span.start..span.end], "world");
+    }
+
+    #[test]
+    fn match_ambiguous_no_context() {
+        let source = "bar bar bar";
+        let err = resolve_match(source, "bar", None, None).unwrap_err();
+        assert!(matches!(err, EditError::AmbiguousMatch { count: 3, .. }));
+    }
+
+    #[test]
+    fn match_not_found() {
+        let source = "hello world";
+        let err = resolve_match(source, "xyz", None, None).unwrap_err();
+        assert!(matches!(err, EditError::NoMatch(_)));
+    }
+
+    // ── resolve_match: context_before ───────────────────────────
+
+    #[test]
+    fn context_before_disambiguates() {
+        let source = "a = \"foo bar\"\nb = \"baz bar\"\nc = \"qux bar\"";
+        let span = resolve_match(source, "bar", Some("baz"), None).unwrap();
+        let replaced = apply_replacement(source, &span, "BAR");
+        assert_eq!(
+            replaced,
+            "a = \"foo bar\"\nb = \"baz BAR\"\nc = \"qux bar\""
+        );
+    }
+
+    #[test]
+    fn context_before_with_gap() {
+        // "goodbye" is before "world" but not immediately adjacent
+        let source = "greeting = \"hello nteract\"\nfarewell = \"goodbye world\"";
+        let span = resolve_match(source, "world", Some("goodbye"), None).unwrap();
+        assert_eq!(&source[span.start..span.end], "world");
+    }
+
+    #[test]
+    fn context_before_no_match() {
+        let source = "a = \"foo bar\"\nb = \"baz bar\"";
+        let err = resolve_match(source, "bar", Some("zzz"), None).unwrap_err();
+        assert!(matches!(err, EditError::NoMatch(_)));
+    }
+
+    // ── resolve_match: context_after ────────────────────────────
+
+    #[test]
+    fn context_after_disambiguates() {
+        let source = "a = \"foo bar\"\nb = \"baz bar\"\nc = \"qux bar\"";
+        let span = resolve_match(source, "bar", None, Some("c =")).unwrap();
+        let replaced = apply_replacement(source, &span, "BAR");
+        assert_eq!(
+            replaced,
+            "a = \"foo bar\"\nb = \"baz BAR\"\nc = \"qux bar\""
+        );
+    }
+
+    // ── resolve_match: both contexts ────────────────────────────
+
+    #[test]
+    fn both_contexts() {
+        let source = "x bar y\na bar b\nx bar y";
+        let span = resolve_match(source, "bar", Some("a"), Some("b")).unwrap();
+        let replaced = apply_replacement(source, &span, "BAR");
+        assert_eq!(replaced, "x bar y\na BAR b\nx bar y");
+    }
+
+    // ── resolve_match: unique match with context still works ────
+
+    #[test]
+    fn unique_match_with_context_succeeds() {
+        let source = "greeting = \"hello nteract\"\nfarewell = \"goodbye world\"\nprint(greeting)\nprint(farewell)";
+        let span = resolve_match(source, "world", Some("goodbye"), None).unwrap();
+        let replaced = apply_replacement(source, &span, "universe");
+        assert!(replaced.contains("goodbye universe"));
+    }
+
+    // ── apply_replacement ───────────────────────────────────────
+
+    #[test]
+    fn apply_basic_replacement() {
+        let source = "hello world";
+        let span = EditSpan { start: 6, end: 11 };
+        assert_eq!(apply_replacement(source, &span, "rust"), "hello rust");
+    }
+
+    // ── resolve_regex ───────────────────────────────────────────
+
+    #[test]
+    fn regex_unique() {
+        let source = "foo = 42\nbar = 99";
+        let span = resolve_regex(source, r"\d+").unwrap_err();
+        // Two matches → ambiguous
+        assert!(matches!(span, EditError::AmbiguousMatch { count: 2, .. }));
+    }
+
+    #[test]
+    fn regex_multiline_anchor() {
+        let source = "foo = 42\nbar = 99";
+        let span = resolve_regex(source, r"^bar = \d+$").unwrap();
+        assert_eq!(&source[span.start..span.end], "bar = 99");
+    }
 }

--- a/crates/runt-mcp/src/editing.rs
+++ b/crates/runt-mcp/src/editing.rs
@@ -193,6 +193,7 @@ pub fn apply_replacement(source: &str, span: &EditSpan, replacement: &str) -> St
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -405,7 +405,15 @@ pub async fn create_notebook(
 
             let pkg_manager = arg_str(request, "package_manager").unwrap_or("uv");
 
-            if runtime != "deno" {
+            if runtime != "deno" && !deps.is_empty() {
+                // Flush any pending sync frames from the daemon so we have
+                // the full document structure (metadata map, runt map) before
+                // writing deps.  Without this, a concurrent daemon sync can
+                // race with the client-side put_object and shadow our writes.
+                if let Err(e) = result.handle.confirm_sync().await {
+                    tracing::warn!("confirm_sync before create_notebook deps failed: {e}");
+                }
+
                 for dep in &deps {
                     let _ = super::deps::add_dep_for_manager(&result.handle, dep, pkg_manager);
                 }


### PR DESCRIPTION
## Summary

- **replace_match context_before/context_after** (#1588): Rewrote `resolve_match` to find all occurrences of the match text first, then filter by checking whether context strings appear in the inter-match gap (the text region between adjacent occurrences). The old approach concatenated context + match into a single regex (`bazbar`), which failed whenever there was any whitespace or gap between context and match text.

- **create_notebook deps persistence** (#1587): Added `confirm_sync()` before writing dependencies to the CRDT after `connect_create`, ensuring the daemon's document structure (metadata map, runt map) is fully received before client-side `put_object` calls. Without this, a concurrent daemon sync could race and shadow the writes. Also tightened the condition to skip the dep-writing loop entirely when deps are empty.

## Test plan

- [x] `replace_match` with `context_before="baz"` on `"baz bar"` — now finds the correct occurrence
- [x] `replace_match` with `context_after="c ="` — disambiguates correctly
- [x] `replace_match` with both contexts — narrows to unique match
- [x] Unique match with context still succeeds (no false negatives)
- [x] 12 unit tests in `editing::tests` all pass
- [x] `create_notebook(dependencies=["pandas>=2.0", "numpy"])` → `get_dependencies` returns them
- [x] All 29 runt-mcp tests pass
- [x] Python editing tests (48) still pass

Closes #1587
Closes #1588