### PR TITLE
fix(ci): fail the release when a PyPI publish step errors

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -950,16 +950,24 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      # PyPI publish steps fail the release if they error. Nightly runs
+      # generate unique per-minute versions (e.g. 2.2.1a202604150406) so
+      # "version already exists" collisions shouldn't happen under normal
+      # scheduling. If they do happen, the right response is to fail loudly
+      # and investigate — not pretend the release shipped.
+      #
+      # Trusted-publisher config on PyPI must include an entry for this
+      # workflow (`release-common.yml`) per published project. Missing
+      # entries surface here as "403 Invalid API Token … not valid for
+      # project 'X'". Fix at https://pypi.org/manage/project/{name}/settings/publishing/.
+
       - name: Publish runtimed to PyPI
-        continue-on-error: true
         run: uv publish --trusted-publishing always ./wheels/*.whl
 
       - name: Publish nteract to PyPI
-        continue-on-error: true
         run: uv publish --trusted-publishing always ./nteract-dist/*
 
       - name: Publish dx to PyPI
-        continue-on-error: true
         run: uv publish --trusted-publishing always ./dx-dist/*
 
       - name: Generate release body


### PR DESCRIPTION
## Summary

`continue-on-error: true` on the three "Publish … to PyPI" steps turned publish failures into silent misses. Today's nightly published runtimed + nteract but dropped dx with a **403** (trusted-publisher config on PyPI didn't include `release-common.yml` for the `dx` project yet) — the overall release still ran green.

Dropping `continue-on-error` so a real publish failure fails the release loudly. Nightly versions are per-minute timestamped, so "version already exists" collisions shouldn't occur under normal scheduling — and if they do, that's a state mismatch we want to investigate, not hide.

Also adds a comment in the workflow pointing at the PyPI publishing-settings URL so the trusted-publisher fix is one click away for the next person.

## Test plan

- [x] YAML parses
- [ ] Next nightly run fails if any publish 4xx/5xx (verify after merge)
- [ ] Next nightly run succeeds if all three publishes land (verify dx ends up on pypi.org/project/dx/#history)