### PR TITLE
fix(build): eliminate triple compilation of shared crates

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -366,6 +366,11 @@ fn run_maturin_develop(project_root: &Path) -> bool {
     // is installed where the MCP server actually runs from. Without this,
     // maturin installs into python/runtimed/.venv (the test-only venv)
     // and the MCP server never sees the updated bindings.
+    // Use a separate target directory so maturin's cdylib build doesn't
+    // invalidate fingerprints in the main target/ dir. Without this,
+    // concurrent or subsequent cargo builds see stale timestamps from
+    // maturin's writes and recompile the entire dependency tree.
+    let maturin_target = project_root.join("target/maturin");
     let status = std::process::Command::new("uv")
         .args([
             "run",
@@ -373,6 +378,8 @@ fn run_maturin_develop(project_root: &Path) -> bool {
             &project_root.join("python/runtimed").to_string_lossy(),
             "maturin",
             "develop",
+            "--target-dir",
+            &maturin_target.to_string_lossy(),
         ])
         .env(
             "VIRTUAL_ENV",

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -571,6 +571,11 @@ fn ensure_maturin_develop() {
         eprintln!("Warning: failed to get current directory for maturin develop");
         return;
     };
+    // Use a separate target directory so maturin's cdylib build doesn't
+    // invalidate fingerprints in the main target/ dir. Without this,
+    // cargo tauri build (Phase 3) sees stale timestamps from maturin's
+    // concurrent writes and recompiles the entire dependency tree.
+    let maturin_target = cwd.join("target/maturin");
     let status = Command::new("uv")
         .args([
             "run",
@@ -578,6 +583,8 @@ fn ensure_maturin_develop() {
             "python/runtimed",
             "maturin",
             "develop",
+            "--target-dir",
+            &maturin_target.to_string_lossy(),
         ])
         .env("VIRTUAL_ENV", cwd.join(".venv"))
         .env_remove("CONDA_PREFIX")
@@ -627,11 +634,15 @@ fn cmd_build(rust_only: bool) {
         None
     };
 
-    // Phase 1: Single cargo invocation for all binaries.
-    // Building all packages together ensures workspace feature unification
-    // happens in one pass, so the later `cargo tauri build` finds everything
-    // cached instead of recompiling the entire dependency tree.
-    println!("Building all Rust targets (runtimed, runt, mcpb-runt, mcp-supervisor, notebook)...");
+    // Phase 1: Build all Rust crates except `notebook`.
+    // The `notebook` crate's build.rs declares `rerun-if-changed` on
+    // `apps/notebook/dist`, so building it here would be wasted work —
+    // Phase 2 rebuilds the frontend (updating dist/), which invalidates
+    // notebook's fingerprint and forces cargo tauri build to recompile it
+    // anyway. By excluding notebook here, we still pre-warm the entire
+    // dependency tree (all shared crates are built via the other targets),
+    // and Phase 3 only needs to compile notebook + link.
+    println!("Building Rust targets (runtimed, runt, mcpb-runt, mcp-supervisor)...");
     run_cmd(
         "cargo",
         &[
@@ -644,8 +655,6 @@ fn cmd_build(rust_only: bool) {
             "mcpb-runt",
             "-p",
             "mcp-supervisor",
-            "-p",
-            "notebook",
         ],
     );
 


### PR DESCRIPTION
## Summary
- **Give maturin its own target directory** (`target/maturin/`) so it doesn't poison cargo fingerprints in the main `target/debug/` dir. Applied in both `xtask` and `mcp-supervisor`.
- **Exclude `notebook` from Phase 1 cargo build** — its build.rs watches `apps/notebook/dist`, which Phase 2 updates, causing a forced recompile in Phase 3. All shared dependencies are still pre-warmed via the other targets (runtimed, runt-cli, mcp-supervisor).

### Root cause
Shared crates (runtimed-client, notebook-doc, kernel-env, etc.) were compiling **three times** per `cargo xtask build`:
1. Phase 1: `cargo build -p runtimed -p runt-cli ... -p notebook`
2. Phase 2: `maturin develop` (writes to same target dir, invalidates fingerprints)
3. Phase 3: `cargo tauri build` (sees stale timestamps from both maturin writes and frontend dist/ updates)

### Result
Warm build: **~1m16s → ~35s**. Shared crates compile once; `notebook` compiles once in Phase 3 after frontend assets are ready.

## Test plan
- [x] `cargo check -p xtask -p mcp-supervisor` passes
- [x] `cargo xtask lint` passes
- [x] `cargo xtask build` — warm build completes in ~35s with no duplicate compilations
- [x] Maturin develop uses `target/maturin/` (verified via build log)
- [ ] CI build passes