### PR TITLE
fix(runtimed): ephemeral notebook review cleanups

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1723,6 +1723,21 @@ impl NotebookDoc {
         Ok(())
     }
 
+    /// Delete a metadata key. Returns `true` if the key existed and was removed.
+    pub fn delete_metadata(&mut self, key: &str) -> Result<bool, AutomergeError> {
+        let meta_id = match self.metadata_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        match self.doc.get(&meta_id, key)? {
+            Some(_) => {
+                self.doc.delete(&meta_id, key)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
     // ── Sync protocol ───────────────────────────────────────────────
 
     /// Generate a sync message to send to a peer.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4366,7 +4366,7 @@ async fn rekey_ephemeral_room(
 
     // Clear the ephemeral flag — this room is now backed by a file on disk.
     // After promotion, persist_tx remains None — the room gets .ipynb autosave
-    // (via the file watcher spawned below) but NOT .automerge persistence.
+    // (via the autosave debouncer spawned above) but NOT .automerge persistence.
     // This is intentional: .ipynb is the source of truth for file-backed notebooks.
     room.is_ephemeral.store(false, Ordering::Relaxed);
     {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2515,6 +2515,18 @@ where
                                             // Prune old entries (older than 1 hour)
                                             let cutoff = tokio::time::Instant::now() - std::time::Duration::from_secs(3600);
                                             redirects.retain(|_, v| v.created_at > cutoff);
+                                            // Cap at 1000 entries to bound memory under extreme agent churn
+                                            while redirects.len() > 1000 {
+                                                if let Some(oldest_key) = redirects
+                                                    .iter()
+                                                    .min_by_key(|(_, v)| v.created_at)
+                                                    .map(|(k, _)| k.clone())
+                                                {
+                                                    redirects.remove(&oldest_key);
+                                                } else {
+                                                    break;
+                                                }
+                                            }
                                         }
                                         notebook_id = new_id.clone();
                                         NotebookResponse::NotebookSaved {
@@ -4353,10 +4365,13 @@ async fn rekey_ephemeral_room(
         });
 
     // Clear the ephemeral flag — this room is now backed by a file on disk.
+    // After promotion, persist_tx remains None — the room gets .ipynb autosave
+    // (via the file watcher spawned below) but NOT .automerge persistence.
+    // This is intentional: .ipynb is the source of truth for file-backed notebooks.
     room.is_ephemeral.store(false, Ordering::Relaxed);
     {
         let mut doc = room.doc.write().await;
-        let _ = doc.set_metadata("ephemeral", "");
+        let _ = doc.delete_metadata("ephemeral");
     }
 
     info!(


### PR DESCRIPTION
## Summary

Follow-up from #1669 code review — three small cleanups:

1. **Cap redirect map at 1000 entries** — prevents unbounded growth under extreme agent churn (thousands of save-and-disconnect cycles within an hour). Evicts oldest entries when the cap is hit.

2. **Add `delete_metadata()` to NotebookDoc** — replaces `set_metadata("ephemeral", "")` with a clean key deletion. No more empty string keys left in the CRDT.

3. **Document promoted room persistence** — clarifies that `persist_tx` remains `None` after ephemeral→persistent promotion. The `.ipynb` autosave (via file watcher) is the source of truth for file-backed notebooks, not `.automerge` persistence.

## Test plan

- [x] 224 lib tests pass (`cargo test -p runtimed --lib`)
- [x] Tokio mutex lint passes
- [x] Ephemeral room tests pass
- [x] Lint clean (`cargo xtask lint`)