### PR TITLE
feat(kernel-env): persist conda/pixi lock files for offline re-creation

### DIFF
--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -46,6 +46,8 @@ export function getStatusText(event: EnvProgressEvent): string {
       return "Preparing environment...";
     case "cache_hit":
       return "Using cached environment";
+    case "lock_file_hit":
+      return "Rebuilding from lock file";
     case "fetching_repodata": {
       const e = event as Extract<
         EnvProgressPhase,

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -82,6 +82,7 @@ export interface JupyterMessage {
 export type EnvProgressPhase =
   | { phase: "starting"; env_hash: string }
   | { phase: "cache_hit"; env_path: string }
+  | { phase: "lock_file_hit" }
   | { phase: "fetching_repodata"; channels: string[] }
   | { phase: "repodata_complete"; record_count: number; elapsed_ms: number }
   | { phase: "solving"; spec_count: number }

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -145,6 +145,51 @@ pub async fn prepare_environment_in(
 
     tokio::fs::create_dir_all(cache_dir).await?;
 
+    // Try lock-based rebuild before full re-creation
+    if env_path.exists() && !python_path.exists() {
+        if let Some(lock) = crate::lock::LockFile::read_from(&env_path).await {
+            // Build expected specs to match against the lock
+            let expected_specs = build_spec_strings(deps);
+            let expected_channels = if deps.channels.is_empty() {
+                vec!["conda-forge".to_string()]
+            } else {
+                deps.channels.clone()
+            };
+            if lock.matches(&expected_specs, &expected_channels) {
+                info!("Rebuilding conda env from lock file at {:?}", env_path);
+                tokio::fs::remove_dir_all(&env_path).await?;
+                tokio::fs::create_dir_all(&env_path).await?;
+                match crate::lock::install_from_lock(&env_path, &lock, handler.clone(), "conda")
+                    .await
+                {
+                    Ok(()) => {
+                        if python_path.exists() {
+                            crate::gc::touch_last_used(&env_path).await;
+                            handler.on_progress(
+                                "conda",
+                                EnvProgressPhase::Ready {
+                                    env_path: env_path.to_string_lossy().to_string(),
+                                    python_path: python_path.to_string_lossy().to_string(),
+                                },
+                            );
+                            return Ok(CondaEnvironment {
+                                env_path,
+                                python_path,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Lock-based rebuild failed: {}, falling back to full solve",
+                            e
+                        );
+                        tokio::fs::remove_dir_all(&env_path).await.ok();
+                    }
+                }
+            }
+        }
+    }
+
     // Remove partial environment
     if env_path.exists() {
         tokio::fs::remove_dir_all(&env_path).await?;
@@ -203,7 +248,7 @@ async fn install_conda_env(
     handler.on_progress(
         "conda",
         EnvProgressPhase::FetchingRepodata {
-            channels: channel_names,
+            channels: channel_names.clone(),
         },
     );
 
@@ -230,6 +275,9 @@ async fn install_conda_env(
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
+
+    // Capture spec strings for lock file before specs are moved into the solver
+    let spec_strings_for_lock: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
 
     // Rattler cache
     let rattler_cache_dir = default_cache_dir()
@@ -319,6 +367,9 @@ async fn install_conda_env(
     let reporter = RattlerReporter::new(handler.clone());
     let install_start = Instant::now();
 
+    // Clone packages before install (which consumes them) so we can write the lock file
+    let packages_for_lock = required_packages.clone();
+
     match Installer::new()
         .with_download_client(download_client)
         .with_target_platform(install_platform)
@@ -350,6 +401,10 @@ async fn install_conda_env(
             elapsed_ms: install_elapsed.as_millis() as u64,
         },
     );
+
+    // Write lock file for offline re-creation
+    let lock = crate::lock::LockFile::new(spec_strings_for_lock, channel_names, packages_for_lock);
+    crate::lock::try_write_lock(env_path, &lock).await;
 
     Ok(())
 }
@@ -729,6 +784,31 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the list of spec strings that `install_conda_env` would produce,
+/// for matching against a lock file.
+fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
+    let mut specs = Vec::new();
+
+    if let Some(ref py) = deps.python {
+        specs.push(format!("python={}", py));
+    } else {
+        specs.push("python>=3.13".to_string());
+    }
+
+    specs.push("ipykernel".to_string());
+    specs.push("ipywidgets".to_string());
+    specs.push("anywidget".to_string());
+    specs.push("nbformat".to_string());
+
+    for dep in &deps.dependencies {
+        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
+            specs.push(dep.clone());
+        }
+    }
+
+    specs
 }
 
 /// Find the site-packages directory inside a venv/env.

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -164,6 +164,8 @@ pub async fn prepare_environment_in(
                 {
                     Ok(()) => {
                         if python_path.exists() {
+                            // Re-persist lock so it survives future rebuilds
+                            crate::lock::try_write_lock(&env_path, &lock).await;
                             crate::gc::touch_last_used(&env_path).await;
                             handler.on_progress(
                                 "conda",
@@ -276,8 +278,9 @@ async fn install_conda_env(
         }
     }
 
-    // Capture spec strings for lock file before specs are moved into the solver
-    let spec_strings_for_lock: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
+    // Capture spec strings for lock file using the same format as build_spec_strings()
+    // (raw input strings, not MatchSpec::to_string() which may normalize differently)
+    let spec_strings_for_lock = build_spec_strings(deps);
 
     // Rattler cache
     let rattler_cache_dir = default_cache_dir()

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -29,6 +29,8 @@ pub mod conda;
 #[cfg(feature = "runtime")]
 pub mod gc;
 #[cfg(feature = "runtime")]
+pub mod lock;
+#[cfg(feature = "runtime")]
 pub mod pixi;
 pub mod progress;
 #[cfg(feature = "runtime")]

--- a/crates/kernel-env/src/lock.rs
+++ b/crates/kernel-env/src/lock.rs
@@ -1,0 +1,183 @@
+//! Lock file persistence for conda/pixi environments.
+//!
+//! After a successful solve + install, we write a `.lock.json` file alongside
+//! the environment prefix. On subsequent rebuilds (e.g. corrupted env where
+//! the directory exists but python is missing), we can skip the repodata fetch
+//! and solve phases entirely and install directly from the lock.
+//!
+//! All lock operations are non-fatal — failures log warnings and fall back to
+//! the normal solve path.
+
+use anyhow::Result;
+use log::{info, warn};
+use rattler_conda_types::{Platform, RepoDataRecord};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const LOCK_FILE_NAME: &str = ".lock.json";
+
+/// Persisted solve result for a conda/pixi environment.
+///
+/// Contains everything needed to recreate the environment without
+/// re-fetching repodata or re-solving: the original specs, channels,
+/// platform, and the full list of resolved packages.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LockFile {
+    /// Schema version (currently 1).
+    pub version: u32,
+    /// Platform the solve was performed on (e.g. `osx-arm64`).
+    pub platform: String,
+    /// Original dependency specs (e.g. `["python>=3.13", "numpy"]`).
+    pub specs: Vec<String>,
+    /// Channels used for the solve (e.g. `["conda-forge"]`).
+    pub channels: Vec<String>,
+    /// Fully resolved packages from the solver.
+    pub packages: Vec<RepoDataRecord>,
+}
+
+impl LockFile {
+    /// Create a new lock file from solve results.
+    pub fn new(specs: Vec<String>, channels: Vec<String>, packages: Vec<RepoDataRecord>) -> Self {
+        Self {
+            version: 1,
+            platform: Platform::current().to_string(),
+            specs,
+            channels,
+            packages,
+        }
+    }
+
+    /// Write the lock file to `<env_path>/.lock.json`.
+    pub async fn write_to(&self, env_path: &Path) -> Result<()> {
+        let lock_path = env_path.join(LOCK_FILE_NAME);
+        let json = serde_json::to_string_pretty(self)?;
+        tokio::fs::write(&lock_path, json).await?;
+        info!("Wrote lock file to {:?}", lock_path);
+        Ok(())
+    }
+
+    /// Read a lock file from `<env_path>/.lock.json`, returning `None` if
+    /// missing or unparseable.
+    pub async fn read_from(env_path: &Path) -> Option<Self> {
+        let lock_path = env_path.join(LOCK_FILE_NAME);
+        let data = tokio::fs::read_to_string(&lock_path).await.ok()?;
+        match serde_json::from_str(&data) {
+            Ok(lock) => Some(lock),
+            Err(e) => {
+                warn!("Failed to parse lock file at {:?}: {}", lock_path, e);
+                None
+            }
+        }
+    }
+
+    /// Check if this lock matches the given specs and channels (order-independent).
+    pub fn matches(&self, specs: &[String], channels: &[String]) -> bool {
+        self.version == 1
+            && self.platform == Platform::current().to_string()
+            && sorted_eq(&self.specs, specs)
+            && sorted_eq(&self.channels, channels)
+    }
+}
+
+fn sorted_eq(a: &[String], b: &[String]) -> bool {
+    let mut a: Vec<_> = a.iter().map(|s| s.to_lowercase()).collect();
+    let mut b: Vec<_> = b.iter().map(|s| s.to_lowercase()).collect();
+    a.sort();
+    b.sort();
+    a == b
+}
+
+/// Non-fatal lock file write. Logs warning on failure.
+pub async fn try_write_lock(env_path: &Path, lock: &LockFile) {
+    if let Err(e) = lock.write_to(env_path).await {
+        warn!("Failed to write lock file: {}", e);
+    }
+}
+
+/// Install packages from a lock file directly, skipping repodata + solve.
+pub async fn install_from_lock(
+    env_path: &Path,
+    lock: &LockFile,
+    handler: std::sync::Arc<dyn crate::progress::ProgressHandler>,
+    env_type: &str,
+) -> Result<()> {
+    use rattler::install::Installer;
+    use rattler_conda_types::Platform;
+
+    handler.on_progress(env_type, crate::progress::EnvProgressPhase::LockFileHit);
+
+    let download_client = reqwest::Client::builder().build()?;
+    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
+
+    let install_platform = Platform::current();
+
+    handler.on_progress(
+        env_type,
+        crate::progress::EnvProgressPhase::Installing {
+            total: lock.packages.len(),
+        },
+    );
+
+    let reporter = crate::progress::RattlerReporter::new_with_env_type(handler.clone(), env_type);
+
+    Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform)
+        .with_reporter(reporter)
+        .install(env_path, lock.packages.clone())
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lock_file_matches() {
+        let lock = LockFile::new(
+            vec!["python>=3.13".into(), "numpy".into()],
+            vec!["conda-forge".into()],
+            vec![],
+        );
+        assert!(lock.matches(
+            &["numpy".into(), "python>=3.13".into()],
+            &["conda-forge".into()]
+        ));
+    }
+
+    #[test]
+    fn test_lock_file_no_match_different_specs() {
+        let lock = LockFile::new(vec!["numpy".into()], vec!["conda-forge".into()], vec![]);
+        assert!(!lock.matches(&["pandas".into()], &["conda-forge".into()]));
+    }
+
+    #[test]
+    fn test_lock_file_no_match_different_channels() {
+        let lock = LockFile::new(vec!["numpy".into()], vec!["conda-forge".into()], vec![]);
+        assert!(!lock.matches(&["numpy".into()], &["defaults".into()]));
+    }
+
+    #[tokio::test]
+    async fn test_lock_file_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock = LockFile::new(
+            vec!["numpy".into(), "pandas".into()],
+            vec!["conda-forge".into()],
+            vec![],
+        );
+        lock.write_to(dir.path()).await.unwrap();
+        let loaded = LockFile::read_from(dir.path()).await.unwrap();
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.specs, lock.specs);
+        assert_eq!(loaded.channels, lock.channels);
+    }
+
+    #[tokio::test]
+    async fn test_lock_file_read_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(LockFile::read_from(dir.path()).await.is_none());
+    }
+}

--- a/crates/kernel-env/src/lock.rs
+++ b/crates/kernel-env/src/lock.rs
@@ -50,7 +50,7 @@ impl LockFile {
     /// Write the lock file to `<env_path>/.lock.json`.
     pub async fn write_to(&self, env_path: &Path) -> Result<()> {
         let lock_path = env_path.join(LOCK_FILE_NAME);
-        let json = serde_json::to_string_pretty(self)?;
+        let json = serde_json::to_string(self)?;
         tokio::fs::write(&lock_path, json).await?;
         info!("Wrote lock file to {:?}", lock_path);
         Ok(())

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -213,11 +213,6 @@ async fn install_pixi_env(
         specs.push(spec);
     }
 
-    // Capture strings for lock file before specs/channels are moved
-    let spec_strings_for_lock: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
-    let channel_names_for_lock: Vec<String> =
-        channels.iter().map(|c| c.name().to_string()).collect();
-
     // Rattler cache
     let rattler_cache_dir = default_cache_dir()
         .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
@@ -306,9 +301,6 @@ async fn install_pixi_env(
     let reporter = RattlerReporter::new_with_env_type(handler.clone(), "pixi");
     let install_start = Instant::now();
 
-    // Clone packages before install (which consumes them) so we can write the lock file
-    let packages_for_lock = required_packages.clone();
-
     match Installer::new()
         .with_download_client(download_client)
         .with_target_platform(install_platform)
@@ -340,14 +332,6 @@ async fn install_pixi_env(
             elapsed_ms: install_elapsed.as_millis() as u64,
         },
     );
-
-    // Write lock file for offline re-creation
-    let lock = crate::lock::LockFile::new(
-        spec_strings_for_lock,
-        channel_names_for_lock,
-        packages_for_lock,
-    );
-    crate::lock::try_write_lock(env_path, &lock).await;
 
     Ok(())
 }

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -213,6 +213,11 @@ async fn install_pixi_env(
         specs.push(spec);
     }
 
+    // Capture strings for lock file before specs/channels are moved
+    let spec_strings_for_lock: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
+    let channel_names_for_lock: Vec<String> =
+        channels.iter().map(|c| c.name().to_string()).collect();
+
     // Rattler cache
     let rattler_cache_dir = default_cache_dir()
         .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
@@ -301,6 +306,9 @@ async fn install_pixi_env(
     let reporter = RattlerReporter::new_with_env_type(handler.clone(), "pixi");
     let install_start = Instant::now();
 
+    // Clone packages before install (which consumes them) so we can write the lock file
+    let packages_for_lock = required_packages.clone();
+
     match Installer::new()
         .with_download_client(download_client)
         .with_target_platform(install_platform)
@@ -332,6 +340,14 @@ async fn install_pixi_env(
             elapsed_ms: install_elapsed.as_millis() as u64,
         },
     );
+
+    // Write lock file for offline re-creation
+    let lock = crate::lock::LockFile::new(
+        spec_strings_for_lock,
+        channel_names_for_lock,
+        packages_for_lock,
+    );
+    crate::lock::try_write_lock(env_path, &lock).await;
 
     Ok(())
 }

--- a/crates/kernel-env/src/progress.rs
+++ b/crates/kernel-env/src/progress.rs
@@ -34,6 +34,8 @@ pub enum EnvProgressPhase {
     Starting { env_hash: String },
     /// Using a cached environment (fast path).
     CacheHit { env_path: String },
+    /// Environment being rebuilt from lock file (skipping repodata + solve).
+    LockFileHit,
     /// Environment resolved from local package cache without network access.
     OfflineHit,
     /// Fetching package metadata from channels.
@@ -115,6 +117,9 @@ impl ProgressHandler for LogHandler {
             }
             EnvProgressPhase::CacheHit { env_path } => {
                 log::info!("[{env_type}] Cache hit: {env_path}");
+            }
+            EnvProgressPhase::LockFileHit => {
+                log::info!("[{env_type}] Rebuilding from lock file (skipping repodata + solve)");
             }
             EnvProgressPhase::OfflineHit => {
                 log::info!("[{env_type}] Resolved from local cache (offline mode)");

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -2208,6 +2208,7 @@ fn env_progress_message(phase: &EnvProgressPhase) -> String {
     match phase {
         EnvProgressPhase::Starting { .. } => "Preparing environment...".to_string(),
         EnvProgressPhase::CacheHit { .. } => "Using cached environment".to_string(),
+        EnvProgressPhase::LockFileHit => "Rebuilding from lock file".to_string(),
         EnvProgressPhase::OfflineHit => "Using cached packages (offline)".to_string(),
         EnvProgressPhase::FetchingRepodata { channels } => {
             format!("Fetching package index ({})", channels.join(", "))


### PR DESCRIPTION
## Summary
- Persist solved package records as `.lock.json` alongside cached conda/pixi environments
- On corrupted env rebuild (dir exists but python missing), read lock to skip repodata + solve
- All lock operations non-fatal -- falls back to normal solve path on any failure
- Add `LockFileHit` progress phase across Rust, Python bindings, and TypeScript frontend

## Follow-up to #1699

#1699 added offline-first env resolution. This PR goes further: if we've solved deps before, we never need to re-solve -- just install from the lock.

## Test plan
- [x] `cargo test -p kernel-env` passes (30 tests)
- [x] Lock file roundtrip serialization
- [x] Spec/channel matching (order-independent)
- [x] Missing lock file returns None
- [x] `cargo xtask lint --fix` clean