### PR TITLE
fix(runtime-agent): reconnect on sync-socket framing errors

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -958,20 +958,27 @@ where
                 .to_string_lossy()
                 .to_string();
 
-            // Verify the running daemon version matches what we intended to install
-            if let Some(info) = runtimed::singleton::get_running_daemon_info() {
-                let running_commit = extract_commit_hash(&info.version);
+            // Verify the running daemon version matches what we intended to install.
+            // Prefer the socket (source of truth); fall back to the legacy
+            // daemon.json for one release while older daemons haven't
+            // learned the GetDaemonInfo request.
+            let running_version = match client.daemon_info().await {
+                Ok(info) => Some(info.daemon_version),
+                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
+            };
+            if let Some(version) = running_version {
+                let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
                 if running_commit == bundled_commit {
                     log::info!(
                         "[startup] Upgraded daemon version confirmed: {} (attempt {})",
-                        info.version,
+                        version,
                         attempt
                     );
                 } else {
                     log::warn!(
                         "[startup] Daemon version mismatch after upgrade! running={}, bundled={}",
-                        info.version,
+                        version,
                         bundled
                     );
                 }
@@ -1369,18 +1376,25 @@ where
     // Check if daemon is already running
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
-        // Daemon is running - check version alignment (production only)
+        // Daemon is running - check version alignment (production only).
+        // Prefer socket-sourced daemon info; fall back to the legacy
+        // daemon.json file for one release window while older daemons
+        // haven't learned GetDaemonInfo.
         if !runt_workspace::is_dev_mode() {
-            if let Some(info) = runtimed::singleton::get_running_daemon_info() {
+            let running_version = match client.daemon_info().await {
+                Ok(info) => Some(info.daemon_version),
+                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
+            };
+            if let Some(version) = running_version {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.
-                let running_commit = extract_commit_hash(&info.version);
+                let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled_version);
 
                 if running_commit != bundled_commit {
                     log::info!(
                         "[startup] Daemon commit mismatch — will upgrade: running={}, bundled={}",
-                        info.version,
+                        version,
                         bundled_version
                     );
                     // Upgrade daemon to match bundled version
@@ -1388,12 +1402,13 @@ where
                 }
                 log::info!(
                     "[startup] Daemon version aligned: running={}, bundled={}",
-                    info.version,
+                    version,
                     bundled_version
                 );
             } else {
                 log::warn!(
-                    "[startup] Daemon responded to ping but info file missing (bundled={})",
+                    "[startup] Daemon responded to ping but version unavailable via \
+                     socket or daemon.json (bundled={})",
                     bundled_version
                 );
             }
@@ -1663,26 +1678,14 @@ async fn get_feedback_system_info() -> FeedbackSystemInfo {
 
 /// Get the blob server port from the running daemon.
 ///
-/// Primary path: query the daemon directly via the singleton Unix socket
-/// (`GetDaemonInfo` request). The daemon is the source of truth — this
-/// fixes the "output void" bug when `daemon.json` is missing but the
-/// daemon is alive.
-///
-/// Upgrade-window fallback: if the request fails (old daemon that doesn't
-/// recognize `GetDaemonInfo` and drops the connection), fall back to
-/// reading the on-disk `daemon.json` written by the old daemon. This
-/// fallback can be removed after one release cycle.
+/// Uses `query_daemon_info`, which prefers the socket-based
+/// `GetDaemonInfo` request (daemon is the source of truth — fixes the
+/// "output void" bug when `daemon.json` disappears) and falls back to
+/// the on-disk sidecar for the upgrade window against older daemons.
 #[tauri::command]
 async fn get_blob_port() -> Result<u16, String> {
-    let client = runtimed::client::PoolClient::new(runtimed_client::default_socket_path());
-    if let Ok(info) = client.daemon_info().await {
-        return info
-            .blob_port
-            .ok_or_else(|| "Blob server not available".to_string());
-    }
-    // Socket path failed — try the legacy sidecar. Only reachable when
-    // the daemon is a pre-GetDaemonInfo build.
-    let info = runtimed::singleton::get_running_daemon_info()
+    let info = runtimed::singleton::query_daemon_info(runtimed_client::default_socket_path())
+        .await
         .ok_or_else(|| "Daemon not running".to_string())?;
     info.blob_port
         .ok_or_else(|| "Blob server not available".to_string())

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use runtimed_client::client::PoolClient;
-use runtimed_client::singleton::{daemon_info_path, read_daemon_info, DaemonInfo};
+use runtimed_client::singleton::{query_daemon_info, DaemonInfo};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
@@ -73,7 +73,6 @@ pub async fn daemon_health_monitor(
     peer_label: Arc<RwLock<String>>,
 ) -> i32 {
     let client = PoolClient::new(socket_path.clone());
-    let info_path = daemon_info_path();
 
     loop {
         // Determine sleep duration based on current state
@@ -89,10 +88,16 @@ pub async fn daemon_health_monitor(
 
         match client.ping().await {
             Ok(()) => {
+                // Fetch daemon info BEFORE acquiring the state lock — every
+                // MCP tool call reads daemon_state in its hot path, and
+                // holding the write lock across an awaited IPC would block
+                // the tool surface whenever a GetDaemonInfo query is slow.
+                let current_info = query_daemon_info(socket_path.clone()).await;
+
                 let mut state = daemon_state.write().await;
                 match &*state {
                     DaemonState::Connected { info } => {
-                        if let Some(current) = read_daemon_info(&info_path) {
+                        if let Some(current) = current_info {
                             if current.version != info.version {
                                 // Version changed — genuine upgrade, exit for new binary
                                 info!(
@@ -122,9 +127,7 @@ pub async fn daemon_health_monitor(
                         attempt,
                         last_info,
                     } => {
-                        // Daemon is back — check if it's the same version or an upgrade
                         let elapsed = since.elapsed();
-                        let current_info = read_daemon_info(&info_path);
 
                         if let (Some(ref current), Some(ref last)) = (&current_info, last_info) {
                             if current.version != last.version {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -761,21 +761,25 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
 
-    // Capture initial daemon info for health monitoring
-    let info_path = runtimed_client::singleton::daemon_info_path();
-    let initial_state = match runtimed_client::singleton::read_daemon_info(&info_path) {
-        Some(info) => runt_mcp::health::DaemonState::Connected { info },
-        None => {
-            // Daemon not yet available — start in reconnecting mode with no
-            // prior version info. The health monitor will treat the first
-            // successful connection as a fresh connect (not an upgrade).
-            runt_mcp::health::DaemonState::Reconnecting {
-                since: std::time::Instant::now(),
-                attempt: 0,
-                last_info: None,
+    // Capture initial daemon info for health monitoring.
+    // Must query the SAME socket the health monitor will poll — otherwise
+    // a non-default RUNTIMED_SOCKET_PATH seeds state from the wrong daemon
+    // and the first successful ping flags a phantom version-mismatch
+    // "upgrade" (EXIT_DAEMON_UPGRADED).
+    let initial_state =
+        match runtimed_client::singleton::query_daemon_info(socket_path.clone()).await {
+            Some(info) => runt_mcp::health::DaemonState::Connected { info },
+            None => {
+                // Daemon not yet available — start in reconnecting mode with no
+                // prior version info. The health monitor will treat the first
+                // successful connection as a fresh connect (not an upgrade).
+                runt_mcp::health::DaemonState::Reconnecting {
+                    since: std::time::Instant::now(),
+                    attempt: 0,
+                    last_info: None,
+                }
             }
-        }
-    };
+        };
 
     use rmcp::service::ServiceExt;
     let server = if no_show {

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -52,6 +52,66 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
     read_daemon_info(&daemon_info_path())
 }
 
+/// Get daemon info, preferring the socket-based `GetDaemonInfo` request
+/// and falling back to the on-disk `daemon.json` sidecar.
+///
+/// This is the intended replacement for `get_running_daemon_info()` —
+/// the socket is the source of truth (the daemon fills the response
+/// from live state, so the result can't be stale the way the file
+/// can). The file is read only when the socket query fails, which
+/// happens when an older daemon doesn't recognise the new request.
+/// Once every daemon in the wild knows `GetDaemonInfo`, the fallback
+/// (and the whole file) can be deleted.
+///
+/// `socket_path` pins which daemon is being queried. The fallback
+/// reads `daemon.json` from the **same directory as the socket**, so
+/// callers that pin a non-default daemon (tests, worktree isolation,
+/// cross-channel lookups) still resolve to the correct instance — not
+/// the process's default namespace.
+pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<DaemonInfo> {
+    let client = crate::client::PoolClient::new(socket_path.clone());
+    if let Ok(info) = client.daemon_info().await {
+        return Some(DaemonInfo {
+            endpoint: socket_path.to_string_lossy().into_owned(),
+            pid: info.pid,
+            version: info.daemon_version,
+            started_at: info.started_at,
+            blob_port: info.blob_port,
+            worktree_path: info.worktree_path,
+            workspace_description: info.workspace_description,
+        });
+    }
+
+    // `GetDaemonInfo` failed. Only fall back to `daemon.json` when the
+    // failure means "old daemon doesn't recognise this request." We
+    // distinguish that from a generic transient failure by sending a
+    // `Ping`: an old daemon will respond to Ping fine but tear down
+    // the connection on `GetDaemonInfo` (unknown serde tag → drop).
+    // A genuinely unreachable daemon fails Ping too, and we return
+    // None so callers don't consume a stale sidecar.
+    if client.ping().await.is_err() {
+        return None;
+    }
+
+    // Daemon is alive but doesn't know `GetDaemonInfo` — legacy path.
+    // The base notebook app case (nightly app ↔ nightly daemon) has the
+    // socket and `daemon.json` in the same `daemon_base_dir()`, so the
+    // colocated path covers every realistic upgrade-window configuration.
+    // Windows named pipes have no on-disk parent — skip the fallback,
+    // because this whole path is a one-release compatibility shim and
+    // we don't have Windows daemons pre-GetDaemonInfo in the wild anyway.
+    #[cfg(unix)]
+    {
+        let parent = socket_path.parent()?;
+        read_daemon_info(&parent.join("daemon.json"))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = &socket_path;
+        None
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -75,38 +75,8 @@ pub async fn run_runtime_agent(
 
     // -- 1. Connect to daemon socket ----------------------------------------
 
-    #[cfg(unix)]
-    let stream = tokio::net::UnixStream::connect(&socket_path).await?;
-
-    #[cfg(windows)]
-    let stream = {
-        let pipe_name = socket_path.to_string_lossy().to_string();
-        let mut attempts = 0u32;
-        loop {
-            match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-                Ok(client) => break client,
-                Err(_) if attempts < 10 => {
-                    attempts += 1;
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
-    };
-
-    let (mut reader, mut writer) = tokio::io::split(stream);
-
-    // Send preamble + RuntimeAgent handshake
-    send_preamble(&mut writer).await?;
-    send_json_frame(
-        &mut writer,
-        &Handshake::RuntimeAgent {
-            notebook_id: notebook_id.clone(),
-            runtime_agent_id: runtime_agent_id.clone(),
-            blob_root: blob_root.display().to_string(),
-        },
-    )
-    .await?;
+    let (mut reader, mut writer) =
+        connect_and_handshake(&socket_path, &notebook_id, &runtime_agent_id, &blob_root).await?;
 
     info!("[runtime-agent] Connected to daemon, handshake sent");
 
@@ -119,7 +89,7 @@ pub async fn run_runtime_agent(
 
     // -- 3. Create local infrastructure -------------------------------------
 
-    let blob_store = Arc::new(BlobStore::new(blob_root));
+    let blob_store = Arc::new(BlobStore::new(blob_root.clone()));
     let (broadcast_tx, _broadcast_rx) =
         broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(16);
     let presence = Arc::new(RwLock::new(PresenceState::new()));
@@ -274,8 +244,53 @@ pub async fn run_runtime_agent(
                         break;
                     }
                     Err(e) => {
-                        info!("[runtime-agent] Socket read error: {}", e);
-                        break;
+                        // A framing error here means one of two things:
+                        //   - the daemon half-closed the sync stream (clean),
+                        //     which we treat as a disconnect,
+                        //   - or a byte-level desync corrupted the stream
+                        //     (e.g. a stray writer, a massive length field
+                        //     tripping the MAX_FRAME_SIZE cap).
+                        // Either way the kernel state is still ours to own.
+                        // Try to reconnect before tearing down the kernel —
+                        // a brief network-side blip should not cost the user
+                        // their session. Reconnection does a fresh handshake
+                        // and a fresh Automerge sync state; the kernel,
+                        // queue, seen_execution_ids, and local doc stay.
+                        warn!(
+                            "[runtime-agent] Socket read error: {} — reconnecting \
+                             (kernel stays running)",
+                            e
+                        );
+                        match reconnect_with_backoff(
+                            &socket_path,
+                            &notebook_id,
+                            &runtime_agent_id,
+                            &blob_root,
+                        )
+                        .await
+                        {
+                            Ok((new_reader, new_writer)) => {
+                                reader = new_reader;
+                                writer = new_writer;
+                                // The daemon creates a fresh sync state for
+                                // each connection; match that or the doc
+                                // won't converge.
+                                coordinator_sync_state = automerge::sync::State::new();
+                                // Kick off a full resync so the daemon gets
+                                // everything the kernel produced while we
+                                // were disconnected.
+                                let _ = state_changed_tx.send(());
+                                info!("[runtime-agent] Reconnected to daemon");
+                                continue;
+                            }
+                            Err(reconnect_err) => {
+                                error!(
+                                    "[runtime-agent] Reconnect failed after retries: {}",
+                                    reconnect_err
+                                );
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -325,6 +340,95 @@ pub async fn run_runtime_agent(
     }
 
     Ok(())
+}
+
+/// Concrete reader/writer halves returned by connect helpers.
+#[cfg(unix)]
+type AgentReader = tokio::io::ReadHalf<tokio::net::UnixStream>;
+#[cfg(unix)]
+type AgentWriter = tokio::io::WriteHalf<tokio::net::UnixStream>;
+#[cfg(windows)]
+type AgentReader = tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
+#[cfg(windows)]
+type AgentWriter = tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
+
+/// Open a stream to the daemon socket and perform the RuntimeAgent
+/// handshake. Extracted from the main startup path so the reconnect
+/// path on framing errors can reuse it without duplicating handshake
+/// logic.
+async fn connect_and_handshake(
+    socket_path: &std::path::Path,
+    notebook_id: &str,
+    runtime_agent_id: &str,
+    blob_root: &std::path::Path,
+) -> anyhow::Result<(AgentReader, AgentWriter)> {
+    #[cfg(unix)]
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+
+    #[cfg(windows)]
+    let stream = {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let mut attempts = 0u32;
+        loop {
+            match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
+                Ok(client) => break client,
+                Err(_) if attempts < 10 => {
+                    attempts += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    };
+
+    let (reader, mut writer) = tokio::io::split(stream);
+
+    send_preamble(&mut writer).await?;
+    send_json_frame(
+        &mut writer,
+        &Handshake::RuntimeAgent {
+            notebook_id: notebook_id.to_string(),
+            runtime_agent_id: runtime_agent_id.to_string(),
+            blob_root: blob_root.display().to_string(),
+        },
+    )
+    .await?;
+
+    Ok((reader, writer))
+}
+
+/// Attempt to reconnect to the daemon with exponential backoff.
+///
+/// Called after a framing error on the existing sync stream. Preserves
+/// the kernel state by staying alive across transient socket trouble
+/// (rogue client writing to the socket, daemon restart, etc.). Gives up
+/// after a bounded number of attempts so a genuinely-gone daemon still
+/// lets the agent exit rather than spin forever.
+async fn reconnect_with_backoff(
+    socket_path: &std::path::Path,
+    notebook_id: &str,
+    runtime_agent_id: &str,
+    blob_root: &std::path::Path,
+) -> anyhow::Result<(AgentReader, AgentWriter)> {
+    const MAX_ATTEMPTS: u32 = 10;
+    const BASE_DELAY_MS: u64 = 100;
+
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match connect_and_handshake(socket_path, notebook_id, runtime_agent_id, blob_root).await {
+            Ok(pair) => return Ok(pair),
+            Err(e) => {
+                let delay = BASE_DELAY_MS.saturating_mul(1 << (attempt - 1).min(6));
+                warn!(
+                    "[runtime-agent] Reconnect attempt {}/{} failed: {} (retrying in {}ms)",
+                    attempt, MAX_ATTEMPTS, e, delay
+                );
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("reconnect gave up with no last error")))
 }
 
 /// Handle a `RuntimeAgentRequest` and return a `RuntimeAgentResponse`.


### PR DESCRIPTION
## Summary

Closes part of #26. Previously, any recoverable error on the runtime-agent ↔ daemon sync socket — including the `frame too large: 1819243560` cap-trip observed in the nightly diagnostics (a 4-byte length prefix that read as ASCII `"loga"`, probably text bytes from a stray writer landing at a header offset) — would break the runtime agent's main select loop, which:

1. ran `k.shutdown().await` on the kernel
2. let the daemon notice the broken pipe
3. triggered `RuntimeAgentHandle::Drop` on the coordinator side, which SIGKILLs the agent's process group (agent + kernel)

Net effect: a single byte-level desync on the sync stream — which can be caused by anything as mundane as a misbehaving local process connecting to the Unix socket — tore down the kernel and lost the user's session.

## Change

Framing errors now trigger a reconnect instead of an exit:

- `kernel`, `KernelState`, `seen_execution_ids`, and the in-memory `RuntimeStateDoc` all stay alive across the blip.
- On reconnect, the Automerge sync state is reset (the daemon rebuilds its peer state too), and `state_changed_tx` is pulsed so any outputs produced while disconnected flow back on the next sync.
- Handshake logic is extracted into `connect_and_handshake()` so the initial and reconnect paths share one implementation.
- `reconnect_with_backoff()` retries up to 10 times with exponential backoff (100ms → 6.4s cap); a genuinely-gone daemon still lets the agent exit rather than spin forever.

## What this doesn't address

Deeper hardening proposals from the investigation notes — per-frame magic bytes, a cap on control-frame sizes, per-frame type gating — stay in #26 as follow-ups. The root cause of the specific "loga" desync observed in the field is still unknown; this PR just ensures the user doesn't lose their kernel when it recurs.

## Test plan

- [x] `cargo check -p runtimed` clean
- [x] `cargo test -p runtimed --lib` — 291 passing
- [x] `cargo xtask lint` clean