### PR TITLE
docs: fix stale references and missing entries across documentation

### DIFF
--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -32,6 +32,7 @@ paths:
 │   │   ├── wasm/                 <- WASM bindings (runtimed-wasm)
 │   │   ├── App.tsx               <- Root component
 │   │   └── types.ts              <- App types
+│   ├── notebook/feedback/         <- Feedback sub-app
 │   ├── notebook/onboarding/      <- Onboarding sub-app
 │   ├── notebook/settings/        <- Settings sub-app
 │   └── notebook/upgrade/         <- Upgrade sub-app
@@ -75,6 +76,9 @@ Put code in `apps/notebook/src/` when:
 | `usePresence` | Remote cursor/selection tracking via presence frames |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
+| `usePixiDependencies` | Pixi/conda dependency management |
+| `usePoolState` | Daemon pool state via PoolDoc sync |
+| `useCrdtBridge` | CodeMirror ↔ CRDT character-level sync |
 | `useManifestResolver` | Resolves blob hashes to output data |
 | `useCellKeyboardNavigation` | Arrow keys, enter/escape modes |
 | `useEditorRegistry` | CodeMirror editor instance registry |
@@ -120,7 +124,7 @@ Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_
 
 ## CellChangeset Types
 
-Defined in `notebook-doc/src/diff.rs`, with TypeScript mirrors in `useAutomergeNotebook.ts`:
+Defined in `notebook-doc/src/diff.rs`, with TypeScript types in `packages/runtimed/src/cell-changeset.ts` (re-exported via `apps/notebook/src/lib/cell-changeset.ts`):
 - `CellChangeset` -- `{ changed, added, removed, order_changed }`
 - `ChangedCell` -- `{ cell_id, fields }` where `fields` has boolean flags: `source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`
 - `mergeChangesets()` -- union semantics for the coalescing window

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -52,8 +52,9 @@ After handshake, frames are typed by first byte:
 | `0x03` | NotebookBroadcast | JSON |
 | `0x04` | Presence | Binary (CBOR) |
 | `0x05` | RuntimeStateSync | Binary (raw Automerge sync for RuntimeStateDoc) |
+| `0x06` | PoolStateSync | Binary (raw Automerge sync for PoolDoc — global daemon pool state) |
 
-Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types from the frontend.
+Only `0x00` (AutomergeSync), `0x04` (Presence), and `0x06` (PoolStateSync) are valid outgoing types from the frontend.
 
 ## Key Request Types
 
@@ -169,7 +170,7 @@ Each cell execution is assigned a unique `execution_id` (UUID). The `QueueEntry`
 | `crates/notebook-sync/src/relay.rs` | Relay handle for sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` -- sync, per-cell accessors |
-| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00-0x05) |
+| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00-0x06) |
 | `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc` schema |
 | `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub |

--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -23,7 +23,7 @@ pnpm dlx shadcn@latest add dialog -yo
 ├── components.json          # shadcn configuration
 ├── tailwind.config.js       # Tailwind config (covers src/ and apps/)
 ├── src/
-│   ├── components/ui/       # 23 shared shadcn components
+│   ├── components/ui/       # 24 shared shadcn components
 │   └── lib/utils.ts         # cn() utility
 └── apps/
     └── notebook/            # Uses @/components/ui/* via path alias

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -46,10 +46,10 @@ The system is split into 16 Rust crates, a React/TypeScript frontend, and 3
 Python packages. The major architectural seams are:
 
 ### Daemon ↔ Client Protocol
-- Unix socket, length-prefixed typed frames (6 frame types)
+- Unix socket, length-prefixed typed frames (7 frame types)
 - Preamble (magic + version) → JSON handshake → Automerge initial sync → steady state
 - Frame types: AutomergeSync (0x00), Request (0x01), Response (0x02),
-  Broadcast (0x03), Presence (0x04), RuntimeStateSync (0x05)
+  Broadcast (0x03), Presence (0x04), RuntimeStateSync (0x05), PoolStateSync (0x06)
 - Requests are fire-and-forget style (ExecuteCell, LaunchKernel, etc.)
 - Broadcasts push state changes to all connected clients
 
@@ -77,6 +77,12 @@ Python packages. The major architectural seams are:
 - `kernel-env`: UV/Conda venv creation with progress reporting
 - `runt-trust`: HMAC-SHA256 notebook trust
 - `runt-workspace`: Per-worktree daemon socket isolation
+- `runt`: CLI binary (daemon management, kernel control, notebook launching, MCP server)
+- `runtimed-client`: Shared client library (output resolution, daemon paths, pool client)
+- `runt-mcp`: Rust-native MCP server (27 tools for notebook interaction)
+- `mcp-supervisor`: nteract-dev MCP supervisor proxy, daemon/vite lifecycle
+- `repr-llm`: LLM-friendly text summaries of visualization specs
+- `notebook`: Tauri desktop app (main GUI, bundles daemon+CLI as sidecars)
 
 ### Frontend
 - React + CodeMirror, split cell store (per-cell subscriptions)
