### PR TITLE
feat(sift): add theme picker with Classic and Cream themes

### DIFF
--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -116,7 +116,23 @@ function renderShell(app: HTMLElement) {
               ).join("")}
             </select>
           </div>
-          <button class="sift-theme-toggle" id="theme-toggle" title="Toggle dark mode">◑</button>
+          <div class="sift-appearance">
+            <div class="sift-appearance-group">
+              <span class="sift-appearance-label">Mode</span>
+              <div class="sift-toggle-group" id="mode-toggle">
+                <button class="sift-toggle-btn" data-mode="light">Light</button>
+                <button class="sift-toggle-btn" data-mode="dark">Dark</button>
+                <button class="sift-toggle-btn" data-mode="system">System</button>
+              </div>
+            </div>
+            <div class="sift-appearance-group">
+              <span class="sift-appearance-label">Theme</span>
+              <div class="sift-toggle-group" id="theme-toggle">
+                <button class="sift-toggle-btn" data-theme-name="classic">Classic</button>
+                <button class="sift-toggle-btn" data-theme-name="cream">Cream</button>
+              </div>
+            </div>
+          </div>
           <a href="https://github.com/rgbkrk/sift" class="sift-github-btn" target="_blank" rel="noopener">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             Star on GitHub
@@ -148,18 +164,64 @@ function renderShell(app: HTMLElement) {
     }
   });
 
-  // Theme toggle: simple light ↔ dark
+  // --- Appearance controls ---
   const root = document.documentElement;
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const savedTheme = localStorage.getItem("theme");
-  const initialDark = savedTheme ? savedTheme === "dark" : prefersDark;
-  if (initialDark) root.setAttribute("data-theme", "dark");
-  else root.setAttribute("data-theme", "light");
 
-  document.getElementById("theme-toggle")!.addEventListener("click", () => {
-    const isDark = root.getAttribute("data-theme") === "dark";
-    root.setAttribute("data-theme", isDark ? "light" : "dark");
-    localStorage.setItem("theme", isDark ? "light" : "dark");
+  // Mode: light | dark | system
+  const savedMode = localStorage.getItem("sift-mode") ?? "system";
+  const darkMedia = window.matchMedia("(prefers-color-scheme: dark)");
+
+  function applyMode(mode: string) {
+    if (mode === "system") {
+      root.setAttribute("data-theme", darkMedia.matches ? "dark" : "light");
+    } else {
+      root.setAttribute("data-theme", mode);
+    }
+    // Update toggle button states
+    for (const btn of document.querySelectorAll<HTMLButtonElement>(
+      "#mode-toggle .sift-toggle-btn",
+    )) {
+      btn.setAttribute("aria-pressed", btn.dataset.mode === mode ? "true" : "false");
+    }
+  }
+
+  applyMode(savedMode);
+  darkMedia.addEventListener("change", () => {
+    if ((localStorage.getItem("sift-mode") ?? "system") === "system") {
+      root.setAttribute("data-theme", darkMedia.matches ? "dark" : "light");
+    }
+  });
+
+  document.getElementById("mode-toggle")!.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".sift-toggle-btn");
+    if (!btn?.dataset.mode) return;
+    localStorage.setItem("sift-mode", btn.dataset.mode);
+    applyMode(btn.dataset.mode);
+  });
+
+  // Theme: cream | classic
+  const savedColorTheme = localStorage.getItem("sift-color-theme") ?? "cream";
+
+  function applyColorTheme(theme: string) {
+    if (theme === "cream") {
+      root.removeAttribute("data-color-theme");
+    } else {
+      root.setAttribute("data-color-theme", theme);
+    }
+    for (const btn of document.querySelectorAll<HTMLButtonElement>(
+      "#theme-toggle .sift-toggle-btn",
+    )) {
+      btn.setAttribute("aria-pressed", btn.dataset.themeName === theme ? "true" : "false");
+    }
+  }
+
+  applyColorTheme(savedColorTheme);
+
+  document.getElementById("theme-toggle")!.addEventListener("click", (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".sift-toggle-btn");
+    if (!btn?.dataset.themeName) return;
+    localStorage.setItem("sift-color-theme", btn.dataset.themeName);
+    applyColorTheme(btn.dataset.themeName);
   });
 }
 

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1,4 +1,5 @@
 @import "./themes/cream.css";
+@import "./themes/classic.css";
 @import "tailwindcss";
 
 * {
@@ -100,25 +101,63 @@ h1 {
   outline-offset: 1px;
 }
 
-/* --- Theme toggle --- */
+/* --- Appearance controls --- */
 
-.sift-theme-toggle {
-  background: none;
-  border: 1px solid var(--sift-rule);
-  border-radius: 8px;
-  padding: 4px 10px;
-  font: 14px/1.3 var(--sift-font);
-  color: var(--sift-muted);
-  cursor: pointer;
+.sift-appearance {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
   align-self: center;
-  transition:
-    color 150ms ease,
-    border-color 150ms ease;
 }
 
-.sift-theme-toggle:hover {
+.sift-appearance-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sift-appearance-label {
+  font: 500 11px/1 var(--sift-font);
+  color: var(--sift-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sift-toggle-group {
+  display: inline-flex;
+  border: 1px solid var(--sift-rule);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sift-toggle-btn {
+  background: none;
+  border: none;
+  border-right: 1px solid var(--sift-rule);
+  padding: 5px 12px;
+  font: 13px/1.3 var(--sift-font);
+  color: var(--sift-muted);
+  cursor: pointer;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+  white-space: nowrap;
+}
+
+.sift-toggle-btn:last-child {
+  border-right: none;
+}
+
+.sift-toggle-btn:hover {
   color: var(--sift-ink);
-  border-color: var(--sift-muted);
+  background: color-mix(in srgb, var(--sift-accent) 5%, transparent);
+}
+
+.sift-toggle-btn[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--sift-ink) 8%, transparent);
+  color: var(--sift-ink);
+  font-weight: 600;
 }
 
 .sift-github-btn {


### PR DESCRIPTION
## Summary

Adds a theme picker to the sift demo page with two toggle groups matching the notebook settings UI pattern:

- **Mode:** Light | Dark | System
- **Theme:** Classic | Cream

Both themes are now imported in `style.css`. The classic theme (`themes/classic.css`) activates via `data-color-theme="classic"` on the document element. Cream remains the default when no attribute is set.

### Screenshots

All four combinations verified:
- Cream Light — warm tan background, brown accents
- Cream Dark — warm dark background, lighter brown accents
- Classic Light — white background, blue accents
- Classic Dark — near-black background, lighter blue accents

### Changes

- `packages/sift/src/style.css` — import `themes/classic.css`, replace old `.sift-theme-toggle` with `.sift-appearance` toggle group styles
- `packages/sift/src/main.ts` — replace single ◑ toggle with Mode + Theme toggle groups, localStorage persistence

## Test plan

- [x] `pnpm --filter @nteract/sift exec vp test run` — 124 tests pass
- [x] `cargo xtask lint --fix` — clean
- [x] Visual: all 4 theme combinations verified in browser
- [x] localStorage persistence works across page reloads