### PR TITLE
feat(dx): register formatters for narwhals DataFrame wrappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "polars",
     "pyarrow>=14",
     "numpy>=2.2.6",
+    "narwhals>=1.0",
 ]
 
 [build-system]

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -29,4 +29,5 @@ dev = [
     "pyarrow>=14",
     "polars>=0.20",
     "ipykernel>=6.0",
+    "narwhals>=1.0",
 ]

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -117,6 +117,21 @@ def install_formatters() -> None:
     except ImportError:
         pass
 
+    # Narwhals wraps pandas/polars/pyarrow/modin/dask/cudf behind a common
+    # DataFrame API. Users may type an nw.DataFrame as a last expression
+    # without thinking about the underlying flavor. We unwrap via
+    # `.to_native()` and dispatch through the pandas/polars paths, with
+    # a `.to_pandas()` fallback for other narwhals-supported backends.
+    # LazyFrame is deliberately not handled here — displaying a lazy
+    # query would force `.collect()`, which has side effects.
+    try:
+        import narwhals as nw
+
+        mimebundle.for_type(nw.DataFrame, _narwhals_mimebundle)
+        ipython_display.for_type(nw.DataFrame, _narwhals_ipython_display)
+    except ImportError:
+        pass
+
     _install_display_pub_hook()
     _enable_third_party_nteract_renderers()
 
@@ -208,6 +223,21 @@ def _polars_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
     return _emit_dataframe(df, total_rows=df.height)
 
 
