### PR TITLE
fix(build): stop watching .git files in build scripts

### DIFF
--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -78,46 +78,37 @@ fn maybe_disable_external_bin_for_local_checks() {
 }
 
 fn main() {
-    // Capture git branch name
-    let branch = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    // Capture git metadata for About menu and version strings.
+    let branch = git_output(&["rev-parse", "--abbrev-ref", "HEAD"]);
+    let commit = git_output(&["rev-parse", "--short=7", "HEAD"]);
+    let release_date = git_output(&["show", "-s", "--format=%cs", "HEAD"]);
 
-    // Capture short commit hash
-    let commit = Command::new("git")
-        .args(["rev-parse", "--short=7", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
+    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    println!("cargo:rustc-env=GIT_COMMIT_DATE={release_date}");
 
-    // Capture commit date (used as release date in About metadata)
-    let release_date = Command::new("git")
-        .args(["show", "-s", "--format=%cs", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    // Set environment variables for use in Rust code
-    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
-    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
-    println!("cargo:rustc-env=GIT_COMMIT_DATE={}", release_date);
-
-    // Re-run if git HEAD changes (detects branch switches, commits)
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/index");
-
-    // Re-run if frontend dist changes (ensures fresh frontend is embedded)
+    // Re-run if frontend dist changes (ensures fresh frontend is embedded).
+    // This is the only non-git watcher — Phase 2 builds the frontend, then
+    // Phase 3 (cargo tauri build) picks up the updated dist/.
     println!("cargo:rerun-if-changed=../../apps/notebook/dist");
+
+    // We intentionally do NOT watch .git/HEAD, .git/index, or refs.
+    // That caused recompilation of notebook + all dependents on every
+    // commit, branch switch, pull, or fetch. The git metadata is refreshed
+    // whenever dist/ changes (every build) or this build script changes.
+    // CI always starts clean so release builds always get the right hash.
 
     maybe_disable_external_bin_for_local_checks();
 
     tauri_build::build()
+}
+
+fn git_output(args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/runt/build.rs
+++ b/crates/runt/build.rs
@@ -1,53 +1,29 @@
 use std::process::Command;
 
 fn main() {
-    let commit = Command::new("git")
+    let commit = git_commit_short();
+    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+
+    let variant = std::env::var("RUNT_VARIANT").unwrap_or_default();
+    println!("cargo:rustc-env=RUNT_VARIANT={variant}");
+    println!("cargo:rerun-if-env-changed=RUNT_VARIANT");
+
+    // Also rerun when this build script changes (since we emit
+    // rerun-if-changed above, cargo won't use its default behavior).
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // We intentionally do NOT watch .git/HEAD or refs — that causes
+    // recompilation on every commit, branch switch, pull, or fetch.
+    // The hash is refreshed when build.rs or RUNT_VARIANT changes.
+    // CI always starts clean so release builds always get the right hash.
+}
+
+fn git_commit_short() -> String {
+    Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
-
-    let variant = std::env::var("RUNT_VARIANT").unwrap_or_default();
-    println!("cargo:rustc-env=RUNT_VARIANT={}", variant);
-    println!("cargo:rerun-if-env-changed=RUNT_VARIANT");
-
-    // Use `git rev-parse --git-dir` to find the actual git metadata directory.
-    // In a worktree, `.git` is a file pointing elsewhere (e.g.
-    // `../../.git/worktrees/<name>`), so hard-coding `../../.git/HEAD` would
-    // watch a path that doesn't exist and Cargo would never re-run this script.
-    let git_dir = Command::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string());
-
-    if let Some(git_dir) = git_dir {
-        println!("cargo:rerun-if-changed={}/HEAD", git_dir);
-
-        if let Ok(head) = std::fs::read_to_string(format!("{}/HEAD", git_dir)) {
-            let head = head.trim();
-            if let Some(refpath) = head.strip_prefix("ref: ") {
-                // The ref itself may live in the common git dir (for worktrees,
-                // that's the parent repo's .git), so check both locations.
-                let common_dir = Command::new("git")
-                    .args(["rev-parse", "--git-common-dir"])
-                    .output()
-                    .ok()
-                    .and_then(|o| String::from_utf8(o.stdout).ok())
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_else(|| git_dir.clone());
-
-                println!("cargo:rerun-if-changed={}/{}", git_dir, refpath);
-                if common_dir != git_dir {
-                    println!("cargo:rerun-if-changed={}/{}", common_dir, refpath);
-                }
-                println!("cargo:rerun-if-changed={}/packed-refs", common_dir);
-            }
-        }
-    }
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/runtimed-client/build.rs
+++ b/crates/runtimed-client/build.rs
@@ -4,56 +4,22 @@ fn main() {
     // Capture short commit hash for version-mismatch detection.
     // This ensures the daemon gets restarted when the binary changes,
     // even if the crate version (Cargo.toml) hasn't been bumped.
-    let commit = Command::new("git")
+    let commit = git_commit_short();
+    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+
+    // No rerun-if-changed directives — cargo's default behavior reruns
+    // this script when any file in the package changes, which is exactly
+    // when we want a fresh commit hash. We intentionally do NOT watch
+    // .git/HEAD or refs — that causes recompilation of this crate (and
+    // all dependents) on every commit, branch switch, pull, or fetch.
+}
+
+fn git_commit_short() -> String {
+    Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
-
-    // Use `git rev-parse --git-dir` to find the actual git metadata directory.
-    // In a worktree, `.git` is a file pointing elsewhere (e.g.
-    // `../../.git/worktrees/<name>`), so hard-coding `../../.git/HEAD` would
-    // watch a path that doesn't exist and Cargo would never re-run this script.
-    let git_dir = Command::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string());
-
-    if let Some(git_dir) = git_dir {
-        // Re-run if git HEAD changes (detects branch switches).
-        println!("cargo:rerun-if-changed={}/HEAD", git_dir);
-
-        // Also track the ref that HEAD points to (detects new commits on the
-        // current branch). When HEAD is "ref: refs/heads/main", new commits
-        // update refs/heads/main but NOT HEAD itself.
-        if let Ok(head) = std::fs::read_to_string(format!("{}/HEAD", git_dir)) {
-            let head = head.trim();
-            if let Some(refpath) = head.strip_prefix("ref: ") {
-                // The ref itself may live in the common git dir (for worktrees,
-                // that's the parent repo's .git), so check both locations.
-                let common_dir = Command::new("git")
-                    .args(["rev-parse", "--git-common-dir"])
-                    .output()
-                    .ok()
-                    .and_then(|o| String::from_utf8(o.stdout).ok())
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_else(|| git_dir.clone());
-
-                println!("cargo:rerun-if-changed={}/{}", git_dir, refpath);
-                if common_dir != git_dir {
-                    println!("cargo:rerun-if-changed={}/{}", common_dir, refpath);
-                }
-
-                // Packed-refs is updated when git packs loose refs or during
-                // fetch/gc. A ref might only exist here, so track it too.
-                println!("cargo:rerun-if-changed={}/packed-refs", common_dir);
-            }
-        }
-    }
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -13,59 +13,27 @@ fn main() {
         println!("cargo:rerun-if-changed=../runt-mcp/assets/plugins/{file}");
     }
 
+    // Also rerun when this build script changes (since we emit
+    // rerun-if-changed above, cargo won't use its default behavior).
+    println!("cargo:rerun-if-changed=build.rs");
+
     // Capture short commit hash for version-mismatch detection.
-    // This ensures the daemon gets restarted when the binary changes,
-    // even if the crate version (Cargo.toml) hasn't been bumped.
-    let commit = Command::new("git")
+    let commit = git_commit_short();
+    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+
+    // We intentionally do NOT watch .git/HEAD or refs — that causes
+    // recompilation of this crate and all dependents on every commit,
+    // branch switch, pull, or fetch. The hash is refreshed whenever
+    // this build script reruns (plugin asset change or build.rs edit).
+    // CI always starts clean so release builds always get the right hash.
+}
+
+fn git_commit_short() -> String {
+    Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
-
-    // Use `git rev-parse --git-dir` to find the actual git metadata directory.
-    // In a worktree, `.git` is a file pointing elsewhere (e.g.
-    // `../../.git/worktrees/<name>`), so hard-coding `../../.git/HEAD` would
-    // watch a path that doesn't exist and Cargo would never re-run this script.
-    let git_dir = Command::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string());
-
-    if let Some(git_dir) = git_dir {
-        // Re-run if git HEAD changes (detects branch switches).
-        println!("cargo:rerun-if-changed={}/HEAD", git_dir);
-
-        // Also track the ref that HEAD points to (detects new commits on the
-        // current branch). When HEAD is "ref: refs/heads/main", new commits
-        // update refs/heads/main but NOT HEAD itself.
-        if let Ok(head) = std::fs::read_to_string(format!("{}/HEAD", git_dir)) {
-            let head = head.trim();
-            if let Some(refpath) = head.strip_prefix("ref: ") {
-                // The ref itself may live in the common git dir (for worktrees,
-                // that's the parent repo's .git), so check both locations.
-                let common_dir = Command::new("git")
-                    .args(["rev-parse", "--git-common-dir"])
-                    .output()
-                    .ok()
-                    .and_then(|o| String::from_utf8(o.stdout).ok())
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_else(|| git_dir.clone());
-
-                println!("cargo:rerun-if-changed={}/{}", git_dir, refpath);
-                if common_dir != git_dir {
-                    println!("cargo:rerun-if-changed={}/{}", common_dir, refpath);
-                }
-
-                // Packed-refs is updated when git packs loose refs or during
-                // fetch/gc. A ref might only exist here, so track it too.
-                println!("cargo:rerun-if-changed={}/packed-refs", common_dir);
-            }
-        }
-    }
+        .unwrap_or_else(|| "unknown".to_string())
 }


### PR DESCRIPTION
## Summary
- **Remove `.git/HEAD`, `.git/refs/`, `.git/packed-refs` watchers** from build scripts in `runtimed`, `runtimed-client`, `runt`, and `notebook`. These caused every git operation (commit, branch switch, pull, fetch) to recompile 4 crates + all dependents.
- **Keep `GIT_COMMIT` computation** — build scripts still run `git rev-parse` when triggered by their other watchers (dist/ changes, plugin assets, env vars, or build.rs edits). CI always starts clean.
- **Extract `git_commit_short()` / `git_output()` helpers** to reduce duplicated boilerplate in each build script.

### Root cause
The `cargo:rerun-if-changed=.git/HEAD` (and refs, packed-refs) directives told cargo to rerun build scripts on any git state change. Since the build script output is part of cargo's compilation fingerprint, this cascaded into full recompilation of `runtimed-client` (depended on by nearly everything) plus `runtimed`, `runt`, and `notebook`.

### Before / After
| Operation | Before | After |
|-----------|--------|-------|
| Branch switch | ~60s+ (4 crates + deps recompile) | 0.2s |
| `git commit` | ~60s+ | 0.2s |
| `git pull` | ~60s+ | 0.2s |
| `git fetch` | Could trigger via packed-refs | 0.2s |

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo xtask lint` passes
- [x] Branch switch cycle (main → temp → main) shows 0.2s with zero recompilation
- [x] `touch .git/HEAD` does not trigger recompilation
- [x] GIT_COMMIT env var is still set (verified via build script output)
- [ ] CI build passes