### PR TITLE
fix(cell): match output area width to CodeMirror editor

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -473,16 +473,14 @@ export function OutputArea({
   // Hide the entire output area when only preloading (no visible outputs)
   const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
 
-  // pl-6 aligns the output left edge with the code editor indent.
-  // pr-9 compensates for the right gutter (w-10) so that centered
-  // content (widgets, plots) appears visually centered between the
-  // code indent and the right edge. The CellContainer output wrapper
+  // pl-6 pr-3 matches the code editor row padding so outputs align
+  // flush with the editor content. The CellContainer output wrapper
   // has no horizontal padding — it must live here because the iframe
   // ignores padding on its parent container.
   return (
     <div
       data-slot="output-area"
-      className={cn("output-area pl-6 pr-9", isPreloadOnly && "hidden", className)}
+      className={cn("output-area pl-6 pr-3", isPreloadOnly && "hidden", className)}
     >
       {/* Collapse toggle */}
       {hasCollapseControl && (


### PR DESCRIPTION
## Summary

- Output area right padding was `pr-9` (36px) while the code editor row uses `pr-3` (12px), making outputs ~24px narrower than the editor
- Both rows share the same flex layout with a `w-10` right gutter, so padding should match
- Changed to `pr-3` so sift tables, plots, and other outputs fill the same width as the code above them

## Test plan

- [ ] Open a notebook with code + output (parquet table, plot, etc.)
- [ ] Verify output fills the same width as the CodeMirror editor
- [ ] Check widgets (ipywidgets) still render correctly — they were the original reason for the extra padding