### PR TITLE
chore: bump runtimelib 1.6.0, nbformat 2.0.0, wire held-listener pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1187,7 +1187,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1663,7 +1663,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1880,7 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2987,7 +2987,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3488,7 +3488,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3959,7 +3959,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4002,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "1.2.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bd627a9b44814f546a1ce9dbc088599d3a030b8667b8816c07f2bd5a4507ba"
+checksum = "e55e8791a340886b1c863f508281ae9f1b23f7fe519803094ad02fd7e2920671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4251,7 +4251,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4717,7 +4717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6816,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524187cd923df8c146810a9f09be45fcaf4e5ba168f22f5f85598ca3c08c9202"
+checksum = "a1c46eb84b80531e9745a859f60fd599eab9f6397d0db1bda8c99720796d3000"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -6893,7 +6893,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6961,7 +6961,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7668,7 +7668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8430,7 +8430,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9767,7 +9767,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.5.0", default-features = false }
+runtimelib = { version = "1.6.0", default-features = false }
 jupyter-protocol = "1.4.0"
 thiserror = "2"
 schemars = "1"

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -37,7 +37,7 @@ notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 runt-trust = { path = "../runt-trust" }
 runt-workspace = { path = "../runt-workspace" }
-nbformat = "1.2.1"
+nbformat = "2.0.0"
 log = "0.4"
 tauri-plugin-log = "2"
 strsim = "0.11"  # For Levenshtein distance (typosquat detection)

--- a/crates/runt/src/kernel_client.rs
+++ b/crates/runt/src/kernel_client.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 use runtimelib::{
     create_client_control_connection, create_client_iopub_connection,
     create_client_shell_connection_with_identity, create_client_stdin_connection_with_identity,
-    peek_ports, peer_identity_for_session, runtime_dir, KernelspecDir, Result, RuntimeError,
+    peek_ports_with_listeners, peer_identity_for_session, runtime_dir, KernelspecDir, Result,
+    RuntimeError,
 };
 
 /// Get the default working directory for kernel processes.
