### PR TITLE
docs: blob GC correctness + ipynb save without base64 (two specs)

### DIFF
--- a/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
+++ b/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
@@ -1,0 +1,66 @@
+# Blob GC correctness
+
+**Status:** Design
+**Date:** 2026-04-14
+**Related:** #1762 (dx), [spec: ipynb save without base64 inlining](./2026-04-14-ipynb-save-blob-refs-design.md)
+
+## Motivation
+
+The blob-store GC (`crates/runtimed/src/daemon.rs`, ~lines 2591–2700) runs every 30 minutes, marks blobs referenced by active rooms, and sweeps everything else older than 1 hour. Two scenarios can delete a blob that is still semantically in use:
+
+- **A. Close + reopen within the GC window.** A user opens an untitled notebook with a parquet output, closes it (room evicted from `notebook_rooms` after 30s). 1 hour later the GC finds no active reference, deletes the blob. The persisted `notebook-docs/{hash}.automerge` file still exists (24 h retention), but its refs aren't walked. Reopen between hour 1 and hour 24 → blob URLs 404 → rich output lost.
+- **F. Daemon restart before any client reconnects.** Daemon restarts, `notebook_rooms` is empty, first GC pass within 30 min sees zero refs and deletes every blob older than 1 hour.
+
+Once [`.ipynb` save switches to blob refs](./2026-04-14-ipynb-save-blob-refs-design.md), scenario A extends to saved-and-closed notebooks as well — not just untitled ones. The same GC scan that was merely an optimization becomes a correctness dependency.
+
+## Non-goals
+
+- Walking arbitrary `.ipynb` files anywhere on the user filesystem. The daemon doesn't own the user's filesystem; we can't discover every saved notebook.
+- A persistent reference-count in the blob metadata. Too invasive for what's effectively a correctness patch on the existing mark-and-sweep loop.
+- Changing the GC cadence (stays at 30 minutes).
+
+## Changes
+
+Three small changes to the GC loop in `crates/runtimed/src/daemon.rs`:
+
+### 1. Refuse to sweep when `notebook_rooms` is empty
+
+```rust
+if room_arcs.is_empty() {
+    info!("[runtimed] GC: 0 active rooms; skipping sweep this cycle");
+} else {
+    // existing mark + sweep
+}
+```
+
+Zero active rooms is a classic fail-open scenario: either every notebook is genuinely closed (safe to sweep) or the daemon just started and hasn't loaded refs yet (unsafe). The two are indistinguishable at this layer, so err toward keeping data. The cost is at most one extra GC cycle of staleness on a truly idle daemon — not a problem.
+
+### 2. Walk `notebook-docs/*.automerge` in the mark phase
+
+The daemon owns `config.notebook_docs_dir`. Files there (emergency persist + re-open state for untitled notebooks) contain `RuntimeStateDoc` references we currently ignore.
+
+Add a mark pass that opens each `.automerge` file, reads its `RuntimeStateDoc`, and calls the existing `collect_blob_hashes` / `collect_blob_hashes_recursive` helpers on its executions + comms. Skip files already represented by an active room (we already have their refs).
+
+Batched the same way the in-memory walk is: up to N docs per tick, `tokio::task::yield_now()` between batches. Reading `.automerge` files is I/O-bound; if it starves the loop we drop the batch size.
+
+### 3. Extend the blob grace period
+
+`blob_max_age` goes from **1 hour** to **30 days**. Rationale: after Spec 2 ships, saved-and-closed notebooks rely on the blob store surviving until they're reopened. A week-long vacation shouldn't eat someone's rich outputs. Disk is cheap; data loss isn't.
+
+Introduce a constant `BLOB_GC_GRACE_SECS` (default 30 * 24 * 3600) and, for dev flexibility, honor a `RUNTIMED_BLOB_GC_GRACE_SECS` env var override.
+
+## Out of scope / follow-ups
+
+- **Explicit purge CLI** (`runt daemon vacuum`) for users who want to reclaim disk aggressively. Nice to have; not this spec.
+- **Walking `.ipynb` files on disk.** When a `.ipynb` is loaded into a room, its refs land in the room's `RuntimeStateDoc` and the existing mark phase sees them. Closed saved notebooks are protected by the 30-day grace period instead. If that proves insufficient in practice, a later spec can add a "recent-save refs" manifest.
+
+## Testing
+
+- Unit: `collect_blob_hashes` already has coverage; add a test for the `walk_persisted_automerge_docs` helper with a fixture `.automerge` file containing a known blob ref.
+- Integration: write a `.automerge` file to a temp `notebook_docs_dir`, put a blob in a temp `blob_store`, run one GC cycle, assert the blob survives.
+- Integration: assert GC with zero active rooms is a no-op (no deletions).
+- Integration: bump the grace-period test constant to a short value (e.g., 2s) via env var, assert the sweep deletes blobs older than that when they're actually unreferenced.
+
+## Rollout
+
+Ship before Spec 2 (ipynb save without base64). Order matters: Spec 2 moves the "truth" of dx outputs into the blob store. Spec 1 makes the blob store robust enough to hold that truth.

