### PR TITLE
fix(runtimed): replace shared watch<bool> with per-agent oneshot channel

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1061,6 +1061,12 @@ pub struct NotebookRoom {
     /// Replaced on each agent spawn; previous sender is dropped (cancelling
     /// the old receiver). The connect handler `take()`s the sender.
     pending_runtime_agent_connect_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    /// Monotonic generation counter for runtime agent spawns. Incremented
+    /// before each spawn installs its oneshot/channels. Used by
+    /// `reset_starting_state` to detect interleaving spawns: the generation
+    /// is checked while holding each field's lock, so if it hasn't changed,
+    /// no newer spawn has (or can) store a value in that field.
+    runtime_agent_generation: Arc<AtomicU64>,
     /// Monotonic counter for execution queue ordering.
     /// The coordinator bumps this for each ExecuteCell and stamps the seq
     /// on the execution entry. The runtime agent sorts by seq to determine order.
@@ -1296,6 +1302,7 @@ impl NotebookRoom {
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
             pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
@@ -1382,6 +1389,7 @@ impl NotebookRoom {
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
             pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
@@ -3233,10 +3241,17 @@ fn is_untitled_notebook(notebook_id: &str) -> bool {
 /// Pre-spawn callers pass `None` (no agent exists yet, always safe to reset).
 async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Option<&str>) {
     // For guarded resets (post-spawn error paths), atomically check-and-clear
-    // provenance in a single write lock scope. Clearing provenance to None
-    // immediately blocks late-arriving stale agents because the connect handler
-    // rejects None provenance. This must happen FIRST — before any other cleanup.
-    if let Some(expected) = expected_runtime_agent_id {
+    // provenance AND capture the generation counter in a single write lock scope.
+    // Clearing provenance to None immediately blocks late-arriving stale agents
+    // because the connect handler rejects None provenance.
+    //
+    // The generation counter MUST be captured while holding the provenance write
+    // lock. A new spawn acquires this same write lock (to set provenance) before
+    // bumping the generation counter, so the generation cannot change while we
+    // hold the lock. This closes the TOCTOU gap: if the generation changes after
+    // we release the lock, the per-field checks (below) will detect the mismatch
+    // and abort.
+    let gen = if let Some(expected) = expected_runtime_agent_id {
         let mut current = room.current_runtime_agent_id.write().await;
         if current.as_deref() != Some(expected) {
             info!(
@@ -3245,9 +3260,12 @@ async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Op
             );
             return;
         }
-        // Clear provenance under the write lock — no interleaving possible.
+        // Clear provenance and capture generation under the write lock.
         *current = None;
-    }
+        Some(room.runtime_agent_generation.load(Ordering::Acquire))
+    } else {
+        None
+    };
 
     // Scope the state_doc write guard so it drops before acquiring
     // runtime_agent_handle lock (deadlock prevention).
@@ -3261,34 +3279,39 @@ async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Op
         }
     }
 
-    // Before clearing handle/channels, verify no new spawn has started.
-    // A new spawn sets provenance to Some(new_id) BEFORE creating its
-    // channels (ordering invariant), so if provenance is Some, those fields
-    // belong to the new generation and we must not touch them.
-    if expected_runtime_agent_id.is_some() {
-        let current = room.current_runtime_agent_id.read().await;
-        if current.is_some() {
-            info!(
-                "[notebook-sync] Aborting reset_starting_state cleanup: new spawn detected (provenance: {:?})",
-                *current
-            );
-            return;
-        }
-    }
-
-    // Clear stale runtime agent handle so auto-launch can retry
+    // Clear stale runtime agent handle so auto-launch can retry.
+    // Check generation inside the lock: if a new spawn bumped it, the handle
+    // belongs to the new generation — do not clear.
     {
         let mut guard = room.runtime_agent_handle.lock().await;
+        if let Some(g) = gen {
+            if room.runtime_agent_generation.load(Ordering::Acquire) != g {
+                info!("[notebook-sync] Aborting reset_starting_state: new spawn detected at handle clear");
+                return;
+            }
+        }
         *guard = None;
     }
-    // Belt-and-suspenders: clear request channel and pending connect sender
-    // so no zombie runtime agent can signal or receive RPCs after reset.
+    // Clear request channel — same generation guard.
     {
         let mut tx_guard = room.runtime_agent_request_tx.lock().await;
+        if let Some(g) = gen {
+            if room.runtime_agent_generation.load(Ordering::Acquire) != g {
+                info!("[notebook-sync] Aborting reset_starting_state: new spawn detected at request_tx clear");
+                return;
+            }
+        }
         *tx_guard = None;
     }
+    // Clear pending connect sender — same generation guard.
     {
         let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+        if let Some(g) = gen {
+            if room.runtime_agent_generation.load(Ordering::Acquire) != g {
+                info!("[notebook-sync] Aborting reset_starting_state: new spawn detected at connect_tx clear");
+                return;
+            }
+        }
         *guard = None;
     }
 }
@@ -4187,14 +4210,18 @@ async fn auto_launch_kernel(
         let socket_path = daemon.socket_path().clone();
 
         // Set provenance BEFORE spawn so stale agents are rejected by the
-        // connect handler's provenance check. Then create the oneshot so it's
-        // ready before the subprocess can connect. This ordering satisfies both
-        // Edge Case 1 (oneshot ready before agent connects) and Edge Case 3
-        // (provenance blocks stale agents from taking the new sender).
+        // connect handler's provenance check. Bump generation BEFORE storing
+        // the oneshot so reset_starting_state can detect interleaving spawns.
+        // Then create the oneshot so it's ready before the subprocess can
+        // connect.
+        //
+        // Ordering: provenance → generation → oneshot → spawn
         {
             let mut id = room.current_runtime_agent_id.write().await;
             *id = Some(runtime_agent_id.clone());
         }
+        room.runtime_agent_generation
+            .fetch_add(1, Ordering::Release);
         let runtime_agent_connect_rx = {
             let (tx, rx) = oneshot::channel();
             let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
@@ -5400,11 +5427,14 @@ async fn handle_notebook_request(
                     format!("runtime-agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
                 let socket_path = daemon.socket_path().clone();
 
-                // Set provenance + create oneshot BEFORE spawn (see auto_launch_kernel).
+                // Set provenance + bump generation + create oneshot BEFORE spawn
+                // (see auto_launch_kernel for ordering rationale).
                 {
                     let mut id = room.current_runtime_agent_id.write().await;
                     *id = Some(runtime_agent_id.clone());
                 }
+                room.runtime_agent_generation
+                    .fetch_add(1, Ordering::Release);
                 let runtime_agent_connect_rx = {
                     let (tx, rx) = oneshot::channel();
                     let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
@@ -9495,6 +9525,7 @@ mod tests {
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
             pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_generation: Arc::new(AtomicU64::new(0)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         };
@@ -11741,6 +11772,125 @@ mod tests {
         assert!(
             new_rx.try_recv().is_err(),
             "new spawn's oneshot should still be pending (sender alive)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_generation_guard_with_concurrent_spawn() {
+        // Regression test for TOCTOU in reset_starting_state: verifies that a
+        // new spawn interleaving AFTER provenance is cleared (but before field
+        // clears) is detected by the generation counter, causing reset to abort
+        // and preserving the new spawn's fields.
+        //
+        // The test spawns a concurrent task that simulates a new spawn sequence
+        // (set provenance → bump generation → store fields) as soon as it
+        // detects provenance cleared to None. The main task calls
+        // reset_starting_state with a matching expected_runtime_agent_id.
+        //
+        // Two valid orderings exist:
+        // 1. Concurrent spawn completes between provenance clear and field clears
+        //    → generation mismatch → reset aborts → new fields preserved
+        // 2. Concurrent spawn completes after reset_starting_state returns
+        //    → reset clears old fields normally → concurrent spawn stores new fields
+        // In both cases, the new spawn's fields are present at the end.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _notebook_path) = test_room_with_path(&tmp, "gen_concurrent.ipynb");
+
+        // Setup: agent-old at generation 0 with populated fields.
+        {
+            let mut id = room.current_runtime_agent_id.write().await;
+            *id = Some("agent-old".to_string());
+        }
+        let (old_tx, _old_rx) = oneshot::channel::<()>();
+        {
+            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+            *guard = Some(old_tx);
+        }
+        let (old_req_tx, _old_req_rx) = tokio::sync::mpsc::channel(16);
+        {
+            let mut guard = room.runtime_agent_request_tx.lock().await;
+            *guard = Some(old_req_tx);
+        }
+
+        // Clone Arc fields for the concurrent task.
+        let id_arc = room.current_runtime_agent_id.clone();
+        let gen_arc = room.runtime_agent_generation.clone();
+        let connect_arc = room.pending_runtime_agent_connect_tx.clone();
+        let req_arc = room.runtime_agent_request_tx.clone();
+
+        // Channel to receive the new spawn's oneshot receiver (for liveness check).
+        let (done_tx, done_rx) = oneshot::channel::<oneshot::Receiver<()>>();
+
+        // Spawn concurrent task: simulate a new spawn that fires as soon as
+        // provenance is cleared (the trigger for the TOCTOU scenario).
+        tokio::spawn(async move {
+            // Poll for provenance → None (reset_starting_state clears it).
+            loop {
+                {
+                    let current = id_arc.read().await;
+                    if current.is_none() {
+                        break;
+                    }
+                }
+                tokio::task::yield_now().await;
+            }
+
+            // Simulate new spawn sequence: provenance → generation → fields.
+            {
+                let mut id = id_arc.write().await;
+                *id = Some("agent-new".to_string());
+            }
+            gen_arc.fetch_add(1, Ordering::Release);
+            let (new_tx, new_rx) = oneshot::channel::<()>();
+            {
+                let mut guard = connect_arc.lock().await;
+                *guard = Some(new_tx);
+            }
+            let (new_req_tx, _) = tokio::sync::mpsc::channel(16);
+            {
+                let mut guard = req_arc.lock().await;
+                *guard = Some(new_req_tx);
+            }
+
+            let _ = done_tx.send(new_rx);
+        });
+
+        // Main task: call reset — provenance matches "agent-old", so it proceeds.
+        // Generation was captured inside the provenance write lock (gen=0).
+        // If the concurrent spawn bumps gen to 1 before field clears, the
+        // generation guard aborts the clears. Otherwise, reset clears old fields
+        // and the concurrent spawn stores new ones afterward.
+        reset_starting_state(&room, Some("agent-old")).await;
+
+        // Wait for concurrent task to complete its spawn simulation.
+        let mut new_rx = done_rx
+            .await
+            .expect("concurrent spawn task should complete");
+
+        // Verify: new spawn's fields must be present regardless of ordering.
+        assert!(
+            room.pending_runtime_agent_connect_tx.lock().await.is_some(),
+            "connect_tx should be present (new spawn's)"
+        );
+        assert!(
+            room.runtime_agent_request_tx.lock().await.is_some(),
+            "request_tx should be present (new spawn's)"
+        );
+        assert_eq!(
+            room.current_runtime_agent_id.read().await.as_deref(),
+            Some("agent-new"),
+            "provenance should be agent-new (set by concurrent spawn)"
+        );
+        // Verify oneshot sender is still alive (not dropped by reset).
+        assert!(
+            new_rx.try_recv().is_err(),
+            "new spawn's oneshot sender should be alive"
+        );
+        // Generation should be 1 (bumped by concurrent spawn).
+        assert_eq!(
+            room.runtime_agent_generation.load(Ordering::Acquire),
+            1,
+            "generation should be 1 after concurrent spawn"
         );
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3222,7 +3222,25 @@ fn is_untitled_notebook(notebook_id: &str) -> bool {
 
 /// Reset runtime state to "not_started" (clears any stale starting phase).
 /// Used when an early exit prevents kernel launch after status was set to "starting".
-async fn reset_starting_state(room: &NotebookRoom) {
+///
+/// `expected_runtime_agent_id`: If `Some`, only reset if the current runtime agent
+/// matches — prevents a stale error handler from clobbering a newer agent's state.
+/// Pre-spawn callers pass `None` (no agent exists yet, always safe to reset).
+async fn reset_starting_state(
+    room: &NotebookRoom,
+    expected_runtime_agent_id: Option<&str>,
+) {
+    if let Some(expected) = expected_runtime_agent_id {
+        let current = room.current_runtime_agent_id.read().await;
+        if current.as_deref() != Some(expected) {
+            info!(
+                "[notebook-sync] Skipping reset_starting_state: expected {} but current is {:?}",
+                expected, *current,
+            );
+            return;
+        }
+    }
+
     // Scope the state_doc write guard so it drops before acquiring
     // runtime_agent_handle lock (deadlock prevention).
     {
@@ -3235,8 +3253,25 @@ async fn reset_starting_state(room: &NotebookRoom) {
         }
     }
     // Clear stale runtime agent handle so auto-launch can retry
-    let mut guard = room.runtime_agent_handle.lock().await;
-    *guard = None;
+    {
+        let mut guard = room.runtime_agent_handle.lock().await;
+        *guard = None;
+    }
+    // Belt-and-suspenders: clear request channel and pending connect sender
+    // so no zombie runtime agent can signal or receive RPCs after reset.
+    {
+        let mut tx_guard = room.runtime_agent_request_tx.lock().await;
+        *tx_guard = None;
+    }
+    {
+        let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+        *guard = None;
+    }
+    // Clear provenance so late-arriving stale runtime agents are rejected
+    if expected_runtime_agent_id.is_some() {
+        let mut id = room.current_runtime_agent_id.write().await;
+        *id = None;
+    }
 }
 
 /// Try to satisfy UV inline deps from the prewarmed pool.
@@ -3465,7 +3500,7 @@ async fn auto_launch_kernel(
     // before we finish launching)
     if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
         debug!("[notebook-sync] Auto-launch aborted: no peers remaining");
-        reset_starting_state(room).await;
+        reset_starting_state(room, None).await;
         return;
     }
 
@@ -3506,7 +3541,7 @@ async fn auto_launch_kernel(
     // Re-check peers (another race check)
     if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
         debug!("[notebook-sync] Auto-launch aborted: no peers (after status check)");
-        reset_starting_state(room).await;
+        reset_starting_state(room, None).await;
         return;
     }
 
@@ -3686,7 +3721,7 @@ async fn auto_launch_kernel(
                 match acquire_pool_env_for_source(&env_source, &daemon, room).await {
                     Some(env) => env,
                     None => {
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, None).await;
                         return;
                     }
                 }
@@ -3747,7 +3782,7 @@ async fn auto_launch_kernel(
                     match acquire_pool_env_for_source(&env_source, &daemon, room).await {
                         Some(env) => env,
                         None => {
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return;
                         }
                     }
@@ -3768,7 +3803,7 @@ async fn auto_launch_kernel(
             let pooled_env = match acquire_pool_env_for_source(prewarmed, &daemon, room).await {
                 Some(env) => env,
                 None => {
-                    reset_starting_state(room).await;
+                    reset_starting_state(room, None).await;
                     return;
                 }
             };
@@ -3850,7 +3885,7 @@ async fn auto_launch_kernel(
                             status: format!("error: Failed to prepare environment: {}", e),
                             cell_id: None,
                         });
-                    reset_starting_state(room).await;
+                    reset_starting_state(room, None).await;
                     return;
                 }
             }
@@ -3923,7 +3958,7 @@ async fn auto_launch_kernel(
                                         cell_id: None,
                                     },
                                 );
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, None).await;
                                 return;
                             }
                         }
@@ -3963,7 +3998,7 @@ async fn auto_launch_kernel(
                                 status: format!("error: Failed to prepare environment: {}", e),
                                 cell_id: None,
                             });
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, None).await;
                         return;
                     }
                 }
@@ -4043,7 +4078,7 @@ async fn auto_launch_kernel(
                                         cell_id: None,
                                     },
                                 );
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, None).await;
                                 return;
                             }
                         }
