### PR TITLE
feat(dx): register ipython_display_formatter handler for DataFrames

### DIFF
--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -99,11 +99,13 @@ def install_formatters() -> None:
     # IPython's InteractiveShell exposes DisplayFormatter as an attribute,
     # not a method — do not call it.
     mimebundle = ip.display_formatter.mimebundle_formatter
+    ipython_display = ip.display_formatter.ipython_display_formatter
 
     try:
         import pandas as pd
 
         mimebundle.for_type(pd.DataFrame, _pandas_mimebundle)
+        ipython_display.for_type(pd.DataFrame, _pandas_ipython_display)
     except ImportError:
         pass
 
@@ -111,6 +113,7 @@ def install_formatters() -> None:
         import polars as pl
 
         mimebundle.for_type(pl.DataFrame, _polars_mimebundle)
+        ipython_display.for_type(pl.DataFrame, _polars_ipython_display)
     except ImportError:
         pass
 
@@ -203,6 +206,54 @@ def _pandas_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
 
 def _polars_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
     return _emit_dataframe(df, total_rows=df.height)
+
+
+def _pandas_ipython_display(df: Any) -> None:
+    """`ipython_display_formatter` handler for `pd.DataFrame`.
+
+    IPython's `DisplayFormatter.format()` checks `ipython_display_formatter`
+    before walking mimebundle/per-MIME formatters. If our handler matches,
+    `format()` returns `({}, {})` and the displayhook's send is suppressed.
+    We publish our own `display_data` message via `publish_display_data`,
+    which flows through `ZMQDisplayPublisher.publish` → the existing
+    `_dx_display_pub_hook`, which attaches parquet buffers.
+
+    Net effect for a last-expression `df`: one `display_data` message goes
+    on the wire (with buffers). No `execute_result` is emitted — the saved
+    `.ipynb` records the output as `display_data`, which is valid nbformat.
+    `_`, `__`, `___` and `ExecutionResult` bookkeeping still update because
+    they run at steps 4–5 of `DisplayHook.__call__`, independently of the
+    message send.
+    """
+    _publish_via_ipython_display(df, total_rows=len(df))
+
+
+def _polars_ipython_display(df: Any) -> None:
+    """`ipython_display_formatter` handler for `pl.DataFrame`."""
+    _publish_via_ipython_display(df, total_rows=df.height)
+
+
+def _publish_via_ipython_display(df: Any, *, total_rows: int) -> None:
+    """Shared body for the pandas / polars `ipython_display` handlers."""
+    # Lazy import so dx.install() doesn't hard-depend on IPython being
+    # importable from the install site (it already is under ipykernel,
+    # but stay symmetrical with _emit_dataframe).
+    try:
+        from IPython.display import publish_display_data
+    except ImportError:
+        return
+
+    try:
+        bundle = _emit_dataframe(df, total_rows=total_rows)
+    except Exception as exc:
+        log.debug("dx: _emit_dataframe failed: %s — falling back to repr", exc)
+        bundle = None
+
+    if bundle:
+        publish_display_data(data=bundle, metadata={})
+    else:
+        # Fallback so a failed formatter doesn't silently eat the output.
+        print(repr(df))
 
 
 def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -15,6 +15,7 @@ class FakeMimebundleFormatter:
 class FakeDisplayFormatter:
     def __init__(self) -> None:
         self.mimebundle_formatter = FakeMimebundleFormatter()
+        self.ipython_display_formatter = FakeMimebundleFormatter()
 
 
 class FakeSession:
@@ -93,6 +94,7 @@ def test_install_treats_display_formatter_as_attribute_not_method(monkeypatch):
     class NonCallableFormatter:
         def __init__(self):
             self.mimebundle_formatter = FakeMimebundleFormatter()
+            self.ipython_display_formatter = FakeMimebundleFormatter()
 
         def __call__(self, *a, **kw):
             raise TypeError("real IPython's display_formatter is not callable")
