### PR TITLE
feat(sift): add parquet renderer plugin + serve WASM from blob server

### DIFF
--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -24,3 +24,8 @@ declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;
 }
+
+declare module "virtual:renderer-plugin/sift" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/renderer-test/src/vite-env.d.ts
+++ b/apps/renderer-test/src/vite-env.d.ts
@@ -24,3 +24,8 @@ declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;
 }
+
+declare module "virtual:renderer-plugin/sift" {
+  export const code: string;
+  export const css: string;
+}

--- a/crates/runt-mcp/assets/plugins/nteract-predicate.wasm
+++ b/crates/runt-mcp/assets/plugins/nteract-predicate.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac9b1ec9cac69256e7d51d212ca8853347ce25c6380b83cedcba6937b388236
+size 5515463

--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -21,6 +21,11 @@ const _: () = {
         MARKDOWN.len() > 1024,
         "markdown.js appears to be a Git LFS pointer — run `git lfs pull`"
     );
+    const WASM: &[u8] = include_bytes!("../../runt-mcp/assets/plugins/nteract-predicate.wasm");
+    assert!(
+        WASM.len() > 1024,
+        "nteract-predicate.wasm appears to be a Git LFS pointer — run `git lfs pull`"
+    );
 };
 
 /// Look up an embedded renderer plugin asset by filename.
@@ -50,6 +55,10 @@ pub fn get(name: &str) -> Option<(&'static [u8], &'static str)> {
         "leaflet.css" => Some((
             include_bytes!("../../runt-mcp/assets/plugins/leaflet.css"),
             "text/css; charset=utf-8",
+        )),
+        "nteract-predicate.wasm" => Some((
+            include_bytes!("../../runt-mcp/assets/plugins/nteract-predicate.wasm"),
+            "application/wasm",
         )),
         _ => None,
     }

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -9,6 +9,7 @@
  * (plotly alone is 20MB unminified).
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -53,7 +54,21 @@ export const RENDERER_PLUGINS: RendererPluginDef[] = [
   { name: "plotly", entry: path.resolve(srcDir, "isolated-renderer/plotly-renderer.tsx") },
   { name: "vega", entry: path.resolve(srcDir, "isolated-renderer/vega-renderer.tsx") },
   { name: "leaflet", entry: path.resolve(srcDir, "isolated-renderer/leaflet-renderer.tsx") },
+  { name: "sift", entry: path.resolve(srcDir, "isolated-renderer/sift-renderer.tsx") },
 ];
