### PR TITLE
docs: refresh stale RoomKernel/kernel_manager.rs references

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -182,7 +182,9 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 |------|------|
 | `crates/runtimed/src/daemon.rs` | Pool management |
 | `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` -- detection and resolution |
-| `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` -- spawns kernels |
+| `crates/runtimed/src/runtime_agent.rs` | Spawned as a subprocess by `RuntimeAgentHandle::spawn()`. `run_runtime_agent()` is the per-notebook event loop owning sockets, `QueueCommand` channels, and RuntimeStateDoc writes; `handle_runtime_agent_request()` dispatches each `LaunchKernel`/`RestartKernel`/etc. RPC |
+| `crates/runtimed/src/jupyter_kernel.rs` | `JupyterKernel::launch()` -- spawns the kernel process and wires ZMQ sockets |
+| `crates/runtimed/src/kernel_manager.rs` | Shared kernel plumbing — `QueueCommand`, `KernelStatus`, `QueuedCell`, output conversion + display-update helpers, widget-buffer offload to the blob store. Imported by `runtime_agent.rs`, `jupyter_kernel.rs`, and `kernel_state.rs` |
 | `crates/runtimed/src/project_file.rs` | Unified closest-wins project file detection |
 | `crates/runtimed/src/inline_env.rs` | Cached inline dep environments (UV and Conda) |
 

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -162,7 +162,8 @@ crates/runtimed/src/
   main.rs                  — CLI entry point
   daemon.rs                — Daemon state, pool management, connection routing
   notebook_sync_server.rs  — NotebookRoom, room lifecycle, autosave, re-keying
-  kernel_manager.rs        — RoomKernel: lifecycle, execution queue, IOPub routing
+  jupyter_kernel.rs        — JupyterKernel: process spawn, ZMQ socket wiring, IOPub output routing
+  kernel_manager.rs        — Shared kernel plumbing: QueueCommand, KernelStatus, QueuedCell, output conversion, widget buffers
   runtime_agent.rs         — Process-isolated runtime agent: kernel lifecycle, IOPub, RuntimeStateDoc writes
   runtime_agent_handle.rs  — Coordinator-side runtime agent process management
   output_store.rs          — Output manifest creation, blob inlining threshold

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -266,10 +266,10 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-doc/src/runtime_state.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
 - `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
 - `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, runtime agent sync handler, CRDT execution queue
-- `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
-- `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
-- `crates/runtimed/src/kernel_manager.rs` — `RoomKernel`: kernel process lifecycle, execution queue, IOPub output routing
 - `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, comm state diffing, kernel ownership
+- `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
+- `crates/runtimed/src/jupyter_kernel.rs` — `JupyterKernel`: kernel process spawn, ZMQ socket wiring, IOPub output routing
+- `crates/runtimed/src/kernel_manager.rs` — Shared kernel plumbing: `QueueCommand`, `KernelStatus`, `QueuedCell`, output conversion + display-update helpers, widget-buffer offload to the blob store
 - `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `ContentRef`
 - `crates/notebook-doc/src/mime.rs` — Canonical MIME classification (`is_binary_mime`, `mime_kind`, `MimeKind`)
 - `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -79,7 +79,8 @@ graph TB
 
     subgraph Daemon ["runtimed Daemon (owns kernels)"]
         NSS[notebook_sync_server.rs<br/>auto_launch_kernel]
-        KM[kernel_manager.rs<br/>RoomKernel::launch]
+        RA[runtime_agent.rs<br/>(spawned as subprocess)<br/>run_runtime_agent]
+        JK[jupyter_kernel.rs<br/>JupyterKernel::launch<br/>(in runtime-agent process)]
 
         subgraph Detection ["Project File Detection"]
             PF[project_file.rs<br/>find_nearest_project_file]
@@ -105,13 +106,14 @@ graph TB
             NDS[Notebook Doc Sync]
         end
 