@@ -407,3 +409,60 @@ def test_install_third_party_renderer_activation_is_noop_when_absent(monkeypatch
     import dx
 
     dx.install()  # must not raise
+
+
+def test_install_registers_ipython_display_handler_for_pandas(monkeypatch):
+    """dx.install() must register a handler on ipython_display_formatter
+    alongside the existing mimebundle_formatter registration, so last-
+    expression `df` short-circuits the execute_result path."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+
+    dx.install()
+    assert pd.DataFrame in ip.display_formatter.ipython_display_formatter.registrations
+
+
+def test_ipython_display_handler_publishes_and_stashes_buffers(monkeypatch):
+    """The handler builds a mimebundle via _emit_dataframe (which stashes
+    parquet bytes in _pending_buffers keyed by hash) and publishes a
+    display_data message carrying BLOB_REF_MIME. The publisher hook is
+    the piece that later attaches the buffers — this test covers just
+    the formatter side."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import dx._format_install as fi
+
+    dx.install()
+    handler = ip.display_formatter.ipython_display_formatter.registrations[pd.DataFrame]
+
+    published: list[dict] = []
+
+    def fake_publish_display_data(data, metadata=None, **kwargs):
+        published.append({"data": data, "metadata": metadata})
+
+    # Patch the real publish_display_data *inside* the function scope where
+    # the handler imports it. The handler does `from IPython.display import
+    # publish_display_data` lazily, so patch IPython.display.
+    import IPython.display as ipd
+
+    monkeypatch.setattr(ipd, "publish_display_data", fake_publish_display_data)
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    handler(df)
+
+    assert len(published) == 1, f"expected one publish call, got {len(published)}"
+    bundle = published[0]["data"]
+    assert BLOB_REF_MIME in bundle, f"expected BLOB_REF_MIME in bundle keys: {list(bundle)}"
+    ref = bundle[BLOB_REF_MIME]
+    assert ref["content_type"] == "application/vnd.apache.parquet"
+    assert isinstance(ref["hash"], str) and len(ref["hash"]) == 64  # sha256 hex
+
+    # The parquet bytes must be in the pending stash so the publisher hook
+    # can pop them on the subsequent IOPub send.
+    assert ref["hash"] in fi._pending_buffers(), "buffer not stashed for hash"


### PR DESCRIPTION
## Summary

Fixes the last-expression `df` case that was silently broken: a fresh DataFrame as a cell's last expression emitted `BLOB_REF_MIME` with no buffers attached (the existing `ZMQDisplayPublisher.register_hook` only fires on `display_data` / `update_display_data`, not on `execute_result`). The daemon dropped the ref; the UI fell back to the pandas HTML table.

It deceptively "worked" in live sessions because any df whose content hash was already in the blob store from a prior `display(df)` would resolve — a content-addressed cache hit, not a feature.

## Approach

Register a handler on `ip.display_formatter.ipython_display_formatter` for `pd.DataFrame` (and polars when available). IPython's `DisplayFormatter.format()` checks `ipython_display_formatter` **before** walking mimebundle/per-MIME formatters (see `formatters.py:204-206`). When our handler fires:

1. It calls `_emit_dataframe(df)` → builds the `BLOB_REF_MIME` bundle, stashes parquet bytes in `_pending_buffers[hash]`.
2. It calls `publish_display_data(bundle)` directly → `display_data` message hits `ZMQDisplayPublisher.publish` → existing `_dx_display_pub_hook` attaches the buffers.
3. It returns truthy → `DisplayFormatter.format()` returns `({}, {})` → `DisplayHook.__call__` skips `write_format_data` and `finish_displayhook`'s guarded send → no `execute_result` message is published.

One message on the wire. The same publisher hook serves both `display(df)` and last-expression `df`.

Uses only public APIs (`for_type` on `ipython_display_formatter`, symmetric to the existing `mimebundle_formatter.for_type`). No ipykernel internals touched.

## Trade-off

Last-expression `df` cells now save as `output_type: display_data` instead of `execute_result`. Both are valid nbformat, all mainstream viewers render them identically, and `_`/`__`/`___` bookkeeping is unaffected (runs at step 4 of `DisplayHook.__call__`). The visible difference: no `Out[N]:` prompt on last-expression DataFrame cells — which already matches `display(df)` behavior.

## Test plan

- [x] Unit test: `ipython_display_formatter` gets a registration for `pd.DataFrame` after `install()`
- [x] Unit test: calling the handler publishes one `display_data` message with `BLOB_REF_MIME` and stashes parquet bytes under the hash
- [x] `uv run pytest python/dx/tests/` — 37/37 pass
- [x] `uv run ty check python/dx/` — clean
- [x] `cargo xtask lint` — clean
- [x] Manual: opened a fresh df as last-expression in a live notebook, sift rendered end-to-end

## Out of scope / follow-up

C1 — upload parquet bytes via the reserved `nteract.dx.blob` comm namespace — would delete both the publisher hook and this handler's dependency on it (bytes arrive at the blob store before the display message, so `blob_store.exists(hash)` is True without any buffer routing). Worth a design spec; not needed for this fix.