### PR TITLE
chore: fix all 14 eslint warnings across JS/TS codebase

### DIFF
--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -7,7 +7,7 @@
  * Time-dependent tests use RxJS VirtualTimeScheduler instead of vi.useFakeTimers.
  */
 
-import { describe, expect, it, vi, beforeEach, afterEach } from "vite-plus/test";
+import { describe, expect, it, vi, beforeEach } from "vite-plus/test";
 import { VirtualTimeScheduler, VirtualAction } from "rxjs";
 import { SyncEngine } from "../src/sync-engine";
 import { DirectTransport } from "../src/direct-transport";
@@ -101,13 +101,6 @@ function makeRuntimeState(
     executions: executions as RuntimeState["executions"],
   };
 }
-
-const EMPTY_CHANGESET: CellChangeset = {
-  changed: [],
-  added: [],
-  removed: [],
-  order_changed: false,
-};
 
 // ── Helper: advance scheduler to a given time ───────────────────────
 
@@ -855,9 +848,7 @@ describe("SyncEngine", () => {
     });
 
     it("does not emit cellChanges$ during initial sync phase", () => {
-      let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        callCount++;
         return [
           syncAppliedEvent({
             changed: true,

--- a/packages/sift/e2e/odometer.spec.ts
+++ b/packages/sift/e2e/odometer.spec.ts
@@ -36,7 +36,7 @@ test.describe("Odometer", () => {
     await expect(stats).toHaveAttribute("data-value", /100,000/, {
       timeout: 10_000,
     });
-    const beforeFilter = await stats.getAttribute("data-value");
+    const _beforeFilter = await stats.getAttribute("data-value");
     await page.screenshot({ path: "test-results/odometer-before-filter.png" });
 
     // Apply a range filter on Score column via brush

--- a/packages/sift/e2e/perf.spec.ts
+++ b/packages/sift/e2e/perf.spec.ts
@@ -201,7 +201,7 @@ test.describe("Performance Benchmarks (100k rows)", () => {
                 bubbles: true,
               }),
             );
-            document.body.offsetHeight;
+            void document.body.offsetHeight;
             results.push(performance.now() - t0);
             step++;
             if (step < 20) requestAnimationFrame(tick);

--- a/packages/sift/e2e/profiling.spec.ts
+++ b/packages/sift/e2e/profiling.spec.ts
@@ -25,7 +25,7 @@ test.describe("Column Profiling", () => {
   test("profiling stats survive filter application", async ({ page }) => {
     // Find a profile element before filtering
     const profileEls = page.locator(".sift-th-profile");
-    const countBefore = await profileEls.count();
+    const _countBefore = await profileEls.count();
 
     // Apply a filter via the Score histogram
     const scoreTh = page.locator(".sift-th", { hasText: "SCORE" });

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -217,7 +217,7 @@ export function createTable(
   const cellCaches: (CellCache[] | null)[] = [];
 
   function prepareCellRow(r: number): CellCache[] {
-    const row = new Array<CellCache>(columns.length);
+    const row = Array.from<CellCache>({ length: columns.length });
     for (let c = 0; c < columns.length; c++) {
       row[c] = {
         prepared: prepare(data.getCell(r, c), FONT),
@@ -1027,7 +1027,7 @@ export function createTable(
       if (!summary || (summary.kind !== "numeric" && summary.kind !== "timestamp")) continue;
 
       const bins = summary.bins;
-      const visibleBins = new Array<number>(bins.length).fill(0);
+      const visibleBins = Array.from<number>({ length: bins.length }).fill(0);
       const binWidth = (summary.max - summary.min) / bins.length || 1;
 
       for (let r = visFirst; r <= visLast; r++) {
@@ -2042,7 +2042,7 @@ export function createTable(
   // Precompute cumulative left offsets for pinned columns
   let pinnedLeftOffsets: number[] = [];
   function recomputePinnedOffsets() {
-    pinnedLeftOffsets = new Array(columns.length).fill(-1);
+    pinnedLeftOffsets = Array.from<number>({ length: columns.length }).fill(-1);
     let cumLeft = 0;
     for (let c = 0; c < columns.length; c++) {
       if (pinnedColumns.has(c)) {

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { createWidgetStore, type WidgetStore } from "../widget-store";
+import { createWidgetStore } from "../widget-store";
 import { WidgetUpdateManager } from "../widget-update-manager";
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/components/widgets/ipycanvas/ipycanvas-commands.ts
+++ b/src/components/widgets/ipycanvas/ipycanvas-commands.ts
@@ -335,7 +335,8 @@ function drawPolygonOrLineSegments(
     }
     start = stop;
     if (close) ctx.closePath();
-    fill ? ctx.fill() : ctx.stroke();
+    if (fill) ctx.fill();
+    else ctx.stroke();
   }
 }
 
@@ -478,7 +479,8 @@ function drawStyledPolygonOrLineSegments(
     }
     start = stop;
     if (close) ctx.closePath();
-    fill ? ctx.fill() : ctx.stroke();
+    if (fill) ctx.fill();
+    else ctx.stroke();
   }
   ctx.restore();
 }

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -23,10 +23,8 @@ import {
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_INSTALL_RENDERER,
   NTERACT_RENDER_BATCH,
-  NTERACT_RENDER_COMPLETE,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
-  NTERACT_RESIZE,
   NTERACT_THEME,
 } from "@/components/isolated/rpc-methods";
 // Import output components directly (not through MediaRouter's lazy loading)


### PR DESCRIPTION
## Summary
- Remove unused imports (`afterEach`, `WidgetStore`, `NTERACT_RENDER_COMPLETE`, `NTERACT_RESIZE`)
- Remove unused variables (`EMPTY_CHANGESET`, `callCount`) and prefix intentionally unused vars with `_`
- Add `void` prefix to force-layout expression, convert ternary side-effects to `if/else`, replace ambiguous `new Array(n)` with `Array.from({ length: n })`

Brings `cargo xtask lint` from 14 warnings → 0 across 348 JS/TS files. No behavior changes.

## Test plan
- [x] `cargo xtask lint --fix` passes with 0 warnings, 0 errors
- [ ] CI passes (Rust clippy, JS/TS lint, Python ruff)