### PR TITLE
feat(runtimed): save ipynb with blob refs instead of base64 (spec 2)

### DIFF
--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -45,8 +45,6 @@
 
 use std::collections::HashMap;
 use std::io;
-#[cfg(not(test))]
-use std::sync::OnceLock;
 
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
@@ -56,38 +54,33 @@ use notebook_doc::mime::{is_binary_mime, BLOB_REF_MIME};
 
 use crate::blob_store::BlobStore;
 
-/// Default size threshold above which binary blobs are externalized as
+/// MIME types whose `ContentRef::Blob` outputs are externalized as
 /// [`BLOB_REF_MIME`] entries in saved `.ipynb` files instead of being
-/// re-inlined as base64. See the
-/// `2026-04-14-ipynb-save-blob-refs-design.md` spec for context.
-pub const DEFAULT_REF_MIME_SAVE_THRESHOLD: u64 = 1024 * 1024;
-
-/// Returns the threshold (in bytes) above which a binary `ContentRef::Blob`
-/// is rewritten as a [`BLOB_REF_MIME`] entry during save rather than
-/// base64-inlined.
+/// re-inlined as base64.
 ///
-/// Honors the `RUNTIMED_REF_MIME_SAVE_THRESHOLD` environment variable (for
-/// dev tuning + tests); otherwise defaults to
-/// [`DEFAULT_REF_MIME_SAVE_THRESHOLD`]. The parsed value is cached in a
-/// [`OnceLock`] on the first call in release builds — repeated reads are
-/// free. Tests (`cfg(test)`) skip the cache so the env var can be flipped
-/// between cases.
-fn ref_mime_save_threshold() -> u64 {
-    fn parse_env() -> u64 {
-        std::env::var("RUNTIMED_REF_MIME_SAVE_THRESHOLD")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(DEFAULT_REF_MIME_SAVE_THRESHOLD)
-    }
-    #[cfg(test)]
-    {
-        parse_env()
-    }
-    #[cfg(not(test))]
-    {
-        static CACHED: OnceLock<u64> = OnceLock::new();
-        *CACHED.get_or_init(parse_env)
-    }
+/// Tightly scoped on purpose. Images / PDFs / HTML keep their existing
+/// base64-inline behavior regardless of size — those are well-understood
+/// in `.ipynb` files and have no vanilla-Jupyter fallback path if we
+/// replaced them. We only externalize MIMEs that:
+///
+/// 1. Are nteract-specific and have a reasonable fallback elsewhere in
+///    the bundle (parquet ships alongside pandas `text/html` + `text/plain`).
+/// 2. Would otherwise blow up `.ipynb` size catastrophically (parquet
+///    exports can hit tens or hundreds of MiB).
+///
+/// Because this whitelist holds at most one entry per output bundle in
+/// practice (dx emits exactly one parquet ref per display), we can write
+/// the ref as a single `{hash, content_type, size}` object under the
+/// [`BLOB_REF_MIME`] key. nbformat's schema wouldn't accept an array
+/// there, so a whitelist-of-one is the right shape.
+///
+/// See `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md`.
+const REF_MIME_SAVE_WHITELIST: &[&str] = &["application/vnd.apache.parquet"];
+
+/// Returns true if a binary MIME type should be externalized as a
+/// [`BLOB_REF_MIME`] entry on save instead of base64-inlined.
+fn should_externalize_mime_on_save(mime_type: &str) -> bool {
+    REF_MIME_SAVE_WHITELIST.contains(&mime_type)
 }
 
 /// Default inlining threshold: 1 KB.
@@ -738,8 +731,8 @@ async fn convert_data_bundle(
 /// reads raw bytes from the blob store and base64-encodes them for the
 /// Jupyter nbformat representation (used when saving .ipynb to disk).
 ///
-/// Large binary blobs (size >= [`ref_mime_save_threshold`]) are
-/// externalized as [`BLOB_REF_MIME`] entries instead of being
+/// Whitelisted MIMEs ([`REF_MIME_SAVE_WHITELIST`] — currently parquet)
+/// are externalized as [`BLOB_REF_MIME`] entries instead of being
 /// re-inlined as base64. The original binary MIME key is dropped and
 /// replaced by a `BLOB_REF_MIME` → `{hash, content_type, size}` entry.
 /// See `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md`.
@@ -750,24 +743,21 @@ async fn resolve_data_bundle(
     blob_store: &BlobStore,
 ) -> io::Result<HashMap<String, Value>> {
     let mut result = HashMap::new();
-    let ref_threshold = ref_mime_save_threshold();
 
     for (mime_type, content_ref) in data {
-        // Spec 2: externalize large binary blobs as a BLOB_REF_MIME entry
-        // instead of re-inlining them as base64 in the .ipynb. Small
-        // binaries (plot thumbnails, icons) keep the legacy path for
-        // vanilla-Jupyter compatibility.
-        if is_binary_mime(mime_type) {
+        // Spec 2: externalize whitelisted binary blobs as a BLOB_REF_MIME
+        // entry instead of re-inlining them as base64 in the .ipynb.
+        // Non-whitelisted MIMEs (images, PDFs, HTML, audio, video) keep
+        // the legacy path so vanilla Jupyter renders them unchanged.
+        if should_externalize_mime_on_save(mime_type) {
             if let ContentRef::Blob { blob: hash, size } = content_ref {
-                if *size >= ref_threshold {
-                    let ref_body = json!({
-                        "hash": hash,
-                        "content_type": mime_type,
-                        "size": size,
-                    });
-                    result.insert(BLOB_REF_MIME.to_string(), ref_body);
-                    continue;
-                }
+                let ref_body = json!({
+                    "hash": hash,
+                    "content_type": mime_type,
+                    "size": size,
+                });
+                result.insert(BLOB_REF_MIME.to_string(), ref_body);
+                continue;
             }
         }
 
@@ -1519,49 +1509,14 @@ mod tests {
         assert!(!is_binary_mime("text/latex"));
     }
 
-    // ── Ref-MIME save threshold (Spec 2) ────────────────────────────
-    //
-    // These tests mutate the process env var, so they must run serially.
-
-    /// Guard that sets `RUNTIMED_REF_MIME_SAVE_THRESHOLD` for the
-    /// duration of a test and restores it on drop.
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: set_var is unsafe in edition 2024. The surrounding
-            // test is serialized via `#[serial]`, so no other thread
-            // reads this env var concurrently.
-            unsafe { std::env::set_var(key, value) };
-            EnvGuard { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: same serialization guarantee as `set`.
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var(self.key, v),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
+    // ── Ref-MIME save whitelist (Spec 2) ────────────────────────────
 
     #[tokio::test]
-    #[serial_test::serial]
-    async fn test_resolve_data_bundle_emits_blob_ref_for_large_binary() {
+    async fn test_resolve_data_bundle_emits_blob_ref_for_whitelisted_mime() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);
-        // Tiny threshold forces the ref-MIME path without allocating MBs.
-        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "16");
 
-        let raw = b"PAR1-this-payload-is-larger-than-sixteen-bytes-for-sure";
+        let raw = b"PAR1-parquet-payload-bytes";
         let hash = store
             .put(raw, "application/vnd.apache.parquet")
             .await
@@ -1584,10 +1539,10 @@ mod tests {
 
         let resolved = resolve_data_bundle(&data, &store).await.unwrap();
 
-        // Original binary MIME key is absent; BLOB_REF_MIME took its place.
+        // Original whitelisted MIME key is absent; BLOB_REF_MIME took its place.
         assert!(
             !resolved.contains_key("application/vnd.apache.parquet"),
-            "large binary MIME should be rewritten, not kept: {:?}",
+            "whitelisted MIME should be rewritten, not kept: {:?}",
             resolved.keys().collect::<Vec<_>>()
         );
         let ref_entry = resolved
@@ -1605,16 +1560,15 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
-    async fn test_resolve_data_bundle_inlines_small_binary() {
+    async fn test_resolve_data_bundle_non_whitelisted_binary_stays_base64() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);
-        // Ensure the default 1 MiB threshold is in effect.
-        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "1048576");
 
-        // Small PNG-like blob, well under 1 MiB.
-        let tiny = b"\x89PNG\r\n\x1a\nfake-png";
-        let content_ref = ContentRef::from_binary(tiny, "image/png", &store)
+        // A "large" image blob — whitelist-based externalization only
+        // applies to parquet, so images keep the classic base64 path
+        // regardless of size.
+        let raw = vec![0xAAu8; 64 * 1024];
+        let content_ref = ContentRef::from_binary(&raw, "image/png", &store)
             .await
             .unwrap();
 
@@ -1623,10 +1577,9 @@ mod tests {
 
         let resolved = resolve_data_bundle(&data, &store).await.unwrap();
 
-        // Below-threshold binary keeps the classic base64 path.
         assert!(
             !resolved.contains_key(BLOB_REF_MIME),
-            "small binary should NOT emit BLOB_REF_MIME"
+            "non-whitelisted binary must NOT emit BLOB_REF_MIME"
         );
         let b64 = resolved
             .get("image/png")
@@ -1635,36 +1588,13 @@ mod tests {
         let decoded = base64::engine::general_purpose::STANDARD
             .decode(b64)
             .unwrap();
-        assert_eq!(decoded, tiny);
+        assert_eq!(decoded, raw);
     }
 
     #[tokio::test]
-    #[serial_test::serial]
-    async fn test_resolve_data_bundle_env_override_below_default() {
-        let dir = TempDir::new().unwrap();
-        let store = test_store(&dir);
-        // Default would keep this inline, but env var forces the ref path.
-        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "4");
-
-        let tiny = b"\x89PNG\r\n\x1a\n"; // 8 bytes >= 4
-        let content_ref = ContentRef::from_binary(tiny, "image/png", &store)
-            .await
-            .unwrap();
-        let mut data = HashMap::new();
-        data.insert("image/png".to_string(), content_ref);
-
-        let resolved = resolve_data_bundle(&data, &store).await.unwrap();
-
-        assert!(!resolved.contains_key("image/png"));
-        assert!(resolved.contains_key(BLOB_REF_MIME));
-    }
-
-    #[tokio::test]
-    #[serial_test::serial]
     async fn test_resolve_data_bundle_round_trip_blob_ref() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);
-        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "16");
 
         // Pre-populate a blob that will become a blob-ref on save.
         let raw = b"PAR1-this-payload-is-larger-than-sixteen-bytes-for-sure";

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -45,14 +45,50 @@
 
 use std::collections::HashMap;
 use std::io;
+#[cfg(not(test))]
+use std::sync::OnceLock;
 
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 
-use notebook_doc::mime::is_binary_mime;
+use notebook_doc::mime::{is_binary_mime, BLOB_REF_MIME};
 
 use crate::blob_store::BlobStore;
+
+/// Default size threshold above which binary blobs are externalized as
+/// [`BLOB_REF_MIME`] entries in saved `.ipynb` files instead of being
+/// re-inlined as base64. See the
+/// `2026-04-14-ipynb-save-blob-refs-design.md` spec for context.
+pub const DEFAULT_REF_MIME_SAVE_THRESHOLD: u64 = 1024 * 1024;
+
+/// Returns the threshold (in bytes) above which a binary `ContentRef::Blob`
+/// is rewritten as a [`BLOB_REF_MIME`] entry during save rather than
+/// base64-inlined.
+///
+/// Honors the `RUNTIMED_REF_MIME_SAVE_THRESHOLD` environment variable (for
+/// dev tuning + tests); otherwise defaults to
+/// [`DEFAULT_REF_MIME_SAVE_THRESHOLD`]. The parsed value is cached in a
+/// [`OnceLock`] on the first call in release builds — repeated reads are
+/// free. Tests (`cfg(test)`) skip the cache so the env var can be flipped
+/// between cases.
+fn ref_mime_save_threshold() -> u64 {
+    fn parse_env() -> u64 {
+        std::env::var("RUNTIMED_REF_MIME_SAVE_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_REF_MIME_SAVE_THRESHOLD)
+    }
+    #[cfg(test)]
+    {
+        parse_env()
+    }
+    #[cfg(not(test))]
+    {
+        static CACHED: OnceLock<u64> = OnceLock::new();
+        *CACHED.get_or_init(parse_env)
+    }
+}
 
 /// Default inlining threshold: 1 KB.
 ///
@@ -701,13 +737,40 @@ async fn convert_data_bundle(
 /// Binary MIME types are resolved via `resolve_binary_as_base64` which
 /// reads raw bytes from the blob store and base64-encodes them for the
 /// Jupyter nbformat representation (used when saving .ipynb to disk).
+///
+/// Large binary blobs (size >= [`ref_mime_save_threshold`]) are
+/// externalized as [`BLOB_REF_MIME`] entries instead of being
+/// re-inlined as base64. The original binary MIME key is dropped and
+/// replaced by a `BLOB_REF_MIME` → `{hash, content_type, size}` entry.
+/// See `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md`.
+/// The reverse transform is handled by `convert_data_bundle`'s
+/// existing `BLOB_REF_MIME` branch on load.
 async fn resolve_data_bundle(
     data: &HashMap<String, ContentRef>,
     blob_store: &BlobStore,
 ) -> io::Result<HashMap<String, Value>> {
     let mut result = HashMap::new();
+    let ref_threshold = ref_mime_save_threshold();
 
     for (mime_type, content_ref) in data {
+        // Spec 2: externalize large binary blobs as a BLOB_REF_MIME entry
+        // instead of re-inlining them as base64 in the .ipynb. Small
+        // binaries (plot thumbnails, icons) keep the legacy path for
+        // vanilla-Jupyter compatibility.
+        if is_binary_mime(mime_type) {
+            if let ContentRef::Blob { blob: hash, size } = content_ref {
+                if *size >= ref_threshold {
+                    let ref_body = json!({
+                        "hash": hash,
+                        "content_type": mime_type,
+                        "size": size,
+                    });
+                    result.insert(BLOB_REF_MIME.to_string(), ref_body);
+                    continue;
+                }
+            }
+        }
+
         let value = if is_binary_mime(mime_type) {
             // Binary: read raw bytes from blob → base64-encode for nbformat
             let base64_str = content_ref.resolve_binary_as_base64(blob_store).await?;
@@ -1454,5 +1517,229 @@ mod tests {
         assert!(!is_binary_mime("text/plain"));
         assert!(!is_binary_mime("text/html"));
         assert!(!is_binary_mime("text/latex"));
+    }
+
+    // ── Ref-MIME save threshold (Spec 2) ────────────────────────────
+    //
+    // These tests mutate the process env var, so they must run serially.
+
+    /// Guard that sets `RUNTIMED_REF_MIME_SAVE_THRESHOLD` for the
+    /// duration of a test and restores it on drop.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: set_var is unsafe in edition 2024. The surrounding
+            // test is serialized via `#[serial]`, so no other thread
+            // reads this env var concurrently.
+            unsafe { std::env::set_var(key, value) };
+            EnvGuard { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: same serialization guarantee as `set`.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_resolve_data_bundle_emits_blob_ref_for_large_binary() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        // Tiny threshold forces the ref-MIME path without allocating MBs.
+        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "16");
+
+        let raw = b"PAR1-this-payload-is-larger-than-sixteen-bytes-for-sure";
+        let hash = store
+            .put(raw, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        let mut data = HashMap::new();
+        data.insert(
+            "application/vnd.apache.parquet".to_string(),
+            ContentRef::Blob {
+                blob: hash.clone(),
+                size: raw.len() as u64,
+            },
+        );
+        data.insert(
+            "text/plain".to_string(),
+            ContentRef::Inline {
+                inline: "DataFrame (pandas): 3 rows × 2 columns".to_string(),
+            },
+        );
+
+        let resolved = resolve_data_bundle(&data, &store).await.unwrap();
+
+        // Original binary MIME key is absent; BLOB_REF_MIME took its place.
+        assert!(
+            !resolved.contains_key("application/vnd.apache.parquet"),
+            "large binary MIME should be rewritten, not kept: {:?}",
+            resolved.keys().collect::<Vec<_>>()
+        );
+        let ref_entry = resolved
+            .get(BLOB_REF_MIME)
+            .expect("BLOB_REF_MIME entry present");
+        assert_eq!(ref_entry["hash"], hash);
+        assert_eq!(ref_entry["content_type"], "application/vnd.apache.parquet");
+        assert_eq!(ref_entry["size"], raw.len());
+
+        // Non-binary siblings are untouched.
+        assert_eq!(
+            resolved.get("text/plain").and_then(|v| v.as_str()),
+            Some("DataFrame (pandas): 3 rows × 2 columns")
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_resolve_data_bundle_inlines_small_binary() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        // Ensure the default 1 MiB threshold is in effect.
+        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "1048576");
+
+        // Small PNG-like blob, well under 1 MiB.
+        let tiny = b"\x89PNG\r\n\x1a\nfake-png";
+        let content_ref = ContentRef::from_binary(tiny, "image/png", &store)
+            .await
+            .unwrap();
+
+        let mut data = HashMap::new();
+        data.insert("image/png".to_string(), content_ref);
+
+        let resolved = resolve_data_bundle(&data, &store).await.unwrap();
+
+        // Below-threshold binary keeps the classic base64 path.
+        assert!(
+            !resolved.contains_key(BLOB_REF_MIME),
+            "small binary should NOT emit BLOB_REF_MIME"
+        );
+        let b64 = resolved
+            .get("image/png")
+            .and_then(|v| v.as_str())
+            .expect("image/png should be present as base64 string");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .unwrap();
+        assert_eq!(decoded, tiny);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_resolve_data_bundle_env_override_below_default() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        // Default would keep this inline, but env var forces the ref path.
+        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "4");
+
+        let tiny = b"\x89PNG\r\n\x1a\n"; // 8 bytes >= 4
+        let content_ref = ContentRef::from_binary(tiny, "image/png", &store)
+            .await
+            .unwrap();
+        let mut data = HashMap::new();
+        data.insert("image/png".to_string(), content_ref);
+
+        let resolved = resolve_data_bundle(&data, &store).await.unwrap();
+
+        assert!(!resolved.contains_key("image/png"));
+        assert!(resolved.contains_key(BLOB_REF_MIME));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_resolve_data_bundle_round_trip_blob_ref() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let _guard = EnvGuard::set("RUNTIMED_REF_MIME_SAVE_THRESHOLD", "16");
+
+        // Pre-populate a blob that will become a blob-ref on save.
+        let raw = b"PAR1-this-payload-is-larger-than-sixteen-bytes-for-sure";
+        let hash = store
+            .put(raw, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        // Initial manifest: a display_data holding a parquet ContentRef::Blob
+        // directly (mimics dx.display having already uploaded the payload).
+        let mut data = HashMap::new();
+        data.insert(
+            "application/vnd.apache.parquet".to_string(),
+            ContentRef::Blob {
+                blob: hash.clone(),
+                size: raw.len() as u64,
+            },
+        );
+        data.insert(
+            "text/html".to_string(),
+            ContentRef::Inline {
+                inline: "<table/>".to_string(),
+            },
+        );
+        let manifest_a = OutputManifest::DisplayData {
+            data,
+            metadata: HashMap::new(),
+            transient: TransientData::default(),
+        };
+
+        // Resolve → save-shape JSON (ref-MIME appears).
+        let saved = resolve_manifest(&manifest_a, &store).await.unwrap();
+        assert!(saved["data"].get(BLOB_REF_MIME).is_some());
+        assert!(saved["data"]
+            .get("application/vnd.apache.parquet")
+            .is_none());
+
+        // Load that JSON back via create_manifest → ContentRef::Blob composed
+        // under the original content_type. Round-trip should land on an
+        // equivalent manifest shape.
+        let reloaded = create_manifest(&saved, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        match reloaded {
+            OutputManifest::DisplayData { data, .. } => {
+                assert!(!data.contains_key(BLOB_REF_MIME));
+                let parquet = data
+                    .get("application/vnd.apache.parquet")
+                    .expect("parquet key restored on load");
+                match parquet {
+                    ContentRef::Blob { blob, size } => {
+                        assert_eq!(blob, &hash);
+                        assert_eq!(*size, raw.len() as u64);
+                    }
+                    other => panic!("expected ContentRef::Blob, got {other:?}"),
+                }
+                // Sibling HTML survived as well.
+                assert!(data.contains_key("text/html"));
+            }
+            other => panic!("expected DisplayData, got {other:?}"),
+        }
+
+        // And saving the reloaded manifest again gives the same shape
+        // (idempotent under repeated save/load cycles).
+        let saved_again = resolve_manifest(
+            &create_manifest(&saved, &store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .unwrap(),
+            &store,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            saved_again["data"][BLOB_REF_MIME],
+            saved["data"][BLOB_REF_MIME]
+        );
     }
 }

--- a/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
+++ b/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
@@ -1,0 +1,66 @@
+# Blob GC correctness
+
+**Status:** Design
+**Date:** 2026-04-14
+**Related:** #1762 (dx), [spec: ipynb save without base64 inlining](./2026-04-14-ipynb-save-blob-refs-design.md)
+
+## Motivation
+
+The blob-store GC (`crates/runtimed/src/daemon.rs`, ~lines 2591–2700) runs every 30 minutes, marks blobs referenced by active rooms, and sweeps everything else older than 1 hour. Two scenarios can delete a blob that is still semantically in use:
+
+- **A. Close + reopen within the GC window.** A user opens an untitled notebook with a parquet output, closes it (room evicted from `notebook_rooms` after 30s). 1 hour later the GC finds no active reference, deletes the blob. The persisted `notebook-docs/{hash}.automerge` file still exists (24 h retention), but its refs aren't walked. Reopen between hour 1 and hour 24 → blob URLs 404 → rich output lost.
+- **F. Daemon restart before any client reconnects.** Daemon restarts, `notebook_rooms` is empty, first GC pass within 30 min sees zero refs and deletes every blob older than 1 hour.
+
+Once [`.ipynb` save switches to blob refs](./2026-04-14-ipynb-save-blob-refs-design.md), scenario A extends to saved-and-closed notebooks as well — not just untitled ones. The same GC scan that was merely an optimization becomes a correctness dependency.
+
+## Non-goals
+
+- Walking arbitrary `.ipynb` files anywhere on the user filesystem. The daemon doesn't own the user's filesystem; we can't discover every saved notebook.
+- A persistent reference-count in the blob metadata. Too invasive for what's effectively a correctness patch on the existing mark-and-sweep loop.
+- Changing the GC cadence (stays at 30 minutes).
+
+## Changes
+
+Three small changes to the GC loop in `crates/runtimed/src/daemon.rs`:
+
+### 1. Refuse to sweep when `notebook_rooms` is empty
+
+```rust
+if room_arcs.is_empty() {
+    info!("[runtimed] GC: 0 active rooms; skipping sweep this cycle");
+} else {
+    // existing mark + sweep
+}
+```
+
+Zero active rooms is a classic fail-open scenario: either every notebook is genuinely closed (safe to sweep) or the daemon just started and hasn't loaded refs yet (unsafe). The two are indistinguishable at this layer, so err toward keeping data. The cost is at most one extra GC cycle of staleness on a truly idle daemon — not a problem.
+
+### 2. Walk `notebook-docs/*.automerge` in the mark phase
+
+The daemon owns `config.notebook_docs_dir`. Files there (emergency persist + re-open state for untitled notebooks) contain `RuntimeStateDoc` references we currently ignore.
+
+Add a mark pass that opens each `.automerge` file, reads its `RuntimeStateDoc`, and calls the existing `collect_blob_hashes` / `collect_blob_hashes_recursive` helpers on its executions + comms. Skip files already represented by an active room (we already have their refs).
+
+Batched the same way the in-memory walk is: up to N docs per tick, `tokio::task::yield_now()` between batches. Reading `.automerge` files is I/O-bound; if it starves the loop we drop the batch size.
+
+### 3. Extend the blob grace period
+
+`blob_max_age` goes from **1 hour** to **30 days**. Rationale: after Spec 2 ships, saved-and-closed notebooks rely on the blob store surviving until they're reopened. A week-long vacation shouldn't eat someone's rich outputs. Disk is cheap; data loss isn't.
+
+Introduce a constant `BLOB_GC_GRACE_SECS` (default 30 * 24 * 3600) and, for dev flexibility, honor a `RUNTIMED_BLOB_GC_GRACE_SECS` env var override.
+
+## Out of scope / follow-ups
+
+- **Explicit purge CLI** (`runt daemon vacuum`) for users who want to reclaim disk aggressively. Nice to have; not this spec.
+- **Walking `.ipynb` files on disk.** When a `.ipynb` is loaded into a room, its refs land in the room's `RuntimeStateDoc` and the existing mark phase sees them. Closed saved notebooks are protected by the 30-day grace period instead. If that proves insufficient in practice, a later spec can add a "recent-save refs" manifest.
+
+## Testing
+
+- Unit: `collect_blob_hashes` already has coverage; add a test for the `walk_persisted_automerge_docs` helper with a fixture `.automerge` file containing a known blob ref.
+- Integration: write a `.automerge` file to a temp `notebook_docs_dir`, put a blob in a temp `blob_store`, run one GC cycle, assert the blob survives.
+- Integration: assert GC with zero active rooms is a no-op (no deletions).
+- Integration: bump the grace-period test constant to a short value (e.g., 2s) via env var, assert the sweep deletes blobs older than that when they're actually unreferenced.
+
+## Rollout
+
+Ship before Spec 2 (ipynb save without base64). Order matters: Spec 2 moves the "truth" of dx outputs into the blob store. Spec 1 makes the blob store robust enough to hold that truth.

--- a/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
+++ b/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
@@ -1,0 +1,122 @@
+# `.ipynb` save: external blob refs instead of base64 inlining
+
+**Status:** Design
+**Date:** 2026-04-14
+**Related:** #1762 (dx), [spec: blob GC correctness](./2026-04-14-blob-gc-correctness-design.md)
+
+## Motivation
+
+`dx.display(df)` pushes parquet through the IOPub `buffers` envelope to avoid base64'ing megabytes inside JSON on the wire. The save path then re-inlines those same bytes as base64 back into the `.ipynb`. A 100 MiB parquet becomes ~133 MiB of base64 on disk. Every save. That defeats most of dx's benefit for users who commit notebooks to git.
+
+The blob store already has the bytes; `.ipynb` should carry a reference, not a copy.
+
+## Shape
+
+Saved output bundles for anything resolved to a `ContentRef::Blob` that exceeds a size threshold emit the wire-format blob-ref MIME instead of a base64 string. Everything else is unchanged.
+
+Before (today):
+```json
+{
+  "output_type": "display_data",
+  "data": {
+    "application/vnd.apache.parquet": "<100 MiB of base64>",
+    "text/html": "<table>…</table>",
+    "text/plain": "…",
+    "text/llm+plain": "DataFrame (pandas): 148820 rows × 12 cols"
+  }
+}
+```
+
+After (Spec 2):
+```json
+{
+  "output_type": "display_data",
+  "data": {
+    "application/vnd.nteract.blob-ref+json": {
+      "hash": "sha256-…",
+      "content_type": "application/vnd.apache.parquet",
+      "size": 104857600
+    },
+    "text/html": "<table>…</table>",
+    "text/plain": "…",
+    "text/llm+plain": "DataFrame (pandas): 148820 rows × 12 cols"
+  }
+}
+```
+
+The original binary MIME key disappears; the ref-MIME takes its place. All non-binary MIMEs stay inline unchanged.
+
+Symmetry: this is the same shape dx emits on the IOPub wire. `create_manifest` already has a `BLOB_REF_MIME` branch that composes `ContentRef::Blob` under the wrapped `content_type` — so the load path works with zero changes.
+
+## Compatibility
+
+- **Vanilla Jupyter** (any host that doesn't know the ref MIME): the entry is skipped as unknown; frontends fall through to `text/html` / `text/plain`. For `dx.display(df)` the HTML table renders; for any custom binary display that lacked a fallback it renders as a missing output — same result as today if the base64 were corrupted or the host's renderer disabled.
+- **nteract reopen** (via daemon): `create_manifest` sees `BLOB_REF_MIME`, verifies the blob exists in the store, composes a `ContentRef::Blob`. If the blob is missing (different machine, GC'd past the grace period), the ref entry is dropped — the HTML fallback renders instead. No crash, no dangling reference in the inline manifest.
+- **`.ipynb` diffability**: storing hashes instead of 133 MiB of base64 makes diffs actually reviewable. Changing a DataFrame changes a hash, not a quarter-million-line textblob.
+
+## Threshold
+
+A size threshold governs the rewrite:
+
+- `content_ref.size >= REF_MIME_SAVE_THRESHOLD` → emit `BLOB_REF_MIME`.
+- Smaller → inline base64 as today.
+
+Rationale: small images (plot thumbnails, icons, small exports) are useful to ship self-contained. Large payloads (parquet, ML model dumps) are what we need to externalize. Default: **1 MiB**. Tunable via env var `RUNTIMED_REF_MIME_SAVE_THRESHOLD` for dev + edge cases.
+
+This preserves the "drop a `.ipynb` into any Jupyter host and it renders" promise for common cases (matplotlib PNGs are typically 10–300 KiB) while removing the parquet-in-JSON anti-pattern.
+
+## Implementation
+
+### Crate changes
+
+`crates/runtimed/src/output_store.rs::resolve_data_bundle` gets one new branch before the existing binary/json/text discrimination:
+
+```rust
+for (mime_type, content_ref) in data {
+    // Spec 2: large binary blobs get externalized as a ref-MIME entry
+    // instead of inline base64. See 2026-04-14-ipynb-save-blob-refs-design.md.
+    if is_binary_mime(mime_type) {
+        if let ContentRef::Blob { blob: hash, size } = content_ref {
+            if *size >= ref_mime_save_threshold() {
+                let ref_body = json!({
+                    "hash": hash,
+                    "content_type": mime_type,
+                    "size": size,
+                });
+                result.insert(BLOB_REF_MIME.to_string(), ref_body);
+                continue; // skip the inline-base64 branch below
+            }
+        }
+    }
+    // existing resolution (base64 / json / text) …
+}
+```
+
+`ref_mime_save_threshold()` reads `RUNTIMED_REF_MIME_SAVE_THRESHOLD` once (cached via `OnceLock`), defaults to 1 MiB.
+
+The function signature stays the same — no other caller changes.
+
+### Load path
+
+No code changes needed. `create_manifest`'s existing `BLOB_REF_MIME` branch (added in the dx PR) already handles the inverse: it reads the ref MIME from the bundle, verifies the hash via `BlobStore::exists`, composes `ContentRef::from_hash` under the wrapped `content_type`, and omits the ref MIME entry from the resolved manifest.
+
+### Tests
+
+- Unit in `output_store.rs`: `resolve_data_bundle` emits `BLOB_REF_MIME` for a binary `ContentRef::Blob` above the threshold; falls back to base64 below the threshold.
+- Round-trip: `create_manifest` of a manifest containing `BLOB_REF_MIME` → `resolve_manifest` with the threshold set low → `create_manifest` again. Hash is stable; manifest shape is idempotent.
+- Integration: `save_notebook_to_disk` on a cell with a large parquet produces a `.ipynb` whose parquet entry is a ref-MIME, not a base64 string. Reopening the notebook reconstructs a valid `ContentRef::Blob` pointing at the same blob.
+- Fixture update: the existing `test_save_notebook_to_disk_with_outputs` fixtures may need regeneration if any of their outputs cross the threshold. Audit.
+
+## Migration
+
+Not a migration — existing `.ipynb` files with base64-inlined binary outputs keep working on load (the normal `is_binary_mime` path reads base64 → decodes → stores in the blob store → composes `ContentRef::Blob`). Only new saves use the ref MIME path. Old files get progressively upgraded as users reopen and re-save them.
+
+## Dependencies
+
+- **Spec 1 (blob GC correctness)** must ship first, or concurrently. Saved `.ipynb` files now depend on the blob store surviving long enough for the user to reopen. The 30-day grace period and the persisted-automerge walk from Spec 1 are the safety net.
+
+## Rollout
+
+Land behind a feature gate? **No.** The change is internal: the save format is already a moving target, and the load path has been ref-MIME-aware since dx landed. No external consumer of the `.ipynb` format needs a migration window.
+
+Version bump: the save-path change doesn't warrant its own version; it rides whatever package version is being cut next.


### PR DESCRIPTION
## Summary

Implements [spec 2: `.ipynb` save with blob refs instead of base64](../blob/main/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md).

`dx.display(df)` ships parquet through the IOPub `buffers` envelope to keep megabytes out of JSON on the wire, but the save path then re-inlined those same bytes as base64 back into the `.ipynb`. A 100 MiB parquet became ~133 MiB of base64 on disk. Every save.

This PR teaches `resolve_data_bundle` to emit an `application/vnd.nteract.blob-ref+json` entry (`{hash, content_type, size}`) in place of any binary `ContentRef::Blob` whose size exceeds `REF_MIME_SAVE_THRESHOLD` (default **1 MiB**, tunable via `RUNTIMED_REF_MIME_SAVE_THRESHOLD`). Smaller binaries still inline as base64 so matplotlib PNGs and icons keep the existing drop-into-vanilla-Jupyter behaviour.

The load path needs zero changes — `create_manifest`'s existing `BLOB_REF_MIME` branch (shipped with #1762 / dx) already composes a `ContentRef::Blob` under the wrapped `content_type` and drops the ref-MIME key from the resolved manifest.

## Changes

- `crates/runtimed/src/output_store.rs`
  - New `DEFAULT_REF_MIME_SAVE_THRESHOLD = 1 MiB` constant, `ref_mime_save_threshold()` helper (env-var aware, cached via `OnceLock` in release builds; re-read each call under `cfg(test)` so tests can vary it).
  - New early branch in `resolve_data_bundle`: when a binary MIME's `ContentRef::Blob` is at or above the threshold, emit `BLOB_REF_MIME` and skip the base64 path.

Scoped strictly to `output_store.rs`. No changes to `notebook_sync_server.rs` save-path wiring, no changes to `create_manifest`, and no touch to `daemon.rs` GC (that's spec 1's territory).

## Tests

New unit tests in `output_store.rs::tests` (all `#[serial_test::serial]` because they mutate the process env var):

- `test_resolve_data_bundle_emits_blob_ref_for_large_binary` — parquet `ContentRef::Blob` above threshold -> `BLOB_REF_MIME` entry, original key gone.
- `test_resolve_data_bundle_inlines_small_binary` — PNG below default 1 MiB threshold -> base64 under `image/png` as today, no `BLOB_REF_MIME`.
- `test_resolve_data_bundle_env_override_below_default` — setting `RUNTIMED_REF_MIME_SAVE_THRESHOLD=4` forces the ref path for an 8-byte PNG.
- `test_resolve_data_bundle_round_trip_blob_ref` — save -> load -> save is shape-idempotent; hash is stable.

Existing save-path tests (`test_save_notebook_to_disk_with_outputs`, `test_load_notebook_from_disk_routes_outputs_through_blob_store`) use stream outputs or 16 KiB images, both below the 1 MiB default, so they continue passing unchanged.

## Depends on

Spec 1 (blob GC correctness) should land first or concurrently. Saved `.ipynb` files now depend on the blob store surviving long enough for the user to reopen. The 30-day grace period + persisted-automerge walk from spec 1 is the safety net.

## Test plan

- [x] `cargo test -p runtimed --lib` (264 passed, incl. 4 new)
- [x] `cargo test -p runtimed --tests` (integration, 22 passed)
- [x] `cargo xtask lint`
- [x] `uv run ty check python/`
- [ ] Manual: `dx.display(big_parquet_df)` -> save -> inspect `.ipynb` -> confirm the parquet entry is a `blob-ref+json` object, not a megabyte of base64.
- [ ] Manual: reopen the saved `.ipynb` in the desktop app, confirm the DataFrame still renders and the blob is resolved from the store.