### PR TITLE
docs: update agent-facing docs to the up/down/status supervisor surface

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -28,7 +28,7 @@ Consolidated around two verbs plus three read-only tools:
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent "bring the dev environment to a working state." Sweeps zombie Vite processes, ensures the daemon is running, ensures the MCP child is healthy. Optional args: `vite=true` to also start Vite, `rebuild=true` to rebuild daemon + Python bindings first, `mode='debug'\|'release'` to switch build mode. Safe to call repeatedly — this is the first thing to reach for when things feel off. |
-| `down` | Stop managed processes (Vite + child). Leaves the daemon running by default (launchd / the installed app may own it). Pass `daemon=true` to also stop the managed daemon process. |
+| `down` | Stop the managed Vite dev server. Leaves the daemon running by default (launchd / the installed app may own it). Pass `daemon=true` to also stop the managed daemon process. |
 | `status` | Read-only report of supervisor, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log. Arg: `lines` (default 50). |
 | `vite_logs` | Tail the Vite dev server log. Arg: `lines` (default 50). |

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -165,7 +165,7 @@ cargo xtask dev-mcp
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent bring-up. Sweeps zombie Vite processes, ensures daemon + child healthy. Args: `vite=true` (start Vite, health-probed), `rebuild=true` (rebuild daemon + bindings first), `mode="debug"\|"release"` |
-| `down` | Stop managed Vite + child. `daemon=true` also stops daemon. |
+| `down` | Stop the managed Vite dev server. `daemon=true` also stops daemon. |
 | `status` | Read-only report of child, daemon, managed processes, build mode |
 | `logs` | Tail daemon log file |
 | `vite_logs` | Tail Vite dev server log file |

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -164,14 +164,13 @@ cargo xtask dev-mcp
 
 | Tool | Purpose |
 |------|---------|
-| `supervisor_status` | Child process, daemon, restart count, last error |
-| `supervisor_restart` | Restart child or daemon |
-| `supervisor_rebuild` | Rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child |
-| `supervisor_logs` | Tail daemon log file |
-| `supervisor_vite_logs` | Tail Vite dev server log file |
-| `supervisor_start_vite` | Start Vite dev server for hot-reload frontend dev |
-| `supervisor_stop` | Stop a managed process by name |
-| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds |
+| `up` | Idempotent bring-up. Sweeps zombie Vite processes, ensures daemon + child healthy. Args: `vite=true` (start Vite, health-probed), `rebuild=true` (rebuild daemon + bindings first), `mode="debug"\|"release"` |
+| `down` | Stop managed Vite + child. `daemon=true` also stops daemon. |
+| `status` | Read-only report of child, daemon, managed processes, build mode |
+| `logs` | Tail daemon log file |
+| `vite_logs` | Tail Vite dev server log file |
+
+The older `supervisor_*` names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases.
 
 ### Hot Reload
 

--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -21,7 +21,7 @@ cd crates/runtimed-py
 VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
-This is what `supervisor_rebuild` does automatically.
+This is what `up rebuild=true` does automatically.
 
 ### Into test venv (for pytest)
 
@@ -230,4 +230,4 @@ cd crates/runtimed-py
 VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
-Or if using nteract-dev supervisor, call `supervisor_rebuild`.
+Or if using nteract-dev supervisor, call `up rebuild=true`.

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -23,7 +23,7 @@ Run `git diff --name-only` to see changed files and match them to the table belo
 | `crates/kernel-launch/src/**` | `cargo test -p kernel-launch` |
 | `crates/runt/src/**` | `cargo test -p runt` |
 | `crates/runt-workspace/src/**` | `cargo test -p runt-workspace` |
-| `crates/runtimed-py/src/**` | `supervisor_rebuild` (rebuilds Python bindings) |
+| `crates/runtimed-py/src/**` | `up rebuild=true` (rebuilds Python bindings) |
 | `python/nteract/src/**` | Supervisor auto-restarts; no explicit test needed |
 | `python/runtimed/src/**` | Supervisor auto-restarts; run `pytest python/runtimed/tests/test_session_unit.py -v` |
 | `apps/notebook/src/**` | `pnpm test:run` |
