### PR TITLE
chore(build): check in pre-built renderer plugins via git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.parquet filter=lfs diff=lfs merge=lfs -text
 crates/runt-mcp/assets/plugins/*.css filter=lfs diff=lfs merge=lfs -text
 crates/runt-mcp/assets/plugins/*.js filter=lfs diff=lfs merge=lfs -text
+apps/notebook/src/renderer-plugins/*.js filter=lfs diff=lfs merge=lfs -text
+apps/notebook/src/renderer-plugins/*.css filter=lfs diff=lfs merge=lfs -text

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2771981f97fa7ebda37d3debfa2387b959f20134a95dec4f60348fe552ea5f47
+size 1588222

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00e01b7e1431d9aeba044d2fca1eaa8d463336e785b2debf811f829b642326e8
+size 1085616

--- a/apps/notebook/src/renderer-plugins/leaflet.css
+++ b/apps/notebook/src/renderer-plugins/leaflet.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9104fecbec9f6686fc11168a463dbdff6985a51dfae851b7ea9881a2ed8459a0
+size 15107

--- a/apps/notebook/src/renderer-plugins/leaflet.js
+++ b/apps/notebook/src/renderer-plugins/leaflet.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3838674a599941a103bdc0208c24bb655946a719fd2cccfddfe3544fbee20300
+size 177776

--- a/apps/notebook/src/renderer-plugins/markdown.css
+++ b/apps/notebook/src/renderer-plugins/markdown.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be8421ce3041b914c8cd911304ee99becc5e55c7aabef19fff7ae16848bfee1d
+size 1458336

--- a/apps/notebook/src/renderer-plugins/markdown.js
+++ b/apps/notebook/src/renderer-plugins/markdown.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4c615f45d3c3ed56b7b4aa2ed0b87835c19c199d7dc36628e51861034ce7b9
+size 731986

--- a/apps/notebook/src/renderer-plugins/plotly.js
+++ b/apps/notebook/src/renderer-plugins/plotly.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f76c040bf55a6c23dd6a928b604e25afe553a27aa82a1ab7b66eed9044088b6
+size 4630802

--- a/apps/notebook/src/renderer-plugins/vega.js
+++ b/apps/notebook/src/renderer-plugins/vega.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ded5795ed8e6f1f7dd9a66b403e3a84cf81c7e033e2f5c1f84a0e0bd1863ff2
+size 846877

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -152,7 +152,7 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
             warn(warning);
           },
         },
-        minify: true,
+        minify: false, // Dev-mode rebuilds skip minification for faster HMR
         sourcemap,
       },
       define: {
@@ -191,12 +191,14 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     name: "isolated-renderer",
 
     async buildStart() {
-      // Production builds: verify pre-built artifacts exist
+      // Production builds: verify all pre-built artifacts exist
       if (!isDevMode) {
-        const coreJs = readPrebuilt("isolated-renderer.js");
-        if (!coreJs) {
+        const missing = ["isolated-renderer.js", ...PLUGIN_NAMES.map((n) => `${n}.js`)].filter(
+          (f) => !readPrebuilt(f),
+        );
+        if (missing.length > 0) {
           throw new Error(
-            "Pre-built renderer plugins not found at apps/notebook/src/renderer-plugins/.\n" +
+            `Pre-built renderer plugins missing: ${missing.join(", ")}\n` +
               "Run `cargo xtask renderer-plugins` to build them.",
           );
         }

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -1,13 +1,23 @@
 /**
  * Vite Plugin: Isolated Renderer
  *
- * Builds the isolated renderer bundle during the notebook build and exposes
- * it as a virtual module. This eliminates the need for a separate build step.
+ * Loads pre-built renderer plugin artifacts from disk and exposes them as
+ * virtual modules. The artifacts are checked into the repo (via git LFS)
+ * at `apps/notebook/src/renderer-plugins/`, following the same pattern as
+ * the WASM bindings in `apps/notebook/src/wasm/`.
+ *
+ * To rebuild the artifacts: `cargo xtask renderer-plugins`
+ *
+ * In dev mode (Vite dev server), changes to isolated renderer source files
+ * trigger a live rebuild + HMR reload so you don't need to re-run the
+ * xtask command during active renderer development.
  *
  * Usage:
  *   import { rendererCode, rendererCss } from 'virtual:isolated-renderer';
+ *   import { code, css } from 'virtual:renderer-plugin/plotly';
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { build, type Plugin } from "vite-plus";
@@ -24,61 +34,69 @@ const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
 const VIRTUAL_PLUGIN_PREFIX = "virtual:renderer-plugin/";
 const RESOLVED_PLUGIN_PREFIX = "\0virtual:renderer-plugin/";
 
+/** Directory containing pre-built renderer plugin artifacts (checked in via git LFS). */
+const PREBUILT_DIR = path.resolve(__dirname, "../notebook/src/renderer-plugins");
+
+/** Plugin names that have pre-built artifacts (excludes sift — built from source). */
+const PLUGIN_NAMES = ["markdown", "plotly", "vega", "leaflet"];
+
 interface IsolatedRendererPluginOptions {
   /**
-   * Path to the isolated renderer entry file.
+   * Path to the isolated renderer entry file (used only for dev-mode rebuilds).
    * @default "../../src/isolated-renderer/index.tsx"
    */
   entry?: string;
   /**
-   * Enable minification for production builds.
-   * @default false
-   */
-  minify?: boolean;
-  /**
-   * Source map mode for the embedded renderer bundle.
-   * Use inline source maps when the bundle is in-memory or injected.
+   * Source map mode for dev-mode rebuilds.
    * @default false
    */
   sourcemap?: false | "inline";
 }
 
