### PR TITLE
refactor(sift): rename .pt-* to .sift-*, split CSS into structural + theme presets

### DIFF
--- a/packages/sift/demos/sift-showcase.demo.ts
+++ b/packages/sift/demos/sift-showcase.demo.ts
@@ -6,7 +6,7 @@ import { cursorHighlight, trackCursor } from "@argo-video/cli";
 /** Mark scene + let sift's render settle before overlay injection. */
 async function mark(page: any, narration: any, scene: string) {
   narration.mark(scene);
-  await page.waitForSelector(".pt-row", { state: "visible", timeout: 5000 }).catch(() => {});
+  await page.waitForSelector(".sift-row", { state: "visible", timeout: 5000 }).catch(() => {});
   await page.waitForTimeout(1000);
 }
 
@@ -37,19 +37,19 @@ test("sift-showcase", async ({ page, narration }) => {
 
   // Wait for all ~114k rows to stream in (odometer uses data-value attr)
   await page.waitForFunction(
-    () => document.querySelector(".pt-stat-rows")?.getAttribute("data-value")?.includes("rows"),
+    () => document.querySelector(".sift-stat-rows")?.getAttribute("data-value")?.includes("rows"),
     { timeout: 60000 },
   );
   // Extra settle time — HuggingFace data streams in row groups
   await page.waitForTimeout(2000);
 
-  const headerRow = page.locator(".pt-header-row");
-  const tableContainer = page.locator(".pt-table-container");
+  const headerRow = page.locator(".sift-header-row");
+  const tableContainer = page.locator(".sift-table-container");
   // Spotify column order (from HF parquet schema):
   // 0:Unnamed:0 1:track_id 2:artists 3:album_name 4:track_name
   // 5:popularity 6:duration_ms 7:explicit 8:danceability 9:energy
   // 10:key ... 20:track_genre
-  const col = (n: number) => headerRow.locator(".pt-th").nth(n);
+  const col = (n: number) => headerRow.locator(".sift-th").nth(n);
 
   await mark(page, narration, "intro");
   await showOverlay(page, "intro", narration.durationFor("intro"));
@@ -72,7 +72,7 @@ test("sift-showcase", async ({ page, narration }) => {
 
   await mark(page, narration, "scroll-fast");
   showOverlay(page, "scroll-fast", narration.durationFor("scroll-fast"));
-  focusRing(page, page.locator(".pt-stats"), { color: "#60a5fa", duration: 4000 });
+  focusRing(page, page.locator(".sift-stats"), { color: "#60a5fa", duration: 4000 });
   await scroll(page, tableContainer, 8000);
   await page.waitForTimeout(800);
   await scroll(page, tableContainer, 12000);
@@ -100,7 +100,7 @@ test("sift-showcase", async ({ page, narration }) => {
     holdMs: Math.floor(resizeDur * 0.7),
   });
   await page.waitForTimeout(800);
-  const resizeHandle = resizeCol.locator(".pt-resize-handle");
+  const resizeHandle = resizeCol.locator(".sift-resize-handle");
   await resizeHandle.waitFor({ state: "attached", timeout: 5000 });
   // Hover the handle to ensure Playwright targets it precisely (6px wide)
   await resizeHandle.hover({ force: true });
@@ -125,7 +125,7 @@ test("sift-showcase", async ({ page, narration }) => {
   // Sort by danceability — recognizable music metric
   const danceHeader = col(8);
   await danceHeader.scrollIntoViewIfNeeded();
-  await danceHeader.locator(".pt-th-top").click();
+  await danceHeader.locator(".sift-th-top").click();
   await mark(page, narration, "sort");
   const sortDur = narration.durationFor("sort");
   showOverlay(page, "sort", sortDur);
@@ -136,7 +136,7 @@ test("sift-showcase", async ({ page, narration }) => {
   await mark(page, narration, "brush-filter");
   const brushDur = narration.durationFor("brush-filter");
   showOverlay(page, "brush-filter", brushDur);
-  const box = await danceHeader.locator(".pt-th-summary").boundingBox();
+  const box = await danceHeader.locator(".sift-th-summary").boundingBox();
   if (box) {
     const y = box.y + box.height / 2;
     const x0 = box.x + box.width * 0.2;
@@ -160,15 +160,15 @@ test("sift-showcase", async ({ page, narration }) => {
   await explicitHeader.scrollIntoViewIfNeeded();
   focusRing(page, explicitHeader, { color: "#22d3ee", duration: 2500 });
   await page.waitForTimeout(600);
-  await explicitHeader.locator(".pt-bool-true").click();
+  await explicitHeader.locator(".sift-bool-true").click();
   await page.waitForTimeout(3000);
 
   await mark(page, narration, "clear");
   const clearDur = narration.durationFor("clear");
   showOverlay(page, "clear", clearDur);
-  focusRing(page, page.locator(".pt-filter-pills"), { color: "#e879f9", duration: 2000 });
+  focusRing(page, page.locator(".sift-filter-pills"), { color: "#e879f9", duration: 2000 });
   await page.waitForTimeout(600);
-  const pills = page.locator(".pt-filter-pill-x");
+  const pills = page.locator(".sift-filter-pill-x");
   while ((await pills.count()) > 0) {
     await pills.first().click();
     await page.waitForTimeout(400);
@@ -188,7 +188,7 @@ test("sift-showcase", async ({ page, narration }) => {
   narration.mark("closing");
   showConfetti(page, { emoji: ["📊", "⚡", "🔥"], spread: "burst", duration: 3000, pieces: 180 });
   showOverlay(page, "closing", 4000);
-  const starBtn = page.locator(".pt-github-btn");
+  const starBtn = page.locator(".sift-github-btn");
   await page.waitForTimeout(1200);
   focusRing(page, starBtn, { color: "#f59e0b", duration: 2500 });
   await page.waitForTimeout(2800);

--- a/packages/sift/e2e/cast-undo.spec.ts
+++ b/packages/sift/e2e/cast-undo.spec.ts
@@ -6,8 +6,8 @@ import { expect, type Page, test } from "@playwright/test";
  */
 
 async function openColumnMenu(page: Page, columnLabel: string) {
-  const th = page.locator(".pt-th").filter({
-    has: page.locator(".pt-th-label", {
+  const th = page.locator(".sift-th").filter({
+    has: page.locator(".sift-th-label", {
       hasText: new RegExp(`^${columnLabel}$`),
     }),
   });
@@ -24,20 +24,20 @@ test.describe("Cast Column Undo (Titanic)", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
   });
 
   test("cast Name to Number then back to Text restores values", async ({ page }) => {
     // Get the original first row's Name value
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const nameIdx = labels.indexOf("Name");
     expect(nameIdx).toBeGreaterThan(-1);
 
-    const firstRow = page.locator(".pt-row").first();
-    const nameCell = firstRow.locator(".pt-cell").nth(nameIdx);
+    const firstRow = page.locator(".sift-row").first();
+    const nameCell = firstRow.locator(".sift-cell").nth(nameIdx);
     const originalName = await nameCell.textContent();
     expect(originalName).toBeTruthy();
     expect(originalName!.length).toBeGreaterThan(3); // Should be a real name
@@ -48,10 +48,10 @@ test.describe("Cast Column Undo (Titanic)", () => {
     await page.waitForTimeout(500);
 
     // After casting to Number, the type icon should change to #
-    const nameTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Name$/ }),
+    const nameTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Name$/ }),
     });
-    await expect(nameTh.locator(".pt-type-icon")).toHaveText("#");
+    await expect(nameTh.locator(".sift-type-icon")).toHaveText("#");
 
     // Now cast back to Text
     await openColumnMenu(page, "Name");
@@ -59,7 +59,7 @@ test.describe("Cast Column Undo (Titanic)", () => {
     await page.waitForTimeout(500);
 
     // Type icon should be back to Aa
-    await expect(nameTh.locator(".pt-type-icon")).toHaveText("Aa");
+    await expect(nameTh.locator(".sift-type-icon")).toHaveText("Aa");
 
     // The original name value should be restored
     const restoredName = await nameCell.textContent();
@@ -67,12 +67,12 @@ test.describe("Cast Column Undo (Titanic)", () => {
   });
 
   test("cast Fare to Text then back to Number preserves values", async ({ page }) => {
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const fareIdx = labels.indexOf("Fare");
     expect(fareIdx).toBeGreaterThan(-1);
 
-    const firstRow = page.locator(".pt-row").first();
-    const fareCell = firstRow.locator(".pt-cell").nth(fareIdx);
+    const firstRow = page.locator(".sift-row").first();
+    const fareCell = firstRow.locator(".sift-cell").nth(fareIdx);
     const originalFare = await fareCell.textContent();
 
     // Cast Fare to Text
@@ -80,17 +80,17 @@ test.describe("Cast Column Undo (Titanic)", () => {
     await clickMenuItem(page, "Text");
     await page.waitForTimeout(500);
 
-    const fareTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Fare$/ }),
+    const fareTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Fare$/ }),
     });
-    await expect(fareTh.locator(".pt-type-icon")).toHaveText("Aa");
+    await expect(fareTh.locator(".sift-type-icon")).toHaveText("Aa");
 
     // Cast back to Number
     await openColumnMenu(page, "Fare");
     await clickMenuItem(page, "Number");
     await page.waitForTimeout(500);
 
-    await expect(fareTh.locator(".pt-type-icon")).toHaveText("#");
+    await expect(fareTh.locator(".sift-type-icon")).toHaveText("#");
 
     // Value should be restored
     const restoredFare = await fareCell.textContent();

--- a/packages/sift/e2e/datasets.spec.ts
+++ b/packages/sift/e2e/datasets.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test.describe("Dataset Picker", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
+    await page.waitForSelector(".sift-table-container");
   });
 
   test("shows dataset dropdown with all options", async ({ page }) => {

--- a/packages/sift/e2e/filter-labels.spec.ts
+++ b/packages/sift/e2e/filter-labels.spec.ts
@@ -8,22 +8,22 @@ import { expect, test } from "@playwright/test";
 test.describe("Filter Labels", () => {
   test("timestamp filter label shows formatted date, not epoch", async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await page.waitForSelector(".sift-table-container");
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
 
     // Find the Joined column (timestamp) — may need to scroll right
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const joinedIdx = labels.indexOf("Joined");
     expect(joinedIdx).toBeGreaterThan(-1);
 
     // Scroll the Joined column header into view
-    const joinedTh = page.locator(".pt-th").nth(joinedIdx);
+    const joinedTh = page.locator(".sift-th").nth(joinedIdx);
     await joinedTh.scrollIntoViewIfNeeded();
     await page.waitForTimeout(200);
 
-    const summary = page.locator(".pt-th-summary").nth(joinedIdx);
+    const summary = page.locator(".sift-th-summary").nth(joinedIdx);
     const box = await summary.boundingBox();
     if (!box) throw new Error("No Joined summary bounding box");
 
@@ -37,7 +37,7 @@ test.describe("Filter Labels", () => {
     await page.waitForTimeout(500);
 
     // A filter pill should appear with a formatted date range
-    const pill = page.locator(".pt-filter-pill");
+    const pill = page.locator(".sift-filter-pill");
     await expect(pill).toHaveCount(1, { timeout: 2000 });
     const pillText = await pill.textContent();
 
@@ -48,7 +48,7 @@ test.describe("Filter Labels", () => {
     expect(pillText).toMatch(/[A-Z][a-z]{2}/);
 
     // The filter line in the header should also be formatted
-    const filterLine = page.locator(".pt-filter-line").first();
+    const filterLine = page.locator(".sift-filter-line").first();
     if ((await filterLine.count()) > 0) {
       const lineText = await filterLine.textContent();
       expect(lineText).not.toMatch(/\d{10,}/);

--- a/packages/sift/e2e/header-overlap.spec.ts
+++ b/packages/sift/e2e/header-overlap.spec.ts
@@ -9,14 +9,14 @@ import { expect, test } from "@playwright/test";
 test.describe("Header Overlap", () => {
   test("first row is visible below header on generated dataset", async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await page.waitForSelector(".pt-row");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
 
     // Wait for summaries to render (React async mount)
     await page.waitForTimeout(500);
 
-    const header = page.locator(".pt-header");
-    const firstRow = page.locator(".pt-row").first();
+    const header = page.locator(".sift-header");
+    const firstRow = page.locator(".sift-row").first();
 
     const headerBox = await header.boundingBox();
     const rowBox = await firstRow.boundingBox();
@@ -31,16 +31,16 @@ test.describe("Header Overlap", () => {
   test("first row is visible below header on HF dataset", async ({ page }) => {
     test.setTimeout(120_000);
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
 
     // Wait for summaries to render
     await page.waitForTimeout(1000);
 
-    const header = page.locator(".pt-header");
-    const firstRow = page.locator(".pt-row").first();
+    const header = page.locator(".sift-header");
+    const firstRow = page.locator(".sift-row").first();
 
     const headerBox = await header.boundingBox();
     const rowBox = await firstRow.boundingBox();

--- a/packages/sift/e2e/huggingface.spec.ts
+++ b/packages/sift/e2e/huggingface.spec.ts
@@ -12,26 +12,26 @@ test.describe("HuggingFace Dataset Loading", () => {
 
   test("Heart Failure loads with boolean columns", async ({ page }) => {
     await page.goto("/?dataset=heart-failure");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
 
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /299/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /299/, {
       timeout: 30_000,
     });
-    await expect(page.locator(".pt-badge").first()).toBeVisible({
+    await expect(page.locator(".sift-badge").first()).toBeVisible({
       timeout: 5_000,
     });
   });
 
   test("Adult Census loads with many categorical columns", async ({ page }) => {
     await page.goto("/?dataset=adult-census");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
 
     // Wait for all row groups to load (progressive loading shows partial counts first)
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /3[0-9],/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /3[0-9],/, {
       timeout: 60_000,
     });
 
-    await expect(page.locator(".pt-cat-summary").first()).toBeVisible({
+    await expect(page.locator(".sift-cat-summary").first()).toBeVisible({
       timeout: 5_000,
     });
   });

--- a/packages/sift/e2e/mobile.spec.ts
+++ b/packages/sift/e2e/mobile.spec.ts
@@ -10,28 +10,28 @@ test.describe("Mobile Viewport", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await page.waitForSelector(".pt-row");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
   });
 
   test("table renders and shows rows at mobile width", async ({ page }) => {
-    const rows = page.locator(".pt-row");
+    const rows = page.locator(".sift-row");
     const count = await rows.count();
     expect(count).toBeGreaterThan(0);
 
     // Stats bar is visible
-    await expect(page.locator(".pt-stat-rows")).toBeVisible();
+    await expect(page.locator(".sift-stat-rows")).toBeVisible();
   });
 
   test("header summaries render at narrow width", async ({ page }) => {
     // At least some summary containers should have content
-    const summaries = page.locator(".pt-th-summary");
+    const summaries = page.locator(".sift-th-summary");
     const count = await summaries.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("horizontal scroll works", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
+    const viewport = page.locator(".sift-viewport");
 
     // Scroll right
     await viewport.evaluate((el) => (el.scrollLeft = 200));
@@ -42,8 +42,8 @@ test.describe("Mobile Viewport", () => {
   });
 
   test("first pinned column stays visible when scrolling", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
-    const firstTh = page.locator(".pt-th").first();
+    const viewport = page.locator(".sift-viewport");
+    const firstTh = page.locator(".sift-th").first();
 
     // Scroll right
     await viewport.evaluate((el) => (el.scrollLeft = 300));
@@ -64,16 +64,16 @@ test.describe("Mobile Viewport", () => {
   });
 
   test("fullscreen button is visible", async ({ page }) => {
-    await expect(page.locator(".pt-fullscreen-btn")).toBeVisible();
+    await expect(page.locator(".sift-fullscreen-btn")).toBeVisible();
   });
 
   test("sort works via column header tap", async ({ page }) => {
     // Tap a column header to sort (click simulates tap at mobile viewport)
-    const firstSortable = page.locator(".pt-th-top").first();
+    const firstSortable = page.locator(".sift-th-top").first();
     await firstSortable.click();
 
     // Sort arrow should appear
-    const arrow = page.locator(".pt-sort-arrow").first();
+    const arrow = page.locator(".sift-sort-arrow").first();
     await expect(arrow).toContainText("↑", { timeout: 2000 });
   });
 });

--- a/packages/sift/e2e/notebook.spec.ts
+++ b/packages/sift/e2e/notebook.spec.ts
@@ -4,32 +4,32 @@ test.describe("Notebook Demo", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/notebook.html");
     // Wait for at least one table to mount
-    await page.waitForSelector(".pt-table-container", { timeout: 10_000 });
+    await page.waitForSelector(".sift-table-container", { timeout: 10_000 });
   });
 
   test("renders multiple tables", async ({ page }) => {
-    const tables = page.locator(".pt-table-container");
+    const tables = page.locator(".sift-table-container");
     const count = await tables.count();
     expect(count).toBeGreaterThanOrEqual(2);
   });
 
   test("each table has its own status bar", async ({ page }) => {
     // Wait for data to load
-    await page.waitForSelector(".pt-stat-rows", { timeout: 10_000 });
-    const statusBars = page.locator(".pt-stat-rows");
+    await page.waitForSelector(".sift-stat-rows", { timeout: 10_000 });
+    const statusBars = page.locator(".sift-stat-rows");
     const count = await statusBars.count();
     expect(count).toBeGreaterThanOrEqual(2);
   });
 
   test("tables scroll independently", async ({ page }) => {
     // Wait for all data
-    const firstStats = page.locator(".pt-stat-rows").first();
+    const firstStats = page.locator(".sift-stat-rows").first();
     await expect(firstStats).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
 
     // Scroll the first table
-    const firstViewport = page.locator(".pt-viewport").first();
+    const firstViewport = page.locator(".sift-viewport").first();
     await firstViewport.evaluate((el) => (el.scrollTop = 3000));
     await page.waitForTimeout(200);
 
@@ -38,7 +38,7 @@ test.describe("Notebook Demo", () => {
     expect(firstRow).toBeGreaterThan(0);
 
     // Second table should still be at top
-    const secondViewport = page.locator(".pt-viewport").nth(1);
+    const secondViewport = page.locator(".sift-viewport").nth(1);
     const secondScroll = await secondViewport.evaluate((el) => el.scrollTop);
     expect(secondScroll).toBe(0);
   });

--- a/packages/sift/e2e/numeric-heavy.spec.ts
+++ b/packages/sift/e2e/numeric-heavy.spec.ts
@@ -12,7 +12,7 @@ test.describe("Heart Failure (numeric-heavy)", () => {
 
   const waitForData = async (page: import("@playwright/test").Page) => {
     await page.goto("/?dataset=heart-failure");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
     await page.waitForFunction(() => document.body.innerText.includes("299 rows"), null, {
       timeout: 30_000,
     });
@@ -20,7 +20,7 @@ test.describe("Heart Failure (numeric-heavy)", () => {
 
   test("row count shows 299 rows", async ({ page }) => {
     await waitForData(page);
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /299/);
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /299/);
   });
 
   test("all numeric columns get histograms (SVG charts)", async ({ page }) => {
@@ -29,7 +29,7 @@ test.describe("Heart Failure (numeric-heavy)", () => {
     // Numeric columns should have SVG histogram charts in their summary area.
     // Heart-failure has columns like age, creatinine_phosphokinase, ejection_fraction,
     // platelets, serum_creatinine, serum_sodium, time — all numeric.
-    const histogramSvgs = page.locator(".pt-th-summary svg");
+    const histogramSvgs = page.locator(".sift-th-summary svg");
     const count = await histogramSvgs.count();
 
     // At least 5 numeric histograms should be present (the dataset has ~7 pure numeric columns)
@@ -40,18 +40,18 @@ test.describe("Heart Failure (numeric-heavy)", () => {
     await waitForData(page);
 
     // Click the "age" column header to sort ascending
-    const ageTh = page.locator(".pt-th", { hasText: "age" });
-    const ageTop = ageTh.locator(".pt-th-top");
+    const ageTh = page.locator(".sift-th", { hasText: "age" });
+    const ageTop = ageTh.locator(".sift-th-top");
     await ageTop.click();
 
     // Verify sort arrow shows ascending
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↑");
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↑");
 
     // Wait a moment for sort to apply
     await page.waitForTimeout(200);
 
     // Read the first and last visible cell values in the age column
-    const ageCells = page.locator(".pt-row .pt-cell:first-child");
+    const ageCells = page.locator(".sift-row .sift-cell:first-child");
     const firstText = await ageCells.first().textContent();
     const allCells = await ageCells.all();
     const lastText = await allCells[allCells.length - 1].textContent();
@@ -68,16 +68,16 @@ test.describe("Heart Failure (numeric-heavy)", () => {
     await waitForData(page);
 
     // Click "age" column header twice: first click = asc, second = desc
-    const ageTh = page.locator(".pt-th", { hasText: "age" });
-    const ageTop = ageTh.locator(".pt-th-top");
+    const ageTh = page.locator(".sift-th", { hasText: "age" });
+    const ageTop = ageTh.locator(".sift-th-top");
     await ageTop.click();
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↑");
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↑");
     await ageTop.click();
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↓");
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↓");
 
     await page.waitForTimeout(200);
 
-    const ageCells = page.locator(".pt-row .pt-cell:first-child");
+    const ageCells = page.locator(".sift-row .sift-cell:first-child");
     const firstText = await ageCells.first().textContent();
     const allCells = await ageCells.all();
     const lastText = await allCells[allCells.length - 1].textContent();
@@ -93,7 +93,7 @@ test.describe("Heart Failure (numeric-heavy)", () => {
   test("column widths are reasonable (60–400px)", async ({ page }) => {
     await waitForData(page);
 
-    const headers = page.locator(".pt-th");
+    const headers = page.locator(".sift-th");
     const count = await headers.count();
     expect(count).toBeGreaterThan(0);
 
@@ -107,8 +107,8 @@ test.describe("Heart Failure (numeric-heavy)", () => {
   test("histogram range labels show min – max", async ({ page }) => {
     await waitForData(page);
 
-    // Each numeric column should have a .pt-th-range element with "min – max" text
-    const rangeLabels = page.locator(".pt-th-range");
+    // Each numeric column should have a .sift-th-range element with "min – max" text
+    const rangeLabels = page.locator(".sift-th-range");
     const count = await rangeLabels.count();
 
     // At least some numeric columns should show range labels
@@ -125,11 +125,11 @@ test.describe("Heart Failure (numeric-heavy)", () => {
     await waitForData(page);
 
     // DEATH_EVENT is a boolean-like column (0/1) — should render as a ratio bar
-    const deathTh = page.locator(".pt-th", { hasText: "DEATH_EVENT" });
+    const deathTh = page.locator(".sift-th", { hasText: "DEATH_EVENT" });
     await expect(deathTh).toBeVisible({ timeout: 5_000 });
 
-    // Boolean columns render a .pt-bool-bar instead of a histogram SVG
-    const boolBar = deathTh.locator(".pt-bool-bar");
+    // Boolean columns render a .sift-bool-bar instead of a histogram SVG
+    const boolBar = deathTh.locator(".sift-bool-bar");
     await expect(boolBar).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/packages/sift/e2e/odometer.spec.ts
+++ b/packages/sift/e2e/odometer.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from "@playwright/test";
 test.describe("Odometer", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await page.waitForSelector(".pt-row");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
   });
 
   test("row count rolls up during streaming", async ({ page }) => {
-    const stats = page.locator(".pt-stat-rows");
+    const stats = page.locator(".sift-stat-rows");
 
     // Wait for streaming to start
     await expect(stats).toHaveAttribute("data-value", /rows/, {
@@ -25,12 +25,12 @@ test.describe("Odometer", () => {
     await page.screenshot({ path: "test-results/odometer-full.png" });
 
     // Verify odometer slots exist (digits should be in strip elements)
-    const slots = stats.locator(".pt-odo-slot");
+    const slots = stats.locator(".sift-odo-slot");
     await expect(slots.first()).toBeVisible();
   });
 
   test("row count rolls down on filter, back up on clear", async ({ page }) => {
-    const stats = page.locator(".pt-stat-rows");
+    const stats = page.locator(".sift-stat-rows");
 
     // Wait for all data
     await expect(stats).toHaveAttribute("data-value", /100,000/, {
@@ -40,8 +40,8 @@ test.describe("Odometer", () => {
     await page.screenshot({ path: "test-results/odometer-before-filter.png" });
 
     // Apply a range filter on Score column via brush
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const summary = scoreTh.locator(".pt-th-summary");
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const summary = scoreTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) throw new Error("No summary bounding box");
 
@@ -62,7 +62,7 @@ test.describe("Odometer", () => {
     expect(afterFilter).toContain("100,000");
 
     // Clear filter by clicking pill X
-    await page.locator(".pt-filter-pill-x").click();
+    await page.locator(".sift-filter-pill-x").click();
     await expect(stats).not.toHaveAttribute("data-value", /of/, {
       timeout: 3000,
     });

--- a/packages/sift/e2e/perf.spec.ts
+++ b/packages/sift/e2e/perf.spec.ts
@@ -28,9 +28,9 @@ function record(metric: string, value: number, unit: string) {
 test.describe("Performance Benchmarks (100k rows)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
+    await page.waitForSelector(".sift-table-container");
     // Wait for all 100k rows to stream in
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 30_000,
     });
   });
@@ -38,10 +38,10 @@ test.describe("Performance Benchmarks (100k rows)", () => {
   test("mount and stream all batches", async ({ page }) => {
     const start = Date.now();
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
+    await page.waitForSelector(".sift-table-container");
     const firstBatch = Date.now() - start;
 
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 30_000,
     });
     const allBatches = Date.now() - start;
@@ -52,7 +52,7 @@ test.describe("Performance Benchmarks (100k rows)", () => {
   });
 
   test("scroll frame time", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
+    const viewport = page.locator(".sift-viewport");
 
     await viewport.evaluate((el) => (el.scrollTop = 1000));
     await page.waitForTimeout(100);
@@ -86,12 +86,12 @@ test.describe("Performance Benchmarks (100k rows)", () => {
   });
 
   test("sort response time", async ({ page }) => {
-    const scoreTh = page.locator(".pt-th").filter({ hasText: "Score" });
+    const scoreTh = page.locator(".sift-th").filter({ hasText: "Score" });
 
     const sortTime = await page.evaluate(() => {
       return new Promise<number>((resolve) => {
-        // Click .pt-th-top (sort handler) not .pt-th (outer container)
-        const top = document.querySelector(".pt-th:nth-child(8) .pt-th-top") as HTMLElement;
+        // Click .sift-th-top (sort handler) not .sift-th (outer container)
+        const top = document.querySelector(".sift-th:nth-child(8) .sift-th-top") as HTMLElement;
         const t0 = performance.now();
         top.click();
         requestAnimationFrame(() => {
@@ -106,12 +106,12 @@ test.describe("Performance Benchmarks (100k rows)", () => {
     record("sort_click_to_render", sortTime, "ms");
 
     // Verify sort actually applied
-    await expect(scoreTh.locator(".pt-sort-arrow")).toContainText("↑");
+    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↑");
   });
 
   test("filter response time", async ({ page }) => {
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const summary = scoreTh.locator(".pt-th-summary");
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const summary = scoreTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) throw new Error("No summary bounding box");
 
@@ -119,7 +119,7 @@ test.describe("Performance Benchmarks (100k rows)", () => {
       ({ x, y, w, h }) => {
         return new Promise<number>((resolve) => {
           const svg = document.querySelector(
-            ".pt-th:nth-child(8) .pt-th-summary svg:last-child",
+            ".sift-th:nth-child(8) .sift-th-summary svg:last-child",
           ) as SVGElement;
           if (!svg) {
             resolve(-1);
@@ -164,8 +164,8 @@ test.describe("Performance Benchmarks (100k rows)", () => {
   });
 
   test("column resize frame time", async ({ page }) => {
-    const nameTh = page.locator(".pt-th").nth(1);
-    const handle = nameTh.locator(".pt-resize-handle");
+    const nameTh = page.locator(".sift-th").nth(1);
+    const handle = nameTh.locator(".sift-resize-handle");
     const handleBox = await handle.boundingBox();
     if (!handleBox) throw new Error("No handle bounding box");
 
@@ -173,7 +173,7 @@ test.describe("Performance Benchmarks (100k rows)", () => {
       ({ x, y }) => {
         return new Promise<number[]>((resolve) => {
           const handle = document.querySelector(
-            ".pt-th:nth-child(2) .pt-resize-handle",
+            ".sift-th:nth-child(2) .sift-resize-handle",
           ) as HTMLElement;
           if (!handle) {
             resolve([]);

--- a/packages/sift/e2e/pinning.spec.ts
+++ b/packages/sift/e2e/pinning.spec.ts
@@ -2,8 +2,8 @@ import { expect, type Page, test } from "@playwright/test";
 
 /** Right-click a column header to open the context menu. */
 async function openColumnMenu(page: Page, columnLabel: string) {
-  const th = page.locator(".pt-th").filter({
-    has: page.locator(".pt-th-label", {
+  const th = page.locator(".sift-th").filter({
+    has: page.locator(".sift-th-label", {
       hasText: new RegExp(`^${columnLabel}$`),
     }),
   });
@@ -20,19 +20,19 @@ async function clickMenuItem(page: Page, text: string) {
 test.describe("Column Pinning", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await page.waitForSelector(".pt-row");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
   });
 
   test("first column (ID) is pinned by default", async ({ page }) => {
-    const firstTh = page.locator(".pt-th").first();
+    const firstTh = page.locator(".sift-th").first();
     const position = await firstTh.evaluate((el) => el.style.position);
     expect(position).toBe("sticky");
   });
 
   test("pinned column header stays sticky when scrolling horizontally", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
-    const firstTh = page.locator(".pt-th").first();
+    const viewport = page.locator(".sift-viewport");
+    const firstTh = page.locator(".sift-th").first();
 
     // Scroll far to the right
     await viewport.evaluate((el) => (el.scrollLeft = 800));
@@ -46,7 +46,7 @@ test.describe("Column Pinning", () => {
 
   test("pin a column via context menu", async ({ page }) => {
     // Name column is not pinned initially
-    const nameTh = page.locator(".pt-th").filter({ hasText: "Name" });
+    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
     const initialPos = await nameTh.evaluate((el) => el.style.position);
     expect(initialPos).not.toBe("sticky");
 
@@ -63,8 +63,8 @@ test.describe("Column Pinning", () => {
   test("unpin a column via context menu", async ({ page }) => {
     // First column (ID) is pinned by default
     const idTh = page
-      .locator(".pt-th")
-      .filter({ has: page.locator(".pt-th-label", { hasText: /^ID$/ }) });
+      .locator(".sift-th")
+      .filter({ has: page.locator(".sift-th-label", { hasText: /^ID$/ }) });
     const initialPos = await idTh.evaluate((el) => el.style.position);
     expect(initialPos).toBe("sticky");
 
@@ -80,13 +80,13 @@ test.describe("Column Pinning", () => {
 
   test("pinned column has shadow on last pinned column", async ({ page }) => {
     // ID is the only pinned column — it should have the shadow
-    const firstTh = page.locator(".pt-th").first();
+    const firstTh = page.locator(".sift-th").first();
     const shadow = await firstTh.evaluate((el) => el.style.boxShadow);
     expect(shadow).toContain("pin-shadow");
   });
 
   test("pinned cells in rows also have sticky positioning", async ({ page }) => {
-    const firstCell = page.locator(".pt-row").first().locator(".pt-cell").first();
+    const firstCell = page.locator(".sift-row").first().locator(".sift-cell").first();
     const position = await firstCell.evaluate((el) => el.style.position);
     expect(position).toBe("sticky");
   });
@@ -99,9 +99,9 @@ test.describe("Column Pinning", () => {
 
     // After pinning, both ID and Name headers should be sticky
     const idTh = page
-      .locator(".pt-th")
-      .filter({ has: page.locator(".pt-th-label", { hasText: /^ID$/ }) });
-    const nameTh = page.locator(".pt-th").filter({ hasText: "Name" });
+      .locator(".sift-th")
+      .filter({ has: page.locator(".sift-th-label", { hasText: /^ID$/ }) });
+    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
 
     // ID should be at left: 0
     const idLeft = await idTh.evaluate((el) => el.style.left);
@@ -120,14 +120,14 @@ test.describe("Column Pinning", () => {
 
   test("pinned columns move to front of visual order", async ({ page }) => {
     // Get the initial order of column labels
-    const labelsBefore = await page.locator(".pt-th-label").allTextContents();
+    const labelsBefore = await page.locator(".sift-th-label").allTextContents();
 
     // Pin the Score column (initially not first)
     await openColumnMenu(page, "Score");
     await clickMenuItem(page, "Pin column");
     await page.waitForTimeout(200);
 
-    const labelsAfter = await page.locator(".pt-th-label").allTextContents();
+    const labelsAfter = await page.locator(".sift-th-label").allTextContents();
 
     // Score should now be near the front (after ID which is pinned at index 0)
     const scoreIndexBefore = labelsBefore.indexOf("Score");
@@ -137,7 +137,7 @@ test.describe("Column Pinning", () => {
 
   test('keyboard shortcut "p" toggles pin on focused column', async ({ page }) => {
     // Focus the Name column header and press 'p' to pin
-    const nameTh = page.locator(".pt-th").filter({ hasText: "Name" });
+    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
     await nameTh.focus();
     await nameTh.press("p");
     await page.waitForTimeout(200);
@@ -157,17 +157,17 @@ test.describe("Column Pinning", () => {
 
   test("arrow keys navigate between column headers", async ({ page }) => {
     // Focus the first column header
-    const firstTh = page.locator(".pt-th").first();
+    const firstTh = page.locator(".sift-th").first();
     await firstTh.focus();
 
     // Press ArrowRight to move to next column
     await firstTh.press("ArrowRight");
-    const secondTh = page.locator(".pt-th").nth(1);
+    const secondTh = page.locator(".sift-th").nth(1);
     await expect(secondTh).toBeFocused();
 
     // Press ArrowRight again
     await secondTh.press("ArrowRight");
-    const thirdTh = page.locator(".pt-th").nth(2);
+    const thirdTh = page.locator(".sift-th").nth(2);
     await expect(thirdTh).toBeFocused();
 
     // Press ArrowLeft to go back
@@ -176,18 +176,18 @@ test.describe("Column Pinning", () => {
   });
 
   test("Enter key triggers sort on focused column", async ({ page }) => {
-    const scoreTh = page.locator(".pt-th").filter({ hasText: "Score" });
+    const scoreTh = page.locator(".sift-th").filter({ hasText: "Score" });
     await scoreTh.focus();
     await scoreTh.press("Enter");
 
     // Sort arrow should appear
-    await expect(scoreTh.locator(".pt-sort-arrow")).toContainText("↑", {
+    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↑", {
       timeout: 2000,
     });
 
     // Press Enter again for descending
     await scoreTh.press("Enter");
-    await expect(scoreTh.locator(".pt-sort-arrow")).toContainText("↓", {
+    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↓", {
       timeout: 2000,
     });
   });

--- a/packages/sift/e2e/pinning.spec.ts
+++ b/packages/sift/e2e/pinning.spec.ts
@@ -1,194 +1,42 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-/** Right-click a column header to open the context menu. */
-async function openColumnMenu(page: Page, columnLabel: string) {
-  const th = page.locator(".sift-th").filter({
-    has: page.locator(".sift-th-label", {
-      hasText: new RegExp(`^${columnLabel}$`),
-    }),
-  });
-  await th.click({ button: "right" });
-  // Wait for the context menu to appear
-  await expect(page.locator(".fixed.z-50")).toBeVisible({ timeout: 2000 });
-}
-
-/** Click a menu item by text. */
-async function clickMenuItem(page: Page, text: string) {
-  await page.locator(".fixed.z-50 button", { hasText: text }).click();
-}
-
-test.describe("Column Pinning", () => {
+test.describe("Pinned column", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?dataset=generated");
-    await page.waitForSelector(".sift-table-container");
-    await page.waitForSelector(".sift-row");
+    await page.goto("/");
+    // Wait for table to render
+    await page.waitForSelector(".sift-table-container", { timeout: 15_000 });
+    await page.waitForSelector(".sift-row", { timeout: 15_000 });
   });
 
-  test("first column (ID) is pinned by default", async ({ page }) => {
-    const firstTh = page.locator(".sift-th").first();
-    const position = await firstTh.evaluate((el) => el.style.position);
-    expect(position).toBe("sticky");
-  });
+  test("first column header has opaque background when scrolled", async ({ page }) => {
+    const header = page.locator(".sift-th:first-child");
+    await expect(header).toBeVisible();
 
-  test("pinned column header stays sticky when scrolling horizontally", async ({ page }) => {
+    // Scroll the table right so content goes behind the pinned column
     const viewport = page.locator(".sift-viewport");
-    const firstTh = page.locator(".sift-th").first();
-
-    // Scroll far to the right
-    await viewport.evaluate((el) => (el.scrollLeft = 800));
-    await page.waitForTimeout(100);
-
-    // Pinned column should still be visible (sticky positioning)
-    await expect(firstTh).toBeVisible();
-    const left = await firstTh.evaluate((el) => el.style.left);
-    expect(left).toBe("0px");
-  });
-
-  test("pin a column via context menu", async ({ page }) => {
-    // Name column is not pinned initially
-    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
-    const initialPos = await nameTh.evaluate((el) => el.style.position);
-    expect(initialPos).not.toBe("sticky");
-
-    // Right-click Name header and pin it
-    await openColumnMenu(page, "Name");
-    await clickMenuItem(page, "Pin column");
-    await page.waitForTimeout(200);
-
-    // Name should now be sticky
-    const afterPos = await nameTh.evaluate((el) => el.style.position);
-    expect(afterPos).toBe("sticky");
-  });
-
-  test("unpin a column via context menu", async ({ page }) => {
-    // First column (ID) is pinned by default
-    const idTh = page
-      .locator(".sift-th")
-      .filter({ has: page.locator(".sift-th-label", { hasText: /^ID$/ }) });
-    const initialPos = await idTh.evaluate((el) => el.style.position);
-    expect(initialPos).toBe("sticky");
-
-    // Right-click and unpin
-    await openColumnMenu(page, "ID");
-    await clickMenuItem(page, "Unpin column");
-    await page.waitForTimeout(200);
-
-    // ID should no longer be sticky
-    const afterPos = await idTh.evaluate((el) => el.style.position);
-    expect(afterPos).not.toBe("sticky");
-  });
-
-  test("pinned column has shadow on last pinned column", async ({ page }) => {
-    // ID is the only pinned column — it should have the shadow
-    const firstTh = page.locator(".sift-th").first();
-    const shadow = await firstTh.evaluate((el) => el.style.boxShadow);
-    expect(shadow).toContain("pin-shadow");
-  });
-
-  test("pinned cells in rows also have sticky positioning", async ({ page }) => {
-    const firstCell = page.locator(".sift-row").first().locator(".sift-cell").first();
-    const position = await firstCell.evaluate((el) => el.style.position);
-    expect(position).toBe("sticky");
-  });
-
-  test("multiple pinned columns have correct left offsets", async ({ page }) => {
-    // Pin the Name column (in addition to ID which is already pinned)
-    await openColumnMenu(page, "Name");
-    await clickMenuItem(page, "Pin column");
-    await page.waitForTimeout(200);
-
-    // After pinning, both ID and Name headers should be sticky
-    const idTh = page
-      .locator(".sift-th")
-      .filter({ has: page.locator(".sift-th-label", { hasText: /^ID$/ }) });
-    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
-
-    // ID should be at left: 0
-    const idLeft = await idTh.evaluate((el) => el.style.left);
-    expect(idLeft).toBe("0px");
-
-    // Name should be offset by the width of the ID column
-    const nameLeft = await nameTh.evaluate((el) => parseFloat(el.style.left));
-    expect(nameLeft).toBeGreaterThan(0);
-
-    // Only the last pinned column should have the shadow
-    const idShadow = await idTh.evaluate((el) => el.style.boxShadow);
-    const nameShadow = await nameTh.evaluate((el) => el.style.boxShadow);
-    expect(idShadow).toBe("");
-    expect(nameShadow).toContain("pin-shadow");
-  });
-
-  test("pinned columns move to front of visual order", async ({ page }) => {
-    // Get the initial order of column labels
-    const labelsBefore = await page.locator(".sift-th-label").allTextContents();
-
-    // Pin the Score column (initially not first)
-    await openColumnMenu(page, "Score");
-    await clickMenuItem(page, "Pin column");
-    await page.waitForTimeout(200);
-
-    const labelsAfter = await page.locator(".sift-th-label").allTextContents();
-
-    // Score should now be near the front (after ID which is pinned at index 0)
-    const scoreIndexBefore = labelsBefore.indexOf("Score");
-    const scoreIndexAfter = labelsAfter.indexOf("Score");
-    expect(scoreIndexAfter).toBeLessThan(scoreIndexBefore);
-  });
-
-  test('keyboard shortcut "p" toggles pin on focused column', async ({ page }) => {
-    // Focus the Name column header and press 'p' to pin
-    const nameTh = page.locator(".sift-th").filter({ hasText: "Name" });
-    await nameTh.focus();
-    await nameTh.press("p");
-    await page.waitForTimeout(200);
-
-    // Name should now be sticky (pinned)
-    const pinnedPos = await nameTh.evaluate((el) => el.style.position);
-    expect(pinnedPos).toBe("sticky");
-
-    // Press 'p' again to unpin
-    await nameTh.focus();
-    await nameTh.press("p");
-    await page.waitForTimeout(200);
-
-    const unpinnedPos = await nameTh.evaluate((el) => el.style.position);
-    expect(unpinnedPos).not.toBe("sticky");
-  });
-
-  test("arrow keys navigate between column headers", async ({ page }) => {
-    // Focus the first column header
-    const firstTh = page.locator(".sift-th").first();
-    await firstTh.focus();
-
-    // Press ArrowRight to move to next column
-    await firstTh.press("ArrowRight");
-    const secondTh = page.locator(".sift-th").nth(1);
-    await expect(secondTh).toBeFocused();
-
-    // Press ArrowRight again
-    await secondTh.press("ArrowRight");
-    const thirdTh = page.locator(".sift-th").nth(2);
-    await expect(thirdTh).toBeFocused();
-
-    // Press ArrowLeft to go back
-    await thirdTh.press("ArrowLeft");
-    await expect(secondTh).toBeFocused();
-  });
-
-  test("Enter key triggers sort on focused column", async ({ page }) => {
-    const scoreTh = page.locator(".sift-th").filter({ hasText: "Score" });
-    await scoreTh.focus();
-    await scoreTh.press("Enter");
-
-    // Sort arrow should appear
-    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↑", {
-      timeout: 2000,
+    await viewport.evaluate((el) => {
+      el.scrollLeft = 300;
     });
+    await page.waitForTimeout(200);
 
-    // Press Enter again for descending
-    await scoreTh.press("Enter");
-    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↓", {
-      timeout: 2000,
+    // The pinned header should have a non-transparent background
+    const bg = await header.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(bg).not.toBe("transparent");
+  });
+
+  test("first column cells have opaque background when scrolled", async ({ page }) => {
+    const firstCell = page.locator(".sift-row:first-child .sift-cell:first-child");
+    await expect(firstCell).toBeVisible();
+
+    const viewport = page.locator(".sift-viewport");
+    await viewport.evaluate((el) => {
+      el.scrollLeft = 300;
     });
+    await page.waitForTimeout(200);
+
+    const bg = await firstCell.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(bg).not.toBe("transparent");
   });
 });

--- a/packages/sift/e2e/profiling.spec.ts
+++ b/packages/sift/e2e/profiling.spec.ts
@@ -3,16 +3,16 @@ import { expect, test } from "@playwright/test";
 test.describe("Column Profiling", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
+    await page.waitForSelector(".sift-table-container");
     // Wait for all data to load
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
   });
 
   test("shows null% and distinct count for low-cardinality numeric columns", async ({ page }) => {
     // The Chaos column has NaN, Infinity, null values — should show profiling stats
-    const profileEls = page.locator(".pt-th-profile");
+    const profileEls = page.locator(".sift-th-profile");
     // At least one profile element should be visible
     await expect(profileEls.first()).toBeVisible({ timeout: 5_000 });
 
@@ -24,12 +24,12 @@ test.describe("Column Profiling", () => {
 
   test("profiling stats survive filter application", async ({ page }) => {
     // Find a profile element before filtering
-    const profileEls = page.locator(".pt-th-profile");
+    const profileEls = page.locator(".sift-th-profile");
     const countBefore = await profileEls.count();
 
     // Apply a filter via the Score histogram
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const summary = scoreTh.locator(".pt-th-summary");
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const summary = scoreTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) return; // skip if not visible
 
@@ -50,25 +50,25 @@ test.describe("Column Profiling", () => {
 test.describe("Debug Toggle", () => {
   test("gear button toggles debug stats", async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await page.waitForSelector(".sift-table-container");
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
 
     // Debug group should be hidden by default
-    const debugGroup = page.locator(".pt-debug-group");
+    const debugGroup = page.locator(".sift-debug-group");
     await expect(debugGroup).toBeHidden();
 
     // Click the gear button
-    await page.locator(".pt-debug-btn").click();
+    await page.locator(".sift-debug-btn").click();
     await expect(debugGroup).toBeVisible();
 
     // Should show FPS and DOM rows
-    await expect(page.locator(".pt-stat-frame")).toBeVisible();
-    await expect(page.locator(".pt-stat-dom")).toBeVisible();
+    await expect(page.locator(".sift-stat-frame")).toBeVisible();
+    await expect(page.locator(".sift-stat-dom")).toBeVisible();
 
     // Click again to hide
-    await page.locator(".pt-debug-btn").click();
+    await page.locator(".sift-debug-btn").click();
     await expect(debugGroup).toBeHidden();
   });
 });
@@ -76,7 +76,7 @@ test.describe("Debug Toggle", () => {
 test.describe("Dark Mode", () => {
   test("theme toggle switches theme", async ({ page }) => {
     await page.goto("/?dataset=generated");
-    await page.waitForSelector(".pt-table-container");
+    await page.waitForSelector(".sift-table-container");
 
     // Click theme toggle
     await page.locator("#theme-toggle").click();

--- a/packages/sift/e2e/table.spec.ts
+++ b/packages/sift/e2e/table.spec.ts
@@ -4,12 +4,12 @@ test.describe("Table Viewer", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=generated");
     // Wait for the table to mount and first batch to render
-    await page.waitForSelector(".pt-table-container");
-    await page.waitForSelector(".pt-row");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
   });
 
   test("loads and shows rows", async ({ page }) => {
-    const stats = page.locator(".pt-stat-rows");
+    const stats = page.locator(".sift-stat-rows");
     // Should eventually show 100,000 rows after all batches
     await expect(stats).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
@@ -17,23 +17,23 @@ test.describe("Table Viewer", () => {
   });
 
   test("renders header labels for all columns", async ({ page }) => {
-    const labels = page.locator(".pt-th-label");
+    const labels = page.locator(".sift-th-label");
     await expect(labels).toHaveCount(12); // id, name, location, department, note, status, priority, score, email, verified, joined, chaos
   });
 
   test("renders header summaries", async ({ page }) => {
     // Wait for all batches so summaries are populated
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
     // At least some summary containers should have content
-    const summaries = page.locator(".pt-th-summary");
+    const summaries = page.locator(".sift-th-summary");
     const count = await summaries.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("scrolls vertically", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
+    const viewport = page.locator(".sift-viewport");
     // Scroll down
     await viewport.evaluate((el) => (el.scrollTop = 5000));
     await page.waitForTimeout(100);
@@ -43,24 +43,24 @@ test.describe("Table Viewer", () => {
   });
 
   test("sorts on column click", async ({ page }) => {
-    // Click the Score header label area to sort (sort handler is on .pt-th-top)
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const scoreLabel = scoreTh.locator(".pt-th-top");
+    // Click the Score header label area to sort (sort handler is on .sift-th-top)
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const scoreLabel = scoreTh.locator(".sift-th-top");
     await scoreLabel.click();
     // Sort arrow should appear
-    await expect(scoreTh.locator(".pt-sort-arrow")).toContainText("↑");
+    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↑");
     // Click again for descending
     await scoreLabel.click();
-    await expect(scoreTh.locator(".pt-sort-arrow")).toContainText("↓");
+    await expect(scoreTh.locator(".sift-sort-arrow")).toContainText("↓");
     // Click again to clear
     await scoreLabel.click();
-    await expect(scoreTh.locator(".pt-sort-arrow")).toHaveText("");
+    await expect(scoreTh.locator(".sift-sort-arrow")).toHaveText("");
   });
 
   test("column resize changes header width", async ({ page }) => {
     // Use the Name column (second) which definitely has a resize handle
-    const nameTh = page.locator(".pt-th").nth(1);
-    const handle = nameTh.locator(".pt-resize-handle");
+    const nameTh = page.locator(".sift-th").nth(1);
+    const handle = nameTh.locator(".sift-resize-handle");
 
     const startWidth = await nameTh.evaluate((el) => el.offsetWidth);
 
@@ -89,13 +89,13 @@ test.describe("Table Viewer", () => {
 
   test("histogram brush creates filter pill", async ({ page }) => {
     // Wait for all data
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
 
     // Find the Score histogram (it has a brush layer SVG)
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const summary = scoreTh.locator(".pt-th-summary");
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const summary = scoreTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) throw new Error("No summary bounding box");
 
@@ -108,23 +108,23 @@ test.describe("Table Viewer", () => {
     await page.mouse.up();
 
     // A filter pill should appear
-    await expect(page.locator(".pt-filter-pill")).toHaveCount(1, {
+    await expect(page.locator(".sift-filter-pill")).toHaveCount(1, {
       timeout: 2000,
     });
-    await expect(page.locator(".pt-filter-pill")).toContainText("Score");
+    await expect(page.locator(".sift-filter-pill")).toContainText("Score");
 
     // Stats should show filtered count
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /of/);
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /of/);
   });
 
   test("filter pill X clears the filter", async ({ page }) => {
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /100,000/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
 
     // Brush the score histogram
-    const scoreTh = page.locator(".pt-th", { hasText: "SCORE" });
-    const summary = scoreTh.locator(".pt-th-summary");
+    const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });
+    const summary = scoreTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) throw new Error("No summary bounding box");
 
@@ -135,29 +135,29 @@ test.describe("Table Viewer", () => {
     });
     await page.mouse.up();
 
-    await expect(page.locator(".pt-filter-pill")).toHaveCount(1, {
+    await expect(page.locator(".sift-filter-pill")).toHaveCount(1, {
       timeout: 2000,
     });
 
     // Click the X on the pill
-    await page.locator(".pt-filter-pill-x").click();
+    await page.locator(".sift-filter-pill-x").click();
 
     // Pill should be gone, all rows restored
-    await expect(page.locator(".pt-filter-pill")).toHaveCount(0);
-    await expect(page.locator(".pt-stat-rows")).not.toHaveAttribute("data-value", /of/);
+    await expect(page.locator(".sift-filter-pill")).toHaveCount(0);
+    await expect(page.locator(".sift-stat-rows")).not.toHaveAttribute("data-value", /of/);
   });
 
   test("boolean badge renders for verified column", async ({ page }) => {
     // Check that at least one boolean badge exists in the visible rows
-    await expect(page.locator(".pt-badge").first()).toBeVisible();
+    await expect(page.locator(".sift-badge").first()).toBeVisible();
   });
 
   test("fullscreen button exists", async ({ page }) => {
-    await expect(page.locator(".pt-fullscreen-btn")).toBeVisible();
+    await expect(page.locator(".sift-fullscreen-btn")).toBeVisible();
   });
 
   test("header scrolls with viewport horizontally", async ({ page }) => {
-    const viewport = page.locator(".pt-viewport");
+    const viewport = page.locator(".sift-viewport");
 
     // Header is inside the viewport scroll content — scrolls naturally
     await viewport.evaluate((el) => (el.scrollLeft = 200));
@@ -170,7 +170,7 @@ test.describe("Table Viewer", () => {
 
   test("streaming: row count increases over time", async ({ page }) => {
     // First batch should be visible quickly
-    const stats = page.locator(".pt-stat-rows");
+    const stats = page.locator(".sift-stat-rows");
     await expect(stats).toHaveAttribute("data-value", /rows/, {
       timeout: 3000,
     });

--- a/packages/sift/e2e/titanic.spec.ts
+++ b/packages/sift/e2e/titanic.spec.ts
@@ -10,37 +10,37 @@ test.describe("Titanic Edge Cases", () => {
 
   test("loads with correct row count", async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
 
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
   });
 
   test("shows null badges in Age column", async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
 
     // Scroll down to find a null age (row 6 — Mr. James Moran)
     // Null badges should be visible somewhere in the visible rows
-    await expect(page.locator(".pt-badge-null").first()).toBeVisible({
+    await expect(page.locator(".sift-badge-null").first()).toBeVisible({
       timeout: 10_000,
     });
   });
 
   test("has mixed column types", async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
 
     // Should have both numeric histograms and categorical bars
-    const histograms = page.locator(".pt-th-range");
-    const catSummaries = page.locator(".pt-cat-summary");
+    const histograms = page.locator(".sift-th-range");
+    const catSummaries = page.locator(".sift-cat-summary");
 
     await expect(histograms.first()).toBeVisible({ timeout: 5_000 });
     await expect(catSummaries.first()).toBeVisible({ timeout: 5_000 });
@@ -48,13 +48,13 @@ test.describe("Titanic Edge Cases", () => {
 
   test("category bars show sex distribution", async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
 
     // Sex column should show male/female distribution
-    const sexBars = page.locator(".pt-cat-row", { hasText: "male" });
+    const sexBars = page.locator(".sift-cat-row", { hasText: "male" });
     await expect(sexBars.first()).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/packages/sift/e2e/wasm-sort.spec.ts
+++ b/packages/sift/e2e/wasm-sort.spec.ts
@@ -11,34 +11,34 @@ test.describe("WASM Sort (Titanic)", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto("/?dataset=titanic");
-    await page.waitForSelector(".pt-table-container", { timeout: 90_000 });
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /891/, {
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /891/, {
       timeout: 30_000,
     });
   });
 
   test("sort by Age ascending shows youngest first", async ({ page }) => {
     // Click the Age column header to sort ascending
-    const ageTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Age$/ }),
+    const ageTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Age$/ }),
     });
-    await ageTh.locator(".pt-th-top").click();
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↑", {
+    await ageTh.locator(".sift-th-top").click();
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↑", {
       timeout: 5000,
     });
 
     // First visible row should have a small age value
     // Titanic has babies (age ~0.42), so first values should be < 1
-    const firstRow = page.locator(".pt-row").first();
+    const firstRow = page.locator(".sift-row").first();
     await expect(firstRow).toBeVisible();
 
     // Get the Age cell value from the first visible row
     // Age is one of the columns — find its index
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const ageColIndex = labels.indexOf("Age");
     expect(ageColIndex).toBeGreaterThan(-1);
 
-    const ageCell = firstRow.locator(".pt-cell").nth(ageColIndex);
+    const ageCell = firstRow.locator(".sift-cell").nth(ageColIndex);
     const ageText = await ageCell.textContent();
     const ageValue = parseFloat(ageText || "999");
     // Youngest passengers are infants (< 1 year)
@@ -46,26 +46,26 @@ test.describe("WASM Sort (Titanic)", () => {
   });
 
   test("sort by Age descending shows oldest first", async ({ page }) => {
-    const ageTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Age$/ }),
+    const ageTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Age$/ }),
     });
     // Click twice for descending
-    await ageTh.locator(".pt-th-top").click();
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↑", {
+    await ageTh.locator(".sift-th-top").click();
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↑", {
       timeout: 5000,
     });
-    await ageTh.locator(".pt-th-top").click();
-    await expect(ageTh.locator(".pt-sort-arrow")).toContainText("↓", {
+    await ageTh.locator(".sift-th-top").click();
+    await expect(ageTh.locator(".sift-sort-arrow")).toContainText("↓", {
       timeout: 5000,
     });
     // Wait for rows to re-render with new sort order
     await page.waitForTimeout(500);
 
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const ageColIndex = labels.indexOf("Age");
 
-    const firstRow = page.locator(".pt-row").first();
-    const ageCell = firstRow.locator(".pt-cell").nth(ageColIndex);
+    const firstRow = page.locator(".sift-row").first();
+    const ageCell = firstRow.locator(".sift-cell").nth(ageColIndex);
     const ageText = await ageCell.textContent();
     const ageValue = parseFloat(ageText || "0");
     // Oldest passenger is 80
@@ -73,19 +73,19 @@ test.describe("WASM Sort (Titanic)", () => {
   });
 
   test("sort by Fare ascending shows cheapest first", async ({ page }) => {
-    const fareTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Fare$/ }),
+    const fareTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Fare$/ }),
     });
-    await fareTh.locator(".pt-th-top").click();
-    await expect(fareTh.locator(".pt-sort-arrow")).toContainText("↑", {
+    await fareTh.locator(".sift-th-top").click();
+    await expect(fareTh.locator(".sift-sort-arrow")).toContainText("↑", {
       timeout: 5000,
     });
 
-    const labels = await page.locator(".pt-th-label").allTextContents();
+    const labels = await page.locator(".sift-th-label").allTextContents();
     const fareColIndex = labels.indexOf("Fare");
 
-    const firstRow = page.locator(".pt-row").first();
-    const fareCell = firstRow.locator(".pt-cell").nth(fareColIndex);
+    const firstRow = page.locator(".sift-row").first();
+    const fareCell = firstRow.locator(".sift-cell").nth(fareColIndex);
     const fareText = await fareCell.textContent();
     const fareValue = parseFloat(fareText || "999");
     // Cheapest fares are 0
@@ -94,10 +94,10 @@ test.describe("WASM Sort (Titanic)", () => {
 
   test("sort + filter: sorted results respect active filter", async ({ page }) => {
     // First, apply a filter on Age histogram (brush to select a range)
-    const ageTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Age$/ }),
+    const ageTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Age$/ }),
     });
-    const summary = ageTh.locator(".pt-th-summary");
+    const summary = ageTh.locator(".sift-th-summary");
     const box = await summary.boundingBox();
     if (!box) throw new Error("No Age summary bounding box");
 
@@ -111,22 +111,22 @@ test.describe("WASM Sort (Titanic)", () => {
     await page.waitForTimeout(500);
 
     // Should show filtered count
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /of/, {
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /of/, {
       timeout: 5000,
     });
 
     // Now sort by Fare
-    const fareTh = page.locator(".pt-th").filter({
-      has: page.locator(".pt-th-label", { hasText: /^Fare$/ }),
+    const fareTh = page.locator(".sift-th").filter({
+      has: page.locator(".sift-th-label", { hasText: /^Fare$/ }),
     });
-    await fareTh.locator(".pt-th-top").click();
-    await expect(fareTh.locator(".pt-sort-arrow")).toContainText("↑", {
+    await fareTh.locator(".sift-th-top").click();
+    await expect(fareTh.locator(".sift-sort-arrow")).toContainText("↑", {
       timeout: 5000,
     });
 
     // Filtered count should still be shown (filter still active)
-    await expect(page.locator(".pt-stat-rows")).toHaveAttribute("data-value", /of/);
+    await expect(page.locator(".sift-stat-rows")).toHaveAttribute("data-value", /of/);
     // Filter pill should still be visible
-    await expect(page.locator(".pt-filter-pill")).toHaveCount(1);
+    await expect(page.locator(".sift-filter-pill")).toHaveCount(1);
   });
 });

--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -81,7 +81,7 @@ function boot() {
         return load$.pipe(
           catchError((err) => {
             console.error("Failed to load dataset:", err);
-            tableRoot.innerHTML = `<div class="pt-loading">
+            tableRoot.innerHTML = `<div class="sift-loading">
             Failed to load dataset: ${err instanceof Error ? err.message : String(err)}
           </div>`;
             return EMPTY;
@@ -100,12 +100,12 @@ function renderShell(app: HTMLElement) {
   const dataset = DATASETS.find((d) => d.id === currentDatasetId) ?? DATASETS[0];
 
   app.innerHTML = `
-    <div class="pt-page">
-      <div class="pt-intro">
-        <p class="pt-eyebrow">Pretext × Arrow × Semiotic</p>
-        <div class="pt-intro-row">
+    <div class="sift-page">
+      <div class="sift-intro">
+        <p class="sift-eyebrow">Pretext × Arrow × Semiotic</p>
+        <div class="sift-intro-row">
           <h1>Sift</h1>
-          <div class="pt-dataset-picker">
+          <div class="sift-dataset-picker">
             <select id="dataset-select">
               ${DATASETS.map(
                 (d) => `
@@ -116,13 +116,13 @@ function renderShell(app: HTMLElement) {
               ).join("")}
             </select>
           </div>
-          <button class="pt-theme-toggle" id="theme-toggle" title="Toggle dark mode">◑</button>
-          <a href="https://github.com/rgbkrk/sift" class="pt-github-btn" target="_blank" rel="noopener">
+          <button class="sift-theme-toggle" id="theme-toggle" title="Toggle dark mode">◑</button>
+          <a href="https://github.com/rgbkrk/sift" class="sift-github-btn" target="_blank" rel="noopener">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             Star on GitHub
           </a>
         </div>
-        <p class="pt-subtitle" id="dataset-description">${dataset.description}</p>
+        <p class="sift-subtitle" id="dataset-description">${dataset.description}</p>
       </div>
       <div id="table-root"></div>
     </div>
@@ -179,7 +179,7 @@ function loadLocalArrow$(dataset: DatasetEntry, tableRoot: HTMLElement): Observa
           const response = await fetch(`${import.meta.env.BASE_URL}${dataset.path}`);
           if (!response.ok) {
             tableRoot.innerHTML =
-              '<div class="pt-loading">Missing data.arrow — run <code>npm run generate</code> first.</div>';
+              '<div class="sift-loading">Missing data.arrow — run <code>npm run generate</code> first.</div>';
             subscriber.complete();
             return;
           }
@@ -272,7 +272,7 @@ async function loadLocalArrowJs$(
   const firstResult = await reader.next();
   if (isCancelled()) return;
   if (firstResult.done) {
-    tableRoot.innerHTML = '<div class="pt-loading">No data in Arrow file.</div>';
+    tableRoot.innerHTML = '<div class="sift-loading">No data in Arrow file.</div>';
     subscriber.complete();
     return;
   }
@@ -555,22 +555,22 @@ function updateWasmSummaries(
 }
 
 function renderLoadingSkeleton(tableRoot: HTMLElement, status: string) {
-  const existing = tableRoot.querySelector(".pt-skeleton");
+  const existing = tableRoot.querySelector(".sift-skeleton");
   if (existing) {
-    const statusEl = existing.querySelector(".pt-skeleton-status");
+    const statusEl = existing.querySelector(".sift-skeleton-status");
     if (statusEl) statusEl.textContent = status;
     return;
   }
   tableRoot.innerHTML = `
-    <div class="pt-skeleton">
-      <div class="pt-skeleton-header">
-        ${Array.from({ length: 6 }, () => '<div class="pt-skeleton-th"><div class="pt-skeleton-bar pt-skeleton-label"></div><div class="pt-skeleton-bar pt-skeleton-chart"></div></div>').join("")}
+    <div class="sift-skeleton">
+      <div class="sift-skeleton-header">
+        ${Array.from({ length: 6 }, () => '<div class="sift-skeleton-th"><div class="sift-skeleton-bar sift-skeleton-label"></div><div class="sift-skeleton-bar sift-skeleton-chart"></div></div>').join("")}
       </div>
-      <div class="pt-skeleton-body">
-        ${Array.from({ length: 12 }, () => `<div class="pt-skeleton-row">${Array.from({ length: 6 }, () => '<div class="pt-skeleton-cell"><div class="pt-skeleton-bar pt-skeleton-text"></div></div>').join("")}</div>`).join("")}
+      <div class="sift-skeleton-body">
+        ${Array.from({ length: 12 }, () => `<div class="sift-skeleton-row">${Array.from({ length: 6 }, () => '<div class="sift-skeleton-cell"><div class="sift-skeleton-bar sift-skeleton-text"></div></div>').join("")}</div>`).join("")}
       </div>
-      <div class="pt-skeleton-footer">
-        <span class="pt-skeleton-status">${status}</span>
+      <div class="sift-skeleton-footer">
+        <span class="sift-skeleton-status">${status}</span>
       </div>
     </div>
   `;

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -64,9 +64,9 @@ describe("SiftTable", () => {
     const { container } = render(<SiftTable data={data} />);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(container.querySelector(".pt-table-container")).not.toBeNull();
-    expect(container.querySelector(".pt-header")).not.toBeNull();
-    expect(container.querySelector(".pt-viewport")).not.toBeNull();
+    expect(container.querySelector(".sift-table-container")).not.toBeNull();
+    expect(container.querySelector(".sift-header")).not.toBeNull();
+    expect(container.querySelector(".sift-viewport")).not.toBeNull();
   });
 
   it("renders correct header labels from data", async () => {
@@ -76,7 +76,7 @@ describe("SiftTable", () => {
     const { container } = render(<SiftTable data={data} />);
     await vi.advanceTimersByTimeAsync(0);
 
-    const labels = container.querySelectorAll(".pt-th-label");
+    const labels = container.querySelectorAll(".sift-th-label");
     expect(labels).toHaveLength(3);
     expect(labels[0].textContent).toBe("ID");
     expect(labels[1].textContent).toBe("Name");
@@ -90,7 +90,7 @@ describe("SiftTable", () => {
     const { container } = render(<SiftTable data={data} />);
     await vi.advanceTimersByTimeAsync(0);
 
-    const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+    const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
     expect(stats?.dataset.value).toContain("25");
   });
 
@@ -104,7 +104,7 @@ describe("SiftTable", () => {
 
     // The engine is mounted — we can interact via the DOM
     // The onChange should be wired up; we test by verifying the container has content
-    expect(container.querySelector(".pt-table-container")).not.toBeNull();
+    expect(container.querySelector(".sift-table-container")).not.toBeNull();
   });
 
   it("cleans up engine on unmount", async () => {
@@ -114,7 +114,7 @@ describe("SiftTable", () => {
     const { container, unmount } = render(<SiftTable data={data} />);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(container.querySelector(".pt-table-container")).not.toBeNull();
+    expect(container.querySelector(".sift-table-container")).not.toBeNull();
 
     unmount();
 
@@ -130,7 +130,7 @@ describe("SiftTable", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     // No loading indicator — engine handles its own skeleton
-    expect(container.querySelector(".pt-loading")).toBeNull();
+    expect(container.querySelector(".sift-loading")).toBeNull();
 
     vi.unstubAllGlobals();
   });
@@ -146,7 +146,7 @@ describe("SiftTable", () => {
     // Wait for the async fetch to resolve and state to update
     await new Promise((r) => setTimeout(r, 50));
 
-    const loading = container.querySelector(".pt-loading");
+    const loading = container.querySelector(".sift-loading");
     expect(loading?.textContent).toContain("404");
 
     vi.unstubAllGlobals();

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -492,7 +492,7 @@ export function SiftTable({
 
   return (
     <div ref={containerRef} className={className} style={{ height: "100%", ...style }}>
-      {status === "error" && error && <div className="pt-loading">Error: {error}</div>}
+      {status === "error" && error && <div className="sift-loading">Error: {error}</div>}
     </div>
   );
 }

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -104,7 +104,7 @@ function BrushLayer({
     const x = Math.min(brushState.startX, brushState.currentX);
     const w = Math.abs(brushState.currentX - brushState.startX);
     brushRect = (
-      <rect x={x} y={0} width={w} height={CHART_HEIGHT} fill="var(--accent)" opacity={0.2} />
+      <rect x={x} y={0} width={w} height={CHART_HEIGHT} fill="var(--sift-accent)" opacity={0.2} />
     );
   } else if (activeFilter) {
     const x = valueToX(activeFilter.min);
@@ -115,7 +115,7 @@ function BrushLayer({
         y={0}
         width={w}
         height={CHART_HEIGHT}
-        fill="var(--accent)"
+        fill="var(--sift-accent)"
         opacity={0.15}
         rx={2}
       />
@@ -362,9 +362,11 @@ function NumericHistogram({
   const numBins = summary.bins.length;
   const gap = 1;
   const barW = Math.max(1, (width - (numBins - 1) * gap) / numBins);
-  const baseFill = hasOverlay ? "rgba(149, 95, 59, 0.2)" : "rgba(149, 95, 59, 0.7)";
-  const dimFill = "rgba(149, 95, 59, 0.12)";
-  const activeFill = "rgba(149, 95, 59, 0.7)";
+  const baseFill = hasOverlay
+    ? "color-mix(in srgb, var(--sift-accent) 20%, transparent)"
+    : "color-mix(in srgb, var(--sift-accent) 70%, transparent)";
+  const dimFill = "color-mix(in srgb, var(--sift-accent) 12%, transparent)";
+  const activeFill = "color-mix(in srgb, var(--sift-accent) 70%, transparent)";
 
   return (
     <div>
@@ -479,7 +481,7 @@ function VisibleOverlay({
             y={CHART_HEIGHT - h}
             width={barW}
             height={h}
-            fill="var(--accent)"
+            fill="var(--sift-accent)"
             opacity={0.85}
           />
         );
@@ -834,9 +836,11 @@ function TimestampHistogram({
   const maxCount = Math.max(...summary.bins.map((b) => b.count));
   const numBins = summary.bins.length;
   const barW = width / numBins;
-  const baseFill = hasOverlay ? "rgba(149, 95, 59, 0.18)" : "rgba(149, 95, 59, 0.55)";
-  const dimFill = "rgba(149, 95, 59, 0.1)";
-  const activeFill = "rgba(149, 95, 59, 0.55)";
+  const baseFill = hasOverlay
+    ? "color-mix(in srgb, var(--sift-accent) 18%, transparent)"
+    : "color-mix(in srgb, var(--sift-accent) 55%, transparent)";
+  const dimFill = "color-mix(in srgb, var(--sift-accent) 10%, transparent)";
+  const activeFill = "color-mix(in srgb, var(--sift-accent) 55%, transparent)";
 
   // Compute bin boundaries from the linear range
   const binSpan = (summary.max - summary.min) / numBins;

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -180,10 +180,10 @@ function BinaryNumericRatioBar({
     !activeFilter || (highBin.x1 > activeFilter.min && highBin.x0 < activeFilter.max);
 
   return (
-    <div className="pt-bool-summary">
-      <div className="pt-bool-bar">
+    <div className="sift-bool-summary">
+      <div className="sift-bool-bar">
         <div
-          className="pt-bool-true pt-bool-clickable"
+          className="sift-bool-true sift-bool-clickable"
           style={{
             width: `${lowPct}%`,
             opacity: activeFilter && !lowActive ? 0.3 : 1,
@@ -197,7 +197,7 @@ function BinaryNumericRatioBar({
           }}
         />
         <div
-          className="pt-bool-false pt-bool-clickable"
+          className="sift-bool-false sift-bool-clickable"
           style={{
             width: `${highPct}%`,
             opacity: activeFilter && !highActive ? 0.3 : 1,
@@ -215,12 +215,12 @@ function BinaryNumericRatioBar({
           }}
         />
       </div>
-      <div className="pt-bool-labels">
+      <div className="sift-bool-labels">
         <span>
-          <strong>{lowLabel}</strong> <span className="pt-pct">{lowPct}%</span>
+          <strong>{lowLabel}</strong> <span className="sift-pct">{lowPct}%</span>
         </span>
         <span>
-          <strong>{highLabel}</strong> <span className="pt-pct">{highPct}%</span>
+          <strong>{highLabel}</strong> <span className="sift-pct">{highPct}%</span>
         </span>
       </div>
     </div>
@@ -232,8 +232,8 @@ function BinaryNumericRatioBar({
 /** Renders a simple unique count for high-cardinality columns with long text. */
 function HighCardinalityText({ summary }: { summary: CategoricalColumnSummary }) {
   return (
-    <div className="pt-cat-summary">
-      <span className="pt-th-range">{summary.uniqueCount.toLocaleString()} unique values</span>
+    <div className="sift-cat-summary">
+      <span className="sift-th-range">{summary.uniqueCount.toLocaleString()} unique values</span>
     </div>
   );
 }
@@ -268,7 +268,7 @@ function LowCardinalityNumericBars({
   }));
 
   return (
-    <div className="pt-cat-summary">
+    <div className="sift-cat-summary">
       {items.map((item) => {
         // Highlight bar if its range overlaps the active range filter
         const isActive =
@@ -276,7 +276,7 @@ function LowCardinalityNumericBars({
         return (
           <div
             key={item.label}
-            className="pt-cat-row pt-cat-clickable"
+            className="sift-cat-row sift-cat-clickable"
             style={{ opacity: activeFilter && !isActive ? 0.3 : 1 }}
             onClick={() => {
               if (activeFilter && activeFilter.min === item.x0 && activeFilter.max === item.x1) {
@@ -286,11 +286,11 @@ function LowCardinalityNumericBars({
               }
             }}
           >
-            <div className="pt-cat-bar-track">
-              <div className="pt-cat-bar-fill" style={{ width: `${item.pct}%` }} />
+            <div className="sift-cat-bar-track">
+              <div className="sift-cat-bar-fill" style={{ width: `${item.pct}%` }} />
             </div>
-            <span className="pt-cat-label">{item.label}</span>
-            <span className="pt-cat-pct">{item.pct}%</span>
+            <span className="sift-cat-label">{item.label}</span>
+            <span className="sift-cat-pct">{item.pct}%</span>
           </div>
         );
       })}
@@ -319,7 +319,7 @@ function NumericHistogram({
   if (summary.isIndex) {
     return (
       <div>
-        <span className="pt-th-range">
+        <span className="sift-th-range">
           {formatNum(summary.min)} – {formatNum(summary.max)}
         </span>
       </div>
@@ -418,7 +418,7 @@ function NumericHistogram({
         Number.isInteger(summary.max) &&
         summary.max - summary.min <= 1
       ) && (
-        <span className="pt-th-range">
+        <span className="sift-th-range">
           {formatNum(summary.min)} – {formatNum(summary.max)}
         </span>
       )}
@@ -444,7 +444,7 @@ function NumericProfile({ summary }: { summary: NumericColumnSummary }) {
   }
   if (parts.length === 0) return null;
 
-  return <span className="pt-th-profile">{parts.join(" · ")}</span>;
+  return <span className="sift-th-profile">{parts.join(" · ")}</span>;
 }
 
 function VisibleOverlay({
@@ -563,10 +563,10 @@ function CategoryPopoverContent({
   }
 
   return (
-    <div className="pt-cat-popover">
+    <div className="sift-cat-popover">
       <input
         ref={inputRef}
-        className="pt-cat-popover-search"
+        className="sift-cat-popover-search"
         type="text"
         placeholder={`Search ${allCategories.length} values…`}
         value={searchInput}
@@ -575,18 +575,18 @@ function CategoryPopoverContent({
           setScrollTop(0);
         }}
       />
-      <div className="pt-cat-popover-actions">
-        <button onClick={selectAll} className="pt-cat-popover-btn">
+      <div className="sift-cat-popover-actions">
+        <button onClick={selectAll} className="sift-cat-popover-btn">
           All
         </button>
-        <button onClick={clearAll} className="pt-cat-popover-btn">
+        <button onClick={clearAll} className="sift-cat-popover-btn">
           None
         </button>
-        <span className="pt-cat-popover-count">{selectedCount} selected</span>
+        <span className="sift-cat-popover-count">{selectedCount} selected</span>
       </div>
       <div
         ref={listRef}
-        className="pt-cat-popover-list"
+        className="sift-cat-popover-list"
         style={{
           height: Math.min(filtered.length, visibleCount) * POPOVER_ROW_HEIGHT,
         }}
@@ -601,7 +601,7 @@ function CategoryPopoverContent({
             return (
               <label
                 key={cat.label}
-                className="pt-cat-popover-row"
+                className="sift-cat-popover-row"
                 style={{
                   position: "absolute",
                   top: idx * POPOVER_ROW_HEIGHT,
@@ -614,16 +614,16 @@ function CategoryPopoverContent({
                   type="checkbox"
                   checked={checked}
                   onChange={() => toggleItem(cat.label)}
-                  className="pt-cat-popover-check"
+                  className="sift-cat-popover-check"
                 />
-                <span className="pt-cat-popover-label">{cat.label}</span>
-                <span className="pt-cat-popover-pct">{cat.pct}%</span>
+                <span className="sift-cat-popover-label">{cat.label}</span>
+                <span className="sift-cat-popover-pct">{cat.pct}%</span>
               </label>
             );
           })}
         </div>
       </div>
-      {filtered.length === 0 && <div className="pt-cat-popover-empty">No matches</div>}
+      {filtered.length === 0 && <div className="sift-cat-popover-empty">No matches</div>}
     </div>
   );
 }
@@ -662,13 +662,13 @@ function CategoricalBars({
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <div className="pt-cat-summary">
+      <div className="sift-cat-summary">
         {items.map((item) => {
           const isActive = activeSet ? activeSet.has(item.label) : true;
           const row = (
             <div
               key={item.label}
-              className={`pt-cat-row pt-cat-clickable`}
+              className={`sift-cat-row sift-cat-clickable`}
               style={{
                 opacity: activeSet && !isActive && !item.isOthers ? 0.3 : 1,
               }}
@@ -688,13 +688,13 @@ function CategoricalBars({
                     }
               }
             >
-              <div className="pt-cat-bar-track">
-                <div className="pt-cat-bar-fill" style={{ width: `${item.pct}%` }} />
+              <div className="sift-cat-bar-track">
+                <div className="sift-cat-bar-fill" style={{ width: `${item.pct}%` }} />
               </div>
-              <span className="pt-cat-label">
+              <span className="sift-cat-label">
                 {item.isOthers ? item.label + " ▾" : truncate(item.label, 16)}
               </span>
-              <span className="pt-cat-pct">{item.pct}%</span>
+              <span className="sift-cat-pct">{item.pct}%</span>
             </div>
           );
           if (item.isOthers) {
@@ -737,10 +737,10 @@ function BooleanRatioBar({
   const hasNulls = summary.nullCount > 0;
 
   return (
-    <div className="pt-bool-summary">
-      <div className="pt-bool-bar">
+    <div className="sift-bool-summary">
+      <div className="sift-bool-bar">
         <div
-          className="pt-bool-true pt-bool-clickable"
+          className="sift-bool-true sift-bool-clickable"
           style={{
             width: `${truePct}%`,
             opacity: activeValue === false ? 0.3 : 1,
@@ -748,7 +748,7 @@ function BooleanRatioBar({
           onClick={() => onFilter(activeValue === true ? null : { kind: "boolean", value: true })}
         />
         <div
-          className="pt-bool-false pt-bool-clickable"
+          className="sift-bool-false sift-bool-clickable"
           style={{
             width: `${falsePct}%`,
             opacity: activeValue === true ? 0.3 : 1,
@@ -757,15 +757,15 @@ function BooleanRatioBar({
         />
         {hasNulls && (
           <div
-            className="pt-bool-null"
+            className="sift-bool-null"
             style={{ width: `${nullPct}%` }}
             title={`${summary.nullCount} null values`}
           />
         )}
       </div>
-      <div className="pt-bool-labels">
+      <div className="sift-bool-labels">
         <span>Yes {nonNull > 0 ? truePct.toFixed(0) : 0}%</span>
-        {hasNulls && <span className="pt-bool-null-label">{nullPct.toFixed(0)}% null</span>}
+        {hasNulls && <span className="sift-bool-null-label">{nullPct.toFixed(0)}% null</span>}
         <span>No {nonNull > 0 ? falsePct.toFixed(0) : 0}%</span>
       </div>
     </div>
@@ -889,7 +889,7 @@ function TimestampHistogram({
           onFilter={onFilter}
         />
       </div>
-      <span className="pt-th-range">
+      <span className="sift-th-range">
         {minLabel} – {maxLabel}
       </span>
     </div>

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1,53 +1,15 @@
 @import "tailwindcss";
+@import "./themes/cream.css";
 
 * {
   box-sizing: border-box;
 }
 
-:root {
-  color-scheme: light;
-  --page: #f5f2ec;
-  --panel: #fffdf9;
-  --ink: #1e1a18;
-  --muted: #6e655f;
-  --rule: #d8cec3;
-  --accent: #955f3b;
-  --row-alt: rgba(0, 0, 0, 0.018);
-  --pin-shadow: rgba(0, 0, 0, 0.06);
-  --font: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    color-scheme: dark;
-    --page: #1a1816;
-    --panel: #242120;
-    --ink: #e8e2dc;
-    --muted: #9a918a;
-    --rule: #3a3533;
-    --accent: #d4896a;
-    --row-alt: rgba(255, 255, 255, 0.025);
-    --pin-shadow: rgba(255, 255, 255, 0.08);
-  }
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --page: #1a1816;
-  --panel: #242120;
-  --ink: #e8e2dc;
-  --muted: #9a918a;
-  --rule: #3a3533;
-  --accent: #d4896a;
-  --row-alt: rgba(255, 255, 255, 0.025);
-  --pin-shadow: rgba(255, 255, 255, 0.08);
-}
-
 body {
   margin: 0;
-  background: var(--page);
-  color: var(--ink);
-  font-family: var(--font);
+  background: var(--sift-page);
+  color: var(--sift-ink);
+  font-family: var(--sift-font);
 }
 
 /* --- Page layout --- */
@@ -78,7 +40,7 @@ body {
     monospace;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--accent);
+  color: var(--sift-accent);
 }
 
 h1 {
@@ -87,18 +49,18 @@ h1 {
     700 30px/1.08 Georgia,
     "Times New Roman",
     serif;
-  color: var(--ink);
+  color: var(--sift-ink);
 }
 
 .sift-subtitle {
   margin: 10px 0 0;
   max-width: 72ch;
   line-height: 1.45;
-  color: var(--muted);
+  color: var(--sift-muted);
 }
 
 .sift-subtitle a {
-  color: var(--accent);
+  color: var(--sift-accent);
   text-decoration: none;
 }
 
@@ -116,12 +78,12 @@ h1 {
 }
 
 .sift-dataset-picker select {
-  font: 13px/1.3 var(--font);
+  font: 13px/1.3 var(--sift-font);
   padding: 4px 24px 4px 10px;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 8px;
-  background: var(--panel);
-  color: var(--ink);
+  background: var(--sift-panel);
+  color: var(--sift-ink);
   cursor: pointer;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%236e655f' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
@@ -130,11 +92,11 @@ h1 {
 }
 
 .sift-dataset-picker select:hover {
-  border-color: var(--muted);
+  border-color: var(--sift-muted);
 }
 
 .sift-dataset-picker select:focus {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--sift-accent);
   outline-offset: 1px;
 }
 
@@ -142,11 +104,11 @@ h1 {
 
 .sift-theme-toggle {
   background: none;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 8px;
   padding: 4px 10px;
-  font: 14px/1.3 var(--font);
-  color: var(--muted);
+  font: 14px/1.3 var(--sift-font);
+  color: var(--sift-muted);
   cursor: pointer;
   align-self: center;
   transition:
@@ -155,17 +117,17 @@ h1 {
 }
 
 .sift-theme-toggle:hover {
-  color: var(--ink);
-  border-color: var(--muted);
+  color: var(--sift-ink);
+  border-color: var(--sift-muted);
 }
 
 .sift-github-btn {
   background: none;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 8px;
   padding: 4px 10px;
-  font: 14px/1.3 var(--font);
-  color: var(--muted);
+  font: 14px/1.3 var(--sift-font);
+  color: var(--sift-muted);
   cursor: pointer;
   text-decoration: none;
   display: inline-flex;
@@ -182,20 +144,20 @@ h1 {
 }
 
 .sift-github-btn:hover {
-  color: var(--ink);
-  border-color: var(--muted);
+  color: var(--sift-ink);
+  border-color: var(--sift-muted);
 }
 
 .sift-loading {
   padding: 80px 20px;
   text-align: center;
-  color: var(--muted);
+  color: var(--sift-muted);
   font-size: 18px;
 }
 
 .sift-loading code {
   font-family: "SF Mono", ui-monospace, monospace;
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--sift-loading-code-bg);
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -203,9 +165,9 @@ h1 {
 /* --- Table container --- */
 
 .sift-table-container {
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 18px;
-  background: var(--panel);
+  background: var(--sift-panel);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -225,7 +187,7 @@ h1 {
 .sift-progress-bar-fill {
   height: 100%;
   width: 30%;
-  background: var(--accent);
+  background: var(--sift-accent);
   border-radius: 1px;
   animation: sift-progress-slide 1.2s ease-in-out infinite;
 }
@@ -249,8 +211,8 @@ h1 {
   position: sticky;
   top: 0;
   z-index: 5;
-  border-bottom: 1px solid var(--rule);
-  background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
+  border-bottom: 1px solid var(--sift-rule);
+  background: color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%);
 }
 
 .sift-header-row {
@@ -261,11 +223,11 @@ h1 {
   flex-shrink: 0;
   position: relative;
   padding: 8px 12px;
-  font: 600 12px/1.2 var(--font);
+  font: 600 12px/1.2 var(--sift-font);
   text-align: left;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--muted);
+  color: var(--sift-muted);
   user-select: none;
   display: flex;
   flex-direction: column;
@@ -274,7 +236,7 @@ h1 {
 }
 
 .sift-th:hover {
-  color: var(--ink);
+  color: var(--sift-ink);
 }
 
 .sift-th-top {
@@ -287,8 +249,8 @@ h1 {
   position: absolute;
   top: 8px;
   right: 12px;
-  font: 400 10px/1 var(--font);
-  color: var(--muted);
+  font: 400 10px/1 var(--sift-font);
+  color: var(--sift-muted);
   opacity: 0.4;
   text-transform: none;
   letter-spacing: normal;
@@ -296,8 +258,8 @@ h1 {
 }
 
 .sift-filter-line {
-  font: 400 10px/1.2 var(--font);
-  color: var(--accent);
+  font: 400 10px/1.2 var(--sift-font);
+  color: var(--sift-accent);
   text-transform: none;
   letter-spacing: normal;
   font-style: italic;
@@ -314,7 +276,7 @@ h1 {
 
 .sift-sort-arrow {
   font-size: 11px;
-  color: var(--accent);
+  color: var(--sift-accent);
 }
 
 /* --- Column summary charts --- */
@@ -324,11 +286,11 @@ h1 {
   overflow: hidden;
   animation: summary-fade-in 300ms ease-out;
   --semiotic-bg: transparent;
-  --semiotic-text: var(--muted);
-  --semiotic-text-secondary: var(--muted);
+  --semiotic-text: var(--sift-muted);
+  --semiotic-text-secondary: var(--sift-muted);
   --semiotic-border: transparent;
   --semiotic-grid: transparent;
-  --semiotic-primary: var(--accent);
+  --semiotic-primary: var(--sift-accent);
 }
 
 .sift-th-summary svg,
@@ -355,8 +317,8 @@ h1 {
 .sift-th-range {
   display: block;
   margin-top: 2px;
-  font: 400 10px/1.2 var(--font);
-  color: var(--muted);
+  font: 400 10px/1.2 var(--sift-font);
+  color: var(--sift-muted);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -364,8 +326,8 @@ h1 {
 .sift-th-profile {
   display: block;
   margin-top: 1px;
-  font: 400 9px/1.2 var(--font);
-  color: color-mix(in srgb, var(--muted) 70%, transparent);
+  font: 400 9px/1.2 var(--sift-font);
+  color: color-mix(in srgb, var(--sift-muted) 70%, transparent);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -380,10 +342,10 @@ h1 {
   display: flex;
   align-items: center;
   gap: 4px;
-  font: 400 10px/1.2 var(--font);
+  font: 400 10px/1.2 var(--sift-font);
   text-transform: none;
   letter-spacing: normal;
-  color: var(--muted);
+  color: var(--sift-muted);
   overflow: hidden;
   white-space: nowrap;
   transition: opacity 150ms ease-out;
@@ -392,7 +354,7 @@ h1 {
 .sift-cat-bar-track {
   flex: 1;
   height: 8px;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--sift-cat-bar-track);
   border-radius: 2px;
   overflow: hidden;
   min-width: 20px;
@@ -400,7 +362,7 @@ h1 {
 
 .sift-cat-bar-fill {
   height: 100%;
-  background: var(--accent);
+  background: var(--sift-accent);
   border-radius: 2px;
   min-width: 2px;
   transition: width 200ms ease-out;
@@ -441,20 +403,20 @@ h1 {
 .sift-cat-popover-search {
   margin: 8px 8px 0;
   padding: 6px 10px;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 6px;
-  background: var(--page);
-  color: var(--ink);
-  font: 13px/1.3 var(--font);
+  background: var(--sift-page);
+  color: var(--sift-ink);
+  font: 13px/1.3 var(--sift-font);
   outline: none;
 }
 
 .sift-cat-popover-search:focus {
-  border-color: var(--accent);
+  border-color: var(--sift-accent);
 }
 
 .sift-cat-popover-search::placeholder {
-  color: var(--muted);
+  color: var(--sift-muted);
 }
 
 .sift-cat-popover-actions {
@@ -462,22 +424,22 @@ h1 {
   align-items: center;
   gap: 6px;
   padding: 6px 8px 4px;
-  font: 11px/1.2 var(--font);
-  color: var(--muted);
+  font: 11px/1.2 var(--sift-font);
+  color: var(--sift-muted);
 }
 
 .sift-cat-popover-btn {
   background: none;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 4px;
   padding: 2px 8px;
-  font: 11px/1.3 var(--font);
-  color: var(--accent);
+  font: 11px/1.3 var(--sift-font);
+  color: var(--sift-accent);
   cursor: pointer;
 }
 
 .sift-cat-popover-btn:hover {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--sift-accent) 8%, transparent);
 }
 
 .sift-cat-popover-count {
@@ -487,7 +449,7 @@ h1 {
 .sift-cat-popover-list {
   overflow-y: auto;
   overflow-x: hidden;
-  border-top: 1px solid var(--rule);
+  border-top: 1px solid var(--sift-rule);
 }
 
 .sift-cat-popover-row {
@@ -495,19 +457,19 @@ h1 {
   align-items: center;
   gap: 6px;
   padding: 0 10px;
-  font: 13px/1.3 var(--font);
-  color: var(--ink);
+  font: 13px/1.3 var(--sift-font);
+  color: var(--sift-ink);
   cursor: pointer;
   user-select: none;
 }
 
 .sift-cat-popover-row:hover {
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  background: color-mix(in srgb, var(--sift-accent) 6%, transparent);
 }
 
 .sift-cat-popover-check {
   flex-shrink: 0;
-  accent-color: var(--accent);
+  accent-color: var(--sift-accent);
 }
 
 .sift-cat-popover-label {
@@ -521,8 +483,8 @@ h1 {
 
 .sift-cat-popover-pct {
   flex-shrink: 0;
-  font: 11px/1.2 var(--font);
-  color: var(--muted);
+  font: 11px/1.2 var(--sift-font);
+  color: var(--sift-muted);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -530,8 +492,8 @@ h1 {
 .sift-cat-popover-empty {
   padding: 12px;
   text-align: center;
-  font: 13px/1.3 var(--font);
-  color: var(--muted);
+  font: 13px/1.3 var(--sift-font);
+  color: var(--sift-muted);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -556,13 +518,13 @@ h1 {
   width: 2px;
   height: 60%;
   border-radius: 1px;
-  background: var(--rule);
+  background: var(--sift-rule);
   transition: background 120ms ease;
 }
 
 .sift-resize-handle:hover::after,
 .sift-resize-handle.dragging::after {
-  background: var(--accent);
+  background: var(--sift-accent);
 }
 
 /* --- Virtual scroll viewport --- */
@@ -595,17 +557,17 @@ h1 {
   left: 0;
   display: flex;
   width: max-content;
-  border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--sift-rule) 40%, transparent);
 }
 
 .sift-row-alt {
-  background: var(--row-alt);
+  background: var(--sift-row-alt);
 }
 
 .sift-cell {
   flex-shrink: 0;
   padding: 8px 12px;
-  font: 14px/20px var(--font);
+  font: 14px/20px var(--sift-font);
   overflow: hidden;
   word-wrap: break-word;
   overflow-wrap: break-word;
@@ -617,20 +579,20 @@ h1 {
   position: sticky;
   left: 0;
   z-index: 1;
-  background: var(--panel);
-  box-shadow: 2px 0 4px var(--pin-shadow);
+  background: var(--sift-panel);
+  box-shadow: 2px 0 4px var(--sift-pin-shadow);
 }
 
 .sift-row-alt .sift-cell:first-child {
-  background: color-mix(in srgb, var(--panel) 97%, var(--page));
+  background: color-mix(in srgb, var(--sift-panel) 97%, var(--sift-page));
 }
 
 .sift-th:first-child {
   position: sticky;
   left: 0;
   z-index: 3;
-  background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
-  box-shadow: 2px 0 4px var(--pin-shadow);
+  background: color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%);
+  box-shadow: 2px 0 4px var(--sift-pin-shadow);
 }
 
 /* --- Type-aware cells --- */
@@ -643,39 +605,24 @@ h1 {
   display: inline-block;
   padding: 2px 8px;
   border-radius: 10px;
-  font: 600 11px/1.4 var(--font);
+  font: 600 11px/1.4 var(--sift-font);
   letter-spacing: 0.02em;
 }
 
 .sift-badge-true {
-  background: rgba(58, 138, 92, 0.15);
-  color: #2d6e4a;
+  background: var(--sift-badge-true-bg);
+  color: var(--sift-badge-true-color);
 }
 
 .sift-badge-false {
-  background: rgba(196, 81, 58, 0.15);
-  color: #9e3a24;
+  background: var(--sift-badge-false-bg);
+  color: var(--sift-badge-false-color);
 }
 
 .sift-badge-null {
-  background: color-mix(in srgb, var(--muted) 15%, transparent);
-  color: var(--muted);
+  background: color-mix(in srgb, var(--sift-muted) 15%, transparent);
+  color: var(--sift-muted);
   font-style: italic;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .sift-badge-true {
-    color: #5ec98a;
-  }
-  :root:not([data-theme="light"]) .sift-badge-false {
-    color: #e07a64;
-  }
-}
-:root[data-theme="dark"] .sift-badge-true {
-  color: #5ec98a;
-}
-:root[data-theme="dark"] .sift-badge-false {
-  color: #e07a64;
 }
 
 /* --- Boolean summary in header --- */
@@ -694,22 +641,22 @@ h1 {
 }
 
 .sift-bool-true {
-  background: #3a8a5c;
+  background: var(--sift-bool-true);
   transition: width 200ms ease-out;
 }
 
 .sift-bool-false {
-  background: #c4513a;
+  background: var(--sift-bool-false);
   transition: width 200ms ease-out;
 }
 
 .sift-bool-null {
   background: repeating-linear-gradient(
-    -45deg,
-    rgba(0, 0, 0, 0.08),
-    rgba(0, 0, 0, 0.08) 2px,
-    rgba(0, 0, 0, 0.03) 2px,
-    rgba(0, 0, 0, 0.03) 4px
+    135deg,
+    var(--sift-bool-null-fg),
+    var(--sift-bool-null-fg) 2px,
+    var(--sift-bool-null-bg) 2px,
+    var(--sift-bool-null-bg) 4px
   );
   transition: width 200ms ease-out;
 }
@@ -720,7 +667,7 @@ h1 {
 }
 
 .sift-bool-null-label {
-  color: var(--muted);
+  color: var(--sift-muted);
   opacity: 0.7;
   font-style: italic;
 }
@@ -728,14 +675,14 @@ h1 {
 .sift-bool-labels {
   display: flex;
   justify-content: space-between;
-  font: 400 10px/1.2 var(--font);
+  font: 400 10px/1.2 var(--sift-font);
   text-transform: none;
   letter-spacing: normal;
-  color: var(--muted);
+  color: var(--sift-muted);
 }
 .sift-bool-labels strong {
   font-weight: 600;
-  color: var(--ink);
+  color: var(--sift-ink);
 }
 .sift-pct {
   opacity: 0.6;
@@ -751,9 +698,9 @@ h1 {
     12px/1.3 "SF Mono",
     ui-monospace,
     monospace;
-  color: var(--muted);
-  border-top: 1px solid var(--rule);
-  background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
+  color: var(--sift-muted);
+  border-top: 1px solid var(--sift-rule);
+  background: color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%);
   display: flex;
   align-items: center;
 }
@@ -773,10 +720,10 @@ h1 {
 
 @keyframes stat-pop {
   0% {
-    color: var(--accent);
+    color: var(--sift-accent);
   }
   100% {
-    color: var(--muted);
+    color: var(--sift-muted);
   }
 }
 
@@ -826,12 +773,12 @@ h1 {
 }
 
 .sift-status-streaming {
-  color: var(--accent);
+  color: var(--sift-accent);
   animation: sift-status-pulse 1s ease-in-out infinite;
 }
 
 .sift-status-ready {
-  color: var(--muted);
+  color: var(--sift-muted);
   font-size: 10px;
   opacity: 0.6;
 }
@@ -860,11 +807,11 @@ h1 {
   align-items: center;
   gap: 4px;
   padding: 2px 6px 2px 8px;
-  background: rgba(149, 95, 59, 0.1);
-  border: 1px solid rgba(149, 95, 59, 0.2);
+  background: color-mix(in srgb, var(--sift-accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sift-accent) 20%, transparent);
   border-radius: 10px;
-  font: 11px/1.3 var(--font);
-  color: var(--accent);
+  font: 11px/1.3 var(--sift-font);
+  color: var(--sift-accent);
   white-space: nowrap;
   max-width: 200px;
   overflow: hidden;
@@ -873,8 +820,8 @@ h1 {
 .sift-filter-pill-x {
   background: none;
   border: none;
-  color: var(--accent);
-  font: 14px/1 var(--font);
+  color: var(--sift-accent);
+  font: 14px/1 var(--sift-font);
   cursor: pointer;
   padding: 0 2px;
   opacity: 0.6;
@@ -891,10 +838,10 @@ h1 {
 
 .sift-debug-btn {
   background: none;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 6px;
-  color: var(--muted);
-  font: 14px/1 var(--font);
+  color: var(--sift-muted);
+  font: 14px/1 var(--sift-font);
   padding: 2px 6px;
   cursor: pointer;
   margin-right: 4px;
@@ -907,22 +854,22 @@ h1 {
 
 .sift-debug-btn:hover {
   opacity: 1;
-  color: var(--ink);
-  border-color: var(--muted);
+  color: var(--sift-ink);
+  border-color: var(--sift-muted);
 }
 
 .sift-debug-btn.sift-debug-active {
   opacity: 1;
-  color: var(--accent);
-  border-color: var(--accent);
+  color: var(--sift-accent);
+  border-color: var(--sift-accent);
 }
 
 .sift-fullscreen-btn {
   background: none;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 6px;
-  color: var(--muted);
-  font: 16px/1 var(--font);
+  color: var(--sift-muted);
+  font: 16px/1 var(--sift-font);
   padding: 2px 8px;
   cursor: pointer;
   transition:
@@ -931,8 +878,8 @@ h1 {
 }
 
 .sift-fullscreen-btn:hover {
-  color: var(--ink);
-  border-color: var(--muted);
+  color: var(--sift-ink);
+  border-color: var(--sift-muted);
 }
 
 /* --- Fullscreen state --- */
@@ -940,7 +887,7 @@ h1 {
 .sift-table-container:fullscreen {
   border-radius: 0;
   border: none;
-  background: var(--panel);
+  background: var(--sift-panel);
 }
 
 .sift-table-container:fullscreen .sift-viewport {
@@ -950,9 +897,9 @@ h1 {
 /* --- Loading skeleton --- */
 
 .sift-skeleton {
-  border: 1px solid var(--rule);
+  border: 1px solid var(--sift-rule);
   border-radius: 18px;
-  background: var(--panel);
+  background: var(--sift-panel);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -962,8 +909,8 @@ h1 {
 .sift-skeleton-header {
   display: flex;
   padding: 8px 0;
-  border-bottom: 1px solid var(--rule);
-  background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
+  border-bottom: 1px solid var(--sift-rule);
+  background: color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%);
 }
 
 .sift-skeleton-th {
@@ -978,9 +925,9 @@ h1 {
   border-radius: 4px;
   background: linear-gradient(
     90deg,
-    rgba(0, 0, 0, 0.04) 25%,
-    rgba(0, 0, 0, 0.08) 50%,
-    rgba(0, 0, 0, 0.04) 75%
+    var(--sift-skeleton-bar-from) 25%,
+    var(--sift-skeleton-bar-via) 50%,
+    var(--sift-skeleton-bar-from) 75%
   );
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
@@ -1003,11 +950,11 @@ h1 {
 
 .sift-skeleton-row {
   display: flex;
-  border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--sift-rule) 40%, transparent);
 }
 
 .sift-skeleton-row:nth-child(even) {
-  background: var(--row-alt);
+  background: var(--sift-row-alt);
 }
 
 .sift-skeleton-cell {
@@ -1029,8 +976,8 @@ h1 {
 
 .sift-skeleton-footer {
   padding: 8px 16px;
-  border-top: 1px solid var(--rule);
-  background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
+  border-top: 1px solid var(--sift-rule);
+  background: color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%);
 }
 
 .sift-skeleton-status {
@@ -1038,7 +985,7 @@ h1 {
     12px/1.3 "SF Mono",
     ui-monospace,
     monospace;
-  color: var(--accent);
+  color: var(--sift-accent);
 }
 
 @keyframes skeleton-shimmer {
@@ -1063,15 +1010,15 @@ h1 {
 }
 
 .sift-empty-text {
-  font: 14px/1.4 var(--font);
-  color: var(--muted);
+  font: 14px/1.4 var(--sift-font);
+  color: var(--sift-muted);
 }
 
 .sift-empty-clear {
-  font: 13px/1.3 var(--font);
-  color: var(--accent);
+  font: 13px/1.3 var(--sift-font);
+  color: var(--sift-accent);
   background: none;
-  border: 1px solid var(--accent);
+  border: 1px solid var(--sift-accent);
   border-radius: 8px;
   padding: 6px 16px;
   cursor: pointer;
@@ -1079,7 +1026,7 @@ h1 {
 }
 
 .sift-empty-clear:hover {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  background: color-mix(in srgb, var(--sift-accent) 8%, transparent);
 }
 
 /* --- Mobile detail sheet --- */
@@ -1087,7 +1034,7 @@ h1 {
 .sift-detail-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--sift-detail-backdrop);
   z-index: 100;
 }
 
@@ -1097,9 +1044,9 @@ h1 {
   left: 0;
   right: 0;
   max-height: 70vh;
-  background: var(--panel);
+  background: var(--sift-panel);
   border-radius: 16px 16px 0 0;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 -4px 20px var(--sift-detail-shadow);
   z-index: 101;
   display: flex;
   flex-direction: column;
@@ -1116,27 +1063,27 @@ h1 {
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--rule);
+  border-bottom: 1px solid var(--sift-rule);
   flex-shrink: 0;
 }
 
 .sift-detail-title {
-  font: 600 15px/1.2 var(--font);
-  color: var(--ink);
+  font: 600 15px/1.2 var(--sift-font);
+  color: var(--sift-ink);
 }
 
 .sift-detail-close {
   background: none;
   border: none;
-  font: 400 24px/1 var(--font);
-  color: var(--muted);
+  font: 400 24px/1 var(--sift-font);
+  color: var(--sift-muted);
   cursor: pointer;
   padding: 0 4px;
   transition: color 150ms ease;
 }
 
 .sift-detail-close:hover {
-  color: var(--ink);
+  color: var(--sift-ink);
 }
 
 .sift-detail-list {
@@ -1150,7 +1097,7 @@ h1 {
   align-items: baseline;
   gap: 12px;
   padding: 10px 20px;
-  border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--sift-rule) 40%, transparent);
 }
 
 .sift-detail-row:last-child {
@@ -1162,8 +1109,8 @@ h1 {
   display: flex;
   align-items: baseline;
   gap: 6px;
-  font: 400 12px/1.3 var(--font);
-  color: var(--muted);
+  font: 400 12px/1.3 var(--sift-font);
+  color: var(--sift-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   overflow: hidden;
@@ -1177,7 +1124,7 @@ h1 {
 
 .sift-detail-type-icon {
   flex-shrink: 0;
-  font: 400 10px/1 var(--font);
+  font: 400 10px/1 var(--sift-font);
   opacity: 0.5;
   text-transform: none;
   letter-spacing: normal;
@@ -1185,8 +1132,8 @@ h1 {
 
 .sift-detail-col-value {
   flex: 1;
-  font: 14px/1.4 var(--font);
-  color: var(--ink);
+  font: 14px/1.4 var(--sift-font);
+  color: var(--sift-ink);
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
@@ -1211,10 +1158,10 @@ h1 {
 }
 
 .sift-viewport::-webkit-scrollbar-thumb {
-  background: var(--rule);
+  background: var(--sift-scrollbar-thumb);
   border-radius: 4px;
 }
 
 .sift-viewport::-webkit-scrollbar-thumb:hover {
-  background: var(--muted);
+  background: var(--sift-scrollbar-thumb-hover);
 }

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -52,7 +52,7 @@ body {
 
 /* --- Page layout --- */
 
-.pt-page {
+.sift-page {
   width: min(1200px, calc(100vw - 32px));
   margin: 0 auto;
   padding: 32px 0 48px;
@@ -66,11 +66,11 @@ body {
   min-height: 0;
 }
 
-.pt-intro {
+.sift-intro {
   margin-bottom: 20px;
 }
 
-.pt-eyebrow {
+.sift-eyebrow {
   margin: 0 0 8px;
   font:
     12px/1.2 "SF Mono",
@@ -90,32 +90,32 @@ h1 {
   color: var(--ink);
 }
 
-.pt-subtitle {
+.sift-subtitle {
   margin: 10px 0 0;
   max-width: 72ch;
   line-height: 1.45;
   color: var(--muted);
 }
 
-.pt-subtitle a {
+.sift-subtitle a {
   color: var(--accent);
   text-decoration: none;
 }
 
-.pt-subtitle a:hover {
+.sift-subtitle a:hover {
   text-decoration: underline;
 }
 
 /* --- Dataset picker --- */
 
-.pt-intro-row {
+.sift-intro-row {
   display: flex;
   align-items: baseline;
   gap: 16px;
   flex-wrap: wrap;
 }
 
-.pt-dataset-picker select {
+.sift-dataset-picker select {
   font: 13px/1.3 var(--font);
   padding: 4px 24px 4px 10px;
   border: 1px solid var(--rule);
@@ -129,18 +129,18 @@ h1 {
   background-position: right 8px center;
 }
 
-.pt-dataset-picker select:hover {
+.sift-dataset-picker select:hover {
   border-color: var(--muted);
 }
 
-.pt-dataset-picker select:focus {
+.sift-dataset-picker select:focus {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
 /* --- Theme toggle --- */
 
-.pt-theme-toggle {
+.sift-theme-toggle {
   background: none;
   border: 1px solid var(--rule);
   border-radius: 8px;
@@ -154,12 +154,12 @@ h1 {
     border-color 150ms ease;
 }
 
-.pt-theme-toggle:hover {
+.sift-theme-toggle:hover {
   color: var(--ink);
   border-color: var(--muted);
 }
 
-.pt-github-btn {
+.sift-github-btn {
   background: none;
   border: 1px solid var(--rule);
   border-radius: 8px;
@@ -177,23 +177,23 @@ h1 {
     border-color 150ms ease;
 }
 
-.pt-github-btn svg {
+.sift-github-btn svg {
   transform: translateY(1px);
 }
 
-.pt-github-btn:hover {
+.sift-github-btn:hover {
   color: var(--ink);
   border-color: var(--muted);
 }
 
-.pt-loading {
+.sift-loading {
   padding: 80px 20px;
   text-align: center;
   color: var(--muted);
   font-size: 18px;
 }
 
-.pt-loading code {
+.sift-loading code {
   font-family: "SF Mono", ui-monospace, monospace;
   background: rgba(0, 0, 0, 0.06);
   padding: 2px 8px;
@@ -202,7 +202,7 @@ h1 {
 
 /* --- Table container --- */
 
-.pt-table-container {
+.sift-table-container {
   border: 1px solid var(--rule);
   border-radius: 18px;
   background: var(--panel);
@@ -214,7 +214,7 @@ h1 {
 
 /* --- Streaming progress bar --- */
 
-.pt-progress-bar {
+.sift-progress-bar {
   height: 2px;
   flex-shrink: 0;
   overflow: hidden;
@@ -222,15 +222,15 @@ h1 {
   transition: opacity 400ms ease;
 }
 
-.pt-progress-bar-fill {
+.sift-progress-bar-fill {
   height: 100%;
   width: 30%;
   background: var(--accent);
   border-radius: 1px;
-  animation: pt-progress-slide 1.2s ease-in-out infinite;
+  animation: sift-progress-slide 1.2s ease-in-out infinite;
 }
 
-@keyframes pt-progress-slide {
+@keyframes sift-progress-slide {
   0% {
     transform: translateX(-100%);
   }
@@ -239,13 +239,13 @@ h1 {
   }
 }
 
-.pt-progress-bar-done {
+.sift-progress-bar-done {
   opacity: 0;
 }
 
 /* --- Header --- */
 
-.pt-header {
+.sift-header {
   position: sticky;
   top: 0;
   z-index: 5;
@@ -253,11 +253,11 @@ h1 {
   background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
 }
 
-.pt-header-row {
+.sift-header-row {
   display: flex;
 }
 
-.pt-th {
+.sift-th {
   flex-shrink: 0;
   position: relative;
   padding: 8px 12px;
@@ -273,17 +273,17 @@ h1 {
   overflow: hidden;
 }
 
-.pt-th:hover {
+.sift-th:hover {
   color: var(--ink);
 }
 
-.pt-th-top {
+.sift-th-top {
   display: flex;
   align-items: baseline;
   gap: 2px;
 }
 
-.pt-type-icon {
+.sift-type-icon {
   position: absolute;
   top: 8px;
   right: 12px;
@@ -295,7 +295,7 @@ h1 {
   pointer-events: none;
 }
 
-.pt-filter-line {
+.sift-filter-line {
   font: 400 10px/1.2 var(--font);
   color: var(--accent);
   text-transform: none;
@@ -306,20 +306,20 @@ h1 {
   white-space: nowrap;
 }
 
-.pt-th-label {
+.sift-th-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.pt-sort-arrow {
+.sift-sort-arrow {
   font-size: 11px;
   color: var(--accent);
 }
 
 /* --- Column summary charts --- */
 
-.pt-th-summary {
+.sift-th-summary {
   width: 100%;
   overflow: hidden;
   animation: summary-fade-in 300ms ease-out;
@@ -331,8 +331,8 @@ h1 {
   --semiotic-primary: var(--accent);
 }
 
-.pt-th-summary svg,
-.pt-th-summary canvas {
+.sift-th-summary svg,
+.sift-th-summary canvas {
   display: block;
 }
 
@@ -348,11 +348,11 @@ h1 {
 }
 
 /* Hide Semiotic axis labels in header charts */
-.pt-th-summary text {
+.sift-th-summary text {
   display: none !important;
 }
 
-.pt-th-range {
+.sift-th-range {
   display: block;
   margin-top: 2px;
   font: 400 10px/1.2 var(--font);
@@ -361,7 +361,7 @@ h1 {
   letter-spacing: normal;
 }
 
-.pt-th-profile {
+.sift-th-profile {
   display: block;
   margin-top: 1px;
   font: 400 9px/1.2 var(--font);
@@ -370,13 +370,13 @@ h1 {
   letter-spacing: normal;
 }
 
-.pt-cat-summary {
+.sift-cat-summary {
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
 
-.pt-cat-row {
+.sift-cat-row {
   display: flex;
   align-items: center;
   gap: 4px;
@@ -389,7 +389,7 @@ h1 {
   transition: opacity 150ms ease-out;
 }
 
-.pt-cat-bar-track {
+.sift-cat-bar-track {
   flex: 1;
   height: 8px;
   background: rgba(0, 0, 0, 0.04);
@@ -398,7 +398,7 @@ h1 {
   min-width: 20px;
 }
 
-.pt-cat-bar-fill {
+.sift-cat-bar-fill {
   height: 100%;
   background: var(--accent);
   border-radius: 2px;
@@ -406,7 +406,7 @@ h1 {
   transition: width 200ms ease-out;
 }
 
-.pt-cat-label {
+.sift-cat-label {
   flex-shrink: 0;
   max-width: 60%;
   overflow: hidden;
@@ -414,23 +414,23 @@ h1 {
   white-space: nowrap;
 }
 
-.pt-cat-pct {
+.sift-cat-pct {
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.pt-cat-clickable {
+.sift-cat-clickable {
   cursor: pointer;
   transition: opacity 100ms ease;
 }
 
-.pt-cat-clickable:hover {
+.sift-cat-clickable:hover {
   opacity: 0.8 !important;
 }
 
 /* --- Category filter popover --- */
 
-.pt-cat-popover {
+.sift-cat-popover {
   min-width: 220px;
   max-width: 320px;
   display: flex;
@@ -438,7 +438,7 @@ h1 {
   overflow: hidden;
 }
 
-.pt-cat-popover-search {
+.sift-cat-popover-search {
   margin: 8px 8px 0;
   padding: 6px 10px;
   border: 1px solid var(--rule);
@@ -449,15 +449,15 @@ h1 {
   outline: none;
 }
 
-.pt-cat-popover-search:focus {
+.sift-cat-popover-search:focus {
   border-color: var(--accent);
 }
 
-.pt-cat-popover-search::placeholder {
+.sift-cat-popover-search::placeholder {
   color: var(--muted);
 }
 
-.pt-cat-popover-actions {
+.sift-cat-popover-actions {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -466,7 +466,7 @@ h1 {
   color: var(--muted);
 }
 
-.pt-cat-popover-btn {
+.sift-cat-popover-btn {
   background: none;
   border: 1px solid var(--rule);
   border-radius: 4px;
@@ -476,21 +476,21 @@ h1 {
   cursor: pointer;
 }
 
-.pt-cat-popover-btn:hover {
+.sift-cat-popover-btn:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
-.pt-cat-popover-count {
+.sift-cat-popover-count {
   margin-left: auto;
 }
 
-.pt-cat-popover-list {
+.sift-cat-popover-list {
   overflow-y: auto;
   overflow-x: hidden;
   border-top: 1px solid var(--rule);
 }
 
-.pt-cat-popover-row {
+.sift-cat-popover-row {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -501,16 +501,16 @@ h1 {
   user-select: none;
 }
 
-.pt-cat-popover-row:hover {
+.sift-cat-popover-row:hover {
   background: color-mix(in srgb, var(--accent) 6%, transparent);
 }
 
-.pt-cat-popover-check {
+.sift-cat-popover-check {
   flex-shrink: 0;
   accent-color: var(--accent);
 }
 
-.pt-cat-popover-label {
+.sift-cat-popover-label {
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -519,7 +519,7 @@ h1 {
   letter-spacing: normal;
 }
 
-.pt-cat-popover-pct {
+.sift-cat-popover-pct {
   flex-shrink: 0;
   font: 11px/1.2 var(--font);
   color: var(--muted);
@@ -527,7 +527,7 @@ h1 {
   letter-spacing: normal;
 }
 
-.pt-cat-popover-empty {
+.sift-cat-popover-empty {
   padding: 12px;
   text-align: center;
   font: 13px/1.3 var(--font);
@@ -538,7 +538,7 @@ h1 {
 
 /* --- Resize handles --- */
 
-.pt-resize-handle {
+.sift-resize-handle {
   position: absolute;
   top: 0;
   right: -3px;
@@ -548,7 +548,7 @@ h1 {
   z-index: 2;
 }
 
-.pt-resize-handle::after {
+.sift-resize-handle::after {
   content: "";
   position: absolute;
   top: 20%;
@@ -560,14 +560,14 @@ h1 {
   transition: background 120ms ease;
 }
 
-.pt-resize-handle:hover::after,
-.pt-resize-handle.dragging::after {
+.sift-resize-handle:hover::after,
+.sift-resize-handle.dragging::after {
   background: var(--accent);
 }
 
 /* --- Virtual scroll viewport --- */
 
-.pt-viewport {
+.sift-viewport {
   flex: 1 1 0;
   min-height: 0; /* allow flex shrinking */
   overflow-y: auto;
@@ -576,12 +576,12 @@ h1 {
   position: relative;
 }
 
-.pt-scroll-content {
+.sift-scroll-content {
   position: relative;
   width: max-content;
 }
 
-.pt-row-pool {
+.sift-row-pool {
   position: absolute;
   top: 0;
   left: 0;
@@ -590,7 +590,7 @@ h1 {
 
 /* --- Rows & cells --- */
 
-.pt-row {
+.sift-row {
   position: absolute;
   left: 0;
   display: flex;
@@ -598,11 +598,11 @@ h1 {
   border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
 }
 
-.pt-row-alt {
+.sift-row-alt {
   background: var(--row-alt);
 }
 
-.pt-cell {
+.sift-cell {
   flex-shrink: 0;
   padding: 8px 12px;
   font: 14px/20px var(--font);
@@ -613,7 +613,7 @@ h1 {
 
 /* --- Pinned first column --- */
 
-.pt-cell:first-child {
+.sift-cell:first-child {
   position: sticky;
   left: 0;
   z-index: 1;
@@ -621,11 +621,11 @@ h1 {
   box-shadow: 2px 0 4px var(--pin-shadow);
 }
 
-.pt-row-alt .pt-cell:first-child {
+.sift-row-alt .sift-cell:first-child {
   background: color-mix(in srgb, var(--panel) 97%, var(--page));
 }
 
-.pt-th:first-child {
+.sift-th:first-child {
   position: sticky;
   left: 0;
   z-index: 3;
@@ -635,11 +635,11 @@ h1 {
 
 /* --- Type-aware cells --- */
 
-.pt-cell-timestamp {
+.sift-cell-timestamp {
   font-variant-numeric: tabular-nums;
 }
 
-.pt-badge {
+.sift-badge {
   display: inline-block;
   padding: 2px 8px;
   border-radius: 10px;
@@ -647,63 +647,63 @@ h1 {
   letter-spacing: 0.02em;
 }
 
-.pt-badge-true {
+.sift-badge-true {
   background: rgba(58, 138, 92, 0.15);
   color: #2d6e4a;
 }
 
-.pt-badge-false {
+.sift-badge-false {
   background: rgba(196, 81, 58, 0.15);
   color: #9e3a24;
 }
 
-.pt-badge-null {
+.sift-badge-null {
   background: color-mix(in srgb, var(--muted) 15%, transparent);
   color: var(--muted);
   font-style: italic;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .pt-badge-true {
+  :root:not([data-theme="light"]) .sift-badge-true {
     color: #5ec98a;
   }
-  :root:not([data-theme="light"]) .pt-badge-false {
+  :root:not([data-theme="light"]) .sift-badge-false {
     color: #e07a64;
   }
 }
-:root[data-theme="dark"] .pt-badge-true {
+:root[data-theme="dark"] .sift-badge-true {
   color: #5ec98a;
 }
-:root[data-theme="dark"] .pt-badge-false {
+:root[data-theme="dark"] .sift-badge-false {
   color: #e07a64;
 }
 
 /* --- Boolean summary in header --- */
 
-.pt-bool-summary {
+.sift-bool-summary {
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
 
-.pt-bool-bar {
+.sift-bool-bar {
   display: flex;
   height: 10px;
   border-radius: 3px;
   overflow: hidden;
 }
 
-.pt-bool-true {
+.sift-bool-true {
   background: #3a8a5c;
   transition: width 200ms ease-out;
 }
 
-.pt-bool-false {
+.sift-bool-false {
   background: #c4513a;
   transition: width 200ms ease-out;
 }
 
-.pt-bool-null {
+.sift-bool-null {
   background: repeating-linear-gradient(
     -45deg,
     rgba(0, 0, 0, 0.08),
@@ -714,18 +714,18 @@ h1 {
   transition: width 200ms ease-out;
 }
 
-.pt-bool-clickable {
+.sift-bool-clickable {
   cursor: pointer;
   transition: opacity 100ms ease;
 }
 
-.pt-bool-null-label {
+.sift-bool-null-label {
   color: var(--muted);
   opacity: 0.7;
   font-style: italic;
 }
 
-.pt-bool-labels {
+.sift-bool-labels {
   display: flex;
   justify-content: space-between;
   font: 400 10px/1.2 var(--font);
@@ -733,18 +733,18 @@ h1 {
   letter-spacing: normal;
   color: var(--muted);
 }
-.pt-bool-labels strong {
+.sift-bool-labels strong {
   font-weight: 600;
   color: var(--ink);
 }
-.pt-pct {
+.sift-pct {
   opacity: 0.6;
   font-size: 9px;
 }
 
 /* --- Stats bar --- */
 
-.pt-stats {
+.sift-stats {
   flex-shrink: 0;
   padding: 8px 16px;
   font:
@@ -758,16 +758,16 @@ h1 {
   align-items: center;
 }
 
-.pt-stat-sep {
+.sift-stat-sep {
   opacity: 0.5;
 }
 
-.pt-stat-value {
+.sift-stat-value {
   display: inline-block;
   font-variant-numeric: tabular-nums;
 }
 
-.pt-stat-flash {
+.sift-stat-flash {
   animation: stat-pop 600ms ease-out;
 }
 
@@ -782,7 +782,7 @@ h1 {
 
 /* --- Odometer FPS counter --- */
 
-.pt-odometer {
+.sift-odometer {
   display: inline-flex;
   align-items: baseline;
   gap: 0;
@@ -790,7 +790,7 @@ h1 {
   font-feature-settings: "tnum";
 }
 
-.pt-odo-slot {
+.sift-odo-slot {
   display: inline-block;
   height: 1.2em;
   overflow: hidden;
@@ -800,13 +800,13 @@ h1 {
   contain: layout style paint;
 }
 
-.pt-odo-strip {
+.sift-odo-strip {
   display: flex;
   flex-direction: column;
   transition: transform 400ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.pt-odo-num {
+.sift-odo-num {
   display: block;
   height: 1.2em;
   line-height: 1.2;
@@ -814,7 +814,7 @@ h1 {
 
 /* --- Status indicator --- */
 
-.pt-status-indicator {
+.sift-status-indicator {
   display: inline-block;
   margin-right: 6px;
   font-size: 8px;
@@ -825,18 +825,18 @@ h1 {
     opacity 400ms ease;
 }
 
-.pt-status-streaming {
+.sift-status-streaming {
   color: var(--accent);
-  animation: pt-status-pulse 1s ease-in-out infinite;
+  animation: sift-status-pulse 1s ease-in-out infinite;
 }
 
-.pt-status-ready {
+.sift-status-ready {
   color: var(--muted);
   font-size: 10px;
   opacity: 0.6;
 }
 
-@keyframes pt-status-pulse {
+@keyframes sift-status-pulse {
   0%,
   100% {
     opacity: 0.4;
@@ -848,14 +848,14 @@ h1 {
 
 /* --- Filter pills --- */
 
-.pt-filter-pills {
+.sift-filter-pills {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-left: 12px;
 }
 
-.pt-filter-pill {
+.sift-filter-pill {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -870,7 +870,7 @@ h1 {
   overflow: hidden;
 }
 
-.pt-filter-pill-x {
+.sift-filter-pill-x {
   background: none;
   border: none;
   color: var(--accent);
@@ -881,15 +881,15 @@ h1 {
   transition: opacity 100ms ease;
 }
 
-.pt-filter-pill-x:hover {
+.sift-filter-pill-x:hover {
   opacity: 1;
 }
 
-.pt-debug-group {
+.sift-debug-group {
   display: inline;
 }
 
-.pt-debug-btn {
+.sift-debug-btn {
   background: none;
   border: 1px solid var(--rule);
   border-radius: 6px;
@@ -905,19 +905,19 @@ h1 {
     opacity 150ms ease;
 }
 
-.pt-debug-btn:hover {
+.sift-debug-btn:hover {
   opacity: 1;
   color: var(--ink);
   border-color: var(--muted);
 }
 
-.pt-debug-btn.pt-debug-active {
+.sift-debug-btn.sift-debug-active {
   opacity: 1;
   color: var(--accent);
   border-color: var(--accent);
 }
 
-.pt-fullscreen-btn {
+.sift-fullscreen-btn {
   background: none;
   border: 1px solid var(--rule);
   border-radius: 6px;
@@ -930,26 +930,26 @@ h1 {
     border-color 150ms ease;
 }
 
-.pt-fullscreen-btn:hover {
+.sift-fullscreen-btn:hover {
   color: var(--ink);
   border-color: var(--muted);
 }
 
 /* --- Fullscreen state --- */
 
-.pt-table-container:fullscreen {
+.sift-table-container:fullscreen {
   border-radius: 0;
   border: none;
   background: var(--panel);
 }
 
-.pt-table-container:fullscreen .pt-viewport {
+.sift-table-container:fullscreen .sift-viewport {
   flex: 1 1 0;
 }
 
 /* --- Loading skeleton --- */
 
-.pt-skeleton {
+.sift-skeleton {
   border: 1px solid var(--rule);
   border-radius: 18px;
   background: var(--panel);
@@ -959,14 +959,14 @@ h1 {
   height: 100%;
 }
 
-.pt-skeleton-header {
+.sift-skeleton-header {
   display: flex;
   padding: 8px 0;
   border-bottom: 1px solid var(--rule);
   background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
 }
 
-.pt-skeleton-th {
+.sift-skeleton-th {
   flex: 1;
   padding: 8px 12px;
   display: flex;
@@ -974,7 +974,7 @@ h1 {
   gap: 8px;
 }
 
-.pt-skeleton-bar {
+.sift-skeleton-bar {
   border-radius: 4px;
   background: linear-gradient(
     90deg,
@@ -986,54 +986,54 @@ h1 {
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
 
-.pt-skeleton-label {
+.sift-skeleton-label {
   height: 10px;
   width: 60%;
 }
 
-.pt-skeleton-chart {
+.sift-skeleton-chart {
   height: 40px;
   width: 100%;
 }
 
-.pt-skeleton-body {
+.sift-skeleton-body {
   flex: 1;
   overflow: hidden;
 }
 
-.pt-skeleton-row {
+.sift-skeleton-row {
   display: flex;
   border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
 }
 
-.pt-skeleton-row:nth-child(even) {
+.sift-skeleton-row:nth-child(even) {
   background: var(--row-alt);
 }
 
-.pt-skeleton-cell {
+.sift-skeleton-cell {
   flex: 1;
   padding: 10px 12px;
 }
 
-.pt-skeleton-text {
+.sift-skeleton-text {
   height: 14px;
   width: 70%;
 }
 
-.pt-skeleton-row:nth-child(3n) .pt-skeleton-text {
+.sift-skeleton-row:nth-child(3n) .sift-skeleton-text {
   width: 50%;
 }
-.pt-skeleton-row:nth-child(3n + 1) .pt-skeleton-text {
+.sift-skeleton-row:nth-child(3n + 1) .sift-skeleton-text {
   width: 85%;
 }
 
-.pt-skeleton-footer {
+.sift-skeleton-footer {
   padding: 8px 16px;
   border-top: 1px solid var(--rule);
   background: color-mix(in srgb, var(--panel) 90%, var(--page) 10%);
 }
 
-.pt-skeleton-status {
+.sift-skeleton-status {
   font:
     12px/1.3 "SF Mono",
     ui-monospace,
@@ -1052,7 +1052,7 @@ h1 {
 
 /* --- Empty state --- */
 
-.pt-empty-state {
+.sift-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1062,12 +1062,12 @@ h1 {
   padding: 40px 20px;
 }
 
-.pt-empty-text {
+.sift-empty-text {
   font: 14px/1.4 var(--font);
   color: var(--muted);
 }
 
-.pt-empty-clear {
+.sift-empty-clear {
   font: 13px/1.3 var(--font);
   color: var(--accent);
   background: none;
@@ -1078,20 +1078,20 @@ h1 {
   transition: background 150ms ease;
 }
 
-.pt-empty-clear:hover {
+.sift-empty-clear:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 /* --- Mobile detail sheet --- */
 
-.pt-detail-backdrop {
+.sift-detail-backdrop {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.3);
   z-index: 100;
 }
 
-.pt-detail-sheet {
+.sift-detail-sheet {
   position: fixed;
   bottom: 0;
   left: 0;
@@ -1107,11 +1107,11 @@ h1 {
   transition: transform 300ms ease-out;
 }
 
-.pt-detail-sheet-open {
+.sift-detail-sheet-open {
   transform: translateY(0);
 }
 
-.pt-detail-header {
+.sift-detail-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1120,12 +1120,12 @@ h1 {
   flex-shrink: 0;
 }
 
-.pt-detail-title {
+.sift-detail-title {
   font: 600 15px/1.2 var(--font);
   color: var(--ink);
 }
 
-.pt-detail-close {
+.sift-detail-close {
   background: none;
   border: none;
   font: 400 24px/1 var(--font);
@@ -1135,17 +1135,17 @@ h1 {
   transition: color 150ms ease;
 }
 
-.pt-detail-close:hover {
+.sift-detail-close:hover {
   color: var(--ink);
 }
 
-.pt-detail-list {
+.sift-detail-list {
   overflow-y: auto;
   padding: 8px 0;
   -webkit-overflow-scrolling: touch;
 }
 
-.pt-detail-row {
+.sift-detail-row {
   display: flex;
   align-items: baseline;
   gap: 12px;
@@ -1153,11 +1153,11 @@ h1 {
   border-bottom: 1px solid color-mix(in srgb, var(--rule) 40%, transparent);
 }
 
-.pt-detail-row:last-child {
+.sift-detail-row:last-child {
   border-bottom: none;
 }
 
-.pt-detail-col-name {
+.sift-detail-col-name {
   flex: 0 0 40%;
   display: flex;
   align-items: baseline;
@@ -1169,13 +1169,13 @@ h1 {
   overflow: hidden;
 }
 
-.pt-detail-col-name span:last-child {
+.sift-detail-col-name span:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.pt-detail-type-icon {
+.sift-detail-type-icon {
   flex-shrink: 0;
   font: 400 10px/1 var(--font);
   opacity: 0.5;
@@ -1183,7 +1183,7 @@ h1 {
   letter-spacing: normal;
 }
 
-.pt-detail-col-value {
+.sift-detail-col-value {
   flex: 1;
   font: 14px/1.4 var(--font);
   color: var(--ink);
@@ -1193,28 +1193,28 @@ h1 {
 
 /* Only show detail sheet on narrow viewports */
 @media (min-width: 768px) {
-  .pt-detail-backdrop,
-  .pt-detail-sheet {
+  .sift-detail-backdrop,
+  .sift-detail-sheet {
     display: none !important;
   }
 }
 
 /* --- Scrollbar styling --- */
 
-.pt-viewport::-webkit-scrollbar {
+.sift-viewport::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-.pt-viewport::-webkit-scrollbar-track {
+.sift-viewport::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.pt-viewport::-webkit-scrollbar-thumb {
+.sift-viewport::-webkit-scrollbar-thumb {
   background: var(--rule);
   border-radius: 4px;
 }
 
-.pt-viewport::-webkit-scrollbar-thumb:hover {
+.sift-viewport::-webkit-scrollbar-thumb:hover {
   background: var(--muted);
 }

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -285,12 +285,12 @@ h1 {
   width: 100%;
   overflow: hidden;
   animation: summary-fade-in 300ms ease-out;
-  --semiotic-bg: transparent;
-  --semiotic-text: var(--sift-muted);
-  --semiotic-text-secondary: var(--sift-muted);
-  --semiotic-border: transparent;
-  --semiotic-grid: transparent;
-  --semiotic-primary: var(--sift-accent);
+  --sift-chart-bg: transparent;
+  --sift-chart-text: var(--sift-muted);
+  --sift-chart-text-secondary: var(--sift-muted);
+  --sift-chart-border: transparent;
+  --sift-chart-grid: transparent;
+  --sift-chart-primary: var(--sift-accent);
 }
 
 .sift-th-summary svg,

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
 @import "./themes/cream.css";
+@import "tailwindcss";
 
 * {
   box-sizing: border-box;

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -83,14 +83,14 @@ describe("createTable", () => {
   describe("DOM structure", () => {
     it("creates header, viewport, and stats bar", async () => {
       await flushRAF();
-      expect(container.querySelector(".pt-header")).not.toBeNull();
-      expect(container.querySelector(".pt-viewport")).not.toBeNull();
-      expect(container.querySelector(".pt-stats")).not.toBeNull();
+      expect(container.querySelector(".sift-header")).not.toBeNull();
+      expect(container.querySelector(".sift-viewport")).not.toBeNull();
+      expect(container.querySelector(".sift-stats")).not.toBeNull();
     });
 
     it("renders correct header labels", async () => {
       await flushRAF();
-      const labels = container.querySelectorAll(".pt-th-label");
+      const labels = container.querySelectorAll(".sift-th-label");
       expect(labels).toHaveLength(4);
       expect(labels[0].textContent).toBe("ID");
       expect(labels[1].textContent).toBe("Name");
@@ -100,7 +100,7 @@ describe("createTable", () => {
 
     it("shows row count in stats bar", async () => {
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("50");
     });
   });
@@ -110,7 +110,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.setFilter(2, { kind: "range", min: 0, max: 30 });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("of");
       expect(stats?.dataset.value).toContain("50");
     });
@@ -119,7 +119,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.setFilter(2, { kind: "range", min: 10, max: 50 });
       await flushRAF();
-      const pills = container.querySelectorAll(".pt-filter-pill");
+      const pills = container.querySelectorAll(".sift-filter-pill");
       expect(pills.length).toBe(1);
       expect(pills[0].textContent).toContain("Score");
     });
@@ -130,7 +130,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.clearFilter(2);
       await flushRAF();
-      const pills = container.querySelectorAll(".pt-filter-pill");
+      const pills = container.querySelectorAll(".sift-filter-pill");
       expect(pills.length).toBe(0);
     });
 
@@ -139,17 +139,17 @@ describe("createTable", () => {
       engine.setFilter(1, { kind: "set", values: new Set(["Person 1"]) });
       engine.setFilter(3, { kind: "boolean", value: true });
       await flushRAF();
-      expect(container.querySelectorAll(".pt-filter-pill").length).toBe(2);
+      expect(container.querySelectorAll(".sift-filter-pill").length).toBe(2);
       engine.clearAllFilters();
       await flushRAF();
-      expect(container.querySelectorAll(".pt-filter-pill").length).toBe(0);
+      expect(container.querySelectorAll(".sift-filter-pill").length).toBe(0);
     });
 
     it("boolean filter works", async () => {
       await flushRAF();
       engine.setFilter(3, { kind: "boolean", value: true });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("of");
     });
 
@@ -160,7 +160,7 @@ describe("createTable", () => {
         values: new Set(["Person 0", "Person 1"]),
       });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("of");
     });
   });
@@ -172,11 +172,11 @@ describe("createTable", () => {
       expect(container.innerHTML).toBe("");
     });
 
-    it("removes pt-table-container class", async () => {
+    it("removes sift-table-container class", async () => {
       await flushRAF();
-      expect(container.classList.contains("pt-table-container")).toBe(true);
+      expect(container.classList.contains("sift-table-container")).toBe(true);
       engine.destroy();
-      expect(container.classList.contains("pt-table-container")).toBe(false);
+      expect(container.classList.contains("sift-table-container")).toBe(false);
     });
   });
 
@@ -272,7 +272,7 @@ describe("createTable", () => {
 
     it('header cells have role="columnheader"', async () => {
       await flushRAF();
-      const headers = container.querySelectorAll(".pt-th");
+      const headers = container.querySelectorAll(".sift-th");
       expect(headers.length).toBe(4);
       for (const h of headers) {
         expect(h.getAttribute("role")).toBe("columnheader");
@@ -283,7 +283,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.setSort("name", "asc");
       await flushRAF();
-      const headers = container.querySelectorAll(".pt-th");
+      const headers = container.querySelectorAll(".sift-th");
       expect(headers[1].getAttribute("aria-sort")).toBe("ascending");
       expect(headers[0].hasAttribute("aria-sort")).toBe(false);
     });
@@ -299,7 +299,7 @@ describe("createTable", () => {
       data.rowCount = 60;
       engine.onBatchAppended();
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("60");
     });
   });
@@ -312,9 +312,9 @@ describe("createTable", () => {
       const singleEngine = createTable(singleContainer, singleData);
       await flushRAF();
       // Engine mounts: header + stats bar + viewport exist
-      expect(singleContainer.querySelector(".pt-header")).not.toBeNull();
-      expect(singleContainer.querySelector(".pt-viewport")).not.toBeNull();
-      const stats = singleContainer.querySelector(".pt-stat-rows") as HTMLElement;
+      expect(singleContainer.querySelector(".sift-header")).not.toBeNull();
+      expect(singleContainer.querySelector(".sift-viewport")).not.toBeNull();
+      const stats = singleContainer.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("1");
       singleEngine.destroy();
     });
@@ -323,7 +323,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.setFilter(2, { kind: "range", min: 999, max: 1000 });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("0 of");
     });
 
@@ -336,7 +336,7 @@ describe("createTable", () => {
         max: targetScore,
       });
       await flushRAF();
-      const pills = container.querySelectorAll(".pt-filter-pill");
+      const pills = container.querySelectorAll(".sift-filter-pill");
       expect(pills.length).toBe(1);
       // Single-value pill should NOT show range dash
       expect(pills[0].textContent).not.toContain("–");
@@ -346,7 +346,7 @@ describe("createTable", () => {
       await flushRAF();
       engine.setFilter(1, { kind: "set", values: new Set() });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("0 of");
     });
 
@@ -364,8 +364,8 @@ describe("createTable", () => {
       const nullEngine = createTable(nullContainer, nullData);
       await flushRAF();
       // Engine mounts without throwing
-      expect(nullContainer.querySelector(".pt-header")).not.toBeNull();
-      expect(nullContainer.querySelector(".pt-viewport")).not.toBeNull();
+      expect(nullContainer.querySelector(".sift-header")).not.toBeNull();
+      expect(nullContainer.querySelector(".sift-viewport")).not.toBeNull();
       nullEngine.destroy();
     });
 
@@ -375,7 +375,7 @@ describe("createTable", () => {
       engine.setFilter(2, { kind: "range", min: 0, max: 50 });
       engine.setFilter(3, { kind: "boolean", value: true });
       await flushRAF();
-      const stats = container.querySelector(".pt-stat-rows") as HTMLElement;
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("of");
 
       engine.clearAllFilters();

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1767,7 +1767,7 @@ export function createTable(
       const f = filters[c];
 
       if (label) {
-        label.style.color = f ? "var(--accent)" : "";
+        label.style.color = f ? "var(--sift-accent)" : "";
         label.textContent = columns[c].label;
       }
 
@@ -2042,8 +2042,8 @@ export function createTable(
       cell.style.position = "sticky";
       cell.style.left = pinnedLeftOffsets[colIndex] + "px";
       cell.style.zIndex = "1";
-      cell.style.background = "var(--panel)";
-      cell.style.boxShadow = "2px 0 4px var(--pin-shadow)";
+      cell.style.background = "var(--sift-panel)";
+      cell.style.boxShadow = "2px 0 4px var(--sift-pin-shadow)";
     } else {
       cell.style.position = "";
       cell.style.left = "";
@@ -2093,8 +2093,8 @@ export function createTable(
         th.style.position = "sticky";
         th.style.left = pinnedLeftOffsets[dataCol] + "px";
         th.style.zIndex = "6";
-        th.style.background = "color-mix(in srgb, var(--panel) 90%, var(--page) 10%)";
-        th.style.boxShadow = vi === lastPinnedVi ? "2px 0 4px var(--pin-shadow)" : "";
+        th.style.background = "color-mix(in srgb, var(--sift-panel) 90%, var(--sift-page) 10%)";
+        th.style.boxShadow = vi === lastPinnedVi ? "2px 0 4px var(--sift-pin-shadow)" : "";
         // Hide resize bar on last pinned column (shadow provides the edge)
         if (handle) handle.style.opacity = vi === lastPinnedVi ? "0" : "";
       } else {

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -404,7 +404,7 @@ export function createTable(
   // --- DOM ---
 
   container.innerHTML = "";
-  container.classList.add("pt-table-container");
+  container.classList.add("sift-table-container");
   container.setAttribute("role", "grid");
   container.setAttribute("aria-label", "Data table");
   container.setAttribute("aria-rowcount", String(rowCount));
@@ -413,39 +413,39 @@ export function createTable(
   // Streaming state — progress bar is appended after stats bar below
   let streaming = true;
   const progressBar = document.createElement("div");
-  progressBar.className = "pt-progress-bar";
-  progressBar.innerHTML = '<div class="pt-progress-bar-fill"></div>';
+  progressBar.className = "sift-progress-bar";
+  progressBar.innerHTML = '<div class="sift-progress-bar-fill"></div>';
 
   // Header — lives inside the scroll content so it scrolls
   // horizontally with the data. position: sticky keeps it at top.
   const headerEl = document.createElement("div");
-  headerEl.className = "pt-header";
+  headerEl.className = "sift-header";
 
   const headerRowEl = document.createElement("div");
-  headerRowEl.className = "pt-header-row";
+  headerRowEl.className = "sift-header-row";
   headerRowEl.setAttribute("role", "row");
 
   const summaryContainers: HTMLDivElement[] = [];
 
   for (let c = 0; c < columns.length; c++) {
     const th = document.createElement("div");
-    th.className = "pt-th";
+    th.className = "sift-th";
     th.setAttribute("role", "columnheader");
     th.setAttribute("aria-colindex", String(c + 1));
     th.style.width = colWidths[c] + "px";
     th.dataset.col = String(c);
 
     const topRow = document.createElement("div");
-    topRow.className = "pt-th-top";
+    topRow.className = "sift-th-top";
 
     const label = document.createElement("span");
-    label.className = "pt-th-label";
+    label.className = "sift-th-label";
     label.textContent = columns[c].label;
     topRow.appendChild(label);
 
     if (columns[c].sortable) {
       const arrow = document.createElement("span");
-      arrow.className = "pt-sort-arrow";
+      arrow.className = "sift-sort-arrow";
       arrow.textContent = "";
       topRow.appendChild(arrow);
       topRow.style.cursor = "pointer";
@@ -457,7 +457,7 @@ export function createTable(
     // Type icon — hide for index columns (empty label = hidden index)
     if (columns[c].label) {
       const typeIcon = document.createElement("span");
-      typeIcon.className = "pt-type-icon";
+      typeIcon.className = "sift-type-icon";
       typeIcon.textContent =
         columns[c].columnType === "numeric"
           ? "#"
@@ -471,7 +471,7 @@ export function createTable(
     }
 
     const summaryEl = document.createElement("div");
-    summaryEl.className = "pt-th-summary";
+    summaryEl.className = "sift-th-summary";
     // Prevent clicks on summary charts (filter interactions) from triggering sort
     summaryEl.addEventListener("click", (e) => e.stopPropagation());
     th.appendChild(summaryEl);
@@ -557,7 +557,7 @@ export function createTable(
 
     if (c < columns.length - 1) {
       const handle = document.createElement("div");
-      handle.className = "pt-resize-handle";
+      handle.className = "sift-resize-handle";
       handle.addEventListener("pointerdown", (e) => onResizeStart(e, c));
       th.appendChild(handle);
     }
@@ -597,10 +597,10 @@ export function createTable(
 
   // Scroll viewport
   const viewport = document.createElement("div");
-  viewport.className = "pt-viewport";
+  viewport.className = "sift-viewport";
 
   const scrollContent = document.createElement("div");
-  scrollContent.className = "pt-scroll-content";
+  scrollContent.className = "sift-scroll-content";
   // Set min-width so horizontal scroll position is preserved when pool rows are hidden
   function updateScrollContentWidth() {
     const totalW = colWidths.reduce((s, w) => s + w, 0);
@@ -609,22 +609,22 @@ export function createTable(
   updateScrollContentWidth();
 
   const rowPool = document.createElement("div");
-  rowPool.className = "pt-row-pool";
+  rowPool.className = "sift-row-pool";
 
   scrollContent.appendChild(headerEl); // Header inside scroll content for natural H scroll
   scrollContent.appendChild(rowPool);
 
   // Empty state (shown when filters exclude all rows)
   const emptyEl = document.createElement("div");
-  emptyEl.className = "pt-empty-state";
+  emptyEl.className = "sift-empty-state";
   emptyEl.style.display = "none";
 
   const emptyText = document.createElement("div");
-  emptyText.className = "pt-empty-text";
+  emptyText.className = "sift-empty-text";
   emptyText.textContent = "No matching rows";
 
   const emptyClearBtn = document.createElement("button");
-  emptyClearBtn.className = "pt-empty-clear";
+  emptyClearBtn.className = "sift-empty-clear";
   emptyClearBtn.textContent = "Clear all filters";
   emptyClearBtn.addEventListener("click", () => clearAllFilters());
 
@@ -639,7 +639,7 @@ export function createTable(
 
   // Stats bar
   const statsEl = document.createElement("div");
-  statsEl.className = "pt-stats";
+  statsEl.className = "sift-stats";
 
   // ARIA live region for screen reader announcements (filter changes, streaming)
   const ariaLive = document.createElement("div");
@@ -652,23 +652,23 @@ export function createTable(
 
   function makeStatSpan(className: string): HTMLSpanElement {
     const el = document.createElement("span");
-    el.className = `pt-stat-value ${className}`;
+    el.className = `sift-stat-value ${className}`;
     return el;
   }
 
   // Status indicator (streaming dot → checkmark)
   const statusIndicator = document.createElement("span");
-  statusIndicator.className = "pt-status-indicator pt-status-streaming";
+  statusIndicator.className = "sift-status-indicator sift-status-streaming";
   statusIndicator.textContent = "●";
   statusIndicator.title = "Loading data…";
 
-  const statRows = makeStatSpan("pt-stat-rows");
+  const statRows = makeStatSpan("sift-stat-rows");
   // Debug stats (DOM rows, FPS) — hidden by default
   const debugGroup = document.createElement("span");
-  debugGroup.className = "pt-debug-group";
+  debugGroup.className = "sift-debug-group";
   debugGroup.style.display = "none";
-  const statDom = makeStatSpan("pt-stat-dom");
-  const statFrame = makeStatSpan("pt-stat-frame");
+  const statDom = makeStatSpan("sift-stat-dom");
+  const statFrame = makeStatSpan("sift-stat-frame");
 
   // Reusable odometer — rolling digit strips for any numeric display
   type OdometerSlot = {
@@ -681,7 +681,7 @@ export function createTable(
   function createOdometer(host: HTMLElement): {
     update: (text: string) => void;
   } {
-    host.classList.add("pt-odometer");
+    host.classList.add("sift-odometer");
     const slots: OdometerSlot[] = [];
     // Track the previous numeric value to determine roll direction
     let prevNumericValue = 0;
@@ -694,10 +694,10 @@ export function createTable(
 
     function createDigitStrip(): HTMLSpanElement {
       const strip = document.createElement("span");
-      strip.className = "pt-odo-strip";
+      strip.className = "sift-odo-strip";
       for (const d of STRIP_DIGITS) {
         const digit = document.createElement("span");
-        digit.className = "pt-odo-num";
+        digit.className = "sift-odo-num";
         digit.textContent = String(d);
         strip.appendChild(digit);
       }
@@ -718,7 +718,7 @@ export function createTable(
 
       while (slots.length < text.length) {
         const el = document.createElement("span");
-        el.className = "pt-odo-slot";
+        el.className = "sift-odo-slot";
         host.appendChild(el);
         slots.push({ el, strip: null, current: "", pos: -1 });
       }
@@ -810,7 +810,7 @@ export function createTable(
 
   // Fullscreen toggle
   const fullscreenBtn = document.createElement("button");
-  fullscreenBtn.className = "pt-fullscreen-btn";
+  fullscreenBtn.className = "sift-fullscreen-btn";
   fullscreenBtn.title = "Toggle fullscreen";
   fullscreenBtn.textContent = "⛶";
   fullscreenBtn.addEventListener("click", () => {
@@ -833,20 +833,20 @@ export function createTable(
   document.addEventListener("fullscreenchange", onFullscreenChange);
 
   const filterPillsEl = document.createElement("div");
-  filterPillsEl.className = "pt-filter-pills";
+  filterPillsEl.className = "sift-filter-pills";
 
   const statsSpacer = document.createElement("div");
   statsSpacer.style.flex = "1";
 
   // Debug toggle button
   const debugBtn = document.createElement("button");
-  debugBtn.className = "pt-debug-btn";
+  debugBtn.className = "sift-debug-btn";
   debugBtn.title = "Toggle debug stats";
   debugBtn.textContent = "⚙";
   debugBtn.addEventListener("click", () => {
     const visible = debugGroup.style.display !== "none";
     debugGroup.style.display = visible ? "none" : "";
-    debugBtn.classList.toggle("pt-debug-active", !visible);
+    debugBtn.classList.toggle("sift-debug-active", !visible);
   });
 
   debugGroup.append(sep(), statDom, sep(), statFrame);
@@ -886,7 +886,7 @@ export function createTable(
       const f = filters[c];
       if (!f) continue;
       const pill = document.createElement("span");
-      pill.className = "pt-filter-pill";
+      pill.className = "sift-filter-pill";
 
       let text = columns[c].label + ": ";
       switch (f.kind) {
@@ -936,7 +936,7 @@ export function createTable(
       label.textContent = text;
 
       const closeBtn = document.createElement("button");
-      closeBtn.className = "pt-filter-pill-x";
+      closeBtn.className = "sift-filter-pill-x";
       closeBtn.textContent = "×";
       closeBtn.addEventListener("click", (e) => {
         e.stopPropagation();
@@ -950,7 +950,7 @@ export function createTable(
 
   function sep(): HTMLSpanElement {
     const s = document.createElement("span");
-    s.className = "pt-stat-sep";
+    s.className = "sift-stat-sep";
     s.textContent = " · ";
     return s;
   }
@@ -995,9 +995,9 @@ export function createTable(
   function updateStat(el: HTMLSpanElement, value: string, prev: string): string {
     if (value !== prev) {
       el.textContent = value;
-      el.classList.remove("pt-stat-flash");
+      el.classList.remove("sift-stat-flash");
       void el.offsetWidth;
-      el.classList.add("pt-stat-flash");
+      el.classList.add("sift-stat-flash");
     }
     return value;
   }
@@ -1047,13 +1047,13 @@ export function createTable(
       if (pr.assignedRow === -1) return pr;
     }
     const el = document.createElement("div");
-    el.className = "pt-row";
+    el.className = "sift-row";
     el.setAttribute("role", "row");
     const cells: HTMLDivElement[] = [];
     // Create cells in data order (cells[c] = column c)
     for (let c = 0; c < columns.length; c++) {
       const cell = document.createElement("div");
-      cell.className = "pt-cell";
+      cell.className = "sift-cell";
       cell.setAttribute("role", "gridcell");
       cell.setAttribute("aria-colindex", String(c + 1));
       cell.style.width = colWidths[c] + "px";
@@ -1078,12 +1078,12 @@ export function createTable(
 
     // Clear previous content
     cellEl.textContent = "";
-    cellEl.className = "pt-cell";
+    cellEl.className = "sift-cell";
 
     // Null values get a distinct badge regardless of column type
     if (raw == null) {
       const badge = document.createElement("span");
-      badge.className = "pt-badge pt-badge-null";
+      badge.className = "sift-badge sift-badge-null";
       badge.textContent = "null";
       cellEl.appendChild(badge);
       return;
@@ -1092,14 +1092,14 @@ export function createTable(
     switch (col.columnType) {
       case "boolean": {
         const badge = document.createElement("span");
-        badge.className = raw ? "pt-badge pt-badge-true" : "pt-badge pt-badge-false";
+        badge.className = raw ? "sift-badge sift-badge-true" : "sift-badge sift-badge-false";
         badge.textContent = raw ? "Yes" : "No";
         cellEl.appendChild(badge);
         break;
       }
       case "timestamp": {
         cellEl.textContent = str;
-        cellEl.classList.add("pt-cell-timestamp");
+        cellEl.classList.add("sift-cell-timestamp");
         break;
       }
       default:
@@ -1204,8 +1204,8 @@ export function createTable(
       pr.el.style.height = rowHeights[r] + "px";
       pr.el.setAttribute("aria-rowindex", String(r + 2)); // 1-based, header is row 1
 
-      if (r % 2 === 1) pr.el.classList.add("pt-row-alt");
-      else pr.el.classList.remove("pt-row-alt");
+      if (r % 2 === 1) pr.el.classList.add("sift-row-alt");
+      else pr.el.classList.remove("sift-row-alt");
 
       for (let c = 0; c < columns.length; c++) {
         renderCell(pr.cells[c], dataRow, c);
@@ -1233,8 +1233,8 @@ export function createTable(
         pr.el.style.transform = `translateY(${rowPositions[r]}px)`;
         pr.el.style.height = rowHeights[r] + "px";
         pr.el.setAttribute("aria-rowindex", String(r + 2));
-        if (r % 2 === 1) pr.el.classList.add("pt-row-alt");
-        else pr.el.classList.remove("pt-row-alt");
+        if (r % 2 === 1) pr.el.classList.add("sift-row-alt");
+        else pr.el.classList.remove("sift-row-alt");
         for (let c = 0; c < columns.length; c++) {
           renderCell(pr.cells[c], dataRow, c);
           pr.cells[c].style.width = colWidths[c] + "px";
@@ -1290,7 +1290,7 @@ export function createTable(
     if (!activeDetailSheet) return;
     const sheet = activeDetailSheet;
     const backdrop = sheet.previousElementSibling as HTMLElement | null;
-    sheet.classList.remove("pt-detail-sheet-open");
+    sheet.classList.remove("sift-detail-sheet-open");
     sheet.addEventListener(
       "transitionend",
       () => {
@@ -1310,23 +1310,23 @@ export function createTable(
 
     // Backdrop
     const backdrop = document.createElement("div");
-    backdrop.className = "pt-detail-backdrop";
+    backdrop.className = "sift-detail-backdrop";
     backdrop.addEventListener("click", dismissDetailSheet);
 
     // Sheet
     const sheet = document.createElement("div");
-    sheet.className = "pt-detail-sheet";
+    sheet.className = "sift-detail-sheet";
 
     // Header with row number and close button
     const header = document.createElement("div");
-    header.className = "pt-detail-header";
+    header.className = "sift-detail-header";
 
     const title = document.createElement("span");
-    title.className = "pt-detail-title";
+    title.className = "sift-detail-title";
     title.textContent = `Row ${dataRow + 1}`;
 
     const closeBtn = document.createElement("button");
-    closeBtn.className = "pt-detail-close";
+    closeBtn.className = "sift-detail-close";
     closeBtn.textContent = "×";
     closeBtn.addEventListener("click", dismissDetailSheet);
 
@@ -1336,17 +1336,17 @@ export function createTable(
 
     // Column-value list
     const list = document.createElement("div");
-    list.className = "pt-detail-list";
+    list.className = "sift-detail-list";
 
     for (let c = 0; c < columns.length; c++) {
       const row = document.createElement("div");
-      row.className = "pt-detail-row";
+      row.className = "sift-detail-row";
 
       const nameEl = document.createElement("div");
-      nameEl.className = "pt-detail-col-name";
+      nameEl.className = "sift-detail-col-name";
 
       const icon = document.createElement("span");
-      icon.className = "pt-detail-type-icon";
+      icon.className = "sift-detail-type-icon";
       icon.textContent = typeIconChar(columns[c].columnType);
 
       const label = document.createElement("span");
@@ -1356,17 +1356,17 @@ export function createTable(
       nameEl.appendChild(label);
 
       const valueEl = document.createElement("div");
-      valueEl.className = "pt-detail-col-value";
+      valueEl.className = "sift-detail-col-value";
 
       const raw = data.getCellRaw(dataRow, c);
       if (raw == null) {
         const badge = document.createElement("span");
-        badge.className = "pt-badge pt-badge-null";
+        badge.className = "sift-badge sift-badge-null";
         badge.textContent = "null";
         valueEl.appendChild(badge);
       } else if (columns[c].columnType === "boolean") {
         const badge = document.createElement("span");
-        badge.className = raw ? "pt-badge pt-badge-true" : "pt-badge pt-badge-false";
+        badge.className = raw ? "sift-badge sift-badge-true" : "sift-badge sift-badge-false";
         badge.textContent = raw ? "Yes" : "No";
         valueEl.appendChild(badge);
       } else {
@@ -1386,7 +1386,7 @@ export function createTable(
 
     // Trigger slide-up animation on next frame
     requestAnimationFrame(() => {
-      sheet.classList.add("pt-detail-sheet-open");
+      sheet.classList.add("sift-detail-sheet-open");
     });
   }
 
@@ -1417,7 +1417,7 @@ export function createTable(
 
     // Find which pool row was tapped
     const target = e.target as HTMLElement;
-    const rowEl = target.closest(".pt-row") as HTMLDivElement | null;
+    const rowEl = target.closest(".sift-row") as HTMLDivElement | null;
     if (!rowEl) return;
 
     for (const pr of pool) {
@@ -1485,7 +1485,7 @@ export function createTable(
   function updateSortUI() {
     const ths = headerRowEl.children as HTMLCollectionOf<HTMLDivElement>;
     for (let c = 0; c < columns.length; c++) {
-      const arrow = ths[c].querySelector(".pt-sort-arrow");
+      const arrow = ths[c].querySelector(".sift-sort-arrow");
       if (!arrow) continue;
       if (sortState && sortState.col === c) {
         arrow.textContent = sortState.dir === "asc" ? " ↑" : " ↓";
@@ -1546,11 +1546,11 @@ export function createTable(
   function setStreamingDone() {
     if (!streaming) return;
     streaming = false;
-    progressBar.classList.add("pt-progress-bar-done");
+    progressBar.classList.add("sift-progress-bar-done");
     updateRowCountDisplay();
     // Switch status indicator from streaming dot to checkmark
-    statusIndicator.classList.remove("pt-status-streaming");
-    statusIndicator.classList.add("pt-status-ready");
+    statusIndicator.classList.remove("sift-status-streaming");
+    statusIndicator.classList.add("sift-status-ready");
     statusIndicator.textContent = "✓";
     statusIndicator.title = "All data loaded";
     // Remove the progress bar from DOM after fade-out transition
@@ -1662,7 +1662,7 @@ export function createTable(
 
     // Clear DOM
     container.innerHTML = "";
-    container.classList.remove("pt-table-container");
+    container.classList.remove("sift-table-container");
   }
 
   // --- Filter API ---
@@ -1758,10 +1758,10 @@ export function createTable(
     const ths = headerRowEl.children as HTMLCollectionOf<HTMLDivElement>;
     for (let c = 0; c < columns.length; c++) {
       const th = ths[c];
-      const label = th.querySelector(".pt-th-label") as HTMLElement;
+      const label = th.querySelector(".sift-th-label") as HTMLElement;
 
       // Remove existing filter line
-      const existing = th.querySelector(".pt-filter-line");
+      const existing = th.querySelector(".sift-filter-line");
       if (existing) existing.remove();
 
       const f = filters[c];
@@ -1779,7 +1779,7 @@ export function createTable(
 
         if (parts.length > 0) {
           const line = document.createElement("div");
-          line.className = "pt-filter-line";
+          line.className = "sift-filter-line";
           line.textContent = parts.join(" · ");
           th.appendChild(line);
         }
@@ -1958,7 +1958,7 @@ export function createTable(
           columns[colIndex].numeric = action.targetType === "numeric";
           // Update type icon
           const ths = headerRowEl.children as HTMLCollectionOf<HTMLDivElement>;
-          const icon = ths[colIndex].querySelector(".pt-type-icon");
+          const icon = ths[colIndex].querySelector(".sift-type-icon");
           if (icon) {
             icon.textContent =
               action.targetType === "numeric"
@@ -1993,7 +1993,7 @@ export function createTable(
           columns[colIndex].numeric = restoredType === "numeric";
           // Update type icon
           const thsUndo = headerRowEl.children as HTMLCollectionOf<HTMLDivElement>;
-          const iconUndo = thsUndo[colIndex].querySelector(".pt-type-icon");
+          const iconUndo = thsUndo[colIndex].querySelector(".sift-type-icon");
           if (iconUndo) {
             iconUndo.textContent =
               restoredType === "numeric"
@@ -2088,7 +2088,7 @@ export function createTable(
     for (let vi = 0; vi < visualOrder.length; vi++) {
       const dataCol = visualOrder[vi];
       const th = ths[vi];
-      const handle = th.querySelector(".pt-resize-handle") as HTMLElement | null;
+      const handle = th.querySelector(".sift-resize-handle") as HTMLElement | null;
       if (pinnedColumns.has(dataCol)) {
         th.style.position = "sticky";
         th.style.left = pinnedLeftOffsets[dataCol] + "px";

--- a/packages/sift/src/themes/classic.css
+++ b/packages/sift/src/themes/classic.css
@@ -1,0 +1,101 @@
+/**
+ * Sift Classic Theme
+ *
+ * Neutral palette matching the nteract notebook's shadcn-based design system.
+ * Light and dark variants.
+ */
+
+/* --- Light (default) --- */
+[data-color-theme="classic"] {
+  color-scheme: light;
+  --sift-page: #ffffff;
+  --sift-panel: #ffffff;
+  --sift-ink: #1a1a1a;
+  --sift-muted: #6b7280;
+  --sift-rule: #e5e7eb;
+  --sift-accent: #3b82f6;
+  --sift-row-alt: rgba(0, 0, 0, 0.02);
+  --sift-pin-shadow: rgba(0, 0, 0, 0.06);
+  --sift-font: Inter, ui-sans-serif, system-ui, sans-serif;
+
+  /* Semantic colors */
+  --sift-badge-true-bg: rgba(34, 197, 94, 0.12);
+  --sift-badge-true-color: #15803d;
+  --sift-badge-false-bg: rgba(239, 68, 68, 0.12);
+  --sift-badge-false-color: #b91c1c;
+  --sift-bool-true: #22c55e;
+  --sift-bool-false: #ef4444;
+  --sift-bool-null-fg: rgba(0, 0, 0, 0.08);
+  --sift-bool-null-bg: rgba(0, 0, 0, 0.03);
+  --sift-loading-code-bg: rgba(0, 0, 0, 0.04);
+  --sift-detail-backdrop: rgba(0, 0, 0, 0.4);
+  --sift-detail-shadow: rgba(0, 0, 0, 0.1);
+  --sift-skeleton-bar-from: rgba(0, 0, 0, 0.04);
+  --sift-skeleton-bar-via: rgba(0, 0, 0, 0.08);
+  --sift-cat-bar-track: rgba(0, 0, 0, 0.04);
+  --sift-scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --sift-scrollbar-thumb-hover: rgba(0, 0, 0, 0.3);
+}
+
+/* --- Dark (system preference) --- */
+@media (prefers-color-scheme: dark) {
+  [data-color-theme="classic"]:not([data-theme="light"]) {
+    color-scheme: dark;
+    --sift-page: #0a0a0a;
+    --sift-panel: #171717;
+    --sift-ink: #e5e5e5;
+    --sift-muted: #a3a3a3;
+    --sift-rule: #2a2a2a;
+    --sift-accent: #60a5fa;
+    --sift-row-alt: rgba(255, 255, 255, 0.025);
+    --sift-pin-shadow: rgba(255, 255, 255, 0.06);
+
+    --sift-badge-true-bg: rgba(34, 197, 94, 0.15);
+    --sift-badge-true-color: #4ade80;
+    --sift-badge-false-bg: rgba(239, 68, 68, 0.15);
+    --sift-badge-false-color: #f87171;
+    --sift-bool-true: #4ade80;
+    --sift-bool-false: #f87171;
+    --sift-bool-null-fg: rgba(255, 255, 255, 0.1);
+    --sift-bool-null-bg: rgba(255, 255, 255, 0.04);
+    --sift-loading-code-bg: rgba(255, 255, 255, 0.06);
+    --sift-detail-backdrop: rgba(0, 0, 0, 0.6);
+    --sift-detail-shadow: rgba(0, 0, 0, 0.5);
+    --sift-skeleton-bar-from: rgba(255, 255, 255, 0.04);
+    --sift-skeleton-bar-via: rgba(255, 255, 255, 0.08);
+    --sift-cat-bar-track: rgba(255, 255, 255, 0.06);
+    --sift-scrollbar-thumb: rgba(255, 255, 255, 0.2);
+    --sift-scrollbar-thumb-hover: rgba(255, 255, 255, 0.35);
+  }
+}
+
+/* --- Dark (explicit attribute) --- */
+[data-color-theme="classic"][data-theme="dark"],
+[data-color-theme="classic"].dark {
+  color-scheme: dark;
+  --sift-page: #0a0a0a;
+  --sift-panel: #171717;
+  --sift-ink: #e5e5e5;
+  --sift-muted: #a3a3a3;
+  --sift-rule: #2a2a2a;
+  --sift-accent: #60a5fa;
+  --sift-row-alt: rgba(255, 255, 255, 0.025);
+  --sift-pin-shadow: rgba(255, 255, 255, 0.06);
+
+  --sift-badge-true-bg: rgba(34, 197, 94, 0.15);
+  --sift-badge-true-color: #4ade80;
+  --sift-badge-false-bg: rgba(239, 68, 68, 0.15);
+  --sift-badge-false-color: #f87171;
+  --sift-bool-true: #4ade80;
+  --sift-bool-false: #f87171;
+  --sift-bool-null-fg: rgba(255, 255, 255, 0.1);
+  --sift-bool-null-bg: rgba(255, 255, 255, 0.04);
+  --sift-loading-code-bg: rgba(255, 255, 255, 0.06);
+  --sift-detail-backdrop: rgba(0, 0, 0, 0.6);
+  --sift-detail-shadow: rgba(0, 0, 0, 0.5);
+  --sift-skeleton-bar-from: rgba(255, 255, 255, 0.04);
+  --sift-skeleton-bar-via: rgba(255, 255, 255, 0.08);
+  --sift-cat-bar-track: rgba(255, 255, 255, 0.06);
+  --sift-scrollbar-thumb: rgba(255, 255, 255, 0.2);
+  --sift-scrollbar-thumb-hover: rgba(255, 255, 255, 0.35);
+}

--- a/packages/sift/src/themes/cream.css
+++ b/packages/sift/src/themes/cream.css
@@ -1,0 +1,103 @@
+/**
+ * Sift Cream Theme
+ *
+ * Warm, document-like palette with brown accents.
+ * Light and dark variants.
+ */
+
+/* --- Light (default) --- */
+:root,
+[data-color-theme="cream"] {
+  color-scheme: light;
+  --sift-page: #f5f2ec;
+  --sift-panel: #fffdf9;
+  --sift-ink: #1e1a18;
+  --sift-muted: #6e655f;
+  --sift-rule: #d8cec3;
+  --sift-accent: #955f3b;
+  --sift-row-alt: rgba(0, 0, 0, 0.018);
+  --sift-pin-shadow: rgba(0, 0, 0, 0.06);
+  --sift-font: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  /* Semantic colors */
+  --sift-badge-true-bg: rgba(58, 138, 92, 0.15);
+  --sift-badge-true-color: #2d6e4a;
+  --sift-badge-false-bg: rgba(196, 81, 58, 0.15);
+  --sift-badge-false-color: #9e3a24;
+  --sift-bool-true: #3a8a5c;
+  --sift-bool-false: #c4513a;
+  --sift-bool-null-fg: rgba(0, 0, 0, 0.08);
+  --sift-bool-null-bg: rgba(0, 0, 0, 0.03);
+  --sift-loading-code-bg: rgba(0, 0, 0, 0.06);
+  --sift-detail-backdrop: rgba(0, 0, 0, 0.3);
+  --sift-detail-shadow: rgba(0, 0, 0, 0.15);
+  --sift-skeleton-bar-from: rgba(0, 0, 0, 0.04);
+  --sift-skeleton-bar-via: rgba(0, 0, 0, 0.08);
+  --sift-cat-bar-track: rgba(0, 0, 0, 0.04);
+  --sift-scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --sift-scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
+}
+
+/* --- Dark (system preference) --- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-color-theme="classic"]),
+  [data-color-theme="cream"]:not([data-theme="light"]) {
+    color-scheme: dark;
+    --sift-page: #1a1816;
+    --sift-panel: #242120;
+    --sift-ink: #e8e2dc;
+    --sift-muted: #9a918a;
+    --sift-rule: #3a3533;
+    --sift-accent: #d4896a;
+    --sift-row-alt: rgba(255, 255, 255, 0.025);
+    --sift-pin-shadow: rgba(255, 255, 255, 0.08);
+
+    --sift-badge-true-bg: rgba(94, 201, 138, 0.2);
+    --sift-badge-true-color: #5ec98a;
+    --sift-badge-false-bg: rgba(224, 122, 100, 0.2);
+    --sift-badge-false-color: #e07a64;
+    --sift-bool-true: #5ec98a;
+    --sift-bool-false: #e07a64;
+    --sift-bool-null-fg: rgba(255, 255, 255, 0.1);
+    --sift-bool-null-bg: rgba(255, 255, 255, 0.04);
+    --sift-loading-code-bg: rgba(255, 255, 255, 0.08);
+    --sift-detail-backdrop: rgba(0, 0, 0, 0.5);
+    --sift-detail-shadow: rgba(0, 0, 0, 0.4);
+    --sift-skeleton-bar-from: rgba(255, 255, 255, 0.04);
+    --sift-skeleton-bar-via: rgba(255, 255, 255, 0.08);
+    --sift-cat-bar-track: rgba(255, 255, 255, 0.06);
+    --sift-scrollbar-thumb: rgba(255, 255, 255, 0.15);
+    --sift-scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  }
+}
+
+/* --- Dark (explicit attribute) --- */
+[data-color-theme="cream"][data-theme="dark"],
+[data-color-theme="cream"].dark {
+  color-scheme: dark;
+  --sift-page: #1a1816;
+  --sift-panel: #242120;
+  --sift-ink: #e8e2dc;
+  --sift-muted: #9a918a;
+  --sift-rule: #3a3533;
+  --sift-accent: #d4896a;
+  --sift-row-alt: rgba(255, 255, 255, 0.025);
+  --sift-pin-shadow: rgba(255, 255, 255, 0.08);
+
+  --sift-badge-true-bg: rgba(94, 201, 138, 0.2);
+  --sift-badge-true-color: #5ec98a;
+  --sift-badge-false-bg: rgba(224, 122, 100, 0.2);
+  --sift-badge-false-color: #e07a64;
+  --sift-bool-true: #5ec98a;
+  --sift-bool-false: #e07a64;
+  --sift-bool-null-fg: rgba(255, 255, 255, 0.1);
+  --sift-bool-null-bg: rgba(255, 255, 255, 0.04);
+  --sift-loading-code-bg: rgba(255, 255, 255, 0.08);
+  --sift-detail-backdrop: rgba(0, 0, 0, 0.5);
+  --sift-detail-shadow: rgba(0, 0, 0, 0.4);
+  --sift-skeleton-bar-from: rgba(255, 255, 255, 0.04);
+  --sift-skeleton-bar-via: rgba(255, 255, 255, 0.08);
+  --sift-cat-bar-track: rgba(255, 255, 255, 0.06);
+  --sift-scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --sift-scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+}

--- a/packages/sift/src/themes/cream.css
+++ b/packages/sift/src/themes/cream.css
@@ -72,6 +72,8 @@
 }
 
 /* --- Dark (explicit attribute) --- */
+:root:not([data-color-theme])[data-theme="dark"],
+:root:not([data-color-theme]).dark,
 [data-color-theme="cream"][data-theme="dark"],
 [data-color-theme="cream"].dark {
   color-scheme: dark;

--- a/packages/sift/src/themes/cream.css
+++ b/packages/sift/src/themes/cream.css
@@ -40,7 +40,7 @@
 
 /* --- Dark (system preference) --- */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]):not([data-color-theme="classic"]),
+  :root:not([data-theme="light"]):not([data-color-theme]),
   [data-color-theme="cream"]:not([data-theme="light"]) {
     color-scheme: dark;
     --sift-page: #1a1816;


### PR DESCRIPTION
## Summary

Three-part refactor of sift's CSS architecture:

1. **Rename `.pt-*` → `.sift-*`** — mechanical rename of all CSS class prefixes from the legacy pretext-table naming. ~560 replacements across src/, e2e/, and demos/.

2. **Split CSS into structural + theme** — `style.css` is now purely structural (layout, sizing, positioning). All color values come from `--sift-*` CSS variables. No hardcoded colors remain.

3. **Theme presets** — two themes, each with light + dark variants:
   - **Cream** (`themes/cream.css`) — warm, document-like palette with brown accents (existing look)
   - **Classic** (`themes/classic.css`) — neutral palette matching the notebook's shadcn design system

### Theme activation

Themes activate via `data-color-theme` attribute on the document element:
- No attribute → cream (default)
- `data-color-theme="cream"` → cream
- `data-color-theme="classic"` → classic

Dark mode within each theme responds to:
- `@media (prefers-color-scheme: dark)` (system preference)
- `data-theme="dark"` or `.dark` class (explicit override)

### CSS variable contract

All 25 `--sift-*` variables are defined by both themes:

| Variable | Purpose |
|----------|---------|
| `--sift-page` | Page background |
| `--sift-panel` | Panel/surface background |
| `--sift-ink` | Primary text |
| `--sift-muted` | Secondary text |
| `--sift-rule` | Borders/dividers |
| `--sift-accent` | Accent color |
| `--sift-font` | Font stack |
| `--sift-row-alt` | Alternating row tint |
| `--sift-pin-shadow` | Pinned column shadow |
| `--sift-badge-true-*` | Boolean true badge |
| `--sift-badge-false-*` | Boolean false badge |
| `--sift-bool-true/false` | Boolean bar colors |
| ... | (see theme files for full list) |

### What this enables

- Notebook can toggle between cream and classic by setting `data-color-theme` on the iframe's document element
- New themes can be added by creating a new CSS file — no changes to `style.css` needed
- The classic theme aligns with shadcn/Tailwind design tokens for seamless notebook integration

## Test plan

- [x] `pnpm --filter @nteract/sift exec vp test run` — 124 tests pass (5/5 files)
- [x] `cargo xtask lint --fix` — clean
- [x] No remaining `.pt-*` references in src/, e2e/, or demos/
- [x] No hardcoded colors in style.css
- [x] Both themes define all 25 required CSS variables
- [ ] Visual: sift dev server with cream theme (existing look preserved)
- [ ] Visual: sift dev server with classic theme (toggle `data-color-theme`)