@@ -90,7 +96,7 @@ Python packages. The major architectural seams are:
 - Prewarmed pool: 3 UV + 3 Conda envs, warmed every 30s, max 2-day age
 
 ### Invariants That Bite
-- `is_binary_mime()` must be identical in 3 places (Rust daemon, Rust Python bindings, TypeScript)
+- `is_binary_mime()` has one canonical Rust implementation in `notebook-doc::mime` — the single source of truth. All Rust crates (`runtimed`, `runtimed-client`, `runtimed-wasm`) use this module. On the TypeScript side, `looksLikeBinaryMime()` in `manifest-resolution.ts` exists only as a safety net for blob refs that WASM couldn't resolve — it is not an authoritative copy.
 - Iframe must never get `allow-same-origin`
 - Per-cell accessors must stay in sync across WASM, Rust, and Python
 

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -163,7 +163,8 @@ crates/runtimed/src/
   daemon.rs                — Daemon state, pool management, connection routing
   notebook_sync_server.rs  — NotebookRoom, room lifecycle, autosave, re-keying
   kernel_manager.rs        — RoomKernel: lifecycle, execution queue, IOPub routing
-  comm_state.rs            — Widget comm state + Output widget capture routing
+  runtime_agent.rs         — Process-isolated runtime agent: kernel lifecycle, IOPub, RuntimeStateDoc writes
+  runtime_agent_handle.rs  — Coordinator-side runtime agent process management
   output_store.rs          — Output manifest creation, blob inlining threshold
   blob_store.rs            — Content-addressed blob store with metadata sidecars
   blob_server.rs           — HTTP read server for blobs
@@ -174,8 +175,14 @@ crates/runtimed/src/
   markdown_assets.rs       — Markdown output asset rendering and resolution
   terminal_size.rs         — Terminal size detection for kernel PTY
   project_file.rs          — Unified project file discovery (pyproject, pixi, env.yml)
+  sync_server.rs           — Settings Automerge sync handler
 crates/runtimed-client/src/
+  lib.rs                   — Crate root
   client.rs                — Client APIs used by Python bindings and MCP
