### PR TITLE
fix(runt-mcp): coerce string booleans in MCP tool params (claude-code#32524)

### DIFF
--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -12,7 +12,7 @@ use notebook_protocol::protocol::NotebookRequest;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -89,12 +89,7 @@ pub async fn create_cell(
         .as_ref()
         .and_then(|a| a.get("index"))
         .and_then(|v| v.as_i64());
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
     let timeout_secs = request
         .arguments
         .as_ref()
@@ -167,12 +162,7 @@ pub async fn set_cell(
 
     let source = arg_str(request, "source");
     let cell_type = arg_str(request, "cell_type");
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
     let timeout_secs = request
         .arguments
         .as_ref()

--- a/crates/runt-mcp/src/tools/cell_meta.rs
+++ b/crates/runt-mcp/src/tools/cell_meta.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -154,12 +154,7 @@ pub async fn set_cells_source_hidden(
         .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
         .unwrap_or_default();
 
-    let hidden = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("hidden"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let hidden = arg_bool(request, "hidden").unwrap_or(false);
 
     let mut not_found = Vec::new();
 
@@ -193,12 +188,7 @@ pub async fn set_cells_outputs_hidden(
         .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
         .unwrap_or_default();
 
-    let hidden = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("hidden"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let hidden = arg_bool(request, "hidden").unwrap_or(false);
 
     let mut not_found = Vec::new();
 

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -10,7 +10,7 @@ use runtimed_client::output_resolver;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -139,12 +139,7 @@ pub async fn get_all_cells(
         .and_then(|a| a.get("count"))
         .and_then(|v| v.as_i64())
         .map(|v| v as usize);
-    let include_outputs = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("include_outputs"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let include_outputs = arg_bool(request, "include_outputs").unwrap_or(false);
     let preview_chars = request
         .arguments
         .as_ref()

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -11,7 +11,7 @@ use crate::editing;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error};
+use super::{arg_bool, arg_str, tool_error};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -69,12 +69,7 @@ pub async fn replace_match(
     let context_before = arg_str(request, "context_before").filter(|s| !s.is_empty());
     let context_after = arg_str(request, "context_after").filter(|s| !s.is_empty());
 
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
     let timeout_secs = request
         .arguments
         .as_ref()
@@ -146,12 +141,7 @@ pub async fn replace_regex(
     let content = arg_str(request, "content")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: content", None))?;
 
-    let and_run = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("and_run"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let and_run = arg_bool(request, "and_run").unwrap_or(false);
     let timeout_secs = request
         .arguments
         .as_ref()

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -11,7 +11,7 @@ use crate::execution;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -84,12 +84,7 @@ pub async fn run_all_cells(
 ) -> Result<CallToolResult, McpError> {
     let handle = require_handle!(server);
 
-    let wait = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("wait"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
+    let wait = arg_bool(request, "wait").unwrap_or(true);
 
     let timeout_secs = request
         .arguments

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -367,13 +367,41 @@ pub async fn dispatch(
     }
 }
 
-/// Helper: extract a typed argument or return a default.
+/// Helper: extract a string argument.
 pub fn arg_str<'a>(request: &'a CallToolRequestParams, key: &str) -> Option<&'a str> {
     request
         .arguments
         .as_ref()
         .and_then(|args| args.get(key))
         .and_then(|v| v.as_str())
+}
+
+/// Helper: extract a boolean argument, tolerating string "true"/"false".
+///
+/// Claude Code's MCP client has a known bug where boolean params are sometimes
+/// serialized as strings (e.g., `"true"` instead of `true`). This affects
+/// tools with `required` fields inconsistently.
+/// See: https://github.com/anthropics/claude-code/issues/32524
+pub fn arg_bool(request: &CallToolRequestParams, key: &str) -> Option<bool> {
+    let val = request.arguments.as_ref()?.get(key)?;
+    if let Some(b) = val.as_bool() {
+        return Some(b);
+    }
+    match val.as_str() {
+        Some("true") => {
+            tracing::warn!(
+                "[mcp] Boolean param '{key}' arrived as string \"true\" (claude-code#32524)"
+            );
+            Some(true)
+        }
+        Some("false") => {
+            tracing::warn!(
+                "[mcp] Boolean param '{key}' arrived as string \"false\" (claude-code#32524)"
+            );
+            Some(false)
+        }
+        _ => None,
+    }
 }
 
 /// Helper: create a text error result.

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -464,3 +464,65 @@ pub async fn build_execution_result(
     call_result.structured_content = structured_content;
     Ok(call_result)
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn make_request(args: serde_json::Value) -> CallToolRequestParams {
+        serde_json::from_value(serde_json::json!({
+            "name": "test",
+            "arguments": args,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn arg_bool_json_true() {
+        let req = make_request(serde_json::json!({"flag": true}));
+        assert_eq!(arg_bool(&req, "flag"), Some(true));
+    }
+
+    #[test]
+    fn arg_bool_json_false() {
+        let req = make_request(serde_json::json!({"flag": false}));
+        assert_eq!(arg_bool(&req, "flag"), Some(false));
+    }
+
+    #[test]
+    fn arg_bool_string_true() {
+        let req = make_request(serde_json::json!({"flag": "true"}));
+        assert_eq!(arg_bool(&req, "flag"), Some(true));
+    }
+
+    #[test]
+    fn arg_bool_string_false() {
+        let req = make_request(serde_json::json!({"flag": "false"}));
+        assert_eq!(arg_bool(&req, "flag"), Some(false));
+    }
+
+    #[test]
+    fn arg_bool_missing_key() {
+        let req = make_request(serde_json::json!({"other": 1}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+    }
+
+    #[test]
+    fn arg_bool_invalid_string() {
+        let req = make_request(serde_json::json!({"flag": "yes"}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+    }
+
+    #[test]
+    fn arg_bool_number() {
+        let req = make_request(serde_json::json!({"flag": 1}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+    }
+
+    #[test]
+    fn arg_bool_null() {
+        let req = make_request(serde_json::json!({"flag": null}));
+        assert_eq!(arg_bool(&req, "flag"), None);
+    }
+}

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -61,7 +61,7 @@ fn resolve_path(path: &str) -> String {
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, tool_error, tool_success};
 
 /// Collect runtime info from RuntimeStateDoc, polling briefly for it to sync.
 /// Matches Python's `_collect_runtime_info()`.
@@ -385,12 +385,7 @@ pub async fn create_notebook(
 
     let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
     let working_dir_for_detection = working_dir.clone();
-    let ephemeral = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("ephemeral"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
+    let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 
     let prev = previous_notebook_id(server).await;
 


### PR DESCRIPTION
## Summary

Workaround for a known Claude Code MCP client bug where boolean params are inconsistently serialized as strings.

**Confirmed via debug logging:**
```
create_cell:    "and_run": true      ← boolean (works)
replace_match:  "and_run": "true"    ← STRING (broken)
```
Same proxy, same binary, same JSON schema. The server's `v.as_bool()` returns `None` on the string, defaulting to `false`.

**Upstream issues:**
- https://github.com/anthropics/claude-code/issues/32524 (numbers as strings, open)
- https://github.com/anthropics/claude-code/issues/29104 (booleans as strings, closed as dup)

## Fix

Add `arg_bool()` helper that accepts both JSON booleans and string `"true"`/`"false"`, with `warn!()` logging when coercion triggers. Applied to all 9 boolean params across 6 tool files.

## Changes

- `tools/mod.rs` — new `arg_bool()` helper with warning log
- `tools/editing.rs` — `and_run` on replace_match and replace_regex
- `tools/cell_crud.rs` — `and_run` on create_cell and set_cell
- `tools/execution.rs` — `wait` on run_all_cells
- `tools/cell_meta.rs` — `hidden` on set_cells_source/outputs_hidden
- `tools/cell_read.rs` — `include_outputs` on get_all_cells
- `tools/session.rs` — `ephemeral` on create_notebook

## Test plan

- [x] 32 tests pass (`cargo test -p runt-mcp --lib`)
- [x] Lint clean
- [x] Debug logging confirmed the root cause before implementing
- [ ] Manual: ship nightly, test `replace_match(and_run=true)` via nteract-nightly proxy
- [ ] Local code review