### PR TITLE
fix(runtimed): clean up ZeroMQ sockets when kernel dies

### DIFF
--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -794,6 +794,10 @@ async fn handle_queue_command(
 
         QueueCommand::KernelDied => {
             warn!("[runtime-agent] Kernel died");
+            if let Some(ref mut k) = kernel {
+                k.shutdown().await.ok();
+            }
+            *kernel = None;
             let (interrupted, cleared) = state.kernel_died();
             let mut sd = ctx.state_doc.write().await;
             if let Some((_, ref eid)) = interrupted {


### PR DESCRIPTION
## Summary

When a kernel process dies unexpectedly, the `KernelDied` handler updated execution state but never called `shutdown()` on the `JupyterKernel`. This left the IOPub `SubSocket` alive with its reconnect task retrying connections to the dead kernel's port indefinitely (150+ attempts observed in daemon logs, every ~30 seconds).

**Root cause:** The `SubSocket`'s reconnect handler detects the TCP disconnect when the kernel dies and starts retrying. Since `shutdown()` was never called, the socket was never dropped, and the reconnect task was never stopped.

**Fix:** Call `kernel.shutdown()` and set `*kernel = None` in the `KernelDied` handler before updating state, matching the pattern used by `ShutdownKernel` and `RestartKernel`.

Found by gremlin testing (finding #11).

## Test plan

- [x] 241 unit tests pass
- [x] `cargo xtask lint` clean
- [ ] After deploy: daemon logs should show zero `zeromq::reconnect` WARN messages during normal operation