### PR TITLE
test(runtimed/broadcast-types): cover type guards

### DIFF
--- a/packages/runtimed/tests/broadcast-types.test.ts
+++ b/packages/runtimed/tests/broadcast-types.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for broadcast type guards.
+ *
+ * These guards narrow the untyped `broadcasts$` observable into typed
+ * sub-streams. A bug here silently drops events (guard returns false
+ * when it shouldn't) or lets the wrong type through (guard returns
+ * true for a mismatched event). Both failure modes are quiet — no
+ * runtime error, just missing kernel output or a TypeScript cast
+ * that turns into NaN / undefined deep in a render.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import {
+  isCommBroadcast,
+  isDisplayUpdateBroadcast,
+  isKernelErrorBroadcast,
+  isOutputBroadcast,
+  isOutputsClearedBroadcast,
+  isRuntimeStateSnapshotBroadcast,
+} from "../src/broadcast-types";
+
+// All guards share `hasBroadcastEvent` — exercise the invalid-payload
+// matrix once so every guard inherits the coverage.
+const INVALID_PAYLOADS: Array<[string, unknown]> = [
+  ["null", null],
+  ["undefined", undefined],
+  ["number", 42],
+  ["string", "output"],
+  ["boolean", true],
+  ["array", ["output"]],
+  ["empty object", {}],
+  ["object missing `event`", { cell_id: "c1", output_type: "stream" }],
+  ["event is not a string", { event: 7 }],
+  ["event is an object", { event: { nested: "output" } }],
+];
+
+const GUARDS = [
+  ["isOutputBroadcast", isOutputBroadcast, "output"],
+  ["isDisplayUpdateBroadcast", isDisplayUpdateBroadcast, "display_update"],
+  ["isOutputsClearedBroadcast", isOutputsClearedBroadcast, "outputs_cleared"],
+  ["isCommBroadcast", isCommBroadcast, "comm"],
+  ["isKernelErrorBroadcast", isKernelErrorBroadcast, "kernel_error"],
+  ["isRuntimeStateSnapshotBroadcast", isRuntimeStateSnapshotBroadcast, "runtime_state_snapshot"],
+] as const;
+
+describe("broadcast type guards", () => {
+  describe.each(GUARDS)("%s", (_name, guard, event) => {
+    it("accepts a payload with the matching event", () => {
+      // Only the `event` field is checked; the rest of the payload is
+      // carried through as `any` into the narrowed type. The guard is
+      // deliberately permissive so the daemon can add fields without
+      // breaking the frontend — pin that behavior.
+      expect(guard({ event })).toBe(true);
+      expect(guard({ event, extra: "ignored", nested: { a: 1 } })).toBe(true);
+    });
+
+    it.each(INVALID_PAYLOADS)("rejects %s", (_label, payload) => {
+      expect(guard(payload)).toBe(false);
+    });
+
+    it("rejects payloads with a different event discriminator", () => {
+      // The point of having separate guards is that only the matching
+      // one fires. A guard that returns true for the wrong event would
+      // cross-wire kernel errors into the output stream (or similar).
+      const otherEvents = GUARDS.filter(([, , e]) => e !== event).map(([, , e]) => e);
+      for (const other of otherEvents) {
+        expect(guard({ event: other })).toBe(false);
+      }
+    });
+  });
+
+  it("guards are mutually exclusive for a given payload", () => {
+    // A single broadcast must be claimed by at most one guard. If a
+    // future refactor accidentally normalizes event names such that
+    // two guards pass simultaneously, the first matching subscriber
+    // would silently double-handle.
+    for (const [, , event] of GUARDS) {
+      const payload = { event };
+      const hits = GUARDS.filter(([, guard]) => guard(payload));
+      expect(hits.length).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

\`broadcast-types.ts\` narrows the untyped \`broadcasts\$\` observable into typed sub-streams. A bug in one of the guards silently drops events (returns \`false\` when it shouldn't) or lets the wrong type through (returns \`true\` for a mismatched event) — both failure modes are quiet and surface as missing kernel output or \`undefined\` deep in a render.

Adds 73 Vitest cases (6 guards × invalid-payload matrix) with a table-driven \`describe.each\`:

- Each guard accepts its matching event and carries extra fields through (guards are deliberately permissive so the daemon can add fields without breaking the frontend — pin that behavior).
- Each guard rejects 10 invalid-payload shapes: \`null\`, \`undefined\`, primitives, arrays, objects missing \`event\`, \`event\` is not a string, etc.
- Each guard rejects the other 5 guards' event discriminators — no cross-wiring between streams.
- Guards are mutually exclusive for any given payload — at most one guard claims a broadcast.

## Test plan

- [x] \`pnpm test:run packages/runtimed/tests/broadcast-types.test.ts\` — 73/73 passing
- [x] \`cargo xtask lint\` clean
- [x] \`codex review --base main\` — no issues