### PR TITLE
fix(mcp): graceful restart on daemon upgrade in mcpb wrapper

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -785,6 +785,11 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let transport = rmcp::transport::io::stdio();
     let handle = server.serve(transport).await?;
 
+    // Grab a cancellation token before `waiting()` moves ownership of `handle`.
+    // Used to gracefully close the MCP transport on daemon upgrade so the
+    // client sees a clean EOF instead of a broken pipe.
+    let cancel_token = handle.cancellation_token();
+
     // Spawn the health monitor alongside the MCP server
     let monitor_socket = socket_path;
     let monitor_handle = tokio::spawn(async move {
@@ -798,9 +803,14 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
             result?;
         }
         exit_code = monitor_handle => {
-            // Health monitor returned — daemon was upgraded
+            // Health monitor returned — daemon was upgraded.
+            // Gracefully close the MCP transport so the client sees a clean
+            // EOF rather than a broken pipe, then exit with EX_TEMPFAIL (75)
+            // so the wrapper or client knows to restart us.
             let code = exit_code.unwrap_or(runt_mcp::health::EXIT_DAEMON_UPGRADED);
             eprintln!("Daemon upgraded, exiting for restart (exit code {code}).");
+            cancel_token.cancel();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             std::process::exit(code);
         }
     }

--- a/mcpb/server/launch.js
+++ b/mcpb/server/launch.js
@@ -6,6 +6,11 @@
  * channel (stable or nightly). The channel is determined by the NTERACT_CHANNEL
  * env var, set by the manifest's mcp_config.
  *
+ * Acts as a line-based JSON-RPC proxy so it can transparently restart the
+ * server when the daemon upgrades (exit code 75 / EX_TEMPFAIL). The proxy
+ * captures the MCP initialize handshake and replays it to new child processes,
+ * preserving client identity for notebook presence.
+ *
  * Search order:
  * 1. PATH (covers /usr/local/bin/ where the app installer puts the binary)
  * 2. Platform-specific app bundle / install locations
@@ -15,12 +20,20 @@
  */
 
 const { execFileSync, spawn } = require("node:child_process");
+const { createInterface } = require("node:readline");
 const { existsSync } = require("node:fs");
 const { join } = require("node:path");
 
 const channel = process.env.NTERACT_CHANNEL || "stable";
 const binaryName = channel === "nightly" ? "runt-nightly" : "runt";
 const appName = channel === "nightly" ? "nteract Nightly" : "nteract";
+
+/** Exit code used by runt mcp when the daemon has been upgraded. */
+const EX_TEMPFAIL = 75;
+
+/** Circuit breaker: max restarts in the time window before giving up. */
+const MAX_RESTARTS = 5;
+const RESTART_WINDOW_MS = 30_000;
 
 /** App bundle name candidates — must match runt_workspace::desktop_app_launch_candidates_for(). */
 const appBundleNames =
@@ -92,6 +105,23 @@ function findBinary() {
   return null;
 }
 
