### PR TITLE
chore(xtask): run `ty check` as part of `cargo xtask lint`

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2160,8 +2160,22 @@ fn cmd_lint(fix: bool) {
                 failed = true;
             }
             println!();
+
+            // ty type-check. ty is a dev-dep at the workspace root; the
+            // python-package workflow already gates PRs on it, so we run
+            // the same command here to give local `cargo xtask lint` the
+            // same coverage. `ty check` is read-only — the --fix flag has
+            // no effect on it.
+            println!("=== Python (ty) ===");
+            let ty_status = Command::new("uv")
+                .args(["run", "ty", "check", "python/"])
+                .status();
+            if !ty_status.map(|s| s.success()).unwrap_or(false) {
+                failed = true;
+            }
+            println!();
         } else {
-            println!("=== Python (ruff) ===");
+            println!("=== Python (ruff + ty) ===");
             println!("Skipping: uv not found in PATH");
             println!();
         }


### PR DESCRIPTION
## Summary

The python-package CI workflow gates PRs on `uv run ty check python/`, but local `cargo xtask lint` only ran ruff. Local and CI lint signals disagreed — devs could push PRs that passed locally and failed in CI on type errors.

Adds `ty check python/` as a third section in the Python lint block, after ruff check + ruff format. Same command, same arguments as CI.

`ty check` is read-only — the existing `--fix` flag doesn't affect it. Renamed the "skip if uv missing" header to "ruff + ty" for accuracy.

## Test plan

- [x] `cargo xtask lint` runs ruff and ty, both pass on current main (closes #13)
- [x] `cargo xtask lint --fix` behaves the same (ty is skipped-by-design for fixes)
- [x] `codex review --base main` clean — no regressions identified