@@ -33,11 +33,11 @@ If multiple crates changed, run tests for each: `cargo test -p runtimed -p noteb
 
 ## Step 3: MCP Live Verification (when supervisor tools are available)
 
-If narrow tests pass and you have `supervisor_*` and `open_notebook`/`execute_cell` tools, do a live check:
+If narrow tests pass and you have the nteract-dev supervisor (`up`/`down`/`status`) and `open_notebook`/`execute_cell` tools, do a live check:
 
 ### For daemon/kernel changes (`crates/runtimed/`, `crates/runtimed-py/`):
 
-1. `supervisor_rebuild` (if Rust changed)
+1. `up rebuild=true` (if Rust changed)
 2. `create_notebook` with runtime "python"
 3. `create_cell` with source `1 + 1`
 4. `execute_cell` on that cell
@@ -60,7 +60,7 @@ If narrow tests pass and you have `supervisor_*` and `open_notebook`/`execute_ce
 
 ### For kernel environment changes (`crates/kernel-env/`, `crates/kernel-launch/`):
 
-1. `supervisor_rebuild` (if Rust changed)
+1. `up rebuild=true` (if Rust changed)
 2. `create_notebook`
 3. `create_cell` with source `import sys; print(sys.executable)`
 4. `execute_cell` — verify output shows a Python path

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -63,7 +63,7 @@ Start or restart the worktree daemon when:
 If the nteract-dev MCP supervisor is available, prefer:
 
 - `up` — idempotent "bring the dev environment up". Ensures daemon + child are healthy. Args: `vite=true`, `rebuild=true`, `mode="debug"|"release"`
-- `down` — stop managed Vite + child. `daemon=true` also stops the daemon
+- `down` — stop the managed Vite dev server. `daemon=true` also stops the daemon
 - `status` — read-only report
 - `logs` — tail daemon logs
 - `vite_logs` — tail Vite dev server logs when you need the Vite side of a hot-reload session

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -60,15 +60,15 @@ Start or restart the worktree daemon when:
 
 ## Prefer supervisor tools when available
 
-If the MCP supervisor is available, prefer:
+If the nteract-dev MCP supervisor is available, prefer:
 
-- `supervisor_restart(target="daemon")`
-- `supervisor_status`
-- `supervisor_logs`
-- `supervisor_vite_logs` when you need the Vite side of a hot-reload session
-- `supervisor_set_mode` when you intentionally need the managed daemon in `release` instead of `debug`
+- `up` — idempotent "bring the dev environment up". Ensures daemon + child are healthy. Args: `vite=true`, `rebuild=true`, `mode="debug"|"release"`
+- `down` — stop managed Vite + child. `daemon=true` also stops the daemon
+- `status` — read-only report
+- `logs` — tail daemon logs
+- `vite_logs` — tail Vite dev server logs when you need the Vite side of a hot-reload session
 
-These avoid manual env-var mistakes.
+These avoid manual env-var mistakes. The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases.
 
 ## Safety rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (the nte
 | `runt daemon status` (with env vars) | `status` |
 | `runt daemon logs` | `logs` |
 | `cargo xtask vite` | `up vite=true` |
-| `cargo xtask notebook` (stop dev processes) | `down` (stops Vite + child; `daemon=true` also stops daemon) |
+| `cargo xtask notebook` (stop dev processes) | `down` (stops Vite; `daemon=true` also stops daemon) |
 
 The supervisor automatically handles per-worktree isolation, env var plumbing, zombie Vite cleanup, health probes, and lockfile-drift re-installs. You only need the manual commands below when the supervisor isn't available (e.g. cloud sessions, CI).
 
@@ -325,7 +325,7 @@ Consolidated around two verbs plus three read-only tools:
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent "bring the dev environment to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild daemon + Python bindings first, `mode="debug"\|"release"` to switch build mode. Safe to call repeatedly. |
-| `down` | Stop managed processes (Vite + child). Leaves the daemon alone by default (launchd / installed app may own it). Pass `daemon=true` to also stop the managed daemon. |
+| `down` | Stop the managed Vite dev server. Leaves the daemon alone by default (launchd / installed app may own it). Pass `daemon=true` to also stop the managed daemon. |
 | `status` | Read-only report of supervisor, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log file. |
 | `vite_logs` | Tail the Vite dev server log file. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,21 +82,24 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 
 ## Quick Recipes (Common Dev Tasks)
 
