### PR TITLE
fix(runtimed): auto-create directories on save + block ephemeral UUID saves

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -568,8 +568,8 @@ pub async fn save_notebook(
         }
     };
 
-    // If no path and notebook is ephemeral (UUID-keyed), require a path
-    if path.is_none() && !notebook_id.contains('/') && !notebook_id.ends_with(".ipynb") {
+    // If no path and notebook is ephemeral (UUID-keyed, not a file path), require a path
+    if path.is_none() && !looks_like_path(&notebook_id) {
         return tool_error(
             "No path specified for ephemeral notebook. \
              Provide a path: save_notebook(path='/path/to/notebook.ipynb')",

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -568,6 +568,14 @@ pub async fn save_notebook(
         }
     };
 
+    // If no path and notebook is ephemeral (UUID-keyed), require a path
+    if path.is_none() && !notebook_id.contains('/') && !notebook_id.ends_with(".ipynb") {
+        return tool_error(
+            "No path specified for ephemeral notebook. \
+             Provide a path: save_notebook(path='/path/to/notebook.ipynb')",
+        );
+    }
+
     // Ensure daemon has latest
     if let Err(e) = handle.confirm_sync().await {
         tracing::warn!("confirm_sync failed before save: {e}");

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -6835,14 +6835,12 @@ async fn save_notebook_to_disk(
 
     // Ensure parent directory exists (agents often construct paths programmatically)
     if let Some(parent) = notebook_path.parent() {
-        if !parent.exists() {
-            tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                SaveError::Unrecoverable(format!(
-                    "Failed to create directory '{}': {e}",
-                    parent.display()
-                ))
-            })?;
-        }
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            SaveError::Unrecoverable(format!(
+                "Failed to create directory '{}': {e}",
+                parent.display()
+            ))
+        })?;
     }
 
     // Write to disk (async to avoid blocking the runtime)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -6833,6 +6833,18 @@ async fn save_notebook_to_disk(
         .map_err(|e| SaveError::Retryable(format!("Failed to serialize notebook: {e}")))?;
     let content_with_newline = format!("{content}\n");
 
+    // Ensure parent directory exists (agents often construct paths programmatically)
+    if let Some(parent) = notebook_path.parent() {
+        if !parent.exists() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                SaveError::Unrecoverable(format!(
+                    "Failed to create directory '{}': {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+
     // Write to disk (async to avoid blocking the runtime)
     tokio::fs::write(&notebook_path, content_with_newline)
         .await


### PR DESCRIPTION
## Summary

Two save_notebook improvements for agent workflows:

1. **Auto-create parent directories** before writing `.ipynb`. Agents construct paths programmatically — `save_notebook(path="/data/project/analysis.ipynb")` now works even if `/data/project/` doesn't exist yet.

2. **Block ephemeral saves without path.** Previously, `save_notebook()` on an ephemeral notebook wrote a bare UUID file to `$HOME`. Now returns a clear error: "Provide a path: save_notebook(path='...')"

## Test plan

- [x] Existing save tests pass (9 runtimed + 45 runt-mcp)
- [x] Lint clean
- [ ] Manual: `save_notebook(path="/tmp/new/deep/dir/test.ipynb")` creates directories
- [ ] Manual: `save_notebook()` on ephemeral returns error