### PR TITLE
fix(runtimed): set current_runtime_agent_id in LaunchKernel request path

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5326,7 +5326,7 @@ async fn handle_notebook_request(
 
                 match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
                     notebook_id,
-                    runtime_agent_id,
+                    runtime_agent_id.clone(),
                     room.blob_store.root().to_path_buf(),
                     socket_path,
                 )
@@ -5336,6 +5336,10 @@ async fn handle_notebook_request(
                         {
                             let mut ra_guard = room.runtime_agent_handle.lock().await;
                             *ra_guard = Some(ra);
+                        }
+                        {
+                            let mut id = room.current_runtime_agent_id.write().await;
+                            *id = Some(runtime_agent_id.clone());
                         }
 
                         // Write "connecting" phase — fills the gap between spawn and connect


### PR DESCRIPTION
## Summary

- The `handle_notebook_request` spawn path (explicit LaunchKernel) stored the runtime agent handle but never set `current_runtime_agent_id`
- The `auto_launch_kernel` path already does this — this PR matches that pattern
- Without this, the provenance check in `handle_runtime_agent_sync` can't reject stale agents from a previous launch cycle

## Context

Extracted from the closed #1732. The broader stale-timeout race is tracked in #1734 (CancellationToken approach). This fix is independent and correct regardless of that design.

## Test plan

- [ ] CI passes
- [ ] `cargo check -p runtimed` clean