### PR TITLE
feat(conda): use project's real conda env for conda:env_yml notebooks

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -726,17 +726,33 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
         })
         .collect();
 
+    if !constrained_names.is_empty() {
+        info!(
+            "Constrained specs (excluded from locked): {:?}",
+            constrained_names
+        );
+    }
+
+    let locked: Vec<_> = installed_packages
+        .iter()
+        .filter(|r| {
+            let name = r.repodata_record.package_record.name.as_normalized();
+            !constrained_names.contains(name)
+        })
+        .map(|r| r.repodata_record.clone())
+        .collect();
+
+    info!(
+        "Solver input: {} specs, {} locked (from {} installed)",
+        specs.len(),
+        locked.len(),
+        installed_packages.len()
+    );
+
     let solver_task = SolverTask {
         virtual_packages,
         specs,
-        locked_packages: installed_packages
-            .iter()
-            .filter(|r| {
-                let name = r.repodata_record.package_record.name.as_normalized();
-                !constrained_names.contains(name)
-            })
-            .map(|r| r.repodata_record.clone())
-            .collect(),
+        locked_packages: locked,
         ..SolverTask::from_iter(&repo_data)
     };
 

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -726,33 +726,17 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
         })
         .collect();
 
-    if !constrained_names.is_empty() {
-        info!(
-            "Constrained specs (excluded from locked): {:?}",
-            constrained_names
-        );
-    }
-
-    let locked: Vec<_> = installed_packages
-        .iter()
-        .filter(|r| {
-            let name = r.repodata_record.package_record.name.as_normalized();
-            !constrained_names.contains(name)
-        })
-        .map(|r| r.repodata_record.clone())
-        .collect();
-
-    info!(
-        "Solver input: {} specs, {} locked (from {} installed)",
-        specs.len(),
-        locked.len(),
-        installed_packages.len()
-    );
-
     let solver_task = SolverTask {
         virtual_packages,
         specs,
-        locked_packages: locked,
+        locked_packages: installed_packages
+            .iter()
+            .filter(|r| {
+                let name = r.repodata_record.package_record.name.as_normalized();
+                !constrained_names.contains(name)
+            })
+            .map(|r| r.repodata_record.clone())
+            .collect(),
         ..SolverTask::from_iter(&repo_data)
     };
 

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -711,11 +711,30 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
 
     let installed_packages = PrefixRecord::collect_from_prefix::<PrefixRecord>(&env.env_path)?;
 