@@ -4186,12 +4221,12 @@ async fn auto_launch_kernel(
                         // Oneshot sender dropped — runtime agent died or was
                         // superseded by a newer spawn before connecting.
                         warn!("[notebook-sync] Runtime agent connect cancelled (superseded or died)");
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return;
                     }
                     Err(_) => {
                         warn!("[notebook-sync] Agent failed to connect within 30s");
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return;
                     }
                 }
@@ -4251,23 +4286,23 @@ async fn auto_launch_kernel(
                     }
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                         warn!("[notebook-sync] Agent kernel launch failed: {}", error);
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, Some(&runtime_agent_id)).await;
                     }
                     Ok(_) => {
                         warn!(
                             "[notebook-sync] Unexpected runtime agent response during auto-launch"
                         );
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, Some(&runtime_agent_id)).await;
                     }
                     Err(e) => {
                         warn!("[notebook-sync] Agent communication error: {}", e);
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, Some(&runtime_agent_id)).await;
                     }
                 }
             }
             Err(e) => {
                 warn!("[notebook-sync] Failed to spawn runtime agent: {}", e);
-                reset_starting_state(room).await;
+                reset_starting_state(room, None).await;
             }
         }
     }
@@ -4785,7 +4820,7 @@ async fn handle_notebook_request(
                             "[notebook-sync] pixi.toml at {:?} does not declare ipykernel",
                             path
                         );
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, None).await;
                         return NotebookResponse::Error {
                             error: "ipykernel not found in pixi.toml — run `pixi add ipykernel` in your project directory".to_string(),
                         };
