### PR TITLE
test(notebook-frame-bus): cover pub/sub semantics

### DIFF
--- a/apps/notebook/src/lib/__tests__/notebook-frame-bus.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-frame-bus.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  emitBroadcast,
+  emitPresence,
+  subscribeBroadcast,
+  subscribePresence,
+} from "../notebook-frame-bus";
+
+/**
+ * The frame bus owns module-level Sets, so a leaking subscriber from one
+ * test will see dispatches in later tests and fail noisily. Every test
+ * tracks its own unsubscribes and cleans up in afterEach.
+ */
+describe("notebook-frame-bus", () => {
+  const cleanups: Array<() => void> = [];
+  const track = (unsub: () => void): (() => void) => {
+    cleanups.push(unsub);
+    return unsub;
+  };
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      const u = cleanups.pop();
+      u?.();
+    }
+  });
+
+  describe("broadcast", () => {
+    it("delivers payloads to all subscribers", () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      track(subscribeBroadcast(a));
+      track(subscribeBroadcast(b));
+
+      emitBroadcast({ type: "kernel_status", status: "idle" });
+
+      expect(a).toHaveBeenCalledWith({ type: "kernel_status", status: "idle" });
+      expect(b).toHaveBeenCalledWith({ type: "kernel_status", status: "idle" });
+    });
+
+    it("unsubscribe stops delivery without affecting other subscribers", () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      const unsubA = subscribeBroadcast(a);
+      track(subscribeBroadcast(b));
+
+      unsubA();
+      emitBroadcast("hi");
+
+      expect(a).not.toHaveBeenCalled();
+      expect(b).toHaveBeenCalledWith("hi");
+    });
+
+    it("unsubscribe is idempotent", () => {
+      // If useEffect cleanup fires twice (React 18 strict mode), the second
+      // call must not throw or corrupt internal state.
+      const a = vi.fn();
+      const unsub = subscribeBroadcast(a);
+      unsub();
+      unsub();
+
+      emitBroadcast("x");
+      expect(a).not.toHaveBeenCalled();
+    });
+
+    it("registering the same callback twice only delivers once", () => {
+      // Sets dedupe by reference — this is how React StrictMode's
+      // double-invocation effectively becomes a no-op.
+      const a = vi.fn();
+      track(subscribeBroadcast(a));
+      track(subscribeBroadcast(a));
+
+      emitBroadcast("once");
+      expect(a).toHaveBeenCalledTimes(1);
+    });
+
+    it("a throwing subscriber does not break dispatch to later subscribers", () => {
+      // This is load-bearing: one buggy handler would otherwise take down
+      // kernel status, output rendering, env progress — everything that
+      // rides the bus.
+      const thrower = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const after = vi.fn();
+      track(subscribeBroadcast(thrower));
+      track(subscribeBroadcast(after));
+
+      expect(() => emitBroadcast({ type: "x" })).not.toThrow();
+      expect(thrower).toHaveBeenCalled();
+      expect(after).toHaveBeenCalled();
+    });
+
+    it("no subscribers is a valid state (no-op emit)", () => {
+      expect(() => emitBroadcast("orphan")).not.toThrow();
+    });
+  });
+
+  describe("presence", () => {
+    it("delivers payloads only to presence subscribers, not broadcast", () => {
+      // Presence and broadcast share a bus-like pattern but are
+      // separate channels. Cross-delivery would flood cursor handlers
+      // with kernel status events (and vice versa).
+      const broadcast = vi.fn();
+      const presence = vi.fn();
+      track(subscribeBroadcast(broadcast));
+      track(subscribePresence(presence));
+
+      emitPresence({ type: "update" });
+      expect(presence).toHaveBeenCalledWith({ type: "update" });
+      expect(broadcast).not.toHaveBeenCalled();
+    });
+
+    it("broadcast emits do not reach presence subscribers", () => {
+      const broadcast = vi.fn();
+      const presence = vi.fn();
+      track(subscribeBroadcast(broadcast));
+      track(subscribePresence(presence));
+
+      emitBroadcast({ type: "kernel_status" });
+      expect(broadcast).toHaveBeenCalled();
+      expect(presence).not.toHaveBeenCalled();
+    });
+
+    it("throwing presence subscriber does not break dispatch", () => {
+      const thrower = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const after = vi.fn();
+      track(subscribePresence(thrower));
+      track(subscribePresence(after));
+
+      expect(() => emitPresence({})).not.toThrow();
+      expect(after).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

\`notebook-frame-bus.ts\` is the in-memory bus that every daemon frame rides after WASM demux — kernel status, output events, env progress, presence updates. 88 lines, zero tests before this. A regression here silently breaks every downstream consumer at once.

Adds 9 Vitest tests, split by channel, with strict \`afterEach\` cleanup since the module owns subscriber Sets at module scope (leaks between tests would cause cascading false failures):

### Broadcast
- delivers payloads to all subscribers
- unsubscribe stops that one subscriber; others still receive
- unsubscribe is idempotent (React 18 strict mode fires cleanup twice)
- the same callback subscribed twice is Set-deduped to a single delivery
- **a throwing subscriber does not break dispatch to later ones** — load-bearing: without it, one buggy handler would take down every other consumer
- zero subscribers is a valid state (no-op emit)

### Presence
- payloads reach only presence subscribers, not broadcast
- broadcast emits don't leak to presence subscribers
- throwing presence subscribers don't break dispatch

## Test plan

- [x] \`pnpm test:run apps/notebook/src/lib/__tests__/notebook-frame-bus.test.ts\` — 9/9 passing
- [x] \`cargo xtask lint\` clean
- [x] \`codex review --base main\` — no issues found

## Note on CI

Depends on #1787 (\`uv sync\` before \`maturin develop\`) to unblock the \`runtimed-py Integration Tests\` job.