### PR TITLE
fix(env-progress): emit Ready after additive pool delta install

### DIFF
--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -1,4 +1,3 @@
-import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import type { DaemonBroadcast, EnvProgressEvent, EnvProgressPhase } from "../types";
@@ -178,12 +177,7 @@ export function useEnvProgress() {
       }));
     };
 
-    // Listen for direct env:progress events (from notebook process)
-    const unlisten = listen<EnvProgressEvent>("env:progress", (event) => {
-      processEvent(event.payload);
-    });
-
-    // Also subscribe to broadcast events with env_progress via the frame bus
+    // Subscribe to broadcast events with env_progress via the frame bus
     // (from daemon-managed environment preparation during kernel launch)
     const unsubscribeBroadcast = subscribeBroadcast((payload) => {
       const broadcast = payload as DaemonBroadcast;
@@ -196,7 +190,6 @@ export function useEnvProgress() {
 
     return () => {
       cancelled = true;
-      unlisten.then((fn) => fn());
       unsubscribeBroadcast();
     };
   }, []);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3373,6 +3373,13 @@ async fn try_uv_pool_for_inline_deps(
                         "[notebook-sync] Installed {} delta packages into pool env",
                         delta.len()
                     );
+                    progress_handler.on_progress(
+                        "uv",
+                        kernel_env::EnvProgressPhase::Ready {
+                            env_path: env.venv_path.to_string_lossy().to_string(),
+                            python_path: env.python_path.to_string_lossy().to_string(),
+                        },
+                    );
                     Ok((env, actual_packages))
                 }
                 Err(e) => {
@@ -3487,6 +3494,13 @@ async fn try_conda_pool_for_inline_deps(
                     info!(
                         "[notebook-sync] Installed {} delta packages into Conda pool env",
                         delta.len()
+                    );
+                    progress_handler.on_progress(
+                        "conda",
+                        kernel_env::EnvProgressPhase::Ready {
+                            env_path: env.venv_path.to_string_lossy().to_string(),
+                            python_path: env.python_path.to_string_lossy().to_string(),
+                        },
                     );
                     Ok((env, actual_packages))
                 }


### PR DESCRIPTION
## Summary

When a notebook has inline UV/Conda deps partially covered by the prewarmed pool (the "additive" path), the toolbar gets stuck showing "Installing N packages..." forever — even after the kernel is idle and cells have executed.

**Root cause:** `try_uv_pool_for_inline_deps` and `try_conda_pool_for_inline_deps` emit `EnvProgressPhase::Installing` before the delta install, but never emit a terminal `Ready` event on success. The frontend `useEnvProgress` hook only clears `isActive` on `Ready`/`CacheHit`/`Error`, so it stays stuck.

**Fix:** Emit `EnvProgressPhase::Ready` after successful `sync_dependencies()` in both the UV and Conda additive pool paths.

Also removes a dead `listen("env:progress")` Tauri event listener from `useEnvProgress.ts` — the Rust emitter was deleted in #316 when local kernel mode was removed; all env progress flows through daemon broadcasts on the frame bus since #359.

## Verification

- [ ] Open a notebook with 2+ bare inline UV deps (e.g. `pandas`, `seaborn`) where the pool covers some but not all — the "Installing" spinner should clear once the kernel reaches idle
- [ ] Open a notebook whose deps are fully covered by the pool (subset) — no "Installing" status should appear
- [ ] Open a notebook with version-pinned deps (triggers full build, not pool) — progress should show and clear normally

_PR submitted by @rgbkrk's agent, Quill_