### PR TITLE
fix(runtimed): enforce external settings.json edits over stale window sync

### DIFF
--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -236,6 +236,11 @@ pub fn write_settings_schema() -> std::io::Result<()> {
 /// containing lists for environment-specific settings.
 pub struct SettingsDoc {
     doc: AutoCommit,
+    /// When the file watcher applies external JSON changes, the values are stored
+    /// here so they can be re-applied after incoming sync messages. This ensures
+    /// external edits are authoritative over stale window state.
+    /// See <https://github.com/nteract/desktop/issues/1598>.
+    pending_external_values: Option<serde_json::Value>,
 }
 
 impl SettingsDoc {
@@ -275,7 +280,10 @@ impl SettingsDoc {
             let _ = doc.put_object(&conda_id, "default_packages", ObjType::List);
         }
 
-        Self { doc }
+        Self {
+            doc,
+            pending_external_values: None,
+        }
     }
 
     /// Load a settings document from a saved binary, or create a new one with
@@ -292,7 +300,10 @@ impl SettingsDoc {
             if let Ok(data) = std::fs::read(automerge_path) {
                 if let Ok(doc) = AutoCommit::load(&data) {
                     info!("[settings] Loaded Automerge doc from {:?}", automerge_path);
-                    let mut settings = Self { doc };
+                    let mut settings = Self {
+                        doc,
+                        pending_external_values: None,
+                    };
                     settings.migrate_flat_to_nested();
                     settings.migrate_null_keep_alive();
 
@@ -430,7 +441,10 @@ impl SettingsDoc {
     /// Load a settings document from raw bytes.
     pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
         let doc = AutoCommit::load(data)?;
-        Ok(Self { doc })
+        Ok(Self {
+            doc,
+            pending_external_values: None,
+        })
     }
 
     /// Serialize the document to bytes for persistence.
@@ -596,7 +610,8 @@ impl SettingsDoc {
 
     /// Replace a list of strings at a dotted path.
     ///
-    /// Deletes the existing list (if any) and creates a new one with the given items.
+    /// Reuses the existing Automerge List object when possible to avoid
+    /// competing `put_object` calls from different peers. See #1594, #1602.
     pub fn put_list(&mut self, key: &str, values: &[String]) {
         let (map_key, sub_key) = match key.split_once('.') {
             Some(pair) => pair,
@@ -604,14 +619,24 @@ impl SettingsDoc {
         };
         let map_id = self.ensure_map(map_key);
 
-        // Delete existing value at this key (list or otherwise)
-        let _ = self.doc.delete(&map_id, sub_key);
-
-        // Create new list and insert items
-        if let Ok(list_id) = self.doc.put_object(&map_id, sub_key, ObjType::List) {
-            for (i, item) in values.iter().enumerate() {
-                let _ = self.doc.insert(&list_id, i, item.as_str());
+        // Reuse existing List if present, only create if missing or wrong type
+        let list_id = match self.doc.get(&map_id, sub_key).ok().flatten() {
+            Some((automerge::Value::Object(ObjType::List), id)) => {
+                // Clear existing elements from end to avoid index shifting
+                let len = self.doc.length(&id);
+                for i in (0..len).rev() {
+                    let _ = self.doc.delete(&id, i);
+                }
+                id
             }
+            _ => match self.doc.put_object(&map_id, sub_key, ObjType::List) {
+                Ok(id) => id,
+                Err(_) => return,
+            },
+        };
+
+        for (i, item) in values.iter().enumerate() {
+            let _ = self.doc.insert(&list_id, i, item.as_str());
         }
     }
 
@@ -817,6 +842,30 @@ impl SettingsDoc {
         }
 
         changed
+    }
+
+    /// Store the last externally-applied JSON so it can be re-applied after
+    /// sync messages that might revert it via conflict resolution.
+    pub fn set_pending_external_values(&mut self, json: serde_json::Value) {
+        self.pending_external_values = Some(json);
+    }
+
+    /// Re-apply pending external values if a sync merge reverted them.
+    ///
+    /// Returns `true` if any values were re-applied (i.e., a sync message
+    /// had overwritten the file watcher's changes). Clears the pending state
+    /// once all peers have converged (apply_json_changes returns false).
+    pub fn enforce_external_values(&mut self) -> bool {
+        let json = match self.pending_external_values.take() {
+            Some(json) => json,
+            None => return false,
+        };
+        let reapplied = self.apply_json_changes(&json);
+        if reapplied {
+            // Values drifted — keep enforcing until peers converge
+            self.pending_external_values = Some(json);
+        }
+        reapplied
     }
 }
 
@@ -1150,6 +1199,7 @@ mod tests {
         // Automerge CRDT conflicts that resolve nondeterministically).
         let mut client = SettingsDoc {
             doc: AutoCommit::new(),
+            pending_external_values: None,
         };
 
         let mut server_state = sync::State::new();
@@ -1389,7 +1439,10 @@ mod tests {
         let _ = automerge_doc.put(automerge::ROOT, "keep_alive_secs", -5_i64);
 
         // Wrap in SettingsDoc
-        let doc = SettingsDoc { doc: automerge_doc };
+        let doc = SettingsDoc {
+            doc: automerge_doc,
+            pending_external_values: None,
+        };
 
         // Negative Int should return None (invalid)
         let result = doc.get_u64("keep_alive_secs");
@@ -1408,7 +1461,10 @@ mod tests {
             automerge::ScalarValue::Null,
         );
 
-        let mut doc = SettingsDoc { doc: automerge_doc };
+        let mut doc = SettingsDoc {
+            doc: automerge_doc,
+            pending_external_values: None,
+        };
 
         // Verify it's detected as null
         assert!(doc.is_null("keep_alive_secs"));
@@ -1467,7 +1523,10 @@ mod tests {
 
         // Empty doc with no keep_alive_secs key
         let automerge_doc = AutoCommit::new();
-        let doc = SettingsDoc { doc: automerge_doc };
+        let doc = SettingsDoc {
+            doc: automerge_doc,
+            pending_external_values: None,
+        };
 
         // Missing key is not the same as null
         assert!(!doc.is_null("keep_alive_secs"));

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -313,9 +313,14 @@ impl SettingsDoc {
                     if let Some(json_path) = settings_json_path {
                         if json_path.exists() {
                             if let Ok(contents) = std::fs::read_to_string(json_path) {
-                                if let Ok(json) = serde_json::from_str(&contents) {
+                                if let Ok(json) =
+                                    serde_json::from_str::<serde_json::Value>(&contents)
+                                {
                                     if settings.apply_json_changes(&json) {
                                         info!("[settings] Reconciled Automerge doc with settings.json");
+                                        // Protect against stale clients reconnecting after
+                                        // restart — same as the live file-watcher path.
+                                        settings.set_pending_external_values(json);
                                     }
                                 }
                             }
@@ -853,19 +858,25 @@ impl SettingsDoc {
     /// Re-apply pending external values if a sync merge reverted them.
     ///
     /// Returns `true` if any values were re-applied (i.e., a sync message
-    /// had overwritten the file watcher's changes). Clears the pending state
-    /// once all peers have converged (apply_json_changes returns false).
+    /// had overwritten the file watcher's changes via conflict resolution).
+    ///
+    /// Pending values are never cleared here — they persist until the next
+    /// file-watcher event replaces them. This is intentional: an up-to-date
+    /// peer's no-op sync must not disarm the protection before a stale peer
+    /// has a chance to sync.
     pub fn enforce_external_values(&mut self) -> bool {
-        let json = match self.pending_external_values.take() {
+        let json = match self.pending_external_values.clone() {
             Some(json) => json,
             None => return false,
         };
-        let reapplied = self.apply_json_changes(&json);
-        if reapplied {
-            // Values drifted — keep enforcing until peers converge
-            self.pending_external_values = Some(json);
-        }
-        reapplied
+        self.apply_json_changes(&json)
+    }
+
+    /// Clear pending external values. Called by the file watcher when it
+    /// detects a self-write (values already match the doc), indicating
+    /// all peers have converged and the override is no longer needed.
+    pub fn clear_pending_external_values(&mut self) {
+        self.pending_external_values = None;
     }
 }
 

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -316,11 +316,13 @@ impl SettingsDoc {
                                 if let Ok(json) =
                                     serde_json::from_str::<serde_json::Value>(&contents)
                                 {
-                                    if settings.apply_json_changes(&json) {
+                                    if let Some(changed_fields) =
+                                        settings.apply_json_changes_with_diff(&json)
+                                    {
                                         info!("[settings] Reconciled Automerge doc with settings.json");
                                         // Protect against stale clients reconnecting after
-                                        // restart — same as the live file-watcher path.
-                                        settings.set_pending_external_values(json);
+                                        // restart — store only the changed fields.
+                                        settings.set_pending_external_values(changed_fields);
                                     }
                                 }
                             }
@@ -784,7 +786,26 @@ impl SettingsDoc {
     /// Only updates fields that are **present** in the JSON and **differ** from
     /// the current document state. Returns `true` if any field was modified.
     pub fn apply_json_changes(&mut self, json: &serde_json::Value) -> bool {
-        let mut changed = false;
+        self.apply_json_changes_inner(json).is_some()
+    }
+
+    /// Like [`apply_json_changes`], but also returns a JSON object containing
+    /// only the fields that were actually modified. Returns `None` if nothing
+    /// changed.
+    ///
+    /// This is used by the file watcher to store only the changed fields as
+    /// pending external values, so that `enforce_external_values` only
+    /// protects those specific fields — leaving other fields free to change
+    /// via the UI. See #1598.
+    pub fn apply_json_changes_with_diff(
+        &mut self,
+        json: &serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        self.apply_json_changes_inner(json)
+    }
+
+    fn apply_json_changes_inner(&mut self, json: &serde_json::Value) -> Option<serde_json::Value> {
+        let mut diff = serde_json::Map::new();
 
         // Scalar fields — only update if present in JSON and different
         for key in &["theme", "default_runtime", "default_python_env"] {
@@ -796,7 +817,10 @@ impl SettingsDoc {
                         current.as_deref()
                     );
                     self.put(key, value);
-                    changed = true;
+                    diff.insert(
+                        (*key).to_string(),
+                        serde_json::Value::String(value.to_string()),
+                    );
                 }
             }
         }
@@ -806,7 +830,9 @@ impl SettingsDoc {
             let uv_packages = Self::extract_packages_from_json(json, "uv");
             if self.get_list("uv.default_packages") != uv_packages {
                 self.put_list("uv.default_packages", &uv_packages);
-                changed = true;
+                if let Some(uv_val) = json.get("uv") {
+                    diff.insert("uv".to_string(), uv_val.clone());
+                }
             }
         }
 
@@ -815,11 +841,12 @@ impl SettingsDoc {
             let conda_packages = Self::extract_packages_from_json(json, "conda");
             if self.get_list("conda.default_packages") != conda_packages {
                 self.put_list("conda.default_packages", &conda_packages);
-                changed = true;
+                if let Some(conda_val) = json.get("conda") {
+                    diff.insert("conda".to_string(), conda_val.clone());
+                }
             }
         }
 
-        // keep_alive_secs (numeric or null for forever)
         // keep_alive_secs: numeric value in seconds (invalid values are ignored)
         if let Some(new_secs) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
             let current = self.get_u64("keep_alive_secs");
@@ -829,7 +856,10 @@ impl SettingsDoc {
                     current, new_secs
                 );
                 self.put_u64("keep_alive_secs", new_secs);
-                changed = true;
+                diff.insert(
+                    "keep_alive_secs".to_string(),
+                    serde_json::Value::Number(new_secs.into()),
+                );
             }
         }
 
@@ -842,15 +872,26 @@ impl SettingsDoc {
                     current, completed
                 );
                 self.put_bool("onboarding_completed", completed);
-                changed = true;
+                diff.insert(
+                    "onboarding_completed".to_string(),
+                    serde_json::Value::Bool(completed),
+                );
             }
         }
 
-        changed
+        if diff.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(diff))
+        }
     }
 
-    /// Store the last externally-applied JSON so it can be re-applied after
-    /// sync messages that might revert it via conflict resolution.
+    /// Store the externally-changed fields so they can be re-applied after
+    /// sync messages that might revert them via conflict resolution.
+    ///
+    /// Only the fields that were actually modified should be stored (use
+    /// the return value of `apply_json_changes_with_diff`), so that
+    /// unrelated fields remain free to change via the UI.
     pub fn set_pending_external_values(&mut self, json: serde_json::Value) {
         self.pending_external_values = Some(json);
     }
@@ -860,10 +901,9 @@ impl SettingsDoc {
     /// Returns `true` if any values were re-applied (i.e., a sync message
     /// had overwritten the file watcher's changes via conflict resolution).
     ///
-    /// Pending values are never cleared here — they persist until the next
-    /// file-watcher event replaces them. This is intentional: an up-to-date
-    /// peer's no-op sync must not disarm the protection before a stale peer
-    /// has a chance to sync.
+    /// Only the fields originally changed by the external edit are enforced —
+    /// other fields remain free to change via the UI. Pending values persist
+    /// until a new external edit replaces them or the daemon restarts.
     pub fn enforce_external_values(&mut self) -> bool {
         let json = match self.pending_external_values.clone() {
             Some(json) => json,

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -871,13 +871,6 @@ impl SettingsDoc {
         };
         self.apply_json_changes(&json)
     }
-
-    /// Clear pending external values. Called by the file watcher when it
-    /// detects a self-write (values already match the doc), indicating
-    /// all peers have converged and the override is no longer needed.
-    pub fn clear_pending_external_values(&mut self) {
-        self.pending_external_values = None;
-    }
 }
 
 impl Default for SettingsDoc {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -910,11 +910,6 @@ impl Daemon {
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
                                     }
-                                } else {
-                                    // Self-write detected (persist_settings wrote the JSON
-                                    // mirror and the watcher fired, but values already match).
-                                    // All peers have converged — clear the override.
-                                    doc.clear_pending_external_values();
                                 }
                                 changed
                             };

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -897,6 +897,11 @@ impl Daemon {
                                 let mut doc = self.settings.write().await;
                                 let changed = doc.apply_json_changes(&json);
                                 if changed {
+                                    // Store the external values so they can be re-applied
+                                    // after sync messages that might revert them via CRDT
+                                    // conflict resolution. See #1598.
+                                    doc.set_pending_external_values(json.clone());
+
                                     // Only persist the Automerge binary — do NOT write
                                     // the JSON mirror back, as serde_json formatting
                                     // differs from editors (e.g. arrays expand to one

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -892,15 +892,16 @@ impl Daemon {
                                 }
                             };
 
-                            // Apply changes to the Automerge doc
+                            // Apply changes to the Automerge doc, capturing only the
+                            // fields that actually changed so we can enforce just those
+                            // fields without blocking unrelated UI changes. See #1598.
                             let changed = {
                                 let mut doc = self.settings.write().await;
-                                let changed = doc.apply_json_changes(&json);
-                                if changed {
-                                    // Store the external values so they can be re-applied
-                                    // after sync messages that might revert them via CRDT
-                                    // conflict resolution. See #1598.
-                                    doc.set_pending_external_values(json.clone());
+                                let changed = doc.apply_json_changes_with_diff(&json);
+                                if let Some(changed_fields) = changed {
+                                    // Store only the changed fields so enforce_external_values
+                                    // protects just those fields, not the entire settings JSON.
+                                    doc.set_pending_external_values(changed_fields);
 
                                     // Only persist the Automerge binary — do NOT write
                                     // the JSON mirror back, as serde_json formatting
@@ -910,8 +911,10 @@ impl Daemon {
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
                                     }
+                                    true
+                                } else {
+                                    false
                                 }
-                                changed
                             };
 
                             if changed {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -910,6 +910,11 @@ impl Daemon {
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
                                     }
+                                } else {
+                                    // Self-write detected (persist_settings wrote the JSON
+                                    // mirror and the watcher fired, but values already match).
+                                    // All peers have converged — clear the override.
+                                    doc.clear_pending_external_values();
                                 }
                                 changed
                             };

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -71,6 +71,12 @@ where
                         let mut doc = settings.write().await;
                         doc.receive_sync_message(&mut peer_state, message)?;
 
+                        // Re-apply any pending file-watcher values that CRDT
+                        // conflict resolution may have reverted. See #1598.
+                        if doc.enforce_external_values() {
+                            info!("[sync] Re-applied external settings after sync merge");
+                        }
+
                         // Persist and notify others
                         persist_settings(&mut doc);
                         let _ = changed_tx.send(());

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1013,7 +1013,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // Connect pipe client (relay mode — no local doc, no initial sync)
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe00sync01".to_string(),
+        "00000000-0000-0000-0000-000000000001".to_string(),
         frame_tx,
     )
     .await
@@ -1022,7 +1022,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // Second client (full peer) adds a cell and updates source
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe00sync01".to_string(),
+        "00000000-0000-0000-0000-000000000001".to_string(),
         "test",
     )
     .await
@@ -1080,7 +1080,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
 
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe0bcast01".to_string(),
+        "00000000-0000-0000-0000-000000000002".to_string(),
         frame_tx,
     )
     .await
@@ -1092,7 +1092,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     // verifies the type-byte filter, not broadcast-specific forwarding.
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipe0bcast01".to_string(),
+        "00000000-0000-0000-0000-000000000002".to_string(),
         "test",
     )
     .await
@@ -1230,7 +1230,7 @@ async fn test_pipe_mode_preserves_frame_order() {
 
     let _result = connect::connect_relay(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         frame_tx,
     )
     .await
@@ -1239,7 +1239,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     // Second client rapidly adds multiple cells
     let client2 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         "test",
     )
     .await
@@ -1310,7 +1310,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     // received (in channel order) represents the correct state transitions.
     let client3 = connect::connect(
         socket_path.clone(),
-        "00000000-0000-0000-0000-pipeorder001".to_string(),
+        "00000000-0000-0000-0000-000000000003".to_string(),
         "test",
     )
     .await


### PR DESCRIPTION
## Summary

- When `settings.json` is edited externally, the daemon's file watcher applies the change but a notebook window's stale CRDT state could silently revert it during the next sync via Automerge's conflict resolution
- Stores the last externally-applied JSON in `SettingsDoc` and re-applies it after each incoming sync message, making file-watcher changes authoritative until all peers converge
- Fixes `put_list` in `settings_doc.rs` to reuse existing Automerge List objects instead of `delete` + `put_object`, following the same pattern as #1602
- Fixes pipe mode integration test IDs that were invalid UUIDs (contained non-hex chars like `pipe`, `bcast`), causing the daemon to treat them as file paths and leak `.ipynb` files into the crate directory via autosave

## Verification

- [ ] Externally edit `settings.json` (e.g. change `default_python_env` from `"uv"` to `"conda"`) while a notebook window is open — the change should persist after window sync
- [ ] Check daemon logs for `[settings-watch] Applied external settings.json changes` and no `[sync] Re-applied external settings` on subsequent syncs (confirms convergence)
- [ ] Verify no `0000*` files appear in `crates/runtimed/` after running `cargo test -p runtimed`

Closes #1598

_PR submitted by @rgbkrk's agent, Quill_