### PR TITLE
chore(release): bump to 2.2.0 + add dx to PyPI publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,9 +1,10 @@
-# Build and publish Python packages (runtimed + nteract).
+# Build and publish Python packages (runtimed + nteract + dx).
 #
 # runtimed: PyO3 bindings for the daemon client, bundles the runtimed binary.
 # nteract: Pure-Python MCP server that depends on runtimed.
+# dx:      Pure-Python data-experience library (kernel-side display helpers).
 #
-# To publish: push a tag matching `python-v*` (e.g. `python-v0.1.0`).
+# To publish: push a tag matching `python-v*` (e.g. `python-v2.2.0`).
 
 name: Python Package
 
@@ -44,6 +45,7 @@ jobs:
               - 'pyproject.toml'
               - 'python/runtimed/**'
               - 'python/nteract/**'
+              - 'python/dx/**'
               - 'python/gremlin/**'
               - 'python/prewarm/**'
               - 'crates/runtimed-py/**'
@@ -83,10 +85,10 @@ jobs:
         run: uv sync
 
       - name: Ruff check
-        run: uv run ruff check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/prewarm/src/ python/prewarm/tests/
+        run: uv run ruff check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/dx/src/ python/dx/tests/ python/prewarm/src/ python/prewarm/tests/
 
       - name: Ruff format check
-        run: uv run ruff format --check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/prewarm/src/ python/prewarm/tests/
+        run: uv run ruff format --check --config pyproject.toml python/nteract/src/ python/runtimed/src/ python/runtimed/tests/ python/dx/src/ python/dx/tests/ python/prewarm/src/ python/prewarm/tests/
 
       - name: Type check
         run: uv run ty check python/
@@ -94,6 +96,9 @@ jobs:
       - name: Run runtimed-py unit tests
         working-directory: python/runtimed
         run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
+
+      - name: Run dx unit tests
+        run: uv run pytest python/dx/tests/ -v --tb=short
 
       - name: Run prewarm unit tests
         run: |
@@ -276,11 +281,48 @@ jobs:
           name: nteract-dist
           path: dist
 
+  dx-build:
+    name: Build dx sdist + wheel
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Set dev version
+        run: |
+          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAJOR_MINOR="${CURRENT_VERSION%.*}"
+          PATCH="${CURRENT_VERSION##*.}"
+          NEXT_PATCH=$((PATCH + 1))
+          TIMESTAMP=$(date -u +%Y%m%d%H%M)
+          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
+          echo "Setting dx version to: ${DEV_VERSION}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+        working-directory: python/dx
+
+      - name: Build
+        run: uv build --no-sources
+        working-directory: python/dx
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dx-dist
+          path: dist
+
   release:
     name: Release
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [macos, linux, nteract-build]
+    needs: [macos, linux, nteract-build, dx-build]
     permissions:
       id-token: write
       contents: write
@@ -302,6 +344,9 @@ jobs:
       - name: Publish nteract to PyPI
         run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/nteract/ 'nteract-dist/*'
 
+      - name: Publish dx to PyPI
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/dx/ 'dx-dist/*'
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -310,5 +355,6 @@ jobs:
           files: |
             wheels-*/*
             nteract-dist/*
+            dx-dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6782,7 +6782,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -6967,7 +6967,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.1.3"
+version = "2.2.0"
 dependencies = [
  "kernel-env",
  "log",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.1.3"
+version = "2.2.0"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.1.3"
+version = "2.2.0"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.1.3"
+version = "2.2.0"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.1.3"
+version = "2.2.0"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.1.3"
+version = "2.2.0"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.1.3"
+version = "2.2.0"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.1.3"
+version = "2.2.0"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- Bump core packages to **2.2.0**: `runtimed`, `runt`, `runtimed-client`, `runtimed-py`, `notebook` (Cargo) and `nteract`, `runtimed` (Python).
- Keep `python/dx` at **2.0.0** — its own version line; first release of the rewritten library (1.4.0 was the last Noteable-era release).
- Wire `dx` into the existing `.github/workflows/python-package.yml`:
  - Added `python/dx/**` to the path filter so dx changes trigger CI.
  - dx ruff + format checks alongside nteract / runtimed / prewarm.
  - dx unit tests run in the lint-and-test job.
  - New `dx-build` job mirrors `nteract-build` (hatchling sdist + wheel, same dev-version stamping pattern on tag push).
  - `release` job now depends on `dx-build` and publishes dx to PyPI + attaches the artifact to the GitHub Release.

`Cargo.lock` updated by `cargo check` for the version bumps.

## Test plan

- [x] `cargo check -p runtimed -p runt-cli -p runtimed-client -p runtimed-py -p notebook` — clean compile at 2.2.0.
- [x] `cargo xtask lint` clean.
- [x] `uv run --package dx pytest python/dx/tests` — 35/35 pass.
- [x] `uv run ty check python/` clean.
- [x] CI Python Package workflow exercises the new path filter + dx ruff/format/tests on this PR.
- [ ] When a `python-v2.2.0` tag is pushed, verify `dx-build` artifact gets uploaded and dx is published to PyPI alongside runtimed + nteract.