### PR TITLE
feat(runtimed-client): query_daemon_info helper prefers socket

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -958,20 +958,27 @@ where
                 .to_string_lossy()
                 .to_string();
 
-            // Verify the running daemon version matches what we intended to install
-            if let Some(info) = runtimed::singleton::get_running_daemon_info() {
-                let running_commit = extract_commit_hash(&info.version);
+            // Verify the running daemon version matches what we intended to install.
+            // Prefer the socket (source of truth); fall back to the legacy
+            // daemon.json for one release while older daemons haven't
+            // learned the GetDaemonInfo request.
+            let running_version = match client.daemon_info().await {
+                Ok(info) => Some(info.daemon_version),
+                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
+            };
+            if let Some(version) = running_version {
+                let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
                 if running_commit == bundled_commit {
                     log::info!(
                         "[startup] Upgraded daemon version confirmed: {} (attempt {})",
-                        info.version,
+                        version,
                         attempt
                     );
                 } else {
                     log::warn!(
                         "[startup] Daemon version mismatch after upgrade! running={}, bundled={}",
-                        info.version,
+                        version,
                         bundled
                     );
                 }
@@ -1369,18 +1376,25 @@ where
     // Check if daemon is already running
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
-        // Daemon is running - check version alignment (production only)
+        // Daemon is running - check version alignment (production only).
+        // Prefer socket-sourced daemon info; fall back to the legacy
+        // daemon.json file for one release window while older daemons
+        // haven't learned GetDaemonInfo.
         if !runt_workspace::is_dev_mode() {
-            if let Some(info) = runtimed::singleton::get_running_daemon_info() {
+            let running_version = match client.daemon_info().await {
+                Ok(info) => Some(info.daemon_version),
+                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
+            };
+            if let Some(version) = running_version {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.
-                let running_commit = extract_commit_hash(&info.version);
+                let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled_version);
 
                 if running_commit != bundled_commit {
                     log::info!(
                         "[startup] Daemon commit mismatch — will upgrade: running={}, bundled={}",
-                        info.version,
+                        version,
                         bundled_version
                     );
                     // Upgrade daemon to match bundled version
@@ -1388,12 +1402,13 @@ where
                 }
                 log::info!(
                     "[startup] Daemon version aligned: running={}, bundled={}",
-                    info.version,
+                    version,
                     bundled_version
                 );
             } else {
                 log::warn!(
-                    "[startup] Daemon responded to ping but info file missing (bundled={})",
+                    "[startup] Daemon responded to ping but version unavailable via \
+                     socket or daemon.json (bundled={})",
                     bundled_version
                 );
             }
@@ -1663,26 +1678,14 @@ async fn get_feedback_system_info() -> FeedbackSystemInfo {
 
 /// Get the blob server port from the running daemon.
 ///
-/// Primary path: query the daemon directly via the singleton Unix socket
-/// (`GetDaemonInfo` request). The daemon is the source of truth — this
-/// fixes the "output void" bug when `daemon.json` is missing but the
-/// daemon is alive.
-///
-/// Upgrade-window fallback: if the request fails (old daemon that doesn't
-/// recognize `GetDaemonInfo` and drops the connection), fall back to
-/// reading the on-disk `daemon.json` written by the old daemon. This
-/// fallback can be removed after one release cycle.
+/// Uses `query_daemon_info`, which prefers the socket-based
+/// `GetDaemonInfo` request (daemon is the source of truth — fixes the
+/// "output void" bug when `daemon.json` disappears) and falls back to
+/// the on-disk sidecar for the upgrade window against older daemons.
 #[tauri::command]
 async fn get_blob_port() -> Result<u16, String> {
-    let client = runtimed::client::PoolClient::new(runtimed_client::default_socket_path());
-    if let Ok(info) = client.daemon_info().await {
-        return info
-            .blob_port
-            .ok_or_else(|| "Blob server not available".to_string());
-    }
-    // Socket path failed — try the legacy sidecar. Only reachable when
-    // the daemon is a pre-GetDaemonInfo build.
-    let info = runtimed::singleton::get_running_daemon_info()
+    let info = runtimed::singleton::query_daemon_info(runtimed_client::default_socket_path())
+        .await
         .ok_or_else(|| "Daemon not running".to_string())?;
     info.blob_port
         .ok_or_else(|| "Blob server not available".to_string())

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use runtimed_client::client::PoolClient;
-use runtimed_client::singleton::{daemon_info_path, read_daemon_info, DaemonInfo};
+use runtimed_client::singleton::{query_daemon_info, DaemonInfo};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
@@ -73,7 +73,6 @@ pub async fn daemon_health_monitor(
     peer_label: Arc<RwLock<String>>,
 ) -> i32 {
     let client = PoolClient::new(socket_path.clone());
-    let info_path = daemon_info_path();
 
     loop {
         // Determine sleep duration based on current state
@@ -89,10 +88,16 @@ pub async fn daemon_health_monitor(
 
         match client.ping().await {
             Ok(()) => {
+                // Fetch daemon info BEFORE acquiring the state lock — every
+                // MCP tool call reads daemon_state in its hot path, and
+                // holding the write lock across an awaited IPC would block
+                // the tool surface whenever a GetDaemonInfo query is slow.
+                let current_info = query_daemon_info(socket_path.clone()).await;
+
                 let mut state = daemon_state.write().await;
                 match &*state {
                     DaemonState::Connected { info } => {
-                        if let Some(current) = read_daemon_info(&info_path) {
+                        if let Some(current) = current_info {
                             if current.version != info.version {
                                 // Version changed — genuine upgrade, exit for new binary
                                 info!(
@@ -122,9 +127,7 @@ pub async fn daemon_health_monitor(
                         attempt,
                         last_info,
                     } => {
-                        // Daemon is back — check if it's the same version or an upgrade
                         let elapsed = since.elapsed();
-                        let current_info = read_daemon_info(&info_path);
 
                         if let (Some(ref current), Some(ref last)) = (&current_info, last_info) {
                             if current.version != last.version {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -761,21 +761,25 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
 
-    // Capture initial daemon info for health monitoring
-    let info_path = runtimed_client::singleton::daemon_info_path();
-    let initial_state = match runtimed_client::singleton::read_daemon_info(&info_path) {
-        Some(info) => runt_mcp::health::DaemonState::Connected { info },
-        None => {
-            // Daemon not yet available — start in reconnecting mode with no
-            // prior version info. The health monitor will treat the first
-            // successful connection as a fresh connect (not an upgrade).
-            runt_mcp::health::DaemonState::Reconnecting {
-                since: std::time::Instant::now(),
-                attempt: 0,
-                last_info: None,
+    // Capture initial daemon info for health monitoring.
+    // Must query the SAME socket the health monitor will poll — otherwise
+    // a non-default RUNTIMED_SOCKET_PATH seeds state from the wrong daemon
+    // and the first successful ping flags a phantom version-mismatch
+    // "upgrade" (EXIT_DAEMON_UPGRADED).
+    let initial_state =
+        match runtimed_client::singleton::query_daemon_info(socket_path.clone()).await {
+            Some(info) => runt_mcp::health::DaemonState::Connected { info },
+            None => {
+                // Daemon not yet available — start in reconnecting mode with no
+                // prior version info. The health monitor will treat the first
+                // successful connection as a fresh connect (not an upgrade).
+                runt_mcp::health::DaemonState::Reconnecting {
+                    since: std::time::Instant::now(),
+                    attempt: 0,
+                    last_info: None,
+                }
             }
-        }
-    };
+        };
 
     use rmcp::service::ServiceExt;
     let server = if no_show {

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -52,6 +52,66 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
     read_daemon_info(&daemon_info_path())
 }
 
+/// Get daemon info, preferring the socket-based `GetDaemonInfo` request
+/// and falling back to the on-disk `daemon.json` sidecar.
+///
+/// This is the intended replacement for `get_running_daemon_info()` —
+/// the socket is the source of truth (the daemon fills the response
+/// from live state, so the result can't be stale the way the file
+/// can). The file is read only when the socket query fails, which
+/// happens when an older daemon doesn't recognise the new request.
+/// Once every daemon in the wild knows `GetDaemonInfo`, the fallback
+/// (and the whole file) can be deleted.
+///
+/// `socket_path` pins which daemon is being queried. The fallback
+/// reads `daemon.json` from the **same directory as the socket**, so
+/// callers that pin a non-default daemon (tests, worktree isolation,
+/// cross-channel lookups) still resolve to the correct instance — not
+/// the process's default namespace.
+pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<DaemonInfo> {
+    let client = crate::client::PoolClient::new(socket_path.clone());
+    if let Ok(info) = client.daemon_info().await {
+        return Some(DaemonInfo {
+            endpoint: socket_path.to_string_lossy().into_owned(),
+            pid: info.pid,
+            version: info.daemon_version,
+            started_at: info.started_at,
+            blob_port: info.blob_port,
+            worktree_path: info.worktree_path,
+            workspace_description: info.workspace_description,
+        });
+    }
+
+    // `GetDaemonInfo` failed. Only fall back to `daemon.json` when the
+    // failure means "old daemon doesn't recognise this request." We
+    // distinguish that from a generic transient failure by sending a
+    // `Ping`: an old daemon will respond to Ping fine but tear down
+    // the connection on `GetDaemonInfo` (unknown serde tag → drop).
+    // A genuinely unreachable daemon fails Ping too, and we return
+    // None so callers don't consume a stale sidecar.
+    if client.ping().await.is_err() {
+        return None;
+    }
+
+    // Daemon is alive but doesn't know `GetDaemonInfo` — legacy path.
+    // The base notebook app case (nightly app ↔ nightly daemon) has the
+    // socket and `daemon.json` in the same `daemon_base_dir()`, so the
+    // colocated path covers every realistic upgrade-window configuration.
+    // Windows named pipes have no on-disk parent — skip the fallback,
+    // because this whole path is a one-release compatibility shim and
+    // we don't have Windows daemons pre-GetDaemonInfo in the wild anyway.
+    #[cfg(unix)]
+    {
+        let parent = socket_path.parent()?;
+        read_daemon_info(&parent.join("daemon.json"))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = &socket_path;
+        None
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {


### PR DESCRIPTION
## Summary

Follow-up to #1803 that actually moves the user-facing callers off `daemon.json`.

Adds `singleton::query_daemon_info(socket_path)` that queries the daemon over the socket first (source of truth) and falls back to the colocated `daemon.json` only when the daemon is alive but too old to recognise `GetDaemonInfo`.

The "is it legacy?" signal is a follow-up `Ping`: an old daemon responds to Ping fine but drops the connection on `GetDaemonInfo` (unknown serde tag). If Ping also fails, the daemon is genuinely down and we return `None` rather than returning stale sidecar data.

### Callers switched

- Tauri `get_blob_port` — the user-visible path that was producing "Daemon not running" / "output void" in the repro that prompted #1803
- Two `ensure_daemon_via_sidecar` / post-upgrade version checks in `crates/notebook/src/lib.rs`
- `runt-mcp` daemon health monitor and its initial state seed in `runt/src/main.rs` (latter switched so the seed and the monitor query the same socket — prevents phantom "upgrade detected" exits under `RUNTIMED_SOCKET_PATH` overrides)

### Lock hygiene

The health monitor now fetches daemon info **before** acquiring the `daemon_state` write lock. Previously the lock was held across an awaited IPC call, which would block every MCP tool call for the duration — a violation of the "no mutex guards across `.await`" invariant in CLAUDE.md.

### Windows

Fallback deliberately omitted on Windows: named pipes have no on-disk parent, and there are no Windows daemons in the wild old enough to need the fallback.

### What's deferred

Remaining `daemon.json` readers — `runt-mcp-proxy` version skew, `mcpb-runt`, Python bindings, and the CLI diagnostic paths in `runt/main.rs` — migrate in the next PR alongside removing the file write entirely (task #24).

## Test plan

- [x] `cargo xtask lint` clean
- [x] `cargo test -p runt-cli -p runt-mcp -p runtimed-client --lib` — all passing (154 in runtimed-client, 63 in runt-mcp)
- [x] `codex review --base main` — iterated through several P1/P2 findings (custom-socket fallback correctness, lock-across-await, stale fallback on transient errors); settled on a simplified version since custom-socket scenarios aren't actually in the wild