### PR TITLE
feat: whole-app cream theme with CodeMirror support

### DIFF
--- a/apps/notebook/feedback/index.css
+++ b/apps/notebook/feedback/index.css
@@ -4,6 +4,7 @@
 
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../../../src/styles/cream-theme.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/notebook/onboarding/index.css
+++ b/apps/notebook/onboarding/index.css
@@ -4,6 +4,7 @@
 
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../../../src/styles/cream-theme.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -210,7 +210,8 @@ export default function App() {
   const { theme, setTheme } = useSyncedTheme();
 
   const {
-    // colorTheme and setColorTheme available but UI hidden until whole-app theming is ready
+    colorTheme,
+    setColorTheme,
     defaultRuntime,
     setDefaultRuntime,
     defaultPythonEnv,
@@ -236,7 +237,7 @@ export default function App() {
             Appearance
           </span>
           <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground">Theme</span>
+            <span className="text-sm text-muted-foreground">Mode</span>
             <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
               {themeOptions.map((option) => {
                 const Icon = option.icon;
@@ -260,9 +261,8 @@ export default function App() {
               })}
             </div>
           </div>
-          {/* Color theme toggle — hidden until whole-app theming is ready
           <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground">Color</span>
+            <span className="text-sm text-muted-foreground">Flavor</span>
             <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
               {(["classic", "cream"] as const).map((option) => {
                 const isActive = colorTheme === option;
@@ -284,7 +284,6 @@ export default function App() {
               })}
             </div>
           </div>
-          */}
         </div>
 
         {/* Default Runtime */}

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -205,13 +205,11 @@ const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
 
 export default function App() {
   // Apply theme to window and get theme controls
-  // IMPORTANT: Use theme/setTheme from useSyncedTheme, not a separate useSyncedSettings call,
-  // so that setTheme updates the same state instance that applies the DOM theme.
-  const { theme, setTheme } = useSyncedTheme();
+  // IMPORTANT: Use theme/setTheme/colorTheme/setColorTheme from useSyncedTheme, not a separate
+  // useSyncedSettings call, so that setState updates the same instance that applies the DOM theme.
+  const { theme, setTheme, colorTheme, setColorTheme } = useSyncedTheme();
 
   const {
-    colorTheme,
-    setColorTheme,
     defaultRuntime,
     setDefaultRuntime,
     defaultPythonEnv,

--- a/apps/notebook/settings/index.css
+++ b/apps/notebook/settings/index.css
@@ -4,6 +4,7 @@
 
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../../../src/styles/cream-theme.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -108,6 +108,8 @@
   }
 }
 
+@import "../../../src/styles/cream-theme.css";
+
 * {
   @apply border-border;
 }

--- a/apps/notebook/upgrade/index.css
+++ b/apps/notebook/upgrade/index.css
@@ -4,6 +4,7 @@
 
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "../../../src/styles/cream-theme.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -101,6 +101,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       baseExtensions = defaultExtensions,
       readOnly = false,
       theme = "system",
+      colorTheme,
     },
     ref,
   ) => {

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -18,7 +18,8 @@ import {
 import { cn } from "@/lib/utils";
 import { defaultExtensions } from "./extensions";
 import { getIPythonExtension, getLanguageExtension, type SupportedLanguage } from "./languages";
-import { darkTheme, isDarkMode, lightTheme, type ThemeMode } from "./themes";
+import { useColorTheme } from "@/lib/dark-mode";
+import { type ColorTheme, getTheme, isDarkMode, type ThemeMode } from "./themes";
 
 export interface CodeMirrorEditorRef {
   /** Focus the editor */
@@ -67,6 +68,8 @@ export interface CodeMirrorEditorProps {
   readOnly?: boolean;
   /** Theme mode: "light", "dark", or "auto" (default) */
   theme?: ThemeMode;
+  /** Color theme: "classic" or "cream" */
+  colorTheme?: ColorTheme;
 }
 
 /**
@@ -122,6 +125,10 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       typeof window !== "undefined" ? isDarkMode() : false,
     );
 
+    // Track color theme from DOM attribute
+    const domColorTheme = useColorTheme();
+    const resolvedColorTheme: ColorTheme = colorTheme ?? (domColorTheme as ColorTheme) ?? "classic";
+
     // Listen for dark mode changes (system preference + document class)
     useEffect(() => {
       if (theme !== "system") return;
@@ -169,10 +176,10 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
     // ── Theme extension ──────────────────────────────────────────────
 
     const themeExtension = useMemo(() => {
-      if (theme === "light") return lightTheme;
-      if (theme === "dark") return darkTheme;
-      return isDark ? darkTheme : lightTheme;
-    }, [theme, isDark]);
+      const mode =
+        theme === "system" ? (isDark ? "dark" : "light") : (theme ?? (isDark ? "dark" : "light"));
+      return getTheme(mode, resolvedColorTheme);
+    }, [theme, resolvedColorTheme, isDark]);
 
     // ── Max height ───────────────────────────────────────────────────
 

--- a/src/components/editor/themes.ts
+++ b/src/components/editor/themes.ts
@@ -1,13 +1,10 @@
 import type { Extension } from "@codemirror/state";
 import {
-  defaultSettingsGithubDark,
-  defaultSettingsGithubLight,
   githubDark,
-  githubDarkStyle,
+  githubDarkInit,
   githubLight,
-  githubLightStyle,
+  githubLightInit,
 } from "@uiw/codemirror-theme-github";
-import { createTheme } from "@uiw/codemirror-themes";
 
 import { documentHasDarkMode, isDarkMode, prefersDarkMode, useDarkMode } from "@/lib/dark-mode";
 
@@ -31,32 +28,27 @@ export const classicLight: Extension = githubLight;
 export const classicDark: Extension = githubDark;
 
 /**
- * Cream themes — warm backgrounds with GitHub syntax highlighting
+ * Cream themes — warm backgrounds with GitHub syntax highlighting.
+ * Uses githubLightInit/githubDarkInit with settings overrides.
  */
-export const creamLight: Extension = createTheme({
-  theme: "light",
+export const creamLight: Extension = githubLightInit({
   settings: {
-    ...defaultSettingsGithubLight,
     background: "#f5f2ec",
     gutterBackground: "#f5f2ec",
     gutterForeground: "#6e655f",
     selection: "#d8cec3",
     selectionMatch: "#d8cec3",
   },
-  styles: githubLightStyle,
 });
 
-export const creamDark: Extension = createTheme({
-  theme: "dark",
+export const creamDark: Extension = githubDarkInit({
   settings: {
-    ...defaultSettingsGithubDark,
     background: "#1a1816",
     gutterBackground: "#1a1816",
     gutterForeground: "#9a918a",
     selection: "#3a3533",
     selectionMatch: "#3a3533",
   },
-  styles: githubDarkStyle,
 });
 
 // Legacy exports for backward compatibility

--- a/src/components/editor/themes.ts
+++ b/src/components/editor/themes.ts
@@ -1,5 +1,13 @@
 import type { Extension } from "@codemirror/state";
-import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
+import {
+  defaultSettingsGithubDark,
+  defaultSettingsGithubLight,
+  githubDark,
+  githubDarkStyle,
+  githubLight,
+  githubLightStyle,
+} from "@uiw/codemirror-theme-github";
+import { createTheme } from "@uiw/codemirror-themes";
 
 import { documentHasDarkMode, isDarkMode, prefersDarkMode, useDarkMode } from "@/lib/dark-mode";
 
@@ -12,38 +20,72 @@ export { documentHasDarkMode, isDarkMode, prefersDarkMode, useDarkMode };
 export type ThemeMode = "light" | "dark" | "system";
 
 /**
- * Light theme - GitHub Light
+ * Color theme options
  */
-export const lightTheme: Extension = githubLight;
+export type ColorTheme = "classic" | "cream";
 
 /**
- * Dark theme - GitHub Dark
+ * Classic themes — GitHub Light/Dark
  */
-export const darkTheme: Extension = githubDark;
+export const classicLight: Extension = githubLight;
+export const classicDark: Extension = githubDark;
 
 /**
- * Get the appropriate theme extension based on mode
+ * Cream themes — warm backgrounds with GitHub syntax highlighting
  */
-export function getTheme(mode: ThemeMode): Extension {
-  if (mode === "light") {
-    return lightTheme;
+export const creamLight: Extension = createTheme({
+  theme: "light",
+  settings: {
+    ...defaultSettingsGithubLight,
+    background: "#f5f2ec",
+    gutterBackground: "#f5f2ec",
+    gutterForeground: "#6e655f",
+    selection: "#d8cec3",
+    selectionMatch: "#d8cec3",
+  },
+  styles: githubLightStyle,
+});
+
+export const creamDark: Extension = createTheme({
+  theme: "dark",
+  settings: {
+    ...defaultSettingsGithubDark,
+    background: "#1a1816",
+    gutterBackground: "#1a1816",
+    gutterForeground: "#9a918a",
+    selection: "#3a3533",
+    selectionMatch: "#3a3533",
+  },
+  styles: githubDarkStyle,
+});
+
+// Legacy exports for backward compatibility
+export const lightTheme: Extension = classicLight;
+export const darkTheme: Extension = classicDark;
+
+/**
+ * Get the appropriate theme extension based on mode and color theme
+ */
+export function getTheme(mode: ThemeMode, colorTheme: ColorTheme = "classic"): Extension {
+  const resolvedDark =
+    mode === "system"
+      ? typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches
+      : mode === "dark";
+
+  if (colorTheme === "cream") {
+    return resolvedDark ? creamDark : creamLight;
   }
-  if (mode === "dark") {
-    return darkTheme;
-  }
-  // System mode - detect from media query
-  if (typeof window !== "undefined") {
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    return prefersDark ? darkTheme : lightTheme;
-  }
-  // SSR fallback
-  return lightTheme;
+  return resolvedDark ? classicDark : classicLight;
 }
 
 /**
  * Get the current theme based on automatic detection
  * Checks document class, color-scheme, data-theme attribute, and system preference
  */
-export function getAutoTheme(): Extension {
-  return isDarkMode() ? darkTheme : lightTheme;
+export function getAutoTheme(colorTheme: ColorTheme = "classic"): Extension {
+  const dark = isDarkMode();
+  if (colorTheme === "cream") {
+    return dark ? creamDark : creamLight;
+  }
+  return dark ? classicDark : classicLight;
 }

--- a/src/styles/cream-theme.css
+++ b/src/styles/cream-theme.css
@@ -1,0 +1,78 @@
+/**
+ * Cream theme — warm palette for the notebook app.
+ *
+ * Overrides shadcn CSS variables when `data-color-theme="cream"` is set
+ * on the document element. Import this file in any app's CSS to enable
+ * cream theme support.
+ */
+
+/* --- Light --- */
+[data-color-theme="cream"] {
+  --background: #f5f2ec;
+  --foreground: #1e1a18;
+  --card: #fffdf9;
+  --card-foreground: #1e1a18;
+  --popover: #fffdf9;
+  --popover-foreground: #1e1a18;
+  --primary: #955f3b;
+  --primary-foreground: #fffdf9;
+  --secondary: #ebe6df;
+  --secondary-foreground: #1e1a18;
+  --muted: #ebe6df;
+  --muted-foreground: #6e655f;
+  --accent: #ebe6df;
+  --accent-foreground: #1e1a18;
+  --destructive: #c4513a;
+  --destructive-foreground: #fffdf9;
+  --border: #d8cec3;
+  --input: #d8cec3;
+  --ring: #955f3b;
+}
+
+/* --- Dark (explicit) --- */
+[data-color-theme="cream"].dark {
+  --background: #1a1816;
+  --foreground: #e8e2dc;
+  --card: #242120;
+  --card-foreground: #e8e2dc;
+  --popover: #242120;
+  --popover-foreground: #e8e2dc;
+  --primary: #d4896a;
+  --primary-foreground: #1a1816;
+  --secondary: #3a3533;
+  --secondary-foreground: #e8e2dc;
+  --muted: #3a3533;
+  --muted-foreground: #9a918a;
+  --accent: #3a3533;
+  --accent-foreground: #e8e2dc;
+  --destructive: #e07a64;
+  --destructive-foreground: #1a1816;
+  --border: rgba(255, 255, 255, 0.1);
+  --input: rgba(255, 255, 255, 0.15);
+  --ring: #d4896a;
+}
+
+/* --- Dark (system preference) --- */
+@media (prefers-color-scheme: dark) {
+  [data-color-theme="cream"]:not(.light) {
+    --background: #1a1816;
+    --foreground: #e8e2dc;
+    --card: #242120;
+    --card-foreground: #e8e2dc;
+    --popover: #242120;
+    --popover-foreground: #e8e2dc;
+    --primary: #d4896a;
+    --primary-foreground: #1a1816;
+    --secondary: #3a3533;
+    --secondary-foreground: #e8e2dc;
+    --muted: #3a3533;
+    --muted-foreground: #9a918a;
+    --accent: #3a3533;
+    --accent-foreground: #e8e2dc;
+    --destructive: #e07a64;
+    --destructive-foreground: #1a1816;
+    --border: rgba(255, 255, 255, 0.1);
+    --input: rgba(255, 255, 255, 0.15);
+    --ring: #d4896a;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a cream theme flavor that transforms the entire notebook app — not just sift outputs. Toggle via Settings → Appearance → Flavor: Classic | Cream.

### What changes

**Cream CSS variables** (`src/styles/cream-theme.css`)
- Shared file imported by main app + all 4 sub-apps (settings, onboarding, upgrade, feedback)
- Overrides all shadcn design tokens when `data-color-theme="cream"` is set
- Light cream: warm off-white background, brown text, beige borders
- Dark cream: warm charcoal background, light cream text

**CodeMirror editor** (`src/components/editor/themes.ts`)
- `creamLight` / `creamDark` themes with warm backgrounds + gutters
- Keeps GitHub syntax highlighting (warm syntax colors are a follow-up)
- Editor reads `colorTheme` from DOM via `useColorTheme()` hook
- Theme compartment reconfigures dynamically on change

**Settings UI** (`apps/notebook/settings/App.tsx`)
- Appearance section: "Mode" (Light/Dark/System) + "Flavor" (Classic/Cream)

### What stays the same
- Classic theme is unchanged (default when no `data-color-theme` attribute)
- Remote cursor colors, Plotly visualization colors (data, not theme)
- ANSI terminal colors (already have light/dark variants)

## Test plan
- [ ] Toggle cream in settings → whole app turns warm
- [ ] Toggle dark + cream → warm dark variant
- [ ] Editor background matches theme
- [ ] Sift parquet output adapts to cream/classic
- [ ] Settings/onboarding sub-apps follow the theme
- [ ] Switching back to classic restores neutral palette