### PR TITLE
fix(runt-mcp): add type coercion for boolean and array MCP params

### DIFF
--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -12,7 +12,7 @@ use notebook_protocol::protocol::NotebookRequest;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_f64, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -89,18 +89,8 @@ pub async fn create_cell(
         .as_ref()
         .and_then(|a| a.get("index"))
         .and_then(|v| v.as_i64());
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(30.0);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(30.0);
 
     // Clone handle, then drop the session lock so other tools
     // (interrupt_kernel, etc.) aren't blocked during execution.
@@ -167,18 +157,8 @@ pub async fn set_cell(
 
     let source = arg_str(request, "source");
     let cell_type = arg_str(request, "cell_type");
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(30.0);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(30.0);
 
     let handle = require_handle!(server);
 

--- a/crates/runt-mcp/src/tools/cell_meta.rs
+++ b/crates/runt-mcp/src/tools/cell_meta.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -154,12 +154,7 @@ pub async fn set_cells_source_hidden(
         .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
         .unwrap_or_default();
 
-    let hidden = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("hidden"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let hidden = arg_bool(request, "hidden").unwrap_or(false);
 
     let mut not_found = Vec::new();
 
@@ -193,12 +188,7 @@ pub async fn set_cells_outputs_hidden(
         .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
         .unwrap_or_default();
 
-    let hidden = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("hidden"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let hidden = arg_bool(request, "hidden").unwrap_or(false);
 
     let mut not_found = Vec::new();
 

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -10,7 +10,7 @@ use runtimed_client::output_resolver;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -139,12 +139,7 @@ pub async fn get_all_cells(
         .and_then(|a| a.get("count"))
         .and_then(|v| v.as_i64())
         .map(|v| v as usize);
-    let include_outputs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("include_outputs"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let include_outputs = arg_bool(request, "include_outputs").unwrap_or(false);
     let preview_chars = request
         .arguments
         .as_ref()

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -11,7 +11,7 @@ use crate::editing;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error};
+use super::{arg_bool, arg_f64, arg_str, tool_error};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -69,18 +69,8 @@ pub async fn replace_match(
     let context_before = arg_str(request, "context_before").filter(|s| !s.is_empty());
     let context_after = arg_str(request, "context_after").filter(|s| !s.is_empty());
 
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(30.0);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(30.0);
 
     let handle = require_handle!(server);
 
@@ -146,18 +136,8 @@ pub async fn replace_regex(
     let content = arg_str(request, "content")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: content", None))?;
 
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(30.0);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(30.0);
 
     let handle = require_handle!(server);
 

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -11,7 +11,7 @@ use crate::execution;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_f64, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -45,12 +45,7 @@ pub async fn execute_cell(
 
     let handle = require_handle!(server);
 
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(30.0);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(30.0);
 
     // Verify cell exists
     if handle.get_cell(cell_id).is_none() {
@@ -84,19 +79,8 @@ pub async fn run_all_cells(
 ) -> Result<CallToolResult, McpError> {
     let handle = require_handle!(server);
 
-    let wait = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("wait"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
-
-    let timeout_secs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("timeout_secs"))
-        .and_then(|v| v.as_f64())
-        .unwrap_or(300.0);
+    let wait = arg_bool(request, "wait").unwrap_or(true);
+    let timeout_secs = arg_f64(request, "timeout_secs").unwrap_or(300.0);
 
     // Fire-and-forget: queue cells and return immediately.
     if !wait {

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -367,13 +367,54 @@ pub async fn dispatch(
     }
 }
 
-/// Helper: extract a typed argument or return a default.
+/// Helper: extract a string argument.
 pub fn arg_str<'a>(request: &'a CallToolRequestParams, key: &str) -> Option<&'a str> {
     request
         .arguments
         .as_ref()
         .and_then(|args| args.get(key))
         .and_then(|v| v.as_str())
+}
+
+/// Helper: extract a boolean argument with type coercion.
+///
+/// MCP clients may send booleans as JSON booleans (`true`/`false`) or as
+/// strings (`"true"`/`"false"`). This handles both for robustness.
+pub fn arg_bool(request: &CallToolRequestParams, key: &str) -> Option<bool> {
+    let val = request.arguments.as_ref()?.get(key)?;
+    // Try JSON boolean first
+    if let Some(b) = val.as_bool() {
+        return Some(b);
+    }
+    // Fall back to string coercion
+    match val.as_str() {
+        Some("true") => Some(true),
+        Some("false") => Some(false),
+        _ => None,
+    }
+}
+
+/// Helper: extract a string array argument with type coercion.
+///
+/// MCP clients may send arrays as JSON arrays or as JSON-encoded strings.
+/// This handles both for robustness.
+pub fn arg_string_array(request: &CallToolRequestParams, key: &str) -> Option<Vec<String>> {
+    let val = request.arguments.as_ref()?.get(key)?;
+    // Try JSON array first
+    if let Some(arr) = val.as_array() {
+        return Some(
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect(),
+        );
+    }
+    // Fall back to parsing a JSON-encoded string
+    if let Some(s) = val.as_str() {
+        if let Ok(parsed) = serde_json::from_str::<Vec<String>>(s) {
+            return Some(parsed);
+        }
+    }
+    None
 }
 
 /// Helper: create a text error result.
@@ -435,4 +476,81 @@ pub async fn build_execution_result(
     let mut call_result = CallToolResult::success(items);
     call_result.structured_content = structured_content;
     Ok(call_result)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn make_request(args: serde_json::Value) -> CallToolRequestParams {
+        serde_json::from_value(serde_json::json!({
+            "name": "test",
+            "arguments": args,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn arg_bool_json_boolean() {
+        let req = make_request(serde_json::json!({"flag": true}));
+        assert_eq!(arg_bool(&req, "flag"), Some(true));
+
+        let req = make_request(serde_json::json!({"flag": false}));
+        assert_eq!(arg_bool(&req, "flag"), Some(false));
+    }
+
+    #[test]
+    fn arg_bool_string_coercion() {
+        let req = make_request(serde_json::json!({"flag": "true"}));
+        assert_eq!(arg_bool(&req, "flag"), Some(true));
+
+        let req = make_request(serde_json::json!({"flag": "false"}));
+        assert_eq!(arg_bool(&req, "flag"), Some(false));
+    }
+
+    #[test]
+    fn arg_bool_missing_and_invalid() {
+        let req = make_request(serde_json::json!({"other": 1}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+
+        let req = make_request(serde_json::json!({"flag": "maybe"}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+
+        let req = make_request(serde_json::json!({"flag": 42}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+    }
+
+    #[test]
+    fn arg_string_array_json_array() {
+        let req = make_request(serde_json::json!({"deps": ["numpy", "pandas"]}));
+        assert_eq!(
+            arg_string_array(&req, "deps"),
+            Some(vec!["numpy".to_string(), "pandas".to_string()])
+        );
+    }
+
+    #[test]
+    fn arg_string_array_string_coercion() {
+        let req = make_request(serde_json::json!({"deps": "[\"numpy\", \"pandas\"]"}));
+        assert_eq!(
+            arg_string_array(&req, "deps"),
+            Some(vec!["numpy".to_string(), "pandas".to_string()])
+        );
+    }
+
+    #[test]
+    fn arg_string_array_empty() {
+        let req = make_request(serde_json::json!({"deps": []}));
+        assert_eq!(arg_string_array(&req, "deps"), Some(vec![]));
+    }
+
+    #[test]
+    fn arg_string_array_missing_and_invalid() {
+        let req = make_request(serde_json::json!({"other": 1}));
+        assert_eq!(arg_string_array(&req, "deps"), None);
+
+        let req = make_request(serde_json::json!({"deps": "not-json-array"}));
+        assert_eq!(arg_string_array(&req, "deps"), None);
+    }
 }

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -417,6 +417,17 @@ pub fn arg_string_array(request: &CallToolRequestParams, key: &str) -> Option<Ve
     None
 }
 
+/// Helper: extract a float argument with type coercion.
+///
+/// MCP clients may send numbers as JSON numbers or as strings.
+pub fn arg_f64(request: &CallToolRequestParams, key: &str) -> Option<f64> {
+    let val = request.arguments.as_ref()?.get(key)?;
+    if let Some(n) = val.as_f64() {
+        return Some(n);
+    }
+    val.as_str().and_then(|s| s.parse::<f64>().ok())
+}
+
 /// Helper: create a text error result.
 pub fn tool_error(msg: &str) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::error(vec![Content::text(msg.to_string())]))
@@ -552,5 +563,26 @@ mod tests {
 
         let req = make_request(serde_json::json!({"deps": "not-json-array"}));
         assert_eq!(arg_string_array(&req, "deps"), None);
+    }
+
+    #[test]
+    fn arg_f64_json_number() {
+        let req = make_request(serde_json::json!({"timeout": 30.5}));
+        assert_eq!(arg_f64(&req, "timeout"), Some(30.5));
+    }
+
+    #[test]
+    fn arg_f64_string_coercion() {
+        let req = make_request(serde_json::json!({"timeout": "45.0"}));
+        assert_eq!(arg_f64(&req, "timeout"), Some(45.0));
+    }
+
+    #[test]
+    fn arg_f64_missing_and_invalid() {
+        let req = make_request(serde_json::json!({"other": 1}));
+        assert_eq!(arg_f64(&req, "timeout"), None);
+
+        let req = make_request(serde_json::json!({"timeout": "not-a-number"}));
+        assert_eq!(arg_f64(&req, "timeout"), None);
     }
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -61,7 +61,7 @@ fn resolve_path(path: &str) -> String {
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, arg_string_array, tool_error, tool_success};
 
 /// Collect runtime info from RuntimeStateDoc, polling briefly for it to sync.
 /// Matches Python's `_collect_runtime_info()`.
@@ -385,12 +385,7 @@ pub async fn create_notebook(
 
     let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
     let working_dir_for_detection = working_dir.clone();
-    let ephemeral = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("ephemeral"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
+    let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 
     let prev = previous_notebook_id(server).await;
 
@@ -411,12 +406,7 @@ pub async fn create_notebook(
             crate::presence::announce(&result.handle, &peer_label).await;
 
             // Add dependencies if specified
-            let deps: Vec<String> = request
-                .arguments
-                .as_ref()
-                .and_then(|a| a.get("dependencies"))
-                .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
-                .unwrap_or_default();
+            let deps: Vec<String> = arg_string_array(request, "dependencies").unwrap_or_default();
 
             let explicit_pkg_manager = arg_str(request, "package_manager");
 


### PR DESCRIPTION
## Summary

Ref #1675

Add `arg_bool()` and `arg_string_array()` helpers to `runt-mcp` that handle type coercion for MCP tool parameters. MCP clients may send boolean values as strings (`"true"`/`"false"`) and arrays as JSON-encoded strings rather than native JSON types.

## Root Cause Discovery

The original issue (#1675) where `ephemeral` and `dependencies` appeared dropped via the nightly proxy was actually caused by **the proxy caching the resolved binary path at startup**. Replacing `runt-nightly` on disk doesn't affect the running proxy — it keeps spawning the old binary. A `/mcp` reconnect (which restarts the proxy process) is required to pick up new binaries.

The type coercion fix is still valuable as **defense-in-depth** for MCP client compatibility, since different MCP transports may serialize types differently.

## Changes

- Added `arg_bool()` — reads JSON boolean or coerces `"true"`/`"false"` strings
- Added `arg_string_array()` — reads JSON array or parses JSON-encoded string arrays
- Updated `create_notebook` to use these for `ephemeral` and `dependencies`
- 7 unit tests covering native types, string coercion, empty, missing, and invalid values

## Test plan

- [x] 7 new tests pass (`cargo test -p runt-mcp --lib -- tools::tests`)
- [x] Lint clean
- [x] All existing MCP tests pass