### PR TITLE
feat(sift): add parquet renderer plugin for iframe outputs

### DIFF
--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -24,3 +24,8 @@ declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;
 }
+
+declare module "virtual:renderer-plugin/sift" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -112,6 +112,8 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
         alias: {
           "@/": `${srcDir}/`,
           "nteract-predicate": path.resolve(__dirname, "../../crates/nteract-predicate/pkg"),
+          "@nteract/sift/style.css": path.resolve(__dirname, "../../packages/sift/src/style.css"),
+          "@nteract/sift": path.resolve(__dirname, "../../packages/sift/src/index.ts"),
         },
       },
       build: {
@@ -275,13 +277,15 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     }
 
     // --- Build renderer plugins (CJS, React externalized) ---
-    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin, siftPlugin] = await Promise.all([
-      buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
-      buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
-      buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
-      buildRendererPlugin(leafletEntry, "leaflet-renderer", srcDir),
-      buildRendererPlugin(siftEntry, "sift-renderer", srcDir),
-    ]);
+    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin, siftPlugin] = await Promise.all(
+      [
+        buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
+        buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
+        buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
+        buildRendererPlugin(leafletEntry, "leaflet-renderer", srcDir),
+        buildRendererPlugin(siftEntry, "sift-renderer", srcDir),
+      ],
+    );
     markdownRendererCode = markdownPlugin.code;
     markdownRendererCss = markdownPlugin.css;
     vegaRendererCode = vegaPlugin.code;

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -127,6 +127,7 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
           external: ["react", "react/jsx-runtime"],
           output: {
             assetFileNames: `${pluginName}.[ext]`,
+            inlineDynamicImports: true,
           },
           onwarn(warning, warn) {
             if (

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -53,6 +53,7 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
   const vegaEntry = path.resolve(__dirname, "../../src/isolated-renderer/vega-renderer.tsx");
   const plotlyEntry = path.resolve(__dirname, "../../src/isolated-renderer/plotly-renderer.tsx");
   const leafletEntry = path.resolve(__dirname, "../../src/isolated-renderer/leaflet-renderer.tsx");
+  const siftEntry = path.resolve(__dirname, "../../src/isolated-renderer/sift-renderer.tsx");
 
   let rendererCode = "";
   let rendererCss = "";
@@ -64,6 +65,8 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
   let plotlyRendererCss = "";
   let leafletRendererCode = "";
   let leafletRendererCss = "";
+  let siftRendererCode = "";
+  let siftRendererCss = "";
   let buildPromise: Promise<void> | null = null;
 
   // Directories to watch for changes that should trigger rebuild
@@ -82,6 +85,8 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     plotlyRendererCss = "";
     leafletRendererCode = "";
     leafletRendererCss = "";
+    siftRendererCode = "";
+    siftRendererCss = "";
   }
 
   /**
@@ -106,6 +111,7 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
       resolve: {
         alias: {
           "@/": `${srcDir}/`,
+          "nteract-predicate": path.resolve(__dirname, "../../crates/nteract-predicate/pkg"),
         },
       },
       build: {
@@ -269,11 +275,12 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     }
 
     // --- Build renderer plugins (CJS, React externalized) ---
-    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin] = await Promise.all([
+    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin, siftPlugin] = await Promise.all([
       buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
       buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
       buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
       buildRendererPlugin(leafletEntry, "leaflet-renderer", srcDir),
+      buildRendererPlugin(siftEntry, "sift-renderer", srcDir),
     ]);
     markdownRendererCode = markdownPlugin.code;
     markdownRendererCss = markdownPlugin.css;
@@ -283,6 +290,8 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     plotlyRendererCss = plotlyPlugin.css;
     leafletRendererCode = leafletPlugin.code;
     leafletRendererCss = leafletPlugin.css;
+    siftRendererCode = siftPlugin.code;
+    siftRendererCss = siftPlugin.css;
   }
 
   return {
@@ -350,6 +359,12 @@ export const code = ${JSON.stringify(leafletRendererCode)};
 export const css = ${JSON.stringify(leafletRendererCss)};
 `;
       }
+      if (pluginName === "sift") {
+        return `
+export const code = ${JSON.stringify(siftRendererCode)};
+export const css = ${JSON.stringify(siftRendererCss)};
+`;
+      }
     },
 
     // For dev server: serve the virtual module
@@ -391,7 +406,7 @@ export const css = ${JSON.stringify(leafletRendererCss)};
           devServer.moduleGraph.invalidateModule(mod);
         }
 
-        const pluginNames = ["markdown", "vega", "plotly", "leaflet"];
+        const pluginNames = ["markdown", "vega", "plotly", "leaflet", "sift"];
         for (const name of pluginNames) {
           const pluginMod = devServer.moduleGraph.getModuleById(`${RESOLVED_PLUGIN_PREFIX}${name}`);
           if (pluginMod) {

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -8,6 +8,7 @@
  *   import { rendererCode, rendererCss } from 'virtual:isolated-renderer';
  */
 
+import { existsSync } from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { build, type Plugin } from "vite-plus";
@@ -111,7 +112,11 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
       resolve: {
         alias: {
           "@/": `${srcDir}/`,
-          "nteract-predicate": path.resolve(__dirname, "../../crates/nteract-predicate/pkg"),
+          "nteract-predicate": existsSync(
+            path.resolve(__dirname, "../../crates/nteract-predicate/pkg/nteract_predicate.js"),
+          )
+            ? path.resolve(__dirname, "../../crates/nteract-predicate/pkg")
+            : path.resolve(__dirname, "../../packages/sift/src/__mocks__/nteract-predicate"),
           "@nteract/sift/style.css": path.resolve(__dirname, "../../packages/sift/src/style.css"),
           "@nteract/sift": path.resolve(__dirname, "../../packages/sift/src/index.ts"),
         },

--- a/crates/runt-mcp/assets/plugins/nteract-predicate.wasm
+++ b/crates/runt-mcp/assets/plugins/nteract-predicate.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac9b1ec9cac69256e7d51d212ca8853347ce25c6380b83cedcba6937b388236
+size 5515463

--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -21,6 +21,11 @@ const _: () = {
         MARKDOWN.len() > 1024,
         "markdown.js appears to be a Git LFS pointer — run `git lfs pull`"
     );
+    const WASM: &[u8] = include_bytes!("../../runt-mcp/assets/plugins/nteract-predicate.wasm");
+    assert!(
+        WASM.len() > 1024,
+        "nteract-predicate.wasm appears to be a Git LFS pointer — run `git lfs pull`"
+    );
 };
 
 /// Look up an embedded renderer plugin asset by filename.

--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -51,6 +51,10 @@ pub fn get(name: &str) -> Option<(&'static [u8], &'static str)> {
             include_bytes!("../../runt-mcp/assets/plugins/leaflet.css"),
             "text/css; charset=utf-8",
         )),
+        "nteract-predicate.wasm" => Some((
+            include_bytes!("../../runt-mcp/assets/plugins/nteract-predicate.wasm"),
+            "application/wasm",
+        )),
         _ => None,
     }
 }

