### PR TITLE
fix(ci): pin ruff to 0.15.10 and reformat dx integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ known-first-party = ["runtimed", "nteract", "prewarm"]
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15",
+    "ruff==0.15.10",
     "ty>=0.0.22",
     "pytest>=8.0",
     "pyzmq>=26.0",

--- a/python/runtimed/tests/test_dx_integration.py
+++ b/python/runtimed/tests/test_dx_integration.py
@@ -243,17 +243,14 @@ df
     # Parquet bytes resolved from the blob store.
     parquet_bytes = output.data.get("application/vnd.apache.parquet")
     assert parquet_bytes is not None, (
-        f"parquet MIME missing — polars encoder may not have run. keys: "
-        f"{list(output.data.keys())}"
+        f"parquet MIME missing — polars encoder may not have run. keys: {list(output.data.keys())}"
     )
     assert isinstance(parquet_bytes, (bytes, bytearray))
     assert parquet_bytes[:4] == b"PAR1", "not a parquet file (bad magic)"
 
     # Python-side llm summary identifies polars specifically.
     llm = output.data.get("text/llm+plain", "")
-    assert llm.startswith("DataFrame (polars)"), (
-        f"expected polars summary, got: {llm[:80]!r}"
-    )
+    assert llm.startswith("DataFrame (polars)"), f"expected polars summary, got: {llm[:80]!r}"
 
     # Round-trip via pyarrow to verify the bytes are valid parquet AND
     # contain the columns we sent.


### PR DESCRIPTION
## Summary

The dev-group constraint `ruff>=0.15` lets each `uv sync` resolve to a different patch version. CI's `uv sync` pulled `0.15.10` when #1788 landed; a developer venv synced earlier with `0.15.7` would then see `cargo xtask lint` flag `main` as unformatted because 0.15.10 changed the line-collapse heuristic on long f-strings.

- Pin `ruff==0.15.10` in `[dependency-groups] dev` so every sync resolves to the same version.
- Apply 0.15.10 formatting to `test_dx_integration.py` so main passes on a local venv too.

Future ruff bumps are now a deliberate single-commit change with a reviewable diff, instead of drifting silently between developer machines and CI.

## Test plan

- [x] `cargo xtask lint` clean after the change
- [x] `uv run ruff --version` → 0.15.10 locally