### PR TITLE
fix(mcp): default create_notebook working_dir to CWD for project detection

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -390,7 +390,9 @@ pub async fn create_notebook(
     let used_kernel_alias = kernel_alias.is_some() && runtime_arg.is_none();
     let runtime = runtime_arg.or(kernel_alias).unwrap_or("python");
 
-    let working_dir = arg_str(request, "working_dir").map(|s| PathBuf::from(resolve_path(s)));
+    let working_dir = arg_str(request, "working_dir")
+        .map(|s| PathBuf::from(resolve_path(s)))
+        .or_else(|| std::env::current_dir().ok());
     let working_dir_for_detection = working_dir.clone();
     let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 


### PR DESCRIPTION
## Summary

`create_notebook()` did not set `working_dir` when the MCP caller omitted it, so untitled notebooks had no path for project file detection. The LaunchKernel handler's `room.working_dir` fallback was present but received `None`, causing `pyproject.toml`, `pixi.toml`, and `environment.yml` to never be discovered for MCP-created notebooks.

Fix: default `working_dir` to `std::env::current_dir()` when not provided, so project-based package managers (UV, Pixi) work out of the box.

## Found by

Autonomous gremlin overnight rotation — pixi gremlin cycle 3, uv-data-scientist gremlin cycle 2 (2026-04-13).

## Test plan

- [x] Verified by gremlin replay against nightly `2.1.3+ab12f14`
- [x] `cargo check -p runt-mcp` passes
- [x] `cargo xtask lint --fix` clean
- [ ] CI passes