### PR TITLE
feat(runtimed): dynamic pool size configuration via settings doc

### DIFF
--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -86,6 +86,18 @@ pub fn load_settings() -> SyncedSettings {
             .get("onboarding_completed")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(true),
+        uv_pool_size: json
+            .get("uv_pool_size")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or(defaults.uv_pool_size),
+        conda_pool_size: json
+            .get("conda_pool_size")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or(defaults.conda_pool_size),
+        pixi_pool_size: json
+            .get("pixi_pool_size")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or(defaults.pixi_pool_size),
     }
 }
 
@@ -117,6 +129,9 @@ mod tests {
             pixi: PixiDefaults::default(),
             keep_alive_secs: 30,
             onboarding_completed: false,
+            uv_pool_size: 3,
+            conda_pool_size: 3,
+            pixi_pool_size: 2,
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -264,6 +279,9 @@ mod tests {
                 .get("onboarding_completed")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or(defaults.onboarding_completed),
+            uv_pool_size: defaults.uv_pool_size,
+            conda_pool_size: defaults.conda_pool_size,
+            pixi_pool_size: defaults.pixi_pool_size,
         };
         // Valid fields are preserved
         assert_eq!(settings.theme, ThemeMode::Dark);

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -453,6 +453,9 @@ const VALID_CONFIG_KEYS: &[&str] = &[
     "uv.default_packages",
     "conda.default_packages",
     "pixi.default_packages",
+    "uv_pool_size",
+    "conda_pool_size",
+    "pixi_pool_size",
 ];
 
 /// Daemon management commands (replaces Pool + runtimed service commands)
@@ -4076,6 +4079,10 @@ async fn config_command(command: Option<ConfigCommands>) -> Result<()> {
                         runtimed::settings_doc::MAX_KEEP_ALIVE_SECS,
                     ),
                     "onboarding_completed" => "Must be true or false".to_string(),
+                    k if k.ends_with("_pool_size") => format!(
+                        "Must be a number between 0 and {}",
+                        runtimed_client::settings_doc::MAX_POOL_SIZE,
+                    ),
                     k if k.ends_with("default_packages") => {
                         "Must be a JSON array '[\"pkg1\",\"pkg2\"]' or comma-separated 'pkg1,pkg2'"
                             .to_string()

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -155,6 +155,11 @@ pub const MIN_KEEP_ALIVE_SECS: u64 = 5;
 /// Maximum keep-alive duration (7 days) for notebook rooms.
 pub const MAX_KEEP_ALIVE_SECS: u64 = 604800;
 
+pub const DEFAULT_UV_POOL_SIZE: u64 = 3;
+pub const DEFAULT_CONDA_POOL_SIZE: u64 = 3;
+pub const DEFAULT_PIXI_POOL_SIZE: u64 = 2;
+pub const MAX_POOL_SIZE: u64 = 20;
+
 /// Snapshot of all synced settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
 #[ts(export)]
@@ -193,6 +198,18 @@ pub struct SyncedSettings {
     /// When false, the app shows the onboarding screen on startup.
     #[serde(default)]
     pub onboarding_completed: bool,
+
+    /// Number of prewarmed UV environments to keep ready. 0 disables the pool.
+    #[serde(default = "default_uv_pool_size")]
+    pub uv_pool_size: u64,
+
+    /// Number of prewarmed Conda environments to keep ready. 0 disables the pool.
+    #[serde(default = "default_conda_pool_size")]
+    pub conda_pool_size: u64,
+
+    /// Number of prewarmed Pixi environments to keep ready. 0 disables the pool.
+    #[serde(default = "default_pixi_pool_size")]
+    pub pixi_pool_size: u64,
 }
 
 impl Default for SyncedSettings {
@@ -206,12 +223,24 @@ impl Default for SyncedSettings {
             pixi: PixiDefaults::default(),
             keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
             onboarding_completed: false,
+            uv_pool_size: DEFAULT_UV_POOL_SIZE,
+            conda_pool_size: DEFAULT_CONDA_POOL_SIZE,
+            pixi_pool_size: DEFAULT_PIXI_POOL_SIZE,
         }
     }
 }
 
 fn default_keep_alive_secs() -> u64 {
     DEFAULT_KEEP_ALIVE_SECS
+}
+fn default_uv_pool_size() -> u64 {
+    DEFAULT_UV_POOL_SIZE
+}
+fn default_conda_pool_size() -> u64 {
+    DEFAULT_CONDA_POOL_SIZE
+}
+fn default_pixi_pool_size() -> u64 {
+    DEFAULT_PIXI_POOL_SIZE
 }
 
 /// Generate a JSON Schema string for the settings file.
@@ -264,6 +293,23 @@ impl SettingsDoc {
         );
         // Store onboarding_completed as boolean
         let _ = doc.put(automerge::ROOT, "onboarding_completed", false);
+
+        // Pool sizes
+        let _ = doc.put(
+            automerge::ROOT,
+            "uv_pool_size",
+            defaults.uv_pool_size as i64,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
+            "conda_pool_size",
+            defaults.conda_pool_size as i64,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
+            "pixi_pool_size",
+            defaults.pixi_pool_size as i64,
+        );
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -732,6 +778,15 @@ impl SettingsDoc {
                 // Check if this is an existing user by looking for other settings
                 self.get("theme").is_some() || self.get("default_runtime").is_some()
             }),
