### PR TITLE
refactor(iframe): tighten sandbox — add fullscreen, drop popups and modals

### DIFF
--- a/.claude/rules/iframe-isolation.md
+++ b/.claude/rules/iframe-isolation.md
@@ -27,11 +27,10 @@ Untrusted content renders inside iframes with `blob:` URLs. Blob URLs have a uni
 ### Sandbox Attributes
 
 ```
-allow-scripts, allow-downloads, allow-forms, allow-pointer-lock,
-allow-popups, allow-popups-to-escape-sandbox, allow-modals
+allow-scripts, allow-downloads, allow-forms, allow-pointer-lock, allow-fullscreen
 ```
 
-No `allow-same-origin`. Ever.
+No `allow-same-origin`. Ever. No `allow-popups` or `allow-modals` — these were removed to reduce phishing surface.
 
 ### Content Security Policy
 

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -39,9 +39,7 @@ const SANDBOX_ATTRS = [
   "allow-downloads",        // Allow file downloads
   "allow-forms",            // Allow form submissions
   "allow-pointer-lock",     // Allow pointer lock API
-  "allow-popups",           // Allow window.open (for links)
-  "allow-popups-to-escape-sandbox",
-  "allow-modals",           // Allow alert/confirm dialogs
+  "allow-fullscreen",       // For sift maximize, interactive visualizations
 ].join(" ");
 ```
 

--- a/src/components/isolated/__tests__/isolated-frame.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame.test.ts
@@ -18,9 +18,7 @@ const EXPECTED_SANDBOX_ATTRS = [
   "allow-downloads",
   "allow-forms",
   "allow-pointer-lock",
-  "allow-popups",
-  "allow-popups-to-escape-sandbox",
-  "allow-modals",
+  "allow-fullscreen",
 ].join(" ");
 
 describe("iframe sandbox security", () => {
@@ -42,8 +40,16 @@ describe("iframe sandbox security", () => {
     expect(EXPECTED_SANDBOX_ATTRS).toContain("allow-scripts");
   });
 
-  it("sandbox includes allow-popups (required for links)", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).toContain("allow-popups");
+  it("sandbox includes allow-fullscreen (required for sift maximize)", () => {
+    expect(EXPECTED_SANDBOX_ATTRS).toContain("allow-fullscreen");
+  });
+
+  it("sandbox does NOT include allow-popups", () => {
+    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-popups");
+  });
+
+  it("sandbox does NOT include allow-modals", () => {
+    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-modals");
   });
 
   /**

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -227,9 +227,7 @@ const SANDBOX_ATTRS = [
   "allow-downloads", // Allow file downloads (e.g., from widgets)
   "allow-forms", // Allow form submissions
   "allow-pointer-lock", // For interactive visualizations
-  "allow-popups", // Allow window.open (for links)
-  "allow-popups-to-escape-sandbox", // Popups should be unrestricted
-  "allow-modals", // Allow alert/confirm/prompt
+  "allow-fullscreen", // For sift maximize, interactive visualizations (e.g., maps, 3D)
 ].join(" ");
 
 /**
@@ -771,6 +769,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         id={id}
         src={blobUrl}
         sandbox={SANDBOX_ATTRS}
+        allowFullScreen
         className={className}
         data-slot="isolated-frame"
         style={{


### PR DESCRIPTION
## Summary

- **Add `allow-fullscreen`** to the iframe sandbox so sift's maximize button and interactive visualizations (maps, 3D) can call `Element.requestFullscreen()`. Also adds the `allowFullScreen` attribute on the `<iframe>` element.
- **Remove `allow-popups`**, `allow-popups-to-escape-sandbox`, and `allow-modals`** to reduce the phishing/social-engineering surface of untrusted outputs.

Links in outputs already route through the iframe's `link_click` JSON-RPC message to the parent — `allow-popups` is not needed for that path. No current widget uses `alert()`/`confirm()`/`prompt()`.

## What to watch

This is a refinement — we'll see how it plays out with custom widgets and sift:

- [ ] Sift maximize/fullscreen works in the notebook (was broken before — `requestFullscreen is not a function`)
- [ ] Links in outputs still open correctly (via `link_click` bridge, not `window.open`)
- [ ] ipywidgets that might use popups or modals (unlikely but worth checking)
- [ ] anywidget compatibility