+def _narwhals_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
+    """`mimebundle_formatter` handler for `narwhals.DataFrame`.
+
+    Mirrors the display-formatter path below: unwrap via `.to_native()`
+    and delegate to the flavor-specific emitter. Kept alongside its
+    pandas/polars siblings so any tooling that bypasses the
+    `ipython_display_formatter` short-circuit still gets a parquet
+    bundle from a narwhals wrapper.
+    """
+    native, total_rows = _unwrap_narwhals(df)
+    if native is None:
+        return None
+    return _emit_dataframe(native, total_rows=total_rows)
+
+
 def _pandas_ipython_display(df: Any) -> None:
     """`ipython_display_formatter` handler for `pd.DataFrame`.
 
@@ -231,6 +261,65 @@ def _pandas_ipython_display(df: Any) -> None:
 def _polars_ipython_display(df: Any) -> None:
     """`ipython_display_formatter` handler for `pl.DataFrame`."""
     _publish_via_ipython_display(df, total_rows=df.height)
+
+
+def _narwhals_ipython_display(nw_df: Any) -> None:
+    """`ipython_display_formatter` handler for `narwhals.DataFrame`.
+
+    Unwrap via `.to_native()` and dispatch through the native-type path.
+    Falls back to `.to_pandas()` for backends `serialize_dataframe` doesn't
+    natively encode (modin, pyarrow Table, dask, cudf).
+    """
+    native, total_rows = _unwrap_narwhals(nw_df)
+    if native is None:
+        # Couldn't unwrap — surface a best-effort repr instead of silently
+        # dropping the output.
+        print(repr(nw_df))
+        return
+    _publish_via_ipython_display(native, total_rows=total_rows)
+
+
+def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
+    """Return ``(native_df, row_count)`` for a ``narwhals.DataFrame``.
+
+    - If the underlying native is pandas or polars, return it directly so
+      ``serialize_dataframe`` hits its fast path.
+    - Otherwise, convert to pandas via narwhals's own adapter. This may
+      materialize a potentially-expensive frame (modin/dask/cudf), which
+      is the expected cost of "show me this DataFrame."
+    - On any unexpected error, return ``(None, 0)`` and let the caller
+      decide on a fallback.
+    """
+    try:
+        native = nw_df.to_native()
+    except Exception as exc:
+        log.debug("dx: narwhals to_native failed: %s", exc)
+        return None, 0
+
+    # Fast path: the native is pandas or polars — use their row counts directly.
+    try:
+        import pandas as pd
+
+        if isinstance(native, pd.DataFrame):
+            return native, len(native)
+    except ImportError:
+        pass
+    try:
+        import polars as pl
+
+        if isinstance(native, pl.DataFrame):
+            return native, native.height
+    except ImportError:
+        pass
+
+    # Fallback: round-trip through narwhals's to_pandas. Works for pyarrow,
+    # modin, dask, cudf, etc. — anything narwhals understands.
+    try:
+        as_pandas = nw_df.to_pandas()
+        return as_pandas, len(as_pandas)
+    except Exception as exc:
+        log.debug("dx: narwhals to_pandas failed: %s", exc)
+        return None, 0
 
 
 def _publish_via_ipython_display(df: Any, *, total_rows: int) -> None:

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -83,8 +83,8 @@ def test_install_is_idempotent(monkeypatch):
     dx.install()
     dx.install()
     assert (
-        len(ip.display_formatter.mimebundle_formatter.registrations) <= 2
-    )  # pandas + optional polars
+        len(ip.display_formatter.mimebundle_formatter.registrations) <= 3
+    )  # pandas + optional polars + optional narwhals
 
 
 def test_install_treats_display_formatter_as_attribute_not_method(monkeypatch):
@@ -466,3 +466,124 @@ def test_ipython_display_handler_publishes_and_stashes_buffers(monkeypatch):
     # The parquet bytes must be in the pending stash so the publisher hook
     # can pop them on the subsequent IOPub send.
     assert ref["hash"] in fi._pending_buffers(), "buffer not stashed for hash"
+
+
+# ── Narwhals wrapping ──────────────────────────────────────────────
+
+
+def test_install_registers_ipython_display_handler_for_narwhals(monkeypatch):
+    """narwhals.DataFrame wraps pandas/polars/pyarrow/modin/dask/cudf.
+    dx.install() should register for the wrapper type too so a
+    last-expression nw.DataFrame doesn't fall back to narwhals's own repr."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import narwhals as nw
+
+    dx.install()
+    assert nw.DataFrame in ip.display_formatter.ipython_display_formatter.registrations
+
+
+def test_narwhals_handler_unwraps_pandas_and_publishes(monkeypatch):
+    """Fast path: nw.DataFrame backed by pandas — unwrap via to_native()
+    and emit via the pandas encoder directly (no to_pandas() round-trip)."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import dx._format_install as fi
+    import narwhals as nw
+
+    dx.install()
+    handler = ip.display_formatter.ipython_display_formatter.registrations[nw.DataFrame]
+
+    published: list[dict] = []
+
+    def fake_publish_display_data(data, metadata=None, **kwargs):
+        published.append({"data": data})
+
+    import IPython.display as ipd
+
+    monkeypatch.setattr(ipd, "publish_display_data", fake_publish_display_data)
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    nw_df = nw.from_native(df)
+    handler(nw_df)
+
+    assert len(published) == 1
+    bundle = published[0]["data"]
+    assert BLOB_REF_MIME in bundle
+    ref = bundle[BLOB_REF_MIME]
+    assert ref["content_type"] == "application/vnd.apache.parquet"
+    assert ref["hash"] in fi._pending_buffers()
+
+
+def test_narwhals_handler_unwraps_polars_and_publishes(monkeypatch):
+    """Fast path: nw.DataFrame backed by polars — unwrap + polars encoder."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import dx._format_install as fi
+    import narwhals as nw
+    import polars as pl
+
+    dx.install()
+    handler = ip.display_formatter.ipython_display_formatter.registrations[nw.DataFrame]
+
+    published: list[dict] = []
+
+    def fake_publish_display_data(data, metadata=None, **kwargs):
+        published.append({"data": data})
+
+    import IPython.display as ipd
+
+    monkeypatch.setattr(ipd, "publish_display_data", fake_publish_display_data)
+
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    nw_df = nw.from_native(df)
+    handler(nw_df)
+
+    assert len(published) == 1
+    bundle = published[0]["data"]
+    assert BLOB_REF_MIME in bundle
+    assert bundle[BLOB_REF_MIME]["hash"] in fi._pending_buffers()
+
+
+def test_narwhals_handler_falls_back_to_pandas_for_pyarrow_table(monkeypatch):
+    """pyarrow Table isn't supported by serialize_dataframe directly.
+    The narwhals handler should round-trip via .to_pandas() so the fast
+    path in _emit_dataframe still hits the pandas encoder."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import dx._format_install as fi
+    import narwhals as nw
+    import pyarrow as pa
+
+    dx.install()
+    handler = ip.display_formatter.ipython_display_formatter.registrations[nw.DataFrame]
+
+    published: list[dict] = []
+
+    def fake_publish_display_data(data, metadata=None, **kwargs):
+        published.append({"data": data})
+
+    import IPython.display as ipd
+
+    monkeypatch.setattr(ipd, "publish_display_data", fake_publish_display_data)
+
+    table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    nw_df = nw.from_native(table, eager_only=True)
+    handler(nw_df)
+
+    assert len(published) == 1
+    bundle = published[0]["data"]
+    assert BLOB_REF_MIME in bundle
+    assert bundle[BLOB_REF_MIME]["hash"] in fi._pending_buffers()


### PR DESCRIPTION
## Summary

Narwhals wraps pandas/polars/pyarrow/modin/dask/cudf behind a unified DataFrame API. Users increasingly write against `narwhals.DataFrame` without thinking about the underlying flavor — and our existing `for_type` registrations on `pd.DataFrame` / `pl.DataFrame` don't catch the wrapper, so a last-expression `nw.DataFrame` falls back to narwhals's own repr.

Adds formatter registration for `narwhals.DataFrame` on both `mimebundle_formatter` and `ipython_display_formatter`. The handler calls `.to_native()` and dispatches:

- **Pandas native** → fast path, pandas encoder
- **Polars native** → fast path, polars encoder
- **Anything else** (pyarrow Table, modin, dask, cudf) → round-trip via narwhals's `.to_pandas()` so `serialize_dataframe` still hits its pandas branch

`narwhals.LazyFrame` is deliberately **not** registered — rendering would force `.collect()`, which has side effects and can be expensive on distributed backends. Users who want it displayed call `lz.collect()` explicitly.

## Smoke test

`notebooks/dx-narwhals-smoke.ipynb` (not in this diff) exercised all paths live against the dev daemon:

| Input | Output MIMEs | Rendered as |
|---|---|---|
| `nw.from_native(pd.DataFrame(...))` | parquet + text/llm+plain ("DataFrame (pandas)") | sift |
| `nw.from_native(pl.DataFrame(...))` | parquet + text/llm+plain ("DataFrame (polars)") | sift |
| `nw.from_native(pa.table(...), eager_only=True)` | parquet + text/llm+plain (pandas, after `to_pandas()` round-trip) | sift |
| `nw.from_native(pl.DataFrame(...).lazy())` | text/plain (narwhals default repr) | untouched — no registration for LazyFrame |

## Test plan

- [x] `uv run pytest python/dx/tests/` — 41/41 pass
- [x] `uv run ty check python/dx/` clean
- [x] `cargo xtask lint` clean
- [x] Live smoke: all four scenarios above
- [x] `dx.install()` remains idempotent (existing test updated to allow up to 3 registrations now that narwhals is in)

## Notes

- `narwhals>=1.0` added as dev-dep in `python/dx/pyproject.toml` and `uv sync` also pulled it into the root workspace `pyproject.toml` so the whole dev env has it. Not a runtime dep of the `dx` package — the registration is guarded by `try/except ImportError`.
- The pyarrow-Table case's `text/llm+plain` summary says "DataFrame (pandas)" because by the time `_emit_dataframe` runs we've already converted via `to_pandas()`. Accurate wrt what was serialized; slight mismatch with what the user typed. Could later thread through the pre-conversion flavor if it matters.