### PR TITLE
feat(runt-mcp): add notebook resource templates (Phase 1)

### DIFF
--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -202,10 +202,6 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, McpError> {
-        Ok(ListResourceTemplatesResult {
-            resource_templates: vec![],
-            next_cursor: None,
-            meta: None,
-        })
+        resources::list_resource_templates(self).await
     }
 }

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -1,8 +1,8 @@
 //! MCP resource serving (output.html, notebook cells, status).
 
 use rmcp::model::{
-    Annotated, ListResourcesResult, Meta, RawResource, ReadResourceRequestParams,
-    ReadResourceResult, ResourceContents,
+    Annotated, ListResourceTemplatesResult, ListResourcesResult, Meta, RawResource,
+    RawResourceTemplate, ReadResourceRequestParams, ReadResourceResult, ResourceContents,
 };
 use rmcp::ErrorData as McpError;
 
@@ -46,7 +46,109 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> Option<Meta> {
     Some(Meta(meta))
 }
 
-/// List available MCP resources.
+/// List available MCP resource templates.
+pub async fn list_resource_templates(
+    server: &NteractMcp,
+) -> Result<ListResourceTemplatesResult, McpError> {
+    let mut templates = vec![
+        // Output renderer (static resource, not a template)
+        Annotated {
+            raw: RawResourceTemplate {
+                uri_template: OUTPUT_RESOURCE_URI.to_string(),
+                name: "nteract output".to_string(),
+                title: None,
+                description: Some("Interactive output renderer for notebook cells".into()),
+                mime_type: Some(OUTPUT_MIME_TYPE.into()),
+                icons: None,
+            },
+            annotations: None,
+        },
+    ];
+
+    // If a session is active, add notebook resource templates
+    if let Some(session) = server.session().read().await.as_ref() {
+        let notebook_id = &session.notebook_id;
+
+        templates.extend(vec![
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/cells", notebook_id),
+                    name: "All cells".to_string(),
+                    title: None,
+                    description: Some("List of all cells in the notebook".into()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/cell/{{cell_id}}", notebook_id),
+                    name: "Single cell".to_string(),
+                    title: None,
+                    description: Some("Cell with source, metadata, and outputs".into()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/cell/{{cell_id}}/source", notebook_id),
+                    name: "Cell source".to_string(),
+                    title: None,
+                    description: Some("Cell source code as plain text".into()),
+                    mime_type: Some("text/plain".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/cell/{{cell_id}}/outputs", notebook_id),
+                    name: "Cell outputs".to_string(),
+                    title: None,
+                    description: Some("Cell execution outputs".into()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/status", notebook_id),
+                    name: "Runtime status".to_string(),
+                    title: None,
+                    description: Some(
+                        "Kernel status, execution queue, and environment info".into(),
+                    ),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+            Annotated {
+                raw: RawResourceTemplate {
+                    uri_template: format!("notebook://{}/dependencies", notebook_id),
+                    name: "Dependencies".to_string(),
+                    title: None,
+                    description: Some("PEP 723 inline script dependencies".into()),
+                    mime_type: Some("application/json".into()),
+                    icons: None,
+                },
+                annotations: None,
+            },
+        ]);
+    }
+
+    Ok(ListResourceTemplatesResult {
+        resource_templates: templates,
+        next_cursor: None,
+        meta: None,
+    })
+}
+
+/// List available MCP resources (for backwards compatibility).
 pub async fn list_resources(_server: &NteractMcp) -> Result<ListResourcesResult, McpError> {
     let mut raw = RawResource::new(OUTPUT_RESOURCE_URI, "nteract output");
     raw.description = Some("Interactive output renderer for notebook cells".into());
@@ -82,8 +184,188 @@ pub async fn read_resource(
         ]));
     }
 
+    // Try notebook:// URIs
+    if uri.starts_with("notebook://") {
+        return read_notebook_resource(server, uri).await;
+    }
+
     Err(McpError::resource_not_found(
         format!("Unknown resource: {}", uri),
         None,
     ))
+}
+
+/// Parse and read notebook:// resources.
+async fn read_notebook_resource(
+    server: &NteractMcp,
+    uri: &str,
+) -> Result<ReadResourceResult, McpError> {
+    let session_guard = server.session().read().await;
+    let session = session_guard.as_ref().ok_or_else(|| {
+        McpError::resource_not_found(
+            "No active notebook session. Use open_notebook or join_notebook first.",
+            None,
+        )
+    })?;
+
+    // Parse URI: notebook://{notebook_id}/{resource}
+    let uri_path = uri
+        .strip_prefix("notebook://")
+        .ok_or_else(|| McpError::invalid_params("URI must start with notebook://", None))?;
+    let parts: Vec<&str> = uri_path.split('/').collect();
+
+    if parts.len() < 2 {
+        return Err(McpError::invalid_params(
+            "Invalid notebook URI format. Expected: notebook://{id}/cells, notebook://{id}/cell/{cell_id}, etc.",
+            None,
+        ));
+    }
+
+    let notebook_id = parts[0];
+    let resource_type = parts[1];
+
+    // Verify notebook ID matches current session
+    if notebook_id != session.notebook_id {
+        return Err(McpError::resource_not_found(
+            format!(
+                "Notebook ID mismatch. Current session: {}, requested: {}",
+                session.notebook_id, notebook_id
+            ),
+            None,
+        ));
+    }
+
+    match resource_type {
+        "cells" => {
+            // Return all cells as JSON
+            let cells = session.handle.get_cells();
+            let json = serde_json::to_string_pretty(&cells).map_err(|e| {
+                McpError::internal_error(format!("Failed to serialize cells: {}", e), None)
+            })?;
+
+            Ok(ReadResourceResult::new(vec![
+                ResourceContents::TextResourceContents {
+                    uri: uri.to_string(),
+                    mime_type: Some("application/json".into()),
+                    text: json,
+                    meta: None,
+                },
+            ]))
+        }
+        "cell" => {
+            // Get specific cell: notebook://{id}/cell/{cell_id} or notebook://{id}/cell/{cell_id}/source or /outputs
+            if parts.len() < 3 {
+                return Err(McpError::invalid_params(
+                    "Cell ID required. Use: notebook://{id}/cell/{cell_id}",
+                    None,
+                ));
+            }
+
+            let cell_id = parts[2];
+            let snapshot = session.handle.snapshot();
+            let cell = snapshot.get_cell(cell_id).ok_or_else(|| {
+                McpError::resource_not_found(format!("Cell not found: {}", cell_id), None)
+            })?;
+
+            // Check for sub-resource (/source or /outputs)
+            if parts.len() >= 4 {
+                match parts[3] {
+                    "source" => {
+                        // Return just the source as plain text
+                        Ok(ReadResourceResult::new(vec![
+                            ResourceContents::TextResourceContents {
+                                uri: uri.to_string(),
+                                mime_type: Some("text/plain".into()),
+                                text: cell.source.clone(),
+                                meta: None,
+                            },
+                        ]))
+                    }
+                    "outputs" => {
+                        // Return outputs as JSON
+                        let json = serde_json::to_string_pretty(&cell.outputs).map_err(|e| {
+                            McpError::internal_error(
+                                format!("Failed to serialize outputs: {}", e),
+                                None,
+                            )
+                        })?;
+
+                        Ok(ReadResourceResult::new(vec![
+                            ResourceContents::TextResourceContents {
+                                uri: uri.to_string(),
+                                mime_type: Some("application/json".into()),
+                                text: json,
+                                meta: None,
+                            },
+                        ]))
+                    }
+                    _ => Err(McpError::resource_not_found(
+                        format!("Unknown cell sub-resource: {}", parts[3]),
+                        None,
+                    )),
+                }
+            } else {
+                // Return full cell as JSON
+                let json = serde_json::to_string_pretty(&cell).map_err(|e| {
+                    McpError::internal_error(format!("Failed to serialize cell: {}", e), None)
+                })?;
+
+                Ok(ReadResourceResult::new(vec![
+                    ResourceContents::TextResourceContents {
+                        uri: uri.to_string(),
+                        mime_type: Some("application/json".into()),
+                        text: json,
+                        meta: None,
+                    },
+                ]))
+            }
+        }
+        "status" => {
+            // Return runtime status (would need to get from RuntimeStateDoc)
+            // For now, return a placeholder
+            let status = serde_json::json!({
+                "kernel_status": "unknown",
+                "message": "Runtime status not yet implemented"
+            });
+
+            let json = serde_json::to_string_pretty(&status).map_err(|e| {
+                McpError::internal_error(format!("Failed to serialize status: {}", e), None)
+            })?;
+
+            Ok(ReadResourceResult::new(vec![
+                ResourceContents::TextResourceContents {
+                    uri: uri.to_string(),
+                    mime_type: Some("application/json".into()),
+                    text: json,
+                    meta: None,
+                },
+            ]))
+        }
+        "dependencies" => {
+            // Return dependencies from notebook metadata (runt.uv.dependencies)
+            let snapshot = session.handle.snapshot();
+            let deps = snapshot
+                .notebook_metadata()
+                .and_then(|m| m.runt.uv.as_ref())
+                .map(|uv| uv.dependencies.clone())
+                .unwrap_or_default();
+
+            let json = serde_json::to_string_pretty(&deps).map_err(|e| {
+                McpError::internal_error(format!("Failed to serialize dependencies: {}", e), None)
+            })?;
+
+            Ok(ReadResourceResult::new(vec![
+                ResourceContents::TextResourceContents {
+                    uri: uri.to_string(),
+                    mime_type: Some("application/json".into()),
+                    text: json,
+                    meta: None,
+                },
+            ]))
+        }
+        _ => Err(McpError::resource_not_found(
+            format!("Unknown notebook resource type: {}", resource_type),
+            None,
+        )),
+    }
 }

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -321,14 +321,12 @@ async fn read_notebook_resource(
             }
         }
         "status" => {
-            // Return runtime status (would need to get from RuntimeStateDoc)
-            // For now, return a placeholder
-            let status = serde_json::json!({
-                "kernel_status": "unknown",
-                "message": "Runtime status not yet implemented"
-            });
+            // Return runtime status from RuntimeStateDoc
+            let runtime_state = session.handle.get_runtime_state().map_err(|e| {
+                McpError::internal_error(format!("Failed to read runtime state: {}", e), None)
+            })?;
 
-            let json = serde_json::to_string_pretty(&status).map_err(|e| {
+            let json = serde_json::to_string_pretty(&runtime_state).map_err(|e| {
                 McpError::internal_error(format!("Failed to serialize status: {}", e), None)
             })?;
 


### PR DESCRIPTION
## Summary

Implements MCP resource templates for notebook state access, inspired by the old Python MCP server design. Phase 1 provides static resources (no subscriptions yet).

**Research findings:** MCP protocol and rmcp 1.4.0 fully support subscriptions via `resources/subscribe` / `resources/unsubscribe` / `notifications/resources/updated`.

## Resource URIs

```
notebook://{notebook_id}/cells              # All cells (JSON array)
notebook://{notebook_id}/cell/{cell_id}     # Single cell with source, metadata, outputs
notebook://{notebook_id}/cell/{cell_id}/source    # Just cell source (text)
notebook://{notebook_id}/cell/{cell_id}/outputs   # Cell outputs (JSON array)
notebook://{notebook_id}/status             # Runtime status (placeholder for Phase 2)
notebook://{notebook_id}/dependencies       # PEP 723 dependencies
```

## Changes

### Resource Listing
- `list_resource_templates()` now returns notebook resources when session is active
- Falls back to empty list when no session (backwards compatible)

### Resource Reading
- `read_resource()` handles `notebook://` URIs via new helper function
- Parses URI to extract notebook ID, resource type, cell ID (if applicable)
- Returns JSON for structured data, plain text for source code
- Proper error messages for missing session, notebook ID mismatch, unknown cells

### Implementation Details
- Uses existing `NotebookSession` and `DocHandle` from `session.rs`
- Reads from `snapshot()` for current notebook state
- Reads from `get_cells()` for cells with outputs from RuntimeStateDoc
- Dependencies come from `metadata.runt.uv.dependencies`

## Phase 1 Limitations

**Session Required:**
Currently requires an active session (`open_notebook` or `join_notebook` first). The `notebook_id` in the URI must match `session.notebook_id`.

**Rationale:** Simplifies implementation, reuses existing DocHandle. Phase 2 can add session-less access if needed (would require on-demand daemon connections).

**No Subscriptions Yet:**
Phase 2 will add:
- `resources.subscribe = true` in capabilities
- Subscription tracking (HashMap<URI, Set<client_id>>)
- Notifications on cell/output changes
- Debouncing for rapid updates

**Status Placeholder:**
The `/status` resource returns a placeholder. Phase 2 will read from RuntimeStateDoc.

## Test Plan

**Manual Testing (TODO):**
```bash
# Via MCP Inspector or Claude Desktop
1. Call open_notebook("test.ipynb")
2. Call resources/list_templates → see 6 notebook:// resources
3. Call resources/read { uri: "notebook://test.ipynb/cells" } → get JSON array
4. Call resources/read { uri: "notebook://test.ipynb/cell/{id}/source" } → get text
5. Call resources/read without session → proper error
6. Call resources/read with wrong notebook_id → proper error
```

**Unit Tests (TODO):**
- URI parsing edge cases
- Error handling (no session, ID mismatch, unknown cell)
- JSON serialization of cells/outputs/dependencies

## Design Questions

1. **Session-less access:** Should resources work without an active session? (Phase 2 decision)
2. **Debouncing:** What interval for rapid cell edits? (500ms? 1s?)
3. **Wildcard subscriptions:** Support `notebook://*/cells` or require explicit IDs?

Discussion in coordination notebook cells 11-12.

## Future Work (Phase 2+)

- [ ] Subscription support with notifications
- [ ] Proper RuntimeStateDoc integration for `/status`
- [ ] Session-less access (optional)
- [ ] Debouncing for rapid updates
- [ ] Integration tests via MCP Inspector
- [ ] Documentation for resource URIs

## Related

- Old Python MCP: `python/nteract/CHANGELOG.md` line 15
- MCP subscriptions spec: `~/code/src/github.com/modelcontextprotocol/specification`
- Coordination notebook: cells 11-12