+// ── Proxy state ──────────────────────────────────────────────────────
+
+/** Saved initialize request line (JSON string) from the MCP client. */
+let savedInitRequest = null;
+/** Saved initialized notification line (JSON string) from the MCP client. */
+let savedInitNotification = null;
+/** Whether we're waiting for the new child's initialize response after restart. */
+let reinitializing = false;
+/** The active child process. */
+let child = null;
+/** Circuit breaker: timestamps of recent restarts. */
+const restartTimestamps = [];
+/** Whether process.stdin has ended (client disconnected). */
+let stdinEnded = false;
+
+// ── Binary discovery ─────────────────────────────────────────────────
+
 const binary = findBinary();
 
 if (!binary) {
@@ -103,21 +133,132 @@ if (!binary) {
   process.exit(1);
 }
 
-// Launch runt mcp with stdio passthrough
-const child = spawn(binary, ["mcp"], {
-  stdio: "inherit",
-  env: process.env,
-});
+// ── Child process management ─────────────────────────────────────────
 
-child.on("error", (err) => {
-  process.stderr.write(`Failed to start ${binary}: ${err.message}\n`);
-  process.exit(1);
-});
+function spawnChild() {
+  const proc = spawn(binary, ["mcp"], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: process.env,
+  });
 
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-  } else {
-    process.exit(code ?? 1);
+  proc.on("error", (err) => {
+    process.stderr.write(`Failed to start ${binary}: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  // Forward child stdout lines to the MCP client (process.stdout)
+  const rl = createInterface({ input: proc.stdout, crlfDelay: Infinity });
+  rl.on("line", (line) => {
+    if (reinitializing) {
+      // Discard the new child's initialize response — the client already
+      // has capabilities from the original handshake.
+      reinitializing = false;
+      // Now send the saved initialized notification to complete the handshake.
+      if (savedInitNotification && proc.stdin.writable) {
+        proc.stdin.write(`${savedInitNotification}\n`);
+      }
+      return;
+    }
+    // Normal forwarding: child -> client
+    process.stdout.write(`${line}\n`);
+  });
+
+  proc.on("exit", (code, signal) => {
+    // Exit code 75 (EX_TEMPFAIL) means daemon upgraded — try to restart
+    if (code === EX_TEMPFAIL && savedInitRequest && !stdinEnded) {
+      if (canRestart()) {
+        process.stderr.write("Daemon upgraded, restarting MCP server...\n");
+        startChild();
+        replayInitHandshake();
+        return;
+      }
+      process.stderr.write(
+        "Daemon upgraded but circuit breaker tripped — too many restarts.\n",
+      );
+    }
+
+    // All other exits: forward to the MCP client as-is
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+
+  child = proc;
+  return proc;
+}
+
+function startChild() {
+  spawnChild();
+}
+
+/** Check circuit breaker: allow restart if < MAX_RESTARTS in the window. */
+function canRestart() {
+  const now = Date.now();
+  // Prune old timestamps outside the window
+  while (
+    restartTimestamps.length > 0 &&
+    now - restartTimestamps[0] > RESTART_WINDOW_MS
+  ) {
+    restartTimestamps.shift();
+  }
+  if (restartTimestamps.length >= MAX_RESTARTS) {
+    return false;
+  }
+  restartTimestamps.push(now);
+  return true;
+}
+
+/** Replay the saved initialize handshake to the new child. */
+function replayInitHandshake() {
+  if (!child?.stdin.writable || !savedInitRequest) return;
+  reinitializing = true;
+  child.stdin.write(`${savedInitRequest}\n`);
+  // The child's initialize response will be intercepted and discarded
+  // by the stdout line handler (reinitializing flag). After that,
+  // the saved initialized notification is sent to complete the handshake.
+}
+
+// ── Client stdin -> child stdin forwarding ───────────────────────────
+
+const stdinRl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+stdinRl.on("line", (line) => {
+  // Capture the initialize handshake for replay on restart.
+  // The initialize request contains clientInfo (name, title) used for
+  // notebook presence — replaying it preserves the client's identity.
+  if (!savedInitRequest) {
+    try {
+      const msg = JSON.parse(line);
+      if (msg.method === "initialize") {
+        savedInitRequest = line;
+      }
+    } catch {
+      // Not valid JSON — forward anyway
+    }
+  } else if (!savedInitNotification) {
+    try {
+      const msg = JSON.parse(line);
+      if (msg.method === "notifications/initialized") {
+        savedInitNotification = line;
+      }
+    } catch {
+      // Not valid JSON — forward anyway
+    }
+  }
+
+  // Forward to child
+  if (child?.stdin.writable) {
+    child.stdin.write(`${line}\n`);
   }
 });
+
+stdinRl.on("close", () => {
+  stdinEnded = true;
+  child?.kill();
+});
+
+// ── Start ────────────────────────────────────────────────────────────
+
+startChild();


### PR DESCRIPTION
## Summary

When the nteract daemon upgrades, `runt mcp` detects the version mismatch and exits with code 75 (EX_TEMPFAIL). Previously the mcpb Node wrapper forwarded this exit code directly, killing the MCP connection — Claude Desktop / Cowork sees the server die unexpectedly.

This PR prototyped making the mcpb wrapper act as a line-based JSON-RPC proxy that captures the MCP `initialize` handshake and replays it to a new child process on restart.

### What we learned

The Node proxy approach has a fundamental gap: **in-flight MCP requests are dropped during restart**. When `runt mcp` exits mid-tool-call, the request/response is lost — the client hangs forever waiting on that request ID. Only the initialize handshake is replayed; active tool calls are neither retried nor errored.

This was validated locally: a request sent during the restart window vanished silently, while requests after re-init succeeded.

### Better approach: ship a Rust binary in the mcpb

Instead of reimplementing supervisor logic in a Node wrapper, we should extract the relevant parts of `mcp-supervisor` into a lightweight binary that ships inside the `.mcpb` bundle. This binary would:

- Handle child process lifecycle with proper request buffering/retry (like the supervisor already does in `forward_tool_call`)
- Do version change detection itself (no dependency on `runt mcp`'s health monitor for this)
- Be well-maintained alongside the supervisor code rather than a parallel JS implementation

### Changes in this PR (for reference)

- **`mcpb/server/launch.js`** — Rewritten from `stdio: "inherit"` passthrough to piped JSON-RPC line proxy with init handshake replay and circuit breaker
- **`crates/runt/src/main.rs`** — Graceful MCP transport close via cancellation token before exit (this part is still good independently)

## Status

**Closing in favor of a Rust-binary approach.** The graceful transport close in `main.rs` may be worth cherry-picking into a future PR.

_PR submitted by @rgbkrk's agent, Quill_