@@ -57,7 +58,7 @@ impl KernelClient {
         let key = Uuid::new_v4().to_string();
 
         let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-        let ports = peek_ports(ip, 5).await?;
+        let (ports, _listeners) = peek_ports_with_listeners(ip, 5).await?;
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
             ip: ip.to_string(),
@@ -80,6 +81,7 @@ impl KernelClient {
         command.current_dir(default_kernel_cwd());
 
         let child = command.spawn()?;
+        drop(_listeners);
 
         let content = serde_json::to_string(&connection_info)?;
         tokio::fs::write(&connection_file, &content).await?;
@@ -104,7 +106,7 @@ impl KernelClient {
         let key = Uuid::new_v4().to_string();
 
         let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-        let ports = peek_ports(ip, 5).await?;
+        let (ports, _listeners) = peek_ports_with_listeners(ip, 5).await?;
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
             ip: ip.to_string(),
@@ -138,6 +140,7 @@ impl KernelClient {
             command: "kernel",
             source: e,
         })?;
+        drop(_listeners);
 
         Ok(Self {
             kernel_id,

--- a/crates/runt/src/kernel_client.rs
+++ b/crates/runt/src/kernel_client.rs
@@ -58,7 +58,7 @@ impl KernelClient {
         let key = Uuid::new_v4().to_string();
 
         let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-        let (ports, _listeners) = peek_ports_with_listeners(ip, 5).await?;
+        let (ports, listeners) = peek_ports_with_listeners(ip, 5).await?;
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
             ip: ip.to_string(),
@@ -81,7 +81,7 @@ impl KernelClient {
         command.current_dir(default_kernel_cwd());
 
         let child = command.spawn()?;
-        drop(_listeners);
+        drop(listeners);
 
         let content = serde_json::to_string(&connection_info)?;
         tokio::fs::write(&connection_file, &content).await?;
@@ -106,7 +106,7 @@ impl KernelClient {
         let key = Uuid::new_v4().to_string();
 
         let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-        let (ports, _listeners) = peek_ports_with_listeners(ip, 5).await?;
+        let (ports, listeners) = peek_ports_with_listeners(ip, 5).await?;
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
             ip: ip.to_string(),
@@ -140,7 +140,7 @@ impl KernelClient {
             command: "kernel",
             source: e,
         })?;
-        drop(_listeners);
+        drop(listeners);
 
         Ok(Self {
             kernel_id,

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -109,7 +109,7 @@ windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32
 
 [dev-dependencies]
 tempfile = "3"
-nbformat = "1.2.1"
+nbformat = "2.0.0"
 serial_test = "3"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }
 notebook-sync = { path = "../notebook-sync" }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -126,9 +126,9 @@ impl KernelConnection for JupyterKernel {
             _ => &kernel_type,
         };
 
-        // Reserve ports
+        // Reserve ports — hold listeners until after spawn() to prevent TOCTOU races
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        let ports = runtimelib::peek_ports(ip, 5).await?;
+        let (ports, _listeners) = runtimelib::peek_ports_with_listeners(ip, 5).await?;
 
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
@@ -419,6 +419,7 @@ impl KernelConnection for JupyterKernel {
         cmd.process_group(0);
 
         let mut process = cmd.kill_on_drop(true).spawn()?;
+        drop(_listeners);
 
         // Capture kernel stderr for diagnostics
         if let Some(stderr) = process.stderr.take() {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -128,7 +128,7 @@ impl KernelConnection for JupyterKernel {
 
         // Reserve ports — hold listeners until after spawn() to prevent TOCTOU races
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        let (ports, _listeners) = runtimelib::peek_ports_with_listeners(ip, 5).await?;
+        let (ports, listeners) = runtimelib::peek_ports_with_listeners(ip, 5).await?;
 
         let connection_info = ConnectionInfo {
             transport: jupyter_protocol::connection_info::Transport::TCP,
@@ -419,7 +419,7 @@ impl KernelConnection for JupyterKernel {
         cmd.process_group(0);
 
         let mut process = cmd.kill_on_drop(true).spawn()?;
-        drop(_listeners);
+        drop(listeners);
 
         // Capture kernel stderr for diagnostics
         if let Some(stderr) = process.stderr.take() {


### PR DESCRIPTION
## Summary

- Bump `runtimelib` 1.5.0 → 1.6.0 (closes the ZMQ port race — runtimed/runtimed#296)
- Bump `nbformat` 1.2.1 → 2.0.0 (v4.5 quirks mode — runtimed/runtimed#295)
- Wire `peek_ports_with_listeners()` in both kernel launch sites so TcpListeners are held across `spawn()`, closing the TOCTOU window

Supersedes #1713 (dep bump portion only — proxy queuing deferred for rethink).

## Changes

**runtimelib 1.6.0** adds `peek_ports_with_listeners(ip, num) -> (Vec<u16>, Vec<TcpListener>)`. Callers keep the listeners alive until after `Command::spawn()` returns, then drop — the kernel subprocess binds the same ports as its first action, so the race window is sub-millisecond.

Two call sites updated:
- `crates/runtimed/src/jupyter_kernel.rs` — `JupyterKernel::launch()`
- `crates/runt/src/kernel_client.rs` — `start_from_kernelspec()` and `start_from_command()`

**nbformat 2.0.0** adds `Notebook::V4QuirksMode` for v4.5 notebooks with missing cell ids. No match arms on `Notebook` in this codebase — the bump is a version-only change with no code modifications needed.

## Test plan

- [x] `cargo build --workspace --exclude runtimed-py` — clean
- [x] `cargo test -p runtimed --lib` — 245 passed
- [x] `cargo test -p notebook --lib` — 131 passed
- [x] `cargo test -p runt-cli` — 12 passed
- [x] `cargo test -p runtimed --test tokio_mutex_lint` — passed
- [x] `cargo xtask lint --fix` — clean