+/**
+ * Read a pre-built artifact from disk, returning empty string if missing.
+ */
+function readPrebuilt(filename: string): string {
+  const filepath = path.join(PREBUILT_DIR, filename);
+  try {
+    return fs.readFileSync(filepath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
 export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = {}): Plugin {
   const {
     entry = path.resolve(__dirname, "../../src/isolated-renderer/index.tsx"),
-    minify = false,
     sourcemap = false,
   } = options;
 
-  let rendererCode = "";
-  let rendererCss = "";
-  let pluginOutputs = new Map<string, RendererPluginOutput>();
-  let buildPromise: Promise<void> | null = null;
+  // In-memory cache for dev-mode rebuilds (overrides pre-built artifacts)
+  let devRendererCode = "";
+  let devRendererCss = "";
+  let devPluginOutputs = new Map<string, RendererPluginOutput>();
+  let devBuildPromise: Promise<void> | null = null;
+  let isDevMode = false;
 
   // Directories to watch for changes that should trigger rebuild
   const isolatedRendererDir = path.resolve(__dirname, "../../src/isolated-renderer");
   const componentsDir = path.resolve(__dirname, "../../src/components");
 
-  function invalidateCache() {
-    buildPromise = null;
-    rendererCode = "";
-    rendererCss = "";
-    pluginOutputs = new Map();
+  function invalidateDevCache() {
+    devBuildPromise = null;
+    devRendererCode = "";
+    devRendererCss = "";
+    devPluginOutputs = new Map();
   }
 
-  async function buildRenderer() {
+  async function buildRendererFromSource() {
     const srcDir = path.resolve(__dirname, "../../src");
 
     const result = await build({
       configFile: false,
-      // Force production mode to ensure esbuild uses jsx-runtime (not jsx-dev-runtime)
       mode: "production",
       plugins: [
-        // Don't use React plugin - use esbuild's native JSX handling instead
-        // The React plugin uses Babel which doesn't respect mode for JSX transform
         tailwindcss(),
-        // Resolve vega-raw/vega-lite-raw/vega-embed-raw virtual modules.
-        // These bypass restrictive "exports" fields in vega packages (v6+).
         {
           name: "vega-raw-resolve",
           resolveId(source: string) {
@@ -97,13 +115,8 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
         },
       ],
       esbuild: {
-        // Use esbuild's native JSX handling with automatic runtime
-        // This properly bundles jsx-runtime into the IIFE
         jsx: "automatic",
         jsxImportSource: "react",
-        // CRITICAL: Explicitly disable jsxDev to use production runtime
-        // Without this, Vite's dev server passes jsxDev: true to esbuild,
-        // which generates jsxDEV calls that fail in the sandboxed iframe
         jsxDev: false,
       },
       resolve: {
@@ -112,7 +125,7 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
         },
       },
       build: {
-        write: false, // Don't write to disk, return in memory
+        write: false,
         lib: {
           entry,
           name: "IsolatedRenderer",
@@ -129,7 +142,6 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
             "@tauri-apps/plugin-fs",
             /^@tauri-apps\/.*/,
           ],
-          // Suppress "use client" directive warnings from node_modules
           onwarn(warning, warn) {
             if (
               warning.code === "MODULE_LEVEL_DIRECTIVE" &&
@@ -140,24 +152,23 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
             warn(warning);
           },
         },
-        minify,
+        minify: true,
         sourcemap,
       },
       define: {
         "process.env.NODE_ENV": JSON.stringify("production"),
       },
-      logLevel: "warn", // Reduce noise during build
+      logLevel: "warn",
     });
 
-    // Extract JS and CSS from build output
     const outputs = Array.isArray(result) ? result : [result];
     for (const output of outputs) {
       if ("output" in output) {
         for (const chunk of output.output) {
           if (chunk.type === "chunk" && chunk.fileName.endsWith(".js")) {
-            rendererCode = chunk.code;
+            devRendererCode = chunk.code;
           } else if (chunk.type === "asset" && chunk.fileName.endsWith(".css")) {
-            rendererCss =
+            devRendererCss =
               typeof chunk.source === "string"
                 ? chunk.source
                 : new TextDecoder().decode(chunk.source);
@@ -166,14 +177,13 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
       }
     }
 
-    if (!rendererCode) {
+    if (!devRendererCode) {
       throw new Error("Failed to build isolated renderer: no JS output produced");
     }
 
-    // --- Build renderer plugins (CJS, React externalized) ---
     const plugins = await buildAllRendererPlugins();
     for (const plugin of plugins) {
-      pluginOutputs.set(plugin.name, plugin);
+      devPluginOutputs.set(plugin.name, plugin);
     }
   }
 
@@ -181,12 +191,16 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     name: "isolated-renderer",
 
     async buildStart() {
-      // Build the isolated renderer at the start of the main build
-      // Cache the promise so we only build once even if called multiple times
-      if (!buildPromise) {
-        buildPromise = buildRenderer();
+      // Production builds: verify pre-built artifacts exist
+      if (!isDevMode) {
+        const coreJs = readPrebuilt("isolated-renderer.js");
+        if (!coreJs) {
+          throw new Error(
+            "Pre-built renderer plugins not found at apps/notebook/src/renderer-plugins/.\n" +
+              "Run `cargo xtask renderer-plugins` to build them.",
+          );
+        }
       }
-      await buildPromise;
     },
 
     resolveId(id) {
@@ -199,54 +213,66 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
     },
 
     async load(id) {
-      if (id === RESOLVED_VIRTUAL_MODULE_ID || id.startsWith(RESOLVED_PLUGIN_PREFIX)) {
-        // Ensure build is complete before returning module content
-        if (buildPromise) {
-          await buildPromise;
-        }
+      // In dev mode, wait for any in-progress build
+      if (isDevMode && devBuildPromise) {
+        await devBuildPromise;
       }
 
-      // Core IIFE bundle (no plugin strings — they have their own modules)
+      // Core IIFE bundle
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+        const code =
+          isDevMode && devRendererCode ? devRendererCode : readPrebuilt("isolated-renderer.js");
+        const css =
+          isDevMode && devRendererCss ? devRendererCss : readPrebuilt("isolated-renderer.css");
         return `
-export const rendererCode = ${JSON.stringify(rendererCode)};
-export const rendererCss = ${JSON.stringify(rendererCss)};
+export const rendererCode = ${JSON.stringify(code)};
+export const rendererCss = ${JSON.stringify(css)};
 `;
       }
 
-      // Renderer plugin modules (code-split from the core bundle)
+      // Renderer plugin modules
       const pluginName = id.startsWith(RESOLVED_PLUGIN_PREFIX)
         ? id.slice(RESOLVED_PLUGIN_PREFIX.length)
         : null;
       if (pluginName) {
-        const plugin = pluginOutputs.get(pluginName);
-        if (plugin) {
+        // Dev mode: use freshly built output if available
+        if (isDevMode) {
+          const devPlugin = devPluginOutputs.get(pluginName);
+          if (devPlugin) {
+            return `
+export const code = ${JSON.stringify(devPlugin.code)};
+export const css = ${JSON.stringify(devPlugin.css)};
+`;
+          }
+        }
+        // Production: read from pre-built artifacts
+        const code = readPrebuilt(`${pluginName}.js`);
+        const css = readPrebuilt(`${pluginName}.css`);
+        if (code) {
           return `
-export const code = ${JSON.stringify(plugin.code)};
-export const css = ${JSON.stringify(plugin.css)};
+export const code = ${JSON.stringify(code)};
+export const css = ${JSON.stringify(css)};
 `;
         }
       }
     },
 
-    // For dev server: serve the virtual module
+    // Dev server: build from source for live development
     configureServer(devServer) {
-      // Ensure renderer is built before serving
+      isDevMode = true;
       devServer.middlewares.use(async (_req, _res, next) => {
-        if (!buildPromise) {
-          buildPromise = buildRenderer();
+        if (!devBuildPromise) {
+          devBuildPromise = buildRendererFromSource();
         }
-        await buildPromise;
+        await devBuildPromise;
         next();
       });
     },
 
-    // Handle HMR: rebuild when isolated renderer source files change
+    // HMR: rebuild from source when isolated renderer files change
     async handleHotUpdate({ file, server: devServer }) {
-      // Check if the changed file is part of the isolated renderer bundle
       const isIsolatedRendererFile =
         file.startsWith(isolatedRendererDir) ||
-        // Components used by the isolated renderer
         (file.startsWith(componentsDir) &&
           (file.includes("/outputs/") ||
             file.includes("/isolated/") ||
@@ -256,26 +282,22 @@ export const css = ${JSON.stringify(plugin.css)};
         console.log(
           `[isolated-renderer] Rebuilding due to change in: ${path.relative(path.resolve(__dirname, "../.."), file)}`,
         );
-        invalidateCache();
-        buildPromise = buildRenderer();
-        await buildPromise;
+        invalidateDevCache();
+        devBuildPromise = buildRendererFromSource();
+        await devBuildPromise;
 
-        // Invalidate the core virtual module and all plugin virtual modules.
-        // Without this, Vite's module graph retains stale load() results for
-        // plugin modules and serves old plugin code after a full-reload.
         const mod = devServer.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
         if (mod) {
           devServer.moduleGraph.invalidateModule(mod);
         }
 
-        for (const name of pluginOutputs.keys()) {
+        for (const name of devPluginOutputs.keys()) {
           const pluginMod = devServer.moduleGraph.getModuleById(`${RESOLVED_PLUGIN_PREFIX}${name}`);
           if (pluginMod) {
             devServer.moduleGraph.invalidateModule(pluginMod);
           }
         }
 
-        // Send HMR update
         devServer.ws.send({
           type: "full-reload",
           path: "*",

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite-plus";
 import { isolatedRendererPlugin } from "./vite-plugin-isolated-renderer";
 import { rawLibPlugin } from "./vite-plugin-raw-lib";
 
-export default defineConfig(({ command }) => {
+export default defineConfig(() => {
   const debugBundleSourceMapsEnabled = process.env.RUNT_NOTEBOOK_DEBUG_BUILD === "1";
 
   return {
@@ -14,9 +14,7 @@ export default defineConfig(({ command }) => {
       react(),
       tailwindcss(),
       rawLibPlugin(path.resolve(__dirname, "../../node_modules")),
-      isolatedRendererPlugin({
-        minify: command !== "serve",
-      }),
+      isolatedRendererPlugin(),
       visualizer({
         filename: "dist/stats.html",
         open: false,

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
             let target = args.get(1).map(|s| s.as_str());
             cmd_wasm(target);
         }
+        "renderer-plugins" => cmd_renderer_plugins(),
         "mcpb" => {
             let output = args
                 .windows(2)
@@ -146,6 +147,7 @@ Other:
   wasm                       Rebuild runtimed-wasm (wasm-pack build)
   wasm sift                  Rebuild nteract-predicate WASM for sift
   wasm --all                 Rebuild all WASM targets
+  renderer-plugins           Rebuild pre-built renderer plugins (notebook + MCP)
   icons [source.png]         Generate icon variants
   mcpb                       Package nteract as a Claude Desktop extension (.mcpb)
   mcpb --variant nightly     Build nightly variant (different name/icon)
@@ -1078,6 +1080,26 @@ fn cmd_wasm(target: Option<&str>) {
         );
         println!("WASM build complete. Output: packages/sift/public/wasm/");
     }
+}
+
+fn cmd_renderer_plugins() {
+    require_pnpm();
+    println!("Building renderer plugins...");
+    // Build both the notebook renderer plugins and the runt-mcp plugin assets.
+    // Uses the shared renderer-plugin-builder.ts to produce:
+    //   - apps/notebook/src/renderer-plugins/ (IIFE + 4 CJS plugins, checked in via git LFS)
+    //   - crates/runt-mcp/assets/plugins/ (MCP-wrapped plugins, checked in via git LFS)
+    run_cmd(
+        "node",
+        &[
+            "--experimental-strip-types",
+            "scripts/build-renderer-plugins.ts",
+        ],
+    );
+    println!("Renderer plugins built.");
+    println!("  Notebook: apps/notebook/src/renderer-plugins/");
+    println!("  MCP:      crates/runt-mcp/assets/plugins/");
+    println!("Commit the updated artifacts (they're tracked via git LFS).");
 }
 
 fn cmd_icons(source: Option<&str>) {

--- a/scripts/build-renderer-plugins.ts
+++ b/scripts/build-renderer-plugins.ts
@@ -1,0 +1,149 @@
+/**
+ * Build pre-built renderer plugin artifacts.
+ *
+ * Produces two sets of outputs:
+ *   1. apps/notebook/src/renderer-plugins/ — Core IIFE + 4 CJS plugins for the notebook app
+ *   2. crates/runt-mcp/assets/plugins/ — MCP-wrapped plugins for the daemon's MCP server
+ *
+ * Both are checked into the repo via git LFS. Run this script when renderer
+ * source files or vendored libraries change:
+ *
+ *   cargo xtask renderer-plugins
+ *
+ * The notebook Vite build reads from (1) instead of rebuilding plugins on
+ * every build. The runtimed daemon embeds (2) via include_str!().
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/vite";
+import { build } from "vite-plus";
+import {
+  buildAllRendererPlugins,
+  RENDERER_PLUGINS,
+} from "../src/build/renderer-plugin-builder.ts";
+import { wrapForMcpApp } from "../apps/mcp-app/src/lib/wrap-plugin.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+const notebookPluginDir = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+const mcpPluginDir = path.join(repoRoot, "crates/runt-mcp/assets/plugins");
+
+async function buildCoreIIFE(): Promise<{ code: string; css: string }> {
+  const srcDir = path.join(repoRoot, "src");
+  const nodeModules = path.join(repoRoot, "node_modules");
+
+  const result = await build({
+    configFile: false,
+    mode: "production",
+    plugins: [
+      tailwindcss(),
+      {
+        name: "vega-raw-resolve",
+        resolveId(source: string) {
+          const mapping: Record<string, string> = {
+            "vega-raw": path.join(nodeModules, "vega/build/vega.min.js"),
+            "vega-lite-raw": path.join(nodeModules, "vega-lite/build/vega-lite.min.js"),
+            "vega-embed-raw": path.join(nodeModules, "vega-embed/build/vega-embed.min.js"),
+            "leaflet-js-raw": path.join(nodeModules, "leaflet/dist/leaflet.js"),
+            "leaflet-css-raw": path.join(nodeModules, "leaflet/dist/leaflet.css"),
+          };
+          const filePath = mapping[source];
+          if (filePath) return `${filePath}?raw`;
+          return null;
+        },
+      },
+    ],
+    esbuild: { jsx: "automatic", jsxImportSource: "react", jsxDev: false },
+    resolve: { alias: { "@/": `${srcDir}/` } },
+    build: {
+      write: false,
+      lib: {
+        entry: path.join(srcDir, "isolated-renderer/index.tsx"),
+        name: "IsolatedRenderer",
+        formats: ["iife"],
+        fileName: () => "isolated-renderer.js",
+      },
+      rolldownOptions: {
+        output: { assetFileNames: "isolated-renderer.[ext]" },
+        external: [
+          "@tauri-apps/api",
+          "@tauri-apps/plugin-shell",
+          "@tauri-apps/plugin-fs",
+          /^@tauri-apps\/.*/,
+        ],
+        onwarn(warning, warn) {
+          if (
+            warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+            warning.message?.includes('"use client"')
+          )
+            return;
+          warn(warning);
+        },
+      },
+      minify: true,
+      sourcemap: false,
+    },
+    define: { "process.env.NODE_ENV": JSON.stringify("production") },
+    logLevel: "warn",
+  });
+
+  let code = "";
+  let css = "";
+  const outputs = Array.isArray(result) ? result : [result];
+  for (const output of outputs) {
+    if ("output" in output) {
+      for (const chunk of output.output) {
+        if (chunk.type === "chunk" && chunk.fileName.endsWith(".js")) {
+          code = chunk.code;
+        } else if (chunk.type === "asset" && chunk.fileName.endsWith(".css")) {
+          css =
+            typeof chunk.source === "string"
+              ? chunk.source
+              : new TextDecoder().decode(chunk.source);
+        }
+      }
+    }
+  }
+
+  if (!code) throw new Error("Failed to build isolated renderer IIFE");
+  return { code, css };
+}
+
+async function main() {
+  fs.mkdirSync(notebookPluginDir, { recursive: true });
+  fs.mkdirSync(mcpPluginDir, { recursive: true });
+
+  // Build core IIFE and renderer plugins in parallel
+  const [iife, plugins] = await Promise.all([buildCoreIIFE(), buildAllRendererPlugins(RENDERER_PLUGINS)]);
+
+  // Write core IIFE (notebook only — MCP doesn't use the IIFE)
+  fs.writeFileSync(path.join(notebookPluginDir, "isolated-renderer.js"), iife.code);
+  fs.writeFileSync(path.join(notebookPluginDir, "isolated-renderer.css"), iife.css);
+  console.log(
+    `  isolated-renderer: ${(iife.code.length / 1024).toFixed(0)} kB JS, ${(iife.css.length / 1024).toFixed(0)} kB CSS`,
+  );
+
+  // Write renderer plugins (both notebook and MCP)
+  for (const { name, code, css } of plugins) {
+    // Notebook: raw CJS
+    fs.writeFileSync(path.join(notebookPluginDir, `${name}.js`), code);
+    if (css) fs.writeFileSync(path.join(notebookPluginDir, `${name}.css`), css);
+
+    // MCP: wrapped for MCP app
+    const wrapped = wrapForMcpApp(code);
+    fs.writeFileSync(path.join(mcpPluginDir, `${name}.js`), wrapped);
+    if (css) fs.writeFileSync(path.join(mcpPluginDir, `${name}.css`), css);
+
+    const sizeParts = [`${(code.length / 1024).toFixed(0)} kB JS`];
+    if (css) sizeParts.push(`${(css.length / 1024).toFixed(0)} kB CSS`);
+    console.log(`  ${name}: ${sizeParts.join(", ")}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ const ignoreNonSource = [
   "**/*.json",
   "**/*.toml",
   "**/wasm/**",
+  "**/renderer-plugins/**",
   "**/dist/**",
   "**/lib/**",
   "**/node_modules/**",


### PR DESCRIPTION
## Summary
- **Check in pre-built renderer plugin artifacts** (core IIFE + markdown, plotly, vega, leaflet) at `apps/notebook/src/renderer-plugins/`, tracked via git LFS — same pattern as WASM bindings and runt-mcp plugin assets.
- **Vite plugin reads from disk** in production builds instead of running 5 Vite sub-builds. Drops `isolated-renderer` plugin from 15% to 5% of frontend build time.
- **Dev mode unchanged** — Vite dev server still builds from source with HMR for active renderer development.
- **`cargo xtask renderer-plugins`** rebuilds both notebook and MCP plugin artifacts from the same shared `renderer-plugin-builder.ts`.
- **Sift excluded** — changes frequently, will be handled separately.

### Artifacts (git LFS)
| File | Size |
|------|------|
| isolated-renderer.js | 1,046 kB |
| isolated-renderer.css | 1,551 kB |
| markdown.js | 701 kB |
| markdown.css | 1,424 kB |
| plotly.js | 4,522 kB |
| vega.js | 827 kB |
| leaflet.js | 174 kB |
| leaflet.css | 15 kB |

## Test plan
- [x] `cargo xtask build` — warm build ~35s, isolated-renderer at 5% (was 15%)
- [x] `cargo xtask renderer-plugins` — builds all artifacts to both notebook and MCP dirs
- [x] `cargo xtask lint` passes (pre-built files excluded)
- [x] LFS upload successful (6 objects, 9.1 MB)
- [ ] CI build passes