### PR TITLE
ci(apt): add APT repository publishing to release pipeline

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1001,6 +1001,20 @@ jobs:
             echo ''
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
+            echo '### Linux (APT repository)'
+            echo ''
+            echo '```bash'
+            echo '# Add the nteract signing key'
+            echo 'curl -fsSL https://apt.runtimed.com/nteract-keyring.gpg \'
+            echo '  | sudo gpg --dearmor -o /usr/share/keyrings/nteract-keyring.gpg'
+            echo ''
+            echo '# Add the repository'
+            echo "echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] https://apt.runtimed.com ${VERSION_SUFFIX} main\" \\"
+            echo '  | sudo tee /etc/apt/sources.list.d/nteract.list'
+            echo ''
+            echo "sudo apt update && sudo apt install nteract-${VERSION_SUFFIX}"
+            echo '```'
+            echo ''
             echo "## ${CLI_NAME} (CLI)"
             echo ''
             echo 'Also bundled inside the desktop app. Standalone binaries:'
@@ -1082,3 +1096,54 @@ jobs:
               \"color\": 3066993
             }]
           }" "$DISCORD_WEBHOOK"
+
+  publish-apt:
+    name: Publish to APT Repository
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: [build-notebook-linux-x64]
+    if: github.event_name != 'pull_request'
+    concurrency:
+      group: apt-publish-${{ inputs.version_suffix }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download Linux x64 notebook artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nteract-linux-x64
+          path: ./linux-artifacts
+
+      - name: Install APT publishing dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends dpkg-dev awscli
+
+      - name: Install publish scripts
+        run: |
+          sudo cp scripts/apt/publish-apt.sh /usr/local/bin/publish-apt.sh
+          sudo cp scripts/apt/prune-packages.py /usr/local/bin/prune-packages.py
+          sudo chmod +x /usr/local/bin/publish-apt.sh /usr/local/bin/prune-packages.py
+
+      - name: Publish .deb to APT repository
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: https://apt.runtimed.com
+          GPG_KEY_ID: ${{ secrets.APT_GPG_KEY_ID }}
+          GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+        run: |
+          CHANNEL="${{ inputs.version_suffix }}"
+          DEB_FILE="./linux-artifacts/nteract-${CHANNEL}-linux-x64.deb"
+
+          if [ ! -f "$DEB_FILE" ]; then
+            echo "ERROR: .deb not found at $DEB_FILE"
+            ls -la ./linux-artifacts/
+            exit 1
+          fi
+
+          publish-apt.sh --channel "$CHANNEL" "$DEB_FILE"

--- a/scripts/apt/.env.example
+++ b/scripts/apt/.env.example
@@ -3,7 +3,7 @@ AWS_ACCESS_KEY_ID=your-r2-access-key-id
 AWS_SECRET_ACCESS_KEY=your-r2-secret-access-key
 AWS_DEFAULT_REGION=auto
 R2_BUCKET_NAME=your-bucket-name
-R2_PUBLIC_URL=https://apt.nteract.io
+R2_PUBLIC_URL=https://apt.runtimed.com
 GPG_KEY_ID=your-key-fingerprint-or-email
 GPG_PRIVATE_KEY=base64-encoded-armored-private-key
 # Generate with: gpg --armor --export-secret-keys "$KEY_ID" | base64


### PR DESCRIPTION
## Summary

- Adds `publish-apt` job to the reusable release workflow — downloads the `.deb` artifact from the Linux build, signs it with GPG, and publishes to the R2-backed APT repository at `apt.runtimed.com`
- Adds APT install instructions to GitHub release notes
- Updates `.env.example` to reflect the production domain

## Infrastructure (already done)

- R2 bucket `nteract-apt` with custom domain `apt.runtimed.com` (active, TLS working)
- GPG signing key `nteract <releases@nteract.io>` (RSA 4096) — public key uploaded to R2
- GitHub Actions secrets configured: `CF_ACCOUNT_ID`, `R2_AWS_ACCESS_KEY_ID`, `R2_AWS_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `APT_GPG_KEY_ID`, `APT_GPG_PRIVATE_KEY`
- All credentials backed up in 1Password

## Design decisions

- **Runs directly on CI runner** (Ubuntu 22.04), not Docker — only `dpkg-dev` and `awscli` need installing. Docker path remains for local publishing.
- **`needs: [build-notebook-linux-x64]`** — runs in parallel with the `prerelease` job since it only needs the `.deb` artifact, not the GitHub release.
- **Concurrency group** per channel serializes APT publishes to prevent index corruption.
- Uses existing `scripts/apt/publish-apt.sh` and `scripts/apt/prune-packages.py` with zero modifications.

## Test plan

- [ ] Trigger manual nightly `workflow_dispatch` and verify `publish-apt` job succeeds
- [ ] Confirm `curl https://apt.runtimed.com/dists/nightly/Release` shows updated metadata
- [ ] Verify `apt install nteract-nightly` works on Ubuntu (Docker test container or VM)