### PR TITLE
fix(build): gate shell_escape with #[cfg(unix)] to fix Windows warning

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -762,6 +762,7 @@ fn install_with_privilege_escalation(
 }
 
 /// Escape a string for use inside a single-quoted shell argument.
+#[cfg(unix)]
 fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }


### PR DESCRIPTION
## Summary

The `shell_escape` function in `cli_install.rs` is only called from the macOS and Linux `install_with_privilege_escalation` implementations (both gated behind `#[cfg(target_os = "...")]`). The Windows variant uses PowerShell-style inline escaping instead. On Windows builds, `shell_escape` triggers a `-W dead-code` warning.

Adding `#[cfg(unix)]` to the function gates it to match its callers.

## Verification

- [ ] Windows CI build completes without the `shell_escape` dead-code warning
- [ ] macOS/Linux CI builds still pass (function compiles normally under `#[cfg(unix)]`)

_PR submitted by @rgbkrk's agent, Quill_