+  daemon_paths.rs          — Shared socket/blob path resolution
+  output_resolver.rs       — Shared Rust manifest resolution
+  resolved_output.rs       — Output resolution types
+  singleton.rs             — File-based daemon discovery/locking helpers
   protocol.rs              — Client-side protocol helpers and typed request wrappers
   settings_doc.rs          — Settings Automerge document, schema, migration
   sync_client.rs           — Settings sync client wrapper

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -142,8 +142,8 @@ Use `nteract-dev` as the repo-local MCP server name so it stays distinct from an
 {
   "context_servers": {
     "nteract-dev": {
-      "command": "./target/debug/mcp-supervisor",
-      "args": [],
+      "command": "cargo",
+      "args": ["run", "-p", "mcp-supervisor"],
       "env": { "RUNTIMED_DEV": "1" }
     }
   }

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -152,6 +152,9 @@ cargo xtask e2e test-fixture \
 | `3-conda-inline.ipynb` | `conda-inline.spec.js` | Conda inline dependency resolution |
 | `10-deno.ipynb` | `deno.spec.js` | Deno kernel start + TypeScript execution |
 | `pyproject-project/5-pyproject.ipynb` | `uv-pyproject.spec.js` | pyproject.toml environment detection |
+| `14-cell-visibility.ipynb` | `cell-visibility.spec.js` | Cell source/output visibility toggling |
+| `15-run-all-output-lifecycle.ipynb` | `run-all-output-lifecycle.spec.js` | Run-all output lifecycle |
+| (directory-based pyproject fixture) | `untitled-pyproject.spec.js` | Untitled notebook with pyproject directory context |
 
 ### Adding a New Fixture Test
 

--- a/.claude/skills/typescript-bindings/SKILL.md
+++ b/.claude/skills/typescript-bindings/SKILL.md
@@ -13,7 +13,7 @@ TypeScript types in `src/bindings/` are auto-generated from Rust structs and enu
 
 | Rust File | Generated Types |
 |-----------|-----------------|
-| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
+| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `PixiDefaults`, `SyncedSettings` |
 | `crates/runtimed-client/src/runtime.rs` | `Runtime` |
 
 ## How It Works
@@ -105,6 +105,7 @@ The ts-rs procedural macro exports types during test compilation. Generated file
 ```
 src/bindings/
   CondaDefaults.ts
+  PixiDefaults.ts
   PythonEnvType.ts
   Runtime.ts
   SyncedSettings.ts

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -16,7 +16,7 @@ When changing the wire handshake or typed frame semantics, also inspect:
 
 ## MIME classification contract
 
-Single canonical Rust implementation in `crates/notebook-doc/src/mime.rs` (`is_binary_mime()`, `mime_kind()`, `MimeKind` enum). All Rust crates use this module. The old per-crate copies in `runtimed/src/output_store.rs`, `runtimed-client/src/output_resolver.rs`, and the TypeScript `isBinaryMime()` in `manifest-resolution.ts` have been deleted — WASM owns MIME classification end-to-end.
+Single canonical Rust implementation in `crates/notebook-doc/src/mime.rs` (`is_binary_mime()`, `mime_kind()`, `MimeKind` enum). All Rust crates use this module. The old per-crate copies have been deleted. WASM owns MIME classification end-to-end. A `looksLikeBinaryMime()` safety net remains in `manifest-resolution.ts` for blob refs that WASM couldn't resolve — it is not an authoritative copy.
 
 Important rule: `image/svg+xml` is text, not binary.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,10 +338,11 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask dev-mcp` | Direct nteract MCP (no supervisor) |
 | | `cargo xtask dev-mcp --print-config` | Print direct MCP client config JSON |
+| | `cargo xtask mcp-inspector` | Launch MCP Inspector UI for testing runt mcp |
 | Lint | `cargo xtask lint` | Check formatting (Rust, JS/TS, Python) |
 | | `cargo xtask lint --fix` | Auto-fix formatting |
 | Test | `cargo xtask integration [filter]` | Python integration tests with isolated daemon |
-| | `cargo xtask e2e` | E2E testing (WebdriverIO) |
+| | `cargo xtask e2e [build|test|test-fixture|test-all]` | E2E testing (WebdriverIO) |
 | Other | `cargo xtask wasm` | Rebuild runtimed-wasm |
 | | `cargo xtask icons [source.png]` | Generate icon variants |
 | | `cargo xtask mcpb` | Package nteract as a Claude Desktop extension (`.mcpb`) |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ nteract/desktop
 |------|---------|---------|
 | Node.js | 20+ | https://nodejs.org |
 | pnpm | 10.12+ | `corepack enable` |
-| Rust | 1.90.0 | https://rustup.rs (version managed by `rust-toolchain.toml`) |
+| Rust | 1.94.0 | https://rustup.rs (version managed by `rust-toolchain.toml`) |
 
 **Linux only:** Install GTK/WebKit dev libraries:
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ macOS builds are signed and notarized. Windows builds are not code signed.
 
 ### Crate publishing
 
-`runt-cli`, `runtimed-py`, and `xtask` are **not published to crates.io** (`publish = false`).
+`runt-cli`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, and `xtask` are **not published to crates.io** (`publish = false`).
 
 ## Python Packages (runtimed, nteract)
 

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -269,7 +269,7 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
 - `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
 - `crates/runtimed/src/kernel_manager.rs` — `RoomKernel`: kernel process lifecycle, execution queue, IOPub output routing
-- `crates/runtimed/src/comm_state.rs` — Widget comm state + Output widget capture routing
+- `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, comm state diffing, kernel ownership
 - `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `ContentRef`
 - `crates/notebook-doc/src/mime.rs` — Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`)
 - `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -29,6 +29,7 @@ This guide explains the frontend code organization and how shared components rel
 │   │   ├── wasm/                 ← WASM bindings (runtimed-wasm)
 │   │   ├── App.tsx               ← Root component
 │   │   └── types.ts              ← App types
+│   ├── notebook/feedback/        ← Feedback sub-app
 │   ├── notebook/onboarding/      ← Onboarding sub-app (separate HTML entry point)
 │   ├── notebook/settings/        ← Settings sub-app
 │   └── notebook/upgrade/         ← Upgrade sub-app
@@ -132,6 +133,9 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 | `useHistorySearch` | Kernel input history search |
 | `useTrust` | Notebook trust verification state |
 | `useUpdater` | App update checking and installation |
+| `usePixiDependencies` | Pixi/conda dependency management |
+| `usePoolState` | Daemon pool state |
+| `useCrdtBridge` | CodeMirror ↔ CRDT character-level sync |
 
 ## Data Flow
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -346,7 +346,7 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 |------|------|
 | `crates/notebook-protocol/src/connection.rs` | Frame protocol: length-prefixed typed frames, handshake, preamble |
 | `crates/notebook-protocol/src/protocol.rs` | Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast` |