-### If you have `supervisor_*` tools — use them
+### If you have `up` / `down` / `status` tools — use them
 
-If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
+If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (the nteract-dev supervisor surface), **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
-**Claude Code has nteract-dev locally** — the local dev environment connects Claude Code to the repo-local `nteract-dev` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
+**Claude Code has nteract-dev locally** — the local dev environment connects Claude Code to the repo-local `nteract-dev` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose these tools, use the manual `cargo xtask` commands below.
 
 | Instead of… | Use… |
 |-------------|------|
-| `cargo xtask dev-daemon` (in a terminal) | `supervisor_restart(target="daemon")` |
-| `maturin develop` (rebuild bindings) | `supervisor_rebuild` |
-| `runt daemon status` (with env vars) | `supervisor_status` |
-| `runt daemon logs` | `supervisor_logs` |
-| `cargo xtask vite` | `supervisor_start_vite` |
+| `cargo xtask dev-daemon` (in a terminal) | `up` (idempotent: ensures daemon + child are healthy) |
+| `maturin develop` (rebuild bindings) | `up rebuild=true` |
+| `runt daemon status` (with env vars) | `status` |
+| `runt daemon logs` | `logs` |
+| `cargo xtask vite` | `up vite=true` |
+| `cargo xtask notebook` (stop dev processes) | `down` (stops Vite + child; `daemon=true` also stops daemon) |
 
-The supervisor automatically handles per-worktree isolation, env var plumbing, and daemon restarts. You only need the manual commands below when the supervisor isn't available (e.g. cloud sessions, CI).
+The supervisor automatically handles per-worktree isolation, env var plumbing, zombie Vite cleanup, health probes, and lockfile-drift re-installs. You only need the manual commands below when the supervisor isn't available (e.g. cloud sessions, CI).
+
+The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases — prefer the new ones.
 
 ### Manual commands (when supervisor is not available)
 
@@ -131,7 +134,7 @@ There are **two venvs** that matter:
 | `python/runtimed/.venv` | Test-only venv — has `runtimed` + `maturin` + test deps | `pytest` integration tests |
 
 ```bash
-# For the MCP server (most common — this is what supervisor_rebuild does):
+# For the MCP server (most common — this is what `up rebuild=true` does):
 cd crates/runtimed-py && VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 
 # For integration tests only:
@@ -317,16 +320,17 @@ For the installed app, `runt mcp` ships as a sidecar binary alongside `runtimed`
 
 ### Supervisor Tools (from nteract-dev / `mcp-supervisor`)
 
+Consolidated around two verbs plus three read-only tools:
+
 | Tool | Purpose |
 |------|---------|
-| `supervisor_status` | Check child process, daemon, build mode, restart count, last error |
-| `supervisor_restart` | Restart child (`target="child"`) or daemon (`target="daemon"`) |
-| `supervisor_rebuild` | Rebuild the daemon binary and Rust Python bindings, restart the daemon, then restart the MCP child |
-| `supervisor_logs` | Tail the daemon log file |
-| `supervisor_vite_logs` | Tail the Vite dev server log file |
-| `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
-| `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
-| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds and restart it |
+| `up` | Idempotent "bring the dev environment to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild daemon + Python bindings first, `mode="debug"\|"release"` to switch build mode. Safe to call repeatedly. |
+| `down` | Stop managed processes (Vite + child). Leaves the daemon alone by default (launchd / installed app may own it). Pass `daemon=true` to also stop the managed daemon. |
+| `status` | Read-only report of supervisor, child, daemon, and managed-process state. |
+| `logs` | Tail the daemon log file. |
+| `vite_logs` | Tail the Vite dev server log file. |
+
+The older `supervisor_*` names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases.
 
 ### nteract MCP Tools (27 tools for notebook interaction)
 
@@ -354,11 +358,11 @@ The supervisor watches source directories and auto-restarts the child on changes
 
 ### Tool availability
 
-- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. nteract-dev exposes all `supervisor_*` tools plus the proxied nteract notebook tools. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. nteract-dev exposes `up` / `down` / `status` / `logs` / `vite_logs` (plus the older `supervisor_*` aliases) and the proxied nteract notebook tools. **Prefer these for daemon lifecycle** — they handle env vars and isolation automatically.
 - **Environments without supervisor tools** → use `cargo xtask` commands directly for build, daemon, and testing.
-- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no `supervisor_*`. Use manual terminal commands for daemon management.
+- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no supervisor surface. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
-- **Dev daemon not running** → nteract-dev starts it automatically via `supervisor_restart(target="daemon")`
+- **Dev daemon not running** → call `up` — nteract-dev starts it if missing
 
 ## Workspace Crates (17)
 
@@ -431,7 +435,7 @@ Use instead:
 
 ### Per-Worktree Daemon Isolation
 
-Each git worktree runs its own isolated daemon in dev mode. If you have supervisor tools, the daemon is managed for you — use `supervisor_restart(target="daemon")` to start or restart it, and `supervisor_status` to check it.
+Each git worktree runs its own isolated daemon in dev mode. If you have supervisor tools, the daemon is managed for you — use `up` to start it (idempotent), and `status` to check it.
 
 Without supervisor (manual two-terminal workflow):
 
@@ -443,7 +447,7 @@ cargo xtask dev-daemon
 cargo xtask notebook
 ```
 
