### PR TITLE
feat(sift): add parquet support to SiftTable url prop

### DIFF
--- a/packages/sift/src/__mocks__/nteract-predicate/nteract_predicate.js
+++ b/packages/sift/src/__mocks__/nteract-predicate/nteract_predicate.js
@@ -1,0 +1,6 @@
+// Stub for when nteract-predicate WASM hasn't been built.
+// Tests using the `data` prop work fine without WASM.
+// The `url` prop's parquet path will fail gracefully (ensureModule rejects).
+export default function init() {
+  throw new Error("nteract-predicate WASM not built — run: cargo xtask wasm sift");
+}

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -68,3 +68,5 @@ export type {
 } from "./table";
 // Imperative engine
 export { createTable } from "./table";
+// WASM configuration
+export { setWasmUrl } from "./predicate";

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -72,11 +72,21 @@ type PredicateModule = {
 };
 
 let mod: PredicateModule | null = null;
+let configuredWasmUrl: string | undefined;
 
-async function ensureModule(): Promise<PredicateModule> {
+/**
+ * Configure an explicit URL for the WASM binary.
+ * Must be called before the first WASM operation.
+ * Used in iframe contexts where import.meta.url doesn't resolve.
+ */
+export function setWasmUrl(url: string): void {
+  configuredWasmUrl = url;
+}
+
+export async function ensureModule(): Promise<PredicateModule> {
   if (mod) return mod;
   const wasm = await import("nteract-predicate/nteract_predicate.js");
-  await wasm.default();
+  await wasm.default(configuredWasmUrl);
   mod = wasm as unknown as PredicateModule;
   return mod;
 }

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -4,8 +4,9 @@
  * Usage:
  *   <SiftTable data={tableData} onChange={handleState} />
  *
- * Or with Arrow IPC URL:
+ * Or with a URL (auto-detects Arrow IPC vs Parquet):
  *   <SiftTable url="/data.arrow" onChange={handleState} />
+ *   <SiftTable url="/data.parquet" onChange={handleState} />
  *
  * The component manages the imperative TableEngine lifecycle —
  * mounting on first render, updating on data changes, and
@@ -24,6 +25,7 @@ import {
   type SummaryAccumulator,
   TimestampAccumulator,
 } from "./accumulators";
+import { ensureModule, getModuleSync } from "./predicate";
 import {
   type Column,
   type ColumnFilter,
@@ -33,13 +35,14 @@ import {
   type TableEngine,
   type TableEngineState,
 } from "./table";
+import { createWasmTableData } from "./wasm-table-data";
 
 // --- Props ---
 
 export type SiftTableProps = {
   /** Pre-built TableData object. Mutually exclusive with `url`. */
   data?: TableData;
-  /** Arrow IPC URL to stream from. Mutually exclusive with `data`. */
+  /** URL to load data from (Arrow IPC or Parquet, auto-detected). Mutually exclusive with `data`. */
   url?: string;
   /** Column type overrides keyed by column name. */
   typeOverrides?: Record<string, ColumnType>;
@@ -54,6 +57,178 @@ export type SiftTableProps = {
 };
 
 import { autoWidth } from "./auto-width";
+
+// --- Format detection ---
+
+/** Parquet magic bytes: PAR1 */
+const PARQUET_MAGIC = new Uint8Array([0x50, 0x41, 0x52, 0x31]);
+
+type DataFormat = "parquet" | "arrow-ipc";
+
+/**
+ * Detect whether a fetch response contains Parquet or Arrow IPC data.
+ * Checks Content-Type header first, then falls back to magic byte inspection.
+ * Returns the format and the response bytes (buffered for parquet, or a
+ * reconstructed ReadableStream for Arrow IPC to preserve streaming).
+ */
+async function detectFormat(
+  response: Response,
+): Promise<
+  | { format: "parquet"; bytes: Uint8Array }
+  | { format: "arrow-ipc"; stream: ReadableStream<Uint8Array> }
+> {
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (contentType.includes("parquet")) {
+    return { format: "parquet", bytes: new Uint8Array(await response.arrayBuffer()) };
+  }
+  if (contentType.includes("arrow") || contentType.includes("ipc")) {
+    return { format: "arrow-ipc", stream: response.body! };
+  }
+
+  // Ambiguous content type — peek magic bytes
+  const reader = response.body!.getReader();
+  const { value: firstChunk, done } = await reader.read();
+
+  if (done || !firstChunk || firstChunk.length < 4) {
+    // Too small to detect — try Arrow IPC as default
+    const empty = firstChunk ?? new Uint8Array(0);
+    return {
+      format: "arrow-ipc",
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue(empty);
+          controller.close();
+        },
+      }),
+    };
+  }
+
+  const isParquet =
+    firstChunk[0] === PARQUET_MAGIC[0] &&
+    firstChunk[1] === PARQUET_MAGIC[1] &&
+    firstChunk[2] === PARQUET_MAGIC[2] &&
+    firstChunk[3] === PARQUET_MAGIC[3];
+
+  if (isParquet) {
+    // Buffer the rest for parquet (needs random access)
+    const chunks: Uint8Array[] = [firstChunk];
+    while (true) {
+      const { value, done: streamDone } = await reader.read();
+      if (streamDone) break;
+      chunks.push(value);
+    }
+    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+    const bytes = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return { format: "parquet", bytes };
+  }
+
+  // Reconstruct stream with peeked chunk for Arrow IPC streaming
+  return {
+    format: "arrow-ipc",
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue(firstChunk);
+      },
+      async pull(controller) {
+        const { value, done: streamDone } = await reader.read();
+        if (streamDone) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      },
+      cancel() {
+        reader.cancel();
+      },
+    }),
+  };
+}
+
+// --- WASM summary computation ---
+
+function updateWasmSummaries(
+  mod: ReturnType<typeof getModuleSync>,
+  handle: number,
+  tableData: TableData,
+  columns: Column[],
+) {
+  const numRows = mod.num_rows(handle);
+  const BIN_COUNT = 25;
+
+  tableData.rowCount = numRows;
+  tableData.columnSummaries = columns.map((col, c) => {
+    switch (col.columnType) {
+      case "categorical": {
+        const counts = mod.store_value_counts(handle, c) as {
+          label: string;
+          count: number;
+        }[];
+        const allCategories = counts.map(({ label, count }) => ({
+          label,
+          count,
+          pct: Math.round((count / numRows) * 1000) / 10,
+        }));
+        const topCategories = allCategories.slice(0, 3);
+        const othersCount = counts.slice(3).reduce((s, e) => s + e.count, 0);
+        const othersPct = Math.round((othersCount / numRows) * 1000) / 10;
+        const lengths = counts.map(({ label }) => label.length).sort((a, b) => a - b);
+        const medianTextLength = lengths.length > 0 ? lengths[Math.floor(lengths.length / 2)] : 0;
+        return {
+          kind: "categorical" as const,
+          uniqueCount: counts.length,
+          topCategories,
+          othersCount,
+          othersPct,
+          allCategories,
+          medianTextLength,
+        };
+      }
+      case "boolean": {
+        const [trueCount, falseCount, nullCount] = mod.store_bool_counts(handle, c);
+        return {
+          kind: "boolean" as const,
+          trueCount,
+          falseCount,
+          nullCount,
+          total: numRows,
+        };
+      }
+      case "timestamp": {
+        const bins = mod.store_temporal_histogram(handle, c) as {
+          x0: number;
+          x1: number;
+          count: number;
+        }[];
+        if (bins.length === 0) return null;
+        return {
+          kind: "timestamp" as const,
+          min: bins[0].x0,
+          max: bins[bins.length - 1].x1,
+          bins,
+        };
+      }
+      case "numeric": {
+        const bins = mod.store_histogram(handle, c, BIN_COUNT) as {
+          x0: number;
+          x1: number;
+          count: number;
+        }[];
+        if (bins.length === 0) return null;
+        return {
+          kind: "numeric" as const,
+          min: bins[0].x0,
+          max: bins[bins.length - 1].x1,
+          bins,
+        };
+      }
+    }
+  });
+}
 
 // --- Helpers ---
 
