### PR TITLE
fix(kernel-launch): parse UV checksum as hash+filename format

### DIFF
--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -707,8 +707,11 @@ async fn download_uv_from_github(version: &str) -> Result<BootstrappedTool> {
         ));
     }
     let checksum_text = checksum_response.text().await?;
-    // UV checksums are just the hash (no filename)
-    let expected_hash = checksum_text.trim().to_lowercase();
+    let expected_hash = checksum_text
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| anyhow!("Invalid checksum format"))?
+        .to_lowercase();
 
     // Download archive
     info!("Downloading {}...", asset_name);


### PR DESCRIPTION
## Summary

UV `.sha256` files from GitHub releases use the standard sha256sum format: `hash  filename`. The checksum parser assumed bare hash and used `.trim()`, which kept the filename suffix — causing every comparison to fail. This forced every UV env creation to fall back to rattler/conda-forge, adding latency to pool warming.

One-line fix: `split_whitespace().next()` to extract the hash, matching the pattern already used by the deno/ruff checksum handler on line 459.

Found by gremlin testing (finding #9).

## Test plan

- [x] `cargo check -p kernel-launch` passes
- [x] `cargo xtask lint` clean
- [x] Verified actual checksum format: `curl -sL ...uv-x86_64-unknown-linux-gnu.tar.gz.sha256` → `f0c566b...ae2f  uv-x86_64-unknown-linux-gnu.tar.gz`