--- a/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
+++ b/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
@@ -1,0 +1,122 @@
+# `.ipynb` save: external blob refs instead of base64 inlining
+
+**Status:** Design
+**Date:** 2026-04-14
+**Related:** #1762 (dx), [spec: blob GC correctness](./2026-04-14-blob-gc-correctness-design.md)
+
+## Motivation
+
+`dx.display(df)` pushes parquet through the IOPub `buffers` envelope to avoid base64'ing megabytes inside JSON on the wire. The save path then re-inlines those same bytes as base64 back into the `.ipynb`. A 100 MiB parquet becomes ~133 MiB of base64 on disk. Every save. That defeats most of dx's benefit for users who commit notebooks to git.
+
+The blob store already has the bytes; `.ipynb` should carry a reference, not a copy.
+
+## Shape
+
+Saved output bundles for anything resolved to a `ContentRef::Blob` that exceeds a size threshold emit the wire-format blob-ref MIME instead of a base64 string. Everything else is unchanged.
+
+Before (today):
+```json
+{
+  "output_type": "display_data",
+  "data": {
+    "application/vnd.apache.parquet": "<100 MiB of base64>",
+    "text/html": "<table>…</table>",
+    "text/plain": "…",
+    "text/llm+plain": "DataFrame (pandas): 148820 rows × 12 cols"
+  }
+}
+```
+
+After (Spec 2):
+```json
+{
+  "output_type": "display_data",
+  "data": {
+    "application/vnd.nteract.blob-ref+json": {
+      "hash": "sha256-…",
+      "content_type": "application/vnd.apache.parquet",
+      "size": 104857600
+    },
+    "text/html": "<table>…</table>",
+    "text/plain": "…",
+    "text/llm+plain": "DataFrame (pandas): 148820 rows × 12 cols"
+  }
+}
+```
+
+The original binary MIME key disappears; the ref-MIME takes its place. All non-binary MIMEs stay inline unchanged.
+
+Symmetry: this is the same shape dx emits on the IOPub wire. `create_manifest` already has a `BLOB_REF_MIME` branch that composes `ContentRef::Blob` under the wrapped `content_type` — so the load path works with zero changes.
+
+## Compatibility
+
+- **Vanilla Jupyter** (any host that doesn't know the ref MIME): the entry is skipped as unknown; frontends fall through to `text/html` / `text/plain`. For `dx.display(df)` the HTML table renders; for any custom binary display that lacked a fallback it renders as a missing output — same result as today if the base64 were corrupted or the host's renderer disabled.
+- **nteract reopen** (via daemon): `create_manifest` sees `BLOB_REF_MIME`, verifies the blob exists in the store, composes a `ContentRef::Blob`. If the blob is missing (different machine, GC'd past the grace period), the ref entry is dropped — the HTML fallback renders instead. No crash, no dangling reference in the inline manifest.
+- **`.ipynb` diffability**: storing hashes instead of 133 MiB of base64 makes diffs actually reviewable. Changing a DataFrame changes a hash, not a quarter-million-line textblob.
+
+## Threshold
+
+A size threshold governs the rewrite:
+
+- `content_ref.size >= REF_MIME_SAVE_THRESHOLD` → emit `BLOB_REF_MIME`.
+- Smaller → inline base64 as today.
+
+Rationale: small images (plot thumbnails, icons, small exports) are useful to ship self-contained. Large payloads (parquet, ML model dumps) are what we need to externalize. Default: **1 MiB**. Tunable via env var `RUNTIMED_REF_MIME_SAVE_THRESHOLD` for dev + edge cases.
+
+This preserves the "drop a `.ipynb` into any Jupyter host and it renders" promise for common cases (matplotlib PNGs are typically 10–300 KiB) while removing the parquet-in-JSON anti-pattern.
+
+## Implementation
+
+### Crate changes
+
+`crates/runtimed/src/output_store.rs::resolve_data_bundle` gets one new branch before the existing binary/json/text discrimination:
+
+```rust
+for (mime_type, content_ref) in data {
+    // Spec 2: large binary blobs get externalized as a ref-MIME entry
+    // instead of inline base64. See 2026-04-14-ipynb-save-blob-refs-design.md.
+    if is_binary_mime(mime_type) {
+        if let ContentRef::Blob { blob: hash, size } = content_ref {
+            if *size >= ref_mime_save_threshold() {
+                let ref_body = json!({
+                    "hash": hash,
+                    "content_type": mime_type,
+                    "size": size,
+                });
+                result.insert(BLOB_REF_MIME.to_string(), ref_body);
+                continue; // skip the inline-base64 branch below
+            }
+        }
+    }
+    // existing resolution (base64 / json / text) …
+}
+```
+
+`ref_mime_save_threshold()` reads `RUNTIMED_REF_MIME_SAVE_THRESHOLD` once (cached via `OnceLock`), defaults to 1 MiB.
+
+The function signature stays the same — no other caller changes.
+
+### Load path
+
+No code changes needed. `create_manifest`'s existing `BLOB_REF_MIME` branch (added in the dx PR) already handles the inverse: it reads the ref MIME from the bundle, verifies the hash via `BlobStore::exists`, composes `ContentRef::from_hash` under the wrapped `content_type`, and omits the ref MIME entry from the resolved manifest.
+
+### Tests
+
+- Unit in `output_store.rs`: `resolve_data_bundle` emits `BLOB_REF_MIME` for a binary `ContentRef::Blob` above the threshold; falls back to base64 below the threshold.
+- Round-trip: `create_manifest` of a manifest containing `BLOB_REF_MIME` → `resolve_manifest` with the threshold set low → `create_manifest` again. Hash is stable; manifest shape is idempotent.
+- Integration: `save_notebook_to_disk` on a cell with a large parquet produces a `.ipynb` whose parquet entry is a ref-MIME, not a base64 string. Reopening the notebook reconstructs a valid `ContentRef::Blob` pointing at the same blob.
+- Fixture update: the existing `test_save_notebook_to_disk_with_outputs` fixtures may need regeneration if any of their outputs cross the threshold. Audit.
+
+## Migration
+
+Not a migration — existing `.ipynb` files with base64-inlined binary outputs keep working on load (the normal `is_binary_mime` path reads base64 → decodes → stores in the blob store → composes `ContentRef::Blob`). Only new saves use the ref MIME path. Old files get progressively upgraded as users reopen and re-save them.
+
+## Dependencies
+
+- **Spec 1 (blob GC correctness)** must ship first, or concurrently. Saved `.ipynb` files now depend on the blob store surviving long enough for the user to reopen. The 30-day grace period and the persisted-automerge walk from Spec 1 are the safety net.
+
+## Rollout
+
+Land behind a feature gate? **No.** The change is internal: the save format is already a moving target, and the load path has been ref-MIME-aware since dx landed. No external consumer of the `.ipynb` format needs a migration window.
+
+Version bump: the save-path change doesn't warrant its own version; it rides whatever package version is being cut next.


### PR DESCRIPTION
Two design specs for storage correctness in the dx era. Implementation will land via separate PRs (one per spec, dispatched to worktree agents).

- `docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md` — fail-safe when zero rooms, walk persisted notebook-docs/*.automerge, extend grace from 1h to 30d.
- `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md` — large binary outputs save as `application/vnd.nteract.blob-ref+json` instead of base64; keeps small images inline for vanilla-Jupyter compat.

Spec 1 is a prerequisite for Spec 2 — once .ipynb holds refs instead of bytes, GC becomes a correctness dependency.