### PR TITLE
feat(protocol): add GetDaemonInfo to replace daemon.json sidecar

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1662,9 +1662,26 @@ async fn get_feedback_system_info() -> FeedbackSystemInfo {
 }
 
 /// Get the blob server port from the running daemon.
-/// Used by the frontend to resolve manifest hashes to outputs.
+///
+/// Primary path: query the daemon directly via the singleton Unix socket
+/// (`GetDaemonInfo` request). The daemon is the source of truth — this
+/// fixes the "output void" bug when `daemon.json` is missing but the
+/// daemon is alive.
+///
+/// Upgrade-window fallback: if the request fails (old daemon that doesn't
+/// recognize `GetDaemonInfo` and drops the connection), fall back to
+/// reading the on-disk `daemon.json` written by the old daemon. This
+/// fallback can be removed after one release cycle.
 #[tauri::command]
 async fn get_blob_port() -> Result<u16, String> {
+    let client = runtimed::client::PoolClient::new(runtimed_client::default_socket_path());
+    if let Ok(info) = client.daemon_info().await {
+        return info
+            .blob_port
+            .ok_or_else(|| "Blob server not available".to_string());
+    }
+    // Socket path failed — try the legacy sidecar. Only reachable when
+    // the daemon is a pre-GetDaemonInfo build.
     let info = runtimed::singleton::get_running_daemon_info()
         .ok_or_else(|| "Daemon not running".to_string())?;
     info.blob_port

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -69,6 +69,27 @@ pub struct PongInfo {
     pub daemon_version: Option<String>,
 }
 
+/// Rich daemon metadata. Replaces the `daemon.json` sidecar file —
+/// query this from the daemon directly via `PoolClient::daemon_info()`.
+#[derive(Debug, Clone)]
+pub struct DaemonInfo {
+    /// Numeric protocol version.
+    pub protocol_version: u32,
+    /// Daemon version string (e.g., "2.0.0+abc123").
+    pub daemon_version: String,
+    /// Daemon process ID.
+    pub pid: u32,
+    /// When the daemon process began.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    /// HTTP port for the content-addressed blob server. `None` if the
+    /// blob server hasn't finished binding yet.
+    pub blob_port: Option<u16>,
+    /// Path to the git worktree this dev daemon is pinned to.
+    pub worktree_path: Option<String>,
+    /// Human-readable workspace description (dev mode only).
+    pub workspace_description: Option<String>,
+}
+
 impl PongInfo {
     /// Check whether the daemon's protocol version is compatible with this client.
     ///
@@ -167,6 +188,41 @@ impl PoolClient {
             } => Ok(PongInfo {
                 protocol_version,
                 daemon_version,
+            }),
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError(
+                "Unexpected response".to_string(),
+            )),
+        }
+    }
+
+    /// Query rich daemon metadata (pid, blob port, worktree info, etc.).
+    ///
+    /// This is the socket-based replacement for reading `daemon.json`.
+    /// Returns `Err` with `DaemonError("Unknown request")` on daemons too
+    /// old to know this request — callers can either treat that as
+    /// "metadata unavailable" or fall back to the file (we don't bake in
+    /// a file fallback here because the whole point is to stop relying
+    /// on the file).
+    pub async fn daemon_info(&self) -> Result<DaemonInfo, ClientError> {
+        let response = self.send_request(Request::GetDaemonInfo).await?;
+        match response {
+            Response::DaemonInfo {
+                protocol_version,
+                daemon_version,
+                pid,
+                started_at,
+                blob_port,
+                worktree_path,
+                workspace_description,
+            } => Ok(DaemonInfo {
+                protocol_version,
+                daemon_version,
+                pid,
+                started_at,
+                blob_port,
+                worktree_path,
+                workspace_description,
             }),
             Response::Error { message } => Err(ClientError::DaemonError(message)),
             _ => Err(ClientError::ProtocolError(

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -7,6 +7,7 @@
 //! Daemon-internal types (Request, Response, BlobRequest,
 //! BlobResponse) are defined here.
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -59,6 +60,13 @@ pub enum Request {
     /// Get environment paths currently in use by running kernels.
     /// Used by `runt env clean` to avoid evicting active environments.
     ActiveEnvPaths,
+
+    /// Get rich daemon metadata (pid, version, start time, blob server
+    /// port, dev-mode worktree). Supersedes reading the on-disk
+    /// `daemon.json` sidecar, which can go stale when the daemon crashes
+    /// or is forcibly killed. Clients should prefer this request and
+    /// fall back to `Ping` if they only need the version.
+    GetDaemonInfo,
 }
 
 /// Responses from the daemon to clients.
@@ -90,6 +98,37 @@ pub enum Response {
         /// Daemon version string (e.g., "2.0.0+abc123").
         #[serde(default, skip_serializing_if = "Option::is_none")]
         daemon_version: Option<String>,
+    },
+
+    /// Rich daemon metadata — replaces the `daemon.json` sidecar file.
+    ///
+    /// Returned from `Request::GetDaemonInfo`. Carries everything the
+    /// pre-socket `get_running_daemon_info()` used to read out of the
+    /// file: pid, version, start time, blob server port, and the dev-mode
+    /// worktree fields. Fields are `Option` for backward compatibility —
+    /// older daemons that don't know this request will respond with
+    /// `Response::Error { message: "Unknown request" }` (the client should
+    /// treat that as "metadata unavailable").
+    DaemonInfo {
+        /// Numeric protocol version (matches `PROTOCOL_VERSION`).
+        protocol_version: u32,
+        /// Daemon version string (e.g., "2.0.0+abc123").
+        daemon_version: String,
+        /// Daemon process ID.
+        pid: u32,
+        /// When the daemon started.
+        started_at: DateTime<Utc>,
+        /// HTTP port for the content-addressed blob server. `None` if the
+        /// blob server hasn't finished binding yet.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        blob_port: Option<u16>,
+        /// Path to the git worktree this dev daemon is pinned to.
+        /// Non-dev daemons return None.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree_path: Option<String>,
+        /// Human-readable workspace description (dev mode only).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_description: Option<String>,
     },
 
     /// Shutdown acknowledged.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -519,6 +519,8 @@ pub struct Daemon {
     blob_store: Arc<BlobStore>,
     /// HTTP port for the blob server (set after startup).
     blob_port: Mutex<Option<u16>>,
+    /// When the daemon process began. Reported via Ping for diagnostics.
+    started_at: chrono::DateTime<chrono::Utc>,
     /// Per-notebook Automerge sync rooms.
     notebook_rooms: NotebookRooms,
     /// Set to `true` the first time any client causes a room to be
@@ -620,6 +622,7 @@ impl Daemon {
             pool_doc_changed,
             blob_store,
             blob_port: Mutex::new(None),
+            started_at: chrono::Utc::now(),
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
             rooms_ever_seen: std::sync::atomic::AtomicBool::new(false),
             redirect_map: std::sync::Mutex::new(HashMap::new()),
@@ -633,6 +636,36 @@ impl Daemon {
     pub async fn trigger_shutdown(&self) {
         *self.shutdown.lock().await = true;
         self.shutdown_notify.notify_waiters();
+    }
+
+    /// Build the `DaemonInfo` response from live daemon state.
+    ///
+    /// This carries every field that `daemon.json` used to — `pid`,
+    /// `version`, `started_at`, `blob_port`, plus the dev-mode worktree
+    /// fields — so clients can query the daemon directly over the socket
+    /// instead of reading a sidecar file. Keeping it in its own message
+    /// (not overloaded onto `Pong`) means the frequent liveness-check
+    /// path stays tiny and the one-shot discovery path carries the full
+    /// payload.
+    async fn build_daemon_info(&self) -> Response {
+        let blob_port = *self.blob_port.lock().await;
+        let (worktree_path, workspace_description) = if crate::is_dev_mode() {
+            (
+                crate::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
+                crate::get_workspace_name(),
+            )
+        } else {
+            (None, None)
+        };
+        Response::DaemonInfo {
+            protocol_version: notebook_protocol::connection::PROTOCOL_VERSION,
+            daemon_version: crate::daemon_version().to_string(),
+            pid: std::process::id(),
+            started_at: self.started_at,
+            blob_port,
+            worktree_path,
+            workspace_description,
+        }
     }
 
     /// Get the room eviction delay.
@@ -2226,6 +2259,8 @@ impl Daemon {
                 protocol_version: Some(notebook_protocol::connection::PROTOCOL_VERSION),
                 daemon_version: Some(crate::daemon_version().to_string()),
             },
+
+            Request::GetDaemonInfo => self.build_daemon_info().await,
 
             Request::Shutdown => {
                 self.trigger_shutdown().await;


### PR DESCRIPTION
## Summary

The `~/.cache/runt[-nightly]/daemon.json` sidecar file duplicates state the running daemon already owns (pid, version, blob_port, worktree info) and gets out of sync with reality in the wild — observed today on a user's nightly where the file disappeared while the daemon kept running happily. Every client then treats the daemon as down, frontend `get_blob_port` fails with "Daemon not running", and outputs never render because blob URLs can't be resolved ("sent to the void"). `runt daemon doctor --fix` does not handle this case.

Start moving to a single source of truth: the daemon.

- Add `Request::GetDaemonInfo` + `Response::DaemonInfo` carrying protocol version, daemon version, pid, started_at, blob_port, worktree_path, workspace_description
- Add `PoolClient::daemon_info()` as the socket-based replacement for the file-reading `get_running_daemon_info()`
- `Ping`/`Pong` stays a cheap liveness probe — rich metadata is its own dedicated message so hot-path pings don't grow
- Daemon tracks `started_at` at startup and fills the response from live state
- Switch the Tauri `get_blob_port` command to use the socket with a one-release fallback to `daemon.json` for the upgrade window (new app against an old daemon that doesn't know `GetDaemonInfo`)

## What this doesn't do yet

No behavior change for old-daemon compatibility: the daemon still writes `daemon.json` as before. Follow-up PRs will migrate the remaining readers (runt-mcp health check, runt-mcp-proxy version skew, Python bindings, `runt daemon status`/`doctor`), then stop writing the file entirely.

## Context

The "disappearing daemon.json" is still unexplained. Investigation notes on the branch:
- Only `DaemonLock::Drop` and the CLI `cleanup_stale_daemon_info` remove the file; neither should fire when the daemon keeps running.
- A runtime agent in the log hit a framing desync (`frame too large: 1819243560` = ASCII `"loga"` as a length prefix) and SIGKILL'd itself right before the file went missing — probably related, worth digging into separately.

Moving to a socket-queried source of truth makes the disappearance unrepresentable regardless of root cause.

## Test plan

- [x] `cargo check` clean across workspace
- [x] `cargo test -p runtimed-client --lib` — 154 passing
- [x] `cargo test -p runtimed --lib singleton` — 5 passing
- [x] `cargo xtask lint` clean