--- a/docs/superpowers/plans/2026-04-11-sift-parquet-renderer.md
+++ b/docs/superpowers/plans/2026-04-11-sift-parquet-renderer.md
@@ -1,0 +1,553 @@
+# Sift Parquet Renderer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `@nteract/sift` into the notebook iframe renderer plugin system so `application/vnd.apache.parquet` outputs render as interactive tables.
+
+**Architecture:** Sift becomes an iframe renderer plugin (CJS module, code-split, on-demand loaded) — same pattern as plotly/vega/leaflet. The plugin fetches parquet bytes from the blob URL, loads them into nteract-predicate WASM, builds a `WasmTableData`, and renders via the imperative `createTable` engine. A new `parquetUrl` prop on `SiftTable` encapsulates this loading path.
+
+**Tech Stack:** `@nteract/sift`, `nteract-predicate` WASM, Vite plugin virtual modules, iframe renderer plugin API
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/sift/src/react.tsx` | Modify | Add `parquetUrl` prop to `SiftTable` |
+| `src/isolated-renderer/sift-renderer.tsx` | Create | CJS renderer plugin — thin wrapper |
+| `apps/notebook/vite-plugin-isolated-renderer.ts` | Modify | Add sift plugin build, virtual module, HMR |
+| `src/components/isolated/iframe-libraries.ts` | Modify | Add MIME → plugin mapping |
+| `src/components/outputs/media-router.tsx` | Modify | Add to `DEFAULT_PRIORITY` |
+| `packages/runtimed/src/mime-priority.ts` | Modify | Add to `DEFAULT_MIME_PRIORITY` |
+
+---
+
+### Task 1: Add `parquetUrl` prop to SiftTable
+
+The `SiftTable` React component currently only supports Arrow IPC URLs (`url` prop) and pre-built `TableData` (`data` prop). Parquet loading requires a different pipeline: fetch bytes → `loadParquet()` WASM → `createWasmTableData()` → `createTable()`. Add a `parquetUrl` prop that handles this, following the same progressive row-group loading pattern from `main.ts`.
+
+**Files:**
+- Modify: `packages/sift/src/react.tsx`
+
+- [ ] **Step 1: Add `parquetUrl` prop to `SiftTableProps`**
+
+In `packages/sift/src/react.tsx`, add `parquetUrl` to the props type:
+
+```tsx
+export type SiftTableProps = {
+  /** Pre-built TableData object. Mutually exclusive with `url` and `parquetUrl`. */
+  data?: TableData;
+  /** Arrow IPC URL to stream from. Mutually exclusive with `data` and `parquetUrl`. */
+  url?: string;
+  /** Parquet file URL to load via WASM. Mutually exclusive with `data` and `url`. */
+  parquetUrl?: string;
+  /** Column type overrides keyed by column name. */
+  typeOverrides?: Record<string, ColumnType>;
+  /** Column display overrides (label, width, sortable). */
+  columnOverrides?: Record<string, Partial<Column>>;
+  /** Called whenever sort or filter state changes from UI interaction. */
+  onChange?: (state: TableEngineState) => void;
+  /** CSS class name for the container div. */
+  className?: string;
+  /** Inline styles for the container div. */
+  style?: React.CSSProperties;
+};
+```
+
+- [ ] **Step 2: Add parquet loading imports**
+
+At the top of `packages/sift/src/react.tsx`, add:
+
+```tsx
+import { getModuleSync, isAvailable } from "./predicate";
+import { createWasmTableData } from "./wasm-table-data";
+```
+
+- [ ] **Step 3: Add parquet URL effect**
+
+In the `SiftTable` component body, after the existing `url` effect (around line 249), add a new effect for `parquetUrl`:
+
+```tsx
+  // Load from Parquet URL via nteract-predicate WASM
+  useEffect(() => {
+    if (!parquetUrl || !containerRef.current) return;
+
+    let cancelled = false;
+    const container = containerRef.current;
+
+    async function loadParquet() {
+      setStatus("loading");
+      setError(null);
+
+      try {
+        const [response, wasmOk] = await Promise.all([
+          fetch(parquetUrl!),
+          isAvailable(),
+        ]);
+
+        if (cancelled) return;
+        if (!wasmOk) throw new Error("Failed to load nteract-predicate WASM module");
+        if (!response.ok) throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+
+        const parquetBytes = new Uint8Array(await response.arrayBuffer());
+        if (cancelled) return;
+
+        const mod = getModuleSync();
+        const meta = mod.parquet_metadata(parquetBytes);
+        const numRowGroups = meta[0];
+
+        // Load first row group → mount table immediately
+        const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+        const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+        tableData.prefetchViewport = prefetchViewport;
+
+        // Compute initial summaries
+        const BIN_COUNT = 25;
+        updateSummaries(mod, handle, tableData, columns, BIN_COUNT);
+
+        if (cancelled) return;
+
+        // Clean up previous engine
+        if (engineRef.current) {
+          engineRef.current.destroy();
+          engineRef.current = null;
+        }
+
+        const engineDiv = document.createElement("div");
+        engineDiv.style.height = "100%";
+        container.appendChild(engineDiv);
+
+        engineRef.current = createTable(engineDiv, tableData, {
+          onChange: stableOnChange,
+        });
+        setStatus("ready");
+
+        // Stream remaining row groups progressively
+        for (let g = 1; g < numRowGroups; g++) {
+          if (cancelled) return;
+          await new Promise((r) => setTimeout(r, 0));
+          if (cancelled) return;
+          mod.load_parquet_row_group(parquetBytes, g, handle);
+          tableData.rowCount = mod.num_rows(handle);
+          updateSummaries(mod, handle, tableData, columns, BIN_COUNT);
+          engineRef.current!.onBatchAppended();
+        }
+
+        engineRef.current!.setStreamingDone();
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    }
+
+    loadParquet();
+
+    return () => {
+      cancelled = true;
+      engineRef.current?.destroy();
+      engineRef.current = null;
+    };
+  }, [parquetUrl, typeOverrides, columnOverrides, stableOnChange]);
+```
+
+- [ ] **Step 4: Add the `updateSummaries` helper**
+
+Add this function before the `SiftTable` component (after the `buildTableState` function around line 104):
+
+```tsx
+function updateSummaries(
+  mod: ReturnType<typeof getModuleSync>,
+  handle: number,
+  tableData: TableData,
+  columns: Column[],
+  binCount: number,
+) {
+  const numRows = mod.num_rows(handle);
+  tableData.rowCount = numRows;
+  tableData.columnSummaries = columns.map((col, c) => {
+    switch (col.columnType) {
+      case "categorical": {
+        const counts = mod.store_value_counts(handle, c) as {
+          label: string;
+          count: number;
+        }[];
+        const allCategories = counts.map(({ label, count }) => ({
+          label,
+          count,
+          pct: Math.round((count / numRows) * 1000) / 10,
+        }));
+        const topCategories = allCategories.slice(0, 3);
+        const othersCount = counts.slice(3).reduce((s, e) => s + e.count, 0);
+        const othersPct = Math.round((othersCount / numRows) * 1000) / 10;
+        const lengths = counts.map(({ label }) => label.length).sort((a, b) => a - b);
+        const medianTextLength = lengths.length > 0 ? lengths[Math.floor(lengths.length / 2)] : 0;
+        return {
+          kind: "categorical" as const,
+          uniqueCount: counts.length,
+          topCategories,
+          othersCount,
+          othersPct,
+          allCategories,
+          medianTextLength,
+        };
+      }
+      case "boolean": {
+        const [trueCount, falseCount, nullCount] = mod.store_filtered_bool_counts(
+          handle,
+          c,
+          new Uint8Array(0),
+        );
+        return {
+          kind: "boolean" as const,
+          trueCount,
+          falseCount,
+          nullCount,
+          total: numRows,
+        };
+      }
+      case "numeric":
+      case "timestamp": {
+        const bins = mod.store_histogram(handle, c, binCount) as {
+          x0: number;
+          x1: number;
+          count: number;
+        }[];
+        if (bins.length === 0) return null;
+        return {
+          kind: col.columnType as "numeric" | "timestamp",
+          min: bins[0].x0,
+          max: bins[bins.length - 1].x1,
+          bins,
+        };
+      }
+      default:
+        return null;
+    }
+  });
+}
+```
+
+- [ ] **Step 5: Destructure `parquetUrl` in the component**
+
+Update the destructuring at the top of the `SiftTable` function body to include `parquetUrl`:
+
+```tsx
+export function SiftTable({
+  data,
+  url,
+  parquetUrl,
+  typeOverrides,
+  columnOverrides,
+  onChange,
+  className,
+  style,
+}: SiftTableProps) {
+```
+
+- [ ] **Step 6: Export `parquetUrl` in the public API**
+
+No changes needed — `SiftTableProps` is already exported via the `export type` at the bottom of the file, and `SiftTable` is already a named export.
+
+- [ ] **Step 7: Run sift tests**
+
+Run: `cd packages/sift && pnpm test`
+
+Expected: All existing tests pass (parquetUrl effect is only triggered when prop is provided).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sift/src/react.tsx
+git commit -m "feat(sift): add parquetUrl prop to SiftTable for WASM-based parquet loading"
+```
+
+---
+
+### Task 2: Create sift renderer plugin
+
+Create the CJS renderer plugin module that will be loaded on demand inside the isolated iframe when `application/vnd.apache.parquet` outputs appear.
+
+**Files:**
+- Create: `src/isolated-renderer/sift-renderer.tsx`
+
+- [ ] **Step 1: Create the plugin file**
+
+Create `src/isolated-renderer/sift-renderer.tsx`:
+
+```tsx
+/**
+ * Sift Renderer Plugin
+ *
+ * On-demand renderer plugin for application/vnd.apache.parquet outputs.
+ * Loads parquet bytes via nteract-predicate WASM and renders with sift.
+ * Loaded into the isolated iframe via the renderer plugin API.
+ */
+
+import { SiftTable } from "@nteract/sift";
+import "@nteract/sift/style.css";
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+function SiftRenderer({ data }: RendererProps) {
+  const url = String(data);
+  return (
+    <div style={{ height: "min(600px, 80vh)", width: "100%" }}>
+      <SiftTable parquetUrl={url} />
+    </div>
+  );
+}
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
+}) {
+  ctx.register(["application/vnd.apache.parquet"], SiftRenderer);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/isolated-renderer/sift-renderer.tsx
+git commit -m "feat(sift): add sift iframe renderer plugin for parquet MIME type"
+```
+
+---
+
+### Task 3: Wire sift into the Vite plugin build
+
+Add sift as a renderer plugin to `vite-plugin-isolated-renderer.ts` so it gets built as a CJS module and exposed as `virtual:renderer-plugin/sift`.
+
+**Files:**
+- Modify: `apps/notebook/vite-plugin-isolated-renderer.ts`
+
+- [ ] **Step 1: Add sift entry path**
+
+After the `leafletEntry` declaration (line 55), add:
+
+```typescript
+  const siftEntry = path.resolve(__dirname, "../../src/isolated-renderer/sift-renderer.tsx");
+```
+
+- [ ] **Step 2: Add sift state variables**
+
+After the `leafletRendererCss` declaration (line 66), add:
+
+```typescript
+  let siftRendererCode = "";
+  let siftRendererCss = "";
+```
+
+- [ ] **Step 3: Add sift to invalidateCache**
+
+In the `invalidateCache()` function, after `leafletRendererCss = "";` (around line 84), add:
+
+```typescript
+    siftRendererCode = "";
+    siftRendererCss = "";
+```
+
+- [ ] **Step 4: Add nteract-predicate alias to `buildRendererPlugin`**
+
+The sift plugin imports `@nteract/sift` which internally imports `nteract-predicate`. The plugin build needs the alias. Update the `buildRendererPlugin` function's `resolve.alias` (line 107-109) to include it:
+
+```typescript
+        alias: {
+          "@/": `${srcDir}/`,
+          "nteract-predicate": path.resolve(__dirname, "../../crates/nteract-predicate/pkg"),
+        },
+```
+
+- [ ] **Step 5: Add sift to the parallel plugin build**
+
+Update the `Promise.all` in `buildRenderer()` (lines 272-277) to include sift:
+
+```typescript
+    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin, siftPlugin] = await Promise.all([
+      buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
+      buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
+      buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
+      buildRendererPlugin(leafletEntry, "leaflet-renderer", srcDir),
+      buildRendererPlugin(siftEntry, "sift-renderer", srcDir),
+    ]);
+```
+
+After the leaflet assignments (line 285), add:
+
+```typescript
+    siftRendererCode = siftPlugin.code;
+    siftRendererCss = siftPlugin.css;
+```
+
+- [ ] **Step 6: Add sift virtual module in `load()`**
+
+After the `leaflet` plugin block (around line 351), add:
+
+```typescript
+      if (pluginName === "sift") {
+        return `
+export const code = ${JSON.stringify(siftRendererCode)};
+export const css = ${JSON.stringify(siftRendererCss)};
+`;
+      }
+```
+
+- [ ] **Step 7: Add sift to HMR invalidation**
+
+Update the `pluginNames` array in `handleHotUpdate` (line 394) to include sift:
+
+```typescript
+        const pluginNames = ["markdown", "vega", "plotly", "leaflet", "sift"];
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/notebook/vite-plugin-isolated-renderer.ts
+git commit -m "feat(sift): add sift to isolated renderer plugin build pipeline"
+```
+
+---
+
+### Task 4: Register MIME type → plugin mapping
+
+Add `application/vnd.apache.parquet` to the iframe library mapping so `needsPlugin()` returns true and `injectPluginsForMimes()` loads the sift plugin.
+
+**Files:**
+- Modify: `src/components/isolated/iframe-libraries.ts`
+
+- [ ] **Step 1: Add parquet to PLUGIN_MIME_TYPES**
+
+In `src/components/isolated/iframe-libraries.ts`, add to the `PLUGIN_MIME_TYPES` object (after the `application/geo+json` entry, line 39):
+
+```typescript
+  "application/vnd.apache.parquet": () => import("virtual:renderer-plugin/sift").then(normalize),
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/isolated/iframe-libraries.ts
+git commit -m "feat(sift): register parquet MIME type to sift renderer plugin"
+```
+
+---
+
+### Task 5: Add parquet to MIME priority lists
+
+Add `application/vnd.apache.parquet` to both priority lists so it wins over `text/html` when both are present in an output bundle.
+
+**Files:**
+- Modify: `src/components/outputs/media-router.tsx`
+- Modify: `packages/runtimed/src/mime-priority.ts`
+
+- [ ] **Step 1: Add to DEFAULT_PRIORITY in media-router.tsx**
+
+In `src/components/outputs/media-router.tsx`, add `application/vnd.apache.parquet` after the `application/geo+json` entry (line 59) and before the `// HTML, PDF, markdown, and LaTeX` comment:
+
+```typescript
+  "application/geo+json",
+  "application/vnd.apache.parquet",
+  // HTML, PDF, markdown, and LaTeX
+```
+
+- [ ] **Step 2: Add to DEFAULT_MIME_PRIORITY in mime-priority.ts**
+
+In `packages/runtimed/src/mime-priority.ts`, add `application/vnd.apache.parquet` after `application/geo+json` (line 23) and before the `// HTML, PDF, markdown, and LaTeX` comment:
+
+```typescript
+  "application/geo+json",
+  "application/vnd.apache.parquet",
+  // HTML, PDF, markdown, and LaTeX
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/outputs/media-router.tsx packages/runtimed/src/mime-priority.ts
+git commit -m "feat(sift): add parquet to MIME priority above text/html"
+```
+
+---
+
+### Task 6: Build verification
+
+Verify the plugin builds correctly and the notebook app compiles.
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build nteract-predicate WASM**
+
+Ensure the WASM module is built (needed by the sift plugin build):
+
+```bash
+cargo xtask wasm sift
+```
+
+Expected: WASM output in `crates/nteract-predicate/pkg/`
+
+- [ ] **Step 2: Build the notebook app**
+
+```bash
+cargo xtask build
+```
+
+Expected: Build succeeds. The sift renderer plugin is built as part of `vite-plugin-isolated-renderer.ts` during the Vite build.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+cargo xtask lint --fix
+```
+
+Expected: No formatting issues, or issues are auto-fixed.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add -A && git commit -m "chore: lint fixes" || echo "nothing to commit"
+```
+
+---
+
+### Task 7: Integration test with dev server
+
+Verify the sift renderer plugin loads and renders inside the iframe using the dev server.
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Start the dev daemon and Vite**
+
+Use supervisor tools:
+```
+supervisor_restart(target="daemon")
+supervisor_start_vite
+```
+
+Or manually:
+```bash
+# Terminal 1
+cargo xtask dev-daemon
+# Terminal 2
+cargo xtask vite
+```
+
+- [ ] **Step 2: Create a test notebook with a parquet output**
+
+Use MCP tools to create a notebook, add a cell that produces parquet output, and verify sift renders. The exact kernel integration isn't built yet, but you can test the plugin loading path by manually placing a parquet file in the blob store and creating a synthetic output.
+
+Alternatively, confirm the plugin is included in the build by checking the Vite dev server resolves `virtual:renderer-plugin/sift`:
+1. Open the notebook app
+2. Check browser console for any plugin build errors
+3. Verify `needsPlugin("application/vnd.apache.parquet")` returns true (check in dev tools console)
+
+- [ ] **Step 3: Commit if any fixes were needed**
+
+```bash
+git add -A && git commit -m "fix(sift): integration test fixes" || echo "nothing to commit"
+```

--- a/docs/superpowers/specs/2026-04-11-sift-parquet-renderer-design.md
+++ b/docs/superpowers/specs/2026-04-11-sift-parquet-renderer-design.md
@@ -1,0 +1,140 @@
+# Sift Parquet Renderer — Frontend Integration
+
+**Date:** 2026-04-11
+**Issue:** #1453 (Phase 1 only)
+**Status:** Draft
+
+## Goal
+
+Wire `@nteract/sift` into the notebook frontend so that outputs with MIME type `application/vnd.apache.parquet` render as interactive, filterable, sortable tables. No kernel integration, no python formatter, no blob upload — just the rendering path.
+
+## MIME Type
+
+`application/vnd.apache.parquet` — the registered IANA MIME type for Apache Parquet files.
+
+## Rendering Approach: Main DOM (not iframe plugin)
+
+Sift is pure DOM — no script execution risk from user-supplied specs (unlike plotly/vega which eval user JSON). It renders in the **main DOM** via a custom renderer registered in `MediaProvider`, the same pattern used for `application/vnd.jupyter.widget-view+json`.
+
+This means:
+- No `sift-renderer.tsx` CJS plugin
+- No iframe `installRendererPlugin` path
+- No changes to `vite-plugin-isolated-renderer.ts` or `iframe-libraries.ts`
+
+## Data Flow
+
+```
+CRDT output (application/vnd.apache.parquet)
+  → WASM resolves ContentRef → blob URL (http://127.0.0.1:<port>/blob/<hash>)
+  → MediaRouter selects MIME type
+  → custom renderer in MediaProvider
+  → DataFrameOutput component
+  → <SiftTable url={blobUrl} />
+  → sift fetches parquet bytes from blob URL
+  → parquet-wasm decodes client-side
+  → virtual-scrolled interactive table
+```
+
+`application/vnd.apache.parquet` is `application/*` with no text carve-out in `mime.rs`, so `is_binary_mime()` returns `true`. WASM resolves the `ContentRef` to a `Url` variant pointing at the blob server. The `data` field arriving at the renderer is already a blob URL string.
+
+## Components
+
+### 1. `DataFrameOutput` component
+
+**Location:** `src/components/outputs/dataframe-output.tsx`
+
+A thin wrapper that takes the blob URL from the output data and renders `SiftTable`:
+
+```tsx
+import { SiftTable } from "@nteract/sift";
+
+interface DataFrameOutputProps {
+  data: unknown;
+}
+
+export function DataFrameOutput({ data }: DataFrameOutputProps) {
+  const url = String(data);
+  return <SiftTable url={url} />;
+}
+```
+
+The `data` prop is the resolved blob URL string (e.g. `http://127.0.0.1:8765/blob/abc123`). Sift handles everything else — fetching, parquet decoding via WASM, column type detection, virtual scrolling.
+
+### 2. MediaProvider registration
+
+**Location:** `apps/notebook/src/App.tsx` (existing `MediaProvider` block)
+
+Add `application/vnd.apache.parquet` to the `renderers` map alongside the existing widget-view renderer:
+
+```tsx
+<MediaProvider
+  renderers={{
+    "application/vnd.jupyter.widget-view+json": ({ data }) => {
+      const { model_id } = data as { model_id: string };
+      return <WidgetView modelId={model_id} />;
+    },
+    "application/vnd.apache.parquet": ({ data }) => {
+      return <DataFrameOutput data={data} />;
+    },
+  }}
+>
+```
+
+### 3. MIME priority
+
+**Location:** `src/components/outputs/media-router.tsx` (`DEFAULT_PRIORITY`) and `packages/runtimed/src/mime-priority.ts` (`DEFAULT_MIME_PRIORITY`)
+
+Add `application/vnd.apache.parquet` above `text/html` in both priority lists. When a kernel produces both parquet and HTML representations, sift wins.
+
+### 4. Main DOM safe types
+
+**Location:** `src/components/outputs/safe-mime-types.ts`
+
+Add `application/vnd.apache.parquet` to `MAIN_DOM_SAFE_TYPES`. Sift is pure DOM — no eval, no script injection surface.
+
+### 5. Sift CSS
+
+Sift ships its own stylesheet (`@nteract/sift/style.css`). Import it in `DataFrameOutput` or at the app level. Since this renders in the main DOM (not iframe), normal CSS imports work.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/components/outputs/dataframe-output.tsx` | **New** — `DataFrameOutput` component |
+| `apps/notebook/src/App.tsx` | Add parquet renderer to `MediaProvider` |
+| `src/components/outputs/media-router.tsx` | Add to `DEFAULT_PRIORITY` |
+| `packages/runtimed/src/mime-priority.ts` | Add to `DEFAULT_MIME_PRIORITY` |
+| `src/components/outputs/safe-mime-types.ts` | Add to `MAIN_DOM_SAFE_TYPES` |
+
+## Files NOT Changed
+
+| File | Why |
+|------|-----|
+| `vite-plugin-isolated-renderer.ts` | Not an iframe plugin |
+| `iframe-libraries.ts` | Not an iframe plugin |
+| `isolated-renderer/index.tsx` | Not an iframe plugin |
+| `crates/notebook-doc/src/mime.rs` | Already classifies as binary correctly |
+
+## WASM Dependencies
+
+Sift depends on two WASM modules:
+- **nteract-predicate** — filtering/summary compute kernels (already in Cargo workspace via #1709)
+- **parquet-wasm** — parquet decoding (npm dependency of `@nteract/sift`)
+
+Both are loaded at runtime by sift internally. The Vite build needs to handle `.wasm` files as assets. Verify that sift's WASM initialization works in the Tauri webview context (file:// or custom protocol origins may need CSP adjustments for WASM).
+
+## Testing
+
+Manual verification:
+1. Place a `.parquet` file in the blob store with a known hash
+2. Create a notebook output referencing it (via MCP tools or manual CRDT edit)
+3. Confirm sift renders the interactive table in the main DOM
+4. Verify column detection, sorting, filtering, virtual scroll all work
+
+## Out of Scope
+
+- Kernel integration (python formatter, blob upload) — Phase 2 of #1453
+- iframe fallback for ipywidgets Output contexts — Phase 3
+- Dark/light theme integration — Phase 3
+- `application/vnd.apache.arrow.stream` (Arrow IPC) — future work
+- Streaming by row group — future work

--- a/docs/superpowers/specs/2026-04-11-sift-parquet-renderer-design.md
+++ b/docs/superpowers/specs/2026-04-11-sift-parquet-renderer-design.md
@@ -6,113 +6,114 @@
 
 ## Goal
 
-Wire `@nteract/sift` into the notebook frontend so that outputs with MIME type `application/vnd.apache.parquet` render as interactive, filterable, sortable tables. No kernel integration, no python formatter, no blob upload — just the rendering path.
+Wire `@nteract/sift` into the notebook frontend as an iframe renderer plugin so that outputs with MIME type `application/vnd.apache.parquet` render as interactive, filterable, sortable tables. Must work in both the notebook app and the MCPB (Claude Desktop extension). No kernel integration, no python formatter, no blob upload — just the rendering path.
 
 ## MIME Type
 
 `application/vnd.apache.parquet` — the registered IANA MIME type for Apache Parquet files.
 
-## Rendering Approach: Main DOM (not iframe plugin)
+## Rendering Approach: Iframe Plugin
 
-Sift is pure DOM — no script execution risk from user-supplied specs (unlike plotly/vega which eval user JSON). It renders in the **main DOM** via a custom renderer registered in `MediaProvider`, the same pattern used for `application/vnd.jupyter.widget-view+json`.
+Sift renders as an **iframe renderer plugin** — the same architecture as plotly, vega, leaflet, and markdown. This is required for MCPB support, where all rich output renders inside isolated iframes.
 
-This means:
-- No `sift-renderer.tsx` CJS plugin
-- No iframe `installRendererPlugin` path
-- No changes to `vite-plugin-isolated-renderer.ts` or `iframe-libraries.ts`
+The plugin is:
+- Built as a CJS module with React externalized
+- Loaded on demand via `virtual:renderer-plugin/sift`
+- Installed into the iframe via `installRendererPlugin()`
+- Registered in the iframe's renderer registry for `application/vnd.apache.parquet`
 
 ## Data Flow
 
 ```
 CRDT output (application/vnd.apache.parquet)
   → WASM resolves ContentRef → blob URL (http://127.0.0.1:<port>/blob/<hash>)
-  → MediaRouter selects MIME type
-  → custom renderer in MediaProvider
-  → DataFrameOutput component
-  → <SiftTable url={blobUrl} />
+  → OutputArea pre-scans MIME types, sees needsPlugin() → true
+  → injectPluginsForMimes() loads virtual:renderer-plugin/sift
+  → iframe installRendererPlugin() executes CJS, registers SiftRenderer
+  → iframe receives NTERACT_RENDER_OUTPUT with blob URL as data
+  → SiftRenderer passes blob URL to <SiftTable url={blobUrl} />
   → sift fetches parquet bytes from blob URL
   → parquet-wasm decodes client-side
   → virtual-scrolled interactive table
+  → iframe sends render_complete with height
 ```
 
 `application/vnd.apache.parquet` is `application/*` with no text carve-out in `mime.rs`, so `is_binary_mime()` returns `true`. WASM resolves the `ContentRef` to a `Url` variant pointing at the blob server. The `data` field arriving at the renderer is already a blob URL string.
 
 ## Components
 
-### 1. `DataFrameOutput` component
+### 1. Sift renderer plugin
 
-**Location:** `src/components/outputs/dataframe-output.tsx`
+**Location:** `src/isolated-renderer/sift-renderer.tsx`
 
-A thin wrapper that takes the blob URL from the output data and renders `SiftTable`:
+CJS plugin module following the same pattern as `plotly-renderer.tsx`:
 
 ```tsx
 import { SiftTable } from "@nteract/sift";
+import "@nteract/sift/style.css";
 
-interface DataFrameOutputProps {
+interface RendererProps {
   data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
 }
 
-export function DataFrameOutput({ data }: DataFrameOutputProps) {
+function SiftRenderer({ data }: RendererProps) {
   const url = String(data);
   return <SiftTable url={url} />;
 }
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
+}) {
+  ctx.register(["application/vnd.apache.parquet"], SiftRenderer);
+}
 ```
 
-The `data` prop is the resolved blob URL string (e.g. `http://127.0.0.1:8765/blob/abc123`). Sift handles everything else — fetching, parquet decoding via WASM, column type detection, virtual scrolling.
+### 2. Vite build plugin integration
 
-### 2. MediaProvider registration
+**Location:** `apps/notebook/vite-plugin-isolated-renderer.ts`
 
-**Location:** `apps/notebook/src/App.tsx` (existing `MediaProvider` block)
+- Add `sift-renderer.tsx` as a new plugin entry alongside markdown, vega, plotly, leaflet
+- Build via `buildRendererPlugin(siftEntry, "sift-renderer", srcDir)`
+- Register `virtual:renderer-plugin/sift` virtual module
+- Add to HMR invalidation list
 
-Add `application/vnd.apache.parquet` to the `renderers` map alongside the existing widget-view renderer:
+### 3. MIME → plugin mapping
 
-```tsx
-<MediaProvider
-  renderers={{
-    "application/vnd.jupyter.widget-view+json": ({ data }) => {
-      const { model_id } = data as { model_id: string };
-      return <WidgetView modelId={model_id} />;
-    },
-    "application/vnd.apache.parquet": ({ data }) => {
-      return <DataFrameOutput data={data} />;
-    },
-  }}
->
+**Location:** `src/components/isolated/iframe-libraries.ts`
+
+Add to `PLUGIN_MIME_TYPES`:
+
+```typescript
+"application/vnd.apache.parquet": () => import("virtual:renderer-plugin/sift").then(normalize),
 ```
 
-### 3. MIME priority
+This makes `needsPlugin("application/vnd.apache.parquet")` return `true`, triggering plugin injection before render.
+
+### 4. MIME priority
 
 **Location:** `src/components/outputs/media-router.tsx` (`DEFAULT_PRIORITY`) and `packages/runtimed/src/mime-priority.ts` (`DEFAULT_MIME_PRIORITY`)
 
 Add `application/vnd.apache.parquet` above `text/html` in both priority lists. When a kernel produces both parquet and HTML representations, sift wins.
 
-### 4. Main DOM safe types
-
-**Location:** `src/components/outputs/safe-mime-types.ts`
-
-Add `application/vnd.apache.parquet` to `MAIN_DOM_SAFE_TYPES`. Sift is pure DOM — no eval, no script injection surface.
-
-### 5. Sift CSS
-
-Sift ships its own stylesheet (`@nteract/sift/style.css`). Import it in `DataFrameOutput` or at the app level. Since this renders in the main DOM (not iframe), normal CSS imports work.
-
 ## Files Changed
 
 | File | Change |
 |------|--------|
-| `src/components/outputs/dataframe-output.tsx` | **New** — `DataFrameOutput` component |
-| `apps/notebook/src/App.tsx` | Add parquet renderer to `MediaProvider` |
+| `src/isolated-renderer/sift-renderer.tsx` | **New** — CJS plugin wrapping SiftTable |
+| `apps/notebook/vite-plugin-isolated-renderer.ts` | Add sift to plugin build, virtual module, HMR |
+| `src/components/isolated/iframe-libraries.ts` | Add MIME → plugin mapping |
 | `src/components/outputs/media-router.tsx` | Add to `DEFAULT_PRIORITY` |
 | `packages/runtimed/src/mime-priority.ts` | Add to `DEFAULT_MIME_PRIORITY` |
-| `src/components/outputs/safe-mime-types.ts` | Add to `MAIN_DOM_SAFE_TYPES` |
 
 ## Files NOT Changed
 
 | File | Why |
 |------|-----|
-| `vite-plugin-isolated-renderer.ts` | Not an iframe plugin |
-| `iframe-libraries.ts` | Not an iframe plugin |
-| `isolated-renderer/index.tsx` | Not an iframe plugin |
+| `src/components/outputs/safe-mime-types.ts` | Not rendering in main DOM |
+| `apps/notebook/src/App.tsx` | No MediaProvider registration needed — iframe handles it |
+| `src/isolated-renderer/index.tsx` | Already has generic `installRendererPlugin()` infrastructure |
 | `crates/notebook-doc/src/mime.rs` | Already classifies as binary correctly |
 
 ## WASM Dependencies
@@ -121,20 +122,20 @@ Sift depends on two WASM modules:
 - **nteract-predicate** — filtering/summary compute kernels (already in Cargo workspace via #1709)
 - **parquet-wasm** — parquet decoding (npm dependency of `@nteract/sift`)
 
-Both are loaded at runtime by sift internally. The Vite build needs to handle `.wasm` files as assets. Verify that sift's WASM initialization works in the Tauri webview context (file:// or custom protocol origins may need CSP adjustments for WASM).
+Both are loaded at runtime by sift internally. Since sift runs inside the iframe, WASM must be loadable from the iframe's blob: origin. The iframe CSP already allows `'unsafe-eval'` (required by plotly), which covers WASM instantiation. The `.wasm` files need to be served as assets accessible from the iframe — verify they're included in the Vite build output or accessible via the blob server.
 
 ## Testing
 
 Manual verification:
 1. Place a `.parquet` file in the blob store with a known hash
 2. Create a notebook output referencing it (via MCP tools or manual CRDT edit)
-3. Confirm sift renders the interactive table in the main DOM
+3. Confirm sift renders inside the iframe as an interactive table
 4. Verify column detection, sorting, filtering, virtual scroll all work
+5. Verify iframe height auto-sizing works (render_complete message)
 
 ## Out of Scope
 
 - Kernel integration (python formatter, blob upload) — Phase 2 of #1453
-- iframe fallback for ipywidgets Output contexts — Phase 3
 - Dark/light theme integration — Phase 3
 - `application/vnd.apache.arrow.stream` (Arrow IPC) — future work
 - Streaming by row group — future work

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -21,6 +21,7 @@ export const DEFAULT_MIME_PRIORITY = [
   "application/vnd.vega.v5.json",
   "application/vnd.vega.v4+json",
   "application/geo+json",
+  "application/vnd.apache.parquet",
   // HTML, PDF, markdown, and LaTeX
   "text/html",
   "application/pdf",

--- a/packages/sift/src/__mocks__/nteract-predicate/nteract_predicate.js
+++ b/packages/sift/src/__mocks__/nteract-predicate/nteract_predicate.js
@@ -1,0 +1,5 @@
+// Stub for CI where the WASM crate isn't built.
+// Tests that use SiftTable with `data` prop don't need WASM.
+export default function init() {
+  throw new Error("nteract-predicate WASM not available in test environment");
+}

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -68,3 +68,5 @@ export type {
 } from "./table";
 // Imperative engine
 export { createTable } from "./table";
+// WASM configuration
+export { setWasmUrl } from "./predicate";

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -72,11 +72,17 @@ type PredicateModule = {
 };
 
 let mod: PredicateModule | null = null;
+let configuredWasmUrl: string | undefined;
+
+/** Set an explicit URL for the WASM binary (e.g. blob server URL). */
+export function setWasmUrl(url: string): void {
+  configuredWasmUrl = url;
+}
 
 async function ensureModule(): Promise<PredicateModule> {
   if (mod) return mod;
   const wasm = await import("nteract-predicate/nteract_predicate.js");
-  await wasm.default();
+  await wasm.default(configuredWasmUrl);
   mod = wasm as unknown as PredicateModule;
   return mod;
 }

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -24,6 +24,7 @@ import {
   type SummaryAccumulator,
   TimestampAccumulator,
 } from "./accumulators";
+import { getModuleSync, isAvailable } from "./predicate";
 import {
   type Column,
   type ColumnFilter,
@@ -33,14 +34,17 @@ import {
   type TableEngine,
   type TableEngineState,
 } from "./table";
+import { createWasmTableData } from "./wasm-table-data";
 
 // --- Props ---
 
 export type SiftTableProps = {
-  /** Pre-built TableData object. Mutually exclusive with `url`. */
+  /** Pre-built TableData object. Mutually exclusive with `url` and `parquetUrl`. */
   data?: TableData;
-  /** Arrow IPC URL to stream from. Mutually exclusive with `data`. */
+  /** Arrow IPC URL to stream from. Mutually exclusive with `data` and `parquetUrl`. */
   url?: string;
+  /** Parquet URL to load via WASM. Mutually exclusive with `data` and `url`. */
+  parquetUrl?: string;
   /** Column type overrides keyed by column name. */
   typeOverrides?: Record<string, ColumnType>;
   /** Column display overrides (label, width, sortable). */
@@ -104,11 +108,101 @@ function buildTableState(
   return { columns, fieldNames, stringCols, rawCols, accumulators, tableData };
 }
 
+// --- WASM summary helper ---
+
+/** Compute unfiltered summaries from the WASM store and update tableData. */
+function updateWasmSummaries(
+  mod: ReturnType<typeof getModuleSync>,
+  handle: number,
+  tableData: TableData,
+  columns: Column[],
+) {
+  const numRows = mod.num_rows(handle);
+  const BIN_COUNT = 25;
+
+  tableData.rowCount = numRows;
+  tableData.columnSummaries = columns.map((col, c) => {
+    switch (col.columnType) {
+      case "categorical": {
+        const counts = mod.store_value_counts(handle, c) as {
+          label: string;
+          count: number;
+        }[];
+        const allCategories = counts.map(({ label, count }) => ({
+          label,
+          count,
+          pct: Math.round((count / numRows) * 1000) / 10,
+        }));
+        const topCategories = allCategories.slice(0, 3);
+        const othersCount = counts.slice(3).reduce((s, e) => s + e.count, 0);
+        const othersPct = Math.round((othersCount / numRows) * 1000) / 10;
+        const lengths = counts.map(({ label }) => label.length).sort((a, b) => a - b);
+        const medianTextLength = lengths.length > 0 ? lengths[Math.floor(lengths.length / 2)] : 0;
+
+        return {
+          kind: "categorical" as const,
+          uniqueCount: counts.length,
+          topCategories,
+          othersCount,
+          othersPct,
+          allCategories,
+          medianTextLength,
+        };
+      }
+      case "boolean": {
+        const [trueCount, falseCount, nullCount] = mod.store_bool_counts(handle, c);
+        return {
+          kind: "boolean" as const,
+          trueCount,
+          falseCount,
+          nullCount,
+          total: numRows,
+        };
+      }
+      case "timestamp": {
+        const bins = mod.store_temporal_histogram(handle, c) as {
+          x0: number;
+          x1: number;
+          count: number;
+        }[];
+        if (bins.length === 0) return null;
+        const totalInBins = bins.reduce((s, b) => s + b.count, 0);
+        const nullCount = numRows - totalInBins;
+        return {
+          kind: "timestamp" as const,
+          min: bins[0].x0,
+          max: bins[bins.length - 1].x1,
+          bins,
+          nullCount: nullCount > 0 ? nullCount : undefined,
+        };
+      }
+      case "numeric": {
+        const bins = mod.store_histogram(handle, c, BIN_COUNT) as {
+          x0: number;
+          x1: number;
+          count: number;
+        }[];
+        if (bins.length === 0) return null;
+        const totalInBins = bins.reduce((s, b) => s + b.count, 0);
+        const nullCount = numRows - totalInBins;
+        return {
+          kind: "numeric" as const,
+          min: bins[0].x0,
+          max: bins[bins.length - 1].x1,
+          bins,
+          nullCount: nullCount > 0 ? nullCount : undefined,
+        };
+      }
+    }
+  });
+}
+
 // --- Component ---
 
 export function SiftTable({
   data,
   url,
+  parquetUrl,
   typeOverrides,
   columnOverrides,
   onChange,
@@ -247,6 +341,102 @@ export function SiftTable({
       engineRef.current = null;
     };
   }, [url, typeOverrides, columnOverrides, stableOnChange]);
+
+  // Load from parquet URL via WASM when `parquetUrl` prop is provided
+  useEffect(() => {
+    if (!parquetUrl || !containerRef.current) return;
+
+    let cancelled = false;
+    const container = containerRef.current;
+
+    async function loadFromParquetUrl() {
+      setStatus("loading");
+      setError(null);
+
+      try {
+        // Start WASM init in parallel with data fetch
+        const [response, wasmOk] = await Promise.all([fetch(parquetUrl!), isAvailable()]);
+
+        if (cancelled) return;
+
+        if (!wasmOk) {
+          throw new Error("Failed to load nteract-predicate WASM module");
+        }
+        if (!response.ok) {
+          throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+        }
+
+        const parquetBytes = new Uint8Array(await response.arrayBuffer());
+        if (cancelled) return;
+
+        const mod = getModuleSync();
+
+        // Get metadata to know how many row groups
+        const meta = mod.parquet_metadata(parquetBytes);
+        const numRowGroups = meta[0];
+
+        // Load first row group → mount table immediately
+        const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+
+        const { tableData, columns, prefetchViewport } = createWasmTableData(
+          handle,
+          columnOverrides,
+        );
+        tableData.prefetchViewport = prefetchViewport;
+        tableData.recomputeSummaries = () => updateWasmSummaries(mod, handle, tableData, columns);
+
+        // Compute initial summaries from first row group
+        updateWasmSummaries(mod, handle, tableData, columns);
+
+        if (cancelled) return;
+
+        // Clean up previous engine before creating new one
+        if (engineRef.current) {
+          engineRef.current.destroy();
+          engineRef.current = null;
+        }
+
+        // Create a dedicated div for the engine — don't touch React-managed children
+        const engineDiv = document.createElement("div");
+        engineDiv.style.height = "100%";
+        container.appendChild(engineDiv);
+
+        engineRef.current = createTable(engineDiv, tableData, {
+          onChange: stableOnChange,
+        });
+        setStatus("ready");
+
+        // Stream remaining row groups progressively
+        for (let g = 1; g < numRowGroups; g++) {
+          if (cancelled) break;
+          // Yield to the event loop so the UI stays responsive
+          await new Promise((r) => setTimeout(r, 0));
+          if (cancelled) break;
+          mod.load_parquet_row_group(parquetBytes, g, handle);
+          tableData.rowCount = mod.num_rows(handle);
+          updateWasmSummaries(mod, handle, tableData, columns);
+          engineRef.current!.onBatchAppended();
+        }
+
+        if (!cancelled) {
+          engineRef.current!.setStreamingDone();
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setStatus("error");
+      }
+    }
+
+    loadFromParquetUrl();
+
+    return () => {
+      cancelled = true;
+      engineRef.current?.destroy();
+      engineRef.current = null;
+    };
+  }, [parquetUrl, columnOverrides, stableOnChange]);
 
   return (
     <div ref={containerRef} className={className} style={{ height: "100%", ...style }}>

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -353,6 +353,7 @@ export function SiftTable({
     if (!parquetUrl || !containerRef.current) return;
 
     let cancelled = false;
+    let mountDiv: HTMLDivElement | null = null;
     const container = containerRef.current;
 
     async function loadFromParquetUrl() {
@@ -403,11 +404,11 @@ export function SiftTable({
         }
 
         // Create a dedicated div for the engine — don't touch React-managed children
-        const engineDiv = document.createElement("div");
-        engineDiv.style.height = "100%";
-        container.appendChild(engineDiv);
+        mountDiv = document.createElement("div");
+        mountDiv.style.height = "100%";
+        container.appendChild(mountDiv);
 
-        engineRef.current = createTable(engineDiv, tableData, {
+        engineRef.current = createTable(mountDiv, tableData, {
           onChange: stableOnChange,
         });
         setStatus("ready");
@@ -421,11 +422,11 @@ export function SiftTable({
           mod.load_parquet_row_group(parquetBytes, g, handle);
           tableData.rowCount = mod.num_rows(handle);
           updateWasmSummaries(mod, handle, tableData, columns);
-          engineRef.current!.onBatchAppended();
+          engineRef.current?.onBatchAppended();
         }
 
         if (!cancelled) {
-          engineRef.current!.setStreamingDone();
+          engineRef.current?.setStreamingDone();
         }
       } catch (err) {
         if (cancelled) return;
@@ -441,6 +442,7 @@ export function SiftTable({
       cancelled = true;
       engineRef.current?.destroy();
       engineRef.current = null;
+      mountDiv?.remove();
     };
   }, [parquetUrl, columnOverrides, stableOnChange]);
 

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -354,8 +354,10 @@ export function SiftTable({
 
     let cancelled = false;
     let mountDiv: HTMLDivElement | null = null;
+    let wasmHandle: number | undefined;
     const container = containerRef.current;
 
+    // typeOverrides is intentionally not used here — WASM detects types from the Arrow schema
     async function loadFromParquetUrl() {
       setStatus("loading");
       setError(null);
@@ -383,7 +385,8 @@ export function SiftTable({
         const numRowGroups = meta[0];
 
         // Load first row group → mount table immediately
-        const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+        wasmHandle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+        const handle = wasmHandle;
 
         const { tableData, columns, prefetchViewport } = createWasmTableData(
           handle,
@@ -443,6 +446,9 @@ export function SiftTable({
       engineRef.current?.destroy();
       engineRef.current = null;
       mountDiv?.remove();
+      if (wasmHandle !== undefined) {
+        getModuleSync().free(wasmHandle);
+      }
     };
   }, [parquetUrl, columnOverrides, stableOnChange]);
 

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -166,12 +166,14 @@ function updateWasmSummaries(
           count: number;
         }[];
         if (bins.length === 0) return null;
+        const first = bins[0];
+        const last = bins[bins.length - 1];
         const totalInBins = bins.reduce((s, b) => s + b.count, 0);
         const nullCount = numRows - totalInBins;
         return {
           kind: "timestamp" as const,
-          min: bins[0].x0,
-          max: bins[bins.length - 1].x1,
+          min: first.x0,
+          max: last.x1,
           bins,
           nullCount: nullCount > 0 ? nullCount : undefined,
         };
@@ -183,16 +185,20 @@ function updateWasmSummaries(
           count: number;
         }[];
         if (bins.length === 0) return null;
+        const nFirst = bins[0];
+        const nLast = bins[bins.length - 1];
         const totalInBins = bins.reduce((s, b) => s + b.count, 0);
         const nullCount = numRows - totalInBins;
         return {
           kind: "numeric" as const,
-          min: bins[0].x0,
-          max: bins[bins.length - 1].x1,
+          min: nFirst.x0,
+          max: nLast.x1,
           bins,
           nullCount: nullCount > 0 ? nullCount : undefined,
         };
       }
+      default:
+        return null;
     }
   });
 }

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -15,36 +15,6 @@
   --row-alt: rgba(0, 0, 0, 0.018);
   --pin-shadow: rgba(0, 0, 0, 0.06);
   --font: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
-
-  /* Badge colors */
-  --badge-true-bg: rgba(58, 138, 92, 0.15);
-  --badge-true-text: #2d6e4a;
-  --badge-false-bg: rgba(196, 81, 58, 0.15);
-  --badge-false-text: #9e3a24;
-
-  /* Boolean summary bar */
-  --bool-true: #3a8a5c;
-  --bool-false: #c4513a;
-  --bool-null-stripe-a: rgba(0, 0, 0, 0.08);
-  --bool-null-stripe-b: rgba(0, 0, 0, 0.03);
-
-  /* Category bar track */
-  --cat-bar-track: rgba(0, 0, 0, 0.04);
-
-  /* Filter pills */
-  --filter-pill-bg: rgba(149, 95, 59, 0.1);
-  --filter-pill-border: rgba(149, 95, 59, 0.2);
-
-  /* Loading code background */
-  --loading-code-bg: rgba(0, 0, 0, 0.06);
-
-  /* Skeleton shimmer */
-  --skeleton-from: rgba(0, 0, 0, 0.04);
-  --skeleton-mid: rgba(0, 0, 0, 0.08);
-
-  /* Overlay / backdrop */
-  --backdrop: rgba(0, 0, 0, 0.3);
-  --sheet-shadow: rgba(0, 0, 0, 0.15);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -58,29 +28,6 @@
     --accent: #d4896a;
     --row-alt: rgba(255, 255, 255, 0.025);
     --pin-shadow: rgba(255, 255, 255, 0.08);
-
-    --badge-true-bg: rgba(58, 138, 92, 0.15);
-    --badge-true-text: #5ec98a;
-    --badge-false-bg: rgba(196, 81, 58, 0.15);
-    --badge-false-text: #e07a64;
-
-    --bool-true: #3a8a5c;
-    --bool-false: #c4513a;
-    --bool-null-stripe-a: rgba(255, 255, 255, 0.1);
-    --bool-null-stripe-b: rgba(255, 255, 255, 0.04);
-
-    --cat-bar-track: rgba(255, 255, 255, 0.06);
-
-    --filter-pill-bg: rgba(212, 137, 106, 0.12);
-    --filter-pill-border: rgba(212, 137, 106, 0.25);
-
-    --loading-code-bg: rgba(255, 255, 255, 0.08);
-
-    --skeleton-from: rgba(255, 255, 255, 0.04);
-    --skeleton-mid: rgba(255, 255, 255, 0.08);
-
-    --backdrop: rgba(0, 0, 0, 0.5);
-    --sheet-shadow: rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -94,29 +41,6 @@
   --accent: #d4896a;
   --row-alt: rgba(255, 255, 255, 0.025);
   --pin-shadow: rgba(255, 255, 255, 0.08);
-
-  --badge-true-bg: rgba(58, 138, 92, 0.15);
-  --badge-true-text: #5ec98a;
-  --badge-false-bg: rgba(196, 81, 58, 0.15);
-  --badge-false-text: #e07a64;
-
-  --bool-true: #3a8a5c;
-  --bool-false: #c4513a;
-  --bool-null-stripe-a: rgba(255, 255, 255, 0.1);
-  --bool-null-stripe-b: rgba(255, 255, 255, 0.04);
-
-  --cat-bar-track: rgba(255, 255, 255, 0.06);
-
-  --filter-pill-bg: rgba(212, 137, 106, 0.12);
-  --filter-pill-border: rgba(212, 137, 106, 0.25);
-
-  --loading-code-bg: rgba(255, 255, 255, 0.08);
-
-  --skeleton-from: rgba(255, 255, 255, 0.04);
-  --skeleton-mid: rgba(255, 255, 255, 0.08);
-
-  --backdrop: rgba(0, 0, 0, 0.5);
-  --sheet-shadow: rgba(0, 0, 0, 0.3);
 }
 
 body {
@@ -271,7 +195,7 @@ h1 {
 
 .pt-loading code {
   font-family: "SF Mono", ui-monospace, monospace;
-  background: var(--loading-code-bg);
+  background: rgba(0, 0, 0, 0.06);
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -468,7 +392,7 @@ h1 {
 .pt-cat-bar-track {
   flex: 1;
   height: 8px;
-  background: var(--cat-bar-track);
+  background: rgba(0, 0, 0, 0.04);
   border-radius: 2px;
   overflow: hidden;
   min-width: 20px;
@@ -724,13 +648,13 @@ h1 {
 }
 
 .pt-badge-true {
-  background: var(--badge-true-bg);
-  color: var(--badge-true-text);
+  background: rgba(58, 138, 92, 0.15);
+  color: #2d6e4a;
 }
 
 .pt-badge-false {
-  background: var(--badge-false-bg);
-  color: var(--badge-false-text);
+  background: rgba(196, 81, 58, 0.15);
+  color: #9e3a24;
 }
 
 .pt-badge-null {
@@ -739,7 +663,20 @@ h1 {
   font-style: italic;
 }
 
-/* Badge dark colors are now handled by --badge-true-text / --badge-false-text variables */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .pt-badge-true {
+    color: #5ec98a;
+  }
+  :root:not([data-theme="light"]) .pt-badge-false {
+    color: #e07a64;
+  }
+}
+:root[data-theme="dark"] .pt-badge-true {
+  color: #5ec98a;
+}
+:root[data-theme="dark"] .pt-badge-false {
+  color: #e07a64;
+}
 
 /* --- Boolean summary in header --- */
 
@@ -757,22 +694,22 @@ h1 {
 }
 
 .pt-bool-true {
-  background: var(--bool-true);
+  background: #3a8a5c;
   transition: width 200ms ease-out;
 }
 
 .pt-bool-false {
-  background: var(--bool-false);
+  background: #c4513a;
   transition: width 200ms ease-out;
 }
 
 .pt-bool-null {
   background: repeating-linear-gradient(
     -45deg,
-    var(--bool-null-stripe-a),
-    var(--bool-null-stripe-a) 2px,
-    var(--bool-null-stripe-b) 2px,
-    var(--bool-null-stripe-b) 4px
+    rgba(0, 0, 0, 0.08),
+    rgba(0, 0, 0, 0.08) 2px,
+    rgba(0, 0, 0, 0.03) 2px,
+    rgba(0, 0, 0, 0.03) 4px
   );
   transition: width 200ms ease-out;
 }
@@ -923,8 +860,8 @@ h1 {
   align-items: center;
   gap: 4px;
   padding: 2px 6px 2px 8px;
-  background: var(--filter-pill-bg);
-  border: 1px solid var(--filter-pill-border);
+  background: rgba(149, 95, 59, 0.1);
+  border: 1px solid rgba(149, 95, 59, 0.2);
   border-radius: 10px;
   font: 11px/1.3 var(--font);
   color: var(--accent);
@@ -1041,9 +978,9 @@ h1 {
   border-radius: 4px;
   background: linear-gradient(
     90deg,
-    var(--skeleton-from) 25%,
-    var(--skeleton-mid) 50%,
-    var(--skeleton-from) 75%
+    rgba(0, 0, 0, 0.04) 25%,
+    rgba(0, 0, 0, 0.08) 50%,
+    rgba(0, 0, 0, 0.04) 75%
   );
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
@@ -1150,7 +1087,7 @@ h1 {
 .pt-detail-backdrop {
   position: fixed;
   inset: 0;
-  background: var(--backdrop);
+  background: rgba(0, 0, 0, 0.3);
   z-index: 100;
 }
 
@@ -1162,7 +1099,7 @@ h1 {
   max-height: 70vh;
   background: var(--panel);
   border-radius: 16px 16px 0 0;
-  box-shadow: 0 -4px 24px var(--sheet-shadow);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
   z-index: 101;
   display: flex;
   flex-direction: column;

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -15,6 +15,36 @@
   --row-alt: rgba(0, 0, 0, 0.018);
   --pin-shadow: rgba(0, 0, 0, 0.06);
   --font: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  /* Badge colors */
+  --badge-true-bg: rgba(58, 138, 92, 0.15);
+  --badge-true-text: #2d6e4a;
+  --badge-false-bg: rgba(196, 81, 58, 0.15);
+  --badge-false-text: #9e3a24;
+
+  /* Boolean summary bar */
+  --bool-true: #3a8a5c;
+  --bool-false: #c4513a;
+  --bool-null-stripe-a: rgba(0, 0, 0, 0.08);
+  --bool-null-stripe-b: rgba(0, 0, 0, 0.03);
+
+  /* Category bar track */
+  --cat-bar-track: rgba(0, 0, 0, 0.04);
+
+  /* Filter pills */
+  --filter-pill-bg: rgba(149, 95, 59, 0.1);
+  --filter-pill-border: rgba(149, 95, 59, 0.2);
+
+  /* Loading code background */
+  --loading-code-bg: rgba(0, 0, 0, 0.06);
+
+  /* Skeleton shimmer */
+  --skeleton-from: rgba(0, 0, 0, 0.04);
+  --skeleton-mid: rgba(0, 0, 0, 0.08);
+
+  /* Overlay / backdrop */
+  --backdrop: rgba(0, 0, 0, 0.3);
+  --sheet-shadow: rgba(0, 0, 0, 0.15);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -28,6 +58,29 @@
     --accent: #d4896a;
     --row-alt: rgba(255, 255, 255, 0.025);
     --pin-shadow: rgba(255, 255, 255, 0.08);
+
+    --badge-true-bg: rgba(58, 138, 92, 0.15);
+    --badge-true-text: #5ec98a;
+    --badge-false-bg: rgba(196, 81, 58, 0.15);
+    --badge-false-text: #e07a64;
+
+    --bool-true: #3a8a5c;
+    --bool-false: #c4513a;
+    --bool-null-stripe-a: rgba(255, 255, 255, 0.1);
+    --bool-null-stripe-b: rgba(255, 255, 255, 0.04);
+
+    --cat-bar-track: rgba(255, 255, 255, 0.06);
+
+    --filter-pill-bg: rgba(212, 137, 106, 0.12);
+    --filter-pill-border: rgba(212, 137, 106, 0.25);
+
+    --loading-code-bg: rgba(255, 255, 255, 0.08);
+
+    --skeleton-from: rgba(255, 255, 255, 0.04);
+    --skeleton-mid: rgba(255, 255, 255, 0.08);
+
+    --backdrop: rgba(0, 0, 0, 0.5);
+    --sheet-shadow: rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -41,6 +94,29 @@
   --accent: #d4896a;
   --row-alt: rgba(255, 255, 255, 0.025);
   --pin-shadow: rgba(255, 255, 255, 0.08);
+
+  --badge-true-bg: rgba(58, 138, 92, 0.15);
+  --badge-true-text: #5ec98a;
+  --badge-false-bg: rgba(196, 81, 58, 0.15);
+  --badge-false-text: #e07a64;
+
+  --bool-true: #3a8a5c;
+  --bool-false: #c4513a;
+  --bool-null-stripe-a: rgba(255, 255, 255, 0.1);
+  --bool-null-stripe-b: rgba(255, 255, 255, 0.04);
+
+  --cat-bar-track: rgba(255, 255, 255, 0.06);
+
+  --filter-pill-bg: rgba(212, 137, 106, 0.12);
+  --filter-pill-border: rgba(212, 137, 106, 0.25);
+
+  --loading-code-bg: rgba(255, 255, 255, 0.08);
+
+  --skeleton-from: rgba(255, 255, 255, 0.04);
+  --skeleton-mid: rgba(255, 255, 255, 0.08);
+
+  --backdrop: rgba(0, 0, 0, 0.5);
+  --sheet-shadow: rgba(0, 0, 0, 0.3);
 }
 
 body {
@@ -195,7 +271,7 @@ h1 {
 
 .pt-loading code {
   font-family: "SF Mono", ui-monospace, monospace;
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--loading-code-bg);
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -392,7 +468,7 @@ h1 {
 .pt-cat-bar-track {
   flex: 1;
   height: 8px;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--cat-bar-track);
   border-radius: 2px;
   overflow: hidden;
   min-width: 20px;
@@ -648,13 +724,13 @@ h1 {
 }
 
 .pt-badge-true {
-  background: rgba(58, 138, 92, 0.15);
-  color: #2d6e4a;
+  background: var(--badge-true-bg);
+  color: var(--badge-true-text);
 }
 
 .pt-badge-false {
-  background: rgba(196, 81, 58, 0.15);
-  color: #9e3a24;
+  background: var(--badge-false-bg);
+  color: var(--badge-false-text);
 }
 
 .pt-badge-null {
@@ -663,20 +739,7 @@ h1 {
   font-style: italic;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .pt-badge-true {
-    color: #5ec98a;
-  }
-  :root:not([data-theme="light"]) .pt-badge-false {
-    color: #e07a64;
-  }
-}
-:root[data-theme="dark"] .pt-badge-true {
-  color: #5ec98a;
-}
-:root[data-theme="dark"] .pt-badge-false {
-  color: #e07a64;
-}
+/* Badge dark colors are now handled by --badge-true-text / --badge-false-text variables */
 
 /* --- Boolean summary in header --- */
 
@@ -694,22 +757,22 @@ h1 {
 }
 
 .pt-bool-true {
-  background: #3a8a5c;
+  background: var(--bool-true);
   transition: width 200ms ease-out;
 }
 
 .pt-bool-false {
-  background: #c4513a;
+  background: var(--bool-false);
   transition: width 200ms ease-out;
 }
 
 .pt-bool-null {
   background: repeating-linear-gradient(
     -45deg,
-    rgba(0, 0, 0, 0.08),
-    rgba(0, 0, 0, 0.08) 2px,
-    rgba(0, 0, 0, 0.03) 2px,
-    rgba(0, 0, 0, 0.03) 4px
+    var(--bool-null-stripe-a),
+    var(--bool-null-stripe-a) 2px,
+    var(--bool-null-stripe-b) 2px,
+    var(--bool-null-stripe-b) 4px
   );
   transition: width 200ms ease-out;
 }
@@ -860,8 +923,8 @@ h1 {
   align-items: center;
   gap: 4px;
   padding: 2px 6px 2px 8px;
-  background: rgba(149, 95, 59, 0.1);
-  border: 1px solid rgba(149, 95, 59, 0.2);
+  background: var(--filter-pill-bg);
+  border: 1px solid var(--filter-pill-border);
   border-radius: 10px;
   font: 11px/1.3 var(--font);
   color: var(--accent);
@@ -978,9 +1041,9 @@ h1 {
   border-radius: 4px;
   background: linear-gradient(
     90deg,
-    rgba(0, 0, 0, 0.04) 25%,
-    rgba(0, 0, 0, 0.08) 50%,
-    rgba(0, 0, 0, 0.04) 75%
+    var(--skeleton-from) 25%,
+    var(--skeleton-mid) 50%,
+    var(--skeleton-from) 75%
   );
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
@@ -1087,7 +1150,7 @@ h1 {
 .pt-detail-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--backdrop);
   z-index: 100;
 }
 
@@ -1099,7 +1162,7 @@ h1 {
   max-height: 70vh;
   background: var(--panel);
   border-radius: 16px 16px 0 0;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 -4px 24px var(--sheet-shadow);
   z-index: 101;
   display: flex;
   flex-direction: column;

--- a/packages/sift/vitest.config.ts
+++ b/packages/sift/vitest.config.ts
@@ -1,12 +1,16 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig } from "vite-plus";
 
 const wasmPkg = resolve(__dirname, "../../crates/nteract-predicate/pkg");
+const wasmAvailable = existsSync(resolve(wasmPkg, "nteract_predicate.js"));
 
 export default defineConfig({
   resolve: {
     alias: {
-      "nteract-predicate": wasmPkg,
+      "nteract-predicate": wasmAvailable
+        ? wasmPkg
+        : resolve(__dirname, "src/__mocks__/nteract-predicate"),
     },
   },
   test: {

--- a/packages/sift/vitest.config.ts
+++ b/packages/sift/vitest.config.ts
@@ -1,6 +1,14 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vite-plus";
 
+const wasmPkg = resolve(__dirname, "../../crates/nteract-predicate/pkg");
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "nteract-predicate": wasmPkg,
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -37,6 +37,7 @@ const PLUGIN_MIME_TYPES: Record<string, () => Promise<PluginModule>> = {
   "text/latex": () => import("virtual:renderer-plugin/markdown").then(normalize),
   "application/vnd.plotly.v1+json": () => import("virtual:renderer-plugin/plotly").then(normalize),
   "application/geo+json": () => import("virtual:renderer-plugin/leaflet").then(normalize),
+  "application/vnd.apache.parquet": () => import("virtual:renderer-plugin/sift").then(normalize),
 };
 
 /** Lazy loader for all Vega/Vega-Lite MIME variants. */

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -57,6 +57,7 @@ export const DEFAULT_PRIORITY = [
   "application/vnd.vega.v5.json",
   "application/vnd.vega.v4+json",
   "application/geo+json",
+  "application/vnd.apache.parquet",
   // HTML, PDF, markdown, and LaTeX
   "text/html",
   "application/pdf",

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -13,42 +13,6 @@
 import { setWasmUrl, SiftTable } from "@nteract/sift";
 import "@nteract/sift/style.css";
 
-const themeOverrides = `
-:root, :root[data-theme="dark"], :root[data-theme="light"] {
-  /* Map sift core palette to notebook design tokens */
-  --page: var(--background);
-  --panel: var(--card);
-  --ink: var(--foreground);
-  --muted: var(--muted-foreground);
-  --rule: var(--border);
-  --accent: var(--primary);
-  --row-alt: var(--secondary);
-  --pin-shadow: var(--border);
-
-  /* Badges — use semantic green/red that work on both light and dark */
-  --badge-true-bg: oklch(0.65 0.15 155 / 0.15);
-  --badge-true-text: oklch(0.65 0.15 155);
-  --badge-false-bg: oklch(0.60 0.18 25 / 0.15);
-  --badge-false-text: oklch(0.60 0.18 25);
-
-  /* Boolean summary bar */
-  --bool-true: oklch(0.55 0.15 155);
-  --bool-false: oklch(0.55 0.18 25);
-
-  /* Neutral overlays that adapt to the background */
-  --bool-null-stripe-a: var(--border);
-  --bool-null-stripe-b: transparent;
-  --cat-bar-track: var(--secondary);
-  --filter-pill-bg: var(--secondary);
-  --filter-pill-border: var(--border);
-  --loading-code-bg: var(--secondary);
-  --skeleton-from: var(--secondary);
-  --skeleton-mid: var(--muted);
-  --backdrop: oklch(0 0 0 / 0.5);
-  --sheet-shadow: oklch(0 0 0 / 0.2);
-}
-`;
-
 interface RendererProps {
   data: unknown;
   metadata?: Record<string, unknown>;
@@ -74,7 +38,6 @@ function SiftRenderer({ data }: RendererProps) {
   configureWasm(url);
   return (
     <div style={{ height: 600, width: "100%" }}>
-      <style>{themeOverrides}</style>
       <SiftTable parquetUrl={url} />
     </div>
   );

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -37,7 +37,7 @@ function SiftRenderer({ data }: RendererProps) {
   const url = String(data);
   configureWasm(url);
   return (
-    <div style={{ height: "min(600px, 80vh)", width: "100%" }}>
+    <div style={{ height: 600, width: "100%" }}>
       <SiftTable parquetUrl={url} />
     </div>
   );

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -15,14 +15,37 @@ import "@nteract/sift/style.css";
 
 const themeOverrides = `
 :root, :root[data-theme="dark"], :root[data-theme="light"] {
+  /* Map sift core palette to notebook design tokens */
   --page: var(--background);
   --panel: var(--card);
   --ink: var(--foreground);
   --muted: var(--muted-foreground);
   --rule: var(--border);
   --accent: var(--primary);
-  --row-alt: var(--muted);
+  --row-alt: var(--secondary);
   --pin-shadow: var(--border);
+
+  /* Badges — use semantic green/red that work on both light and dark */
+  --badge-true-bg: oklch(0.65 0.15 155 / 0.15);
+  --badge-true-text: oklch(0.65 0.15 155);
+  --badge-false-bg: oklch(0.60 0.18 25 / 0.15);
+  --badge-false-text: oklch(0.60 0.18 25);
+
+  /* Boolean summary bar */
+  --bool-true: oklch(0.55 0.15 155);
+  --bool-false: oklch(0.55 0.18 25);
+
+  /* Neutral overlays that adapt to the background */
+  --bool-null-stripe-a: var(--border);
+  --bool-null-stripe-b: transparent;
+  --cat-bar-track: var(--secondary);
+  --filter-pill-bg: var(--secondary);
+  --filter-pill-border: var(--border);
+  --loading-code-bg: var(--secondary);
+  --skeleton-from: var(--secondary);
+  --skeleton-mid: var(--muted);
+  --backdrop: oklch(0 0 0 / 0.5);
+  --sheet-shadow: oklch(0 0 0 / 0.2);
 }
 `;
 

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -13,6 +13,19 @@
 import { setWasmUrl, SiftTable } from "@nteract/sift";
 import "@nteract/sift/style.css";
 
+const themeOverrides = `
+:root, :root[data-theme="dark"], :root[data-theme="light"] {
+  --page: var(--background);
+  --panel: var(--card);
+  --ink: var(--foreground);
+  --muted: var(--muted-foreground);
+  --rule: var(--border);
+  --accent: var(--primary);
+  --row-alt: var(--muted);
+  --pin-shadow: var(--border);
+}
+`;
+
 interface RendererProps {
   data: unknown;
   metadata?: Record<string, unknown>;
@@ -38,6 +51,7 @@ function SiftRenderer({ data }: RendererProps) {
   configureWasm(url);
   return (
     <div style={{ height: 600, width: "100%" }}>
+      <style>{themeOverrides}</style>
       <SiftTable parquetUrl={url} />
     </div>
   );

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -4,9 +4,13 @@
  * On-demand renderer plugin for application/vnd.apache.parquet outputs.
  * Loads parquet bytes via nteract-predicate WASM and renders with sift.
  * Loaded into the isolated iframe via the renderer plugin API.
+ *
+ * The WASM binary is served by the daemon's blob server at
+ * /plugins/nteract-predicate.wasm. The blob server port is extracted
+ * from the data URL (which is a blob server URL for the parquet file).
  */
 
-import { SiftTable } from "@nteract/sift";
+import { setWasmUrl, SiftTable } from "@nteract/sift";
 import "@nteract/sift/style.css";
 
 interface RendererProps {
@@ -15,8 +19,23 @@ interface RendererProps {
   mimeType: string;
 }
 
+let wasmConfigured = false;
+
+function configureWasm(blobUrl: string) {
+  if (wasmConfigured) return;
+  try {
+    const parsed = new URL(blobUrl);
+    const wasmUrl = `${parsed.protocol}//${parsed.host}/plugins/nteract-predicate.wasm`;
+    setWasmUrl(wasmUrl);
+    wasmConfigured = true;
+  } catch {
+    // Fall back to default WASM resolution
+  }
+}
+
 function SiftRenderer({ data }: RendererProps) {
   const url = String(data);
+  configureWasm(url);
   return (
     <div style={{ height: "min(600px, 80vh)", width: "100%" }}>
       <SiftTable parquetUrl={url} />

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -1,0 +1,31 @@
+/**
+ * Sift Renderer Plugin
+ *
+ * On-demand renderer plugin for application/vnd.apache.parquet outputs.
+ * Loads parquet bytes via nteract-predicate WASM and renders with sift.
+ * Loaded into the isolated iframe via the renderer plugin API.
+ */
+
+import { SiftTable } from "@nteract/sift";
+import "@nteract/sift/style.css";
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+function SiftRenderer({ data }: RendererProps) {
+  const url = String(data);
+  return (
+    <div style={{ height: "min(600px, 80vh)", width: "100%" }}>
+      <SiftTable parquetUrl={url} />
+    </div>
+  );
+}
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
+}) {
+  ctx.register(["application/vnd.apache.parquet"], SiftRenderer);
+}


### PR DESCRIPTION
## Summary

Adds the rendering foundation for `application/vnd.apache.parquet` MIME type outputs using `@nteract/sift` as an iframe renderer plugin. Works in both the Tauri notebook app and the MCPB (Claude Desktop extension).

- **`parquetUrl` prop on SiftTable** — fetches parquet bytes, initializes WASM, loads row groups progressively with event loop yielding for responsive UI
- **`setWasmUrl()` API** — configures explicit WASM URL for iframe blob: origin (where `import.meta.url` doesn't work)
- **Iframe renderer plugin** (`sift-renderer.tsx`) — extracts blob server host from data URL, configures WASM, renders SiftTable
- **Vite plugin wiring** — CJS build with `inlineDynamicImports` to prevent code-splitting the WASM glue into an unreachable chunk
- **WASM embedded in blob server** — `nteract-predicate.wasm` served from `/plugins/` route with LFS compile-time guard
- **MIME registration** — `application/vnd.apache.parquet` in priority lists and plugin mapping

### Data flow
Kernel outputs parquet bytes → daemon stores in blob server → frontend gets blob URL → iframe loads sift plugin → fetches parquet from blob URL → WASM decodes row groups progressively → table renders

### Theme status
Currently renders with sift's built-in cream theme. Dark mode theming does not match the notebook's dark theme — sift bundles its own Tailwind + theme definitions that conflict with the iframe's design tokens. A follow-up PR will unify CSS by splitting sift's structural styles from theme definitions, enabling notebook-native theming.

### Key fixes discovered during integration
- `inlineDynamicImports: true` required — Vite code-splits the WASM JS glue into a separate CJS chunk that doesn't exist in the iframe's blob: context
- `@nteract/sift` resolve alias needed — `buildRendererPlugin()` uses its own Vite `build()` call that doesn't inherit pnpm workspace resolution
- Fixed 600px height for iframe auto-sizing — `scrollHeight` reports near-zero with percentage-based heights
- WASM handle freed on cleanup to prevent linear memory leak

Closes #1453

## Test plan

- [ ] Run parquet display test in notebook:
  ```python
  import pandas as pd, io
  df = pd.DataFrame({"name": ["Alice", "Bob"] * 100, "score": [95.5, 87.3] * 100, "active": [True, False] * 100})
  buf = io.BytesIO(); df.to_parquet(buf)
  display({"application/vnd.apache.parquet": buf.getvalue()}, raw=True)
  ```
- [ ] Verify table renders with column headers, sparklines, boolean badges
- [ ] Verify scrolling, sorting, filtering work in the iframe
- [ ] Build passes: `cd apps/notebook && npx vp build`
- [ ] Verify WASM served: `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<blob_port>/plugins/nteract-predicate.wasm`