### PR TITLE
fix(runtimed): env cleanup on room eviction and GC improvements

### DIFF
--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -12,7 +12,8 @@
 //! - `runtimed-py` (Python bindings) — PoolClient, SyncClient, settings
 //! - `runtimed` (daemon) — re-exports everything, adds server-only code
 
-use std::path::PathBuf;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -88,6 +89,62 @@ pub struct PooledEnv {
     pub prewarmed_packages: Vec<String>,
 }
 
+// ============================================================================
+// Pool Directory Naming
+// ============================================================================
+
+/// Directory name prefixes for prewarmed pool environments.
+///
+/// Pool envs are created in `default_cache_dir()` with these prefixes
+/// followed by a UUID (e.g. `runtimed-uv-a1b2c3d4-...`). GC, room
+/// eviction, and pool recovery use these to identify pool-managed dirs
+/// vs. content-addressed caches (which are 16-char hex names).
+pub const POOL_PREFIX_UV: &str = "runtimed-uv-";
+pub const POOL_PREFIX_CONDA: &str = "runtimed-conda-";
+pub const POOL_PREFIX_PIXI: &str = "runtimed-pixi-";
+
+/// All pool directory prefixes, for iteration.
+pub const POOL_PREFIXES: &[&str] = &[POOL_PREFIX_UV, POOL_PREFIX_CONDA, POOL_PREFIX_PIXI];
+
+/// Check whether a directory name looks like a pool-managed environment.
+pub fn is_pool_env_dir(name: &str) -> bool {
+    POOL_PREFIXES.iter().any(|prefix| name.starts_with(prefix))
+}
+
+/// Walk up from a pool env's `venv_path` to find the top-level
+/// `runtimed-{uv,conda,pixi}-*` directory.
+///
+/// Pixi envs have nested venv_paths (e.g.
+/// `runtimed-pixi-{uuid}/.pixi/envs/default`) but GC and room eviction
+/// operate on top-level dirs, so this normalises before comparing or
+/// deleting.
+///
+/// Returns the path unchanged if no pool-prefixed ancestor is found
+/// (e.g. for content-addressed envs that are already top-level).
+pub fn pool_env_root(path: &Path) -> PathBuf {
+    let mut cur = path;
+    loop {
+        if let Some(name) = cur.file_name().and_then(|n: &OsStr| n.to_str()) {
+            if is_pool_env_dir(name) {
+                return cur.to_path_buf();
+            }
+        }
+        match cur.parent() {
+            Some(p) if p != cur => cur = p,
+            _ => break,
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Check whether a path is inside the given cache directory.
+///
+/// Used as a safety gate before `remove_dir_all` to ensure we never
+/// accidentally delete paths outside the daemon's cache tree.
+pub fn is_within_cache_dir(path: &Path, cache_dir: &Path) -> bool {
+    path.starts_with(cache_dir)
+}
+
 /// Get the default cache directory for environments.
 pub fn default_cache_dir() -> PathBuf {
     daemon_base_dir().join("envs")
@@ -124,4 +181,56 @@ pub fn settings_schema_path() -> PathBuf {
 /// Get the default directory for persisted notebook Automerge documents.
 pub fn default_notebook_docs_dir() -> PathBuf {
     daemon_base_dir().join("notebook-docs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_pool_env_dir() {
+        assert!(is_pool_env_dir("runtimed-uv-a1b2c3d4"));
+        assert!(is_pool_env_dir("runtimed-conda-a1b2c3d4"));
+        assert!(is_pool_env_dir("runtimed-pixi-a1b2c3d4"));
+        assert!(!is_pool_env_dir("abcdef0123456789")); // content-addressed
+        assert!(!is_pool_env_dir("some-other-dir"));
+    }
+
+    #[test]
+    fn test_pool_env_root_uv() {
+        // UV venv_path IS the top-level dir — returned unchanged
+        let path = Path::new("/cache/envs/runtimed-uv-abc123");
+        assert_eq!(pool_env_root(path), path);
+    }
+
+    #[test]
+    fn test_pool_env_root_pixi_nested() {
+        // Pixi venv_path is nested — walk up to top-level
+        let path = Path::new("/cache/envs/runtimed-pixi-abc123/.pixi/envs/default");
+        assert_eq!(
+            pool_env_root(path),
+            Path::new("/cache/envs/runtimed-pixi-abc123")
+        );
+    }
+
+    #[test]
+    fn test_pool_env_root_content_addressed() {
+        // Content-addressed envs have no runtimed-* ancestor — returned unchanged
+        let path = Path::new("/cache/envs/abcdef0123456789");
+        assert_eq!(pool_env_root(path), path);
+    }
+
+    #[test]
+    fn test_is_within_cache_dir() {
+        let cache = Path::new("/home/user/.cache/runt-nightly/envs");
+        assert!(is_within_cache_dir(
+            Path::new("/home/user/.cache/runt-nightly/envs/runtimed-uv-abc"),
+            cache
+        ));
+        assert!(!is_within_cache_dir(
+            Path::new("/tmp/runtimed-uv-abc"),
+            cache
+        ));
+        assert!(!is_within_cache_dir(Path::new("/home/user/.cache"), cache));
+    }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4,7 +4,7 @@
 //! notebook windows via IPC (Unix domain sockets on Unix, named pipes on Windows).
 
 use std::collections::{HashMap, VecDeque};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Instant;
@@ -30,7 +30,10 @@ use crate::notebook_sync_server::NotebookRooms;
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
 use crate::settings_doc::SettingsDoc;
 use crate::singleton::DaemonLock;
-use crate::{default_blob_store_dir, default_cache_dir, default_socket_path, EnvType, PooledEnv};
+use crate::{
+    default_blob_store_dir, default_cache_dir, default_socket_path, is_pool_env_dir,
+    is_within_cache_dir, pool_env_root, EnvType, PooledEnv,
+};
 use runtimed_client::singleton::DaemonInfo;
 
 /// Configuration for the pool daemon.
@@ -270,33 +273,6 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     ];
     packages.extend(extra.iter().cloned());
     packages
-}
-
-/// Walk up from a pool env's `venv_path` to find the top-level
-/// `runtimed-{uv,conda,pixi}-*` directory. Pixi envs have nested venv_paths
-/// (e.g. `runtimed-pixi-{uuid}/.pixi/envs/default`) but GC and room eviction
-/// operate on top-level dirs, so we need this to normalise before comparing or
-/// deleting.
-///
-/// Returns the path unchanged if no `runtimed-*` ancestor is found (e.g. for
-/// content-addressed envs that are already top-level).
-pub(crate) fn pool_env_root(path: &Path) -> PathBuf {
-    let mut cur = path;
-    loop {
-        if let Some(name) = cur.file_name().and_then(|n| n.to_str()) {
-            if name.starts_with("runtimed-uv-")
-                || name.starts_with("runtimed-conda-")
-                || name.starts_with("runtimed-pixi-")
-            {
-                return cur.to_path_buf();
-            }
-        }
-        match cur.parent() {
-            Some(p) if p != cur => cur = p,
-            _ => break,
-        }
-    }
-    path.to_path_buf()
 }
 
 impl Pool {
@@ -1131,7 +1107,7 @@ impl Daemon {
             let env_path = entry.path();
 
             // Check for runtimed-uv-* directories
-            if name.starts_with("runtimed-uv-") {
+            if name.starts_with(crate::POOL_PREFIX_UV) {
                 #[cfg(target_os = "windows")]
                 let python_path = env_path.join("Scripts").join("python.exe");
                 #[cfg(not(target_os = "windows"))]
@@ -1156,11 +1132,16 @@ impl Daemon {
                     }
                 } else {
                     // Invalid env, clean up
-                    tokio::fs::remove_dir_all(&env_path).await.ok();
+                    if let Err(e) = tokio::fs::remove_dir_all(&env_path).await {
+                        warn!(
+                            "[runtimed] Failed to clean up invalid UV env {:?}: {}",
+                            env_path, e
+                        );
+                    }
                 }
             }
             // Check for runtimed-conda-* directories
-            else if name.starts_with("runtimed-conda-") {
+            else if name.starts_with(crate::POOL_PREFIX_CONDA) {
                 #[cfg(target_os = "windows")]
                 let python_path = env_path.join("python.exe");
                 #[cfg(not(target_os = "windows"))]
@@ -1183,11 +1164,16 @@ impl Daemon {
                         orphans.push(env_path);
                     }
                 } else {
-                    tokio::fs::remove_dir_all(&env_path).await.ok();
+                    if let Err(e) = tokio::fs::remove_dir_all(&env_path).await {
+                        warn!(
+                            "[runtimed] Failed to clean up invalid Conda env {:?}: {}",
+                            env_path, e
+                        );
+                    }
                 }
             }
             // Check for runtimed-pixi-* directories
-            else if name.starts_with("runtimed-pixi-") {
+            else if name.starts_with(crate::POOL_PREFIX_PIXI) {
                 let venv_path = env_path.join(".pixi").join("envs").join("default");
                 #[cfg(target_os = "windows")]
                 let python_path = venv_path.join("python.exe");
@@ -1211,7 +1197,12 @@ impl Daemon {
                         orphans.push(env_path);
                     }
                 } else {
-                    tokio::fs::remove_dir_all(&env_path).await.ok();
+                    if let Err(e) = tokio::fs::remove_dir_all(&env_path).await {
+                        warn!(
+                            "[runtimed] Failed to clean up invalid Pixi env {:?}: {}",
+                            env_path, e
+                        );
+                    }
                 }
             }
         }
@@ -2487,18 +2478,27 @@ impl Daemon {
                     if let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await {
                         while let Ok(Some(entry)) = entries.next_entry().await {
                             let name = entry.file_name().to_string_lossy().to_string();
-                            let is_pool_dir = name.starts_with("runtimed-uv-")
-                                || name.starts_with("runtimed-conda-")
-                                || name.starts_with("runtimed-pixi-");
-                            if !is_pool_dir {
+                            if !is_pool_env_dir(&name) {
                                 continue;
                             }
                             let path = entry.path();
                             if tracked.contains(&path) || in_use.contains(&path) {
                                 continue;
                             }
+                            if !is_within_cache_dir(&path, cache_dir) {
+                                warn!(
+                                    "[runtimed] GC: refusing to delete {:?} (not within cache dir)",
+                                    path
+                                );
+                                continue;
+                            }
                             info!("[runtimed] GC: removing orphaned pool env {:?}", path);
-                            if tokio::fs::remove_dir_all(&path).await.is_ok() {
+                            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                                warn!(
+                                    "[runtimed] GC: failed to remove orphaned pool env {:?}: {}",
+                                    path, e
+                                );
+                            } else {
                                 orphans_deleted += 1;
                             }
                         }
@@ -3143,7 +3143,7 @@ impl Daemon {
         use rattler_repodata_gateway::Gateway;
         use rattler_solve::{resolvo, SolverImpl, SolverTask};
 
-        let temp_id = format!("runtimed-conda-{}", uuid::Uuid::new_v4());
+        let temp_id = format!("{}{}", crate::POOL_PREFIX_CONDA, uuid::Uuid::new_v4());
         let env_path = self.config.cache_dir.join(&temp_id);
 
         #[cfg(target_os = "windows")]
@@ -3553,7 +3553,7 @@ impl Daemon {
     async fn create_pixi_env(&self) {
         let cache_dir = self.config.cache_dir.clone();
         let env_id = uuid::Uuid::new_v4().to_string();
-        let project_dir = cache_dir.join(format!("runtimed-pixi-{}", env_id));
+        let project_dir = cache_dir.join(format!("{}{}", crate::POOL_PREFIX_PIXI, env_id));
 
         info!("[runtimed] Creating Pixi environment at {:?}", project_dir);
 
@@ -3706,7 +3706,7 @@ impl Daemon {
             }
         };
 
-        let temp_id = format!("runtimed-uv-{}", uuid::Uuid::new_v4());
+        let temp_id = format!("{}{}", crate::POOL_PREFIX_UV, uuid::Uuid::new_v4());
         let venv_path = self.config.cache_dir.join(&temp_id);
 
         #[cfg(target_os = "windows")]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2422,6 +2422,64 @@ impl Daemon {
                 );
             }
 
+            // Clean up orphaned pool env directories (runtimed-uv-*, runtimed-conda-*,
+            // runtimed-pixi-*) that are not tracked by the pool and not in use by
+            // running kernels. These can leak when a notebook takes a pool env, mutates
+            // it, and then the room is evicted without cleanup.
+            {
+                let cache_dir = &self.config.cache_dir;
+                if cache_dir.exists() {
+                    // Collect pool-tracked paths
+                    let mut tracked: std::collections::HashSet<PathBuf> =
+                        std::collections::HashSet::new();
+                    {
+                        let pool = self.uv_pool.lock().await;
+                        for entry in &pool.available {
+                            tracked.insert(entry.env.venv_path.clone());
+                        }
+                    }
+                    {
+                        let pool = self.conda_pool.lock().await;
+                        for entry in &pool.available {
+                            tracked.insert(entry.env.venv_path.clone());
+                        }
+                    }
+                    {
+                        let pool = self.pixi_pool.lock().await;
+                        for entry in &pool.available {
+                            tracked.insert(entry.env.venv_path.clone());
+                        }
+                    }
+
+                    let mut orphans_deleted = 0;
+                    if let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await {
+                        while let Ok(Some(entry)) = entries.next_entry().await {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            let is_pool_dir = name.starts_with("runtimed-uv-")
+                                || name.starts_with("runtimed-conda-")
+                                || name.starts_with("runtimed-pixi-");
+                            if !is_pool_dir {
+                                continue;
+                            }
+                            let path = entry.path();
+                            if tracked.contains(&path) || in_use.contains(&path) {
+                                continue;
+                            }
+                            info!("[runtimed] GC: removing orphaned pool env {:?}", path);
+                            if tokio::fs::remove_dir_all(&path).await.is_ok() {
+                                orphans_deleted += 1;
+                            }
+                        }
+                    }
+                    if orphans_deleted > 0 {
+                        info!(
+                            "[runtimed] GC: cleaned up {} orphaned pool environments",
+                            orphans_deleted
+                        );
+                    }
+                }
+            }
+
             // Clean up stale worktree state directories
             let worktrees_dir = dirs::cache_dir()
                 .unwrap_or_else(|| PathBuf::from("/tmp"))

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4,7 +4,7 @@
 //! notebook windows via IPC (Unix domain sockets on Unix, named pipes on Windows).
 
 use std::collections::{HashMap, VecDeque};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Instant;
@@ -270,6 +270,33 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     ];
     packages.extend(extra.iter().cloned());
     packages
+}
+
+/// Walk up from a pool env's `venv_path` to find the top-level
+/// `runtimed-{uv,conda,pixi}-*` directory. Pixi envs have nested venv_paths
+/// (e.g. `runtimed-pixi-{uuid}/.pixi/envs/default`) but GC and room eviction
+/// operate on top-level dirs, so we need this to normalise before comparing or
+/// deleting.
+///
+/// Returns the path unchanged if no `runtimed-*` ancestor is found (e.g. for
+/// content-addressed envs that are already top-level).
+pub(crate) fn pool_env_root(path: &Path) -> PathBuf {
+    let mut cur = path;
+    loop {
+        if let Some(name) = cur.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with("runtimed-uv-")
+                || name.starts_with("runtimed-conda-")
+                || name.starts_with("runtimed-pixi-")
+            {
+                return cur.to_path_buf();
+            }
+        }
+        match cur.parent() {
+            Some(p) if p != cur => cur = p,
+            _ => break,
+        }
+    }
+    path.to_path_buf()
 }
 
 impl Pool {
@@ -2370,9 +2397,11 @@ impl Daemon {
         };
         let mut paths = std::collections::HashSet::new();
         for room in &snapshot {
-            // Check runtime-agent-backed kernel
+            // Check runtime-agent-backed kernel. Normalise to the top-level
+            // pool dir so that GC's top-level scan will match pixi envs
+            // whose venv_path is nested (e.g. .pixi/envs/default).
             if let Some(ref env_path) = *room.runtime_agent_env_path.read().await {
-                paths.insert(env_path.clone());
+                paths.insert(pool_env_root(env_path));
             }
         }
         paths
@@ -2429,25 +2458,28 @@ impl Daemon {
             {
                 let cache_dir = &self.config.cache_dir;
                 if cache_dir.exists() {
-                    // Collect pool-tracked paths
+                    // Collect pool-tracked paths, normalised to top-level
+                    // pool dirs so pixi's nested venv_path
+                    // (runtimed-pixi-{uuid}/.pixi/envs/default) matches the
+                    // top-level directory that the scan below sees.
                     let mut tracked: std::collections::HashSet<PathBuf> =
                         std::collections::HashSet::new();
                     {
                         let pool = self.uv_pool.lock().await;
                         for entry in &pool.available {
-                            tracked.insert(entry.env.venv_path.clone());
+                            tracked.insert(pool_env_root(&entry.env.venv_path));
                         }
                     }
                     {
                         let pool = self.conda_pool.lock().await;
                         for entry in &pool.available {
-                            tracked.insert(entry.env.venv_path.clone());
+                            tracked.insert(pool_env_root(&entry.env.venv_path));
                         }
                     }
                     {
                         let pool = self.pixi_pool.lock().await;
                         for entry in &pool.available {
-                            tracked.insert(entry.env.venv_path.clone());
+                            tracked.insert(pool_env_root(&entry.env.venv_path));
                         }
                     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -77,7 +77,7 @@ impl Default for DaemonConfig {
             max_age_secs: 172800, // 2 days
             lock_dir: None,
             room_eviction_delay_ms: None,
-            env_cache_max_age_secs: 604800, // 7 days
+            env_cache_max_age_secs: 86400, // 1 day
             env_cache_max_count: 10,
         }
     }
@@ -2380,7 +2380,7 @@ impl Daemon {
 
     /// Background GC loop for content-addressed environment caches.
     ///
-    /// Runs once after a 60-second startup delay, then every 6 hours.
+    /// Runs once after a 60-second startup delay, then every 30 minutes.
     /// Evicts stale cached environments from the global UV, Conda, and inline-env
     /// cache directories based on `env_cache_max_age_secs` and `env_cache_max_count`.
     async fn env_gc_loop(&self) {
@@ -2582,8 +2582,9 @@ impl Daemon {
                 }
             }
 
-            // Run every 6 hours
-            tokio::time::sleep(std::time::Duration::from_secs(6 * 3600)).await;
+            // Run every 30 minutes (was 6 hours — too slow for sustained
+            // workloads that create many ephemeral environments).
+            tokio::time::sleep(std::time::Duration::from_secs(30 * 60)).await;
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2131,6 +2131,10 @@ where
                 // the pool's VecDeque on take() and have been mutated with the
                 // notebook's deps, so they cannot be returned. Delete eagerly to
                 // prevent disk pressure during sustained workloads.
+                //
+                // Use pool_env_root() to normalise pixi paths — their venv_path
+                // is nested (e.g. .pixi/envs/default) but we need to delete the
+                // top-level runtimed-pixi-* directory.
                 {
                     let env_path = room_for_eviction
                         .runtime_agent_env_path
@@ -2138,12 +2142,13 @@ where
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        if path.exists() {
+                        let root = crate::daemon::pool_env_root(path);
+                        if root.exists() {
                             info!(
                                 "[notebook-sync] Cleaning up env {:?} on room eviction",
-                                path
+                                root
                             );
-                            tokio::fs::remove_dir_all(path).await.ok();
+                            tokio::fs::remove_dir_all(&root).await.ok();
                         }
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2142,13 +2142,24 @@ where
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        let root = crate::daemon::pool_env_root(path);
-                        if root.exists() {
+                        let root = crate::pool_env_root(path);
+                        let cache_dir = crate::default_cache_dir();
+                        if !crate::is_within_cache_dir(&root, &cache_dir) {
+                            warn!(
+                                "[notebook-sync] Refusing to delete env {:?} on eviction (not within cache dir)",
+                                root
+                            );
+                        } else if root.exists() {
                             info!(
                                 "[notebook-sync] Cleaning up env {:?} on room eviction",
                                 root
                             );
-                            tokio::fs::remove_dir_all(&root).await.ok();
+                            if let Err(e) = tokio::fs::remove_dir_all(&root).await {
+                                warn!(
+                                    "[notebook-sync] Failed to clean up env {:?} on eviction: {}",
+                                    root, e
+                                );
+                            }
                         }
                     }
                 }
@@ -3289,7 +3300,16 @@ async fn try_uv_pool_for_inline_deps(
                     );
                     // Clean up the taken pool env — it's out of the pool's
                     // tracking and would otherwise leak on disk.
-                    tokio::fs::remove_dir_all(&env.venv_path).await.ok();
+                    let root = crate::pool_env_root(&env.venv_path);
+                    let cache_dir = crate::default_cache_dir();
+                    if crate::is_within_cache_dir(&root, &cache_dir) {
+                        if let Err(e) = tokio::fs::remove_dir_all(&root).await {
+                            warn!(
+                                "[notebook-sync] Failed to clean up UV pool env {:?}: {}",
+                                root, e
+                            );
+                        }
+                    }
                     Err(())
                 }
             }
@@ -3297,7 +3317,16 @@ async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
-            tokio::fs::remove_dir_all(&env.venv_path).await.ok();
+            let root = crate::pool_env_root(&env.venv_path);
+            let cache_dir = crate::default_cache_dir();
+            if crate::is_within_cache_dir(&root, &cache_dir) {
+                if let Err(e) = tokio::fs::remove_dir_all(&root).await {
+                    warn!(
+                        "[notebook-sync] Failed to clean up UV pool env {:?}: {}",
+                        root, e
+                    );
+                }
+            }
             Err(())
         }
     }
@@ -3384,14 +3413,32 @@ async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
-                    tokio::fs::remove_dir_all(&env.venv_path).await.ok();
+                    let root = crate::pool_env_root(&env.venv_path);
+                    let cache_dir = crate::default_cache_dir();
+                    if crate::is_within_cache_dir(&root, &cache_dir) {
+                        if let Err(e) = tokio::fs::remove_dir_all(&root).await {
+                            warn!(
+                                "[notebook-sync] Failed to clean up Conda pool env {:?}: {}",
+                                root, e
+                            );
+                        }
+                    }
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
-            tokio::fs::remove_dir_all(&env.venv_path).await.ok();
+            let root = crate::pool_env_root(&env.venv_path);
+            let cache_dir = crate::default_cache_dir();
+            if crate::is_within_cache_dir(&root, &cache_dir) {
+                if let Err(e) = tokio::fs::remove_dir_all(&root).await {
+                    warn!(
+                        "[notebook-sync] Failed to clean up Conda pool env {:?}: {}",
+                        root, e
+                    );
+                }
+            }
             Err(())
         }
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4073,6 +4073,15 @@ async fn auto_launch_kernel(
         (pooled_env, None)
     };
 
+    // Register the env path for GC protection immediately after pool.take(),
+    // BEFORE any async work (agent spawn, connect timeout, delta install).
+    // Without this, there's a race window where GC sees the taken env as an
+    // orphan and deletes it while we're still setting up the kernel.
+    if let Some(ref env) = pooled_env {
+        let mut ep = room.runtime_agent_env_path.write().await;
+        *ep = Some(env.venv_path.clone());
+    }
+
     // Build LaunchedEnvConfig to track what config the kernel was launched with
     let venv_path = pooled_env.as_ref().map(|e| e.venv_path.clone());
     let python_path = pooled_env.as_ref().map(|e| e.python_path.clone());
@@ -4182,11 +4191,7 @@ async fn auto_launch_kernel(
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
-                        // Store env path for GC protection
-                        if let Some(ref env) = pooled_env {
-                            let mut ep = room.runtime_agent_env_path.write().await;
-                            *ep = Some(env.venv_path.clone());
-                        }
+                        // env path already registered for GC protection above (before spawn)
 
                         // Store launched config for env sync drift detection
                         {
@@ -5194,6 +5199,13 @@ async fn handle_notebook_request(
             } else {
                 (pooled_env, None)
             };
+
+            // Register the env path for GC protection immediately after pool.take(),
+            // BEFORE any async work (agent spawn, connect timeout, delta install).
+            if let Some(ref env) = pooled_env {
+                let mut ep = room.runtime_agent_env_path.write().await;
+                *ep = Some(env.venv_path.clone());
+            }
 
             // Build LaunchedEnvConfig to track what config the kernel was launched with
             let venv_path = pooled_env.as_ref().map(|e| e.venv_path.clone());

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2125,6 +2125,35 @@ where
                     );
                 }
 
+                // Clean up content-addressed environment directory on eviction.
+                // Pool envs (runtimed-uv-*, runtimed-conda-*, runtimed-pixi-*) are
+                // managed by the pool and must NOT be deleted here. Content-addressed
+                // envs (16-char hex dirs in envs/, conda-envs/, inline-envs/) are
+                // orphaned once the room is gone — delete them eagerly to prevent
+                // disk pressure during sustained workloads (e.g. gremlin sessions).
+                {
+                    let env_path = room_for_eviction
+                        .runtime_agent_env_path
+                        .read()
+                        .await
+                        .clone();
+                    if let Some(ref path) = env_path {
+                        let is_content_addressed = path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|name| {
+                                name.len() == 16 && name.chars().all(|c| c.is_ascii_hexdigit())
+                            });
+                        if is_content_addressed {
+                            info!(
+                                "[notebook-sync] Cleaning up content-addressed env {:?} on room eviction",
+                                path
+                            );
+                            tokio::fs::remove_dir_all(path).await.ok();
+                        }
+                    }
+                }
+
                 info!(
                     "[notebook-sync] Evicted room {} (idle timeout)",
                     notebook_id_for_eviction

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2125,12 +2125,12 @@ where
                     );
                 }
 
-                // Clean up content-addressed environment directory on eviction.
-                // Pool envs (runtimed-uv-*, runtimed-conda-*, runtimed-pixi-*) are
-                // managed by the pool and must NOT be deleted here. Content-addressed
-                // envs (16-char hex dirs in envs/, conda-envs/, inline-envs/) are
-                // orphaned once the room is gone — delete them eagerly to prevent
-                // disk pressure during sustained workloads (e.g. gremlin sessions).
+                // Clean up the environment directory on eviction. Both pool envs
+                // (runtimed-uv-*, etc.) and content-addressed envs (16-char hex)
+                // are orphaned once the room is gone — pool envs were removed from
+                // the pool's VecDeque on take() and have been mutated with the
+                // notebook's deps, so they cannot be returned. Delete eagerly to
+                // prevent disk pressure during sustained workloads.
                 {
                     let env_path = room_for_eviction
                         .runtime_agent_env_path
@@ -2138,15 +2138,9 @@ where
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        let is_content_addressed = path
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .is_some_and(|name| {
-                                name.len() == 16 && name.chars().all(|c| c.is_ascii_hexdigit())
-                            });
-                        if is_content_addressed {
+                        if path.exists() {
                             info!(
-                                "[notebook-sync] Cleaning up content-addressed env {:?} on room eviction",
+                                "[notebook-sync] Cleaning up env {:?} on room eviction",
                                 path
                             );
                             tokio::fs::remove_dir_all(path).await.ok();
@@ -3288,6 +3282,9 @@ async fn try_uv_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into UV pool env: {}, falling back",
                         e
                     );
+                    // Clean up the taken pool env — it's out of the pool's
+                    // tracking and would otherwise leak on disk.
+                    tokio::fs::remove_dir_all(&env.venv_path).await.ok();
                     Err(())
                 }
             }
@@ -3295,6 +3292,7 @@ async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
+            tokio::fs::remove_dir_all(&env.venv_path).await.ok();
             Err(())
         }
     }
@@ -3381,12 +3379,14 @@ async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
+                    tokio::fs::remove_dir_all(&env.venv_path).await.ok();
                     Err(())
                 }
             }
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
+            tokio::fs::remove_dir_all(&env.venv_path).await.ok();
             Err(())
         }
     }


