### PR TITLE
fix(sift): update Tailwind CSS variable references in UI components

### DIFF
--- a/packages/sift/src/components/column-context-menu.tsx
+++ b/packages/sift/src/components/column-context-menu.tsx
@@ -66,13 +66,13 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[12rem] overflow-hidden rounded-lg border border-[var(--rule)] bg-[var(--panel)] p-1 shadow-lg"
+      className="fixed z-50 min-w-[12rem] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg"
       style={{ left: x, top: y }}
     >
-      <div className="px-2 py-1.5 text-xs font-semibold text-[var(--muted)] uppercase tracking-wider">
+      <div className="px-2 py-1.5 text-xs font-semibold text-[var(--sift-muted)] uppercase tracking-wider">
         {colName}
       </div>
-      <div className="h-px bg-[var(--rule)] -mx-1 my-1" />
+      <div className="h-px bg-[var(--sift-rule)] -mx-1 my-1" />
 
       <MenuItem onClick={() => act({ kind: "sort", direction: "asc" })}>
         Sort ascending {sortDirection === "asc" && <Check />}
@@ -81,7 +81,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
         Sort descending {sortDirection === "desc" && <Check />}
       </MenuItem>
 
-      <div className="h-px bg-[var(--rule)] -mx-1 my-1" />
+      <div className="h-px bg-[var(--sift-rule)] -mx-1 my-1" />
 
       {isPinned ? (
         <MenuItem onClick={() => act({ kind: "unpin" })}>Unpin column</MenuItem>
@@ -89,15 +89,15 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
         <MenuItem onClick={() => act({ kind: "pin" })}>Pin column</MenuItem>
       )}
 
-      <div className="h-px bg-[var(--rule)] -mx-1 my-1" />
+      <div className="h-px bg-[var(--sift-rule)] -mx-1 my-1" />
 
       {isStreaming ? (
-        <div className="px-2 py-1.5 text-xs text-[var(--muted)] italic">
+        <div className="px-2 py-1.5 text-xs text-[var(--sift-muted)] italic">
           Some operations hidden while loading
         </div>
       ) : (
         <>
-          <div className="px-2 py-1 text-xs text-[var(--muted)]">Treat as…</div>
+          <div className="px-2 py-1 text-xs text-[var(--sift-muted)]">Treat as…</div>
           <MenuItem onClick={() => act({ kind: "cast", targetType: "categorical" })}>
             Text {colType === "categorical" && <Check />}
           </MenuItem>
@@ -113,7 +113,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
 
           {isCast && (
             <>
-              <div className="h-px bg-[var(--rule)] -mx-1 my-1" />
+              <div className="h-px bg-[var(--sift-rule)] -mx-1 my-1" />
               <MenuItem onClick={() => act({ kind: "undo-cast" })}>
                 Revert to original type
               </MenuItem>
@@ -128,7 +128,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
 function MenuItem({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
   return (
     <button
-      className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm text-[var(--ink)] hover:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] cursor-default outline-none"
+      className="flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm text-[var(--sift-ink)] hover:bg-[color-mix(in_srgb,var(--sift-accent)_8%,transparent)] cursor-default outline-none"
       onClick={onClick}
     >
       {children}
@@ -137,5 +137,5 @@ function MenuItem({ children, onClick }: { children: React.ReactNode; onClick: (
 }
 
 function Check() {
-  return <span className="text-[var(--accent)] text-xs">✓</span>;
+  return <span className="text-[var(--sift-accent)] text-xs">✓</span>;
 }

--- a/packages/sift/src/components/ui/context-menu.tsx
+++ b/packages/sift/src/components/ui/context-menu.tsx
@@ -18,8 +18,8 @@ const ContextMenuSubTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
-      "data-[state=open]:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)]",
-      "focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)]",
+      "data-[state=open]:bg-[color-mix(in_srgb,var(--sift-accent)_8%,transparent)]",
+      "focus:bg-[color-mix(in_srgb,var(--sift-accent)_8%,transparent)]",
       inset && "pl-8",
       className,
     )}
@@ -38,7 +38,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-[var(--rule)] bg-[var(--panel)] p-1 shadow-lg",
+      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       className,
     )}
@@ -55,8 +55,8 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[10rem] overflow-hidden rounded-lg border border-[var(--rule)] bg-[var(--panel)] p-1 shadow-lg",
-        "text-[var(--ink)] font-[var(--font)]",
+        "z-50 min-w-[10rem] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg",
+        "text-[var(--sift-ink)] font-[var(--sift-font)]",
         className,
       )}
       {...props}
@@ -75,7 +75,7 @@ const ContextMenuItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
-      "focus:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] focus:text-[var(--ink)]",
+      "focus:bg-[color-mix(in_srgb,var(--sift-accent)_8%,transparent)] focus:text-[var(--sift-ink)]",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
@@ -91,7 +91,7 @@ const ContextMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ContextMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-[var(--rule)]", className)}
+    className={cn("-mx-1 my-1 h-px bg-[var(--sift-rule)]", className)}
     {...props}
   />
 ));
@@ -106,7 +106,7 @@ const ContextMenuLabel = React.forwardRef<
   <ContextMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-xs font-semibold text-[var(--muted)]",
+      "px-2 py-1.5 text-xs font-semibold text-[var(--sift-muted)]",
       inset && "pl-8",
       className,
     )}

--- a/packages/sift/src/components/ui/popover.tsx
+++ b/packages/sift/src/components/ui/popover.tsx
@@ -16,7 +16,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[14rem] overflow-hidden rounded-lg border border-[var(--rule)] bg-[var(--panel)] p-0 shadow-lg",
+        "z-50 min-w-[14rem] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-0 shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",


### PR DESCRIPTION
## Summary

Fixes transparent popover/context menu backgrounds caused by old CSS variable names in Tailwind arbitrary value classes.

Three component files used `var(--rule)`, `var(--panel)`, `var(--ink)`, `var(--accent)`, `var(--muted)` instead of `var(--sift-rule)`, etc. These were missed in the `.pt-*` → `.sift-*` rename (#1721) because they're inside Tailwind class strings, not CSS selectors or plain JS strings.

### Files

- `packages/sift/src/components/ui/popover.tsx` — 2 fixes
- `packages/sift/src/components/ui/context-menu.tsx` — 9 fixes
- `packages/sift/src/components/column-context-menu.tsx` — 11 fixes

## Test plan

- [x] `pnpm --filter @nteract/sift exec vp test run` — 124 tests pass
- [x] `grep` confirms zero remaining old variable names in src/