-| `crates/runtimed/src/protocol.rs` | Daemon-internal types (`Request`, `Response`, `BlobRequest`), re-exports from `notebook-protocol` |
+| `crates/runtimed-client/src/protocol.rs` | Daemon-internal types (`Request`, `Response`, `BlobRequest`), re-exports from `notebook-protocol` |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup (`connect_open_relay`, `connect_create_relay`) |
 | `crates/notebook-sync/src/handle.rs` | `DocHandle` — sync infrastructure, per-cell accessors for Python clients |

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -36,6 +36,7 @@ All six version sources must stay in sync. When preparing a release:
 ```bash
 # Update all of these to the same version:
 #   crates/runtimed/Cargo.toml
+#   crates/runtimed-client/Cargo.toml
 #   crates/runt/Cargo.toml
 #   crates/notebook/Cargo.toml
 #   crates/notebook/tauri.conf.json

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -233,7 +233,8 @@ crates/runtimed/
 │   ├── runtime_agent_handle.rs  # Coordinator-side runtime agent process management (spawn + monitor)
 │   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
 │   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
-│   ├── comm_state.rs            # Widget comm state + Output widget capture routing
+│   ├── singleton.rs             # Daemon locking/singleton management
+│   ├── sync_server.rs           # Settings Automerge sync handler
 │   ├── output_store.rs          # Output manifest creation, blob inlining threshold
 │   ├── blob_store.rs            # Content-addressed blob store with metadata sidecars
 │   ├── blob_server.rs           # HTTP read server for blobs (hyper 1.x)
@@ -245,7 +246,11 @@ crates/runtimed/
 ├── tests/
 │   └── integration.rs           # Integration tests (daemon, pool, settings sync, notebook sync)
 crates/runtimed-client/
+├── src/lib.rs                   # Crate root
 ├── src/client.rs                # Pool/notebook client APIs
+├── src/daemon_paths.rs          # Shared socket/blob path resolution
+├── src/output_resolver.rs       # Shared Rust manifest resolution
+├── src/resolved_output.rs       # Output resolution types
 ├── src/protocol.rs              # Client-side protocol helpers and typed request wrappers
 ├── src/settings_doc.rs          # Settings Automerge document, schema, migration
 ├── src/singleton.rs             # File-based daemon discovery/locking helpers

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -73,7 +73,7 @@ describe("AnsiOutput", () => {
 Rust tests are inline modules using `#[cfg(test)]`:
 
 ```rust
-// crates/runtimed/src/runtime.rs
+// crates/runtimed-client/src/runtime.rs
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contributing/typescript-bindings.md
+++ b/contributing/typescript-bindings.md
@@ -10,7 +10,7 @@ The `ts-rs` crate generates TypeScript type definitions from Rust types annotate
 
 | Rust File | Generated Types |
 |-----------|-----------------|
-| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
+| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `PixiDefaults`, `SyncedSettings` |
 | `crates/runtimed-client/src/runtime.rs` | `Runtime` |
 
 ## How It Works
@@ -105,6 +105,7 @@ The ts-rs procedural macro exports types during test compilation. Generated file
 ```
 src/bindings/
 ├── CondaDefaults.ts
+├── PixiDefaults.ts
 ├── PythonEnvType.ts
 ├── Runtime.ts
 ├── SyncedSettings.ts

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -86,6 +86,10 @@ You can open the same notebook in the [nteract desktop app](https://nteract.io) 
 | `move_cell` | Reorder a cell within the notebook |
 | `clear_outputs` | Clear a cell's outputs |
 | `delete_cell` | Remove a cell from the notebook |
+| `set_cells_source_hidden` | Show/hide cell source |
+| `set_cells_outputs_hidden` | Show/hide cell outputs |
+| `add_cell_tags` | Add tags to cells |
+| `remove_cell_tags` | Remove tags from cells |
 | `interrupt_kernel` | Interrupt the currently executing cell |
 | `restart_kernel` | Restart kernel with updated dependencies |
 | `show_notebook` | Open the notebook in the nteract desktop app (disabled with `--no-show`) |


### PR DESCRIPTION
- README.md: Rust version 1.90.0 → 1.94.0 to match rust-toolchain.toml
- AGENTS.md: add mcp-inspector command, e2e sub-commands to xtask table
- RELEASING.md: add mcp-supervisor and runt-mcp to publish=false list
- contributing/releasing.md: add runtimed-client to version bump checklist
- contributing/architecture.md: update comm_state.rs ref to runtime_agent.rs
- contributing/runtimed.md: remove deleted comm_state.rs, add singleton.rs,
  sync_server.rs, and 4 missing runtimed-client source files
- contributing/protocol.md: fix protocol.rs path (runtimed → runtimed-client)
- contributing/testing.md: fix runtime.rs path (runtimed → runtimed-client)
- contributing/typescript-bindings.md: add PixiDefaults.ts to generated files
- contributing/frontend-architecture.md: add missing hooks and feedback/ sub-app
- python/nteract/README.md: add 4 missing cell-metadata MCP tools