-Use `./target/debug/runt` to interact with the worktree daemon (or `supervisor_status`/`supervisor_logs` if available):
+Use `./target/debug/runt` to interact with the worktree daemon (or `status`/`logs` if available):
 
 ```bash
 ./target/debug/runt daemon status

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -168,16 +168,15 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 
 **With nteract-dev (preferred for agents):**
 
-If you have the repo-local `nteract-dev` MCP entry configured, the daemon is managed for you through the `supervisor_*` tools:
+If you have the repo-local `nteract-dev` MCP entry configured, the daemon is managed for you:
 
-- `supervisor_restart(target="daemon")` — start or restart the dev daemon
-- `supervisor_status` — check daemon status (includes `daemon_managed: true/false`)
-- `supervisor_rebuild` — rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child
-- `supervisor_logs` — tail daemon logs
-- `supervisor_vite_logs` — tail the Vite dev server log file
-- `supervisor_set_mode` — switch the managed daemon between `debug` and `release`
+- `up` — idempotent "get me to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` also starts Vite (health-probed), `rebuild=true` rebuilds the daemon binary + Python bindings first, `mode="debug"|"release"` switches build mode.
+- `down` — stop managed Vite + child. Pass `daemon=true` to also stop the daemon.
+- `status` — read-only report (child, daemon, managed processes, build mode, version).
+- `logs` — tail daemon logs.
+- `vite_logs` — tail the Vite dev server log file.
 
-No env vars or extra terminals needed. nteract-dev handles per-worktree isolation automatically.
+No env vars or extra terminals needed. nteract-dev handles per-worktree isolation automatically. The older `supervisor_*` names still work as aliases.
 
 **Two-terminal workflow (without supervisor):**
 
@@ -218,7 +217,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 Per-worktree state is stored in `<cache>/{cache_namespace}/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`). Source builds default to `runt-nightly`; set `RUNT_BUILD_CHANNEL=stable` only when you intentionally need the stable flow.
 
-**For AI agents:** If the repo-local `nteract-dev` MCP entry is available, prefer its `supervisor_*` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
+**For AI agents:** If the repo-local `nteract-dev` MCP entry is available, prefer its `up` / `down` / `status` / `logs` / `vite_logs` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
 
 ```bash
 export RUNTIMED_DEV=1
@@ -361,22 +360,21 @@ Or configure `.zed/settings.json` directly (gitignored):
 }
 ```
 
