### PR TITLE
fix(runtimed): add wall-clock launch deadline and retry for kernel port collisions

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -43,6 +43,84 @@ use notebook_protocol::protocol::LaunchedEnvConfig;
 type PendingCompletions =
     Arc<StdMutex<HashMap<String, oneshot::Sender<(Vec<CompletionItem>, usize, usize)>>>>;
 
+/// RAII guard for resources spawned during `JupyterKernel::launch()`.
+///
+/// Holds the kernel PID and abort handles for all spawned background tasks.
+/// If `launch()` fails — either via an explicit error return **or** because the
+/// outer timeout in `launch_kernel_with_retry` drops the future — the guard's
+/// `Drop` kills the child process and aborts every background task, preventing
+/// orphan kernels.
+///
+/// On success, call [`LaunchGuard::disarm`] so the guard's `Drop` becomes a
+/// no-op (the `JupyterKernel` struct takes ownership of the resources via its
+/// own `Drop` impl).
+struct LaunchGuard {
+    /// Kernel PID for SIGKILL on cleanup (Unix only).
+    #[cfg(unix)]
+    kernel_pid: Option<i32>,
+    /// Abort handles for spawned tasks — invoked on drop.
+    abort_handles: Vec<tokio::task::AbortHandle>,
+    /// Whether the guard has been disarmed (resources transferred to JupyterKernel).
+    disarmed: bool,
+}
+
+impl LaunchGuard {
+    #[cfg(unix)]
+    fn new(kernel_pid: Option<i32>) -> Self {
+        Self {
+            kernel_pid,
+            abort_handles: Vec::new(),
+            disarmed: false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn new() -> Self {
+        Self {
+            abort_handles: Vec::new(),
+            disarmed: false,
+        }
+    }
+
+    /// Register a spawned task's abort handle so it will be aborted on cleanup.
+    fn track(&mut self, handle: &JoinHandle<()>) {
+        self.abort_handles.push(handle.abort_handle());
+    }
+
+    /// Disarm the guard — caller takes ownership of the resources.
+    /// The guard's `Drop` becomes a no-op.
+    fn disarm(mut self) {
+        self.disarmed = true;
+    }
+}
+
+impl Drop for LaunchGuard {
+    fn drop(&mut self) {
+        if self.disarmed {
+            return;
+        }
+        // Kill the child process directly via SIGKILL.  We do this before
+        // aborting the process watcher task because the watcher owns the
+        // `Child` handle (which has `kill_on_drop`).  Tokio task abort is
+        // asynchronous — the Drop may not run immediately — so an explicit
+        // SIGKILL via PID is the only reliable synchronous cleanup.
+        #[cfg(unix)]
+        if let Some(pid) = self.kernel_pid.take() {
+            use nix::sys::signal::{kill, Signal};
+            use nix::unistd::Pid;
+            warn!(
+                "[jupyter-kernel] LaunchGuard cleanup: killing kernel pid {}",
+                pid
+            );
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+        }
+        for handle in self.abort_handles.drain(..) {
+            handle.abort();
+        }
+        warn!("[jupyter-kernel] LaunchGuard cleanup: aborted spawned tasks");
+    }
+}
+
 /// A Jupyter kernel connection that implements `KernelConnection`.
 ///
 /// Holds the IO-bound parts of a kernel connection: ZeroMQ sockets, spawned
@@ -470,10 +548,23 @@ impl KernelConnection for JupyterKernel {
         let mut process = cmd.kill_on_drop(true).spawn()?;
         drop(listeners);
 
+        #[cfg(unix)]
+        let kernel_pid = process.id().map(|pid| pid as i32);
+
+        // ── Launch guard ────────────────────────────────────────────────
+        // Created immediately after spawn so that any subsequent error or
+        // future cancellation (outer timeout) will kill the child and
+        // abort all spawned tasks.  Disarmed at the end of launch() once
+        // the JupyterKernel struct takes ownership.
+        #[cfg(unix)]
+        let mut launch_guard = LaunchGuard::new(kernel_pid);
+        #[cfg(not(unix))]
+        let mut launch_guard = LaunchGuard::new();
+
         // Capture kernel stderr for diagnostics
         if let Some(stderr) = process.stderr.take() {
             let kid = kernel_id.clone();
-            tokio::spawn(async move {
+            let stderr_task = tokio::spawn(async move {
                 use tokio::io::{AsyncBufReadExt, BufReader};
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
@@ -485,10 +576,8 @@ impl KernelConnection for JupyterKernel {
                     }
                 }
             });
+            launch_guard.track(&stderr_task);
         }
-
-        #[cfg(unix)]
-        let kernel_pid = process.id().map(|pid| pid as i32);
 
         info!(
             "[jupyter-kernel] Spawned kernel process (pid={:?}, kernel_id={})",
@@ -562,6 +651,7 @@ impl KernelConnection for JupyterKernel {
             let _ = died_tx.send(msg);
             let _ = process_cmd_tx.try_send(QueueCommand::KernelDied);
         });
+        launch_guard.track(&process_watcher_task);
 
         // ── IOPub listener task ──────────────────────────────────────────
 
@@ -1572,6 +1662,7 @@ impl KernelConnection for JupyterKernel {
             warn!("[jupyter-kernel] iopub loop exited, signaling KernelDied");
             let _ = iopub_cmd_tx.try_send(QueueCommand::KernelDied);
         });
+        launch_guard.track(&iopub_task);
 
         // ── Shell connection + kernel alive check ─────────────────────────
         //
@@ -1622,7 +1713,7 @@ impl KernelConnection for JupyterKernel {
                 }
                 Ok(Err(e)) => {
                     error!("[jupyter-kernel] {}", e);
-                    process_watcher_task.abort();
+                    // launch_guard Drop will kill process + abort tasks
                     return Err(e);
                 }
                 Err(_) => {
@@ -1631,7 +1722,7 @@ impl KernelConnection for JupyterKernel {
                          kernel may be alive but unresponsive (kernel_id={})",
                         kernel_id
                     );
-                    process_watcher_task.abort();
+                    // launch_guard Drop will kill process + abort tasks
                     return Err(anyhow::anyhow!(
                         "Kernel launch deadline exceeded (45s): kernel alive but not responding"
                     ));
@@ -1838,6 +1929,7 @@ impl KernelConnection for JupyterKernel {
                 }
             }
         });
+        launch_guard.track(&shell_reader_task);
 
         // ── Heartbeat monitor ────────────────────────────────────────────
 
@@ -1872,6 +1964,7 @@ impl KernelConnection for JupyterKernel {
                 }
             }
         });
