### PR TITLE
chore: upgrade rmcp 1.3→1.4 and automerge 0.7→0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automerge"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4f9b5e81602f033fac828dafb4fef91742f6f01adfdb8ee5b8bc804cfac7bb"
+checksum = "2aab56635599ee2e9df28d9ce180c155b8dbcdd96e4c3f62895fc6a44137d328"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -2530,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "hexane"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab946df174dbf65fc07610c1f936b3e40b9ca7cfd09c0f827f9509a62e93a39"
+checksum = "8f4ecba0bb4e14df997df7cab6d1b584c6432d8865cf2adfced814706d715a7b"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -4382,7 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6147,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6171,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -12,7 +12,7 @@ name = "mcp-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "1.3", features = ["server", "client", "transport-child-process", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "client", "transport-child-process", "transport-io"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/mcpb-runt/Cargo.toml
+++ b/crates/mcpb-runt/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 runt-mcp-proxy = { path = "../runt-mcp-proxy" }
 runt-workspace = { path = "../runt-workspace" }
 runtimed-client = { path = "../runtimed-client" }
-rmcp = { version = "1.3", features = ["transport-io"] }
+rmcp = { version = "1.4", features = ["transport-io"] }
 tokio = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-automerge = "0.7"
+automerge = "0.8"
 ciborium = "0.2"
 loro_fractional_index = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-automerge = "0.7"
+automerge = "0.8"
 notebook-doc = { path = "../notebook-doc" }
 notebook-protocol = { path = "../notebook-protocol" }
 tokio = { workspace = true }

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-rmcp = { version = "1.3", features = ["server", "client", "transport-child-process", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "client", "transport-child-process", "transport-io"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-rmcp = { version = "1.3", features = ["server", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "transport-io"] }
 repr-llm = { path = "../repr-llm" }
 runtimed-client = { path = "../runtimed-client" }
 notebook-protocol = { path = "../notebook-protocol" }

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -26,7 +26,7 @@ notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 runt-workspace = { path = "../runt-workspace" }
 runt-mcp = { path = "../runt-mcp" }
 kernel-env = { path = "../kernel-env" }
-rmcp = { version = "1.3", features = ["server", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "transport-io"] }
 clap = { version = "4.5.1", features = ["derive", "color"] }
 colored = "3"
 tokio = { version = "1", features = ["full"] }

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -24,7 +24,7 @@ dirs = "6"
 base64 = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 uuid = { workspace = true }
-automerge = "0.7"
+automerge = "0.8"
 schemars = { workspace = true }
 ts-rs = { workspace = true }
 

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -10,7 +10,7 @@ description = "WASM bindings for runtimed notebook document operations, compiled
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-automerge = "0.7"
+automerge = "0.8"
 notebook-doc = { path = "../notebook-doc" }
 wasm-bindgen = "0.2"
 js-sys = "0.3"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -70,7 +70,7 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["tokio"] }
 
 # Automerge CRDT for settings sync
-automerge = "0.7"
+automerge = "0.8"
 
 # Shared notebook document types (cell CRUD, metadata, sync)
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }


### PR DESCRIPTION
## Summary

Upgrade two core dependencies:

- **rmcp 1.3 → 1.4** — adds `subscribe`/`unsubscribe` methods to ServerHandler trait, needed for MCP resource subscriptions feature
- **automerge 0.7 → 0.8** — performance improvements (fast topo sort, large object import speed), dependency updates

## Risk

- **rmcp 1.4:** Minor version bump, backward compatible. No API changes required.
- **automerge 0.8:** 6 commits since 0.7.4. No breaking API changes. The known MissingOps panic (automerge#1327) exists in both versions — existing `catch_automerge_panic` workaround remains.
- **WASM:** `runtimed-wasm` will need a `wasm-pack build` rebuild after merge.

## Test plan

- [x] 323 notebook-doc tests pass
- [x] 241 runtimed tests pass + tokio mutex lint
- [x] 45 runt-mcp tests pass
- [x] 93 runt-mcp-proxy tests pass
- [x] Lint clean
- [ ] Ship to nightly, gremlin bake test
- [ ] WASM rebuild (`cargo xtask wasm`)