### PR TITLE
fix(sift): increase virtualization overscan to prevent blank rows on fast scroll

### DIFF
--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -144,8 +144,9 @@ const LINE_HEIGHT = 20;
 const CELL_PAD_H = 24; // 12px each side
 const CELL_PAD_V = 16; // 8px top + 8px bottom
 const MIN_COL_WIDTH = 60;
-const OVERSCAN = 20; // extra rows above/below viewport
-const OVERSCAN_VELOCITY = 40; // additional rows in scroll direction when scrolling fast
+const OVERSCAN = 40; // base buffer rows above/below viewport
+const OVERSCAN_VELOCITY_SCALE = 3; // extra rows per 10px of scroll delta
+const MAX_OVERSCAN = 120; // cap total overscan per side
 
 // --- Table Engine ---
 
@@ -1161,14 +1162,17 @@ export function createTable(
     const visFirst = rowAtOffset(scrollTop);
     const visLast = Math.min(rowAtOffset(scrollTop + viewportH), filteredCount - 1);
 
-    // Scroll velocity: extra overscan in the direction of travel
+    // Scroll velocity: proportional overscan in the direction of travel
     const scrollDelta = scrollTop - lastScrollTop;
     const scrollingDown = scrollDelta > 0;
-    const scrollingFast = Math.abs(scrollDelta) > 100;
-    const extraOverscan = scrollingFast ? OVERSCAN_VELOCITY : 0;
+    const absDelta = Math.abs(scrollDelta);
+    const velocityOverscan = Math.min(
+      Math.round((absDelta / 10) * OVERSCAN_VELOCITY_SCALE),
+      MAX_OVERSCAN,
+    );
 
-    const overscanBefore = OVERSCAN + (scrollingDown ? 0 : extraOverscan);
-    const overscanAfter = OVERSCAN + (scrollingDown ? extraOverscan : 0);
+    const overscanBefore = OVERSCAN + (scrollingDown ? 0 : velocityOverscan);
+    const overscanAfter = OVERSCAN + (scrollingDown ? velocityOverscan : 0);
 
     const first = Math.max(0, visFirst - overscanBefore);
     const last = Math.min(visLast + overscanAfter, filteredCount - 1);


### PR DESCRIPTION
## Summary

- Doubled base overscan from 20 → 40 rows so there's always a solid buffer even at rest
- Replaced binary velocity boost (0 or 40 rows at >100px threshold) with proportional scaling — 3 extra rows per 10px of scroll delta, capped at 120
- Buffer now smoothly adapts: 40 rows at idle, up to 160 rows ahead during fast trackpad momentum scrolling

## Verification

- [ ] Open a large dataset in sift (e.g. 100k+ rows)
- [ ] Scroll quickly with trackpad momentum — no blank rows should appear
- [ ] Check the DOM stats line at the bottom to confirm the buffer scales with scroll speed
- [ ] Slow scroll still feels snappy (no unnecessary over-rendering)

_PR submitted by @rgbkrk's agent, Quill_