+            uv_pool_size: self
+                .get_u64("uv_pool_size")
+                .unwrap_or(defaults.uv_pool_size),
+            conda_pool_size: self
+                .get_u64("conda_pool_size")
+                .unwrap_or(defaults.conda_pool_size),
+            pixi_pool_size: self
+                .get_u64("pixi_pool_size")
+                .unwrap_or(defaults.pixi_pool_size),
         }
     }
 

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -445,6 +445,9 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         // assume they're upgrading from before onboarding was added → treat as completed
         onboarding_completed: get_bool("onboarding_completed")
             .unwrap_or_else(|| get_str("theme").is_some() || get_str("default_runtime").is_some()),
+        uv_pool_size: get_u64("uv_pool_size").unwrap_or(defaults.uv_pool_size),
+        conda_pool_size: get_u64("conda_pool_size").unwrap_or(defaults.conda_pool_size),
+        pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(defaults.pixi_pool_size),
     }
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2696,7 +2696,7 @@ impl Daemon {
                 break;
             }
 
-            {
+            let (deficit, should_retry, backoff_info) = {
                 let target = {
                     let settings = self.settings.read().await;
                     settings
@@ -2707,10 +2707,6 @@ impl Daemon {
                 };
                 let mut pool = self.uv_pool.lock().await;
                 pool.set_target(target);
-            }
-
-            let (deficit, should_retry, backoff_info) = {
-                let mut pool = self.uv_pool.lock().await;
                 let d = pool.deficit();
                 let retry = pool.should_retry();
                 let info = if pool.failure_state.consecutive_failures > 0 {
@@ -2781,7 +2777,7 @@ impl Daemon {
                 break;
             }
 
-            {
+            let (deficit, should_retry, backoff_info) = {
                 let target = {
                     let settings = self.settings.read().await;
                     settings
@@ -2792,10 +2788,6 @@ impl Daemon {
                 };
                 let mut pool = self.conda_pool.lock().await;
                 pool.set_target(target);
-            }
-
-            let (deficit, should_retry, backoff_info) = {
-                let mut pool = self.conda_pool.lock().await;
                 let d = pool.deficit();
                 let retry = pool.should_retry();
                 let info = if pool.failure_state.consecutive_failures > 0 {
@@ -2876,7 +2868,7 @@ impl Daemon {
                 break;
             }
 
-            {
+            let (deficit, should_retry, backoff_info) = {
                 let target = {
                     let settings = self.settings.read().await;
                     settings
@@ -2887,10 +2879,6 @@ impl Daemon {
                 };
                 let mut pool = self.pixi_pool.lock().await;
                 pool.set_target(target);
-            }
-
-            let (deficit, should_retry, backoff_info) = {
-                let mut pool = self.pixi_pool.lock().await;
                 let d = pool.deficit();
                 let retry = pool.should_retry();
                 let info = if pool.failure_state.consecutive_failures > 0 {
@@ -3258,14 +3246,15 @@ impl Daemon {
                     });
                 }
 
-                let pool = self.conda_pool.lock().await;
-                info!(
-                    "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
-                    env_path,
-                    pool.stats().0,
-                    pool.target()
-                );
-
+                {
+                    let pool = self.conda_pool.lock().await;
+                    info!(
+                        "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
+                        env_path,
+                        pool.stats().0,
+                        pool.target()
+                    );
+                }
                 self.update_pool_doc().await;
             }
             WarmupOutcome::Timeout => {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -513,7 +513,13 @@ impl Daemon {
         // Load or create the settings document
         let automerge_path = crate::default_settings_doc_path();
         let json_path = crate::settings_json_path();
-        let settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        let mut settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+
+        // Seed pool sizes from CLI config into settings doc so the warming
+        // loops use the daemon's configured sizes, not the schema defaults.
+        settings.put_u64("uv_pool_size", config.uv_pool_size as u64);
+        settings.put_u64("conda_pool_size", config.conda_pool_size as u64);
+        settings.put_u64("pixi_pool_size", config.pixi_pool_size as u64);
 
         // Write the settings JSON Schema for editor autocomplete
         if let Err(e) = crate::settings_doc::write_settings_schema() {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -394,6 +394,14 @@ impl Pool {
         self.target.saturating_sub(current)
     }
 
+    fn set_target(&mut self, target: usize) {
+        self.target = target;
+    }
+
+    fn target(&self) -> usize {
+        self.target
+    }
+
     /// Mark that we're starting to create N environments.
     fn mark_warming(&mut self, count: usize) {
         self.warming += count;
@@ -2688,6 +2696,18 @@ impl Daemon {
                 break;
             }
 
+            {
+                let target = {
+                    let settings = self.settings.read().await;
+                    settings
+                        .get_u64("uv_pool_size")
+                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE)
+                        as usize
+                };
+                let mut pool = self.uv_pool.lock().await;
+                pool.set_target(target);
+            }
+
             let (deficit, should_retry, backoff_info) = {
                 let mut pool = self.uv_pool.lock().await;
                 let d = pool.deficit();
@@ -2761,6 +2781,18 @@ impl Daemon {
             // Check shutdown
             if *self.shutdown.lock().await {
                 break;
+            }
+
+            {
+                let target = {
+                    let settings = self.settings.read().await;
+                    settings
+                        .get_u64("conda_pool_size")
+                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE)
+                        as usize
+                };
+                let mut pool = self.conda_pool.lock().await;
+                pool.set_target(target);
             }
 
             let (deficit, should_retry, backoff_info) = {
@@ -2845,6 +2877,18 @@ impl Daemon {
         loop {
             if *self.shutdown.lock().await {
                 break;
+            }
+
+            {
+                let target = {
+                    let settings = self.settings.read().await;
+                    settings
+                        .get_u64("pixi_pool_size")
+                        .unwrap_or(runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE)
+                        as usize
+                };
+                let mut pool = self.pixi_pool.lock().await;
+                pool.set_target(target);
             }
 
             let (deficit, should_retry, backoff_info) = {
@@ -3407,7 +3451,7 @@ impl Daemon {
             RuntimePoolState {
                 available: available as u64,
                 warming: warming as u64,
-                pool_size: self.config.uv_pool_size as u64,
+                pool_size: pool.target() as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
                 error_kind: pool.failure_state.error_kind.clone(),
@@ -3421,7 +3465,7 @@ impl Daemon {
             RuntimePoolState {
                 available: available as u64,
                 warming: warming as u64,
-                pool_size: self.config.conda_pool_size as u64,
+                pool_size: pool.target() as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
                 error_kind: pool.failure_state.error_kind.clone(),
@@ -3436,7 +3480,7 @@ impl Daemon {
             RuntimePoolState {
                 available: available as u64,
                 warming: warming as u64,
-                pool_size: self.config.pixi_pool_size as u64,
+                pool_size: pool.target() as u64,
                 error: pool.failure_state.last_error.clone(),
                 failed_package: pool.failure_state.failed_package.clone(),
                 error_kind: pool.failure_state.error_kind.clone(),

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2702,6 +2702,7 @@ impl Daemon {
                     settings
                         .get_u64("uv_pool_size")
                         .unwrap_or(runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE)
+                        .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
                 let mut pool = self.uv_pool.lock().await;
@@ -2753,11 +2754,14 @@ impl Daemon {
                 }
             }
 
-            // Log status
-            let (available, warming) = self.uv_pool.lock().await.stats();
+            let (available, warming, target) = {
+                let pool = self.uv_pool.lock().await;
+                let (a, w) = pool.stats();
+                (a, w, pool.target())
+            };
             debug!(
                 "[runtimed] UV pool: {}/{} available, {} warming",
-                available, self.config.uv_pool_size, warming
+                available, target, warming
             );
 
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -2789,6 +2793,7 @@ impl Daemon {
                     settings
                         .get_u64("conda_pool_size")
                         .unwrap_or(runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE)
+                        .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
                 let mut pool = self.conda_pool.lock().await;
@@ -2850,11 +2855,14 @@ impl Daemon {
                 }
             }
 
-            // Log status
-            let (available, warming) = self.conda_pool.lock().await.stats();
+            let (available, warming, target) = {
+                let pool = self.conda_pool.lock().await;
+                let (a, w) = pool.stats();
+                (a, w, pool.target())
+            };
             debug!(
                 "[runtimed] Conda pool: {}/{} available, {} warming",
-                available, self.config.conda_pool_size, warming
+                available, target, warming
             );
 
             // Wait before checking again
@@ -2885,6 +2893,7 @@ impl Daemon {
                     settings
                         .get_u64("pixi_pool_size")
                         .unwrap_or(runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE)
+                        .min(runtimed_client::settings_doc::MAX_POOL_SIZE)
                         as usize
                 };
                 let mut pool = self.pixi_pool.lock().await;
@@ -2943,10 +2952,14 @@ impl Daemon {
                 }
             }
 
-            let (available, warming) = self.pixi_pool.lock().await.stats();
+            let (available, warming, target) = {
+                let pool = self.pixi_pool.lock().await;
+                let (a, w) = pool.stats();
+                (a, w, pool.target())
+            };
             debug!(
                 "[runtimed] Pixi pool: {}/{} available, {} warming",
-                available, self.config.pixi_pool_size, warming
+                available, target, warming
             );
 
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1892,7 +1892,7 @@ impl Daemon {
                 return Some(e);
             }
 
-            if self.config.uv_pool_size == 0 {
+            if self.uv_pool.lock().await.target() == 0 {
                 return None;
             }
 
@@ -1967,7 +1967,7 @@ impl Daemon {
                 return Some(e);
             }
 
-            if self.config.conda_pool_size == 0 {
+            if self.conda_pool.lock().await.target() == 0 {
                 return None;
             }
 
@@ -2688,8 +2688,8 @@ impl Daemon {
         };
 
         info!("[runtimed] Starting UV warming loop");
-        // Store uv_path for use in create_uv_env - it's cached so get_uv_path() is instant
         let _ = uv_path;
+        let mut settings_rx = self.settings_changed.subscribe();
 
         loop {
             if *self.shutdown.lock().await {
@@ -2764,25 +2764,19 @@ impl Daemon {
                 available, target, warming
             );
 
-            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                _ = settings_rx.recv() => {}
+            }
         }
     }
 
     /// Conda warming loop - maintains the Conda pool using rattler.
     async fn conda_warming_loop(&self) {
-        // Check if we should even try (pool size > 0)
-        if self.config.conda_pool_size == 0 {
-            info!("[runtimed] Conda pool size is 0, skipping warming");
-            return;
-        }
-
-        info!(
-            "[runtimed] Starting conda warming loop (target: {})",
-            self.config.conda_pool_size
-        );
+        info!("[runtimed] Starting conda warming loop");
+        let mut settings_rx = self.settings_changed.subscribe();
 
         loop {
-            // Check shutdown
             if *self.shutdown.lock().await {
                 break;
             }
@@ -2865,22 +2859,17 @@ impl Daemon {
                 available, target, warming
             );
 
-            // Wait before checking again
-            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                _ = settings_rx.recv() => {}
+            }
         }
     }
 
     /// Background loop that keeps the pixi environment pool at its target size.
     async fn pixi_warming_loop(&self) {
-        if self.config.pixi_pool_size == 0 {
-            info!("[runtimed] Pixi pool size is 0, skipping warming");
-            return;
-        }
-
-        info!(
-            "[runtimed] Starting pixi warming loop (target: {})",
-            self.config.pixi_pool_size
-        );
+        info!("[runtimed] Starting pixi warming loop");
+        let mut settings_rx = self.settings_changed.subscribe();
 
         loop {
             if *self.shutdown.lock().await {
@@ -2962,7 +2951,10 @@ impl Daemon {
                 available, target, warming
             );
 
-            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                _ = settings_rx.recv() => {}
+            }
         }
     }
 
@@ -3266,11 +3258,12 @@ impl Daemon {
                     });
                 }
 
+                let pool = self.conda_pool.lock().await;
                 info!(
                     "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
                     env_path,
-                    self.conda_pool.lock().await.stats().0,
-                    self.config.conda_pool_size
+                    pool.stats().0,
+                    pool.target()
                 );
 
                 self.update_pool_doc().await;

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -44,4 +44,16 @@ keep_alive_secs: bigint,
  * Whether the user has completed the first-launch onboarding flow.
  * When false, the app shows the onboarding screen on startup.
  */
-onboarding_completed: boolean, };
+onboarding_completed: boolean, 
+/**
+ * Number of prewarmed UV environments to keep ready. 0 disables the pool.
+ */
+uv_pool_size: bigint, 
+/**
+ * Number of prewarmed Conda environments to keep ready. 0 disables the pool.
+ */
+conda_pool_size: bigint, 
+/**
+ * Number of prewarmed Pixi environments to keep ready. 0 disables the pool.
+ */
+pixi_pool_size: bigint, };


### PR DESCRIPTION
## Summary

Pool sizes can now be changed at runtime without restarting the daemon:

```bash
runt config set uv_pool_size 6      # scale up UV pool
runt config set conda_pool_size 0   # disable conda pool
runt config list                    # see current pool sizes
```

The daemon reads pool sizes from the settings doc every 30 seconds (the warming loop interval) and adjusts pool targets accordingly. No restart needed.

**Defaults unchanged:** UV=3, Conda=3, Pixi=2. Max=20.

## Changes

- `crates/runtimed-client/src/settings_doc.rs` — add `uv_pool_size`, `conda_pool_size`, `pixi_pool_size` to `SyncedSettings`, defaults, initialization, `get_all()`
- `crates/runtimed-client/src/sync_client.rs` — add pool size fields to `get_all_from_doc()`
- `crates/runtimed/src/daemon.rs` — `Pool::set_target()`, warming loops read from settings, `update_pool_doc` uses `pool.target()`
- `crates/runt/src/main.rs` — add pool size keys to `VALID_CONFIG_KEYS` + validation hint
- `crates/notebook/src/settings.rs` — add pool size fields to Tauri settings loader

## Test plan

- [x] 241 unit tests pass (`cargo test -p runtimed --lib`)
- [x] 44 settings tests pass (`cargo test -p runtimed-client -- settings`)
- [x] `cargo xtask lint` clean
- [ ] Manual: `runt config set uv_pool_size 6`, wait 30s, verify with `runt daemon status`
- [ ] Manual: `runt config set uv_pool_size 0`, verify pool drains