### PR DESCRIPTION
## Summary

- Eagerly clean up environment directories when notebook rooms are evicted
- Reduce GC interval from 6 hours to 30 minutes and max cache age from 7 days to 1 day
- Add GC safety net that scans for orphaned pool env directories (`runtimed-uv-*`, `runtimed-conda-*`, `runtimed-pixi-*`)
- Fix pool env leaks in `try_uv_pool_for_inline_deps` and `try_conda_pool_for_inline_deps` error paths
- Add `pool_env_root()` helper to normalise pixi's nested venv_path for correct GC and eviction

## Root cause

During sustained gremlin runs, 353+ stale env directories (11 GB) accumulated because:

1. **No cleanup on room eviction.** Pool envs are removed from the pool's VecDeque on `take()` and mutated with notebook deps. When the room is evicted, the env directory was orphaned — never returned to the pool, never cleaned up.
2. **GC too slow and too narrow.** 6-hour interval with 7-day max_age, and only scanned content-addressed (16-char hex) dirs — never touched pool-format dirs.
3. **Delta install leak.** `try_uv_pool_for_inline_deps` and `try_conda_pool_for_inline_deps` leaked taken pool envs on error/independent code paths.

## Changes

### Eager cleanup on room eviction (`notebook_sync_server.rs`)
Delete the environment directory (any type) when a room is evicted after idle timeout. Uses `pool_env_root()` to normalise pixi paths so the top-level `runtimed-pixi-*` dir is deleted, not just the nested `.pixi/envs/default`.

