### PR TITLE
ci: run test_dx_integration.py alongside test_daemon_integration.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -719,9 +719,16 @@ jobs:
       - name: Build runtimed binary
         run: cargo build --release -p runtimed
 
-      - name: Build runtimed-py
-        working-directory: python/runtimed
-        run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
+      - name: Build runtimed-py into the workspace venv
+        # `uv sync` at repo root populates .venv with the workspace
+        # members (runtimed, dx, nteract, gremlin) plus their deps
+        # (pandas, polars, pyarrow). VIRTUAL_ENV pins maturin to that
+        # same .venv so the bindings land where pytest will look.
+        run: |
+          uv sync
+          cd crates/runtimed-py && \
+            VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
+            uv run --directory ../../python/runtimed maturin develop
 
       - name: Run integration tests
         timeout-minutes: 30
@@ -736,8 +743,17 @@ jobs:
           export RUNTIMED_LOG_LEVEL=debug
           export RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
 
-          # Run tests (daemon is spawned by the test fixture)
-          uv run pytest tests/test_daemon_integration.py -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
+          # Pin uv to the workspace venv so dx + pandas + pyarrow + polars
+          # are importable for test_dx_integration. The cwd stays at
+          # python/runtimed so `tool.pytest.ini_options` from this
+          # subproject's pyproject.toml applies (asyncio_mode = "auto",
+          # timeout = 600). uv-installed bindings landed in
+          # ${GITHUB_WORKSPACE}/.venv via VIRTUAL_ENV in the previous step.
+          export VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv"
+          uv run pytest \
+            tests/test_daemon_integration.py \
+            tests/test_dx_integration.py \
+            -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
 
           exit "${FAIL:-0}"
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -195,6 +195,12 @@ fn cmd_integration(filter: Option<String>) {
         exit(1);
     });
 
+    // dx integration tests are NOT run here — they require the real repo
+    // pyproject.toml (kernels use `env_source="uv:pyproject"` to install dx
+    // and pandas), but `cmd_integration` deliberately uses a TEMP
+    // RUNTIMED_WORKSPACE_PATH for isolation. dx integration is gated by
+    // the CI workflow `build.yml` instead, which runs from
+    // `${GITHUB_WORKSPACE}` (the real repo root).
     let mut pytest_args = vec![
         "run".to_string(),
         "pytest".to_string(),


### PR DESCRIPTION
## Summary

`test_dx_integration.py` exists and has good coverage of the dx publisher-hook + parquet round-trip path, but no CI workflow runs it today. The integration step in `build.yml` and `cargo xtask integration` both point only at `test_daemon_integration.py`. Adds dx integration tests to the build.yml step so any regression in the dx wiring is gated.

## Why the CI step (and not the xtask)

`cargo xtask integration` deliberately uses a temp `RUNTIMED_WORKSPACE_PATH` for isolation (no conflict with the dev daemon). That temp path doesn't have a `pyproject.toml`, so `uv:pyproject` env_source can't resolve dx for the kernel. The xtask path keeps daemon-only tests; CI has the repo workspace and can run dx tests.

Comment block added to `cmd_integration` explaining why dx tests aren't there.

## How CI gets dx into both the test process and the kernel

- **Test process** (pytest): `uv sync` populates `.venv` with workspace members (runtimed, dx, nteract) and their deps (pandas, polars, pyarrow). `VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv` pins the test step to that venv. `working-directory: python/runtimed` keeps `tool.pytest.ini_options` (asyncio_mode, timeout) from `python/runtimed/pyproject.toml` in effect.
- **Kernel**: `RUNTIMED_WORKSPACE_PATH=${GITHUB_WORKSPACE}` puts the daemon in dev mode (`is_dev_mode()` checks this env var). `default_notebooks_dir()` then returns `${WORKSPACE}/notebooks`, which is the kernel's cwd. `uv:pyproject` env_source walks up from there and finds the repo-root `pyproject.toml` — which lists dx, pandas, polars, pyarrow as workspace deps. So the kernel's uv-managed env has dx.
- **maturin develop**: extended to install runtimed-py into the workspace `.venv` (instead of `python/runtimed/.venv`) via `VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv`.

## Test plan

- [x] Verified locally: `cd python/runtimed && VIRTUAL_ENV=$REPO/.venv uv run pytest tests/test_dx_integration.py::test_dx_display_emits_blob_ref_with_buffers -v` → passes (10s)
- [x] `codex review --base main` — see open thread
- [ ] CI run on this branch will exercise both test files end-to-end

## Note on codex review

A codex review pass flagged "kernel can't find pyproject.toml because the notebook has no working_dir" — but kernels in dev mode default cwd to `${RUNTIMED_WORKSPACE_PATH}/notebooks`, and uv:pyproject resolves up from there, so the workspace pyproject is reachable. The local test run confirms this. If I'm wrong about CI behavior, the failing test will be loud and we can iterate.