### PR TITLE
fix(runt-mcp-proxy): re-resolve child binary on every restart

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1974,9 +1974,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             state.tool_list_changed_tx.take()
         };
 
+        let project_root_for_resolve = project_root.clone();
         let proxy = McpProxy::new(
             ProxyConfig {
-                child_command: cargo_binary(&project_root, "runt"),
+                resolve_child_command: Box::new(move || {
+                    let path = cargo_binary(&project_root_for_resolve, "runt");
+                    if path.exists() {
+                        Ok(path)
+                    } else {
+                        Err(format!("runt binary not found at {}", path.display()))
+                    }
+                }),
                 child_args: vec!["mcp".to_string()],
                 child_env,
                 server_name: "nteract-dev".to_string(),

--- a/crates/mcpb-runt/src/main.rs
+++ b/crates/mcpb-runt/src/main.rs
@@ -138,26 +138,21 @@ async fn main() -> ExitCode {
 
     info!("mcpb-runt starting (channel={channel})");
 
-    // Find the runt binary
-    let runt_path = match find_runt_binary(&channel) {
-        Some(path) => {
-            info!("Found runt binary: {}", path.display());
-            path
-        }
-        None => {
-            let binary_name = if channel == "nightly" {
-                "runt-nightly"
-            } else {
-                "runt"
-            };
-            eprintln!(
-                "Error: {binary_name} not found.\n\n\
-                 Install {app_name} from https://nteract.io to use this MCP server.\n\
-                 The app puts {binary_name} on your PATH during installation."
-            );
-            return ExitCode::FAILURE;
-        }
+    // Validate that the runt binary exists at startup (clear error for users)
+    let binary_name = if channel == "nightly" {
+        "runt-nightly"
+    } else {
+        "runt"
     };
+    if find_runt_binary(&channel).is_none() {
+        eprintln!(
+            "Error: {binary_name} not found.\n\n\
+             Install {app_name} from https://nteract.io to use this MCP server.\n\
+             The app puts {binary_name} on your PATH during installation."
+        );
+        return ExitCode::FAILURE;
+    }
+    info!("Validated {binary_name} is available");
 
     // Resolve daemon info path for version tracking
     let daemon_info_path = Some(runtimed_client::singleton::daemon_info_path());
@@ -166,8 +161,17 @@ async fn main() -> ExitCode {
     let mut child_env = HashMap::new();
     child_env.insert("NTERACT_CHANNEL".to_string(), channel.clone());
 
+    // Pass resolution as a closure so the proxy re-discovers the binary
+    // on every child restart. This is the core upgrade mechanism: the user
+    // upgrades the nteract app (new runt binary), and the proxy picks it up
+    // without needing to reinstall the MCPB extension.
+    let channel_for_resolve = channel.clone();
+    let binary_name_for_resolve = binary_name.to_string();
     let config = ProxyConfig {
-        child_command: runt_path,
+        resolve_child_command: Box::new(move || {
+            find_runt_binary(&channel_for_resolve)
+                .ok_or_else(|| format!("{binary_name_for_resolve} no longer found on PATH or in known install locations"))
+        }),
         child_args: vec!["mcp".to_string()],
         child_env,
         server_name: if channel == "nightly" {

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1011,7 +1011,7 @@ mod tests {
         );
 
         let config = ProxyConfig {
-            resolve_child_command: Box::new(|| Ok(PathBuf::from("/usr/local/bin/runt"))),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: env,
             server_name: "nteract".to_string(),

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -27,8 +27,11 @@ use crate::version::{self, ReconnectionEvent};
 
 /// Configuration for the MCP proxy.
 pub struct ProxyConfig {
-    /// Command to spawn the child (path to `runt` or `runt-nightly`).
-    pub child_command: PathBuf,
+    /// Resolver that returns the path to the child binary.
+    /// Called on every spawn (init and restart) so it picks up binary upgrades on disk.
+    /// This is the core reason the proxy exists: the MCPB bundle is stable while
+    /// the user upgrades the nteract app, and the proxy transparently picks up the new binary.
+    pub resolve_child_command: Box<dyn Fn() -> Result<PathBuf, String> + Send + Sync>,
     /// Arguments to the child (e.g., `["mcp"]`).
     pub child_args: Vec<String>,
     /// Environment variables for the child process.
@@ -131,8 +134,11 @@ impl McpProxy {
             (state.upstream_name.clone(), state.upstream_title.clone())
         };
 
+        let child_command = (self.config.resolve_child_command)()
+            .map_err(|e| format!("Failed to resolve child binary: {e}"))?;
+
         let client = child::spawn_child(
-            &self.config.child_command,
+            &child_command,
             &self.config.child_args,
             &self.config.child_env,
             &upstream_name,
@@ -202,14 +208,29 @@ impl McpProxy {
             state.last_daemon_version.clone()
         };
 
-        // Phase 3: Spawn new child
+        // Phase 3: Resolve binary and spawn new child.
+        // Re-resolve on every restart so binary upgrades take effect.
+        let child_command = match (self.config.resolve_child_command)() {
+            Ok(path) => {
+                info!("Resolved child binary: {}", path.display());
+                path
+            }
+            Err(e) => {
+                let msg = format!("Failed to resolve child binary on restart: {e}");
+                error!("{msg}");
+                let mut state = self.state.write().await;
+                state.reconnection_message = Some(msg.clone());
+                return Err(msg);
+            }
+        };
+
         let (upstream_name, upstream_title) = {
             let state = self.state.read().await;
             (state.upstream_name.clone(), state.upstream_title.clone())
         };
 
         match child::spawn_child(
-            &self.config.child_command,
+            &child_command,
             &self.config.child_args,
             &self.config.child_env,
             &upstream_name,
@@ -614,7 +635,7 @@ mod tests {
 
     fn test_config() -> ProxyConfig {
         ProxyConfig {
-            child_command: PathBuf::from("/nonexistent/runt"),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: HashMap::new(),
             server_name: "test-proxy".to_string(),
@@ -625,7 +646,7 @@ mod tests {
 
     fn test_config_with_cache(dir: &std::path::Path) -> ProxyConfig {
         ProxyConfig {
-            child_command: PathBuf::from("/nonexistent/runt"),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: HashMap::new(),
             server_name: "test-proxy".to_string(),
@@ -990,7 +1011,7 @@ mod tests {
         );
 
         let config = ProxyConfig {
-            child_command: PathBuf::from("/usr/local/bin/runt"),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/usr/local/bin/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: env,
             server_name: "nteract".to_string(),
@@ -1017,7 +1038,7 @@ mod tests {
         std::fs::write(&info_path, serde_json::to_string(&info).unwrap()).unwrap();
 
         let config = ProxyConfig {
-            child_command: PathBuf::from("/nonexistent/runt"),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: HashMap::new(),
             server_name: "test".to_string(),
@@ -1040,7 +1061,7 @@ mod tests {
     #[tokio::test]
     async fn proxy_has_no_version_when_info_file_missing() {
         let config = ProxyConfig {
-            child_command: PathBuf::from("/nonexistent/runt"),
+            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
             child_args: vec!["mcp".to_string()],
             child_env: HashMap::new(),
             server_name: "test".to_string(),


### PR DESCRIPTION
## Summary

Closes #1673

The proxy's entire purpose is upgrade transparency: the MCPB bundle ships a stable `mcpb-runt` binary while the user upgrades the nteract app (new `runt` binary). But the proxy resolved the binary path ONCE at startup and cached it in `ProxyConfig.child_command`, so upgrades were never picked up.

Confirmed via `/proc/PID/exe` — proxy children were running `(deleted)` binaries with a different MD5 than the current binary on disk.

## Fix

Replace `ProxyConfig.child_command: PathBuf` with `resolve_child_command: Box<dyn Fn() -> Result<PathBuf, String> + Send + Sync>` — a resolver closure called fresh on every `init_child()` and `restart_child()`.

Each consumer passes its own resolution strategy:
- **mcpb-runt**: `find_runt_binary()` — searches PATH + platform-specific locations
- **mcp-supervisor**: `cargo_binary()` — respects the debug/release atomic flag

This also fixes a secondary issue: after `supervisor_set_mode` switches between debug/release, the next child restart now correctly picks up the new binary path.

## Changes

- `crates/runt-mcp-proxy/src/proxy.rs` — `ProxyConfig` struct, `init_child()`, `restart_child()`, test helpers
- `crates/mcpb-runt/src/main.rs` — Pass closure; still validates at startup for clear error messages
- `crates/mcp-supervisor/src/main.rs` — Pass closure wrapping `cargo_binary()`

## Test plan

- [x] 93 proxy tests pass
- [x] All three crates compile cleanly
- [x] Lint clean
- [ ] Manual: ship nightly, verify `/proc/PID/exe` shows current binary after proxy child restart