### PR TITLE
fix(widgets): clone state objects in AFM model proxy to prevent readonly errors

### DIFF
--- a/src/components/widgets/__tests__/afm-model-proxy.test.ts
+++ b/src/components/widgets/__tests__/afm-model-proxy.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for createAFMModelProxy — the AFM-compatible model proxy for anywidgets.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createAFMModelProxy } from "../anywidget-view";
+import { createWidgetStore } from "../widget-store";
+
+function makeProxy(state: Record<string, unknown>) {
+  const store = createWidgetStore();
+  const commId = "test-comm";
+  store.createModel(commId, state);
+  const sendMessage = vi.fn();
+  const model = store.getModel(commId)!;
+  const proxy = createAFMModelProxy(model, store, sendMessage, () =>
+    store.getModel(commId)?.state ?? {},
+  );
+  return { proxy, store, sendMessage };
+}
+
+describe("createAFMModelProxy", () => {
+  describe("get", () => {
+    it("returns primitive values directly", () => {
+      const { proxy } = makeProxy({ count: 42, label: "hello", flag: true });
+      expect(proxy.get("count")).toBe(42);
+      expect(proxy.get("label")).toBe("hello");
+      expect(proxy.get("flag")).toBe(true);
+    });
+
+    it("returns cloned objects that can be mutated without affecting the store", () => {
+      const originalData = { x: [1, 2, 3], y: [4, 5, 6] };
+      const { proxy, store } = makeProxy({ _data: [originalData] });
+
+      const data = proxy.get("_data") as Array<{ x: number[]; y: number[] }>;
+      // Mutate the returned value (Plotly.js does this)
+      data[0].x.push(99);
+
+      // Store should be unaffected
+      const storeData = store.getModel("test-comm")!.state._data as Array<{
+        x: number[];
+      }>;
+      expect(storeData[0].x).toEqual([1, 2, 3]);
+    });
+
+    it("returns cloned arrays that can be mutated", () => {
+      const { proxy, store } = makeProxy({ items: [1, 2, 3] });
+
+      const items = proxy.get("items") as number[];
+      items.push(4);
+
+      const storeItems = store.getModel("test-comm")!.state.items as number[];
+      expect(storeItems).toEqual([1, 2, 3]);
+    });
+
+    it("allows mutation of frozen source objects via cloning", () => {
+      const frozenLayout = Object.freeze({
+        title: Object.freeze({ text: "Test" }),
+        margin: Object.freeze({ l: 50, r: 50 }),
+      });
+      const { proxy } = makeProxy({ _layout: frozenLayout });
+
+      const layout = proxy.get("_layout") as Record<string, unknown>;
+      // This would throw "Attempted to assign to readonly property"
+      // without the structuredClone fix
+      expect(() => {
+        (layout as Record<string, unknown>).title = { text: "Modified" };
+      }).not.toThrow();
+    });
+
+    it("returns undefined for missing keys", () => {
+      const { proxy } = makeProxy({ value: 1 });
+      expect(proxy.get("nonexistent")).toBeUndefined();
+    });
+
+    it("returns null without cloning", () => {
+      const { proxy } = makeProxy({ empty: null });
+      expect(proxy.get("empty")).toBeNull();
+    });
+
+    it("returns pending changes over store state", () => {
+      const { proxy } = makeProxy({ value: 1 });
+      proxy.set("value", 2);
+      expect(proxy.get("value")).toBe(2);
+    });
+  });
+
+  describe("set + save_changes", () => {
+    it("buffers changes until save_changes is called", () => {
+      const { proxy, sendMessage } = makeProxy({ value: 0 });
+      proxy.set("value", 42);
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -183,7 +183,15 @@ export function createAFMModelProxy(
       if (key in pendingChanges) {
         return pendingChanges[key];
       }
-      return getCurrentState()[key];
+      const value = getCurrentState()[key];
+      // Deep clone objects/arrays so widget code can mutate them freely.
+      // State objects originating from WASM (serde_wasm_bindgen) can have
+      // readonly properties in WebKit, causing "Attempted to assign to
+      // readonly property" errors when widgets like Plotly mutate in-place.
+      if (value !== null && typeof value === "object") {
+        return structuredClone(value);
+      }
+      return value;
     },
 
     set(key: string, value: unknown): void {

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -179,7 +179,8 @@ export function createAFMModelProxy(
 
   return {
     get(key: string): unknown {
-      // Return pending change if it exists, otherwise current state
+      // Pending changes are caller-owned (just set via model.set()),
+      // so return them directly without cloning.
       if (key in pendingChanges) {
         return pendingChanges[key];
       }
@@ -189,7 +190,11 @@ export function createAFMModelProxy(
       // readonly properties in WebKit, causing "Attempted to assign to
       // readonly property" errors when widgets like Plotly mutate in-place.
       if (value !== null && typeof value === "object") {
-        return structuredClone(value);
+        try {
+          return structuredClone(value);
+        } catch {
+          return value;
+        }
       }
       return value;
     },


### PR DESCRIPTION
## Summary

- FigureWidget (Plotly) throws "Attempted to assign to readonly property" in nteract nightly because the AFM model proxy's `get()` returns direct references to WASM-bridged state objects that WebKit treats as readonly
- `structuredClone` object/array values in `createAFMModelProxy.get()` so widget ESM code always receives mutable deep copies
- Adds test suite for AFM model proxy covering cloning, frozen-object mutation, store isolation, and pending-change precedence

## Test plan

- [x] Existing widget tests pass (130 tests)
- [x] New `afm-model-proxy.test.ts` passes (8 tests)
- [x] Lint clean
- [ ] Manual: run Plotly FigureWidget in nteract nightly — should render without "readonly property" error