### PR TITLE
fix(runtimed): gremlin-found bugs — interrupt race, conda dep loss, project-root detection

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -663,6 +663,10 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
 
     let match_spec_options = ParseMatchSpecOptions::strict();
 
+    // Read currently installed packages first — we need them both for the
+    // solver's locked_packages and to build preservation specs below.
+    let installed_packages = PrefixRecord::collect_from_prefix::<PrefixRecord>(&env.env_path)?;
+
     // Always include base runtime packages — the solver only returns packages
     // needed to satisfy specs, and locked_packages are "preferred" not "required".
     // Without these, the Installer will remove ipykernel etc from the env.
@@ -672,6 +676,26 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
         MatchSpec::from_str("anywidget", match_spec_options)?,
         MatchSpec::from_str("nbformat", match_spec_options)?,
     ];
+
+    // Preserve all packages currently installed in the env. sync_dependencies
+    // is used for delta installs (adding new packages to an existing env).
+    // Without explicit specs for existing packages, the solver omits them
+    // from its solution and the Installer removes them — destroying
+    // prewarmed pool packages (e.g. pandas, matplotlib) that the user expects
+    // to survive a `add_dependency(after="restart")` cycle.
+    let base_names: std::collections::HashSet<&str> =
+        ["ipykernel", "ipywidgets", "anywidget", "nbformat"]
+            .iter()
+            .copied()
+            .collect();
+    for record in &installed_packages {
+        let name = record.repodata_record.package_record.name.as_normalized();
+        if !base_names.contains(name) {
+            if let Ok(spec) = MatchSpec::from_str(name, match_spec_options) {
+                specs.push(spec);
+            }
+        }
+    }
 
     for dep in &deps.dependencies {
         if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
@@ -708,8 +732,6 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
     .iter()
     .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
     .collect::<Vec<_>>();
-
-    let installed_packages = PrefixRecord::collect_from_prefix::<PrefixRecord>(&env.env_path)?;
 
     let solver_task = SolverTask {
         virtual_packages,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -390,7 +390,9 @@ pub async fn create_notebook(
     let used_kernel_alias = kernel_alias.is_some() && runtime_arg.is_none();
     let runtime = runtime_arg.or(kernel_alias).unwrap_or("python");
 
-    let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
+    let working_dir = arg_str(request, "working_dir")
+        .map(|s| PathBuf::from(resolve_path(s)))
+        .or_else(|| std::env::current_dir().ok());
     let working_dir_for_detection = working_dir.clone();
     let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -48,7 +48,7 @@ use crate::protocol::{
 };
 use notebook_doc::diff::diff_metadata_touched;
 use notebook_doc::presence::{self, PresenceState};
-use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
+use notebook_doc::runtime_state::RuntimeStateDoc;
 
 /// Capacity for the per-room kernel broadcast channel. Sized to absorb bursts
 /// of output messages (e.g. fast-printing cells) so slower peers trigger a
@@ -758,7 +758,19 @@ pub(crate) async fn apply_interrupt_to_state_doc(
     room_state_changed_tx: &broadcast::Sender<()>,
     cleared: &[notebook_protocol::protocol::QueueEntry],
 ) {
-    // Fork state_doc so mutations compose with any concurrent writes.
+    // Do NOT clear the CRDT queue on interrupt. SIGINT targets only the
+    // currently-executing cell — the kernel will reply with an error, and
+    // the runtime agent's execution_done() → process_next() will pick up
+    // any remaining queued cells. Clearing the queue here races with
+    // concurrent ExecuteCell requests: an entry written to the CRDT in the
+    // same window as the interrupt gets removed and silently lost.
+    //
+    // If the agent explicitly cleared some entries (legacy path), mark
+    // those as errored so their lifecycle is terminal.
+    if cleared.is_empty() {
+        return;
+    }
+
     let mut fork = {
         let mut sd = room_state_doc.write().await;
         let mut f = sd.fork();
@@ -766,23 +778,10 @@ pub(crate) async fn apply_interrupt_to_state_doc(
         f
     };
 
-    // Read the currently-executing entry from the CRDT (it stays — the
-    // kernel will send an execute_reply for it via the normal IOPub path).
-    let state = fork.read_state();
-    let exec = state.queue.executing.as_ref().map(|e| DocQueueEntry {
-        cell_id: e.cell_id.clone(),
-        execution_id: e.execution_id.clone(),
-    });
-
-    // Clear the queued entries, keeping only the executing one.
-    fork.set_queue(exec.as_ref(), &[]);
-
-    // Mark cleared executions as errored on the fork
     for entry in cleared {
         fork.set_execution_done(&entry.execution_id, false);
     }
 
-    // Merge fork back — concurrent state_doc writes compose via CRDT
     {
         let mut sd = room_state_doc.write().await;
         match catch_automerge_panic("interrupt-state-merge", || sd.merge(&mut fork)) {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -519,17 +519,19 @@ async fn handle_runtime_agent_request(
             if let Some(ref mut k) = kernel {
                 match k.interrupt().await {
                     Ok(()) => {
-                        let cleared = state.clear_queue();
-                        // Write cleared entries to state doc
-                        {
-                            let mut sd = ctx.state_doc.write().await;
-                            for entry in &cleared {
-                                sd.set_execution_done(&entry.execution_id, false);
-                            }
-                        }
-                        state.write_queue_to_state_doc().await;
+                        // Do NOT clear the execution queue here. SIGINT only
+                        // targets the currently-executing cell — queued cells
+                        // should execute after the kernel processes the
+                        // interrupt. Clearing the queue races with concurrent
+                        // ExecuteCell requests: a cell queued in the same
+                        // scheduling window as the interrupt gets silently
+                        // dropped and marked as errored instead of running.
+                        //
+                        // The interrupted cell will receive an error reply via
+                        // the normal IOPub path (KeyboardInterrupt), triggering
+                        // execution_done() → process_next() for any queued cells.
                         (
-                            RuntimeAgentResponse::InterruptAcknowledged { cleared },
+                            RuntimeAgentResponse::InterruptAcknowledged { cleared: vec![] },
                             None,
                         )
                     }


### PR DESCRIPTION
## Summary

Three bugs found and verified by autonomous gremlin agents during overnight stress testing:

- **Interrupt + execute race condition** — `InterruptExecution` cleared the entire execution queue, racing with concurrent `ExecuteCell` requests. Cells queued in the same window as an interrupt were silently dropped. Fix: remove queue clearing from interrupt path; SIGINT only targets the running cell, queued cells proceed normally via `execution_done()` → `process_next()`.

- **Conda dependency loss on restart** — `sync_dependencies()` built solver specs without existing packages, so the rattler Installer removed pre-installed packages (pandas, numpy, matplotlib) after `add_dependency(after="restart")`. Fix: add installed package names as preservation specs before solving.

- **Systemic project-root detection failure** — MCP `create_notebook()` didn't set `working_dir` when the caller omitted it, so untitled notebooks had no path for project file detection. `pyproject.toml`, `pixi.toml`, and `environment.yml` were never discovered. Fix: default `working_dir` to `std::env::current_dir()`.

## Found by

Autonomous gremlin overnight rotation (2026-04-13):
- Breaker gremlin, cycle 1 → interrupt race + conda dep loss
- Pixi gremlin, cycle 3 → project-root detection
- UV-data-scientist gremlin, cycle 2 → project-root detection

## Test plan

- [x] All three fixes verified by gremlin replay against nightly `2.1.3+ab12f14`
- [x] `cargo check` passes on all affected crates (`runtimed`, `kernel-env`, `runt-mcp`)
- [x] `cargo xtask lint --fix` clean
- [x] Rebased on latest main (`6586cd5f`) with no conflicts
- [ ] CI passes