-        NSS --> KM
+        NSS --> RA
+        RA --> JK
         NSS --> PF
         PF --> PP
         PF --> PX
         PF --> EY
-        KM --> IE
-        KM --> DM
+        NSS --> IE
+        NSS --> DM
         DM --> UWL
         DM --> CWL
     end
@@ -131,7 +133,7 @@ graph TB
 
     %% Daemon → relay → frontend (notebook:frame, re-emitted as notebook:broadcast after WASM demux)
     NSS -.->|"notebook:frame → notebook:broadcast {KernelLaunched, env_source}"| UDK
-    KM -.->|"notebook:frame → notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
+    JK -.->|"notebook:frame → notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
     VNT -.->|trust status| UD
 
     %% Environment creation → external tools
@@ -139,8 +141,8 @@ graph TB
     IE -->|"rattler solve + install"| RAT
     UWL -->|"uv venv + warmup"| UV
     CWL -->|"rattler + warmup"| RAT
-    KM -->|"deno jupyter --kernel"| DENO
-    KM -->|"spawn python -m ipykernel_launcher"| PY
+    JK -->|"deno jupyter --kernel"| DENO
+    JK -->|"spawn python -m ipykernel_launcher"| PY
 
     %% Settings sync
     SS <-->|"Automerge sync"| UDK
@@ -153,7 +155,7 @@ graph TB
 
     class UDK,UD,UCD,DH,CDH frontend
     class LKD,SKD,GKINFO,VNT,DETP tauri
-    class NSS,KM,PF,PP,PX,EY,IE,UE,CE,DM,UWL,CWL,SS,NDS daemon
+    class NSS,RA,JK,PF,PP,PX,EY,IE,UE,CE,DM,UWL,CWL,SS,NDS daemon
     class UV,RAT,DENO,PY external
 ```
 
@@ -166,7 +168,8 @@ sequenceDiagram
     participant DM as runtimed Daemon<br/>notebook_sync_server.rs
     participant PF as Project File<br/>Detection
     participant IE as inline_env.rs
-    participant KM as kernel_manager.rs
+    participant RA as runtime_agent.rs
+    participant JK as jupyter_kernel.rs
     participant PY as Python<br/>ipykernel
 
     FE->>FE: Notebook opened, auto-launch
@@ -205,14 +208,16 @@ sequenceDiagram
         end
     end
 
-    DM->>KM: RoomKernel::launch(env_source, python_path)
-    KM->>KM: Reserve 5 TCP ports
-    KM->>KM: Write connection.json
-    KM->>PY: spawn python -m ipykernel_launcher -f connection.json
-    KM->>KM: Connect ZMQ shell + iopub
-    KM->>PY: kernel_info_request
-    PY-->>KM: kernel_info_reply
-    KM-->>DM: Kernel ready
+    DM->>RA: dispatch LaunchKernel to per-notebook runtime agent
+    RA->>JK: JupyterKernel::launch(config, shared_refs)
+    JK->>JK: Reserve 5 TCP ports
+    JK->>JK: Write connection.json
+    JK->>PY: spawn python -m ipykernel_launcher -f connection.json
+    JK->>JK: Connect ZMQ shell + iopub
+    JK->>PY: kernel_info_request
+    PY-->>JK: kernel_info_reply
+    JK-->>RA: Kernel ready
+    RA-->>DM: KernelLaunched response
 
     DM-->>TC: KernelLaunched response
     TC-->>FE: notebook:frame {type 0x03, KernelLaunched, env_source}
@@ -513,7 +518,9 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 |------|------|
 | `crates/runtimed/src/daemon.rs` | Background daemon pool management, passes settings to handlers |
 | `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
