### PR TITLE
fix(runt-mcp): graceful fallback for launch_app in headless environments

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -63,6 +63,13 @@ use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
 use super::{arg_bool, arg_str, arg_string_array, tool_error, tool_success};
 
+fn has_display() -> bool {
+    if cfg!(target_os = "macos") || cfg!(target_os = "windows") {
+        return true;
+    }
+    std::env::var("DISPLAY").is_ok() || std::env::var("WAYLAND_DISPLAY").is_ok()
+}
+
 /// Collect runtime info from RuntimeStateDoc, polling briefly for it to sync.
 /// Matches Python's `_collect_runtime_info()`.
 async fn collect_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::Value {
@@ -669,6 +676,20 @@ pub async fn show_notebook(
         .find(|r| r.notebook_id == target)
         .map(|r| r.ephemeral)
         .unwrap_or(false);
+
+    if !has_display() {
+        let mut result = serde_json::json!({
+            "notebook_id": target,
+            "opened": false,
+            "reason": "No display available (headless environment). The notebook is running in the daemon and accessible via MCP tools."
+        });
+        if is_ephemeral {
+            result["note"] = serde_json::json!(
+                "This notebook is ephemeral. Use save_notebook(path) to persist."
+            );
+        }
+        return tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default());
+    }
 
     // Launch the app using the binary's build channel.
     // NOTE: If RUNTIMED_SOCKET_PATH points at a different channel's daemon,


### PR DESCRIPTION
## Summary

`launch_app` now detects headless environments (no `DISPLAY` or `WAYLAND_DISPLAY` on Linux) and returns a success response instead of an MCP error. The response tells the agent the notebook is running and accessible via MCP tools.

This eliminates ~10 spurious tool errors per gremlin testing cycle. On machines with a display (macOS, Windows, Linux with X11/Wayland), behavior is unchanged — the app still launches.

## Changes

- Added `has_display()` check in the `show_notebook` handler
- Headless returns `{"opened": false, "reason": "No display available..."}` as success
- Ephemeral notebooks get a note about using `save_notebook(path)`

## Test plan

- [x] `cargo check -p runt-mcp` passes
- [x] `cargo xtask lint` clean
- [ ] Gremlin runs show 0 `launch_app` tool errors on headless
- [ ] macOS: `launch_app` still opens the desktop app