### PR TITLE
ci(xtask): run `ty check python/` as part of `cargo xtask lint`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ Run this command before every commit. CI will reject PRs that fail formatting ch
 cargo xtask lint --fix
 ```
 
-This formats Rust, lints/formats TypeScript/JavaScript with Biome, and lints/formats Python with ruff.
+This formats Rust, lints/formats TypeScript/JavaScript with Biome, lints/formats Python with ruff, and type-checks the `python/` workspace with ty (matches the CI `Type check` step).
 
 For CI-style check-only mode: `cargo xtask lint`
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2160,6 +2160,18 @@ fn cmd_lint(fix: bool) {
                 failed = true;
             }
             println!();
+
+            // ty type-check. Scoped to `python/` (matches the CI
+            // `Type check` step in python-package.yml) because scripts/
+            // is intentionally loose and carries historical diagnostics.
+            println!("=== Python (ty) ===");
+            let ty_status = Command::new("uv")
+                .args(["run", "ty", "check", "python/"])
+                .status();
+            if !ty_status.map(|s| s.success()).unwrap_or(false) {
+                failed = true;
+            }
+            println!();
         } else {
             println!("=== Python (ruff) ===");
             println!("Skipping: uv not found in PATH");


### PR DESCRIPTION
## Summary

Closes task #13. The python-package CI workflow already runs `uv run ty check python/`, but `cargo xtask lint` only ran ruff — so local lint could pass while CI failed on type errors.

Adds a `=== Python (ty) ===` step right after ruff, scoped to `python/` (matches the CI `Type check` step exactly). `scripts/` is intentionally excluded because it carries 206 historical ty diagnostics; expand the scope when those are cleaned up.

CLAUDE.md's description of what `cargo xtask lint` does is updated to match.

## Test plan

- [x] `cargo xtask lint` runs ty and passes on a clean tree
- [x] `cargo xtask lint --fix` runs ty and passes
- [x] New `=== Python (ty) ===` section appears in the output
- [x] `codex review --base main` — no issues found