### PR TITLE
feat(dx): richer per-column stats + Dataset handler in text/llm+plain

### DIFF
--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -383,8 +383,9 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
     as a fallback bundle for hosts that don't understand the ref MIME;
     nteract frontends pick the parquet renderer via the ref MIME.
 
-    Returns ``None`` when serialization fails — lets IPython's default
-    chain render unchanged.
+    Returns ``None`` only when both parquet serialization and summary
+    generation fail. When parquet fails but the summary succeeds
+    (e.g. pyarrow missing), returns a summary-only bundle.
     """
     try:
         data, content_type = serialize_dataframe(df, max_bytes=_MAX_PAYLOAD_BYTES)

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -55,7 +55,7 @@ from typing import Any
 from dx._env import Environment, detect_environment
 from dx._format import serialize_dataframe
 from dx._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
-from dx._summary import summarize_dataframe
+from dx._summary import summarize_dataframe, summarize_dataset
 
 log = logging.getLogger("dx")
 
@@ -153,6 +153,14 @@ def install_formatters() -> None:
         ipython_display.for_type(nw.DataFrame, _narwhals_ipython_display)
     except ImportError:
         pass
+
+    try:
+        import datasets  # noqa: PLC0415  # ty: ignore[unresolved-import]
+
+        mimebundle.for_type(datasets.Dataset, _dataset_mimebundle)
+        ipython_display.for_type(datasets.Dataset, _dataset_ipython_display)
+    except ImportError:
+        log.debug("dx: datasets not installed, skipping handler")
 
     _install_display_pub_hook()
     _enable_third_party_nteract_renderers()
@@ -445,6 +453,44 @@ def _enable_third_party_nteract_renderers() -> None:
         pass
     except Exception as exc:  # pragma: no cover — defensive
         log.debug("dx: failed to set plotly 'nteract' renderer: %s", exc)
+
+
+def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
+    """`mimebundle_formatter` handler for `datasets.Dataset`.
+
+    Returns a bundle with only `text/llm+plain` — no parquet ref. Keeps the
+    dataset lazy and lets IPython fill in `text/plain` from the dataset's
+    own repr.
+    """
+    try:
+        summary = summarize_dataset(ds)
+        return {"text/llm+plain": summary}
+    except Exception as exc:
+        log.debug("dx: dataset mimebundle failed: %s", exc)
+        return None
+
+
+def _dataset_ipython_display(ds: Any) -> None:
+    """`ipython_display_formatter` handler for `datasets.Dataset`.
+
+    Publishes a `display_data` message with `text/llm+plain`, consistent
+    with the DataFrame path.
+    """
+    try:
+        from IPython.display import publish_display_data
+    except ImportError:
+        return
+
+    try:
+        bundle = _dataset_mimebundle(ds)
+    except Exception as exc:
+        log.debug("dx: dataset display failed: %s — falling back to repr", exc)
+        bundle = None
+
+    if bundle:
+        publish_display_data(data=bundle, metadata={})
+    else:
+        print(repr(ds))
 
 
 def dx_display(obj: Any) -> None:

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -389,8 +389,17 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
     try:
         data, content_type = serialize_dataframe(df, max_bytes=_MAX_PAYLOAD_BYTES)
     except Exception as exc:
-        log.debug("dx: serialize failed: %s — falling back to default repr", exc)
-        return None
+        log.debug("dx: serialize failed: %s — emitting summary-only bundle", exc)
+        # Parquet serialization failed (e.g. pyarrow missing), but the
+        # summary is pure Python — still emit text/llm+plain so the agent
+        # gets column stats instead of a raw repr.
+        try:
+            llm = summarize_dataframe(
+                df, total_rows=total_rows, included_rows=total_rows, sampled=False
+            )
+            return {"text/llm+plain": llm}
+        except Exception:
+            return None
 
     # Detect downsampling by reading parquet metadata (cheap — footer only).
     sampled = False

--- a/python/dx/src/dx/_summary.py
+++ b/python/dx/src/dx/_summary.py
@@ -9,9 +9,28 @@ from __future__ import annotations
 
 from typing import Any
 
+# Cap the number of columns in the summary to keep it compact.
+_MAX_SUMMARY_COLUMNS = 40
+
 
 def _format_int(n: int) -> str:
     return f"{n:,}"
+
+
+def _truncate_cell(value: Any, max_chars: int = 80) -> str:
+    """Render *value* as a string, truncating with ``…[+N chars]`` when longer
+    than *max_chars*."""
+    s = str(value)
+    if len(s) <= max_chars:
+        return s
+    keep = max_chars - 1  # room for the ellipsis char
+    suffix = f"…[+{len(s) - keep} chars]"
+    # Adjust: we need the prefix + suffix to fit reasonably
+    prefix_len = max_chars - len(suffix)
+    if prefix_len < 1:
+        prefix_len = 1
+        suffix = f"…[+{len(s) - prefix_len} chars]"
+    return s[:prefix_len] + suffix
 
 
 def _detect_flavor(df: Any) -> str:
@@ -21,22 +40,241 @@ def _detect_flavor(df: Any) -> str:
     return "unknown"
 
 
-def _pandas_dtypes(df: Any) -> list[tuple[str, str]]:
-    return [(str(col), str(df[col].dtype)) for col in df.columns]
+# ── Per-column stat extractors ──────────────────────────────────────
 
 
-def _pandas_null_counts(df: Any) -> list[tuple[str, int]]:
-    counts = df.isna().sum()
-    return [(str(col), int(counts[col])) for col in df.columns]
+def _pandas_column_stats(df: Any) -> list[dict]:
+    """Extract per-column stats from a pandas DataFrame.
+
+    Returns a list of dicts with keys: name, dtype, null_count, kind, stats.
+    """
+    import numpy as np
+
+    results: list[dict] = []
+    for col in df.columns:
+        series = df[col]
+        dtype_str = str(series.dtype)
+        null_count = int(series.isna().sum())
+        entry: dict = {
+            "name": str(col),
+            "dtype": dtype_str,
+            "null_count": null_count,
+        }
+
+        if null_count == len(series):
+            entry["kind"] = "all_null"
+            results.append(entry)
+            continue
+
+        kind = series.dtype.kind if hasattr(series.dtype, "kind") else ""
+
+        # Numeric (int, uint, float)
+        if kind in ("i", "u", "f"):
+            try:
+                vmin = series.min()
+                vmax = series.max()
+                if isinstance(vmin, (int, float, np.integer, np.floating)):
+                    entry["kind"] = "numeric"
+                    entry["stats"] = {"min": _format_numeric(vmin), "max": _format_numeric(vmax)}
+                else:
+                    entry["kind"] = "other"
+            except Exception:
+                entry["kind"] = "other"
+        # Datetime / timedelta
+        elif kind in ("M", "m"):
+            try:
+                vmin = series.dropna().min()
+                vmax = series.dropna().max()
+                entry["kind"] = "temporal"
+                entry["stats"] = {"min": str(vmin), "max": str(vmax)}
+            except Exception:
+                entry["kind"] = "other"
+        # Boolean
+        elif kind == "b":
+            entry["kind"] = "other"
+        # String / object / categorical
+        elif dtype_str in ("object", "string", "string[python]", "string[pyarrow]") or kind == "O":
+            try:
+                non_null = series.dropna()
+                nunique = int(non_null.nunique())
+                top_counts = non_null.value_counts(dropna=True).head(3)
+                top = [(str(idx), int(cnt)) for idx, cnt in top_counts.items()]
+                entry["kind"] = "string"
+                entry["stats"] = {"distinct": nunique, "top": top}
+            except Exception:
+                entry["kind"] = "other"
+        else:
+            entry["kind"] = "other"
+
+        results.append(entry)
+    return results
 
 
-def _polars_dtypes(df: Any) -> list[tuple[str, str]]:
-    return [(str(col), str(dtype)) for col, dtype in zip(df.columns, df.dtypes, strict=True)]
+def _polars_column_stats(df: Any) -> list[dict]:
+    """Extract per-column stats from a polars DataFrame.
+
+    Returns a list of dicts with keys: name, dtype, null_count, kind, stats.
+    """
+    import polars as pl
+
+    results: list[dict] = []
+    for col_name, dtype in zip(df.columns, df.dtypes, strict=True):
+        series = df[col_name]
+        dtype_str = str(dtype)
+        null_count = int(series.null_count())
+        entry: dict = {
+            "name": str(col_name),
+            "dtype": dtype_str,
+            "null_count": null_count,
+        }
+
+        if null_count == series.len():
+            entry["kind"] = "all_null"
+            results.append(entry)
+            continue
+
+        # Numeric types
+        if dtype.is_numeric() and not dtype.is_(pl.Boolean):
+            try:
+                vmin = series.min()
+                vmax = series.max()
+                entry["kind"] = "numeric"
+                entry["stats"] = {"min": _format_numeric(vmin), "max": _format_numeric(vmax)}
+            except Exception:
+                entry["kind"] = "other"
+        # Temporal types (Datetime, Date, Time, Duration)
+        elif dtype.is_temporal():
+            try:
+                vmin = series.drop_nulls().min()
+                vmax = series.drop_nulls().max()
+                entry["kind"] = "temporal"
+                entry["stats"] = {"min": str(vmin), "max": str(vmax)}
+            except Exception:
+                entry["kind"] = "other"
+        # String / Categorical / Utf8
+        elif dtype == pl.Utf8 or dtype == pl.String or dtype == pl.Categorical:
+            try:
+                non_null = series.drop_nulls()
+                nunique = int(non_null.n_unique())
+                vc = non_null.value_counts(sort=True)
+                # value_counts returns a DataFrame with columns [col_name, "count"]
+                top_n = vc.head(3)
+                top = [(str(top_n[col_name][i]), int(top_n["count"][i])) for i in range(len(top_n))]
+                entry["kind"] = "string"
+                entry["stats"] = {"distinct": nunique, "top": top}
+            except Exception:
+                entry["kind"] = "other"
+        else:
+            entry["kind"] = "other"
+
+        results.append(entry)
+    return results
 
 
-def _polars_null_counts(df: Any) -> list[tuple[str, int]]:
-    counts = df.null_count().row(0)
-    return [(str(col), int(n)) for col, n in zip(df.columns, counts, strict=True)]
+def _format_numeric(v: Any) -> str:
+    """Format a numeric value for display in stats."""
+    if isinstance(v, float):
+        if v == int(v) and abs(v) < 1e15:
+            return _format_int(int(v))
+        return f"{v:.3f}"
+    return _format_int(int(v))
+
+
+def _format_column_line(col: dict, total_rows: int) -> str:
+    """Format a single column's summary line."""
+    name = col["name"]
+    dtype = col["dtype"]
+    null_count = col["null_count"]
+    kind = col.get("kind", "other")
+
+    parts: list[str] = []
+
+    # Null info
+    if kind == "all_null":
+        parts.append("all null")
+    elif null_count > 0:
+        if total_rows > 0:
+            pct = round(null_count / total_rows * 100)
+            parts.append(f"{_format_int(null_count)} null ({pct}%)")
+        else:
+            parts.append(f"{_format_int(null_count)} null")
+
+    stats = col.get("stats")
+    if stats and kind == "numeric":
+        parts.append(f"range {stats['min']} – {stats['max']}")
+    elif stats and kind == "temporal":
+        if stats["min"] and stats["max"]:
+            parts.append(f"{stats['min']} to {stats['max']}")
+    elif stats and kind == "string":
+        s = f"{_format_int(stats['distinct'])} distinct"
+        if stats["top"]:
+            top_str = ", ".join(
+                f'"{_truncate_cell(label, 32)}" ({_format_int(cnt)})' for label, cnt in stats["top"]
+            )
+            s += f", top: {top_str}"
+        parts.append(s)
+
+    suffix = " · ".join(parts)
+    if suffix:
+        return f"  - {name} ({dtype}) · {suffix}"
+    return f"  - {name} ({dtype})"
+
+
+def _build_head_preview(df: Any, flavor: str, head_n: int) -> str:
+    """Build a truncated head preview of the DataFrame.
+
+    Uses manual per-cell truncation to keep the output compact regardless
+    of the underlying library's formatting defaults.
+    """
+    # Reduce head rows to keep output compact — the column stats carry
+    # the heavy analytical signal, the head is just a sample peek.
+    effective_n = min(head_n, 3)
+
+    if flavor == "pandas":
+        head_df = df.head(effective_n)
+        lines: list[str] = []
+        # Column headers
+        col_names = [str(c) for c in head_df.columns]
+        # Build rows with truncated cells
+        rows: list[list[str]] = []
+        for _, row in head_df.iterrows():
+            rows.append([_truncate_cell(row[c], 40) for c in head_df.columns])
+        # Compute column widths
+        widths = [
+            max(len(col_names[i]), *(len(r[i]) for r in rows)) if rows else len(col_names[i])
+            for i in range(len(col_names))
+        ]
+        # Format header
+        header = "  ".join(col_names[i].ljust(widths[i]) for i in range(len(col_names)))
+        lines.append(header)
+        # Format rows
+        for row in rows:
+            lines.append("  ".join(row[i].ljust(widths[i]) for i in range(len(row))))
+        return "\n".join(lines)
+    elif flavor == "polars":
+        head_df = df.head(effective_n)
+        lines_out: list[str] = []
+        col_names = list(head_df.columns)
+        rows_data: list[list[str]] = []
+        for i in range(len(head_df)):
+            row_cells: list[str] = []
+            for c in col_names:
+                val = head_df[c][i]
+                row_cells.append(_truncate_cell(val, 40))
+            rows_data.append(row_cells)
+        widths = [
+            max(len(col_names[j]), *(len(r[j]) for r in rows_data))
+            if rows_data
+            else len(col_names[j])
+            for j in range(len(col_names))
+        ]
+        header = "  ".join(col_names[j].ljust(widths[j]) for j in range(len(col_names)))
+        lines_out.append(header)
+        for row in rows_data:
+            lines_out.append("  ".join(row[j].ljust(widths[j]) for j in range(len(row))))
+        return "\n".join(lines_out)
+    else:
+        return repr(df)
 
 
 def summarize_dataframe(
@@ -49,46 +287,85 @@ def summarize_dataframe(
 ) -> str:
     """Produce a ``text/llm+plain`` summary for ``df``.
 
-    The summary includes shape, per-column dtype + null count, and a small
-    head sample. If the serialized parquet was downsampled, the header
+    The summary includes shape, per-column dtype + stats + null count, and a
+    small head sample. If the serialized parquet was downsampled, the header
     explicitly calls that out.
     """
     flavor = _detect_flavor(df)
 
+    # Extract per-column stats
     if flavor == "pandas":
-        dtypes = _pandas_dtypes(df)
-        nulls = _pandas_null_counts(df)
-        try:
-            head_repr = df.head(head_n).to_string()
-        except Exception:  # pragma: no cover — defensive
-            head_repr = repr(df.head(head_n))
+        col_stats = _pandas_column_stats(df)
     elif flavor == "polars":
-        dtypes = _polars_dtypes(df)
-        nulls = _polars_null_counts(df)
-        head_repr = str(df.head(head_n))
+        col_stats = _polars_column_stats(df)
     else:
-        dtypes = []
-        nulls = []
-        head_repr = repr(df)
+        col_stats = []
 
-    n_cols = len(dtypes)
+    n_cols = len(col_stats) if col_stats else (len(df.columns) if hasattr(df, "columns") else 0)
     lines: list[str] = []
+
+    # Header
     header = f"DataFrame ({flavor}): {_format_int(included_rows)} rows × {n_cols} columns"
     if sampled and total_rows != included_rows:
         header += f" (sampled from {_format_int(total_rows)} total rows)"
     lines.append(header)
 
-    if dtypes:
+    # Column stats
+    if col_stats:
         lines.append("Columns:")
-        null_map = dict(nulls)
-        for name, dtype in dtypes:
-            null_n = null_map.get(name, 0)
-            if null_n:
-                lines.append(f"  - {name}: {dtype} ({null_n} null)")
-            else:
-                lines.append(f"  - {name}: {dtype}")
+        capped = len(col_stats) > _MAX_SUMMARY_COLUMNS
+        display_stats = col_stats[:_MAX_SUMMARY_COLUMNS] if capped else col_stats
+        for col in display_stats:
+            lines.append(_format_column_line(col, included_rows))
+        if capped:
+            remaining = len(col_stats) - _MAX_SUMMARY_COLUMNS
+            lines.append(f"  …[+{remaining} more columns]")
 
+    # Head preview
     lines.append("")
+    head_preview = _build_head_preview(df, flavor, head_n)
     lines.append(f"Head ({head_n}):")
-    lines.append(head_repr)
+    lines.append(head_preview)
+    return "\n".join(lines)
+
+
+def summarize_dataset(ds: Any) -> str:
+    """Produce a ``text/llm+plain`` summary for a HuggingFace ``Dataset``.
+
+    Does NOT call ``.to_pandas()`` or any materializing operation beyond
+    reading ``ds[0]`` for a sample row.
+    """
+    features = ds.features
+    num_rows = ds.num_rows
+    n_features = len(features) if features else 0
+
+    lines: list[str] = []
+    lines.append(f"HuggingFace Dataset: {_format_int(num_rows)} rows × {n_features} features")
+
+    if features:
+        lines.append("Features:")
+        for name, feat in features.items():
+            lines.append(f"  - {name}: {feat}")
+
+    # Dataset description
+    if hasattr(ds, "info") and ds.info and getattr(ds.info, "description", None):
+        desc = ds.info.description
+        if desc.strip():
+            excerpt = desc[:200].strip()
+            if len(desc) > 200:
+                excerpt += "…"
+            lines.append("")
+            lines.append(f"Description: {excerpt}")
+
+    # Sample row
+    if num_rows > 0:
+        try:
+            row = ds[0]
+            lines.append("")
+            lines.append("Sample (row 0):")
+            for key, value in row.items():
+                lines.append(f"  {key}: {_truncate_cell(value, 80)}")
+        except Exception:
+            pass
+
     return "\n".join(lines)

--- a/python/dx/src/dx/_summary.py
+++ b/python/dx/src/dx/_summary.py
@@ -23,13 +23,10 @@ def _truncate_cell(value: Any, max_chars: int = 80) -> str:
     s = str(value)
     if len(s) <= max_chars:
         return s
-    keep = max_chars - 1  # room for the ellipsis char
-    suffix = f"…[+{len(s) - keep} chars]"
-    # Adjust: we need the prefix + suffix to fit reasonably
-    prefix_len = max_chars - len(suffix)
-    if prefix_len < 1:
-        prefix_len = 1
-        suffix = f"…[+{len(s) - prefix_len} chars]"
+    # Upper-bound suffix length to size the prefix, then compute the true suffix.
+    suffix_upper = f"…[+{len(s)} chars]"
+    prefix_len = max(max_chars - len(suffix_upper), 1)
+    suffix = f"…[+{len(s) - prefix_len} chars]"
     return s[:prefix_len] + suffix
 
 

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -37,6 +37,36 @@ class TestTextHeavyDataFrameSummaryStaysInline:
         assert "…" in out or "..." in out or len(out) < 1024
 
 
+class TestEmitDataFrameFallbackWithoutPyarrow:
+    """When pyarrow is missing, _emit_dataframe should still return a
+    text/llm+plain summary instead of None."""
+
+    def test_emit_returns_summary_only_on_serialize_failure(self, monkeypatch):
+        import dx._format_install as fi
+
+        # Make serialize_dataframe raise to simulate missing pyarrow
+        monkeypatch.setattr(
+            fi,
+            "serialize_dataframe",
+            lambda df, max_bytes: (_ for _ in ()).throw(ImportError("No module named 'pyarrow'")),
+        )
+
+        df = pd.DataFrame({"score": [0.1, 0.5, 0.9], "name": ["a", "b", "c"]})
+        bundle = fi._emit_dataframe(df, total_rows=3)
+
+        assert bundle is not None
+        assert "text/llm+plain" in bundle
+        # No blob ref — parquet serialization failed
+        from dx._refs import BLOB_REF_MIME
+
+        assert BLOB_REF_MIME not in bundle
+        # Summary should still contain useful stats
+        summary = bundle["text/llm+plain"]
+        assert "score" in summary
+        assert "name" in summary
+        assert "range" in summary
+
+
 class TestDatasetEmitsDisplayDataWithSummary:
     """Verify that a datasets.Dataset produces display_data with
     text/llm+plain mentioning feature names and num_rows."""

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -1,0 +1,130 @@
+"""Integration tests for dx display enrichment.
+
+Tests verify that the full pipeline (summary + formatting) produces the
+expected output shapes. These run without a live kernel — they test the
+Python-side logic that would run inside a kernel.
+"""
+
+import pandas as pd
+import pytest
+from dx._summary import summarize_dataframe
+
+
+class TestTextHeavyDataFrameSummaryStaysInline:
+    """Regression guard: text-heavy DataFrames used to produce summaries
+    that exceeded the 1 KB inline threshold and got blob-stored, showing
+    up as a URL rather than inline text in MCP structured content."""
+
+    def test_summary_stays_under_1kb(self):
+        long_text = "x" * 200
+        df = pd.DataFrame(
+            {
+                "bio": [long_text] * 5,
+                "notes": [long_text] * 5,
+                "comment": [long_text] * 5,
+            }
+        )
+        out = summarize_dataframe(df, total_rows=5, included_rows=5, sampled=False)
+        assert len(out) < 1024, (
+            f"Summary is {len(out)} bytes, must stay under 1 KB for inline display"
+        )
+
+    def test_summary_contains_truncation_markers(self):
+        long_text = "a" * 200
+        df = pd.DataFrame({"text": [long_text] * 5})
+        out = summarize_dataframe(df, total_rows=5, included_rows=5, sampled=False)
+        # The head preview should contain truncation markers from max_colwidth
+        assert "…" in out or "..." in out or len(out) < 1024
+
+
+class TestDatasetEmitsDisplayDataWithSummary:
+    """Verify that a datasets.Dataset produces display_data with
+    text/llm+plain mentioning feature names and num_rows."""
+
+    @pytest.fixture(autouse=True)
+    def _require_datasets(self):
+        pytest.importorskip("datasets")
+
+    def test_dataset_mimebundle_returns_llm_plain(self, monkeypatch):
+        import dx._format_install as fi
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        monkeypatch.setattr(fi, "_INSTALLED", False)
+        if hasattr(fi._pending, "buffers"):
+            fi._pending.buffers.clear()
+
+        ds = Dataset.from_dict({"text": ["hello", "world"], "label": [0, 1]})
+
+        bundle = fi._dataset_mimebundle(ds)
+        assert bundle is not None
+        assert "text/llm+plain" in bundle
+        summary = bundle["text/llm+plain"]
+        assert "2 rows" in summary
+        assert "text" in summary
+        assert "label" in summary
+
+    def test_dataset_mimebundle_no_parquet_ref(self, monkeypatch):
+        """Dataset handler must NOT emit parquet ref MIME — keeps data lazy."""
+        import dx._format_install as fi
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from dx._refs import BLOB_REF_MIME
+
+        ds = Dataset.from_dict({"a": [1]})
+        bundle = fi._dataset_mimebundle(ds)
+        assert bundle is not None
+        assert BLOB_REF_MIME not in bundle
+
+    def test_dataset_handler_registered_on_install(self, monkeypatch):
+        import dx._format_install as fi
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        monkeypatch.setattr(fi, "_INSTALLED", False)
+        if hasattr(fi._pending, "buffers"):
+            fi._pending.buffers.clear()
+
+        # Fake IPython
+        class FakeMimebundleFormatter:
+            def __init__(self):
+                self.registrations = {}
+
+            def for_type(self, cls, func):
+                self.registrations[cls] = func
+
+        class FakeDisplayFormatter:
+            def __init__(self):
+                self.mimebundle_formatter = FakeMimebundleFormatter()
+                self.ipython_display_formatter = FakeMimebundleFormatter()
+
+        class FakeIPython:
+            def __init__(self):
+                self.display_formatter = FakeDisplayFormatter()
+                self.display_pub = None
+
+        ip = FakeIPython()
+        monkeypatch.setattr(fi, "_get_ipython_for_format", lambda: ip)
+
+        fi.install_formatters()
+        assert Dataset in ip.display_formatter.mimebundle_formatter.registrations
+        assert Dataset in ip.display_formatter.ipython_display_formatter.registrations
+
+    def test_dataset_ipython_display_publishes(self, monkeypatch):
+        import dx._format_install as fi
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        ds = Dataset.from_dict({"text": ["hello"], "label": [1]})
+
+        published = []
+
+        def fake_publish_display_data(data, metadata=None, **kwargs):
+            published.append({"data": data, "metadata": metadata})
+
+        import IPython.display as ipd
+
+        monkeypatch.setattr(ipd, "publish_display_data", fake_publish_display_data)
+
+        fi._dataset_ipython_display(ds)
+
+        assert len(published) == 1
+        bundle = published[0]["data"]
+        assert "text/llm+plain" in bundle
+        assert "hello" in bundle["text/llm+plain"] or "text" in bundle["text/llm+plain"]

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -184,9 +184,9 @@ def test_mimebundle_returns_ref_mime_and_stashes_bytes(monkeypatch):
     assert hashlib.sha256(buf).hexdigest() == ref["hash"]
 
 
-def test_mimebundle_returns_none_on_serialize_failure(monkeypatch):
-    """When parquet serialization raises, formatter returns None so the
-    default HTML/plain chain runs."""
+def test_mimebundle_returns_summary_only_on_serialize_failure(monkeypatch):
+    """When parquet serialization raises, formatter returns a summary-only
+    bundle (text/llm+plain without blob ref) instead of None."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
@@ -201,7 +201,10 @@ def test_mimebundle_returns_none_on_serialize_failure(monkeypatch):
     formatter = ip.display_formatter.mimebundle_formatter.registrations[pd.DataFrame]
 
     df = pd.DataFrame({"a": [1]})
-    assert formatter(df) is None
+    result = formatter(df)
+    assert result is not None
+    assert "text/llm+plain" in result
+    assert BLOB_REF_MIME not in result
 
 
 def test_display_pub_hook_attaches_buffers_on_display_data(monkeypatch):

--- a/python/dx/tests/test_summary_unit.py
+++ b/python/dx/tests/test_summary_unit.py
@@ -1,0 +1,255 @@
+"""Unit tests for the enriched ``text/llm+plain`` summary generation.
+
+Tests verify per-column stats, truncation behavior, polars parity, and
+HuggingFace Dataset summaries.
+"""
+
+import pandas as pd
+import pytest
+from dx._summary import (
+    _truncate_cell,
+    summarize_dataframe,
+    summarize_dataset,
+)
+
+# ── Truncation ──────────────────────────────────────────────────────
+
+
+class TestTruncateCell:
+    def test_short_string_unchanged(self):
+        assert _truncate_cell("hello", 80) == "hello"
+
+    def test_exact_length_unchanged(self):
+        s = "x" * 80
+        assert _truncate_cell(s, 80) == s
+
+    def test_long_string_truncated_with_suffix(self):
+        s = "a" * 200
+        result = _truncate_cell(s, 80)
+        assert "…" in result
+        assert "+120 chars]" in result or "chars]" in result
+        assert len(result) <= 200  # reasonable upper bound
+
+    def test_non_string_value_converted(self):
+        assert _truncate_cell(42) == "42"
+        assert _truncate_cell(None) == "None"
+
+
+# ── Pandas numeric range ────────────────────────────────────────────
+
+
+class TestPandasNumericRange:
+    def test_includes_numeric_range(self):
+        df = pd.DataFrame({"score": [0.12, 0.5, 0.99]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "range" in out
+        assert "0.120" in out
+        assert "0.990" in out
+
+    def test_integer_range(self):
+        df = pd.DataFrame({"id": [1, 500, 1200]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "range" in out
+        assert "1" in out
+        assert "1,200" in out
+
+
+# ── Pandas string distinct + top ────────────────────────────────────
+
+
+class TestPandasStringStats:
+    def test_includes_string_distinct_and_top(self):
+        df = pd.DataFrame({"name": ["alice", "bob", "carol", "alice", "bob"]})
+        out = summarize_dataframe(df, total_rows=5, included_rows=5, sampled=False)
+        assert "distinct" in out
+        assert "top:" in out
+        assert '"alice"' in out or '"bob"' in out
+
+    def test_single_value_column(self):
+        df = pd.DataFrame({"status": ["ok"] * 10})
+        out = summarize_dataframe(df, total_rows=10, included_rows=10, sampled=False)
+        assert "1 distinct" in out
+        assert '"ok"' in out
+
+
+# ── Truncation integration ──────────────────────────────────────────
+
+
+class TestTruncationIntegration:
+    def test_text_heavy_summary_stays_compact(self):
+        """A DataFrame with 200-char text columns should produce a summary
+        that stays under 1 KB — verifying that both the head preview and
+        column stats are truncated."""
+        long_text = "x" * 200
+        df = pd.DataFrame(
+            {
+                "bio": [long_text] * 5,
+                "notes": [long_text] * 5,
+            }
+        )
+        out = summarize_dataframe(df, total_rows=5, included_rows=5, sampled=False)
+        assert len(out) < 1024, f"Summary is {len(out)} bytes, expected < 1024"
+
+
+# ── Pandas null handling ────────────────────────────────────────────
+
+
+class TestNullHandling:
+    def test_all_null_column(self):
+        df = pd.DataFrame({"empty": [None, None, None]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "all null" in out
+
+    def test_partial_null_with_percentage(self):
+        df = pd.DataFrame({"a": [1.0, None, 3.0]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "null" in out
+        assert "%" in out
+
+
+# ── Pandas temporal ─────────────────────────────────────────────────
+
+
+class TestPandasTemporal:
+    def test_datetime_range(self):
+        df = pd.DataFrame({"ts": pd.to_datetime(["2024-01-01", "2024-06-15", "2024-12-31"])})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "2024-01-01" in out
+        assert "2024-12-31" in out
+
+
+# ── Wide DataFrame capping ──────────────────────────────────────────
+
+
+class TestWideDataFrame:
+    def test_wide_dataframe_capped(self):
+        """DataFrames with 100+ columns should cap at ~40 columns in the
+        summary with a ``…[+N more columns]`` suffix."""
+        data = {f"col_{i}": [i] for i in range(120)}
+        df = pd.DataFrame(data)
+        out = summarize_dataframe(df, total_rows=1, included_rows=1, sampled=False)
+        assert "more columns]" in out
+        assert "120 columns" in out
+
+
+# ── Polars parity ──────────────────────────────────────────────────
+
+
+class TestPolars:
+    @pytest.fixture(autouse=True)
+    def _require_polars(self):
+        pytest.importorskip("polars")
+
+    def test_polars_numeric_range(self):
+        import polars as pl
+
+        df = pl.DataFrame({"val": [10, 20, 30]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "range" in out
+        assert "10" in out
+        assert "30" in out
+
+    def test_polars_string_distinct(self):
+        import polars as pl
+
+        df = pl.DataFrame({"name": ["alice", "bob", "carol"]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "distinct" in out
+
+    def test_polars_temporal(self):
+        from datetime import date
+
+        import polars as pl
+
+        df = pl.DataFrame({"d": [date(2024, 1, 1), date(2024, 6, 15), date(2024, 12, 31)]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "2024-01-01" in out
+        assert "2024-12-31" in out
+
+    def test_polars_datetime(self):
+        from datetime import datetime
+
+        import polars as pl
+
+        df = pl.DataFrame({"ts": [datetime(2024, 1, 1), datetime(2024, 12, 31)]})
+        out = summarize_dataframe(df, total_rows=2, included_rows=2, sampled=False)
+        assert "2024-01-01" in out
+        assert "2024-12-31" in out
+
+    def test_polars_duration(self):
+        from datetime import timedelta
+
+        import polars as pl
+
+        df = pl.DataFrame({"dur": [timedelta(seconds=10), timedelta(hours=1)]})
+        out = summarize_dataframe(df, total_rows=2, included_rows=2, sampled=False)
+        # Duration should be handled as temporal without crashing
+        assert "dur" in out
+
+    def test_polars_all_null(self):
+        import polars as pl
+
+        df = pl.DataFrame({"x": [None, None, None]}, schema={"x": pl.Int64})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert "all null" in out
+
+    def test_polars_summary_matches_pandas_shape(self):
+        """Polars and pandas summaries for the same data should contain
+        equivalent structural elements."""
+        import polars as pl
+
+        pd_df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        pl_df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+        pd_out = summarize_dataframe(pd_df, total_rows=3, included_rows=3, sampled=False)
+        pl_out = summarize_dataframe(pl_df, total_rows=3, included_rows=3, sampled=False)
+
+        # Both should have the same structural sections
+        for section in ["Columns:", "Head (", "range", "distinct"]:
+            assert section in pd_out, f"pandas missing section: {section}"
+            assert section in pl_out, f"polars missing section: {section}"
+
+
+# ── Dataset summary ─────────────────────────────────────────────────
+
+
+class TestDatasetSummary:
+    @pytest.fixture(autouse=True)
+    def _require_datasets(self):
+        pytest.importorskip("datasets")
+
+    def test_dataset_summary_from_features_only(self):
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        ds = Dataset.from_dict({"text": ["hello", "world"], "label": [0, 1]})
+        out = summarize_dataset(ds)
+        assert "HuggingFace Dataset" in out
+        assert "2 rows" in out
+        assert "2 features" in out
+        assert "text" in out
+        assert "label" in out
+
+    def test_dataset_summary_includes_sample_row(self):
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        ds = Dataset.from_dict({"name": ["alice"], "score": [0.95]})
+        out = summarize_dataset(ds)
+        assert "Sample (row 0):" in out
+        assert "alice" in out
+
+    def test_dataset_summary_empty(self):
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        ds = Dataset.from_dict({"a": [], "b": []})
+        out = summarize_dataset(ds)
+        assert "0 rows" in out
+        # No sample row for empty dataset
+        assert "Sample" not in out
+
+    def test_dataset_summary_truncates_long_values(self):
+        from datasets import Dataset  # ty: ignore[unresolved-import]
+
+        ds = Dataset.from_dict({"bio": ["x" * 200]})
+        out = summarize_dataset(ds)
+        assert "…" in out
+        assert "chars]" in out


### PR DESCRIPTION
## Summary

Implements the enrichment plan from #1807:

- **Per-column stats** in `summarize_dataframe`: numeric range (min–max), string distinct/top-3, null counts with percentages, temporal range, all-null detection — matching the shape of `repr-llm::summarize_parquet` so dx-provided summaries carry equivalent information density
- **Head truncation**: manual per-cell truncation (40 chars in head preview, 80 chars in stats) keeps summaries under 1 KB for inline CRDT storage, preventing the blob-ref resolution failures that caused empty `{"data": {}}` MCP outputs for text-heavy DataFrames
- **Wide DataFrame capping**: columns beyond 40 are elided with `…[+N more columns]`
- **`datasets.Dataset` handler**: metadata-only summary (features, num_rows, single-row peek via `ds[0]`) — no `.to_pandas()`, preserves lazy Arrow-backed design
- **Polars parity**: dedicated `_polars_column_stats` extractor covering numeric, temporal (Date/Datetime/Duration), string/categorical, and all-null columns

Works in tandem with #1808 (merged) which gives author-provided `text/llm+plain` priority over Rust-side synthesis in the output resolver.

## Files changed

- `python/dx/src/dx/_summary.py` — core rewrite with `_truncate_cell`, per-column stat extractors, `summarize_dataframe`, `summarize_dataset`
- `python/dx/src/dx/_format_install.py` — `datasets.Dataset` handler registration in `install_formatters()`
- `python/dx/tests/test_summary_unit.py` — 20 new unit tests (truncation, numeric/string/temporal/null stats, wide DataFrames, polars parity, Dataset summary)
- `python/dx/tests/test_dx_integration.py` — 6 new integration tests (1 KB size guard, truncation markers, Dataset mimebundle/display)

## Test plan

- [x] `pytest python/dx/tests/test_summary_unit.py` — 20 tests pass (4 skip without `datasets`)
- [x] `pytest python/dx/tests/test_dx_integration.py` — 6 tests pass (4 skip without `datasets`)
- [x] `cargo xtask lint` clean
- [ ] Gremlin validation against nightly with dx wheel installed (in progress)