-In clients that namespace tools by server name, this keeps repo-local notebook tools separate from the global install while still exposing the same notebook APIs plus the extra `supervisor_*` tools.
+In clients that namespace tools by server name, this keeps repo-local notebook tools separate from the global install while still exposing the same notebook APIs plus the extra supervisor tools.
 
 #### Supervisor tools
 
-These tools are always available, even when the Python child is down:
+These tools are always available, even when the child MCP is down:
 
 | Tool | Purpose |
 |------|---------|
-| `supervisor_status` | Child process, daemon, restart count, last error |
-| `supervisor_restart` | Restart child or daemon |
-| `supervisor_rebuild` | Rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child |
-| `supervisor_logs` | Tail the daemon log file |
-| `supervisor_vite_logs` | Tail the Vite dev server log file |
-| `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
-| `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
-| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds |
+| `up` | Idempotent dev-env bring-up. Sweeps zombie Vite processes, ensures daemon + child healthy. Args: `vite=true`, `rebuild=true`, `mode="debug"\|"release"` |
+| `down` | Stop managed processes (Vite + child). `daemon=true` also stops the daemon. |
+| `status` | Read-only report: child, daemon, managed processes, build mode, version. |
+| `logs` | Tail the daemon log file. |
+| `vite_logs` | Tail the Vite dev server log file. |
+
+The older names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases for backward compatibility.
 
 #### Hot reload
 
@@ -407,10 +405,11 @@ cargo xtask dev-mcp
 ### How it works
 
 `nteract-dev` is the **dev-only supervisor server** for this source tree. It
-exposes the extra `supervisor_*` tools itself, then proxies the regular notebook
-tools from a child `runt mcp` process launched inside the supervisor. That child
-is the Rust-native MCP implementation from `crates/runt-mcp/`, not a Python MCP
-server.
+exposes the supervisor tools (`up`, `down`, `status`, `logs`, `vite_logs`, plus
+the older `supervisor_*` aliases) itself, then proxies the regular notebook
+tools from a child `runt mcp` process launched inside the supervisor. That
+child is the Rust-native MCP implementation from `crates/runt-mcp/`, not a
+Python MCP server.
 
 The Python workspace packages still matter for local development: `python/runtimed/`
 provides the PyO3 bindings, and `python/nteract/` is the convenience wrapper that

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -171,7 +171,7 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 If you have the repo-local `nteract-dev` MCP entry configured, the daemon is managed for you:
 
 - `up` — idempotent "get me to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` also starts Vite (health-probed), `rebuild=true` rebuilds the daemon binary + Python bindings first, `mode="debug"|"release"` switches build mode.
-- `down` — stop managed Vite + child. Pass `daemon=true` to also stop the daemon.
+- `down` — stop the managed Vite dev server. Pass `daemon=true` to also stop the daemon.
 - `status` — read-only report (child, daemon, managed processes, build mode, version).
 - `logs` — tail daemon logs.
 - `vite_logs` — tail the Vite dev server log file.