@@ -155,94 +330,152 @@ export function SiftTable({
     };
   }, [data, stableOnChange]);
 
-  // Stream from URL when `url` prop is provided
+  // Load from URL when `url` prop is provided.
+  // Detects format via Content-Type header + magic byte fallback:
+  // - Parquet: buffer fully, load via WASM with progressive row groups
+  // - Arrow IPC: stream batches (existing behavior)
   useEffect(() => {
     if (!url || !containerRef.current) return;
 
     let cancelled = false;
     const container = containerRef.current;
+    let wasmHandle: number | null = null;
+
+    function mountEngine(tableData: TableData) {
+      if (engineRef.current) {
+        engineRef.current.destroy();
+        engineRef.current = null;
+      }
+      const engineDiv = document.createElement("div");
+      engineDiv.style.height = "100%";
+      container.appendChild(engineDiv);
+      engineRef.current = createTable(engineDiv, tableData, {
+        onChange: stableOnChange,
+      });
+    }
+
+    async function loadParquet(parquetBytes: Uint8Array) {
+      await ensureModule();
+      const mod = getModuleSync();
+      if (cancelled) return;
+
+      const meta = mod.parquet_metadata(parquetBytes);
+      const numRowGroups = meta[0];
+
+      // Load first row group → mount table immediately
+      const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+      wasmHandle = handle;
+
+      const { tableData, columns, prefetchViewport } = createWasmTableData(handle, columnOverrides);
+      tableData.prefetchViewport = prefetchViewport;
+      tableData.recomputeSummaries = () => updateWasmSummaries(mod, handle, tableData, columns);
+      updateWasmSummaries(mod, handle, tableData, columns);
+
+      if (cancelled) return;
+      mountEngine(tableData);
+      setStatus("ready");
+
+      // Stream remaining row groups progressively
+      for (let g = 1; g < numRowGroups; g++) {
+        if (cancelled) return;
+        await new Promise((r) => setTimeout(r, 0));
+        if (cancelled) return;
+        mod.load_parquet_row_group(parquetBytes, g, handle);
+        tableData.rowCount = mod.num_rows(handle);
+        updateWasmSummaries(mod, handle, tableData, columns);
+        engineRef.current!.onBatchAppended();
+      }
+
+      engineRef.current!.setStreamingDone();
+    }
+
+    async function loadArrowIpc(source: Response | ReadableStream<Uint8Array>) {
+      const reader = await RecordBatchReader.from(source);
+      await reader.open();
+      if (cancelled) return;
+
+      const { columns, fieldNames, stringCols, rawCols, accumulators, tableData } = buildTableState(
+        reader.schema,
+        typeOverrides,
+        columnOverrides,
+      );
+
+      let totalRows = 0;
+
+      function appendBatch(batch: RecordBatch) {
+        const batchRows = batch.numRows;
+        const startRow = totalRows;
+        for (let c = 0; c < fieldNames.length; c++) {
+          const col = batch.getChild(fieldNames[c])!;
+          for (let r = 0; r < batchRows; r++) {
+            const val = col.get(r);
+            rawCols[c].push(val);
+            stringCols[c].push(formatCell(columns[c].columnType, val));
+          }
+          accumulators[c].add(rawCols[c], startRow, batchRows);
+        }
+        totalRows += batchRows;
+        tableData.rowCount = totalRows;
+        tableData.columnSummaries = accumulators.map((a) => a.snapshot(totalRows));
+      }
+
+      const firstResult = await reader.next();
+      if (cancelled) return;
+      if (firstResult.done) {
+        setError("No data in file.");
+        setStatus("error");
+        return;
+      }
+      appendBatch(firstResult.value);
+
+      if (cancelled) return;
+      mountEngine(tableData);
+      setStatus("ready");
+
+      for await (const batch of reader) {
+        if (cancelled) break;
+        appendBatch(batch);
+        engineRef.current!.onBatchAppended();
+      }
+      engineRef.current!.setStreamingDone();
+    }
 
     async function loadFromUrl() {
       setStatus("loading");
       setError(null);
 
-      try {
-        const response = await fetch(url!);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
-        }
+      const response = await fetch(url!);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+      }
 
-        const reader = await RecordBatchReader.from(response);
-        await reader.open();
+      const detected = await detectFormat(response);
+      if (cancelled) return;
 
-        if (cancelled) return;
+      if (detected.format === "parquet") {
+        await loadParquet(detected.bytes);
+      } else {
+        await loadArrowIpc(detected.stream);
+      }
+    }
 
-        const { columns, fieldNames, stringCols, rawCols, accumulators, tableData } =
-          buildTableState(reader.schema, typeOverrides, columnOverrides);
-
-        let totalRows = 0;
-
-        function appendBatch(batch: RecordBatch) {
-          const batchRows = batch.numRows;
-          const startRow = totalRows;
-          for (let c = 0; c < fieldNames.length; c++) {
-            const col = batch.getChild(fieldNames[c])!;
-            for (let r = 0; r < batchRows; r++) {
-              const val = col.get(r);
-              rawCols[c].push(val);
-              stringCols[c].push(formatCell(columns[c].columnType, val));
-            }
-            accumulators[c].add(rawCols[c], startRow, batchRows);
-          }
-          totalRows += batchRows;
-          tableData.rowCount = totalRows;
-          tableData.columnSummaries = accumulators.map((a) => a.snapshot(totalRows));
-        }
-
-        const firstResult = await reader.next();
-        if (cancelled) return;
-        if (firstResult.done) {
-          setError("No data in Arrow file.");
-          setStatus("error");
-          return;
-        }
-        appendBatch(firstResult.value);
-
-        // Clean up previous engine before creating new one
-        if (engineRef.current) {
-          engineRef.current.destroy();
-          engineRef.current = null;
-        }
-
-        // Create a dedicated div for the engine — don't touch React-managed children
-        const engineDiv = document.createElement("div");
-        engineDiv.style.height = "100%";
-        container.appendChild(engineDiv);
-
-        engineRef.current = createTable(engineDiv, tableData, {
-          onChange: stableOnChange,
-        });
-        setStatus("ready");
-
-        // Stream remaining batches
-        for await (const batch of reader) {
-          if (cancelled) break;
-          appendBatch(batch);
-          engineRef.current!.onBatchAppended();
-        }
-        engineRef.current!.setStreamingDone();
-      } catch (err) {
-        if (cancelled) return;
+    loadFromUrl().catch((err) => {
+      if (!cancelled) {
         const message = err instanceof Error ? err.message : String(err);
         setError(message);
         setStatus("error");
       }
-    }
-
-    loadFromUrl();
+    });
 
     return () => {
       cancelled = true;
+      if (wasmHandle !== null) {
+        try {
+          getModuleSync().free(wasmHandle);
+        } catch {
+          /* module may not be loaded */
+        }
+      }
       engineRef.current?.destroy();
       engineRef.current = null;
     };

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -63,8 +63,6 @@ import { autoWidth } from "./auto-width";
 /** Parquet magic bytes: PAR1 */
 const PARQUET_MAGIC = new Uint8Array([0x50, 0x41, 0x52, 0x31]);
 
