### PR TITLE
chore: rebuild WASM with automerge 0.8

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aa0afb79c911aaaf6a5bc09976293b594fa1d7072055bce28809daece576e64
-size 1627987
+oid sha256:8e86e74d6bcc90640d077afd914a0f25d7040573a979f981bc4c77721ff1574a
+size 1664723


### PR DESCRIPTION
Follow-up to #1681. Rebuilds runtimed-wasm with automerge 0.8 for frontend sync compatibility.