-| `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns Python or Deno kernel processes |
+| `crates/runtimed/src/runtime_agent.rs` | Spawned as a subprocess by `RuntimeAgentHandle::spawn()`. `run_runtime_agent()` is the per-notebook event loop owning sockets, `QueueCommand` channels, and RuntimeStateDoc writes; `handle_runtime_agent_request()` dispatches each `LaunchKernel`/`RestartKernel`/etc. RPC |
+| `crates/runtimed/src/jupyter_kernel.rs` | `JupyterKernel::launch()` — spawns Python or Deno kernel processes, wires ZMQ sockets |
+| `crates/runtimed/src/kernel_manager.rs` | Shared kernel plumbing — `QueueCommand`, `KernelStatus`, `QueuedCell`, output conversion + display-update helpers, widget-buffer offload. Imported by `runtime_agent.rs`, `jupyter_kernel.rs`, and `kernel_state.rs` |
 | `crates/runtimed/src/project_file.rs` | Unified closest-wins project file detection (pyproject.toml, pixi.toml, environment.yml/yaml) |
 
 ### Notebook Crate (Tauri Commands)

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -231,7 +231,8 @@ crates/runtimed/
 │   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, re-keying, sync loop
 │   ├── runtime_agent.rs         # Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
 │   ├── runtime_agent_handle.rs  # Coordinator-side runtime agent process management (spawn + monitor)
-│   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
+│   ├── jupyter_kernel.rs        # JupyterKernel: process spawn, ZMQ socket wiring, IOPub output routing
+│   ├── kernel_manager.rs        # Shared kernel plumbing: QueueCommand, KernelStatus, QueuedCell, output conversion, widget buffers
 │   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
 │   ├── singleton.rs             # Daemon locking/singleton management
 │   ├── sync_server.rs           # Settings Automerge sync handler


### PR DESCRIPTION
## Summary

`RoomKernel::launch()` lived in `kernel_manager.rs` in an earlier daemon architecture. Today the runtime agent (`runtime_agent.rs`, spawned as a subprocess by `RuntimeAgentHandle::spawn()`) dispatches kernel launches to `JupyterKernel::launch()` in `jupyter_kernel.rs`. `kernel_manager.rs` is now the **shared kernel plumbing module** (`QueueCommand`, `KernelStatus`, `QueuedCell`, output-conversion + display-update helpers, widget-buffer offload), imported by `runtime_agent.rs`, `jupyter_kernel.rs`, and `kernel_state.rs`.

Five live agent docs still pointed at the old name and arrangement:

- `.claude/rules/environments.md` — Daemon files table
- `.claude/skills/daemon-dev/SKILL.md` — Source tree map
- `contributing/architecture.md` — Key files (also de-duplicated a runtime_agent.rs entry)
- `contributing/environments.md` — Architecture mermaid + sequence diagram + Daemon table
- `contributing/runtimed.md` — Source tree map

Each location now references:

- `runtime_agent.rs` — annotated as a subprocess. `run_runtime_agent()` is the per-notebook event loop owning sockets, `QueueCommand` channels, and RuntimeStateDoc writes; `handle_runtime_agent_request()` dispatches each RPC.
- `jupyter_kernel.rs` — `JupyterKernel::launch()` for process spawn and ZMQ wiring, runs in the runtime-agent subprocess.
- `kernel_manager.rs` — shared kernel plumbing (queue/status/output helpers + widget buffers).

The mermaid diagram in `contributing/environments.md` was also corrected so env-resolution edges (`NSS → IE`, `NSS → DM`) stay attached to `notebook_sync_server.rs` (where `prepare_*_inline_env` and pool selection actually run), not on `JupyterKernel`. The runtime-agent + JupyterKernel boxes are now labeled as subprocesses to surface the process boundary.

Two iterations of `codex review` caught and fixed inaccuracies in the first draft (loop owner was wrongly `handle_runtime_agent_request`; kernel_manager.rs was wrongly described as widget-only).

No code change. Historical plan docs (`docs/superpowers/plans/`) intentionally left as-is.

## Test plan

- [x] `grep -rn "RoomKernel" .claude/rules/ .claude/skills/ contributing/ AGENTS.md CLAUDE.md` returns nothing
- [x] `codex review --base main` clean — no remaining inaccuracies