### PR TITLE
fix(iframe): propagate colorTheme to iframe document element

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -8,7 +8,7 @@ import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { injectPluginsForMimes } from "@/components/isolated/iframe-libraries";
-import { useDarkMode } from "@/lib/dark-mode";
+import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
@@ -191,8 +191,11 @@ export const MarkdownCell = memo(function MarkdownCell({
   }, [cell.id, editing]);
 
   const darkMode = useDarkMode();
+  const colorTheme = useColorTheme();
   const darkModeRef = useRef(darkMode);
   darkModeRef.current = darkMode;
+  const colorThemeRef = useRef(colorTheme);
+  colorThemeRef.current = colorTheme;
 
   const blobPort = useBlobPort();
 
@@ -210,7 +213,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const handleFrameReady = useCallback(async () => {
     if (!frameRef.current || !cell.source) return;
     // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
-    frameRef.current.setTheme(darkModeRef.current);
+    frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
     // Clear injected set — a reloaded iframe has a fresh renderer registry
     injectedLibsRef.current.clear();
     // Inject markdown renderer plugin before rendering (idempotent, cached after first load)
@@ -470,6 +473,7 @@ export const MarkdownCell = memo(function MarkdownCell({
               <IsolatedFrame
                 ref={frameRef}
                 darkMode={darkMode}
+                colorTheme={colorTheme}
                 minHeight={24}
                 autoHeight
                 revealOnRender

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,0 +1,181 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { MarkdownCell as MarkdownCellType } from "../../types";
+
+let mockDarkMode = false;
+let mockColorTheme: string | undefined;
+const isolatedFrameProps: Array<Record<string, unknown>> = [];
+
+const mockFrameHandle = {
+  send: vi.fn(),
+  render: vi.fn(),
+  renderBatch: vi.fn(),
+  eval: vi.fn(),
+  installRenderer: vi.fn(),
+  setTheme: vi.fn(),
+  clear: vi.fn(),
+  search: vi.fn(),
+  searchNavigate: vi.fn(),
+  isReady: true,
+  isIframeReady: true,
+};
+
+vi.mock("@/lib/dark-mode", () => ({
+  useDarkMode: () => mockDarkMode,
+  useColorTheme: () => mockColorTheme,
+}));
+
+vi.mock("@/components/isolated/iframe-libraries", () => ({
+  injectPluginsForMimes: vi.fn(async () => {}),
+}));
+
+vi.mock("@/components/isolated", async () => {
+  const React = await import("react");
+
+  const MockIsolatedFrame = React.forwardRef<
+    typeof mockFrameHandle,
+    Record<string, unknown> & { onReady?: () => void }
+  >(function MockIsolatedFrame(props, ref) {
+    isolatedFrameProps.push(props);
+    React.useImperativeHandle(ref, () => mockFrameHandle);
+
+    React.useEffect(() => {
+      props.onReady?.();
+    }, [props.onReady]);
+
+    return <div data-testid="markdown-frame" />;
+  });
+
+  return {
+    IsolatedFrame: MockIsolatedFrame,
+  };
+});
+
+vi.mock("@/components/cell/CellContainer", () => ({
+  CellContainer: ({ codeContent }: { codeContent: React.ReactNode }) => <div>{codeContent}</div>,
+}));
+
+vi.mock("@/components/editor/codemirror-editor", () => ({
+  CodeMirrorEditor: React.forwardRef(function CodeMirrorEditor(_props, _ref) {
+    return <div data-testid="markdown-editor" />;
+  }),
+}));
+
+vi.mock("@/components/editor/remote-cursors", () => ({
+  remoteCursorsExtension: () => [],
+}));
+
+vi.mock("@/components/editor/search-highlight", () => ({
+  searchHighlight: () => [],
+}));
+
+vi.mock("@/components/editor/text-attribution", () => ({
+  textAttributionExtension: () => [],
+}));
+
+vi.mock("../cell/CellPresenceIndicators", () => ({
+  CellPresenceIndicators: () => null,
+}));
+
+vi.mock("../../contexts/PresenceContext", () => ({
+  usePresenceContext: () => null,
+}));
+
+vi.mock("../../hooks/useCellKeyboardNavigation", () => ({
+  useCellKeyboardNavigation: () => [],
+}));
+
+vi.mock("../../hooks/useCrdtBridge", () => ({
+  useCrdtBridge: () => ({ extension: [] }),
+}));
+
+vi.mock("../../lib/blob-port", () => ({
+  useBlobPort: () => null,
+}));
+
+vi.mock("../../lib/cell-ui-state", () => ({
+  useIsCellFocused: () => false,
+  useIsNextCellFromFocused: () => false,
+  useIsPreviousCellFromFocused: () => false,
+  useSearchQuery: () => "",
+}));
+
+vi.mock("../../lib/cursor-registry", () => ({
+  onEditorRegistered: vi.fn(),
+  onEditorUnregistered: vi.fn(),
+}));
+
+vi.mock("../../lib/editor-registry", () => ({
+  registerCellEditor: vi.fn(),
+  unregisterCellEditor: vi.fn(),
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock("../../lib/markdown-assets", () => ({
+  rewriteMarkdownAssetRefs: (source: string) => source,
+}));
+
+vi.mock("../../lib/open-url", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../../lib/presence-sender", () => ({
+  presenceSenderExtension: () => [],
+}));
+
+import { MarkdownCell } from "../MarkdownCell";
+
+function makeCell(): MarkdownCellType {
+  return {
+    cell_type: "markdown",
+    id: "md-1",
+    source: "```python\nprint('hello')\n```",
+    metadata: {},
+  };
+}
+
+describe("MarkdownCell theme sync", () => {
+  beforeEach(() => {
+    mockDarkMode = false;
+    mockColorTheme = undefined;
+    isolatedFrameProps.length = 0;
+    mockFrameHandle.send.mockClear();
+    mockFrameHandle.render.mockClear();
+    mockFrameHandle.renderBatch.mockClear();
+    mockFrameHandle.eval.mockClear();
+    mockFrameHandle.installRenderer.mockClear();
+    mockFrameHandle.setTheme.mockClear();
+    mockFrameHandle.clear.mockClear();
+    mockFrameHandle.search.mockClear();
+    mockFrameHandle.searchNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the current color theme to the markdown iframe and re-syncs it on ready", async () => {
+    mockColorTheme = "cream";
+
+    render(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
+
+    await waitFor(() => {
+      expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, "cream");
+    });
+
+    expect(isolatedFrameProps.at(-1)?.colorTheme).toBe("cream");
+
+    await waitFor(() => {
+      expect(mockFrameHandle.render).toHaveBeenCalledWith({
+        mimeType: "text/markdown",
+        data: "```python\nprint('hello')\n```",
+        cellId: "md-1",
+        replace: true,
+      });
+    });
+  });
+});

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f16847387003e12c6e25b54912c25b1d7948b8cb51cf20287a0f7eaf5f4cab4
+oid sha256:f92a05fd9edb72db3c4bd61540b7d4373731bfba06e644c01cde75f04a7288a7
 size 1588456

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b489ca89268db0b3cdd37da818a6751bfe7850000b3b6cc4c53df1d60bde0682
-size 1472452
+oid sha256:15107ed1d53d47657d49e006f3b1cb6896bea0274c22e6f12f5aa292d860bc3f
+size 1465234

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15107ed1d53d47657d49e006f3b1cb6896bea0274c22e6f12f5aa292d860bc3f
-size 1465234
+oid sha256:1eadd17c258800dc037c678c36a8310bd2e26f41a30b6653a04b8a9e0574f6d3
+size 1465254

--- a/apps/notebook/src/renderer-plugins/sift.css
+++ b/apps/notebook/src/renderer-plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f0e9cd719507d539e80f9096dd7e9fee3b0e073b93024ff181b8569ad8e49ce
+oid sha256:55d5faea83c3e84ded2752244811fabd832c9e7ffc39da25ac44f6c7c5386947
 size 134035

--- a/apps/notebook/src/renderer-plugins/sift.css
+++ b/apps/notebook/src/renderer-plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55d5faea83c3e84ded2752244811fabd832c9e7ffc39da25ac44f6c7c5386947
-size 134035
+oid sha256:bd732e1658220a0fa52fcab2642b237a3c0ccea84bc6732d82cd237bba75c446
+size 134059

--- a/apps/notebook/src/renderer-plugins/sift.js
+++ b/apps/notebook/src/renderer-plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a64a8891b9959181a5246ed2406e933a552e9da404466cc5cbe16c60475f5f9
-size 7917237
+oid sha256:45c605bf6cdbcbcc6f2a75231d079406e661cf2fabaf5ac08044454bcf2be452
+size 7910005

--- a/crates/runt-mcp/assets/plugins/sift.css
+++ b/crates/runt-mcp/assets/plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f0e9cd719507d539e80f9096dd7e9fee3b0e073b93024ff181b8569ad8e49ce
+oid sha256:55d5faea83c3e84ded2752244811fabd832c9e7ffc39da25ac44f6c7c5386947
 size 134035

--- a/crates/runt-mcp/assets/plugins/sift.css
+++ b/crates/runt-mcp/assets/plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55d5faea83c3e84ded2752244811fabd832c9e7ffc39da25ac44f6c7c5386947
-size 134035
+oid sha256:bd732e1658220a0fa52fcab2642b237a3c0ccea84bc6732d82cd237bba75c446
+size 134059

--- a/crates/runt-mcp/assets/plugins/sift.js
+++ b/crates/runt-mcp/assets/plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd4b5727810e924e11f15b17f0458ba6b7b31fcdfdb13f5d0c4c830d129d3f05
-size 7917430
+oid sha256:c0abfad5f6b653c7c60c264e63f452ffb8006e9d45f7acd67897a4583256661f
+size 7910198

--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -200,10 +200,10 @@ function renderShell(app: HTMLElement) {
   });
 
   // Theme: cream | classic
-  const savedColorTheme = localStorage.getItem("sift-color-theme") ?? "cream";
+  const savedColorTheme = localStorage.getItem("sift-color-theme") ?? "classic";
 
   function applyColorTheme(theme: string) {
-    if (theme === "cream") {
+    if (theme === "classic") {
       root.removeAttribute("data-color-theme");
     } else {
       root.setAttribute("data-color-theme", theme);

--- a/packages/sift/src/themes/classic.css
+++ b/packages/sift/src/themes/classic.css
@@ -6,6 +6,7 @@
  */
 
 /* --- Light (default) --- */
+:root,
 [data-color-theme="classic"] {
   color-scheme: light;
   --sift-page: #ffffff;
@@ -39,6 +40,7 @@
 
 /* --- Dark (system preference) --- */
 @media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-color-theme]),
   [data-color-theme="classic"]:not([data-theme="light"]) {
     color-scheme: dark;
     --sift-page: #0a0a0a;
@@ -70,6 +72,8 @@
 }
 
 /* --- Dark (explicit attribute) --- */
+:root:not([data-color-theme])[data-theme="dark"],
+:root:not([data-color-theme]).dark,
 [data-color-theme="classic"][data-theme="dark"],
 [data-color-theme="classic"].dark {
   color-scheme: dark;

--- a/packages/sift/src/themes/classic.css
+++ b/packages/sift/src/themes/classic.css
@@ -6,7 +6,7 @@
  */
 
 /* --- Light (default) --- */
-:root,
+:root:not([data-color-theme]),
 [data-color-theme="classic"] {
   color-scheme: light;
   --sift-page: #ffffff;

--- a/packages/sift/src/themes/cream.css
+++ b/packages/sift/src/themes/cream.css
@@ -5,8 +5,7 @@
  * Light and dark variants.
  */
 
-/* --- Light (default) --- */
-:root,
+/* --- Light --- */
 [data-color-theme="cream"] {
   color-scheme: light;
   --sift-page: #f5f2ec;
@@ -40,7 +39,6 @@
 
 /* --- Dark (system preference) --- */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]):not([data-color-theme]),
   [data-color-theme="cream"]:not([data-theme="light"]) {
     color-scheme: dark;
     --sift-page: #1a1816;
@@ -72,8 +70,6 @@
 }
 
 /* --- Dark (explicit attribute) --- */
-:root:not([data-color-theme])[data-theme="dark"],
-:root:not([data-color-theme]).dark,
 [data-color-theme="cream"][data-theme="dark"],
 [data-color-theme="cream"].dark {
   color-scheme: dark;

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -262,6 +262,8 @@ export function OutputArea({
   // Ref for reading current darkMode in callbacks without adding to deps
   const darkModeRef = useRef(darkMode);
   darkModeRef.current = darkMode;
+  const colorThemeRef = useRef(colorTheme);
+  colorThemeRef.current = colorTheme;
 
   // Get widget store context (may be null if not in provider)
   const widgetContext = useWidgetStore();
@@ -323,7 +325,7 @@ export function OutputArea({
 
     // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
     // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
-    frameRef.current.setTheme(darkModeRef.current);
+    frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
 
     // Install renderer plugins required by the outputs (e.g. plotly, vega).
     // Must happen before clear+render so the installRenderer messages arrive first.

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,0 +1,110 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { OutputArea, type JupyterOutput } from "../OutputArea";
+
+let mockDarkMode = false;
+let mockColorTheme: string | undefined;
+
+const mockFrameHandle = {
+  send: vi.fn(),
+  render: vi.fn(),
+  renderBatch: vi.fn(),
+  eval: vi.fn(),
+  installRenderer: vi.fn(),
+  setTheme: vi.fn(),
+  clear: vi.fn(),
+  search: vi.fn(),
+  searchNavigate: vi.fn(),
+  isReady: false,
+  isIframeReady: true,
+};
+
+vi.mock("@/lib/dark-mode", () => ({
+  useDarkMode: () => mockDarkMode,
+  useColorTheme: () => mockColorTheme,
+}));
+
+vi.mock("@/components/isolated/iframe-libraries", () => ({
+  injectPluginsForMimes: vi.fn(async () => {}),
+  needsPlugin: vi.fn(() => false),
+}));
+
+vi.mock("@/components/isolated", async () => {
+  const React = await import("react");
+
+  const MockIsolatedFrame = React.forwardRef<typeof mockFrameHandle, { onReady?: () => void }>(
+    function MockIsolatedFrame({ onReady }, ref) {
+      React.useImperativeHandle(ref, () => mockFrameHandle);
+
+      React.useEffect(() => {
+        onReady?.();
+      }, [onReady]);
+
+      return <div data-testid="isolated-frame" />;
+    },
+  );
+
+  return {
+    CommBridgeManager: class CommBridgeManager {},
+    IsolatedFrame: MockIsolatedFrame,
+  };
+});
+
+function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): JupyterOutput[] {
+  return [
+    {
+      output_type: "display_data",
+      data: { "text/markdown": content },
+      metadata: {},
+    },
+  ];
+}
+
+describe("OutputArea iframe theme sync", () => {
+  beforeEach(() => {
+    mockDarkMode = false;
+    mockColorTheme = undefined;
+    mockFrameHandle.send.mockClear();
+    mockFrameHandle.render.mockClear();
+    mockFrameHandle.renderBatch.mockClear();
+    mockFrameHandle.eval.mockClear();
+    mockFrameHandle.installRenderer.mockClear();
+    mockFrameHandle.setTheme.mockClear();
+    mockFrameHandle.clear.mockClear();
+    mockFrameHandle.search.mockClear();
+    mockFrameHandle.searchNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-sends the current cream color theme when the iframe becomes ready", async () => {
+    mockColorTheme = "cream";
+
+    render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+
+    await waitFor(() => {
+      expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, "cream");
+    });
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/markdown",
+          data: "```python\nprint('hello')\n```",
+        }),
+      ]);
+    });
+  });
+
+  it("sends null for classic so a reloaded iframe clears stale cream state", async () => {
+    mockColorTheme = undefined;
+
+    render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+
+    await waitFor(() => {
+      expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, null);
+    });
+  });
+});

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -1,0 +1,94 @@
+import { render, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { NTERACT_RENDERER_READY, NTERACT_THEME } from "../rpc-methods";
+
+const { MockJsonRpcTransport } = vi.hoisted(() => {
+  class MockJsonRpcTransport {
+    static instances: MockJsonRpcTransport[] = [];
+
+    notify = vi.fn();
+    start = vi.fn();
+    stop = vi.fn();
+    notificationHandlers = new Map<string, (params: unknown) => void>();
+
+    constructor(
+      public target: Window,
+      public source: MessageEventSource,
+    ) {
+      MockJsonRpcTransport.instances.push(this);
+    }
+
+    onNotification(method: string, handler: (params: unknown) => void) {
+      this.notificationHandlers.set(method, handler);
+    }
+  }
+
+  return { MockJsonRpcTransport };
+});
+
+vi.mock("../jsonrpc-transport", () => ({
+  JsonRpcTransport: MockJsonRpcTransport,
+}));
+
+vi.mock("../frame-html", () => ({
+  createFrameBlobUrl: vi.fn(() => "blob:isolated-frame-test"),
+}));
+
+vi.mock("../isolated-renderer-context", () => ({
+  useIsolatedRenderer: () => ({
+    rendererCode: undefined,
+    rendererCss: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import { IsolatedFrame } from "../isolated-frame";
+
+function dispatchIframeReady(iframeWindow: Window) {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: iframeWindow,
+        data: { type: "ready", payload: null },
+      }),
+    );
+  });
+}
+
+describe("IsolatedFrame theme updates", () => {
+  beforeEach(() => {
+    MockJsonRpcTransport.instances = [];
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses JSON-RPC for live color-theme updates after the renderer is ready", async () => {
+    const { container, rerender } = render(
+      <IsolatedFrame darkMode={false} colorTheme={undefined} />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    act(() => {
+      transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+    });
+
+    rerender(<IsolatedFrame darkMode={false} colorTheme="cream" />);
+
+    await waitFor(() => {
+      expect(transport.notify).toHaveBeenCalledWith(NTERACT_THEME, {
+        isDark: false,
+        colorTheme: "cream",
+      });
+    });
+  });
+});

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -67,7 +67,7 @@ export interface ThemeMessage {
     /** Whether dark mode is active */
     isDark: boolean;
     /** Color theme name (e.g., "classic", "cream") */
-    colorTheme?: string;
+    colorTheme?: string | null;
     /** Optional CSS variables to inject */
     cssVariables?: Record<string, string>;
   };

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -4,6 +4,11 @@ export interface FrameHtmlOptions {
    */
   darkMode?: boolean;
   /**
+   * Color theme to set on the document element (e.g. "cream").
+   * Omit or pass undefined for the default (classic) theme.
+   */
+  colorTheme?: string;
+  /**
    * Additional CSS to inject into the frame.
    */
   additionalCss?: string;
@@ -26,12 +31,13 @@ export interface FrameHtmlOptions {
  * @returns HTML string to be used with a blob URL
  */
 export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
-  const { darkMode = true, additionalCss = "", additionalScript = "" } = options;
+  const { darkMode = true, colorTheme, additionalCss = "", additionalScript = "" } = options;
+  const colorThemeAttr = colorTheme ? ` data-color-theme="${colorTheme}"` : "";
 
   // Start with transparent backgrounds to prevent flash while theme loads
   // Parent will send theme message immediately after iframe is ready
   return `<!DOCTYPE html>
-<html style="background:transparent;color-scheme:${darkMode ? "dark" : "light"}">
+<html style="background:transparent;color-scheme:${darkMode ? "dark" : "light"}"${colorThemeAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -423,8 +429,10 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
           rootEl.style.setProperty('--border-color', isDark ? '#333333' : '#e0e0e0');
         }
 
-        if (colorTheme !== undefined) {
+        if (colorTheme) {
           rootEl.setAttribute('data-color-theme', colorTheme);
+        } else if (colorTheme === null || colorTheme === '') {
+          rootEl.removeAttribute('data-color-theme');
         }
 
         if (cssVariables) {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -167,7 +167,7 @@ export interface IsolatedFrameHandle {
   /**
    * Update theme settings in the iframe.
    */
-  setTheme: (isDark: boolean, colorTheme?: string) => void;
+  setTheme: (isDark: boolean, colorTheme?: string | null) => void;
 
   /**
    * Clear all content in the iframe.
@@ -356,16 +356,19 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       };
     }, []);
 
-    // Send theme as soon as iframe is ready (before renderer bootstrap)
-    // This prevents flash of wrong theme while React initializes
+    // Send theme as soon as iframe is ready (before renderer bootstrap).
+    // Once the renderer transport is active, prefer JSON-RPC so live theme
+    // changes follow the same path as other renderer updates.
     useEffect(() => {
       if (isIframeReady && iframeRef.current?.contentWindow) {
-        iframeRef.current.contentWindow.postMessage(
-          { type: "theme", payload: { isDark: darkMode, colorTheme: colorTheme ?? null } },
-          "*",
-        );
+        const payload = { isDark: darkMode, colorTheme: colorTheme ?? null };
+        if (rpcRef.current && isReadyRef.current) {
+          rpcRef.current.notify(NTERACT_THEME, payload);
+        } else {
+          iframeRef.current.contentWindow.postMessage({ type: "theme", payload }, "*");
+        }
       }
-    }, [darkMode, colorTheme, isIframeReady]);
+    }, [darkMode, colorTheme, isIframeReady, isReady]);
 
     // Keep ref in sync with state (ref avoids stale closures in callbacks)
     useEffect(() => {
@@ -723,7 +726,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         eval: (code: string) => send({ type: "eval", payload: { code } }),
         installRenderer: (code: string, css?: string) =>
           send({ type: "install_renderer", payload: { code, css } }),
-        setTheme: (isDark: boolean, colorTheme?: string) =>
+        setTheme: (isDark: boolean, colorTheme?: string | null) =>
           send({ type: "theme", payload: { isDark, colorTheme } }),
         clear: () => send({ type: "clear" }),
         search: (query: string, caseSensitive?: boolean) => {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -320,6 +320,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
     // Track initial darkMode for blob URL (don't recreate blob on theme change)
     const initialDarkModeRef = useRef(darkMode);
+    const initialColorThemeRef = useRef(colorTheme);
 
     // Stable refs for callback props — avoids tearing down the message
     // handler when callers pass unstable (inline) callbacks.
@@ -344,7 +345,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
     // Create blob URL on mount (only once, with initial darkMode)
     useEffect(() => {
-      const url = createFrameBlobUrl({ darkMode: initialDarkModeRef.current });
+      const url = createFrameBlobUrl({
+        darkMode: initialDarkModeRef.current,
+        colorTheme: initialColorThemeRef.current,
+      });
       setBlobUrl(url);
 
       return () => {
@@ -357,7 +361,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     useEffect(() => {
       if (isIframeReady && iframeRef.current?.contentWindow) {
         iframeRef.current.contentWindow.postMessage(
-          { type: "theme", payload: { isDark: darkMode, colorTheme } },
+          { type: "theme", payload: { isDark: darkMode, colorTheme: colorTheme ?? null } },
           "*",
         );
       }

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -128,7 +128,7 @@ interface RendererState {
  * Update the document theme so components can detect it via isDarkMode().
  * Sets class and data-theme on documentElement (html tag).
  */
-function updateDocumentTheme(isDark: boolean, colorTheme?: string) {
+function updateDocumentTheme(isDark: boolean, colorTheme?: string | null) {
   const root = document.documentElement;
 
   // Set class for Tailwind dark: variant detection
@@ -146,7 +146,7 @@ function updateDocumentTheme(isDark: boolean, colorTheme?: string) {
   // Set color theme for sift and other themed plugins
   if (colorTheme) {
     root.setAttribute("data-color-theme", colorTheme);
-  } else {
+  } else if (colorTheme === null || colorTheme === "") {
     root.removeAttribute("data-color-theme");
   }
 
@@ -314,7 +314,7 @@ function IsolatedRendererApp() {
         break;
 
       case "theme": {
-        const themePayload = payload as { isDark?: boolean; colorTheme?: string };
+        const themePayload = payload as { isDark?: boolean; colorTheme?: string | null };
         if (themePayload?.isDark !== undefined || themePayload?.colorTheme !== undefined) {
           setState((prev) => ({
             ...prev,


### PR DESCRIPTION
## Summary

- Set `data-color-theme` on the iframe `<html>` tag at creation time (not just via postMessage after ready) — prevents cream FOUC
- Send `colorTheme: null` instead of `undefined` in theme postMessage so the iframe can distinguish "no color theme" from "field not sent" (structured clone drops `undefined` values)
- Handle `null`/empty `colorTheme` in the iframe bootstrap `handleTheme()` by removing `data-color-theme` — switching from cream to classic now correctly clears the attribute

Previously, switching from cream to classic left stale `data-color-theme="cream"` on the iframe document, causing sift tables to render with cream (brown) accents even on classic theme.

## Test plan

- [ ] Set theme to cream, open a notebook with sift/parquet output — verify brown accents
- [ ] Switch to classic — verify sift output switches to blue accents
- [ ] Switch back to cream — verify brown accents return
- [ ] Reload on classic — verify sift never shows cream accents
- [ ] Reload on cream — verify sift shows cream accents immediately (no FOUC)