### PR TITLE
fix(runt-mcp-proxy): auto-reset circuit breaker after cooldown

### DIFF
--- a/crates/runt-mcp-proxy/src/circuit_breaker.rs
+++ b/crates/runt-mcp-proxy/src/circuit_breaker.rs
@@ -208,4 +208,31 @@ mod tests {
         assert!(cb.tripped_at.is_none(), "reset should clear tripped_at");
         assert!(cb.record_crash(), "should allow after manual reset");
     }
+
+    #[test]
+    fn repeated_trip_cooldown_cycles() {
+        let mut cb = CircuitBreaker::new();
+
+        for cycle in 0..3 {
+            // Trip the breaker
+            for _ in 0..MAX_CRASHES {
+                cb.record_crash();
+            }
+            assert!(!cb.record_crash(), "cycle {cycle}: should be tripped");
+
+            // Simulate cooldown
+            cb.tripped_at = Some(Instant::now() - COOLDOWN - Duration::from_secs(1));
+
+            // Should allow again
+            assert!(
+                cb.record_crash(),
+                "cycle {cycle}: should allow after cooldown"
+            );
+            assert_eq!(
+                cb.recent_crashes.len(),
+                1,
+                "cycle {cycle}: should have fresh crash count"
+            );
+        }
+    }
 }

--- a/crates/runt-mcp-proxy/src/circuit_breaker.rs
+++ b/crates/runt-mcp-proxy/src/circuit_breaker.rs
@@ -7,28 +7,50 @@ use std::time::{Duration, Instant};
 
 const MAX_CRASHES: usize = 5;
 const WINDOW: Duration = Duration::from_secs(30);
+/// After the breaker trips, wait this long before auto-resetting.
+/// Gives the daemon time to fully restart after a binary upgrade.
+const COOLDOWN: Duration = Duration::from_secs(60);
 
 /// Tracks recent child crashes and decides whether to allow restart.
 pub struct CircuitBreaker {
     recent_crashes: Vec<Instant>,
+    /// When the breaker tripped — used for cooldown-then-retry.
+    tripped_at: Option<Instant>,
 }
 
 impl CircuitBreaker {
     pub fn new() -> Self {
         Self {
             recent_crashes: Vec::new(),
+            tripped_at: None,
         }
     }
 
     /// Record a crash and return whether restart is allowed.
     ///
     /// Returns `false` (tripped) if there have been >= `MAX_CRASHES` in the
-    /// last `WINDOW` seconds.
+    /// last `WINDOW` seconds. After a cooldown period, the breaker auto-resets
+    /// so the proxy can recover from daemon restarts without manual intervention.
     pub fn record_crash(&mut self) -> bool {
         let now = Instant::now();
+
+        // Auto-reset after cooldown: if the breaker tripped long enough ago,
+        // clear state and allow retry. This handles daemon restarts where the
+        // child crashes rapidly during the restart window but should recover
+        // once the new daemon is up.
+        if let Some(tripped) = self.tripped_at {
+            if now.duration_since(tripped) >= COOLDOWN {
+                self.recent_crashes.clear();
+                self.tripped_at = None;
+            }
+        }
+
         self.recent_crashes
             .retain(|t| now.duration_since(*t) < WINDOW);
         if self.recent_crashes.len() >= MAX_CRASHES {
+            if self.tripped_at.is_none() {
+                self.tripped_at = Some(now);
+            }
             return false;
         }
         self.recent_crashes.push(now);
@@ -38,6 +60,7 @@ impl CircuitBreaker {
     /// Reset the circuit breaker (e.g., after a manual restart or file change).
     pub fn reset(&mut self) {
         self.recent_crashes.clear();
+        self.tripped_at = None;
     }
 }
 
@@ -137,5 +160,52 @@ mod tests {
         assert!(cb.record_crash(), "crash at exactly the limit should work");
         // One more should fail
         assert!(!cb.record_crash(), "crash beyond limit should fail");
+    }
+
+    #[test]
+    fn auto_resets_after_cooldown() {
+        let mut cb = CircuitBreaker::new();
+        // Trip the breaker
+        for _ in 0..MAX_CRASHES {
+            cb.record_crash();
+        }
+        assert!(!cb.record_crash(), "should be tripped");
+        assert!(cb.tripped_at.is_some(), "tripped_at should be set");
+
+        // Simulate cooldown by backdating tripped_at
+        cb.tripped_at = Some(Instant::now() - COOLDOWN - Duration::from_secs(1));
+
+        // Next record_crash should auto-reset and allow
+        assert!(cb.record_crash(), "should allow after cooldown auto-reset");
+        assert!(cb.tripped_at.is_none(), "tripped_at should be cleared");
+        assert_eq!(cb.recent_crashes.len(), 1, "should have fresh crash count");
+    }
+
+    #[test]
+    fn stays_tripped_before_cooldown() {
+        let mut cb = CircuitBreaker::new();
+        // Trip the breaker
+        for _ in 0..MAX_CRASHES {
+            cb.record_crash();
+        }
+        assert!(!cb.record_crash());
+
+        // Without cooldown elapsed, should stay tripped
+        assert!(!cb.record_crash(), "should stay tripped before cooldown");
+        assert!(cb.tripped_at.is_some());
+    }
+
+    #[test]
+    fn manual_reset_clears_tripped_at() {
+        let mut cb = CircuitBreaker::new();
+        for _ in 0..MAX_CRASHES {
+            cb.record_crash();
+        }
+        assert!(!cb.record_crash());
+        assert!(cb.tripped_at.is_some());
+
+        cb.reset();
+        assert!(cb.tripped_at.is_none(), "reset should clear tripped_at");
+        assert!(cb.record_crash(), "should allow after manual reset");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1673

The MCP proxy's circuit breaker permanently trips after 5 crashes in 30s with no recovery path. This causes the proxy to become unresponsive after daemon binary upgrades — the child crashes rapidly during the restart window, trips the breaker, and never retries.

## Fix

Add a 60-second cooldown after tripping. Once the cooldown elapses, `record_crash()` auto-resets the breaker and allows retry. This gives the daemon time to fully restart while still protecting against genuine infinite crash loops.

## Changes

- Added `tripped_at: Option<Instant>` to `CircuitBreaker`
- Added `COOLDOWN` constant (60 seconds)
- `record_crash()` checks if cooldown has elapsed and auto-resets
- `reset()` also clears `tripped_at`
- 3 new tests: auto-reset after cooldown, stays tripped before cooldown, manual reset clears tripped_at

## Test plan

- [x] 92 proxy tests pass (`cargo test -p runt-mcp-proxy`)
- [x] Lint clean (`cargo xtask lint`)
- [x] Locally shipped — mcpb-runt-nightly updated on test machine
- [ ] Manual: restart nightly daemon, verify proxy auto-recovers after ~60s