### PR TITLE
fix(mcp-proxy): check child transport state before skipping restart

### DIFF
--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -486,11 +486,13 @@ impl McpProxy {
             }
             Err(e) => {
                 let state = self.state.read().await;
-                if state.child_client.is_some() {
+                let child_alive = state.child_client.as_ref().is_some_and(|c| !c.is_closed());
+                drop(state);
+                if child_alive {
                     warn!("Tool call failed but child still connected, not restarting: {e}");
                     return Err(e);
                 }
-                warn!("Tool call failed and child disconnected, attempting restart: {e}");
+                warn!("Tool call failed and child transport closed, attempting restart: {e}");
             }
         }
 
@@ -531,10 +533,12 @@ impl McpProxy {
             Ok(result) => return Ok(result),
             Err(e) => {
                 let state = self.state.read().await;
-                if state.child_client.is_some() {
+                let child_alive = state.child_client.as_ref().is_some_and(|c| !c.is_closed());
+                drop(state);
+                if child_alive {
                     return Err(e);
                 }
-                warn!("Resource read failed and child disconnected, attempting restart: {e}");
+                warn!("Resource read failed and child transport closed, attempting restart: {e}");
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix mcpb proxy error handling to check `is_closed()` on the child transport instead of `is_some()` on the client struct
- After a daemon redeploy, the child client struct still exists but the transport is dead — the old check skipped restart and returned errors to callers
- Applied to both `forward_tool_call` and `forward_read_resource` error paths

## Root cause

When the daemon restarts, the `runt mcp` health monitor detects the version/PID change and exits. The mcpb proxy's child process dies, but the `child_client` field retains the `McpClient` struct (set to `Some` on spawn). The error handler checked `is_some()` — always true — so it never triggered the restart path. All MCP tool calls failed with "Transport closed" until manual intervention.

## Fix

Replace `state.child_client.is_some()` with `state.child_client.as_ref().is_some_and(|c| !c.is_closed())` to check actual transport liveness. Also `drop(state)` before proceeding to the restart path to avoid holding the read lock across async work.

## Test plan

- [x] Deployed as nightly `2.1.3+b1dfcfb`, verified proxy recovers after daemon restart
- [x] All teammates' MCP connections survived a daemon redeploy
- [ ] `cargo xtask lint` passes
- [ ] CI passes