-type DataFormat = "parquet" | "arrow-ipc";
-
 /**
  * Detect whether a fetch response contains Parquet or Arrow IPC data.
  * Checks Content-Type header first, then falls back to magic byte inspection.
@@ -82,11 +80,13 @@ async function detectFormat(
     return { format: "parquet", bytes: new Uint8Array(await response.arrayBuffer()) };
   }
   if (contentType.includes("arrow") || contentType.includes("ipc")) {
-    return { format: "arrow-ipc", stream: response.body! };
+    if (!response.body) throw new Error("Response has no body");
+    return { format: "arrow-ipc", stream: response.body };
   }
 
   // Ambiguous content type — peek magic bytes
-  const reader = response.body!.getReader();
+  if (!response.body) throw new Error("Response has no body");
+  const reader = response.body.getReader();
   const { value: firstChunk, done } = await reader.read();
 
   if (done || !firstChunk || firstChunk.length < 4) {
@@ -340,13 +340,15 @@ export function SiftTable({
     let cancelled = false;
     const container = containerRef.current;
     let wasmHandle: number | null = null;
+    let engineDiv: HTMLDivElement | null = null;
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
         engineRef.current.destroy();
         engineRef.current = null;
       }
-      const engineDiv = document.createElement("div");
+      engineDiv?.remove();
+      engineDiv = document.createElement("div");
       engineDiv.style.height = "100%";
       container.appendChild(engineDiv);
       engineRef.current = createTable(engineDiv, tableData, {
@@ -361,6 +363,12 @@ export function SiftTable({
 
       const meta = mod.parquet_metadata(parquetBytes);
       const numRowGroups = meta[0];
+
+      if (numRowGroups === 0) {
+        setError("Parquet file has no row groups.");
+        setStatus("error");
+        return;
+      }
 
       // Load first row group → mount table immediately
       const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
@@ -383,10 +391,10 @@ export function SiftTable({
         mod.load_parquet_row_group(parquetBytes, g, handle);
         tableData.rowCount = mod.num_rows(handle);
         updateWasmSummaries(mod, handle, tableData, columns);
-        engineRef.current!.onBatchAppended();
+        engineRef.current?.onBatchAppended();
       }
 
-      engineRef.current!.setStreamingDone();
+      engineRef.current?.setStreamingDone();
     }
 
     async function loadArrowIpc(source: Response | ReadableStream<Uint8Array>) {
@@ -435,9 +443,9 @@ export function SiftTable({
       for await (const batch of reader) {
         if (cancelled) break;
         appendBatch(batch);
-        engineRef.current!.onBatchAppended();
+        engineRef.current?.onBatchAppended();
       }
-      engineRef.current!.setStreamingDone();
+      engineRef.current?.setStreamingDone();
     }
 
     async function loadFromUrl() {
@@ -478,6 +486,7 @@ export function SiftTable({
       }
       engineRef.current?.destroy();
       engineRef.current = null;
+      engineDiv?.remove();
     };
   }, [url, typeOverrides, columnOverrides, stableOnChange]);
 

--- a/packages/sift/vitest.config.ts
+++ b/packages/sift/vitest.config.ts
@@ -1,6 +1,24 @@
+import path from "node:path";
+import fs from "node:fs";
 import { defineConfig } from "vite-plus";
 
+// Use real WASM JS glue if built, otherwise fall back to mock
+const realWasmGlue = path.resolve(
+  __dirname,
+  "../../crates/nteract-predicate/pkg/nteract_predicate.js",
+);
+const mockWasmGlue = path.resolve(
+  __dirname,
+  "src/__mocks__/nteract-predicate/nteract_predicate.js",
+);
+const wasmGluePath = fs.existsSync(realWasmGlue) ? realWasmGlue : mockWasmGlue;
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "nteract-predicate/nteract_predicate.js": wasmGluePath,
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Summary

`SiftTable`'s `url` prop now auto-detects Parquet vs Arrow IPC format and routes to the appropriate loader.

### Format detection

1. Check `Content-Type` header — `parquet` → WASM path, `arrow`/`ipc` → streaming path
2. Ambiguous types (`application/octet-stream`, missing) → peek first 4 bytes for `PAR1` magic
3. Arrow IPC stays streaming (reconstructed `ReadableStream` with peeked chunk prepended)
4. Parquet buffers fully (needs random access for footer) then loads progressively via WASM row groups

### New APIs

- **`setWasmUrl(url)`** — configure WASM binary location for iframe contexts where `import.meta.url` doesn't resolve
- **`ensureModule()`** — now exported for use by the parquet loading path

### Changes

- `packages/sift/src/react.tsx` — format detection + parquet loading path in `url` effect
- `packages/sift/src/predicate.ts` — `setWasmUrl()`, export `ensureModule()`
- `packages/sift/src/index.ts` — export `setWasmUrl`
- `packages/sift/vitest.config.ts` — WASM mock alias for tests
- `packages/sift/src/__mocks__/` — WASM stub for CI

### Usage

```tsx
// Auto-detects format from Content-Type or magic bytes
<SiftTable url="/data.parquet" />
<SiftTable url="/data.arrow" />

// For iframe contexts (e.g., renderer plugin)
import { setWasmUrl } from "@nteract/sift";
setWasmUrl("http://127.0.0.1:PORT/plugins/nteract-predicate.wasm");
```

## Test plan

- [x] `pnpm --filter @nteract/sift exec vp test run` — 124 tests pass (5/5 files)
- [x] `vp build --config vite.lib.config.ts` — lib build succeeds
- [x] `cargo xtask lint --fix` — clean
- [ ] Manual: sift dev server with parquet URL fixture (needs WASM built)