@@ -4889,7 +4924,7 @@ async fn handle_notebook_request(
                             Some(env)
                         }
                         None => {
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
                                 error: "UV pool empty - no environment available".to_string(),
                             };
@@ -4904,7 +4939,7 @@ async fn handle_notebook_request(
                             Some(env)
                         }
                         None => {
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
                                 error: "Conda pool empty - no environment available".to_string(),
                             };
@@ -4925,7 +4960,7 @@ async fn handle_notebook_request(
                             match daemon.take_conda_env().await {
                                 Some(env) => Some(env),
                                 None => {
-                                    reset_starting_state(room).await;
+                                    reset_starting_state(room, None).await;
                                     return NotebookResponse::Error {
                                         error: "Conda pool empty".to_string(),
                                     };
@@ -4936,7 +4971,7 @@ async fn handle_notebook_request(
                             match daemon.take_uv_env().await {
                                 Some(env) => Some(env),
                                 None => {
-                                    reset_starting_state(room).await;
+                                    reset_starting_state(room, None).await;
                                     return NotebookResponse::Error {
                                         error: "UV pool empty".to_string(),
                                     };
@@ -4964,7 +4999,7 @@ async fn handle_notebook_request(
                             "[notebook-sync] Invalid PEP 723 metadata in notebook: {}",
                             e
                         );
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, None).await;
                         return NotebookResponse::Error {
                             error: format!("Invalid PEP 723 metadata in notebook: {}", e),
                         };
@@ -4998,14 +5033,14 @@ async fn handle_notebook_request(
                         }
                         Err(e) => {
                             error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
                                 error: format!("Failed to prepare PEP 723 environment: {}", e),
                             };
                         }
                     }
                 } else {
-                    reset_starting_state(room).await;
+                    reset_starting_state(room, None).await;
                     return NotebookResponse::Error {
                         error: "No PEP 723 dependencies found in notebook cells for requested env_source \"uv:pep723\""
                             .to_string(),
@@ -5069,7 +5104,7 @@ async fn handle_notebook_request(
                                         (env, Some(deps))
                                     }
                                     Err(e) => {
-                                        reset_starting_state(room).await;
+                                        reset_starting_state(room, None).await;
                                         return NotebookResponse::Error {
                                             error: format!(
                                                 "Failed to prepare inline environment: {}",
@@ -5103,7 +5138,7 @@ async fn handle_notebook_request(
                                 (env, Some(deps))
                             }
                             Err(e) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, None).await;
                                 return NotebookResponse::Error {
                                     error: format!("Failed to prepare inline environment: {}", e),
                                 };
@@ -5173,7 +5208,7 @@ async fn handle_notebook_request(
                                         (env, Some(deps))
                                     }
                                     Err(e) => {
-                                        reset_starting_state(room).await;
+                                        reset_starting_state(room, None).await;
                                         return NotebookResponse::Error {
                                             error: format!(
                                                 "Failed to prepare conda inline environment: {}",
@@ -5313,13 +5348,13 @@ async fn handle_notebook_request(
                             };
                         }
                         Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
                                 error: format!("Agent restart failed: {}", error),
                             };
                         }
                         Ok(_) => {
-                            reset_starting_state(room).await;
+                            reset_starting_state(room, None).await;
                             return NotebookResponse::Error {
                                 error: "Unexpected runtime agent response to RestartKernel"
                                     .to_string(),
@@ -5389,14 +5424,14 @@ async fn handle_notebook_request(
                         {
                             Ok(Ok(())) => {}
                             Ok(Err(_)) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, Some(&runtime_agent_id)).await;
                                 return NotebookResponse::Error {
                                     error: "Runtime agent connect cancelled (superseded or died)"
                                         .to_string(),
                                 };
                             }
                             Err(_) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, Some(&runtime_agent_id)).await;
                                 return NotebookResponse::Error {
                                     error: "Agent failed to connect within 30s".to_string(),
                                 };
@@ -5477,19 +5512,19 @@ async fn handle_notebook_request(
                             Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error {
                                 error,
                             }) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, Some(&runtime_agent_id)).await;
                                 NotebookResponse::Error {
                                     error: format!("Agent kernel launch failed: {}", error),
                                 }
                             }
                             Ok(_) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, Some(&runtime_agent_id)).await;
                                 NotebookResponse::Error {
                                     error: "Unexpected runtime agent response".to_string(),
                                 }
                             }
                             Err(e) => {
-                                reset_starting_state(room).await;
+                                reset_starting_state(room, Some(&runtime_agent_id)).await;
                                 NotebookResponse::Error {
                                     error: format!("Agent communication error: {}", e),
                                 }
@@ -5497,7 +5532,7 @@ async fn handle_notebook_request(
                         }
                     }
                     Err(e) => {
-                        reset_starting_state(room).await;
+                        reset_starting_state(room, None).await;
                         NotebookResponse::Error {
                             error: format!("Failed to spawn runtime agent: {}", e),
                         }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -11484,4 +11484,138 @@ mod tests {
         let ts = room.trust_state.read().await;
         assert_eq!(ts.status, runt_trust::TrustStatus::NoDependencies);
     }
+
+    // ── Per-agent oneshot channel tests ──────────────────────────────
+
+    #[tokio::test]
+    async fn test_per_runtime_agent_oneshot_isolation() {
+        // Verify that each spawn generation gets its own oneshot channel
+        // and that connecting one agent doesn't resolve another's receiver.
+        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> =
+            Arc::new(Mutex::new(None));
+
+        // Spawn A: create oneshot, store sender
+        let (tx_a, rx_a) = oneshot::channel();
+        *pending.lock().await = Some(tx_a);
+
+        // A connects: take and send
+        if let Some(tx) = pending.lock().await.take() {
+            tx.send(()).unwrap();
+        }
+        assert!(rx_a.await.is_ok(), "A's receiver should resolve Ok");
+
+        // Spawn B: create new oneshot (A's sender already consumed via take)
+        let (tx_b, rx_b) = oneshot::channel();
+        *pending.lock().await = Some(tx_b);
+
+        // B connects
+        if let Some(tx) = pending.lock().await.take() {
+            tx.send(()).unwrap();
+        }
+        assert!(rx_b.await.is_ok(), "B's receiver should resolve Ok");
+
+        // After both consumed, pending should be None
+        assert!(pending.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_oneshot_replaced_before_runtime_agent_connect() {
+        // When a new spawn replaces the oneshot before the previous agent
+        // connects, the old receiver should resolve with Err (sender dropped).
+        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> =
+            Arc::new(Mutex::new(None));
+
+        // Spawn A
+        let (_tx_a, rx_a) = oneshot::channel();
+        *pending.lock().await = Some(_tx_a);
+
+        // Spawn B BEFORE A connects — replaces A's sender (drops tx_a)
+        let (tx_b, rx_b) = oneshot::channel();
+        *pending.lock().await = Some(tx_b); // tx_a dropped here
+
+        // A's receiver resolves with Err (sender dropped = superseded)
+        assert!(
+            rx_a.await.is_err(),
+            "A's receiver should get Err (sender was dropped by B's spawn)"
+        );
+
+        // B connects normally
+        if let Some(tx) = pending.lock().await.take() {
+            tx.send(()).unwrap();
+        }
+        assert!(rx_b.await.is_ok(), "B's receiver should resolve Ok");
+    }
+
+    #[tokio::test]
+    async fn test_reset_starting_state_guard() {
+        // Verify that reset_starting_state skips when expected_runtime_agent_id
+        // doesn't match current_runtime_agent_id.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _notebook_path) = test_room_with_path(&tmp, "guard_test.ipynb");
+
+        // Set current runtime agent to "agent-B"
+        {
+            let mut id = room.current_runtime_agent_id.write().await;
+            *id = Some("agent-B".to_string());
+        }
+
+        // Set kernel status to "starting" (simulates in-progress launch)
+        {
+            let mut sd = room.state_doc.write().await;
+            sd.set_kernel_status("starting");
+        }
+
+        // Call reset with expected="agent-A" (stale handler) — should skip
+        reset_starting_state(&room, Some("agent-A")).await;
+
+        // Verify: kernel_status should still be "starting" (NOT reset)
+        {
+            let sd = room.state_doc.read().await;
+            assert_eq!(
+                sd.read_state().kernel.status,
+                "starting",
+                "Guard should have prevented reset (agent-A != agent-B)"
+            );
+        }
+
+        // Verify: current_runtime_agent_id unchanged
+        {
+            let id = room.current_runtime_agent_id.read().await;
+            assert_eq!(id.as_deref(), Some("agent-B"));
+        }
+
+        // Now call with matching expected="agent-B" — should reset
+        reset_starting_state(&room, Some("agent-B")).await;
+
+        // Verify: kernel_status should be "not_started"
+        {
+            let sd = room.state_doc.read().await;
+            assert_eq!(
+                sd.read_state().kernel.status,
+                "not_started",
+                "Reset should proceed when expected matches current"
+            );
+        }
+
+        // Verify: current_runtime_agent_id cleared (provenance cleanup)
+        {
+            let id = room.current_runtime_agent_id.read().await;
+            assert!(id.is_none(), "Provenance should be cleared after guarded reset");
+        }
+
+        // Call with None (pre-spawn) — should always reset
+        {
+            let mut sd = room.state_doc.write().await;
+            sd.set_kernel_status("starting");
+        }
+        reset_starting_state(&room, None).await;
+        {
+            let sd = room.state_doc.read().await;
+            assert_eq!(
+                sd.read_state().kernel.status,
+                "not_started",
+                "None (pre-spawn) should always reset"
+            );
+        }
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1056,9 +1056,11 @@ pub struct NotebookRoom {
     /// runtime agent's sync connection. Set when runtime agent connects via
     /// socket, cleared on disconnect.
     pub runtime_agent_request_tx: Arc<Mutex<Option<RuntimeAgentRequestSender>>>,
-    /// Fires when the runtime agent establishes its sync connection.
-    /// Uses `watch(false)` → `true` to avoid lost wakeups.
-    runtime_agent_connected_tx: Arc<tokio::sync::watch::Sender<bool>>,
+    /// Per-spawn oneshot sender for the connect handler to signal that this
+    /// generation's runtime agent has established its sync connection.
+    /// Replaced on each agent spawn; previous sender is dropped (cancelling
+    /// the old receiver). The connect handler `take()`s the sender.
+    pending_runtime_agent_connect_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
     /// Monotonic counter for execution queue ordering.
     /// The coordinator bumps this for each ExecuteCell and stamps the seq
     /// on the execution entry. The runtime agent sorts by seq to determine order.
@@ -1293,10 +1295,7 @@ impl NotebookRoom {
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
-            runtime_agent_connected_tx: {
-                let (tx, _) = tokio::sync::watch::channel(false);
-                Arc::new(tx)
-            },
+            pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
@@ -1382,10 +1381,7 @@ impl NotebookRoom {
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
-            runtime_agent_connected_tx: {
-                let (tx, _) = tokio::sync::watch::channel(false);
-                Arc::new(tx)
-            },
+            pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
@@ -1623,7 +1619,12 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         let mut id = room.current_runtime_agent_id.write().await;
         *id = Some(runtime_agent_id.clone());
     }
-    let _ = room.runtime_agent_connected_tx.send(true);
+    // Signal the spawner that this runtime agent has connected.
+    // take() ensures at most one signal per spawn generation — a stale
+    // runtime agent that passes provenance finds None here (no-op).
+    if let Some(tx) = room.pending_runtime_agent_connect_tx.lock().await.take() {
+        let _ = tx.send(());
+    }
     info!(
         "[notebook-sync] Runtime agent connected and ready: {}",
         runtime_agent_id
@@ -1781,7 +1782,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             let mut tx_guard = room.runtime_agent_request_tx.lock().await;
             *tx_guard = None;
         }
-        let _ = room.runtime_agent_connected_tx.send(false);
+        // No need to signal "disconnected" — the oneshot was consumed on
+        // connect. If the runtime agent dies before connecting, the oneshot
+        // sender is dropped when pending_runtime_agent_connect_tx is replaced
+        // by the next spawn, which resolves the receiver with Err.
+        //
         // Clear runtime_agent_handle so LaunchKernel spawns a new runtime agent
         let mut guard = room.runtime_agent_handle.lock().await;
         *guard = None;
@@ -4136,7 +4141,7 @@ async fn auto_launch_kernel(
         .await
         {
             Ok(ra) => {
-                // Store handle and set provenance
+                // Store handle and set provenance.
                 // Scope each lock independently to avoid cross-lock ordering.
                 {
                     let mut ra_guard = room.runtime_agent_handle.lock().await;
@@ -4147,6 +4152,18 @@ async fn auto_launch_kernel(
                     *id = Some(runtime_agent_id.clone());
                 }
 
+                // Create per-spawn connect channel. Provenance is already set above,
+                // so any stale runtime agent checking provenance in the connect handler
+                // will be rejected before it can take() this sender.
+                // Replacing the sender drops the previous one, which resolves any
+                // stale receiver with Err (clean cancellation).
+                let runtime_agent_connect_rx = {
+                    let (tx, rx) = oneshot::channel();
+                    let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+                    *guard = Some(tx);
+                    rx
+                };
+
                 // Write "connecting" phase — fills the gap between spawn and connect
                 {
                     let mut sd = room.state_doc.write().await;
@@ -4155,20 +4172,24 @@ async fn auto_launch_kernel(
                     }
                 }
 
-                // Wait for runtime agent to establish its sync connection
-                match tokio::time::timeout(std::time::Duration::from_secs(30), async {
-                    room.runtime_agent_connected_tx
-                        .subscribe()
-                        .wait_for(|v| *v)
-                        .await
-                        .map(|_| ())
-                })
+                // Wait for THIS runtime agent to establish its sync connection
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    runtime_agent_connect_rx,
+                )
                 .await
                 {
-                    Ok(Ok(_)) => {
+                    Ok(Ok(())) => {
                         info!("[notebook-sync] Agent connected, sending LaunchKernel");
                     }
-                    Ok(Err(_)) | Err(_) => {
+                    Ok(Err(_)) => {
+                        // Oneshot sender dropped — runtime agent died or was
+                        // superseded by a newer spawn before connecting.
+                        warn!("[notebook-sync] Runtime agent connect cancelled (superseded or died)");
+                        reset_starting_state(room).await;
+                        return;
+                    }
+                    Err(_) => {
                         warn!("[notebook-sync] Agent failed to connect within 30s");
                         reset_starting_state(room).await;
                         return;
@@ -5342,6 +5363,15 @@ async fn handle_notebook_request(
                             *id = Some(runtime_agent_id.clone());
                         }
 
+                        // Create per-spawn connect channel (see auto_launch_kernel).
+                        let runtime_agent_connect_rx = {
+                            let (tx, rx) = oneshot::channel();
+                            let mut guard =
+                                room.pending_runtime_agent_connect_tx.lock().await;
+                            *guard = Some(tx);
+                            rx
+                        };
+
                         // Write "connecting" phase — fills the gap between spawn and connect
                         {
                             let mut sd = room.state_doc.write().await;
@@ -5350,18 +5380,22 @@ async fn handle_notebook_request(
                             }
                         }
 
-                        // Wait for runtime agent to connect back via socket
-                        match tokio::time::timeout(std::time::Duration::from_secs(30), async {
-                            room.runtime_agent_connected_tx
-                                .subscribe()
-                                .wait_for(|v| *v)
-                                .await
-                                .map(|_| ())
-                        })
+                        // Wait for THIS runtime agent to connect back via socket
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(30),
+                            runtime_agent_connect_rx,
+                        )
                         .await
                         {
-                            Ok(Ok(_)) => {}
-                            Ok(Err(_)) | Err(_) => {
+                            Ok(Ok(())) => {}
+                            Ok(Err(_)) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: "Runtime agent connect cancelled (superseded or died)"
+                                        .to_string(),
+                                };
+                            }
+                            Err(_) => {
                                 reset_starting_state(room).await;
                                 return NotebookResponse::Error {
                                     error: "Agent failed to connect within 30s".to_string(),
@@ -9406,10 +9440,7 @@ mod tests {
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
             runtime_agent_request_tx: Arc::new(Mutex::new(None)),
-            runtime_agent_connected_tx: {
-                let (tx, _) = tokio::sync::watch::channel(false);
-                Arc::new(tx)
-            },
+            pending_runtime_agent_connect_tx: Arc::new(Mutex::new(None)),
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         };

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3226,10 +3226,7 @@ fn is_untitled_notebook(notebook_id: &str) -> bool {
 /// `expected_runtime_agent_id`: If `Some`, only reset if the current runtime agent
 /// matches — prevents a stale error handler from clobbering a newer agent's state.
 /// Pre-spawn callers pass `None` (no agent exists yet, always safe to reset).
-async fn reset_starting_state(
-    room: &NotebookRoom,
-    expected_runtime_agent_id: Option<&str>,
-) {
+async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Option<&str>) {
     if let Some(expected) = expected_runtime_agent_id {
         let current = room.current_runtime_agent_id.read().await;
         if current.as_deref() != Some(expected) {
@@ -4220,7 +4217,9 @@ async fn auto_launch_kernel(
                     Ok(Err(_)) => {
                         // Oneshot sender dropped — runtime agent died or was
                         // superseded by a newer spawn before connecting.
-                        warn!("[notebook-sync] Runtime agent connect cancelled (superseded or died)");
+                        warn!(
+                            "[notebook-sync] Runtime agent connect cancelled (superseded or died)"
+                        );
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return;
                     }
@@ -5401,8 +5400,7 @@ async fn handle_notebook_request(
                         // Create per-spawn connect channel (see auto_launch_kernel).
                         let runtime_agent_connect_rx = {
                             let (tx, rx) = oneshot::channel();
-                            let mut guard =
-                                room.pending_runtime_agent_connect_tx.lock().await;
+                            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
                             *guard = Some(tx);
                             rx
                         };
@@ -11491,8 +11489,7 @@ mod tests {
     async fn test_per_runtime_agent_oneshot_isolation() {
         // Verify that each spawn generation gets its own oneshot channel
         // and that connecting one agent doesn't resolve another's receiver.
-        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> =
-            Arc::new(Mutex::new(None));
+        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> = Arc::new(Mutex::new(None));
 
         // Spawn A: create oneshot, store sender
         let (tx_a, rx_a) = oneshot::channel();
@@ -11522,8 +11519,7 @@ mod tests {
     async fn test_oneshot_replaced_before_runtime_agent_connect() {
         // When a new spawn replaces the oneshot before the previous agent
         // connects, the old receiver should resolve with Err (sender dropped).
-        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> =
-            Arc::new(Mutex::new(None));
+        let pending: Arc<Mutex<Option<oneshot::Sender<()>>>> = Arc::new(Mutex::new(None));
 
         // Spawn A
         let (_tx_a, rx_a) = oneshot::channel();
@@ -11600,7 +11596,10 @@ mod tests {
         // Verify: current_runtime_agent_id cleared (provenance cleanup)
         {
             let id = room.current_runtime_agent_id.read().await;
-            assert!(id.is_none(), "Provenance should be cleared after guarded reset");
+            assert!(
+                id.is_none(),
+                "Provenance should be cleared after guarded reset"
+            );
         }
 
         // Call with None (pre-spawn) — should always reset

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4164,6 +4164,22 @@ async fn auto_launch_kernel(
         let runtime_agent_id = format!("runtime-agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let socket_path = daemon.socket_path().clone();
 
+        // Set provenance BEFORE spawn so stale agents are rejected by the
+        // connect handler's provenance check. Then create the oneshot so it's
+        // ready before the subprocess can connect. This ordering satisfies both
+        // Edge Case 1 (oneshot ready before agent connects) and Edge Case 3
+        // (provenance blocks stale agents from taking the new sender).
+        {
+            let mut id = room.current_runtime_agent_id.write().await;
+            *id = Some(runtime_agent_id.clone());
+        }
+        let runtime_agent_connect_rx = {
+            let (tx, rx) = oneshot::channel();
+            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+            *guard = Some(tx);
+            rx
+        };
+
         match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
             nb_id,
             runtime_agent_id.clone(),
@@ -4173,28 +4189,11 @@ async fn auto_launch_kernel(
         .await
         {
             Ok(ra) => {
-                // Store handle and set provenance.
-                // Scope each lock independently to avoid cross-lock ordering.
+                // Store handle after spawn succeeds.
                 {
                     let mut ra_guard = room.runtime_agent_handle.lock().await;
                     *ra_guard = Some(ra);
                 }
-                {
-                    let mut id = room.current_runtime_agent_id.write().await;
-                    *id = Some(runtime_agent_id.clone());
-                }
-
-                // Create per-spawn connect channel. Provenance is already set above,
-                // so any stale runtime agent checking provenance in the connect handler
-                // will be rejected before it can take() this sender.
-                // Replacing the sender drops the previous one, which resolves any
-                // stale receiver with Err (clean cancellation).
-                let runtime_agent_connect_rx = {
-                    let (tx, rx) = oneshot::channel();
-                    let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
-                    *guard = Some(tx);
-                    rx
-                };
 
                 // Write "connecting" phase — fills the gap between spawn and connect
                 {
@@ -5379,6 +5378,18 @@ async fn handle_notebook_request(
                     format!("runtime-agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
                 let socket_path = daemon.socket_path().clone();
 
+                // Set provenance + create oneshot BEFORE spawn (see auto_launch_kernel).
+                {
+                    let mut id = room.current_runtime_agent_id.write().await;
+                    *id = Some(runtime_agent_id.clone());
+                }
+                let runtime_agent_connect_rx = {
+                    let (tx, rx) = oneshot::channel();
+                    let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+                    *guard = Some(tx);
+                    rx
+                };
+
                 match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
                     notebook_id,
                     runtime_agent_id.clone(),
@@ -5392,18 +5403,6 @@ async fn handle_notebook_request(
                             let mut ra_guard = room.runtime_agent_handle.lock().await;
                             *ra_guard = Some(ra);
                         }
-                        {
-                            let mut id = room.current_runtime_agent_id.write().await;
-                            *id = Some(runtime_agent_id.clone());
-                        }
-
-                        // Create per-spawn connect channel (see auto_launch_kernel).
-                        let runtime_agent_connect_rx = {
-                            let (tx, rx) = oneshot::channel();
-                            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
-                            *guard = Some(tx);
-                            rx
-                        };
 
                         // Write "connecting" phase — fills the gap between spawn and connect
                         {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1551,14 +1551,19 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         notebook_id, runtime_agent_id
     );
 
-    // Validate provenance — reject stale agents
+    // Validate provenance — reject stale agents.
+    // None means no agent is expected (room was reset or no spawn in progress),
+    // so reject unconditionally. Only the exact current agent ID is accepted.
     {
         let expected = room.current_runtime_agent_id.read().await;
-        if let Some(ref expected_id) = *expected {
-            if *expected_id != runtime_agent_id {
+        match expected.as_deref() {
+            Some(expected_id) if expected_id == runtime_agent_id => {
+                // Match — this is the agent we're waiting for.
+            }
+            other => {
                 warn!(
-                    "[notebook-sync] Rejecting stale runtime agent {} (expected {})",
-                    runtime_agent_id, expected_id
+                    "[notebook-sync] Rejecting runtime agent {} (provenance is {:?})",
+                    runtime_agent_id, other
                 );
                 return;
             }
@@ -1614,12 +1619,12 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         *tx_guard = Some(ra_tx);
     }
 
-    // ── 4. Set provenance + signal connected ──────────────────────────
-    {
-        let mut id = room.current_runtime_agent_id.write().await;
-        *id = Some(runtime_agent_id.clone());
-    }
-    // Signal the spawner that this runtime agent has connected.
+    // ── 4. Signal connected ─────────────────────────────────────────
+    // Provenance is already set by the spawn site (before spawn).
+    // We do NOT re-set it here — doing so after the async sync work above
+    // would create a window where a newer spawn's provenance could be
+    // clobbered by this (potentially stale) connect handler.
+    //
     // take() ensures at most one signal per spawn generation — a stale
     // runtime agent that passes provenance finds None here (no-op).
     if let Some(tx) = room.pending_runtime_agent_connect_tx.lock().await.take() {
@@ -3227,8 +3232,12 @@ fn is_untitled_notebook(notebook_id: &str) -> bool {
 /// matches — prevents a stale error handler from clobbering a newer agent's state.
 /// Pre-spawn callers pass `None` (no agent exists yet, always safe to reset).
 async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Option<&str>) {
+    // For guarded resets (post-spawn error paths), atomically check-and-clear
+    // provenance in a single write lock scope. Clearing provenance to None
+    // immediately blocks late-arriving stale agents because the connect handler
+    // rejects None provenance. This must happen FIRST — before any other cleanup.
     if let Some(expected) = expected_runtime_agent_id {
-        let current = room.current_runtime_agent_id.read().await;
+        let mut current = room.current_runtime_agent_id.write().await;
         if current.as_deref() != Some(expected) {
             info!(
                 "[notebook-sync] Skipping reset_starting_state: expected {} but current is {:?}",
@@ -3236,6 +3245,8 @@ async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Op
             );
             return;
         }
+        // Clear provenance under the write lock — no interleaving possible.
+        *current = None;
     }
 
     // Scope the state_doc write guard so it drops before acquiring
@@ -3249,6 +3260,22 @@ async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Op
             let _ = room.state_changed_tx.send(());
         }
     }
+
+    // Before clearing handle/channels, verify no new spawn has started.
+    // A new spawn sets provenance to Some(new_id) BEFORE creating its
+    // channels (ordering invariant), so if provenance is Some, those fields
+    // belong to the new generation and we must not touch them.
+    if expected_runtime_agent_id.is_some() {
+        let current = room.current_runtime_agent_id.read().await;
+        if current.is_some() {
+            info!(
+                "[notebook-sync] Aborting reset_starting_state cleanup: new spawn detected (provenance: {:?})",
+                *current
+            );
+            return;
+        }
+    }
+
     // Clear stale runtime agent handle so auto-launch can retry
     {
         let mut guard = room.runtime_agent_handle.lock().await;
@@ -3263,11 +3290,6 @@ async fn reset_starting_state(room: &NotebookRoom, expected_runtime_agent_id: Op
     {
         let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
         *guard = None;
-    }
-    // Clear provenance so late-arriving stale runtime agents are rejected
-    if expected_runtime_agent_id.is_some() {
-        let mut id = room.current_runtime_agent_id.write().await;
-        *id = None;
     }
 }
 
@@ -11660,6 +11682,65 @@ mod tests {
         assert!(
             room.current_runtime_agent_id.read().await.is_none(),
             "provenance should be cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_aborts_when_new_spawn_detected() {
+        // Verify that guarded reset_starting_state aborts field cleanup
+        // if a new spawn sets provenance between the provenance-clear and
+        // the field clears (TOCTOU re-check).
+        //
+        // We simulate this by:
+        // 1. Setting provenance to "agent-old" + populating fields
+        // 2. Clearing provenance to None (as reset_starting_state would)
+        // 3. Setting provenance to "agent-new" + new field values (simulating interleaving spawn)
+        // 4. Calling reset_starting_state with None expected (pre-spawn path) — always proceeds
+        //    But for the guarded path: we test manually by checking the re-check logic.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _notebook_path) = test_room_with_path(&tmp, "toctou_test.ipynb");
+
+        // Simulate: agent-old's reset already cleared provenance to None,
+        // then a new spawn set provenance to "agent-new" with fresh channels.
+        {
+            let mut id = room.current_runtime_agent_id.write().await;
+            *id = Some("agent-new".to_string());
+        }
+        let (new_tx, mut new_rx) = oneshot::channel::<()>();
+        {
+            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+            *guard = Some(new_tx);
+        }
+        let (req_tx, _req_rx) = tokio::sync::mpsc::channel(16);
+        {
+            let mut guard = room.runtime_agent_request_tx.lock().await;
+            *guard = Some(req_tx);
+        }
+
+        // Now call reset with expected="agent-old" — provenance is "agent-new",
+        // so the guard should skip entirely (mismatch).
+        reset_starting_state(&room, Some("agent-old")).await;
+
+        // Verify: new spawn's fields are untouched
+        assert!(
+            room.pending_runtime_agent_connect_tx.lock().await.is_some(),
+            "new spawn's connect_tx should not be cleared"
+        );
+        assert!(
+            room.runtime_agent_request_tx.lock().await.is_some(),
+            "new spawn's request_tx should not be cleared"
+        );
+        assert_eq!(
+            room.current_runtime_agent_id.read().await.as_deref(),
+            Some("agent-new"),
+            "new spawn's provenance should not be cleared"
+        );
+
+        // Verify new_rx is still alive (sender not dropped)
+        // Use try_recv — should return TryRecvError::Empty (not Closed)
+        assert!(
+            new_rx.try_recv().is_err(),
+            "new spawn's oneshot should still be pending (sender alive)"
         );
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -11617,4 +11617,50 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn test_reset_starting_state_cleanup() {
+        // Verify that guarded reset clears request_tx, connect_tx, and handle
+        // (belt-and-suspenders cleanup prevents zombie runtime agents).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _notebook_path) = test_room_with_path(&tmp, "cleanup_test.ipynb");
+
+        // Simulate a runtime agent that has connected: set provenance,
+        // request channel, and connect sender.
+        {
+            let mut id = room.current_runtime_agent_id.write().await;
+            *id = Some("agent-A".to_string());
+        }
+        {
+            let (tx, _rx) = tokio::sync::mpsc::channel(16);
+            let mut guard = room.runtime_agent_request_tx.lock().await;
+            *guard = Some(tx);
+        }
+        {
+            let (tx, _rx) = oneshot::channel();
+            let mut guard = room.pending_runtime_agent_connect_tx.lock().await;
+            *guard = Some(tx);
+        }
+
+        // Reset with matching agent — should clean up everything
+        reset_starting_state(&room, Some("agent-A")).await;
+
+        // Verify all fields cleared
+        assert!(
+            room.runtime_agent_request_tx.lock().await.is_none(),
+            "request_tx should be cleared"
+        );
+        assert!(
+            room.pending_runtime_agent_connect_tx.lock().await.is_none(),
+            "connect_tx should be cleared"
+        );
+        assert!(
+            room.runtime_agent_handle.lock().await.is_none(),
+            "handle should be cleared"
+        );
+        assert!(
+            room.current_runtime_agent_id.read().await.is_none(),
+            "provenance should be cleared"
+        );
+    }
 }


### PR DESCRIPTION
### Problem

Kernel restarts under concentrated load (2+ restarts per gremlin) trigger a race
in `notebook_sync_server.rs` where a stale `watch<bool>` value from a prior
runtime agent causes the spawner to resolve immediately, then send LaunchKernel
through the dead agent's request channel.

**Root cause:** `runtime_agent_connected_tx` is a shared `watch<bool>` per
`NotebookRoom`. When agent A connects, the watch holds `true`. When agent B
replaces A, the disconnect handler's `is_current` check fails (provenance
already changed to B), so it skips `send(false)` — the watch retains A's stale
`true`. B's spawner calls `subscribe().wait_for(|v| *v)`, sees `true`
immediately, and proceeds with A's dead request channel.

**Impact:** 0–36 restart failures per gremlin iteration at concentration >= 2.0.
Bimodal: either clean or worst-case. Gremlins recover after 30s timeout, but
the failures cascade through handle drops and state clobbering.

Closes #1734

### Solution

Replace the shared `watch<bool>` with a per-spawn `oneshot::channel()` stored
behind `Arc<Mutex<Option<oneshot::Sender<()>>>>`.

Each runtime agent spawn creates a fresh `(tx, rx)` pair. The spawner holds `rx`
and waits. The connect handler `take()`s `tx` and sends. When a new spawn
replaces the oneshot, the previous `tx` is dropped — resolving the old `rx`
with `Err` (clean cancellation).

This eliminates three classes of shared-state races:
1. **Stale watch `true`** — impossible (each `rx` is generation-specific)
2. **Dead request channel** — impossible (oneshot fires AFTER request channel is
   set at line 1618)
3. **Double-resolution on overlapping restarts** — superseded spawn gets `Err`
   and bails cleanly

Additionally, `reset_starting_state` gains an `expected_runtime_agent_id` guard
that prevents stale error handlers from clobbering a newer agent's state.

### Changes

Single file: `crates/runtimed/src/notebook_sync_server.rs` (+326, -82)

**Commit 1** — `498cffa9` Core oneshot replacement
- Replace `runtime_agent_connected_tx: Arc<watch::Sender<bool>>` field with
  `pending_runtime_agent_connect_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>`
- Update 3 constructors (production + test helper)
- Update both spawn sites (`auto_launch_kernel`, `handle_notebook_request`) to
  create per-spawn oneshot and wait on receiver with 30s timeout
- Update connect handler: `take()` + `send()` on the oneshot
- Remove `send(false)` from disconnect handler

**Commit 2** — `5360334f` Guard on `reset_starting_state`
- Add `expected_runtime_agent_id: Option<&str>` parameter
- When `Some`, skip reset if current agent doesn't match (logs "Skipping
  reset_starting_state")
- Belt-and-suspenders cleanup: clear `runtime_agent_request_tx`,
  `pending_runtime_agent_connect_tx`, and `current_runtime_agent_id` on reset
- 34 call sites updated (10 guarded post-spawn, 24 unconditional pre-spawn)

**Commit 3** — `9405182a` Unit tests
- `test_per_runtime_agent_oneshot_isolation` — each generation gets its own
  channel, no cross-generation leakage
- `test_oneshot_replaced_before_runtime_agent_connect` — replacing the sender
  before connect resolves old receiver with `Err`
- `test_reset_starting_state_guard` — stale agent ID skips reset, matching ID
  proceeds, `None` always proceeds

**Commit 4** — `917e6be3` rustfmt formatting

**Commit 5** — `2747035e` Additional test
- `test_reset_starting_state_cleanup` — verifies request_tx, connect_tx,
  handle, and provenance are all cleared on reset

**Commit 6** — `0b457c9f` Edge Case 1 fix
- Move provenance setting and oneshot creation to BEFORE
  `RuntimeAgentHandle::spawn()` at both spawn sites
- Prevents fast-connecting agents from reaching the connect handler before
  the oneshot sender is stored (caused 3 connect timeouts in iteration 78)
- New ordering: generate ID → set provenance → create oneshot → spawn →
  store handle → set phase → wait on rx

### Ordering invariant

At each spawn site:
```
1. generate runtime_agent_id      (UUID for provenance)
2. set current_runtime_agent_id   (provenance — blocks stale agents)
3. create oneshot, store tx       (stale agents already rejected by provenance)
4. spawn RuntimeAgentHandle       (subprocess starts, may connect fast)
5. store handle                   (only on success)
6. set starting phase             (UI feedback)
7. wait on rx with 30s timeout    (blocks until THIS agent connects)
```

Provenance MUST be set before the oneshot is stored so that any stale runtime
agent checking provenance in the connect handler is rejected before it can
`take()` the new sender. The oneshot MUST be stored before spawn so that
fast-connecting agents find the sender ready (Edge Case 1).

### Test results

- `cargo xtask lint` — 0 errors
- `cargo test -p runtimed` — 272 tests pass (4 new + 268 existing), 1 ignored
- `cargo test -p runtimed --test tokio_mutex_lint` — pass (no guard-across-await)
- `cargo test -p runtimed --test integration` — 22 pass
- Release build — clean

### Self-review notes

During self-review (commit `2747035e`), one pre-existing edge case was
identified in the connect handler:

The connect handler reads `current_runtime_agent_id` at line ~1556 (provenance
check), then does async sync work (sending frames, writing state), then
overwrites `runtime_agent_request_tx` and `pending_runtime_agent_connect_tx` at
lines ~1618-1627. If a newer spawn occurs during that async window, the newer
spawn's request channel and oneshot could be clobbered by the older agent
completing its connect handler.

This is a **pre-existing issue** not introduced by this PR (the old `watch`
code had the same async window). A follow-up PR should add a second provenance
re-check before the overwrite at line ~1618. Filed for tracking but not
blocking this fix.

### Validation

**Methodology:** Gremlin suite iterations on deployed nightly daemon with
Option C code. Success criteria per validation test plan:
- Zero restart failures at concentration >= 2.0
- Guard fires logged ("Skipping reset_starting_state" in daemon log)
- Zero "RuntimeAgentHandle dropped" cascading from timeout
- Zero tool_errors from restart at any concentration level

**Baseline (pre-fix, build ab12f14):**
- 7 iterations collected
- Bimodal: 0 or 36 failures
- Concentration >= 2.0 triggers failures (100% at intervals < 20s)
- 13.0% connect timeout rate under concentrated restart load

**Post-fix results (build 0b457c9f):**
- Iterations: 78, 79, 80 — **3 of 3 clean** (medium confidence achieved)
- Restart failures: **0** across 36+ total restarts (variance ceiling 36 → 0)
- Connect timeouts: **0** (13.0% → 0%)
- Guard activations: working (stale resets blocked)
- No regressions (cost +8%, performance +71% improvement)

**Iteration 79 temporal stress test:**
- 15 RestartKernel events, 15 successful connects (perfect 1:1 ratio)
- **9 of 15 restarts within <20s gaps** (0s, 1s, 2s, 3s, 4s, 11s, 16s,
  18s, 19s) — pre-fix: <20s gaps = 100% failure rate → post-fix: 0 failures
- 2 concurrent restarts at identical timestamps (0s gap) resolved cleanly
- 15/15 clean gremlins (100%), 0 WARNs, 0 panics
- Cost $4.99, time 5.6 min (vs ~21 min baseline)

### Rollback

Single `git revert HEAD~5..HEAD` reverts all 6 commits (or revert each
independently). The change is contained to one file with no schema, protocol,
or API changes.