@@ -369,7 +369,7 @@ These tools are always available, even when the child MCP is down:
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent dev-env bring-up. Sweeps zombie Vite processes, ensures daemon + child healthy. Args: `vite=true`, `rebuild=true`, `mode="debug"\|"release"` |
-| `down` | Stop managed processes (Vite + child). `daemon=true` also stops the daemon. |
+| `down` | Stop the managed Vite dev server. `daemon=true` also stops the daemon. |
 | `status` | Read-only report: child, daemon, managed processes, build mode, version. |
 | `logs` | Tail the daemon log file. |
 | `vite_logs` | Tail the Vite dev server log file. |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -113,7 +113,7 @@ When iterating on daemon code, you often want to test changes in the notebook ap
 The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
 
 - `up` — idempotent "bring the dev environment up". Ensures the daemon is running and the MCP child is healthy. Pass `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild the daemon binary + Python bindings first, `mode="debug"|"release"` to switch build mode.
-- `down` — stop managed Vite + child. Pass `daemon=true` to also stop the daemon.
+- `down` — stop the managed Vite dev server. Pass `daemon=true` to also stop the daemon.
 - `status` — read-only report (child, daemon, managed processes, build mode).
 - `logs` — tail the daemon log file.
 - `vite_logs` — tail the Vite dev server log file.

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -108,17 +108,17 @@ cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
 
 When iterating on daemon code, you often want to test changes in the notebook app without rebuilding the frontend.
 
-**With nteract-dev supervisor** (if you have `supervisor_*` MCP tools — e.g. in Zed):
+**With nteract-dev supervisor** (if you have `up` / `down` / `status` MCP tools — e.g. in Zed or Claude Code):
 
 The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
 
-- `supervisor_restart(target="daemon")` — start or restart the dev daemon after code changes
-- `supervisor_rebuild` — rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child
-- `supervisor_status` — check daemon status (`daemon_managed: true` confirms it's running)
-- `supervisor_logs` — tail daemon logs
-- `supervisor_vite_logs` — tail the Vite dev server log file
-- `supervisor_start_vite` — start the Vite dev server for hot-reload
-- `supervisor_set_mode` — switch the managed daemon between `debug` and `release`
+- `up` — idempotent "bring the dev environment up". Ensures the daemon is running and the MCP child is healthy. Pass `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild the daemon binary + Python bindings first, `mode="debug"|"release"` to switch build mode.
+- `down` — stop managed Vite + child. Pass `daemon=true` to also stop the daemon.
+- `status` — read-only report (child, daemon, managed processes, build mode).
+- `logs` — tail the daemon log file.
+- `vite_logs` — tail the Vite dev server log file.
+
+The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases.
 
 Then build and run the app normally:
 ```bash

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1434,10 +1434,12 @@ impl ServerHandler for Supervisor {
         ));
         tools.push(Tool::new(
             "down",
-            "Stop the managed dev processes (Vite and MCP child). Does \
-             NOT stop the daemon by default — daemons are often managed \
-             by launchd or the installed app. Pass daemon=true to also \
-             stop the managed daemon process.",
+            "Stop the managed Vite dev server (if running). Does NOT stop \
+             the MCP proxy child — the child auto-restarts on disconnect \
+             and killing it here would just cause a restart. Does NOT \
+             stop the daemon by default — daemons are often managed by \
+             launchd or the installed app. Pass daemon=true to also stop \
+             the managed daemon process.",
             down_schema,
         ));
         tools.push(Tool::new(


### PR DESCRIPTION
## Summary

Follow-up to #1777 (supervisor tool rename). That PR updated `.claude/rules/mcp-servers.md` but left the rest of the agent-facing docs pointing at `supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, etc. — all valid-as-aliases but not the preferred names.

Sweeps every live agent-facing doc to reference the current surface (`up` / `down` / `status` / `logs` / `vite_logs`), with a one-line "the older `supervisor_*` names still work as aliases" callout on each so muscle memory and existing sessions are not surprised.

**Files updated:**
- `AGENTS.md` — quick recipe table + supervisor tools table + workflow examples
- `contributing/development.md` — dev-mode section + MCP supervisor table + how-it-works
- `contributing/runtimed.md` — dev-daemon iteration guide
- `.claude/skills/frontend-dev/SKILL.md` — supervisor tools table
- `.claude/skills/verify-changes/SKILL.md` — MCP live verification intro + rebuild refs
- `.claude/skills/python-bindings/SKILL.md` — rebuild refs
- `.codex/skills/nteract-daemon-dev/references/daemon-workflows.md` — supervisor tool prefs

**Also fixes a latent tool-description bug (caught by `codex review`):**

The `down` tool's own description in `crates/mcp-supervisor/src/main.rs` claimed it stops "Vite and MCP child", but `handle_down()` only stops Vite (and optionally the daemon with `daemon=true`). The MCP proxy child auto-restarts on disconnect, so killing it from `down` would just cause a restart — current behavior is correct, just the description was inaccurate. Updated to match reality.

Historical plan docs (`docs/superpowers/plans/`) intentionally left as-is.

## Test plan

- [x] `cargo build -p mcp-supervisor` green
- [x] `cargo xtask lint` green
- [x] `codex review --base main` clean
- [x] Grep confirms no stray `supervisor_restart` / `supervisor_rebuild` / `supervisor_start_vite` references outside intentional alias-callouts