### PR TITLE
fix(runtimed): merge env.yaml deps with CRDT deps on conda:env_yml restart

### DIFF
--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -444,27 +444,47 @@ pub async fn get_dependencies(
     let deps = get_deps_for_manager(&handle, &manager);
 
     // Include prewarmed packages from RuntimeStateDoc when available
-    let prewarmed = handle
-        .get_runtime_state()
-        .ok()
-        .map(|s| s.env.prewarmed_packages)
+    let state = handle.get_runtime_state().ok();
+    let prewarmed = state
+        .as_ref()
+        .map(|s| s.env.prewarmed_packages.clone())
         .unwrap_or_default();
 
-    // Indicate whether deps come from a project file or notebook metadata
-    let env_source = handle
-        .get_runtime_state()
-        .ok()
-        .map(|s| s.kernel.env_source.clone());
-    let mode = match env_source.as_deref() {
-        Some("pixi:toml") | Some("uv:pyproject") => "project",
-        _ => "inline",
+    let env_source = state
+        .as_ref()
+        .map(|s| s.kernel.env_source.clone())
+        .unwrap_or_default();
+
+    // Classify the dependency mode by env_source so the caller knows where
+    // packages originate and whether they can be add/removed via MCP.
+    //
+    // - "project": deps come from a project file (environment.yaml, pyproject.toml,
+    //   pixi.toml). The project file is the source of truth for baseline deps.
+    //   add_dependency adds ON TOP of the baseline; remove_dependency only
+    //   removes runtime-added deps.
+    // - "prewarmed": deps come from the kernel pool's default packages.
+    //   add_dependency adds on top; baseline changes with pool configuration.
+    // - "inline": deps are self-contained in notebook metadata (CRDT).
+    //   add_dependency/remove_dependency have full control.
+    let (mode, source_file) = match env_source.as_str() {
+        "conda:env_yml" => ("project", Some("environment.yaml")),
+        "uv:pyproject" => ("project", Some("pyproject.toml")),
+        "pixi:toml" => ("project", Some("pixi.toml")),
+        "conda:prewarmed" | "uv:prewarmed" | "pixi:prewarmed" => ("prewarmed", None),
+        _ => ("inline", None),
     };
 
     let mut result = serde_json::json!({
         "dependencies": deps,
         "package_manager": manager,
         "mode": mode,
+        "env_source": env_source,
     });
+
+    if let Some(file) = source_file {
+        result["source_file"] = serde_json::json!(file);
+    }
+
     if !prewarmed.is_empty() {
         result["available_packages"] = serde_json::json!(prewarmed);
     }

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -218,6 +218,12 @@ pub async fn add_dependency(
 
     let manager = detect_package_manager(&handle);
 
+    // When adding the first dep to a prewarmed kernel, bootstrap the pool's
+    // user-default packages into the CRDT so they survive restarts/rebuilds.
+    // Without this, a restart builds a fresh env from CRDT deps alone (just the
+    // newly added package), losing pandas/numpy/etc. that were in the pool env.
+    bootstrap_prewarmed_to_crdt(&handle, &manager);
+
     add_dep_for_manager(&handle, package, &manager)
         .map_err(|e| McpError::internal_error(e, None))?;
 
@@ -288,13 +294,38 @@ pub async fn add_dependency(
         "restart" => {
             // Shutdown + relaunch with scoped auto-detect to preserve the
             // package manager family (auto:uv, auto:conda, auto:pixi)
-            let restart_env_source = match handle
+            let current_env_source = handle
                 .get_runtime_state()
                 .ok()
-                .map(|s| s.kernel.env_source.clone())
-                .as_deref()
-            {
+                .map(|s| s.kernel.env_source.clone());
+            tracing::debug!(
+                "[mcp] restart: current env_source = {:?}",
+                current_env_source
+            );
+
+            // Check if CRDT has inline deps — if so, use inline source on restart
+            // instead of auto-detect, so the LaunchKernel handler builds from CRDT
+            // deps rather than falling back to a generic pool env.
+            let metadata = handle.get_notebook_metadata();
+            let has_conda_deps = metadata
+                .as_ref()
+                .and_then(|s| s.runt.conda.as_ref())
+                .is_some_and(|c| !c.dependencies.is_empty());
+            let has_uv_deps = metadata
+                .as_ref()
+                .and_then(|s| s.runt.uv.as_ref())
+                .is_some_and(|u| !u.dependencies.is_empty());
+
+            let restart_env_source = match current_env_source.as_deref() {
+                Some("uv:prewarmed") if has_uv_deps => {
+                    tracing::info!("[mcp] restart: uv:prewarmed + CRDT has deps → uv:inline");
+                    "uv:inline".to_string()
+                }
                 Some("uv:prewarmed") => "auto:uv".to_string(),
+                Some("conda:prewarmed") if has_conda_deps => {
+                    tracing::info!("[mcp] restart: conda:prewarmed + CRDT has deps → conda:inline");
+                    "conda:inline".to_string()
+                }
                 Some("conda:prewarmed") => "auto:conda".to_string(),
                 Some("pixi:prewarmed") => "auto:pixi".to_string(),
                 Some("") | None => "auto".to_string(),
@@ -306,6 +337,19 @@ pub async fn add_dependency(
             } else {
                 None
             };
+            tracing::debug!(
+                "[mcp] restart: LaunchKernel env_source={:?}, notebook_path={:?}",
+                restart_env_source,
+                notebook_path
+            );
+
+            // Ensure the daemon has all our CRDT changes (bootstrap + new dep)
+            // before we send LaunchKernel. Without this, the daemon may read
+            // stale metadata and build an env missing packages.
+            if let Err(e) = handle.confirm_sync().await {
+                tracing::warn!("[mcp] restart: confirm_sync failed: {e}, proceeding anyway");
+            }
+
             let _ = handle
                 .send_request(NotebookRequest::ShutdownKernel {})
                 .await;
@@ -319,9 +363,22 @@ pub async fn add_dependency(
                 .await
             {
                 Ok(NotebookResponse::KernelLaunched { env_source, .. }) => {
+                    // The new kernel got a pool env that may not include
+                    // runtime-added deps (e.g. conda:env_yml only reads the
+                    // project file). Sync the CRDT metadata deps into the
+                    // running env so the newly added package is available.
+                    let sync_result = handle
+                        .send_request(NotebookRequest::SyncEnvironment {})
+                        .await;
+                    let sync_ok = matches!(
+                        sync_result,
+                        Ok(NotebookResponse::SyncEnvironmentComplete { .. })
+                            | Ok(NotebookResponse::SyncEnvironmentStarted { .. })
+                    );
                     result["restart"] = serde_json::json!({
                         "success": true,
                         "env_source": env_source,
+                        "sync_after_restart": sync_ok,
                     });
                 }
                 Ok(NotebookResponse::Error { error }) => {
@@ -468,6 +525,62 @@ pub async fn sync_environment(
         }
         Ok(_) => tool_success(&serde_json::json!({ "success": true }).to_string()),
         Err(e) => tool_error(&format!("Failed to sync environment: {e}")),
+    }
+}
+
+/// Packages that `install_conda_env` / UV pool always installs.
+/// No need to record them as explicit CRDT deps — they'd just be noise.
+const CONDA_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat"];
+const UV_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget"];
+
+/// When the kernel is prewarmed, copy the pool's user-default packages
+/// (e.g. pandas, numpy, matplotlib) into the CRDT metadata so they survive
+/// a restart that builds a fresh environment from CRDT deps alone.
+///
+/// This is a no-op when:
+/// - the kernel isn't prewarmed (deps already in CRDT from inline/project)
+/// - prewarmed_packages is empty
+/// - all prewarmed packages are base packages (ipykernel etc.)
+fn bootstrap_prewarmed_to_crdt(handle: &notebook_sync::handle::DocHandle, manager: &str) {
+    let state = match handle.get_runtime_state() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let is_prewarmed = match manager {
+        "conda" => state.kernel.env_source == "conda:prewarmed",
+        "uv" => state.kernel.env_source == "uv:prewarmed",
+        _ => false,
+    };
+    if !is_prewarmed {
+        return;
+    }
+
+    let base = match manager {
+        "conda" => CONDA_BASE_PACKAGES,
+        "uv" => UV_BASE_PACKAGES,
+        _ => return,
+    };
+
+    let user_packages: Vec<&String> = state
+        .env
+        .prewarmed_packages
+        .iter()
+        .filter(|p| !base.contains(&p.as_str()))
+        .collect();
+
+    if user_packages.is_empty() {
+        return;
+    }
+
+    tracing::info!(
+        "[mcp] Bootstrapping {} prewarmed packages into CRDT: {:?}",
+        user_packages.len(),
+        user_packages
+    );
+
+    for pkg in user_packages {
+        let _ = add_dep_for_manager(handle, pkg, manager);
     }
 }
 

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -51,7 +51,7 @@ impl ProgressHandler for BroadcastProgressHandler {
 }
 
 /// Get the cache directory for inline dependency environments.
-fn get_inline_cache_dir() -> std::path::PathBuf {
+pub(crate) fn get_inline_cache_dir() -> std::path::PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join("runt")

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -288,25 +288,22 @@ fn extract_pyproject_deps(content: &str) -> Vec<String> {
     deps
 }
 
-/// Extract the bare package name from a conda dependency spec.
-/// e.g., "pandas>=2.0" → "pandas", "numpy" → "numpy", "python=3.12" → "python"
-fn conda_spec_pkg_name(spec: &str) -> &str {
-    let end = spec
-        .find(|c: char| c == '=' || c == '>' || c == '<' || c == '!' || c == '~' || c == ' ')
-        .unwrap_or(spec.len());
-    &spec[..end]
-}
-
 /// Merge environment.yml base deps with CRDT-added deps.
 ///
 /// The env.yml deps form the baseline (e.g. pandas, numpy, matplotlib).
 /// CRDT deps are packages added at runtime via `add_dependency` (e.g. scipy).
-/// Returns the union, preferring the CRDT version spec if a package appears in both.
+/// Returns the union; when a package appears in both, the CRDT version spec
+/// wins (runtime overrides take precedence over the project file).
 fn merge_env_yml_and_crdt_deps(yml_deps: Vec<String>, crdt_deps: Vec<String>) -> Vec<String> {
+    use notebook_doc::metadata::extract_package_name;
+
     let mut merged = yml_deps;
     for dep in crdt_deps {
-        let pkg = conda_spec_pkg_name(&dep);
-        if !merged.iter().any(|d| conda_spec_pkg_name(d) == pkg) {
+        let pkg = extract_package_name(&dep);
+        if let Some(existing) = merged.iter_mut().find(|d| extract_package_name(d) == pkg) {
+            // CRDT spec wins — replace the env.yml entry
+            *existing = dep;
+        } else {
             merged.push(dep);
         }
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -288,6 +288,126 @@ fn extract_pyproject_deps(content: &str) -> Vec<String> {
     deps
 }
 
+/// Extract the bare package name from a conda dependency spec.
+/// e.g., "pandas>=2.0" → "pandas", "numpy" → "numpy", "python=3.12" → "python"
+fn conda_spec_pkg_name(spec: &str) -> &str {
+    let end = spec
+        .find(|c: char| c == '=' || c == '>' || c == '<' || c == '!' || c == '~' || c == ' ')
+        .unwrap_or(spec.len());
+    &spec[..end]
+}
+
+/// Merge environment.yml base deps with CRDT-added deps.
+///
+/// The env.yml deps form the baseline (e.g. pandas, numpy, matplotlib).
+/// CRDT deps are packages added at runtime via `add_dependency` (e.g. scipy).
+/// Returns the union, preferring the CRDT version spec if a package appears in both.
+fn merge_env_yml_and_crdt_deps(yml_deps: Vec<String>, crdt_deps: Vec<String>) -> Vec<String> {
+    let mut merged = yml_deps;
+    for dep in crdt_deps {
+        let pkg = conda_spec_pkg_name(&dep);
+        if !merged.iter().any(|d| conda_spec_pkg_name(d) == pkg) {
+            merged.push(dep);
+        }
+    }
+    merged.sort();
+    merged
+}
+
+/// Extract conda dependencies, channels, and python version from an environment.yml file.
+///
+/// Returns `(deps, channels, python)` where:
+/// - `deps` excludes `python`, `pip`, `ipykernel` (base packages handled elsewhere)
+/// - `channels` defaults to `["conda-forge"]` if not specified
+/// - `python` is the version constraint if `python=X.Y` appears in dependencies
+fn extract_env_yml_config(content: &str) -> (Vec<String>, Vec<String>, Option<String>) {
+    let mut deps = Vec::new();
+    let mut channels = Vec::new();
+    let mut python = None;
+    let mut in_deps = false;
+    let mut in_channels = false;
+    let mut in_pip = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Top-level keys have no leading whitespace
+        if !line.starts_with(' ') && !line.starts_with('\t') {
+            if trimmed.starts_with("dependencies:") {
+                in_deps = true;
+                in_channels = false;
+                in_pip = false;
+                continue;
+            } else if trimmed.starts_with("channels:") {
+                in_channels = true;
+                in_deps = false;
+                in_pip = false;
+                continue;
+            } else if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                // Any other top-level key ends the current section
+                in_deps = false;
+                in_channels = false;
+                in_pip = false;
+                continue;
+            }
+        }
+
+        if in_channels {
+            if let Some(val) = trimmed.strip_prefix("- ") {
+                let val = val.trim().trim_matches('"').trim_matches('\'');
+                if !val.is_empty() {
+                    channels.push(val.to_string());
+                }
+            }
+        }
+
+        if in_deps {
+            // Detect pip sub-list
+            if trimmed == "- pip:" {
+                in_pip = true;
+                continue;
+            }
+            if in_pip {
+                // pip sub-list items are more deeply indented
+                if trimmed.starts_with("- ") && line.starts_with("    ") {
+                    continue; // skip pip deps
+                }
+                // Less-indented line means we left the pip sub-list
+                in_pip = false;
+            }
+            if let Some(val) = trimmed.strip_prefix("- ") {
+                let val = val.trim().trim_matches('"').trim_matches('\'');
+                if val.is_empty() || val.starts_with('#') {
+                    continue;
+                }
+                // Extract bare package name for filtering
+                let name = val
+                    .split(&['=', '>', '<', '!', ' '][..])
+                    .next()
+                    .unwrap_or(val)
+                    .to_lowercase();
+                if name == "python" {
+                    // Capture python version: "python=3.12" → "3.12"
+                    if let Some(ver) = val.strip_prefix("python=") {
+                        python = Some(ver.trim().to_string());
+                    } else if let Some(ver) = val.strip_prefix("python==") {
+                        python = Some(ver.trim().to_string());
+                    }
+                } else if name != "pip" && name != "ipykernel" {
+                    deps.push(val.to_string());
+                }
+            }
+        }
+    }
+
+    if channels.is_empty() {
+        channels.push("conda-forge".to_string());
+    }
+
+    deps.sort();
+    (deps, channels, python)
+}
+
 /// Build a LaunchedEnvConfig from the current metadata snapshot.
 /// This captures what configuration was used at kernel launch time.
 #[allow(clippy::too_many_arguments)]
@@ -385,9 +505,21 @@ fn build_launched_config(
                 config.prewarmed_packages = pkgs.to_vec();
             }
         }
+        "conda:env_yml" => {
+            // environment.yml-backed notebook with deps installed.
+            // Track conda_deps so SyncEnvironment can compute drift.
+            config.conda_deps = inline_deps.map(|d| d.to_vec());
+            config.venv_path = venv_path;
+            config.python_path = python_path;
+            if let Some(snapshot) = metadata_snapshot {
+                config.conda_channels = Some(get_inline_conda_channels(snapshot));
+            }
+            if let Some(pkgs) = prewarmed_packages {
+                config.prewarmed_packages = pkgs.to_vec();
+            }
+        }
         _ => {
-            // All other Python env sources (conda:env_yml, etc.)
-            // use pooled environments — store paths so the runtime agent can reconstruct.
+            // All other Python env sources — store paths for runtime agent.
             config.venv_path = venv_path;
             config.python_path = python_path;
             if let Some(pkgs) = prewarmed_packages {
@@ -3472,8 +3604,12 @@ async fn try_conda_pool_for_inline_deps(
                 env_path: env.venv_path.clone(),
                 python_path: env.python_path.clone(),
             };
+            // Pass ALL requested deps (not just the delta) to sync_dependencies.
+            // The conda solver only keeps packages that appear in its specs;
+            // passing only the delta causes it to remove pool packages (e.g.
+            // pandas, matplotlib) that aren't in the spec list.
             let conda_deps = kernel_env::CondaDependencies {
-                dependencies: delta.clone(),
+                dependencies: deps.to_vec(),
                 channels: vec!["conda-forge".to_string()],
                 python: None,
                 env_id: None,
@@ -3694,7 +3830,35 @@ async fn auto_launch_kernel(
                     }
                 }
             }
-            _ => {}
+            crate::project_file::ProjectFileKind::EnvironmentYml => {
+                // Read environment.yml deps and bootstrap into CRDT conda metadata
+                // so downstream code paths (LaunchKernel, SyncEnvironment) can use them.
+                if let Ok(content) = std::fs::read_to_string(&detected.path) {
+                    let (deps, channels, python) = extract_env_yml_config(&content);
+                    if !deps.is_empty() || python.is_some() {
+                        let mut doc = room.doc.write().await;
+                        doc.fork_and_merge(|fork| {
+                            let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
+                            let conda = snap.runt.conda.get_or_insert_with(|| {
+                                notebook_doc::metadata::CondaInlineMetadata {
+                                    dependencies: Vec::new(),
+                                    channels: vec!["conda-forge".to_string()],
+                                    python: None,
+                                }
+                            });
+                            // Only bootstrap if the CRDT conda section is empty
+                            // (avoid overwriting user-added deps on re-launch)
+                            if conda.dependencies.is_empty() {
+                                conda.dependencies = deps;
+                                conda.channels = channels;
+                                conda.python = python;
+                            }
+                            let _ = fork.set_metadata_snapshot(&snap);
+                        });
+                        info!("[notebook-sync] Bootstrapped environment.yml deps into CRDT");
+                    }
+                }
+            }
         }
     }
 
@@ -3750,6 +3914,7 @@ async fn auto_launch_kernel(
                 || env_source == "uv:inline"
                 || env_source == "uv:pep723"
                 || env_source == "conda:inline"
+                || env_source == "conda:env_yml"
                 || env_source == "pixi:toml"
                 || env_source == "pixi:inline"
                 || env_source == "pixi:pep723"
@@ -3813,6 +3978,7 @@ async fn auto_launch_kernel(
                     || env_source == "uv:inline"
                     || env_source == "uv:pep723"
                     || env_source == "conda:inline"
+                    || env_source == "conda:env_yml"
                     || env_source == "pixi:toml"
                 {
                     info!(
@@ -4129,6 +4295,183 @@ async fn auto_launch_kernel(
             }
         } else {
             (pooled_env, None)
+        }
+    } else if env_source == "conda:env_yml" {
+        // environment.yml-backed notebook: read deps from CRDT metadata
+        // (bootstrapped by Step 3b), then build a proper env with all deps.
+        let crdt_deps = metadata_snapshot.as_ref().and_then(get_inline_conda_deps);
+        let crdt_channels = metadata_snapshot
+            .as_ref()
+            .map(get_inline_conda_channels)
+            .unwrap_or_else(|| vec!["conda-forge".to_string()]);
+        let crdt_python = metadata_snapshot
+            .as_ref()
+            .and_then(|s| s.runt.conda.as_ref())
+            .and_then(|c| c.python.clone());
+
+        // Always read environment.yml as the baseline, then merge any
+        // CRDT deps (added at runtime via add_dependency) on top.
+        let yml_config = notebook_path_opt
+            .as_ref()
+            .and_then(|p| {
+                crate::project_file::find_nearest_project_file(
+                    p,
+                    &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                )
+            })
+            .map(|yml_path| {
+                let content = std::fs::read_to_string(&yml_path.path).unwrap_or_default();
+                extract_env_yml_config(&content)
+            });
+
+        let (deps, channels, python) = match (crdt_deps, yml_config) {
+            (Some(crdt), Some((yml_d, yml_ch, yml_py))) => {
+                info!(
+                    "[notebook-sync] auto_launch: conda:env_yml merging {} env.yml deps + {} CRDT deps",
+                    yml_d.len(), crdt.len()
+                );
+                let merged = merge_env_yml_and_crdt_deps(yml_d, crdt);
+                let channels = if crdt_channels.len() > 1
+                    || (crdt_channels.len() == 1 && crdt_channels[0] != "conda-forge")
+                {
+                    crdt_channels
+                } else {
+                    yml_ch
+                };
+                (merged, channels, crdt_python.or(yml_py))
+            }
+            (Some(crdt), None) => (crdt, crdt_channels, crdt_python),
+            (None, Some((d, ch, py))) if !d.is_empty() => (d, ch, py),
+            _ => {
+                info!("[notebook-sync] auto_launch: conda:env_yml has no deps, using pool");
+                (vec![], vec![], None)
+            }
+        };
+
+        if deps.is_empty() {
+            (pooled_env, None)
+        } else {
+            info!(
+                "[notebook-sync] auto_launch: conda:env_yml deps: {:?} (channels: {:?}, python: {:?})",
+                deps, channels, python
+            );
+
+            let conda_deps = kernel_env::CondaDependencies {
+                dependencies: deps.clone(),
+                channels: channels.clone(),
+                python: python.clone(),
+                env_id: None,
+            };
+
+            // Check content-addressed cache (hash includes python pin)
+            let cache_dir = crate::inline_env::get_inline_cache_dir();
+            let hash = kernel_env::conda::compute_env_hash(&conda_deps);
+            let cached_path = cache_dir.join(&hash);
+            #[cfg(unix)]
+            let cached_python = cached_path.join("bin").join("python");
+            #[cfg(windows)]
+            let cached_python = cached_path.join("Scripts").join("python.exe");
+
+            if cached_python.exists() {
+                info!(
+                    "[notebook-sync] auto_launch: conda:env_yml cache hit at {:?}",
+                    cached_python
+                );
+                let env = Some(crate::PooledEnv {
+                    env_type: crate::EnvType::Conda,
+                    venv_path: cached_path,
+                    python_path: cached_python,
+                    prewarmed_packages: vec![],
+                });
+                (env, Some(deps))
+            } else if python.is_none() {
+                // No python pin — pool reuse is safe
+                match try_conda_pool_for_inline_deps(
+                    &deps,
+                    &channels,
+                    &daemon,
+                    progress_handler.clone(),
+                )
+                .await
+                {
+                    Ok((env, pool_pkgs)) => {
+                        let mut pooled = env;
+                        pooled.prewarmed_packages = pool_pkgs;
+                        (Some(pooled), Some(deps))
+                    }
+                    Err(_) => {
+                        info!("[notebook-sync] auto_launch: conda:env_yml pool path failed, building from scratch");
+                        match kernel_env::conda::prepare_environment_in(
+                            &conda_deps,
+                            &cache_dir,
+                            progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok(env) => {
+                                let pooled = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Conda,
+                                    venv_path: env.env_path,
+                                    python_path: env.python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (pooled, Some(deps))
+                            }
+                            Err(e) => {
+                                error!(
+                                    "[notebook-sync] Failed to prepare conda:env_yml env: {}",
+                                    e
+                                );
+                                let _ = room.kernel_broadcast_tx.send(
+                                    NotebookBroadcast::KernelStatus {
+                                        status: format!(
+                                        "error: Failed to prepare conda:env_yml environment: {}",
+                                        e
+                                    ),
+                                        cell_id: None,
+                                    },
+                                );
+                                reset_starting_state(room, None).await;
+                                return;
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Python pin present — skip pool reuse, build from scratch
+                info!("[notebook-sync] auto_launch: conda:env_yml building env with python pin");
+                match kernel_env::conda::prepare_environment_in(
+                    &conda_deps,
+                    &cache_dir,
+                    progress_handler.clone(),
+                )
+                .await
+                {
+                    Ok(env) => {
+                        let pooled = Some(crate::PooledEnv {
+                            env_type: crate::EnvType::Conda,
+                            venv_path: env.env_path,
+                            python_path: env.python_path,
+                            prewarmed_packages: vec![],
+                        });
+                        (pooled, Some(deps))
+                    }
+                    Err(e) => {
+                        error!("[notebook-sync] Failed to prepare conda:env_yml env: {}", e);
+                        let _ = room
+                            .kernel_broadcast_tx
+                            .send(NotebookBroadcast::KernelStatus {
+                                status: format!(
+                                    "error: Failed to prepare conda:env_yml environment: {}",
+                                    e
+                                ),
+                                cell_id: None,
+                            });
+                        reset_starting_state(room, None).await;
+                        return;
+                    }
+                }
+            }
         }
     } else if env_source == "pixi:inline" {
         // pixi exec handles its own env caching — just extract deps for the -w flags
@@ -4847,8 +5190,17 @@ async fn handle_notebook_request(
                 }
             } else {
                 // Use explicit env_source (e.g., "uv:inline", "conda:inline")
+                info!(
+                    "[notebook-sync] LaunchKernel: using explicit env_source='{}' (not auto-detecting)",
+                    env_source
+                );
                 env_source.clone()
             };
+
+            info!(
+                "[notebook-sync] LaunchKernel: resolved_env_source='{}' (from request env_source='{}')",
+                resolved_env_source, env_source
+            );
 
             // For pixi:toml, verify ipykernel is declared before launching
             if resolved_env_source == "pixi:toml" {
@@ -4992,8 +5344,8 @@ async fn handle_notebook_request(
                             };
                         }
                     },
-                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline" | "pixi:toml"
-                    | "pixi:inline" | "pixi:pep723" => {
+                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline"
+                    | "conda:env_yml" | "pixi:toml" | "pixi:inline" | "pixi:pep723" => {
                         // These sources prepare their own environments, no pooled env needed
                         info!(
                             "[notebook-sync] LaunchKernel: {} prepares its own env, no pool env",
@@ -5003,6 +5355,10 @@ async fn handle_notebook_request(
                     }
                     other => {
                         // For remaining conda sources, route to conda pool
+                        info!(
+                            "[notebook-sync] LaunchKernel: pool gate FALLTHROUGH for env_source='{}' — taking pool env",
+                            other
+                        );
                         if other.starts_with("conda:") {
                             match daemon.take_conda_env().await {
                                 Some(env) => Some(env),
@@ -5299,7 +5655,195 @@ async fn handle_notebook_request(
                     }
                     _ => (pooled_env, None),
                 }
+            } else if resolved_env_source == "conda:env_yml" {
+                // environment.yml-backed notebook: read deps from CRDT metadata
+                // (bootstrapped by Step 3b or added by add_dependency), then
+                // build a proper env with all deps instead of a bare pool env.
+                debug!(
+                    "[notebook-sync] LaunchKernel: conda:env_yml branch (pooled_env={:?})",
+                    pooled_env.as_ref().map(|e| &e.python_path)
+                );
+                let crdt_deps = metadata_snapshot.as_ref().and_then(get_inline_conda_deps);
+                let crdt_channels = metadata_snapshot
+                    .as_ref()
+                    .map(get_inline_conda_channels)
+                    .unwrap_or_else(|| vec!["conda-forge".to_string()]);
+                let crdt_python = metadata_snapshot
+                    .as_ref()
+                    .and_then(|s| s.runt.conda.as_ref())
+                    .and_then(|c| c.python.clone());
+
+                // Always read environment.yml as the baseline, then merge any
+                // CRDT deps (added at runtime via add_dependency) on top.
+                // Without this merge, a restart after add_dependency("scipy")
+                // would build an env with only ["scipy"], losing the env.yml
+                // baseline packages (pandas, numpy, matplotlib, etc.).
+                let yml_config = notebook_path
+                    .as_ref()
+                    .and_then(|p| {
+                        crate::project_file::find_nearest_project_file(
+                            p,
+                            &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                        )
+                    })
+                    .map(|yml_path| {
+                        let content = std::fs::read_to_string(&yml_path.path).unwrap_or_default();
+                        extract_env_yml_config(&content)
+                    });
+
+                let (deps, channels, python) = match (crdt_deps, yml_config) {
+                    (Some(crdt), Some((yml_d, yml_ch, yml_py))) => {
+                        info!(
+                            "[notebook-sync] LaunchKernel: conda:env_yml merging {} env.yml deps + {} CRDT deps",
+                            yml_d.len(), crdt.len()
+                        );
+                        let merged = merge_env_yml_and_crdt_deps(yml_d, crdt);
+                        let channels = if crdt_channels.len() > 1
+                            || (crdt_channels.len() == 1 && crdt_channels[0] != "conda-forge")
+                        {
+                            crdt_channels
+                        } else {
+                            yml_ch
+                        };
+                        (merged, channels, crdt_python.or(yml_py))
+                    }
+                    (Some(crdt), None) => {
+                        // No env.yml found — use CRDT deps alone
+                        (crdt, crdt_channels, crdt_python)
+                    }
+                    (None, Some((d, ch, py))) if !d.is_empty() => (d, ch, py),
+                    _ => {
+                        info!(
+                            "[notebook-sync] LaunchKernel: conda:env_yml has no deps, using pool"
+                        );
+                        (vec![], vec![], None)
+                    }
+                };
+
+                if deps.is_empty() {
+                    (pooled_env, None)
+                } else {
+                    info!(
+                        "[notebook-sync] LaunchKernel: conda:env_yml deps: {:?} (channels: {:?}, python: {:?})",
+                        deps, channels, python
+                    );
+
+                    // Build CondaDependencies with the python pin from environment.yml
+                    // so the env matches the project's Python version, not the pool's.
+                    let conda_deps = kernel_env::CondaDependencies {
+                        dependencies: deps.clone(),
+                        channels: channels.clone(),
+                        python: python.clone(),
+                        env_id: None,
+                    };
+
+                    // Check content-addressed cache (hash includes python pin)
+                    let cache_dir = crate::inline_env::get_inline_cache_dir();
+                    let hash = kernel_env::conda::compute_env_hash(&conda_deps);
+                    let cached_path = cache_dir.join(&hash);
+                    #[cfg(unix)]
+                    let cached_python = cached_path.join("bin").join("python");
+                    #[cfg(windows)]
+                    let cached_python = cached_path.join("Scripts").join("python.exe");
+
+                    if cached_python.exists() {
+                        info!(
+                            "[notebook-sync] LaunchKernel: conda:env_yml cache hit at {:?}",
+                            cached_python
+                        );
+                        let env = Some(crate::PooledEnv {
+                            env_type: crate::EnvType::Conda,
+                            venv_path: cached_path,
+                            python_path: cached_python,
+                            prewarmed_packages: vec![],
+                        });
+                        (env, Some(deps))
+                    } else if python.is_none() {
+                        // No python pin — pool reuse is safe (pool's Python is compatible)
+                        match try_conda_pool_for_inline_deps(
+                            &deps,
+                            &channels,
+                            &daemon,
+                            launch_progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok((env, pool_pkgs)) => {
+                                let mut pooled = env;
+                                pooled.prewarmed_packages = pool_pkgs;
+                                (Some(pooled), Some(deps))
+                            }
+                            Err(_) => {
+                                // Fall through to full build below
+                                info!("[notebook-sync] LaunchKernel: conda:env_yml pool path failed, building from scratch");
+                                match kernel_env::conda::prepare_environment_in(
+                                    &conda_deps,
+                                    &cache_dir,
+                                    launch_progress_handler.clone(),
+                                )
+                                .await
+                                {
+                                    Ok(env) => {
+                                        let pooled = Some(crate::PooledEnv {
+                                            env_type: crate::EnvType::Conda,
+                                            venv_path: env.env_path,
+                                            python_path: env.python_path,
+                                            prewarmed_packages: vec![],
+                                        });
+                                        (pooled, Some(deps))
+                                    }
+                                    Err(e) => {
+                                        reset_starting_state(room, None).await;
+                                        return NotebookResponse::Error {
+                                            error: format!(
+                                                "Failed to prepare conda:env_yml environment: {}",
+                                                e
+                                            ),
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // Python pin present — pool envs have a different Python
+                        // version, so skip pool reuse and build from scratch.
+                        info!(
+                            "[notebook-sync] LaunchKernel: conda:env_yml building env with python pin"
+                        );
+                        match kernel_env::conda::prepare_environment_in(
+                            &conda_deps,
+                            &cache_dir,
+                            launch_progress_handler.clone(),
+                        )
+                        .await
+                        {
+                            Ok(env) => {
+                                let pooled = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Conda,
+                                    venv_path: env.env_path,
+                                    python_path: env.python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (pooled, Some(deps))
+                            }
+                            Err(e) => {
+                                reset_starting_state(room, None).await;
+                                return NotebookResponse::Error {
+                                    error: format!(
+                                        "Failed to prepare conda:env_yml environment: {}",
+                                        e
+                                    ),
+                                };
+                            }
+                        }
+                    }
+                }
             } else {
+                debug!(
+                    "[notebook-sync] LaunchKernel: fallback for resolved_env_source='{}' — using pooled_env={:?}",
+                    resolved_env_source,
+                    pooled_env.as_ref().map(|e| &e.python_path)
+                );
                 (pooled_env, None)
             };
 


### PR DESCRIPTION
## Summary

`add_dependency(after="restart")` for `conda:env_yml` notebooks lost the environment.yaml baseline packages (pandas, numpy, matplotlib) on restart. The handler had either/or logic: "if CRDT has deps, use CRDT; else read env.yaml." After `add_dependency("scipy")`, CRDT contained only `["scipy"]`, so the restart built an env missing the env.yaml packages.

### Fixes

**Daemon — merge env.yaml + CRDT deps on restart** (the core fix):
- Both the `LaunchKernel` and `auto_launch` `conda:env_yml` handlers now always read `environment.yaml` as the baseline, then merge CRDT-added deps on top.
- `merge_env_yml_and_crdt_deps` deduplicates by package name using `extract_package_name`; CRDT version specs override env.yaml entries when both have the same package.
- Bootstrap `environment.yaml` deps into CRDT conda metadata on auto_launch detection, so `SyncEnvironment` drift computation works.

**Daemon — conda solver preservation**:
- `try_conda_pool_for_inline_deps` now passes the full dep list (not just the delta) to `sync_dependencies`, preventing the solver from removing unlisted packages.

**MCP — restart correctness**:
- Bootstrap prewarmed pool packages into CRDT on first `add_dependency` call.
- `confirm_sync` before restart to prevent CRDT race.
- Map prewarmed→inline `env_source` when CRDT has deps.
- Sync environment after restart as a safety net.

**MCP — dependency provenance** (`get_dependencies` enhancement):
- Returns `env_source` and classified `mode` (`"project"`, `"prewarmed"`, `"inline"`) so callers know where packages originate.
- For project-file-backed sources, includes `source_file` (e.g., `"environment.yaml"`).
- `dependencies` = what `add/remove_dependency` manages (CRDT). The project file provides the baseline; runtime deps layer on top.

### Relationship with #1749

This PR and #1749 fix different layers of the same problem:
- **#1749** (kernel-env): Solver uses `pinned_packages` to preserve existing packages during `sync_dependencies`
- **#1751** (this PR): Daemon merges env.yaml + CRDT deps when building restart envs; MCP surfaces provenance

They don't conflict and can land independently. Together they define the full conda dep lifecycle: where deps come from (#1751 provenance), how they survive restart (#1751 merge), and how the solver preserves them during sync (#1749 pinning).

## Test plan

- [x] Local manual test: `create_notebook(conda)` from CWD with `environment.yaml` → baseline OK → `add_dependency(scipy, after=restart)` → all packages present after restart
- [x] Gremlin `conda-sequential`: 5/5 phases pass
- [x] Gremlin `conda-lifecycle`: 6/6 phases pass
- [x] Gremlin `conda-conflict`: 5/5 phases pass