### PR TITLE
fix(theme): cell adder Tailwind classes + cream-aware iframe CSS vars

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -48,12 +48,22 @@ interface NotebookViewProps {
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
 }
 
-const adderRibbonColors: Record<string, { light: string; dark: string }> = {
-  code: { light: "rgb(56, 189, 248)", dark: "rgb(2, 132, 199)" },
-  markdown: { light: "rgb(52, 211, 153)", dark: "rgb(5, 150, 105)" },
-  raw: { light: "rgb(251, 113, 133)", dark: "rgb(225, 29, 72)" },
+/** Tailwind classes for cell adder ribbon colors — must be static strings for tree-shaking. */
+const adderRibbonClasses: Record<string, string> = {
+  code: [
+    "group-hover/adder:bg-sky-400 dark:group-hover/adder:bg-sky-600",
+    "group-focus-within/adder:bg-sky-400 dark:group-focus-within/adder:bg-sky-600",
+  ].join(" "),
+  markdown: [
+    "group-hover/adder:bg-emerald-400 dark:group-hover/adder:bg-emerald-600",
+    "group-focus-within/adder:bg-emerald-400 dark:group-focus-within/adder:bg-emerald-600",
+  ].join(" "),
+  raw: [
+    "group-hover/adder:bg-rose-400 dark:group-hover/adder:bg-rose-600",
+    "group-focus-within/adder:bg-rose-400 dark:group-focus-within/adder:bg-rose-600",
+  ].join(" "),
 };
-const defaultAdderRibbonColor = adderRibbonColors.code;
+const defaultAdderRibbonClass = adderRibbonClasses.code;
 
 function CellAdder({
   afterCellId,
@@ -64,7 +74,7 @@ function CellAdder({
   onAdd: (type: "code" | "markdown", afterCellId?: string | null) => void;
   cellType?: string;
 }) {
-  const ribbonColor = adderRibbonColors[cellType] ?? defaultAdderRibbonColor;
+  const ribbonClass = adderRibbonClasses[cellType] ?? defaultAdderRibbonClass;
 
   return (
     <div className="flex h-7 w-full items-center select-none">
@@ -74,17 +84,12 @@ function CellAdder({
         <div className="w-10" />
         {/* Ribbon zone — widens on hover to reveal cell type options */}
         <div
-          style={
-            {
-              "--adder-ribbon": ribbonColor.light,
-              "--adder-ribbon-dark": ribbonColor.dark,
-            } as React.CSSProperties
-          }
           className={cn(
             "flex h-full flex-shrink-0 items-center overflow-hidden",
             "w-1 bg-gray-200 transition-all duration-200 ease-out dark:bg-gray-700",
-            "group-hover/adder:w-auto group-hover/adder:rounded-r-sm group-hover/adder:bg-[var(--adder-ribbon)] group-hover/adder:pr-1 dark:group-hover/adder:bg-[var(--adder-ribbon-dark)]",
-            "group-focus-within/adder:w-auto group-focus-within/adder:rounded-r-sm group-focus-within/adder:bg-[var(--adder-ribbon)] group-focus-within/adder:pr-1 dark:group-focus-within/adder:bg-[var(--adder-ribbon-dark)]",
+            "group-hover/adder:w-auto group-hover/adder:rounded-r-sm group-hover/adder:pr-1",
+            "group-focus-within/adder:w-auto group-focus-within/adder:rounded-r-sm group-focus-within/adder:pr-1",
+            ribbonClass,
           )}
         >
           <div

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -57,14 +57,25 @@ describe("generateFrameHtml", () => {
 
   describe("dark mode", () => {
     it("bakes theme-correct background to prevent flash", () => {
-      // Background matches theme from the start so iframe never flashes white
+      // --bg-primary is always transparent; the notebook background shows through
       const darkHtml = generateFrameHtml({ darkMode: true });
-      expect(darkHtml).toContain("--bg-primary: #0a0a0a");
+      expect(darkHtml).toContain("--bg-primary: transparent");
       expect(darkHtml).toContain("--bg-secondary: #1a1a1a");
 
       const lightHtml = generateFrameHtml({ darkMode: false });
-      expect(lightHtml).toContain("--bg-primary: #ffffff");
+      expect(lightHtml).toContain("--bg-primary: transparent");
       expect(lightHtml).toContain("--bg-secondary: #f5f5f5");
+
+      // Cream uses warm tones
+      const creamDarkHtml = generateFrameHtml({ darkMode: true, colorTheme: "cream" });
+      expect(creamDarkHtml).toContain("--bg-secondary: #242120");
+      expect(creamDarkHtml).toContain("--text-primary: #e8e2dc");
+      expect(creamDarkHtml).toContain("--border-color: #3a3533");
+
+      const creamLightHtml = generateFrameHtml({ darkMode: false, colorTheme: "cream" });
+      expect(creamLightHtml).toContain("--bg-secondary: #f0ede7");
+      expect(creamLightHtml).toContain("--text-primary: #1e1a18");
+      expect(creamLightHtml).toContain("--border-color: #d8cec3");
     });
 
     it("uses dark text colors when darkMode is true", () => {

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -44,12 +44,12 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https: http://127.0.0.1:*; style-src 'unsafe-inline' https: http://127.0.0.1:*; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
   <style>
     :root {
-      --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};
-      --bg-secondary: ${darkMode ? "#1a1a1a" : "#f5f5f5"};
-      --text-primary: ${darkMode ? "#e0e0e0" : "#1a1a1a"};
-      --text-secondary: ${darkMode ? "#a0a0a0" : "#666666"};
-      --border-color: ${darkMode ? "#333333" : "#e0e0e0"};
-      --accent-color: #3b82f6;
+      --bg-primary: transparent;
+      --bg-secondary: ${colorTheme === "cream" ? (darkMode ? "#242120" : "#f0ede7") : darkMode ? "#1a1a1a" : "#f5f5f5"};
+      --text-primary: ${colorTheme === "cream" ? (darkMode ? "#e8e2dc" : "#1e1a18") : darkMode ? "#e0e0e0" : "#1a1a1a"};
+      --text-secondary: ${colorTheme === "cream" ? (darkMode ? "#9a918a" : "#6e655f") : darkMode ? "#a0a0a0" : "#666666"};
+      --border-color: ${colorTheme === "cream" ? (darkMode ? "#3a3533" : "#d8cec3") : darkMode ? "#333333" : "#e0e0e0"};
+      --accent-color: ${colorTheme === "cream" ? "#d4896a" : "#3b82f6"};
       --error-color: #ef4444;
       --success-color: #22c55e;
     }
@@ -408,6 +408,13 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         const { isDark, colorTheme, cssVariables } = payload || {};
         const rootEl = document.documentElement;
 
+        // Apply color theme attribute first so CSS var computation can read it
+        if (colorTheme) {
+          rootEl.setAttribute('data-color-theme', colorTheme);
+        } else if (colorTheme === null || colorTheme === '') {
+          rootEl.removeAttribute('data-color-theme');
+        }
+
         if (isDark !== undefined) {
           // Set class for Tailwind dark: variant and CSS selectors
           if (isDark) {
@@ -421,18 +428,22 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
           rootEl.setAttribute('data-theme', isDark ? 'dark' : 'light');
           // Set color-scheme for prefers-color-scheme media queries
           rootEl.style.colorScheme = isDark ? 'dark' : 'light';
-          // Set CSS variables
+          // Set CSS variables — cream uses warm tones matching Sift's palette
+          var ct = rootEl.getAttribute('data-color-theme');
+          var isCream = ct === 'cream';
           rootEl.style.setProperty('--bg-primary', 'transparent');
-          rootEl.style.setProperty('--bg-secondary', isDark ? '#1a1a1a' : '#f5f5f5');
-          rootEl.style.setProperty('--text-primary', isDark ? '#e0e0e0' : '#1a1a1a');
-          rootEl.style.setProperty('--text-secondary', isDark ? '#a0a0a0' : '#666666');
-          rootEl.style.setProperty('--border-color', isDark ? '#333333' : '#e0e0e0');
-        }
-
-        if (colorTheme) {
-          rootEl.setAttribute('data-color-theme', colorTheme);
-        } else if (colorTheme === null || colorTheme === '') {
-          rootEl.removeAttribute('data-color-theme');
+          rootEl.style.setProperty('--bg-secondary', isCream
+            ? (isDark ? '#242120' : '#f0ede7')
+            : (isDark ? '#1a1a1a' : '#f5f5f5'));
+          rootEl.style.setProperty('--text-primary', isCream
+            ? (isDark ? '#e8e2dc' : '#1e1a18')
+            : (isDark ? '#e0e0e0' : '#1a1a1a'));
+          rootEl.style.setProperty('--text-secondary', isCream
+            ? (isDark ? '#9a918a' : '#6e655f')
+            : (isDark ? '#a0a0a0' : '#666666'));
+          rootEl.style.setProperty('--border-color', isCream
+            ? (isDark ? '#3a3533' : '#d8cec3')
+            : (isDark ? '#333333' : '#e0e0e0'));
         }
 
         if (cssVariables) {

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -155,7 +155,17 @@ function updateDocumentTheme(isDark: boolean, colorTheme?: string | null) {
   root.style.colorScheme = isDark ? "dark" : "light";
 
   // Update CSS variables for base styles (background kept transparent for cell focus colors to show through)
-  if (isDark) {
+  const isCream = root.getAttribute("data-color-theme") === "cream";
+  // NOTE: sift's --sift-page/--sift-panel are intentionally NOT overridden here.
+  // Sift needs a proper "embedded" mode to drop card chrome (border, shadow,
+  // border-radius) before we can make it blend seamlessly into the notebook.
+  if (isCream) {
+    root.style.setProperty("--bg-primary", "transparent");
+    root.style.setProperty("--bg-secondary", isDark ? "#242120" : "#f0ede7");
+    root.style.setProperty("--text-primary", isDark ? "#e8e2dc" : "#1e1a18");
+    root.style.setProperty("--text-secondary", isDark ? "#9a918a" : "#6e655f");
+    root.style.setProperty("--foreground", isDark ? "#e8e2dc" : "#1e1a18");
+  } else if (isDark) {
     root.style.setProperty("--bg-primary", "#0a0a0a");
     root.style.setProperty("--bg-secondary", "#1a1a1a");
     root.style.setProperty("--text-primary", "#e0e0e0");


### PR DESCRIPTION
## Summary

- Replace hardcoded RGB inline styles in cell adder ribbon with Tailwind classes matching the gutter color system (sky/emerald/rose). The adder was bypassing theme resolution entirely.
- Make iframe CSS variables cream-aware. Both `frame-html.ts` (direct HTML outputs) and the isolated renderer (React outputs) now check `data-color-theme` and apply warm Sift-derived palette values for cream (#242120 panel, #e8e2dc ink, #3a3533 borders) instead of generic cold grays.
- Move `colorTheme` attribute application before CSS var computation in `frame-html.ts` so the attribute is readable when setting vars.

**Deferred:** Sift embedded mode (transparent page background, drop card chrome) needs work in sift itself — trying to override `--sift-page` from outside creates issues with sticky headers and color-mix panel backgrounds.

## Test plan

- [ ] Cell adder ribbon colors match gutter colors for code (sky), markdown (emerald), raw (rose)
- [ ] Cream dark outputs use warm tones (chocolate background, warm text) not cold grays
- [ ] Cream light outputs use warm tones (#f0ede7 secondary, #1e1a18 text)
- [ ] Classic light/dark outputs are unaffected
- [ ] Sift tables render correctly (sticky headers solid, no transparency issues)