### PR TITLE
fix(ci): dx-dist artifact path — uv workspace writes to repo-root dist/

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -673,7 +673,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dx-dist
-          path: python/dx/dist
+          # uv build in a workspace writes to repo-root dist/, not
+          # python/dx/dist — same as the nteract job above.
+          path: dist/dx-*
           if-no-files-found: error
 
   build-python-wheels:


### PR DESCRIPTION
## Summary

Nightly run [24428470275](https://github.com/nteract/desktop/actions/runs/24428470275) failed at the new dx-dist upload step:

```
Successfully built /home/runner/_work/desktop/desktop/dist/dx-2.0.1a....whl
path: python/dx/dist
Error: No files were found with the provided path: python/dx/dist
```

Inside a uv workspace (`pyproject.toml` at repo root), `uv build --no-sources` writes to `$WORKSPACE/dist/` rather than the package subdirectory. The sibling nteract-build step already uses `path: dist` — mirror that with a dx-specific glob so it's unambiguous if the job ever built both.

## Test plan

- [ ] Merge, retrigger Nightly Release, confirm dx-dist artifact uploads and "Publish dx to PyPI" step succeeds