### PR TITLE
fix(runt-mcp-proxy): request queuing during child restart + monitor retry backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jupyter-protocol"
+version = "1.4.0"
+source = "git+https://github.com/runtimed/runtimed?rev=5e24d9b#5e24d9b3b81382bc8a07226bb9523e79599b9902"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "kernel-env"
 version = "0.2.0"
 dependencies = [
@@ -4008,7 +4023,7 @@ checksum = "89bd627a9b44814f546a1ce9dbc088599d3a030b8667b8816c07f2bd5a4507ba"
 dependencies = [
  "anyhow",
  "chrono",
- "jupyter-protocol",
+ "jupyter-protocol 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -6604,7 +6619,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
- "jupyter-protocol",
+ "jupyter-protocol 1.4.0 (git+https://github.com/runtimed/runtimed?rev=5e24d9b)",
  "kernel-env",
  "libc",
  "notebook-doc",
@@ -6709,7 +6724,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jiter",
- "jupyter-protocol",
+ "jupyter-protocol 1.4.0 (git+https://github.com/runtimed/runtimed?rev=5e24d9b)",
  "kernel-env",
  "kernel-launch",
  "libc",
@@ -6817,8 +6832,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524187cd923df8c146810a9f09be45fcaf4e5ba168f22f5f85598ca3c08c9202"
+source = "git+https://github.com/runtimed/runtimed?rev=5e24d9b#5e24d9b3b81382bc8a07226bb9523e79599b9902"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -6828,7 +6842,7 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
- "jupyter-protocol",
+ "jupyter-protocol 1.4.0 (git+https://github.com/runtimed/runtimed?rev=5e24d9b)",
  "serde",
  "serde_json",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
 runtimelib = { git = "https://github.com/runtimed/runtimed", rev = "5e24d9b", default-features = false }
-jupyter-protocol = "1.4.0"
+jupyter-protocol = { git = "https://github.com/runtimed/runtimed", rev = "5e24d9b" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.5.0", default-features = false }
+runtimelib = { git = "https://github.com/runtimed/runtimed", rev = "5e24d9b", default-features = false }
 jupyter-protocol = "1.4.0"
 thiserror = "2"
 schemars = "1"

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -502,6 +502,25 @@ impl McpProxy {
             ));
         }
 
+        // Wait for child to become ready (handles concurrent restart from monitor)
+        // Set up notified BEFORE checking if child exists to avoid race
+        let notified = self.child_ready.notified();
+        let needs_wait = self.state.read().await.child_client.is_none();
+        if needs_wait {
+            info!(
+                "Child restart in progress, waiting up to 2s for child to become ready..."
+            );
+            if tokio::time::timeout(Duration::from_secs(2), notified)
+                .await
+                .is_err()
+            {
+                return Err(McpError::internal_error(
+                    "Child restart timed out after 2 seconds",
+                    None,
+                ));
+            }
+        }
+
         // Check if we should exit due to tool divergence
         {
             let state = self.state.read().await;
@@ -543,6 +562,22 @@ impl McpProxy {
                 format!("Child restart failed: {e}"),
                 None,
             ));
+        }
+
+        // Wait for child to become ready (handles concurrent restart from monitor)
+        let notified = self.child_ready.notified();
+        let needs_wait = self.state.read().await.child_client.is_none();
+        if needs_wait {
+            info!("Child restart in progress, waiting up to 2s for child to become ready...");
+            if tokio::time::timeout(Duration::from_secs(2), notified)
+                .await
+                .is_err()
+            {
+                return Err(McpError::internal_error(
+                    "Child restart timed out after 2 seconds",
+                    None,
+                ));
+            }
         }
 
         self.try_forward_read_resource(&params).await

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -449,21 +449,37 @@ impl McpProxy {
                     "Child process exited, attempting automatic restart"
                 );
 
-                // Attempt to restart the child
-                match proxy.restart_child().await {
-                    Ok(_) => {
-                        info!("Child monitor: restart successful, exiting (new monitor spawned)");
-                        // Exit this monitor — restart_child() spawned a new one
-                        break;
-                    }
-                    Err(e) => {
-                        error!(
-                            event = "child_restart_failed",
-                            error = %e,
-                            "Child monitor: restart failed, stopping monitor task"
-                        );
-                        // Circuit breaker may have tripped, stop monitoring
-                        break;
+                // Attempt to restart the child with exponential backoff
+                let mut backoff_secs = 2u64;
+                loop {
+                    match proxy.restart_child().await {
+                        Ok(_) => {
+                            info!("Child monitor: restart successful, exiting (new monitor spawned)");
+                            // Exit this monitor — restart_child() spawned a new one
+                            return;
+                        }
+                        Err(e) => {
+                            error!(
+                                event = "child_restart_failed",
+                                error = %e,
+                                backoff_secs = backoff_secs,
+                                "Child monitor: restart failed, retrying after backoff"
+                            );
+
+                            // Check if we should give up (circuit breaker or exit signal)
+                            let should_exit = {
+                                let state = proxy.state.read().await;
+                                state.should_exit
+                            };
+                            if should_exit {
+                                error!("Circuit breaker tripped or exit requested, monitor giving up");
+                                return;
+                            }
+
+                            // Wait before retry with exponential backoff (cap at 60s)
+                            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                            backoff_secs = (backoff_secs * 2).min(60);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Requests arriving during a child restart now **wait** (2s timeout) instead of immediately failing with "Transport closed"
- Child monitor retries restart with **exponential backoff** (2s → 4s → 8s… capped at 60s) instead of giving up after one failure
- Temporarily pins `runtimelib` + `jupyter-protocol` to git rev `5e24d9b` for the ZMQ port race fix (revert to version pin when 1.6.0 ships)

Completes the proxy reliability sequence: #1674 (circuit breaker recovery) → #1677 (re-resolve binary) → #1701 (child monitor) → **this PR** (request queuing + retry).

## Changes

**Monitor retry loop** (`proxy.rs:449`): Wraps `restart_child()` in a `loop` with exponential backoff. Checks `state.should_exit` (circuit breaker) before each retry. Uses `return` instead of `break` for clarity in nested loop.

**Wait-for-ready** (`forward_tool_call`, `forward_read_resource`): Before forwarding, checks if `child_client` is `None`. If so, subscribes to `child_ready` Notify *before* the check (avoids race), then waits up to 2s. This pattern already existed in `list_tools`/`call_tool` — this extends it to the internal forwarding methods.

**Dependency pins** (`Cargo.toml`): Pins `runtimelib` and `jupyter-protocol` to git rev `5e24d9b` (runtimed/runtimed#296 — ZMQ `peek_ports` TOCTOU fix). Both must be pinned together due to shared types. Temporary until runtimelib 1.6.0 is published.

## Test plan

- [ ] Existing proxy test suite passes (30+ tests)
- [ ] Manual: kill child process during active MCP session, verify requests queue and succeed after restart
- [ ] Manual: block daemon socket, verify monitor retries with increasing backoff rather than giving up
- [ ] Verify circuit breaker still trips and monitor exits when `should_exit` is set