+        launch_guard.track(&heartbeat_task);
 
         // ── Coalesced comm state writer ──────────────────────────────────
 
@@ -1924,8 +2017,14 @@ impl KernelConnection for JupyterKernel {
                 }
             }
         });
+        launch_guard.track(&comm_coalesce_task);
 
         // ── Construct the kernel struct ──────────────────────────────────
+        //
+        // All resources are now owned by the kernel. Disarm the guard so
+        // its Drop becomes a no-op — JupyterKernel::Drop handles cleanup
+        // from here on.
+        launch_guard.disarm();
 
         let kernel = Self {
             kernel_type,

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -108,7 +108,7 @@ impl Drop for LaunchGuard {
         if let Some(pid) = self.kernel_pid.take() {
             use nix::sys::signal::{kill, Signal};
             use nix::unistd::Pid;
-            warn!(
+            debug!(
                 "[jupyter-kernel] LaunchGuard cleanup: killing kernel pid {}",
                 pid
             );
@@ -117,7 +117,7 @@ impl Drop for LaunchGuard {
         for handle in self.abort_handles.drain(..) {
             handle.abort();
         }
-        warn!("[jupyter-kernel] LaunchGuard cleanup: aborted spawned tasks");
+        debug!("[jupyter-kernel] LaunchGuard cleanup: aborted spawned tasks");
     }
 }
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1573,48 +1573,71 @@ impl KernelConnection for JupyterKernel {
             let _ = iopub_cmd_tx.try_send(QueueCommand::KernelDied);
         });
 
-        // ── Shell connection ─────────────────────────────────────────────
+        // ── Shell connection + kernel alive check ─────────────────────────
+        //
+        // Wrap the entire shell-connect + kernel_info_reply exchange in a hard
+        // wall-clock deadline. The inner `select!` races shell.read() against
+        // died_rx for fast-path detection, but neither may fire if the kernel
+        // is alive-but-broken (e.g., partial ZMQ bind failure). The outer
+        // timeout guarantees we never hang indefinitely.
+        //
+        // See: https://github.com/nteract/desktop/issues/1770
 
-        let identity = runtimelib::peer_identity_for_session(&session_id)?;
-        let mut shell = runtimelib::create_client_shell_connection_with_identity(
-            &connection_info,
-            &session_id,
-            identity,
-        )
-        .await?;
+        let alive_check = async {
+            let identity = runtimelib::peer_identity_for_session(&session_id)?;
+            let mut shell = runtimelib::create_client_shell_connection_with_identity(
+                &connection_info,
+                &session_id,
+                identity,
+            )
+            .await?;
 
-        // Verify kernel is alive — race kernel_info_reply against process death
-        let request: JupyterMessage = KernelInfoRequest::default().into();
-        shell.send(request).await?;
+            let request: JupyterMessage = KernelInfoRequest::default().into();
+            shell.send(request).await?;
 
-        let reply = tokio::select! {
-            result = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()) => {
-                match result {
-                    Ok(Ok(msg)) => Ok(msg),
-                    Ok(Err(e)) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
-                    Err(_) => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
+            let reply = tokio::select! {
+                result = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()) => {
+                    match result {
+                        Ok(Ok(msg)) => Ok(msg),
+                        Ok(Err(e)) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
+                        Err(_) => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
+                    }
                 }
-            }
-            died_msg = died_rx => {
-                let msg = died_msg.unwrap_or_else(|_| "unknown".to_string());
-                Err(anyhow::anyhow!("Kernel process died before responding: {}", msg))
-            }
+                died_msg = died_rx => {
+                    let msg = died_msg.unwrap_or_else(|_| "unknown".to_string());
+                    Err(anyhow::anyhow!("Kernel process died before responding: {}", msg))
+                }
+            };
+            reply.map(|msg| (msg, shell))
         };
 
-        match reply {
-            Ok(msg) => {
-                info!(
-                    "[jupyter-kernel] Kernel alive: got {} reply",
-                    msg.header.msg_type
-                );
-            }
-            Err(e) => {
-                error!("[jupyter-kernel] {}", e);
-                // Abort process watcher to clean up orphaned kernel
-                process_watcher_task.abort();
-                return Err(e);
-            }
-        }
+        let (reply_msg, shell) =
+            match tokio::time::timeout(std::time::Duration::from_secs(45), alive_check).await {
+                Ok(Ok((msg, shell))) => {
+                    info!(
+                        "[jupyter-kernel] Kernel alive: got {} reply",
+                        msg.header.msg_type
+                    );
+                    (msg, shell)
+                }
+                Ok(Err(e)) => {
+                    error!("[jupyter-kernel] {}", e);
+                    process_watcher_task.abort();
+                    return Err(e);
+                }
+                Err(_) => {
+                    error!(
+                        "[jupyter-kernel] Hard launch deadline exceeded (45s) — \
+                         kernel may be alive but unresponsive (kernel_id={})",
+                        kernel_id
+                    );
+                    process_watcher_task.abort();
+                    return Err(anyhow::anyhow!(
+                        "Kernel launch deadline exceeded (45s): kernel alive but not responding"
+                    ));
+                }
+            };
+        let _ = reply_msg; // consumed above for the info! log
 
         // Split shell into reader/writer
         let (shell_writer, mut shell_reader) = shell.split();

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -29,6 +29,7 @@ use notebook_protocol::protocol::LaunchedEnvConfig;
 /// Bundles the parameters that `KernelConnection::launch` needs beyond the
 /// shared references. Extracted so callers don't have to pass 6+ positional
 /// arguments.
+#[derive(Clone)]
 pub struct KernelLaunchConfig {
     /// Kernel type identifier (e.g., "python", "deno").
     pub kernel_type: String,
@@ -49,6 +50,7 @@ pub struct KernelLaunchConfig {
 /// These are `Arc`/`broadcast` handles held by the runtime agent and passed
 /// into the kernel at launch time. Grouped here so `launch()` takes two
 /// structs instead of a dozen parameters.
+#[derive(Clone)]
 pub struct KernelSharedRefs {
     /// Per-notebook runtime state document (daemon-authoritative).
     pub state_doc: Arc<RwLock<RuntimeStateDoc>>,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -336,11 +336,46 @@ const KERNEL_LAUNCH_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// port collisions under high concurrency (TOCTOU race in port allocation).
 const KERNEL_LAUNCH_MAX_ATTEMPTS: usize = 3;
 
+/// Determine whether a launch error is likely transient (worth retrying with
+/// fresh ports) or terminal (will fail again immediately).
+///
+/// Terminal errors include missing binaries, broken environments, unsupported
+/// kernel types, and early process crashes — none of which are fixed by fresh
+/// port allocation.  Retryable errors include timeouts, ZMQ connection
+/// failures, and the port-collision scenarios this retry loop targets.
+fn is_retryable_launch_error(error_msg: &str) -> bool {
+    // Known terminal error patterns from JupyterKernel::launch():
+    const TERMINAL_PATTERNS: &[&str] = &[
+        // Environment / config errors
+        "requires a prepared environment",
+        "has no python binary",
+        "could not resolve conda environment prefix",
+        "Unsupported kernel type",
+        // Process crashed on startup — binary or env is broken
+        "Kernel process exited immediately",
+        "Kernel process died before responding",
+    ];
+
+    for pattern in TERMINAL_PATTERNS {
+        if error_msg.contains(pattern) {
+            return false;
+        }
+    }
+
+    // Everything else (timeouts, ZMQ connect failures, port allocation
+    // failures, partial bind) is worth retrying with fresh ports.
+    true
+}
+
 /// Launch a kernel with timeout and retry. Returns the launched kernel and its
 /// command receiver, or an error if all attempts fail.
 ///
 /// Each attempt gets a fresh `KernelLaunchConfig` (cloned from the template)
 /// so that port allocation starts from scratch on retry.
+///
+/// Only transient errors (timeouts, connection failures, port collisions) are
+/// retried.  Terminal errors (missing binary, broken env, unsupported kernel
+/// type, early crash) fail fast on the first attempt.
 async fn launch_kernel_with_retry(
     config_template: &KernelLaunchConfig,
     shared_template: &KernelSharedRefs,
@@ -357,6 +392,16 @@ async fn launch_kernel_with_retry(
             Ok(Ok((k, rx))) => return Ok((k, rx)),
             Ok(Err(e)) => {
                 last_error = format!("{}", e);
+
+                // Fail fast on terminal errors — retrying won't help.
+                if !is_retryable_launch_error(&last_error) {
+                    error!(
+                        "[runtime-agent] Kernel launch failed (terminal, not retrying): {}",
+                        last_error
+                    );
+                    return Err(format!("Failed to launch kernel: {}", last_error));
+                }
+
                 if attempt < KERNEL_LAUNCH_MAX_ATTEMPTS {
                     warn!(
                         "[runtime-agent] Kernel launch attempt {}/{} failed: {} — retrying with fresh ports",
@@ -371,6 +416,9 @@ async fn launch_kernel_with_retry(
                     );
                 }
             }
+            // Timeouts are always retryable — this is the primary scenario
+            // the retry loop was designed to handle (kernel alive but
+            // unresponsive due to partial ZMQ bind failure).
             Err(_) => {
                 last_error = format!(
                     "Kernel launch timed out after {}s (attempt {}/{})",

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -379,10 +379,7 @@ async fn launch_kernel_with_retry(
                     KERNEL_LAUNCH_MAX_ATTEMPTS
                 );
                 if attempt < KERNEL_LAUNCH_MAX_ATTEMPTS {
-                    warn!(
-                        "[runtime-agent] {} — retrying with fresh ports",
-                        last_error
-                    );
+                    warn!("[runtime-agent] {} — retrying with fresh ports", last_error);
                 } else {
                     error!("[runtime-agent] {}", last_error);
                 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -327,6 +327,72 @@ pub async fn run_runtime_agent(
     Ok(())
 }
 
+/// Maximum wall-clock time allowed for a single `JupyterKernel::launch()` call.
+/// This prevents the runtime agent from hanging indefinitely if the kernel
+/// process starts but never becomes responsive (e.g., partial ZMQ bind failure).
+const KERNEL_LAUNCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Maximum number of launch attempts before giving up. Retries handle transient
+/// port collisions under high concurrency (TOCTOU race in port allocation).
+const KERNEL_LAUNCH_MAX_ATTEMPTS: usize = 3;
+
+/// Launch a kernel with timeout and retry. Returns the launched kernel and its
+/// command receiver, or an error if all attempts fail.
+///
+/// Each attempt gets a fresh `KernelLaunchConfig` (cloned from the template)
+/// so that port allocation starts from scratch on retry.
+async fn launch_kernel_with_retry(
+    config_template: &KernelLaunchConfig,
+    shared_template: &KernelSharedRefs,
+) -> Result<(JupyterKernel, mpsc::Receiver<QueueCommand>), String> {
+    let mut last_error = String::new();
+
+    for attempt in 1..=KERNEL_LAUNCH_MAX_ATTEMPTS {
+        let config = config_template.clone();
+        let shared = shared_template.clone();
+
+        match tokio::time::timeout(KERNEL_LAUNCH_TIMEOUT, JupyterKernel::launch(config, shared))
+            .await
+        {
+            Ok(Ok((k, rx))) => return Ok((k, rx)),
+            Ok(Err(e)) => {
+                last_error = format!("{}", e);
+                if attempt < KERNEL_LAUNCH_MAX_ATTEMPTS {
+                    warn!(
+                        "[runtime-agent] Kernel launch attempt {}/{} failed: {} — retrying with fresh ports",
+                        attempt, KERNEL_LAUNCH_MAX_ATTEMPTS, last_error
+                    );
+                    // Small backoff before retry to let ports settle
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                } else {
+                    error!(
+                        "[runtime-agent] Kernel launch failed after {} attempts: {}",
+                        KERNEL_LAUNCH_MAX_ATTEMPTS, last_error
+                    );
+                }
+            }
+            Err(_) => {
+                last_error = format!(
+                    "Kernel launch timed out after {}s (attempt {}/{})",
+                    KERNEL_LAUNCH_TIMEOUT.as_secs(),
+                    attempt,
+                    KERNEL_LAUNCH_MAX_ATTEMPTS
+                );
+                if attempt < KERNEL_LAUNCH_MAX_ATTEMPTS {
+                    warn!(
+                        "[runtime-agent] {} — retrying with fresh ports",
+                        last_error
+                    );
+                } else {
+                    error!("[runtime-agent] {}", last_error);
+                }
+            }
+        }
+    }
+
+    Err(format!("Failed to launch kernel: {}", last_error))
+}
+
 /// Handle a `RuntimeAgentRequest` and return a `RuntimeAgentResponse`.
 ///
 /// Also returns an optional `cmd_rx` when a kernel is launched/restarted
@@ -388,7 +454,7 @@ async fn handle_runtime_agent_request(
                 pooled_env,
             };
 
-            match JupyterKernel::launch(config, shared).await {
+            match launch_kernel_with_retry(&config, &shared).await {
                 Ok((k, rx)) => {
                     let es = k.env_source().to_string();
                     *kernel = Some(k);
@@ -399,12 +465,7 @@ async fn handle_runtime_agent_request(
                         Some(rx),
                     )
                 }
-                Err(e) => (
-                    RuntimeAgentResponse::Error {
-                        error: format!("Failed to launch kernel: {}", e),
-                    },
-                    None,
-                ),
+                Err(e) => (RuntimeAgentResponse::Error { error: e }, None),
             }
         }
 
@@ -495,7 +556,7 @@ async fn handle_runtime_agent_request(
                 let _ = ctx.state_changed_tx.send(());
             }
 
-            match JupyterKernel::launch(config, shared).await {
+            match launch_kernel_with_retry(&config, &shared).await {
                 Ok((k, rx)) => {
                     let es = k.env_source().to_string();
                     *kernel = Some(k);
@@ -506,12 +567,7 @@ async fn handle_runtime_agent_request(
                         Some(rx),
                     )
                 }
-                Err(e) => (
-                    RuntimeAgentResponse::Error {
-                        error: format!("Failed to restart kernel: {}", e),
-                    },
-                    None,
-                ),
+                Err(e) => (RuntimeAgentResponse::Error { error: e }, None),
             }
         }
 


### PR DESCRIPTION
## Summary

- **Adds a 45-second hard wall-clock deadline** around the shell-connect + `kernel_info_reply` exchange in `JupyterKernel::launch()`, preventing indefinite hangs when a kernel is alive but unresponsive due to partial ZMQ bind failure.
- **Adds `launch_kernel_with_retry()`** in the runtime agent with a 60-second per-attempt timeout and up to 3 retry attempts, each with fresh port allocation. Both `LaunchKernel` and `RestartKernel` handlers use this wrapper.
- **Derives `Clone`** on `KernelLaunchConfig` and `KernelSharedRefs` to support retry cloning.

## Root cause

Discovered by the gremlin suite during v2.2.0 testing: 19 concurrent pixi notebook launches caused one kernel to hang for 20+ minutes, blocking 10/19 gremlins.

Two interacting bugs:

1. **TOCTOU port race** -- `peek_ports_with_listeners()` reserves 5 ports via TCP listeners, but `drop(listeners)` releases them before the kernel process binds its ZMQ sockets. Under high concurrency, the OS can reassign a port to another process during this window.

2. **Missing timeout recovery** -- When a kernel partially binds (e.g., 4/5 ZMQ ports succeed), it stays alive but broken. The existing `select!` racing `shell.read()` (30s timeout) vs `died_rx` (process death) never fires because neither condition is met: the kernel is alive but unresponsive on the shell channel due to the stolen port.

The specific incident: port 33425 (`stdin_port`) was stolen during concurrent launch. The kernel started (4/5 ports bound) but the runtime agent hung in the `kernel_info_reply` check for 20+ minutes until the gremlin suite timed out.

## What changed

| File | Change |
|---|---|
| `crates/runtimed/src/jupyter_kernel.rs` | Wrap shell-connect + kernel_info_reply in `tokio::time::timeout(45s)`. Inner `select!` still handles fast path (kernel dies or responds within 30s); outer timeout catches alive-but-broken kernels. |
| `crates/runtimed/src/runtime_agent.rs` | New `launch_kernel_with_retry()`: 60s per-attempt timeout, 3 attempts max, 500ms backoff between retries. Fresh `KernelLaunchConfig` clone per attempt so port allocation restarts. |
| `crates/runtimed/src/kernel_connection.rs` | `#[derive(Clone)]` on `KernelLaunchConfig` and `KernelSharedRefs`. |

## Test plan

- [x] `cargo clippy -p runtimed` passes with zero warnings
- [x] Stress test: 10 concurrent pixi notebooks during pool warmup (4/10 pixi envs ready) -- 10/10 passed, 2.3s each
- [x] Stress test: 15 concurrent pixi notebooks (exceeds pool of 10) -- 15/15 passed
- [x] Stress test: 10 concurrent pixi notebooks after daemon restart during warmup -- 10/10 passed
- [x] Zero ZMQ port collisions or retry messages in daemon log across all runs (normal path unaffected)
- [ ] Full gremlin suite pass (pending)