+    // Collect package names that have explicit version constraints in specs.
+    // Exclude these from locked_packages so the solver doesn't favor installed
+    // versions that violate the requested constraints (e.g., scikit-learn==1.8.0
+    // locked when spec says <1.6).
+    let constrained_names: std::collections::HashSet<String> = specs
+        .iter()
+        .filter(|s| s.version.is_some())
+        .filter_map(|s| match &s.name {
+            rattler_conda_types::PackageNameMatcher::Exact(name) => {
+                Some(name.as_normalized().to_string())
+            }
+            _ => None,
+        })
+        .collect();
+
     let solver_task = SolverTask {
         virtual_packages,
         specs,
         locked_packages: installed_packages
             .iter()
+            .filter(|r| {
+                let name = r.repodata_record.package_record.name.as_normalized();
+                !constrained_names.contains(name)
+            })
             .map(|r| r.repodata_record.clone())
             .collect(),
         ..SolverTask::from_iter(&repo_data)

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -42,6 +42,15 @@ pub struct LaunchedEnvConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pyproject_path: Option<PathBuf>,
 
+    /// Path to environment.yml (conda:env_yml only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_yml_path: Option<PathBuf>,
+
+    /// Conda deps snapshot from environment.yml for drift detection (conda:env_yml only).
+    /// Combined sorted list of conda dependency names from environment.yml.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_yml_deps: Option<Vec<String>>,
+
     /// Deno config (if kernel_type is "deno")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deno_config: Option<DenoLaunchedConfig>,

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -399,7 +399,7 @@ pub async fn get_dependencies(
         .ok()
         .map(|s| s.kernel.env_source.clone());
     let mode = match env_source.as_deref() {
-        Some("pixi:toml") | Some("uv:pyproject") => "project",
+        Some("pixi:toml") | Some("uv:pyproject") | Some("conda:env_yml") => "project",
         _ => "inline",
     };
 
@@ -408,6 +408,9 @@ pub async fn get_dependencies(
         "package_manager": manager,
         "mode": mode,
     });
+    if let Some(ref source) = env_source {
+        result["env_source"] = serde_json::json!(source);
+    }
     if !prewarmed.is_empty() {
         result["available_packages"] = serde_json::json!(prewarmed);
     }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -235,6 +235,83 @@ impl KernelConnection for JupyterKernel {
                         cmd.stderr(Stdio::piped());
                         cmd
                     }
+                    "conda:env_yml" => {
+                        // Use the project's actual conda environment from environment.yml.
+                        // Rattler creates/syncs a prefix at {project_dir}/.conda-env/.
+                        let env_yml_path = notebook_path.as_deref().and_then(|p| {
+                            crate::project_file::detect_project_file(p)
+                                .filter(|d| {
+                                    d.kind == crate::project_file::ProjectFileKind::EnvironmentYml
+                                })
+                                .map(|d| d.path)
+                        });
+
+                        if let Some(ref yml_path) = env_yml_path {
+                            let project_dir = yml_path
+                                .parent()
+                                .unwrap_or_else(|| std::path::Path::new("."));
+                            let conda_prefix = project_dir.join(".conda-env");
+
+                            #[cfg(target_os = "windows")]
+                            let python = conda_prefix.join("python.exe");
+                            #[cfg(not(target_os = "windows"))]
+                            let python = conda_prefix.join("bin").join("python");
+
+                            if python.exists() {
+                                info!(
+                                    "[jupyter-kernel] Starting Python kernel from conda:env_yml prefix ({})",
+                                    python.display()
+                                );
+                                let mut cmd = tokio::process::Command::new(&python);
+                                cmd.env("CONDA_PREFIX", &conda_prefix);
+                                cmd.current_dir(project_dir);
+                                cmd.args([
+                                    "-Xfrozen_modules=off",
+                                    "-m",
+                                    "ipykernel_launcher",
+                                    "-f",
+                                ]);
+                                cmd.arg(&connection_file_path);
+                                cmd.stdout(Stdio::null());
+                                cmd.stderr(Stdio::piped());
+                                cmd
+                            } else {
+                                warn!(
+                                    "[jupyter-kernel] conda:env_yml prefix exists but python not found at {}, falling back to pooled env",
+                                    python.display()
+                                );
+                                let pooled_env = env.ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "conda:env_yml has no prepared environment (prefix missing python)"
+                                    )
+                                })?;
+                                let mut cmd = tokio::process::Command::new(&pooled_env.python_path);
+                                cmd.args([
+                                    "-Xfrozen_modules=off",
+                                    "-m",
+                                    "ipykernel_launcher",
+                                    "-f",
+                                ]);
+                                cmd.arg(&connection_file_path);
+                                cmd.stdout(Stdio::null());
+                                cmd.stderr(Stdio::piped());
+                                cmd
+                            }
+                        } else {
+                            warn!("[jupyter-kernel] conda:env_yml but no environment.yml found, falling back to pooled env");
+                            let pooled_env = env.ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "conda:env_yml has no environment.yml and no pooled environment"
+                                )
+                            })?;
+                            let mut cmd = tokio::process::Command::new(&pooled_env.python_path);
+                            cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
+                            cmd.arg(&connection_file_path);
+                            cmd.stdout(Stdio::null());
+                            cmd.stderr(Stdio::piped());
+                            cmd
+                        }
+                    }
                     "pixi:toml" => {
                         let manifest_path = notebook_path.as_deref().and_then(|p| {
                             crate::project_file::detect_project_file(p)

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -236,35 +236,40 @@ impl KernelConnection for JupyterKernel {
                         cmd
                     }
                     "conda:env_yml" => {
-                        // Use the project's actual conda environment from environment.yml.
-                        // Rattler creates/syncs a prefix at {project_dir}/.conda-env/.
-                        let env_yml_path = notebook_path.as_deref().and_then(|p| {
-                            crate::project_file::detect_project_file(p)
-                                .filter(|d| {
-                                    d.kind == crate::project_file::ProjectFileKind::EnvironmentYml
+                        // Use the project's named conda environment from environment.yml.
+                        // The env prefix was resolved during launch preparation (named env
+                        // lookup or creation via rattler) and passed as the pooled_env.
+                        let conda_prefix = env
+                            .as_ref()
+                            .map(|e| e.venv_path.clone())
+                            .or_else(|| {
+                                // Fallback: look up the named env from environment.yml
+                                notebook_path.as_deref().and_then(|p| {
+                                    crate::project_file::detect_project_file(p)
+                                        .filter(|d| {
+                                            d.kind
+                                                == crate::project_file::ProjectFileKind::EnvironmentYml
+                                        })
+                                        .and_then(|d| {
+                                            crate::project_file::resolve_conda_env_prefix(&d.path)
+                                        })
                                 })
-                                .map(|d| d.path)
-                        });
+                            });
 
-                        if let Some(ref yml_path) = env_yml_path {
-                            let project_dir = yml_path
-                                .parent()
-                                .unwrap_or_else(|| std::path::Path::new("."));
-                            let conda_prefix = project_dir.join(".conda-env");
-
-                            #[cfg(target_os = "windows")]
-                            let python = conda_prefix.join("python.exe");
-                            #[cfg(not(target_os = "windows"))]
-                            let python = conda_prefix.join("bin").join("python");
-
+                        if let Some(ref prefix) = conda_prefix {
+                            let python = crate::project_file::conda_python_path(prefix);
                             if python.exists() {
                                 info!(
-                                    "[jupyter-kernel] Starting Python kernel from conda:env_yml prefix ({})",
+                                    "[jupyter-kernel] Starting Python kernel from conda:env_yml env ({})",
                                     python.display()
                                 );
                                 let mut cmd = tokio::process::Command::new(&python);
-                                cmd.env("CONDA_PREFIX", &conda_prefix);
-                                cmd.current_dir(project_dir);
+                                cmd.env("CONDA_PREFIX", prefix);
+                                if let Some(ref nb_path) = notebook_path {
+                                    if let Some(parent) = nb_path.parent() {
+                                        cmd.current_dir(parent);
+                                    }
+                                }
                                 cmd.args([
                                     "-Xfrozen_modules=off",
                                     "-m",
@@ -276,40 +281,15 @@ impl KernelConnection for JupyterKernel {
                                 cmd.stderr(Stdio::piped());
                                 cmd
                             } else {
-                                warn!(
-                                    "[jupyter-kernel] conda:env_yml prefix exists but python not found at {}, falling back to pooled env",
-                                    python.display()
-                                );
-                                let pooled_env = env.ok_or_else(|| {
-                                    anyhow::anyhow!(
-                                        "conda:env_yml has no prepared environment (prefix missing python)"
-                                    )
-                                })?;
-                                let mut cmd = tokio::process::Command::new(&pooled_env.python_path);
-                                cmd.args([
-                                    "-Xfrozen_modules=off",
-                                    "-m",
-                                    "ipykernel_launcher",
-                                    "-f",
-                                ]);
-                                cmd.arg(&connection_file_path);
-                                cmd.stdout(Stdio::null());
-                                cmd.stderr(Stdio::piped());
-                                cmd
+                                return Err(anyhow::anyhow!(
+                                    "conda:env_yml env at {:?} has no python binary",
+                                    prefix
+                                ));
                             }
                         } else {
-                            warn!("[jupyter-kernel] conda:env_yml but no environment.yml found, falling back to pooled env");
-                            let pooled_env = env.ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "conda:env_yml has no environment.yml and no pooled environment"
-                                )
-                            })?;
-                            let mut cmd = tokio::process::Command::new(&pooled_env.python_path);
-                            cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
-                            cmd.arg(&connection_file_path);
-                            cmd.stdout(Stdio::null());
-                            cmd.stderr(Stdio::piped());
-                            cmd
+                            return Err(anyhow::anyhow!(
+                                "conda:env_yml could not resolve conda environment prefix"
+                            ));
                         }
                     }
                     "pixi:toml" => {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -239,20 +239,17 @@ impl KernelConnection for JupyterKernel {
                         // Use the project's named conda environment from environment.yml.
                         // The env prefix was resolved during launch preparation (named env
                         // lookup or creation via rattler) and passed as the pooled_env.
-                        let conda_prefix = env
-                            .as_ref()
-                            .map(|e| e.venv_path.clone())
-                            .or_else(|| {
+                        let conda_prefix =
+                            env.as_ref().map(|e| e.venv_path.clone()).or_else(|| {
                                 // Fallback: look up the named env from environment.yml
                                 notebook_path.as_deref().and_then(|p| {
-                                    crate::project_file::detect_project_file(p)
-                                        .filter(|d| {
-                                            d.kind
-                                                == crate::project_file::ProjectFileKind::EnvironmentYml
-                                        })
-                                        .and_then(|d| {
-                                            crate::project_file::resolve_conda_env_prefix(&d.path)
-                                        })
+                                    crate::project_file::find_nearest_project_file(
+                                        p,
+                                        &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                                    )
+                                    .and_then(|d| {
+                                        crate::project_file::resolve_conda_env_prefix(&d.path)
+                                    })
                                 })
                             });
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5357,7 +5357,9 @@ async fn handle_notebook_request(
                     (pooled_env, None)
                 }
             } else if resolved_env_source == "conda:env_yml" {
-                // conda:env_yml: create/sync a project-local conda prefix from environment.yml
+                // conda:env_yml: find or create a named conda env from environment.yml.
+                // Uses standard conda env discovery: name: field → search conda env dirs,
+                // prefix: field → use that path directly. Falls back to creating via rattler.
                 let yml_path = notebook_path.as_ref().and_then(|p| {
                     crate::project_file::detect_project_file(p)
                         .filter(|d| d.kind == crate::project_file::ProjectFileKind::EnvironmentYml)
@@ -5367,9 +5369,30 @@ async fn handle_notebook_request(
                 if let Some(ref yml) = yml_path {
                     match crate::project_file::parse_environment_yml(yml) {
                         Ok(env_config) => {
-                            let project_dir =
-                                yml.parent().unwrap_or_else(|| std::path::Path::new("."));
-                            let conda_prefix = project_dir.join(".conda-env");
+                            // Resolve the conda prefix: prefix: → direct path,
+                            // name: → search standard dirs, create if not found.
+                            let conda_prefix = if let Some(ref prefix) = env_config.prefix {
+                                // Explicit prefix: path from environment.yml
+                                prefix.clone()
+                            } else if let Some(ref name) = env_config.name {
+                                // Named env — search for existing, or determine creation path
+                                crate::project_file::find_named_conda_env(name).unwrap_or_else(
+                                    || {
+                                        // Will create at default location
+                                        crate::project_file::default_conda_envs_dir().join(name)
+                                    },
+                                )
+                            } else {
+                                // No name or prefix — use a hash-based env in cache
+                                let cache_dir = crate::default_cache_dir().join("conda-envs");
+                                let conda_deps_tmp = kernel_env::CondaDependencies {
+                                    dependencies: env_config.dependencies.clone(),
+                                    channels: env_config.channels.clone(),
+                                    python: env_config.python.clone(),
+                                    env_id: None,
+                                };
+                                cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
+                            };
 
                             // Merge env.yml deps with any CRDT notebook deps (additive)
                             let mut all_deps = env_config.dependencies.clone();
@@ -5409,8 +5432,11 @@ async fn handle_notebook_request(
                                 env_config.channels.clone()
                             };
 
+                            let env_name_display =
+                                env_config.name.as_deref().unwrap_or("<unnamed>");
                             info!(
-                                "[notebook-sync] conda:env_yml: preparing prefix at {:?} with {} deps",
+                                "[notebook-sync] conda:env_yml: env '{}' at {:?} with {} deps",
+                                env_name_display,
                                 conda_prefix,
                                 all_deps.len()
                             );
@@ -5422,16 +5448,10 @@ async fn handle_notebook_request(
                                 env_id: None,
                             };
 
-                            // Use prepare_environment_in with the project-local prefix as cache_dir.
-                            // But prepare_environment_in creates a hash-based subdir, which is not
-                            // what we want. Instead, use sync_dependencies on the prefix directly.
-                            #[cfg(target_os = "windows")]
-                            let python_path = conda_prefix.join("python.exe");
-                            #[cfg(not(target_os = "windows"))]
-                            let python_path = conda_prefix.join("bin").join("python");
+                            let python_path = crate::project_file::conda_python_path(&conda_prefix);
 
                             if python_path.exists() {
-                                // Prefix exists — sync deps into it
+                                // Existing env — sync deps into it
                                 let conda_env = kernel_env::CondaEnvironment {
                                     env_path: conda_prefix.clone(),
                                     python_path: python_path.clone(),
@@ -5447,7 +5467,7 @@ async fn handle_notebook_request(
                                         .await
                                 {
                                     warn!(
-                                        "[notebook-sync] conda:env_yml sync failed: {}, continuing with existing prefix",
+                                        "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
                                         e
                                     );
                                 }
@@ -5462,82 +5482,70 @@ async fn handle_notebook_request(
                                     metadata_snapshot.as_ref().and_then(get_inline_conda_deps),
                                 )
                             } else {
-                                // No prefix yet — create it via rattler
-                                // Use the project dir as the cache_dir parent so the env lives at
-                                // {project_dir}/.conda-env/{hash}. But for project envs we want a
-                                // fixed path. Use prepare_environment_in with a temp approach, then
-                                // create at the exact prefix path.
+                                // No existing env — create it via rattler at the target path.
+                                // prepare_environment_in creates {cache_dir}/{hash}/, so we
+                                // pass the parent and then rename to the target name.
+                                let parent = conda_prefix
+                                    .parent()
+                                    .unwrap_or_else(|| std::path::Path::new("/tmp"));
+                                if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                                    reset_starting_state(room, None).await;
+                                    return NotebookResponse::Error {
+                                        error: format!(
+                                            "Failed to create conda envs directory {:?}: {}",
+                                            parent, e
+                                        ),
+                                    };
+                                }
                                 match kernel_env::conda::prepare_environment_in(
                                     &conda_deps,
-                                    project_dir,
+                                    parent,
                                     launch_progress_handler.clone(),
                                 )
                                 .await
                                 {
                                     Ok(prepared) => {
-                                        // Rename the hash-based dir to the canonical .conda-env
-                                        if prepared.env_path != conda_prefix {
-                                            if let Err(e) =
-                                                tokio::fs::rename(&prepared.env_path, &conda_prefix)
-                                                    .await
+                                        // Rename hash-based dir to the target env name
+                                        let final_prefix = if prepared.env_path != conda_prefix {
+                                            match tokio::fs::rename(
+                                                &prepared.env_path,
+                                                &conda_prefix,
+                                            )
+                                            .await
                                             {
-                                                warn!(
-                                                    "[notebook-sync] Failed to rename conda prefix {:?} -> {:?}: {}",
-                                                    prepared.env_path, conda_prefix, e
-                                                );
-                                                // Use it where it was created
-                                                let env = Some(crate::PooledEnv {
-                                                    env_type: crate::EnvType::Conda,
-                                                    venv_path: prepared.env_path,
-                                                    python_path: prepared.python_path,
-                                                    prewarmed_packages: vec![],
-                                                });
-                                                (
-                                                    env,
-                                                    metadata_snapshot
-                                                        .as_ref()
-                                                        .and_then(get_inline_conda_deps),
-                                                )
-                                            } else {
-                                                #[cfg(target_os = "windows")]
-                                                let python_path = conda_prefix.join("python.exe");
-                                                #[cfg(not(target_os = "windows"))]
-                                                let python_path =
-                                                    conda_prefix.join("bin").join("python");
-                                                let env = Some(crate::PooledEnv {
-                                                    env_type: crate::EnvType::Conda,
-                                                    venv_path: conda_prefix,
-                                                    python_path,
-                                                    prewarmed_packages: vec![],
-                                                });
-                                                (
-                                                    env,
-                                                    metadata_snapshot
-                                                        .as_ref()
-                                                        .and_then(get_inline_conda_deps),
-                                                )
+                                                Ok(()) => conda_prefix.clone(),
+                                                Err(e) => {
+                                                    warn!(
+                                                        "[notebook-sync] Failed to rename {:?} -> {:?}: {}, using hash path",
+                                                        prepared.env_path, conda_prefix, e
+                                                    );
+                                                    prepared.env_path
+                                                }
                                             }
                                         } else {
-                                            let env = Some(crate::PooledEnv {
-                                                env_type: crate::EnvType::Conda,
-                                                venv_path: prepared.env_path,
-                                                python_path: prepared.python_path,
-                                                prewarmed_packages: vec![],
-                                            });
-                                            (
-                                                env,
-                                                metadata_snapshot
-                                                    .as_ref()
-                                                    .and_then(get_inline_conda_deps),
-                                            )
-                                        }
+                                            prepared.env_path
+                                        };
+                                        let python =
+                                            crate::project_file::conda_python_path(&final_prefix);
+                                        let env = Some(crate::PooledEnv {
+                                            env_type: crate::EnvType::Conda,
+                                            venv_path: final_prefix,
+                                            python_path: python,
+                                            prewarmed_packages: vec![],
+                                        });
+                                        (
+                                            env,
+                                            metadata_snapshot
+                                                .as_ref()
+                                                .and_then(get_inline_conda_deps),
+                                        )
                                     }
                                     Err(e) => {
                                         reset_starting_state(room, None).await;
                                         return NotebookResponse::Error {
                                             error: format!(
-                                                "Failed to create conda env from environment.yml: {}",
-                                                e
+                                                "Failed to create conda env '{}' from environment.yml: {}",
+                                                env_name_display, e
                                             ),
                                         };
                                     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -374,19 +374,26 @@ fn build_launched_config(
             // CRDT-only conda deps go into conda_deps for sync diff tracking.
             config.conda_deps = metadata_snapshot.and_then(get_inline_conda_deps);
             config.conda_channels = metadata_snapshot.map(get_inline_conda_channels);
+            // Pass venv/python paths so runtime agent can reconstruct PooledEnv
+            config.venv_path = venv_path;
+            config.python_path = python_path;
+            if let Some(pkgs) = prewarmed_packages {
+                config.prewarmed_packages = pkgs.to_vec();
+            }
             if let Some(nb_path) = notebook_path {
-                if let Some(detected) = crate::project_file::detect_project_file(nb_path) {
-                    if detected.kind == crate::project_file::ProjectFileKind::EnvironmentYml {
-                        // Parse environment.yml to snapshot deps at launch time
-                        if let Ok(env_config) =
-                            crate::project_file::parse_environment_yml(&detected.path)
-                        {
-                            let mut deps = env_config.dependencies.clone();
-                            deps.sort();
-                            config.environment_yml_deps = Some(deps);
-                        }
-                        config.environment_yml_path = Some(detected.path);
+                if let Some(detected) = crate::project_file::find_nearest_project_file(
+                    nb_path,
+                    &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                ) {
+                    // Parse environment.yml to snapshot deps at launch time
+                    if let Ok(env_config) =
+                        crate::project_file::parse_environment_yml(&detected.path)
+                    {
+                        let mut deps = env_config.dependencies.clone();
+                        deps.sort();
+                        config.environment_yml_deps = Some(deps);
                     }
+                    config.environment_yml_path = Some(detected.path);
                 }
             }
         }
@@ -407,8 +414,8 @@ fn build_launched_config(
             }
         }
         _ => {
-            // All other Python env sources (conda:env_yml, etc.)
-            // use pooled environments — store paths so the runtime agent can reconstruct.
+            // All other Python env sources use pooled environments
+            // — store paths so the runtime agent can reconstruct.
             config.venv_path = venv_path;
             config.python_path = python_path;
             if let Some(pkgs) = prewarmed_packages {
@@ -4981,12 +4988,11 @@ async fn handle_notebook_request(
                         } else if resolved_env_source == "conda:env_yml" {
                             promo_config.environment_yml_path =
                                 notebook_path.as_ref().and_then(|p| {
-                                    crate::project_file::detect_project_file(p)
-                                        .filter(|d| {
-                                            d.kind
-                                                == crate::project_file::ProjectFileKind::EnvironmentYml
-                                        })
-                                        .map(|d| d.path)
+                                    crate::project_file::find_nearest_project_file(
+                                        p,
+                                        &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                                    )
+                                    .map(|d| d.path)
                                 });
                             // Launched baseline = current env.yml deps (before promotion)
                             if let Some(ref path) = promo_config.environment_yml_path {
@@ -5361,9 +5367,11 @@ async fn handle_notebook_request(
                 // Uses standard conda env discovery: name: field → search conda env dirs,
                 // prefix: field → use that path directly. Falls back to creating via rattler.
                 let yml_path = notebook_path.as_ref().and_then(|p| {
-                    crate::project_file::detect_project_file(p)
-                        .filter(|d| d.kind == crate::project_file::ProjectFileKind::EnvironmentYml)
-                        .map(|d| d.path)
+                    crate::project_file::find_nearest_project_file(
+                        p,
+                        &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                    )
+                    .map(|d| d.path)
                 });
 
                 if let Some(ref yml) = yml_path {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -6493,9 +6493,9 @@ fn find_env_yml_deps_insertion_point(content: &str) -> Option<usize> {
         if !line.starts_with(' ') && !line.starts_with('\t') {
             if trimmed == "dependencies:" {
                 in_deps = true;
-                // Position after this line
+                // Position after this line (clamped for files without trailing newline)
                 let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-                last_dep_end = Some(offset);
+                last_dep_end = Some(offset.min(content.len()));
                 continue;
             } else if in_deps && !trimmed.is_empty() && !trimmed.starts_with('#') {
                 // Hit a new top-level key — insert before it
@@ -6505,7 +6505,7 @@ fn find_env_yml_deps_insertion_point(content: &str) -> Option<usize> {
 
         if in_deps && trimmed.starts_with("- ") {
             let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-            last_dep_end = Some(offset);
+            last_dep_end = Some(offset.min(content.len()));
         }
     }
 
@@ -12330,5 +12330,29 @@ mod tests {
             1,
             "generation should be 1 after concurrent spawn"
         );
+    }
+
+    #[test]
+    fn test_env_yml_insertion_point_no_trailing_newline() {
+        // File without trailing newline — must not panic or return out-of-bounds offset
+        let content = "dependencies:\n  - numpy";
+        let point = find_env_yml_deps_insertion_point(content);
+        assert!(point.is_some());
+        assert!(point.unwrap() <= content.len());
+    }
+
+    #[test]
+    fn test_env_yml_insertion_point_with_trailing_newline() {
+        let content = "dependencies:\n  - numpy\n  - pandas\n";
+        let point = find_env_yml_deps_insertion_point(content);
+        assert_eq!(point, Some(content.len()));
+    }
+
+    #[test]
+    fn test_env_yml_insertion_point_before_next_key() {
+        let content = "dependencies:\n  - numpy\nchannels:\n  - conda-forge\n";
+        let point = find_env_yml_deps_insertion_point(content);
+        // Should insert after "  - numpy\n", before "channels:"
+        assert_eq!(point, Some("dependencies:\n  - numpy\n".len()));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -369,6 +369,27 @@ fn build_launched_config(
                 }
             }
         }
+        "conda:env_yml" => {
+            // Store environment.yml path and deps baseline for drift detection.
+            // CRDT-only conda deps go into conda_deps for sync diff tracking.
+            config.conda_deps = metadata_snapshot.and_then(get_inline_conda_deps);
+            config.conda_channels = metadata_snapshot.map(get_inline_conda_channels);
+            if let Some(nb_path) = notebook_path {
+                if let Some(detected) = crate::project_file::detect_project_file(nb_path) {
+                    if detected.kind == crate::project_file::ProjectFileKind::EnvironmentYml {
+                        // Parse environment.yml to snapshot deps at launch time
+                        if let Ok(env_config) =
+                            crate::project_file::parse_environment_yml(&detected.path)
+                        {
+                            let mut deps = env_config.dependencies.clone();
+                            deps.sort();
+                            config.environment_yml_deps = Some(deps);
+                        }
+                        config.environment_yml_path = Some(detected.path);
+                    }
+                }
+            }
+        }
         "pixi:inline" => {
             // Store pixi deps for drift detection
             config.pixi_deps = inline_deps.map(|d| d.to_vec());
@@ -529,6 +550,29 @@ fn compute_env_sync_diff(
                             .next()
                             .map(|n| n.trim().to_string())
                             .unwrap_or_else(|| dep.clone());
+                        removed.push(name);
+                    }
+                }
+            }
+        }
+    }
+
+    // Check conda:env_yml deps (file-based drift)
+    if let Some(ref launched_yml_deps) = launched.environment_yml_deps {
+        if let Some(ref yml_path) = launched.environment_yml_path {
+            if let Ok(env_config) = crate::project_file::parse_environment_yml(yml_path) {
+                let mut current_deps = env_config.dependencies;
+                current_deps.sort();
+
+                for dep in &current_deps {
+                    if !launched_yml_deps.contains(dep) {
+                        let name = notebook_doc::metadata::extract_package_name(dep).to_string();
+                        added.push(name);
+                    }
+                }
+                for dep in launched_yml_deps {
+                    if !current_deps.contains(dep) {
+                        let name = notebook_doc::metadata::extract_package_name(dep).to_string();
                         removed.push(name);
                     }
                 }
@@ -4892,7 +4936,10 @@ async fn handle_notebook_request(
             // For project-backed envs, promote any inline deps to the project
             // file before launching. This handles the case where add_dependency
             // wrote to CRDT metadata and then triggered a restart.
-            if resolved_env_source == "pixi:toml" || resolved_env_source == "uv:pyproject" {
+            if resolved_env_source == "pixi:toml"
+                || resolved_env_source == "uv:pyproject"
+                || resolved_env_source == "conda:env_yml"
+            {
                 if let Some(ref snap) = metadata_snapshot {
                     let has_inline = match resolved_env_source.as_str() {
                         "pixi:toml" => snap
@@ -4905,6 +4952,11 @@ async fn handle_notebook_request(
                             .uv
                             .as_ref()
                             .is_some_and(|u| !u.dependencies.is_empty()),
+                        "conda:env_yml" => snap
+                            .runt
+                            .conda
+                            .as_ref()
+                            .is_some_and(|c| !c.dependencies.is_empty()),
                         _ => false,
                     };
                     if has_inline {
@@ -4924,6 +4976,26 @@ async fn handle_notebook_request(
                                 if let Ok(content) = std::fs::read_to_string(path) {
                                     promo_config.pixi_toml_deps =
                                         Some(extract_pixi_toml_deps(&content));
+                                }
+                            }
+                        } else if resolved_env_source == "conda:env_yml" {
+                            promo_config.environment_yml_path =
+                                notebook_path.as_ref().and_then(|p| {
+                                    crate::project_file::detect_project_file(p)
+                                        .filter(|d| {
+                                            d.kind
+                                                == crate::project_file::ProjectFileKind::EnvironmentYml
+                                        })
+                                        .map(|d| d.path)
+                                });
+                            // Launched baseline = current env.yml deps (before promotion)
+                            if let Some(ref path) = promo_config.environment_yml_path {
+                                if let Ok(env_config) =
+                                    crate::project_file::parse_environment_yml(path)
+                                {
+                                    let mut deps = env_config.dependencies;
+                                    deps.sort();
+                                    promo_config.environment_yml_deps = Some(deps);
                                 }
                             }
                         } else {
@@ -5006,8 +5078,8 @@ async fn handle_notebook_request(
                             };
                         }
                     },
-                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline" | "pixi:toml"
-                    | "pixi:inline" | "pixi:pep723" => {
+                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline"
+                    | "conda:env_yml" | "pixi:toml" | "pixi:inline" | "pixi:pep723" => {
                         // These sources prepare their own environments, no pooled env needed
                         info!(
                             "[notebook-sync] LaunchKernel: {} prepares its own env, no pool env",
@@ -5282,6 +5354,205 @@ async fn handle_notebook_request(
                         }
                     }
                 } else {
+                    (pooled_env, None)
+                }
+            } else if resolved_env_source == "conda:env_yml" {
+                // conda:env_yml: create/sync a project-local conda prefix from environment.yml
+                let yml_path = notebook_path.as_ref().and_then(|p| {
+                    crate::project_file::detect_project_file(p)
+                        .filter(|d| d.kind == crate::project_file::ProjectFileKind::EnvironmentYml)
+                        .map(|d| d.path)
+                });
+
+                if let Some(ref yml) = yml_path {
+                    match crate::project_file::parse_environment_yml(yml) {
+                        Ok(env_config) => {
+                            let project_dir =
+                                yml.parent().unwrap_or_else(|| std::path::Path::new("."));
+                            let conda_prefix = project_dir.join(".conda-env");
+
+                            // Merge env.yml deps with any CRDT notebook deps (additive)
+                            let mut all_deps = env_config.dependencies.clone();
+                            if let Some(crdt_deps) =
+                                metadata_snapshot.as_ref().and_then(get_inline_conda_deps)
+                            {
+                                let base_names: std::collections::HashSet<String> = all_deps
+                                    .iter()
+                                    .map(|d| {
+                                        notebook_doc::metadata::extract_package_name(d)
+                                            .to_lowercase()
+                                    })
+                                    .collect();
+                                for dep in &crdt_deps {
+                                    let name = notebook_doc::metadata::extract_package_name(dep)
+                                        .to_lowercase();
+                                    if !base_names.contains(&name) {
+                                        all_deps.push(dep.clone());
+                                    }
+                                }
+                            }
+
+                            // Always include ipykernel
+                            let base_names: std::collections::HashSet<String> = all_deps
+                                .iter()
+                                .map(|d| {
+                                    notebook_doc::metadata::extract_package_name(d).to_lowercase()
+                                })
+                                .collect();
+                            if !base_names.contains("ipykernel") {
+                                all_deps.push("ipykernel".to_string());
+                            }
+
+                            let channels = if env_config.channels.is_empty() {
+                                vec!["conda-forge".to_string()]
+                            } else {
+                                env_config.channels.clone()
+                            };
+
+                            info!(
+                                "[notebook-sync] conda:env_yml: preparing prefix at {:?} with {} deps",
+                                conda_prefix,
+                                all_deps.len()
+                            );
+
+                            let conda_deps = kernel_env::CondaDependencies {
+                                dependencies: all_deps,
+                                channels,
+                                python: env_config.python.clone(),
+                                env_id: None,
+                            };
+
+                            // Use prepare_environment_in with the project-local prefix as cache_dir.
+                            // But prepare_environment_in creates a hash-based subdir, which is not
+                            // what we want. Instead, use sync_dependencies on the prefix directly.
+                            #[cfg(target_os = "windows")]
+                            let python_path = conda_prefix.join("python.exe");
+                            #[cfg(not(target_os = "windows"))]
+                            let python_path = conda_prefix.join("bin").join("python");
+
+                            if python_path.exists() {
+                                // Prefix exists — sync deps into it
+                                let conda_env = kernel_env::CondaEnvironment {
+                                    env_path: conda_prefix.clone(),
+                                    python_path: python_path.clone(),
+                                };
+                                launch_progress_handler.on_progress(
+                                    "conda",
+                                    kernel_env::EnvProgressPhase::Installing {
+                                        total: conda_deps.dependencies.len(),
+                                    },
+                                );
+                                if let Err(e) =
+                                    kernel_env::conda::sync_dependencies(&conda_env, &conda_deps)
+                                        .await
+                                {
+                                    warn!(
+                                        "[notebook-sync] conda:env_yml sync failed: {}, continuing with existing prefix",
+                                        e
+                                    );
+                                }
+                                let env = Some(crate::PooledEnv {
+                                    env_type: crate::EnvType::Conda,
+                                    venv_path: conda_prefix,
+                                    python_path,
+                                    prewarmed_packages: vec![],
+                                });
+                                (
+                                    env,
+                                    metadata_snapshot.as_ref().and_then(get_inline_conda_deps),
+                                )
+                            } else {
+                                // No prefix yet — create it via rattler
+                                // Use the project dir as the cache_dir parent so the env lives at
+                                // {project_dir}/.conda-env/{hash}. But for project envs we want a
+                                // fixed path. Use prepare_environment_in with a temp approach, then
+                                // create at the exact prefix path.
+                                match kernel_env::conda::prepare_environment_in(
+                                    &conda_deps,
+                                    project_dir,
+                                    launch_progress_handler.clone(),
+                                )
+                                .await
+                                {
+                                    Ok(prepared) => {
+                                        // Rename the hash-based dir to the canonical .conda-env
+                                        if prepared.env_path != conda_prefix {
+                                            if let Err(e) =
+                                                tokio::fs::rename(&prepared.env_path, &conda_prefix)
+                                                    .await
+                                            {
+                                                warn!(
+                                                    "[notebook-sync] Failed to rename conda prefix {:?} -> {:?}: {}",
+                                                    prepared.env_path, conda_prefix, e
+                                                );
+                                                // Use it where it was created
+                                                let env = Some(crate::PooledEnv {
+                                                    env_type: crate::EnvType::Conda,
+                                                    venv_path: prepared.env_path,
+                                                    python_path: prepared.python_path,
+                                                    prewarmed_packages: vec![],
+                                                });
+                                                (
+                                                    env,
+                                                    metadata_snapshot
+                                                        .as_ref()
+                                                        .and_then(get_inline_conda_deps),
+                                                )
+                                            } else {
+                                                #[cfg(target_os = "windows")]
+                                                let python_path = conda_prefix.join("python.exe");
+                                                #[cfg(not(target_os = "windows"))]
+                                                let python_path =
+                                                    conda_prefix.join("bin").join("python");
+                                                let env = Some(crate::PooledEnv {
+                                                    env_type: crate::EnvType::Conda,
+                                                    venv_path: conda_prefix,
+                                                    python_path,
+                                                    prewarmed_packages: vec![],
+                                                });
+                                                (
+                                                    env,
+                                                    metadata_snapshot
+                                                        .as_ref()
+                                                        .and_then(get_inline_conda_deps),
+                                                )
+                                            }
+                                        } else {
+                                            let env = Some(crate::PooledEnv {
+                                                env_type: crate::EnvType::Conda,
+                                                venv_path: prepared.env_path,
+                                                python_path: prepared.python_path,
+                                                prewarmed_packages: vec![],
+                                            });
+                                            (
+                                                env,
+                                                metadata_snapshot
+                                                    .as_ref()
+                                                    .and_then(get_inline_conda_deps),
+                                            )
+                                        }
+                                    }
+                                    Err(e) => {
+                                        reset_starting_state(room, None).await;
+                                        return NotebookResponse::Error {
+                                            error: format!(
+                                                "Failed to create conda env from environment.yml: {}",
+                                                e
+                                            ),
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            reset_starting_state(room, None).await;
+                            return NotebookResponse::Error {
+                                error: format!("Failed to parse environment.yml: {}", e),
+                            };
+                        }
+                    }
+                } else {
+                    warn!("[notebook-sync] conda:env_yml but no environment.yml found");
                     (pooled_env, None)
                 }
             } else if resolved_env_source == "pixi:inline" {
@@ -6193,6 +6464,38 @@ async fn handle_notebook_request(
 /// them to the project file via `pixi add` / `uv add`, then clears the inline
 /// section from the CRDT.
 ///
+/// Find the byte offset in an environment.yml string where new dependencies
+/// should be inserted (end of the `dependencies:` list, before the next
+/// top-level key or EOF).
+fn find_env_yml_deps_insertion_point(content: &str) -> Option<usize> {
+    let mut in_deps = false;
+    let mut last_dep_end = None;
+
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+
+        if !line.starts_with(' ') && !line.starts_with('\t') {
+            if trimmed == "dependencies:" {
+                in_deps = true;
+                // Position after this line
+                let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
+                last_dep_end = Some(offset);
+                continue;
+            } else if in_deps && !trimmed.is_empty() && !trimmed.starts_with('#') {
+                // Hit a new top-level key — insert before it
+                return last_dep_end;
+            }
+        }
+
+        if in_deps && trimmed.starts_with("- ") {
+            let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
+            last_dep_end = Some(offset);
+        }
+    }
+
+    last_dep_end
+}
+
 /// For removals, compares CRDT deps against launched baseline and runs
 /// `pixi remove` / `uv remove` for any deps that were removed.
 ///
@@ -6285,6 +6588,101 @@ async fn promote_inline_deps_to_project(
                     let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
                     let pixi = snap.pixi_section_or_default();
                     pixi.dependencies = deps;
+                    let _ = fork.set_metadata_snapshot(&snap);
+                });
+            }
+        }
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+    } else if env_source == "conda:env_yml" {
+        let yml_path = launched_config
+            .environment_yml_path
+            .as_ref()
+            .ok_or_else(|| {
+                "conda:env_yml kernel has no environment_yml_path in launched config".to_string()
+            })?;
+
+        let current_deps: Vec<String> = current_metadata
+            .runt
+            .conda
+            .as_ref()
+            .map(|c| c.dependencies.clone())
+            .unwrap_or_default();
+        // Launched baseline = environment.yml deps snapshot at launch time
+        let launched_deps = launched_config
+            .environment_yml_deps
+            .clone()
+            .unwrap_or_default();
+
+        let launched_names: std::collections::HashSet<String> = launched_deps
+            .iter()
+            .map(|d| notebook_doc::metadata::extract_package_name(d).to_lowercase())
+            .collect();
+
+        let to_add: Vec<&str> = current_deps
+            .iter()
+            .filter(|d| {
+                let name = notebook_doc::metadata::extract_package_name(d).to_lowercase();
+                !launched_names.contains(&name)
+            })
+            .map(|d| d.as_str())
+            .collect();
+
+        // For conda:env_yml, we append new deps to environment.yml directly.
+        // This is a simple text-based approach — append to the dependencies: section.
+        let mut errors = Vec::new();
+
+        if !to_add.is_empty() {
+            match std::fs::read_to_string(yml_path) {
+                Ok(content) => {
+                    let mut new_content = content.clone();
+                    // Find the end of the dependencies: section to insert new deps
+                    let insertion_point = find_env_yml_deps_insertion_point(&content);
+                    if let Some(pos) = insertion_point {
+                        let mut insert_str = String::new();
+                        for dep in &to_add {
+                            insert_str.push_str(&format!("  - {}\n", dep));
+                            promoted.push(format!("+{}", dep));
+                        }
+                        new_content.insert_str(pos, &insert_str);
+                        if let Err(e) = std::fs::write(yml_path, &new_content) {
+                            errors.push(format!("Failed to write environment.yml: {}", e));
+                        }
+                    } else {
+                        // No dependencies: section found — append one
+                        let mut append_str = String::from("\ndependencies:\n");
+                        for dep in &to_add {
+                            append_str.push_str(&format!("  - {}\n", dep));
+                            promoted.push(format!("+{}", dep));
+                        }
+                        new_content.push_str(&append_str);
+                        if let Err(e) = std::fs::write(yml_path, &new_content) {
+                            errors.push(format!("Failed to write environment.yml: {}", e));
+                        }
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("Failed to read environment.yml: {}", e));
+                }
+            }
+        }
+
+        // Re-bootstrap CRDT from environment.yml after changes
+        if !promoted.is_empty() || !errors.is_empty() {
+            if let Ok(env_config) = crate::project_file::parse_environment_yml(yml_path) {
+                let deps = env_config.dependencies;
+                let mut doc = room.doc.write().await;
+                doc.fork_and_merge(|fork| {
+                    let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
+                    let conda = snap.runt.conda.get_or_insert_with(|| {
+                        notebook_doc::metadata::CondaInlineMetadata {
+                            dependencies: Vec::new(),
+                            channels: Vec::new(),
+                            python: None,
+                        }
+                    });
+                    conda.dependencies = deps;
                     let _ = fork.set_metadata_snapshot(&snap);
                 });
             }
@@ -6412,7 +6810,7 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
         let sd = room.state_doc.read().await;
         sd.read_state().kernel.env_source.clone()
     };
-    if env_source == "pixi:toml" || env_source == "uv:pyproject" {
+    if env_source == "pixi:toml" || env_source == "uv:pyproject" || env_source == "conda:env_yml" {
         match promote_inline_deps_to_project(room, &env_source, &launched).await {
             Ok(promoted) if promoted.is_empty() => {
                 return NotebookResponse::SyncEnvironmentComplete {
@@ -11089,6 +11487,8 @@ mod tests {
             pixi_toml_deps: None,
             pixi_toml_path: None,
             pyproject_path: None,
+            environment_yml_path: None,
+            environment_yml_deps: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -11112,6 +11512,8 @@ mod tests {
             pixi_toml_deps: None,
             pixi_toml_path: None,
             pyproject_path: None,
+            environment_yml_path: None,
+            environment_yml_deps: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -11135,6 +11537,8 @@ mod tests {
             pixi_toml_deps: None,
             pixi_toml_path: None,
             pyproject_path: None,
+            environment_yml_path: None,
+            environment_yml_deps: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -11157,6 +11561,8 @@ mod tests {
             pixi_toml_deps: None,
             pixi_toml_path: None,
             pyproject_path: None,
+            environment_yml_path: None,
+            environment_yml_deps: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -11179,6 +11585,8 @@ mod tests {
             pixi_toml_deps: None,
             pixi_toml_path: None,
             pyproject_path: None,
+            environment_yml_path: None,
+            environment_yml_deps: None,
             deno_config: None,
             venv_path: None,
             python_path: None,

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -165,13 +165,10 @@ pub struct EnvironmentYmlConfig {
 
 /// Search standard conda env directories for an existing named environment.
 ///
-/// Checks in order:
-/// 1. `$CONDA_ENVS_DIRS` (colon-separated on Unix, semicolon on Windows)
-/// 2. `$CONDA_PREFIX/envs/`
-/// 3. `~/miniconda3/envs/`
-/// 4. `~/anaconda3/envs/`
-/// 5. `~/miniforge3/envs/`
-/// 6. `~/.conda/envs/`
+/// Checks `$CONDA_ENVS_DIRS`, `$CONDA_PREFIX/envs/`, `$MAMBA_ROOT_PREFIX/envs/`,
+/// common install locations (`~/miniconda3`, `~/anaconda3`, `~/miniforge3`),
+/// `~/.conda/envs/`, `~/.local/share/mamba/envs/` (micromamba default),
+/// and any parent dirs from `~/.conda/environments.txt` (conda env registry).
 ///
 /// Returns the first directory that contains `{dir}/{name}/bin/python` (or
 /// `{dir}/{name}/python.exe` on Windows).
@@ -245,36 +242,57 @@ pub fn resolve_conda_env_prefix(yml_path: &Path) -> Option<PathBuf> {
 fn conda_env_search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
+    let mut push_unique = |p: PathBuf| {
+        if !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    };
+
     // $CONDA_ENVS_DIRS (colon-separated on Unix, semicolon on Windows)
     if let Ok(envs_dirs) = std::env::var("CONDA_ENVS_DIRS") {
         let sep = if cfg!(windows) { ';' } else { ':' };
         for dir in envs_dirs.split(sep) {
             let p = PathBuf::from(dir.trim());
             if !p.as_os_str().is_empty() {
-                dirs.push(p);
+                push_unique(p);
             }
         }
     }
 
     // $CONDA_PREFIX/envs/
     if let Ok(prefix) = std::env::var("CONDA_PREFIX") {
-        let p = PathBuf::from(prefix).join("envs");
-        if !dirs.contains(&p) {
-            dirs.push(p);
-        }
+        push_unique(PathBuf::from(prefix).join("envs"));
     }
 
-    // Common conda installations
+    // $MAMBA_ROOT_PREFIX/envs/ (micromamba)
+    if let Ok(prefix) = std::env::var("MAMBA_ROOT_PREFIX") {
+        push_unique(PathBuf::from(prefix).join("envs"));
+    }
+
+    // Common conda/mamba installations
     if let Some(home) = dirs::home_dir() {
         for name in ["miniconda3", "anaconda3", "miniforge3"] {
-            let p = home.join(name).join("envs");
-            if !dirs.contains(&p) {
-                dirs.push(p);
-            }
+            push_unique(home.join(name).join("envs"));
         }
-        let dotconda = home.join(".conda").join("envs");
-        if !dirs.contains(&dotconda) {
-            dirs.push(dotconda);
+        push_unique(home.join(".conda").join("envs"));
+        // micromamba default location
+        push_unique(home.join(".local").join("share").join("mamba").join("envs"));
+    }
+
+    // ~/.conda/environments.txt — conda's env registry, lists full paths to envs.
+    // Extract parent dirs (the "envs/" directories) from each registered env path.
+    if let Some(home) = dirs::home_dir() {
+        let registry = home.join(".conda").join("environments.txt");
+        if let Ok(content) = std::fs::read_to_string(&registry) {
+            for line in content.lines() {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    let env_path = PathBuf::from(trimmed);
+                    if let Some(parent) = env_path.parent() {
+                        push_unique(parent.to_path_buf());
+                    }
+                }
+            }
         }
     }
 

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -149,6 +149,150 @@ pub fn pixi_toml_has_ipykernel(path: &Path) -> bool {
     false
 }
 
+/// Minimal environment.yml parse result for the daemon.
+///
+/// Only extracts what the daemon needs: dependency names, channels, python version.
+/// The full YAML parser lives in `crates/notebook/src/environment_yml.rs` (Tauri side).
+#[derive(Debug, Clone)]
+pub struct EnvironmentYmlConfig {
+    pub dependencies: Vec<String>,
+    pub channels: Vec<String>,
+    pub python: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Parse an environment.yml file with a line-based parser (no serde_yaml dep).
+///
+/// Handles the common structure:
+/// ```yaml
+/// name: myenv
+/// channels:
+///   - conda-forge
+/// dependencies:
+///   - numpy=1.24
+///   - pandas
+///   - python=3.11
+///   - pip:
+///     - requests
+/// ```
+pub fn parse_environment_yml(path: &Path) -> Result<EnvironmentYmlConfig, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {:?}: {}", path, e))?;
+    parse_environment_yml_content(&content)
+}
+
+/// Parse environment.yml content (testable without filesystem).
+fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, String> {
+    let mut name = None;
+    let mut channels = Vec::new();
+    let mut dependencies = Vec::new();
+    let mut python = None;
+
+    #[derive(PartialEq)]
+    enum Section {
+        None,
+        Channels,
+        Dependencies,
+        Pip, // inside dependencies: pip: sub-list
+    }
+    let mut section = Section::None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Skip empty lines and comments
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Top-level keys (no leading whitespace)
+        if !line.starts_with(' ') && !line.starts_with('\t') {
+            if let Some(val) = trimmed.strip_prefix("name:") {
+                name = Some(val.trim().trim_matches('"').trim_matches('\'').to_string());
+                section = Section::None;
+            } else if trimmed == "channels:" {
+                section = Section::Channels;
+            } else if trimmed == "dependencies:" {
+                section = Section::Dependencies;
+            } else {
+                section = Section::None;
+            }
+            continue;
+        }
+
+        // Indented content (list items)
+        match section {
+            Section::Channels => {
+                if let Some(item) = trimmed.strip_prefix("- ") {
+                    channels.push(item.trim().trim_matches('"').trim_matches('\'').to_string());
+                } else if !trimmed.starts_with('-') {
+                    section = Section::None;
+                }
+            }
+            Section::Dependencies => {
+                if trimmed == "- pip:" {
+                    section = Section::Pip;
+                } else if let Some(item) = trimmed.strip_prefix("- ") {
+                    let dep = item.trim().trim_matches('"').trim_matches('\'').to_string();
+                    // Check if this is the python dep
+                    let pkg_name = dep.split(['=', '>', '<', '!', ' ']).next().unwrap_or("");
+                    if pkg_name == "python" {
+                        // Extract version
+                        let version_part = dep
+                            .trim_start_matches("python")
+                            .trim_start_matches(">=")
+                            .trim_start_matches("<=")
+                            .trim_start_matches("==")
+                            .trim_start_matches('=')
+                            .trim_start_matches('>')
+                            .trim_start_matches('<')
+                            .trim();
+                        if !version_part.is_empty() {
+                            let first = version_part.split(',').next().unwrap_or(version_part);
+                            let cleaned = first.trim_end_matches(".*");
+                            let parts: Vec<&str> = cleaned.split('.').collect();
+                            if parts.len() >= 2 {
+                                python = Some(format!("{}.{}", parts[0], parts[1]));
+                            } else if !parts.is_empty() && !parts[0].is_empty() {
+                                python = Some(parts[0].to_string());
+                            }
+                        }
+                    } else {
+                        dependencies.push(dep);
+                    }
+                } else if !trimmed.starts_with('-') && !trimmed.starts_with("pip:") {
+                    section = Section::None;
+                }
+            }
+            Section::Pip => {
+                // Skip pip deps for now — they'd need uv/pip to install
+                if let Some(_item) = trimmed.strip_prefix("- ") {
+                    // pip deps are not supported in conda:env_yml yet
+                } else if !trimmed.starts_with('-') {
+                    section = Section::Dependencies;
+                    // Re-process the line in case it's a new dependency
+                    if let Some(item) = trimmed.strip_prefix("- ") {
+                        let dep = item.trim().trim_matches('"').trim_matches('\'').to_string();
+                        dependencies.push(dep);
+                    }
+                }
+            }
+            Section::None => {}
+        }
+    }
+
+    if channels.is_empty() {
+        channels.push("defaults".to_string());
+    }
+
+    Ok(EnvironmentYmlConfig {
+        dependencies,
+        channels,
+        python,
+        name,
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -298,5 +442,53 @@ mod tests {
             "[project]\nname = \"test\"\n\n[tool.pixi.dependencies]\nipykernel = \"*\"\nnumpy = \"*\"\n",
         );
         assert!(pixi_toml_has_ipykernel(&temp.path().join("pyproject.toml")));
+    }
+
+    #[test]
+    fn test_parse_env_yml_basic() {
+        let content = "name: myenv\nchannels:\n  - conda-forge\ndependencies:\n  - numpy=1.24\n  - pandas\n  - python=3.11\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.name, Some("myenv".to_string()));
+        assert_eq!(config.channels, vec!["conda-forge"]);
+        assert_eq!(config.dependencies, vec!["numpy=1.24", "pandas"]);
+        assert_eq!(config.python, Some("3.11".to_string()));
+    }
+
+    #[test]
+    fn test_parse_env_yml_with_pip() {
+        let content = "name: test\nchannels:\n  - conda-forge\n  - defaults\ndependencies:\n  - numpy\n  - pip:\n    - requests\n    - flask\n  - scipy\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.channels, vec!["conda-forge", "defaults"]);
+        // pip deps are skipped, scipy after pip block should still be captured
+        assert!(config.dependencies.contains(&"numpy".to_string()));
+    }
+
+    #[test]
+    fn test_parse_env_yml_no_channels() {
+        let content = "name: test\ndependencies:\n  - numpy\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.channels, vec!["defaults"]);
+        assert_eq!(config.dependencies, vec!["numpy"]);
+    }
+
+    #[test]
+    fn test_parse_env_yml_python_version_extraction() {
+        let content = "dependencies:\n  - python>=3.9,<4\n  - numpy\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.python, Some("3.9".to_string()));
+        assert_eq!(config.dependencies, vec!["numpy"]);
+    }
+
+    #[test]
+    fn test_parse_env_yml_from_file() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "environment.yml",
+            "name: analysis\nchannels:\n  - conda-forge\ndependencies:\n  - numpy\n  - pandas\n",
+        );
+        let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
+        assert_eq!(config.name, Some("analysis".to_string()));
+        assert_eq!(config.dependencies, vec!["numpy", "pandas"]);
     }
 }

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -335,6 +335,7 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
         Pip, // inside dependencies: pip: sub-list
     }
     let mut section = Section::None;
+    let mut pip_indent = 0usize;
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -365,6 +366,14 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
             continue;
         }
 
+        // Exit pip subsection when indent returns to dependency level
+        if section == Section::Pip {
+            let indent = line.len() - line.trim_start().len();
+            if indent <= pip_indent {
+                section = Section::Dependencies;
+            }
+        }
+
         // Indented content (list items)
         match section {
             Section::Channels => {
@@ -376,6 +385,7 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
             }
             Section::Dependencies => {
                 if trimmed == "- pip:" {
+                    pip_indent = line.len() - line.trim_start().len();
                     section = Section::Pip;
                 } else if let Some(item) = trimmed.strip_prefix("- ") {
                     let dep = item.trim().trim_matches('"').trim_matches('\'').to_string();
@@ -410,17 +420,7 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
                 }
             }
             Section::Pip => {
-                // Skip pip deps for now — they'd need uv/pip to install
-                if let Some(_item) = trimmed.strip_prefix("- ") {
-                    // pip deps are not supported in conda:env_yml yet
-                } else if !trimmed.starts_with('-') {
-                    section = Section::Dependencies;
-                    // Re-process the line in case it's a new dependency
-                    if let Some(item) = trimmed.strip_prefix("- ") {
-                        let dep = item.trim().trim_matches('"').trim_matches('\'').to_string();
-                        dependencies.push(dep);
-                    }
-                }
+                // Pip sub-items at deeper indent — skip (not supported in conda:env_yml yet)
             }
             Section::None => {}
         }
@@ -605,8 +605,16 @@ mod tests {
         let content = "name: test\nchannels:\n  - conda-forge\n  - defaults\ndependencies:\n  - numpy\n  - pip:\n    - requests\n    - flask\n  - scipy\n";
         let config = parse_environment_yml_content(content).unwrap();
         assert_eq!(config.channels, vec!["conda-forge", "defaults"]);
-        // pip deps are skipped, scipy after pip block should still be captured
-        assert!(config.dependencies.contains(&"numpy".to_string()));
+        // pip deps are skipped, conda deps after pip block must still be captured
+        assert_eq!(config.dependencies, vec!["numpy", "scipy"]);
+    }
+
+    #[test]
+    fn test_parse_env_yml_pip_then_multiple_conda_deps() {
+        let content = "name: test\ndependencies:\n  - numpy\n  - pip:\n    - requests\n    - flask\n  - scipy\n  - matplotlib\n  - python=3.11\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.dependencies, vec!["numpy", "scipy", "matplotlib"]);
+        assert_eq!(config.python, Some("3.11".to_string()));
     }
 
     #[test]

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -159,6 +159,126 @@ pub struct EnvironmentYmlConfig {
     pub channels: Vec<String>,
     pub python: Option<String>,
     pub name: Option<String>,
+    /// Explicit prefix path from `prefix:` field (alternative to `name:`).
+    pub prefix: Option<PathBuf>,
+}
+
+/// Search standard conda env directories for an existing named environment.
+///
+/// Checks in order:
+/// 1. `$CONDA_ENVS_DIRS` (colon-separated on Unix, semicolon on Windows)
+/// 2. `$CONDA_PREFIX/envs/`
+/// 3. `~/miniconda3/envs/`
+/// 4. `~/anaconda3/envs/`
+/// 5. `~/miniforge3/envs/`
+/// 6. `~/.conda/envs/`
+///
+/// Returns the first directory that contains `{dir}/{name}/bin/python` (or
+/// `{dir}/{name}/python.exe` on Windows).
+pub fn find_named_conda_env(name: &str) -> Option<PathBuf> {
+    let candidates = conda_env_search_dirs();
+    for dir in &candidates {
+        let env_path = dir.join(name);
+        let python = conda_python_path(&env_path);
+        if python.exists() {
+            return Some(env_path);
+        }
+    }
+    None
+}
+
+/// Return the default directory for creating new named conda environments.
+///
+/// Uses the first writable directory from the search order. Falls back to
+/// `~/.conda/envs/` if nothing else is available.
+pub fn default_conda_envs_dir() -> PathBuf {
+    let candidates = conda_env_search_dirs();
+    for dir in &candidates {
+        if dir.exists() && dir.is_dir() {
+            // Check if writable by attempting to read dir
+            if std::fs::read_dir(dir).is_ok() {
+                return dir.clone();
+            }
+        }
+    }
+    // Fallback: ~/.conda/envs/
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".conda")
+        .join("envs")
+}
+
+/// Get the python path within a conda prefix.
+pub fn conda_python_path(prefix: &Path) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        prefix.join("python.exe")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        prefix.join("bin").join("python")
+    }
+}
+
+/// Resolve the conda prefix for an environment.yml file.
+///
+/// If the yaml has `prefix:` → use that path directly.
+/// If the yaml has `name:` → search standard conda env dirs for it.
+/// Returns `None` if neither is set or no matching env is found.
+pub fn resolve_conda_env_prefix(yml_path: &Path) -> Option<PathBuf> {
+    let config = parse_environment_yml(yml_path).ok()?;
+
+    // prefix: takes precedence — it's an explicit path
+    if let Some(ref prefix) = config.prefix {
+        return Some(prefix.clone());
+    }
+
+    // name: — search standard conda env directories
+    if let Some(ref name) = config.name {
+        return find_named_conda_env(name);
+    }
+
+    None
+}
+
+/// Standard conda environment search directories.
+fn conda_env_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    // $CONDA_ENVS_DIRS (colon-separated on Unix, semicolon on Windows)
+    if let Ok(envs_dirs) = std::env::var("CONDA_ENVS_DIRS") {
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        for dir in envs_dirs.split(sep) {
+            let p = PathBuf::from(dir.trim());
+            if !p.as_os_str().is_empty() {
+                dirs.push(p);
+            }
+        }
+    }
+
+    // $CONDA_PREFIX/envs/
+    if let Ok(prefix) = std::env::var("CONDA_PREFIX") {
+        let p = PathBuf::from(prefix).join("envs");
+        if !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    }
+
+    // Common conda installations
+    if let Some(home) = dirs::home_dir() {
+        for name in ["miniconda3", "anaconda3", "miniforge3"] {
+            let p = home.join(name).join("envs");
+            if !dirs.contains(&p) {
+                dirs.push(p);
+            }
+        }
+        let dotconda = home.join(".conda").join("envs");
+        if !dirs.contains(&dotconda) {
+            dirs.push(dotconda);
+        }
+    }
+
+    dirs
 }
 
 /// Parse an environment.yml file with a line-based parser (no serde_yaml dep).
@@ -184,6 +304,7 @@ pub fn parse_environment_yml(path: &Path) -> Result<EnvironmentYmlConfig, String
 /// Parse environment.yml content (testable without filesystem).
 fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, String> {
     let mut name = None;
+    let mut prefix = None;
     let mut channels = Vec::new();
     let mut dependencies = Vec::new();
     let mut python = None;
@@ -209,6 +330,12 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
         if !line.starts_with(' ') && !line.starts_with('\t') {
             if let Some(val) = trimmed.strip_prefix("name:") {
                 name = Some(val.trim().trim_matches('"').trim_matches('\'').to_string());
+                section = Section::None;
+            } else if let Some(val) = trimmed.strip_prefix("prefix:") {
+                let p = val.trim().trim_matches('"').trim_matches('\'');
+                if !p.is_empty() {
+                    prefix = Some(PathBuf::from(p));
+                }
                 section = Section::None;
             } else if trimmed == "channels:" {
                 section = Section::Channels;
@@ -290,6 +417,7 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
         channels,
         python,
         name,
+        prefix,
     })
 }
 
@@ -490,5 +618,42 @@ mod tests {
         let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
         assert_eq!(config.name, Some("analysis".to_string()));
         assert_eq!(config.dependencies, vec!["numpy", "pandas"]);
+    }
+
+    #[test]
+    fn test_parse_env_yml_with_prefix() {
+        let content = "prefix: /opt/conda/envs/myproject\nchannels:\n  - conda-forge\ndependencies:\n  - numpy\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(
+            config.prefix,
+            Some(PathBuf::from("/opt/conda/envs/myproject"))
+        );
+        assert!(config.name.is_none());
+        assert_eq!(config.dependencies, vec!["numpy"]);
+    }
+
+    #[test]
+    fn test_parse_env_yml_name_and_prefix() {
+        // When both are present, both should be parsed (prefix takes precedence at resolution)
+        let content = "name: myenv\nprefix: /custom/path\ndependencies:\n  - scipy\n";
+        let config = parse_environment_yml_content(content).unwrap();
+        assert_eq!(config.name, Some("myenv".to_string()));
+        assert_eq!(config.prefix, Some(PathBuf::from("/custom/path")));
+    }
+
+    #[test]
+    fn test_find_named_conda_env_not_found() {
+        // A nonsense name should not be found
+        assert!(find_named_conda_env("__nonexistent_env_abc123__").is_none());
+    }
+
+    #[test]
+    fn test_conda_python_path() {
+        let prefix = PathBuf::from("/opt/conda/envs/test");
+        let python = conda_python_path(&prefix);
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(python, PathBuf::from("/opt/conda/envs/test/bin/python"));
+        #[cfg(target_os = "windows")]
+        assert_eq!(python, PathBuf::from("/opt/conda/envs/test/python.exe"));
     }
 }

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -299,20 +299,10 @@ fn conda_env_search_dirs() -> Vec<PathBuf> {
     dirs
 }
 
-/// Parse an environment.yml file with a line-based parser (no serde_yaml dep).
+/// Parse an environment.yml file using rattler's serde_yaml parser.
 ///
-/// Handles the common structure:
-/// ```yaml
-/// name: myenv
-/// channels:
-///   - conda-forge
-/// dependencies:
-///   - numpy=1.24
-///   - pandas
-///   - python=3.11
-///   - pip:
-///     - requests
-/// ```
+/// Handles the full environment.yml spec including pip subsections, proper
+/// YAML syntax validation, and MatchSpec parsing.
 pub fn parse_environment_yml(path: &Path) -> Result<EnvironmentYmlConfig, String> {
     let content =
         std::fs::read_to_string(path).map_err(|e| format!("Failed to read {:?}: {}", path, e))?;
@@ -321,121 +311,61 @@ pub fn parse_environment_yml(path: &Path) -> Result<EnvironmentYmlConfig, String
 
 /// Parse environment.yml content (testable without filesystem).
 fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, String> {
-    let mut name = None;
-    let mut prefix = None;
-    let mut channels = Vec::new();
+    use rattler_conda_types::EnvironmentYaml;
+
+    let env = EnvironmentYaml::from_yaml_str(content)
+        .map_err(|e| format!("Failed to parse environment.yml: {}", e))?;
+
     let mut dependencies = Vec::new();
     let mut python = None;
 
-    #[derive(PartialEq)]
-    enum Section {
-        None,
-        Channels,
-        Dependencies,
-        Pip, // inside dependencies: pip: sub-list
-    }
-    let mut section = Section::None;
-    let mut pip_indent = 0usize;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Skip empty lines and comments
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-
-        // Top-level keys (no leading whitespace)
-        if !line.starts_with(' ') && !line.starts_with('\t') {
-            if let Some(val) = trimmed.strip_prefix("name:") {
-                name = Some(val.trim().trim_matches('"').trim_matches('\'').to_string());
-                section = Section::None;
-            } else if let Some(val) = trimmed.strip_prefix("prefix:") {
-                let p = val.trim().trim_matches('"').trim_matches('\'');
-                if !p.is_empty() {
-                    prefix = Some(PathBuf::from(p));
-                }
-                section = Section::None;
-            } else if trimmed == "channels:" {
-                section = Section::Channels;
-            } else if trimmed == "dependencies:" {
-                section = Section::Dependencies;
-            } else {
-                section = Section::None;
+    for spec in env.match_specs() {
+        let name = match &spec.name {
+            rattler_conda_types::PackageNameMatcher::Exact(name) => {
+                name.as_normalized().to_string()
             }
-            continue;
-        }
+            _ => String::new(),
+        };
 
-        // Exit pip subsection when indent returns to dependency level
-        if section == Section::Pip {
-            let indent = line.len() - line.trim_start().len();
-            if indent <= pip_indent {
-                section = Section::Dependencies;
-            }
-        }
-
-        // Indented content (list items)
-        match section {
-            Section::Channels => {
-                if let Some(item) = trimmed.strip_prefix("- ") {
-                    channels.push(item.trim().trim_matches('"').trim_matches('\'').to_string());
-                } else if !trimmed.starts_with('-') {
-                    section = Section::None;
+        if name == "python" {
+            // Extract major.minor version from the version spec
+            if let Some(ref version_spec) = spec.version {
+                let v = version_spec.to_string();
+                // Parse first version bound (e.g. ">=3.9,<4" → "3.9")
+                let cleaned = v
+                    .trim_start_matches(">=")
+                    .trim_start_matches("<=")
+                    .trim_start_matches("==")
+                    .trim_start_matches('=')
+                    .trim_start_matches('>')
+                    .trim_start_matches('<');
+                let first = cleaned.split(',').next().unwrap_or(cleaned);
+                let first = first.trim_end_matches(".*");
+                let parts: Vec<&str> = first.split('.').collect();
+                if parts.len() >= 2 {
+                    python = Some(format!("{}.{}", parts[0], parts[1]));
+                } else if !parts.is_empty() && !parts[0].is_empty() {
+                    python = Some(parts[0].to_string());
                 }
             }
-            Section::Dependencies => {
-                if trimmed == "- pip:" {
-                    pip_indent = line.len() - line.trim_start().len();
-                    section = Section::Pip;
-                } else if let Some(item) = trimmed.strip_prefix("- ") {
-                    let dep = item.trim().trim_matches('"').trim_matches('\'').to_string();
-                    // Check if this is the python dep
-                    let pkg_name = dep.split(['=', '>', '<', '!', ' ']).next().unwrap_or("");
-                    if pkg_name == "python" {
-                        // Extract version
-                        let version_part = dep
-                            .trim_start_matches("python")
-                            .trim_start_matches(">=")
-                            .trim_start_matches("<=")
-                            .trim_start_matches("==")
-                            .trim_start_matches('=')
-                            .trim_start_matches('>')
-                            .trim_start_matches('<')
-                            .trim();
-                        if !version_part.is_empty() {
-                            let first = version_part.split(',').next().unwrap_or(version_part);
-                            let cleaned = first.trim_end_matches(".*");
-                            let parts: Vec<&str> = cleaned.split('.').collect();
-                            if parts.len() >= 2 {
-                                python = Some(format!("{}.{}", parts[0], parts[1]));
-                            } else if !parts.is_empty() && !parts[0].is_empty() {
-                                python = Some(parts[0].to_string());
-                            }
-                        }
-                    } else {
-                        dependencies.push(dep);
-                    }
-                } else if !trimmed.starts_with('-') && !trimmed.starts_with("pip:") {
-                    section = Section::None;
-                }
-            }
-            Section::Pip => {
-                // Pip sub-items at deeper indent — skip (not supported in conda:env_yml yet)
-            }
-            Section::None => {}
+        } else if !name.is_empty() {
+            // Convert MatchSpec back to the original string form for downstream consumers
+            dependencies.push(spec.to_string());
         }
     }
 
-    if channels.is_empty() {
-        channels.push("defaults".to_string());
-    }
+    let channels: Vec<String> = if env.channels.is_empty() {
+        vec!["defaults".to_string()]
+    } else {
+        env.channels.iter().map(|c| c.to_string()).collect()
+    };
 
     Ok(EnvironmentYmlConfig {
         dependencies,
         channels,
         python,
-        name,
-        prefix,
+        name: env.name,
+        prefix: env.prefix,
     })
 }
 
@@ -596,7 +526,8 @@ mod tests {
         let config = parse_environment_yml_content(content).unwrap();
         assert_eq!(config.name, Some("myenv".to_string()));
         assert_eq!(config.channels, vec!["conda-forge"]);
-        assert_eq!(config.dependencies, vec!["numpy=1.24", "pandas"]);
+        // rattler normalizes conda `=` pin: numpy=1.24 → numpy 1.24.*
+        assert_eq!(config.dependencies, vec!["numpy 1.24.*", "pandas"]);
         assert_eq!(config.python, Some("3.11".to_string()));
     }
 
@@ -665,6 +596,13 @@ mod tests {
         let config = parse_environment_yml_content(content).unwrap();
         assert_eq!(config.name, Some("myenv".to_string()));
         assert_eq!(config.prefix, Some(PathBuf::from("/custom/path")));
+    }
+
+    #[test]
+    fn test_parse_env_yml_rejects_malformed_yaml() {
+        // Malformed YAML must return Err, not silently produce an empty config
+        let content = "dependencies:\n  - numpy\n  invalid: [yaml: {{broken";
+        assert!(parse_environment_yml_content(content).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- When a notebook is near an `environment.yml` / `environment.yaml`, detect the `name:` field and find or create the corresponding named conda env in standard conda directories — matching how conda itself works.
- Discover pre-existing envs across all standard locations: `$CONDA_ENVS_DIRS`, `$CONDA_PREFIX/envs/`, `$MAMBA_ROOT_PREFIX/envs/`, `~/miniconda3/envs/`, `~/anaconda3/envs/`, `~/miniforge3/envs/`, `~/.conda/envs/`, `~/.local/share/mamba/envs/`, plus any dirs registered in `~/.conda/environments.txt`.
- `prefix:` field in environment.yml is respected as a direct path override.
- Deps from environment.yml are merged with CRDT notebook deps (additive) before syncing into the env via rattler.
- `add_dependency(after="restart")` promotes new deps back into environment.yml.
- Drift detection compares current environment.yml deps against the launched baseline.
- Version constraints in `sync_dependencies` are respected by excluding constrained packages from the solver's locked_packages preference list.

## Files changed

| File | Change |
|------|--------|
| `project_file.rs` | `parse_environment_yml`, `find_named_conda_env`, `resolve_conda_env_prefix`, `conda_env_search_dirs` with micromamba/registry support, 9 tests |
| `notebook_sync_server.rs` | Pool gate, env preparation, `build_launched_config`, dep promotion, drift detection for `conda:env_yml` |
| `jupyter_kernel.rs` | Kernel launch arm for `conda:env_yml` with fallback resolution |
| `protocol.rs` | `environment_yml_path` and `environment_yml_deps` fields on `LaunchedEnvConfig` |
| `deps.rs` | `env_source` field in `get_dependencies` response |
| `conda.rs` | Locked packages filter for constrained specs in `sync_dependencies` |

## Test plan

- [x] 4/4 conda gremlin suites pass (conda-sequential, conda-lifecycle, conda-conflict, conda-prebuilt)
- [x] `create_notebook(package_manager="conda")` near an environment.yaml resolves to `conda:env_yml`
- [x] Named env discovery finds envs in `~/.conda/envs/` and `~/.local/share/mamba/envs/`
- [x] Env creation via rattler when named env doesn't exist yet
- [x] `add_dependency(after="restart")` installs into the named env and promotes to environment.yml
- [ ] Manual test with `prefix:` field in environment.yml
- [ ] Existing conda:inline and conda:prewarmed paths unaffected (regression)