+
+/**
+ * Resolve the WASM JS glue for nteract-predicate.
+ * Falls back to a stub if the WASM crate hasn't been built.
+ */
+function resolveWasmGlue(): string {
+  const realPath = path.resolve(srcDir, "../crates/nteract-predicate/pkg/nteract_predicate.js");
+  const mockPath = path.resolve(
+    srcDir,
+    "../packages/sift/src/__mocks__/nteract-predicate/nteract_predicate.js",
+  );
+  return fs.existsSync(realPath) ? realPath : mockPath;
+}
 
 /**
  * Extract JS and CSS from Vite build output
@@ -116,6 +131,10 @@ export async function buildRendererPlugin(
     resolve: {
       alias: {
         "@/": `${srcDir}/`,
+        // Sift plugin needs workspace package resolution + WASM glue
+        "@nteract/sift/style.css": path.resolve(srcDir, "../packages/sift/src/style.css"),
+        "@nteract/sift": path.resolve(srcDir, "../packages/sift/src/index.ts"),
+        "nteract-predicate/nteract_predicate.js": resolveWasmGlue(),
       },
     },
     build: {

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -37,6 +37,7 @@ const PLUGIN_MIME_TYPES: Record<string, () => Promise<PluginModule>> = {
   "text/latex": () => import("virtual:renderer-plugin/markdown").then(normalize),
   "application/vnd.plotly.v1+json": () => import("virtual:renderer-plugin/plotly").then(normalize),
   "application/geo+json": () => import("virtual:renderer-plugin/leaflet").then(normalize),
+  "application/vnd.apache.parquet": () => import("virtual:renderer-plugin/sift").then(normalize),
 };
 
 /** Lazy loader for all Vega/Vega-Lite MIME variants. */

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -1,0 +1,62 @@
+/**
+ * Sift Renderer Plugin
+ *
+ * On-demand renderer plugin for application/vnd.apache.parquet outputs.
+ * Loaded into the isolated iframe via the renderer plugin API.
+ *
+ * Data flow: kernel outputs parquet bytes → daemon stores in blob server →
+ * frontend gets blob URL → iframe loads sift plugin → SiftTable fetches
+ * parquet from blob URL → WASM decodes → table renders.
+ */
+
+import { setWasmUrl, SiftTable } from "@nteract/sift";
+import "@nteract/sift/style.css";
+
+// --- Types ---
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+// --- WASM configuration ---
+
+let wasmConfigured = false;
+
+/**
+ * Extract the blob server origin from a blob URL and configure WASM
+ * to load from the same server's /plugins/ route.
+ */
+function configureWasm(blobUrl: string): void {
+  if (wasmConfigured) return;
+  try {
+    const parsed = new URL(blobUrl);
+    const wasmUrl = `${parsed.protocol}//${parsed.host}/plugins/nteract-predicate.wasm`;
+    setWasmUrl(wasmUrl);
+    wasmConfigured = true;
+  } catch {
+    // Fall back to default WASM resolution
+  }
+}
+
+// --- SiftRenderer component ---
+
+function SiftRenderer({ data }: RendererProps) {
+  const url = String(data);
+  configureWasm(url);
+
+  return (
+    <div style={{ height: 600, width: "100%" }}>
+      <SiftTable url={url} />
+    </div>
+  );
+}
+
+// --- Plugin install ---
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
+}) {
+  ctx.register(["application/vnd.apache.parquet"], SiftRenderer);
+}


### PR DESCRIPTION
## Summary

Wires sift as an iframe renderer plugin for `application/vnd.apache.parquet` outputs and serves the nteract-predicate WASM binary from the blob server.

### Data flow

```
kernel outputs parquet bytes
  → daemon stores in blob server
    → frontend gets blob URL
      → iframe loads sift plugin
        → SiftTable fetches parquet from blob URL
          → WASM decodes row groups progressively
            → table renders
```

### Changes

| File | What |
|------|------|
| `src/isolated-renderer/sift-renderer.tsx` | Renderer plugin — registers for parquet MIME, configures WASM URL, renders SiftTable |
| `src/build/renderer-plugin-builder.ts` | Add sift to RENDERER_PLUGINS with `@nteract/sift` + WASM glue aliases |
| `src/components/isolated/iframe-libraries.ts` | Register `application/vnd.apache.parquet` → sift virtual module |
| `crates/runtimed/src/embedded_plugins.rs` | Serve `nteract-predicate.wasm` at `/plugins/` with LFS compile-time guard |
| `crates/runt-mcp/assets/plugins/nteract-predicate.wasm` | 5.3MB WASM binary (Git LFS) |
| `apps/notebook/src/vite-env.d.ts` | Virtual module type declaration |
| `apps/renderer-test/src/vite-env.d.ts` | Virtual module type declaration |

### WASM configuration

The renderer plugin extracts the blob server origin from the parquet data URL and configures `setWasmUrl()` so the iframe can load the WASM binary:

```
parquet URL: http://127.0.0.1:PORT/blob/abc123
WASM URL:    http://127.0.0.1:PORT/plugins/nteract-predicate.wasm
```

## Test plan

- [x] `cargo build -p runtimed` — clean (WASM embedded)
- [x] `apps/renderer-test npx vp build` — sift plugin builds (7.9MB)
- [x] `apps/renderer-test npx playwright test` — 2/2 pass
- [x] `pnpm --filter @nteract/sift exec vp test run` — 124 tests pass
- [x] `cargo xtask lint --fix` — clean
- [ ] Manual: run notebook, output parquet, verify table renders in cell