### PR TITLE
experiment(runt-mcp): tool consolidation variant D (18 tools)

### DIFF
--- a/crates/runt-mcp/src/tools/cell_meta.rs
+++ b/crates/runt-mcp/src/tools/cell_meta.rs
@@ -187,3 +187,129 @@ pub async fn set_cells_outputs_hidden(
     }
     tool_success(&msg)
 }
+
+// ── Consolidated cell metadata tools ────────────────────────────
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetCellTagsParams {
+    /// ID of the cell.
+    pub cell_id: String,
+    /// Tags to add.
+    #[serde(default)]
+    pub add: Option<Vec<String>>,
+    /// Tags to remove.
+    #[serde(default)]
+    pub remove: Option<Vec<String>>,
+}
+
+/// Add and/or remove tags on a cell in one call.
+pub async fn set_cell_tags(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let handle = require_handle!(server);
+
+    let metadata = match handle.get_cell_metadata(cell_id) {
+        Some(m) => m,
+        None => return tool_error(&format!("Cell {cell_id} not found")),
+    };
+
+    let mut tags: Vec<String> = metadata
+        .get("tags")
+        .and_then(|t| t.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let to_add: Vec<String> = arg_string_array(request, "add").unwrap_or_default();
+    let to_remove: Vec<String> = arg_string_array(request, "remove").unwrap_or_default();
+
+    // Remove first, then add (so you can replace tags atomically)
+    tags.retain(|t| !to_remove.contains(t));
+    for tag in &to_add {
+        if !tags.contains(tag) {
+            tags.push(tag.clone());
+        }
+    }
+
+    let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+    handle
+        .set_cell_tags(cell_id, &tag_refs)
+        .map_err(|e| McpError::internal_error(format!("Failed to set tags: {e}"), None))?;
+
+    tool_success(&format!("Tags for {cell_id}: {tags:?}"))
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetCellVisibilityParams {
+    /// IDs of cells to update.
+    pub cell_ids: Vec<String>,
+    /// Hide source code (input).
+    #[serde(default)]
+    pub source_hidden: Option<bool>,
+    /// Hide outputs.
+    #[serde(default)]
+    pub outputs_hidden: Option<bool>,
+}
+
+/// Set visibility of source and/or outputs on one or more cells.
+pub async fn set_cell_visibility(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let handle = require_handle!(server);
+
+    let cell_ids: Vec<String> = arg_string_array(request, "cell_ids").unwrap_or_default();
+    let source_hidden = arg_bool(request, "source_hidden");
+    let outputs_hidden = arg_bool(request, "outputs_hidden");
+
+    if source_hidden.is_none() && outputs_hidden.is_none() {
+        return tool_error("Provide source_hidden and/or outputs_hidden.");
+    }
+
+    let mut not_found = Vec::new();
+    let mut updated = 0;
+
+    for cell_id in &cell_ids {
+        let mut found = false;
+        if let Some(hidden) = source_hidden {
+            match handle.set_cell_source_hidden(cell_id, hidden) {
+                Ok(true) => found = true,
+                Ok(false) => {}
+                Err(_) => {}
+            }
+        }
+        if let Some(hidden) = outputs_hidden {
+            match handle.set_cell_outputs_hidden(cell_id, hidden) {
+                Ok(true) => found = true,
+                Ok(false) => {}
+                Err(_) => {}
+            }
+        }
+        if found {
+            updated += 1;
+        } else {
+            not_found.push(cell_id.as_str());
+        }
+    }
+
+    let mut msg = format!("Updated visibility on {updated} cell(s)");
+    if let Some(h) = source_hidden {
+        msg.push_str(&format!(", source_hidden={h}"));
+    }
+    if let Some(h) = outputs_hidden {
+        msg.push_str(&format!(", outputs_hidden={h}"));
+    }
+    if !not_found.is_empty() {
+        msg.push_str(&format!("; not found: {not_found:?}"));
+    }
+    tool_success(&msg)
+}

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -1,4 +1,4 @@
-//! Read-only cell tools: get_cell, get_all_cells.
+//! Read-only cell tools: get_cells (consolidated get_cell + get_all_cells).
 
 use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
 use rmcp::ErrorData as McpError;
@@ -14,33 +14,41 @@ use super::{arg_bool, arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetCellParams {
-    /// The cell ID to retrieve.
-    pub cell_id: String,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct GetAllCellsParams {
-    /// Output format: "summary" (default), "json", or "rich".
+pub struct GetCellsParams {
+    /// Cell ID to retrieve. Omit to list all cells.
+    #[serde(default)]
+    pub cell_id: Option<String>,
+    /// Output format: "summary" (default), "json", or "rich". Ignored when cell_id is set.
     #[serde(default = "default_format")]
     pub format: Option<String>,
-    /// Starting cell index (0-based).
+    /// Starting cell index (0-based). Ignored when cell_id is set.
     #[serde(default)]
     pub start: Option<i64>,
-    /// Number of cells to return (null = all).
+    /// Number of cells to return (null = all). Ignored when cell_id is set.
     #[serde(default)]
     pub count: Option<i64>,
-    /// Include output previews in summary format.
+    /// Include output previews in summary format. Ignored when cell_id is set.
     #[serde(default)]
     pub include_outputs: Option<bool>,
-    /// Max chars for source preview in summary format.
+    /// Max chars for source preview in summary format. Ignored when cell_id is set.
     #[serde(default)]
     pub preview_chars: Option<i64>,
 }
 
 fn default_format() -> Option<String> {
     Some("summary".to_string())
+}
+
+/// Consolidated entry point: dispatches to single-cell or all-cells logic.
+pub async fn get_cells(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    if arg_str(request, "cell_id").is_some() {
+        get_cell(server, request).await
+    } else {
+        get_all_cells(server, request).await
+    }
 }
 
 /// Get a single cell by ID with source and outputs.

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -9,7 +9,7 @@ use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
 use crate::NteractMcp;
 
-use super::{arg_str, tool_error, tool_success};
+use super::{arg_str, arg_string_array, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -481,4 +481,189 @@ fn get_deps_for_manager(handle: &notebook_sync::handle::DocHandle, manager: &str
             _ => m.uv_dependencies().to_vec(),
         })
         .unwrap_or_default()
+}
+
+// ── Consolidated dependency tool ────────────────────────────────
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ManageDependenciesParams {
+    /// Packages to add (e.g. ["pandas>=2.0", "numpy"]).
+    #[serde(default)]
+    pub add: Option<Vec<String>>,
+    /// Packages to remove.
+    #[serde(default)]
+    pub remove: Option<Vec<String>>,
+    /// Action after changes: "none" (default), "sync" (hot-install), or "restart".
+    #[serde(default)]
+    pub after: Option<String>,
+}
+
+/// Add and/or remove dependencies in one call, with optional sync or restart.
+pub async fn manage_dependencies(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let to_add: Vec<String> = arg_string_array(request, "add").unwrap_or_default();
+    let to_remove: Vec<String> = arg_string_array(request, "remove").unwrap_or_default();
+    let after = arg_str(request, "after").unwrap_or("none");
+
+    if to_add.is_empty() && to_remove.is_empty() {
+        return tool_error("Provide at least one package to add or remove.");
+    }
+
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                return tool_error(
+                    "No active notebook session. Call open_notebook or create_notebook first.",
+                )
+            }
+        }
+    };
+
+    let manager = detect_package_manager(&handle);
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut errors = Vec::new();
+
+    for pkg in &to_add {
+        match add_dep_for_manager(&handle, pkg, &manager) {
+            Ok(()) => added.push(pkg.as_str()),
+            Err(e) => errors.push(format!("add {pkg}: {e}")),
+        }
+    }
+
+    for pkg in &to_remove {
+        match remove_dep_for_manager(&handle, pkg, &manager) {
+            Ok(true) => removed.push(pkg.as_str()),
+            Ok(false) => {} // wasn't present, not an error
+            Err(e) => errors.push(format!("remove {pkg}: {e}")),
+        }
+    }
+
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed after manage_dependencies: {e}");
+    }
+
+    let deps = get_deps_for_manager(&handle, &manager);
+
+    let mut result = serde_json::json!({
+        "dependencies": deps,
+        "added": added,
+        "removed": removed,
+        "package_manager": manager,
+    });
+
+    if !errors.is_empty() {
+        result["errors"] = serde_json::json!(errors);
+    }
+
+    // Handle after action — reuse the same logic as add_dependency
+    match after {
+        "sync" => {
+            match handle
+                .send_request(NotebookRequest::SyncEnvironment {})
+                .await
+            {
+                Ok(NotebookResponse::SyncEnvironmentComplete {
+                    synced_packages, ..
+                }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": true,
+                        "synced_packages": synced_packages,
+                    });
+                }
+                Ok(NotebookResponse::SyncEnvironmentStarted { packages }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": true,
+                        "synced_packages": packages,
+                    });
+                }
+                Ok(NotebookResponse::SyncEnvironmentFailed {
+                    error,
+                    needs_restart,
+                }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                        "needs_restart": needs_restart,
+                    });
+                }
+                Ok(NotebookResponse::Error { error }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                        "needs_restart": true,
+                    });
+                }
+                Ok(_) => {
+                    result["sync"] = serde_json::json!({ "success": true });
+                }
+                Err(e) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": format!("Failed to sync: {e}"),
+                        "needs_restart": true,
+                    });
+                }
+            }
+        }
+        "restart" => {
+            let restart_env_source = match handle
+                .get_runtime_state()
+                .ok()
+                .map(|s| s.kernel.env_source.clone())
+                .as_deref()
+            {
+                Some("uv:prewarmed") => "auto:uv".to_string(),
+                Some("conda:prewarmed") => "auto:conda".to_string(),
+                Some("pixi:prewarmed") => "auto:pixi".to_string(),
+                Some("") | None => "auto".to_string(),
+                Some(s) => s.to_string(),
+            };
+            let notebook_path = if notebook_id.contains('/') || notebook_id.contains('\\') {
+                Some(notebook_id.clone())
+            } else {
+                None
+            };
+            let _ = handle
+                .send_request(NotebookRequest::ShutdownKernel {})
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            match handle
+                .send_request(NotebookRequest::LaunchKernel {
+                    kernel_type: "python".to_string(),
+                    env_source: restart_env_source,
+                    notebook_path,
+                })
+                .await
+            {
+                Ok(NotebookResponse::KernelLaunched { env_source, .. }) => {
+                    result["restart"] = serde_json::json!({
+                        "success": true,
+                        "env_source": env_source,
+                    });
+                }
+                Ok(NotebookResponse::Error { error }) => {
+                    result["restart"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                    });
+                }
+                Err(e) => {
+                    result["restart"] = serde_json::json!({
+                        "success": false,
+                        "error": format!("Failed to restart: {e}"),
+                    });
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -1,4 +1,4 @@
-//! Editing tools: replace_match, replace_regex.
+//! Editing tools: replace (consolidated replace_match + replace_regex).
 
 use std::time::Duration;
 
@@ -15,18 +15,21 @@ use super::{arg_bool, arg_str, tool_error};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ReplaceMatchParams {
+pub struct ReplaceParams {
     /// The cell ID to edit.
     pub cell_id: String,
-    /// Literal text to find (must match exactly once).
+    /// Mode: "literal" (default) or "regex".
+    #[serde(default = "default_mode")]
+    pub mode: Option<String>,
+    /// Literal text or regex pattern to find (must match exactly once). For regex: MULTILINE enabled, DOTALL off.
     #[serde(rename = "match")]
     pub match_text: String,
-    /// Literal replacement text.
+    /// Replacement text.
     pub content: String,
-    /// Text that must appear before the match.
+    /// Text before the match (literal mode only, for disambiguation).
     #[serde(default)]
     pub context_before: Option<String>,
-    /// Text that must appear after the match.
+    /// Text after the match (literal mode only, for disambiguation).
     #[serde(default)]
     pub context_after: Option<String>,
     /// Execute the cell immediately after edit.
@@ -37,21 +40,24 @@ pub struct ReplaceMatchParams {
     pub timeout_secs: Option<f64>,
 }
 
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ReplaceRegexParams {
-    /// The cell ID to edit.
-    pub cell_id: String,
-    /// Regex pattern (must match exactly once). MULTILINE ((?m)) enabled by default — ^/$ match line boundaries, use \z for end-of-string. DOTALL is off — . does not match \n unless you add (?s).
-    pub pattern: String,
-    /// Literal replacement text — not interpreted as a regex or escape sequence. To insert a newline, use an actual newline character in the JSON string.
-    pub content: String,
-    /// Execute the cell immediately after edit.
-    #[serde(default)]
-    pub and_run: Option<bool>,
-    /// Max seconds to wait for execution.
-    #[serde(default)]
-    pub timeout_secs: Option<f64>,
+fn default_mode() -> Option<String> {
+    Some("literal".to_string())
+}
+
+/// Consolidated replace: dispatches to literal or regex logic.
+pub async fn replace(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let mode = arg_str(request, "mode").unwrap_or("literal");
+    match mode {
+        "literal" => replace_match(server, request).await,
+        "regex" => replace_regex(server, request).await,
+        _ => Err(McpError::invalid_params(
+            format!("Unknown replace mode: {mode}. Use \"literal\" or \"regex\"."),
+            None,
+        )),
+    }
 }
 
 /// Replace matched text in a cell.
@@ -136,8 +142,12 @@ pub async fn replace_regex(
 ) -> Result<CallToolResult, McpError> {
     let cell_id = arg_str(request, "cell_id")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
-    let pattern = arg_str(request, "pattern")
-        .ok_or_else(|| McpError::invalid_params("Missing required parameter: pattern", None))?;
+    // Accept "match" (consolidated schema) or "pattern" (legacy replace_regex)
+    let pattern = arg_str(request, "match")
+        .or_else(|| arg_str(request, "pattern"))
+        .ok_or_else(|| {
+            McpError::invalid_params("Missing required parameter: match (or pattern)", None)
+        })?;
     let content = arg_str(request, "content")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: content", None))?;
 

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -1,13 +1,39 @@
-//! Kernel management tools: interrupt_kernel, restart_kernel.
+//! Kernel management tools: kernel_control (consolidated interrupt + restart).
 
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
 use crate::NteractMcp;
 
-use super::{tool_error, tool_success};
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct KernelControlParams {
+    /// Action: "interrupt" or "restart".
+    pub action: String,
+}
+
+/// Consolidated kernel control: interrupt or restart.
+pub async fn kernel_control(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let action = arg_str(request, "action")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: action", None))?;
+    match action {
+        "interrupt" => interrupt_kernel(server, request).await,
+        "restart" => restart_kernel(server, request).await,
+        _ => Err(McpError::invalid_params(
+            format!("Unknown kernel_control action: {action}. Use \"interrupt\" or \"restart\"."),
+            None,
+        )),
+    }
+}
 
 /// Interrupt the currently executing cell.
 pub async fn interrupt_kernel(

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -117,12 +117,7 @@ pub fn all_tools() -> Vec<Tool> {
                 .idempotent(true)
                 .open_world(true),
         ),
-        Tool::new(
-            "launch_app",
-            "Launch the nteract desktop app for the user, showing the current notebook. The notebook must be running in the daemon.",
-            schema_for::<session::ShowNotebookParams>(),
-        )
-        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
+        // launch_app removed from tool list (still dispatched for backward compat)
         // -- Cell read --
         Tool::new(
             "get_cell",
@@ -181,9 +176,9 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         // -- Cell metadata --
         Tool::new(
-            "add_cell_tags",
-            "Add tags to a cell's metadata. Existing tags are preserved.",
-            schema_for::<cell_meta::AddCellTagsParams>(),
+            "set_cell_tags",
+            "Add and/or remove tags on a cell.",
+            schema_for::<cell_meta::SetCellTagsParams>(),
         )
         .annotate(
             ToolAnnotations::new()
@@ -192,31 +187,9 @@ pub fn all_tools() -> Vec<Tool> {
                 .open_world(false),
         ),
         Tool::new(
-            "remove_cell_tags",
-            "Remove tags from a cell's metadata.",
-            schema_for::<cell_meta::RemoveCellTagsParams>(),
-        )
-        .annotate(
-            ToolAnnotations::new()
-                .destructive(true)
-                .idempotent(true)
-                .open_world(false),
-        ),
-        Tool::new(
-            "set_cells_source_hidden",
-            "Hide or show the source (code input) of one or more cells.",
-            schema_for::<cell_meta::SetCellsSourceHiddenParams>(),
-        )
-        .annotate(
-            ToolAnnotations::new()
-                .destructive(false)
-                .idempotent(true)
-                .open_world(false),
-        ),
-        Tool::new(
-            "set_cells_outputs_hidden",
-            "Hide or show the outputs of one or more cells.",
-            schema_for::<cell_meta::SetCellsOutputsHiddenParams>(),
+            "set_cell_visibility",
+            "Hide or show source and/or outputs on cells.",
+            schema_for::<cell_meta::SetCellVisibilityParams>(),
         )
         .annotate(
             ToolAnnotations::new()
@@ -325,6 +298,9 @@ pub async fn dispatch(
         "move_cell" => cell_crud::move_cell(server, request).await,
         "clear_outputs" => cell_crud::clear_outputs(server, request).await,
         // Cell metadata
+        "set_cell_tags" => cell_meta::set_cell_tags(server, request).await,
+        "set_cell_visibility" => cell_meta::set_cell_visibility(server, request).await,
+        // Backward compat aliases
         "add_cell_tags" => cell_meta::add_cell_tags(server, request).await,
         "remove_cell_tags" => cell_meta::remove_cell_tags(server, request).await,
         "set_cells_source_hidden" => cell_meta::set_cells_source_hidden(server, request).await,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -120,15 +120,9 @@ pub fn all_tools() -> Vec<Tool> {
         // launch_app removed from tool list (still dispatched for backward compat)
         // -- Cell read --
         Tool::new(
-            "get_cell",
-            "Get a cell by ID.",
-            schema_for::<cell_read::GetCellParams>(),
-        )
-        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
-        Tool::new(
-            "get_all_cells",
-            "Get all cells as summary, json, or rich format.",
-            schema_for::<cell_read::GetAllCellsParams>(),
+            "get_cells",
+            "Get one cell by ID, or list all cells.",
+            schema_for::<cell_read::GetCellsParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         // -- Cell CRUD --
@@ -214,20 +208,9 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(app_tool_meta()),
         // -- Kernel --
         Tool::new(
-            "interrupt_kernel",
-            "Interrupt execution.",
-            schema_for::<EmptyParams>(),
-        )
-        .annotate(
-            ToolAnnotations::new()
-                .destructive(true)
-                .idempotent(true)
-                .open_world(false),
-        ),
-        Tool::new(
-            "restart_kernel",
-            "Restart the kernel, clearing all state.",
-            schema_for::<EmptyParams>(),
+            "kernel_control",
+            "Interrupt or restart the kernel.",
+            schema_for::<kernel::KernelControlParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         // -- Dependencies --
@@ -250,16 +233,9 @@ pub fn all_tools() -> Vec<Tool> {
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         // -- Editing --
         Tool::new(
-            "replace_match",
-            "Replace literal text in a cell.",
-            schema_for::<editing::ReplaceMatchParams>(),
-        )
-        .annotate(ToolAnnotations::new().destructive(false).open_world(false))
-        .with_meta(app_tool_meta()),
-        Tool::new(
-            "replace_regex",
-            "Replace a regex match in a cell.",
-            schema_for::<editing::ReplaceRegexParams>(),
+            "replace",
+            "Find and replace text in a cell (literal or regex).",
+            schema_for::<editing::ReplaceParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
@@ -289,6 +265,8 @@ pub async fn dispatch(
         "save_notebook" => session::save_notebook(server, request).await,
         "launch_app" => session::show_notebook(server, request).await,
         // Cell read
+        "get_cells" => cell_read::get_cells(server, request).await,
+        // Backward compat aliases
         "get_cell" => cell_read::get_cell(server, request).await,
         "get_all_cells" => cell_read::get_all_cells(server, request).await,
         // Cell CRUD
@@ -309,6 +287,8 @@ pub async fn dispatch(
         "execute_cell" => execution::execute_cell(server, request).await,
         "run_all_cells" => execution::run_all_cells(server, request).await,
         // Kernel
+        "kernel_control" => kernel::kernel_control(server, request).await,
+        // Backward compat aliases
         "interrupt_kernel" => kernel::interrupt_kernel(server, request).await,
         "restart_kernel" => kernel::restart_kernel(server, request).await,
         // Dependencies
@@ -319,6 +299,8 @@ pub async fn dispatch(
         "remove_dependency" => deps::remove_dependency(server, request).await,
         "sync_environment" => deps::sync_environment(server, request).await,
         // Editing
+        "replace" => editing::replace(server, request).await,
+        // Backward compat aliases
         "replace_match" => editing::replace_match(server, request).await,
         "replace_regex" => editing::replace_regex(server, request).await,
         _ => Err(McpError::invalid_params(

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -83,14 +83,14 @@ pub fn all_tools() -> Vec<Tool> {
         // -- Session management --
         Tool::new(
             "list_active_notebooks",
-            "List all notebook sessions running in the daemon. Returns notebooks opened by any user or agent. Use open_notebook(notebook) to connect to one as your active session.",
+            "List running notebook sessions.",
             schema_for::<EmptyParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false))
         .with_meta(always_load_meta()),
         Tool::new(
             "open_notebook",
-            "Open a notebook by file path or connect to a running session by ID. Accepts a file path (e.g. '~/analysis.ipynb') or a notebook_id from list_active_notebooks. Makes it your active session.",
+            "Open a notebook by path or session ID.",
             schema_for::<session::OpenNotebookParams>(),
         )
         .annotate(
@@ -102,13 +102,13 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(always_load_meta()),
         Tool::new(
             "create_notebook",
-            "Create a new notebook, making it your active session. Notebooks are ephemeral by default (in-memory only) — use save_notebook(path) to persist to disk. Set ephemeral=false for session-restorable persistence. Supports uv, conda, or pixi via package_manager param.",
+            "Create a new notebook.",
             schema_for::<session::CreateNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
         Tool::new(
             "save_notebook",
-            "Save notebook to disk. The daemon automatically re-keys ephemeral rooms to the saved file path.",
+            "Save notebook to disk.",
             schema_for::<session::SaveNotebookParams>(),
         )
         .annotate(
@@ -121,13 +121,13 @@ pub fn all_tools() -> Vec<Tool> {
         // -- Cell read --
         Tool::new(
             "get_cell",
-            "Get a cell's source and outputs by ID.",
+            "Get a cell by ID.",
             schema_for::<cell_read::GetCellParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         Tool::new(
             "get_all_cells",
-            "Get all cells. Use summary (default) for discovery, get_cell() for details. Formats: 'summary', 'json', 'rich'.",
+            "Get all cells as summary, json, or rich format.",
             schema_for::<cell_read::GetAllCellsParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
@@ -141,14 +141,14 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(app_tool_meta()),
         Tool::new(
             "set_cell",
-            "Update a cell's source and/or type. Use replace_match for targeted edits.",
+            "Replace a cell's source or type.",
             schema_for::<cell_crud::SetCellParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
         Tool::new(
             "delete_cell",
-            "Delete a cell by ID.",
+            "Delete a cell.",
             schema_for::<cell_crud::DeleteCellParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
@@ -165,7 +165,7 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "clear_outputs",
-            "Clear cell outputs. Pass cell_ids to clear specific cells, or omit to clear ALL outputs (destructive).",
+            "Clear cell outputs.",
             schema_for::<cell_crud::ClearOutputsParams>(),
         )
         .annotate(
@@ -200,14 +200,14 @@ pub fn all_tools() -> Vec<Tool> {
         // -- Execution --
         Tool::new(
             "execute_cell",
-            "Execute a cell. Returns partial results if timeout exceeded.",
+            "Execute a code cell.",
             schema_for::<execution::ExecuteCellParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(true))
         .with_meta(app_tool_meta()),
         Tool::new(
             "run_all_cells",
-            "Execute all code cells in order. With wait=true (default), waits for completion and returns per-cell outputs with structured content. With wait=false, queues cells and returns immediately.",
+            "Execute all code cells in order.",
             schema_for::<execution::RunAllCellsParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(true))
@@ -215,7 +215,7 @@ pub fn all_tools() -> Vec<Tool> {
         // -- Kernel --
         Tool::new(
             "interrupt_kernel",
-            "Interrupt the currently executing cell.",
+            "Interrupt execution.",
             schema_for::<EmptyParams>(),
         )
         .annotate(
@@ -226,14 +226,14 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "restart_kernel",
-            "Restart kernel, clearing all state. Use after dependency changes.",
+            "Restart the kernel, clearing all state.",
             schema_for::<EmptyParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         // -- Dependencies --
         Tool::new(
             "manage_dependencies",
-            "Add and/or remove packages. Use after='sync' to hot-install or after='restart' to restart kernel with new deps.",
+            "Add or remove packages, optionally syncing or restarting.",
             schema_for::<deps::ManageDependenciesParams>(),
         )
         .annotate(
@@ -244,21 +244,21 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "get_dependencies",
-            "Get the notebook's declared dependencies and package manager.",
+            "Get the notebook's declared dependencies.",
             schema_for::<deps::GetDependenciesParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         // -- Editing --
         Tool::new(
             "replace_match",
-            "Replace matched text in a cell. Prefer this for simple, targeted edits. Use context_before/context_after to disambiguate when match appears multiple times.",
+            "Replace literal text in a cell.",
             schema_for::<editing::ReplaceMatchParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
         Tool::new(
             "replace_regex",
-            "Replace a regex-matched span (fancy-regex engine, Rust). Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches. Replacement content is literal (no escape interpretation — use actual newline chars, not \\n).",
+            "Replace a regex match in a cell.",
             schema_for::<editing::ReplaceRegexParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -259,9 +259,9 @@ pub fn all_tools() -> Vec<Tool> {
         .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         // -- Dependencies --
         Tool::new(
-            "add_dependency",
-            "Add a package dependency (e.g. 'pandas>=2.0'). When a project file (pixi.toml, pyproject.toml) exists, promotes the dependency to the project file via 'pixi add' or 'uv add'. Otherwise stores in notebook metadata. Use after='sync' or after='restart' to apply.",
-            schema_for::<deps::AddDependencyParams>(),
+            "manage_dependencies",
+            "Add and/or remove packages. Use after='sync' to hot-install or after='restart' to restart kernel with new deps.",
+            schema_for::<deps::ManageDependenciesParams>(),
         )
         .annotate(
             ToolAnnotations::new()
@@ -270,28 +270,11 @@ pub fn all_tools() -> Vec<Tool> {
                 .open_world(false),
         ),
         Tool::new(
-            "remove_dependency",
-            "Remove a package dependency. When a project file exists, runs 'pixi remove' or 'uv remove'. Otherwise removes from notebook metadata. Requires restart_kernel() to take effect.",
-            schema_for::<deps::RemoveDependencyParams>(),
-        )
-        .annotate(
-            ToolAnnotations::new()
-                .destructive(true)
-                .idempotent(true)
-                .open_world(false),
-        ),
-        Tool::new(
             "get_dependencies",
-            "Get the notebook's declared dependencies and any pre-installed packages available in the environment.",
+            "Get the notebook's declared dependencies and package manager.",
             schema_for::<deps::GetDependenciesParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
-        Tool::new(
-            "sync_environment",
-            "Hot-install new dependencies without restarting. Use restart_kernel() if this fails.",
-            schema_for::<EmptyParams>(),
-        )
-        .annotate(ToolAnnotations::new().destructive(false).open_world(true)),
         // -- Editing --
         Tool::new(
             "replace_match",
@@ -353,9 +336,11 @@ pub async fn dispatch(
         "interrupt_kernel" => kernel::interrupt_kernel(server, request).await,
         "restart_kernel" => kernel::restart_kernel(server, request).await,
         // Dependencies
+        "manage_dependencies" => deps::manage_dependencies(server, request).await,
+        "get_dependencies" => deps::get_dependencies(server, request).await,
+        // Backward compat aliases
         "add_dependency" => deps::add_dependency(server, request).await,
         "remove_dependency" => deps::remove_dependency(server, request).await,
-        "get_dependencies" => deps::get_dependencies(server, request).await,
         "sync_environment" => deps::sync_environment(server, request).await,
         // Editing
         "replace_match" => editing::replace_match(server, request).await,


### PR DESCRIPTION
## Summary

Variant D of the tool consolidation experiment. Builds on variant C (21 tools) with three additional merges:

- **`get_cells`** -- merges `get_cell` + `get_all_cells`. If `cell_id` is provided, returns that single cell; if omitted, returns all cells with pagination support (`format`, `start`, `count`, `include_outputs`, `preview_chars`).
- **`kernel_control`** -- merges `interrupt_kernel` + `restart_kernel` via `action` param ("interrupt" or "restart").
- **`replace`** -- merges `replace_match` + `replace_regex` via `mode` param ("literal" default, or "regex"). Literal mode supports `context_before`/`context_after` for disambiguation; regex mode accepts the pattern in the same `match` field.

All old tool names are preserved as backward-compat aliases in the dispatch function.

**Tool count:** 27 (original) -> 21 (variant C) -> 18 (variant D)

## Test plan

- [x] `cargo test -p runt-mcp --lib` -- 45 tests pass
- [x] `cargo xtask lint --fix` -- all checks pass
- [x] `cargo build --release -p runt-cli` -- builds successfully
- [ ] Ship binary and measure schema size / ToolSearch deferral behavior