### GC tuning (`daemon.rs`)
- Interval: 6h → 30min (faster response to env accumulation)
- Max age: 7d → 1d (content-addressed caches don't need week-long retention)

### Orphaned pool dir scanning (`daemon.rs`)
New GC pass that scans `cache_dir` for `runtimed-{uv,conda,pixi}-*` dirs not tracked by any pool and not in use by running kernels. Safety net for any envs that slip through eager cleanup.

### `pool_env_root()` normalisation (`daemon.rs`)
Pixi pool envs have nested venv_paths (`runtimed-pixi-{uuid}/.pixi/envs/default`) but GC and eviction operate on top-level dirs. The helper walks up from any venv_path to find the `runtimed-*` ancestor. Applied in GC tracked set, `collect_active_env_paths`, and room eviction.

### Delta install leak fix (`notebook_sync_server.rs`)
`remove_dir_all` on taken pool envs when delta install fails or deps are independent, in both UV and Conda paths.

## Test plan

- [x] Deployed as nightly `2.1.3+b1dfcfb`, verified under sustained gremlin workload
- [x] Pool stability verified: UV 10/10, Conda 10/10, Pixi 10/10 — disk matches in-memory
- [x] GC cycle confirmed: zero false pool deletions post-fix
- [x] Reviewed by systems-engineer-3 (pixi regression caught and fixed before PR)
- [ ] `cargo xtask lint` passes
- [ ] CI passes