### PR TITLE
fix(runtimed): check env sync drift after kernel restart

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5681,13 +5681,11 @@ async fn handle_notebook_request(
                                 }
                             }
 
-                            // Fresh kernel is in sync with its launched config
-                            {
-                                let mut sd = room.state_doc.write().await;
-                                if sd.set_env_sync(true, &[], &[], false, false) {
-                                    let _ = room.state_changed_tx.send(());
-                                }
-                            }
+                            // Compute env sync state against the freshly
+                            // stored launched_config (updated above).
+                            // Covers both inline-dep drift and the
+                            // prewarmed-with-added-inline-deps case.
+                            check_and_broadcast_sync_state(room).await;
 
                             return NotebookResponse::KernelLaunched {
                                 kernel_type: resolved_kernel_type,
@@ -5845,13 +5843,9 @@ async fn handle_notebook_request(
                                     }
                                 }
 
-                                // Fresh kernel is in sync with its launched config
-                                {
-                                    let mut sd = room.state_doc.write().await;
-                                    if sd.set_env_sync(true, &[], &[], false, false) {
-                                        let _ = room.state_changed_tx.send(());
-                                    }
-                                }
+                                // Compute env sync state against the freshly
+                                // stored launched_config (updated above).
+                                check_and_broadcast_sync_state(room).await;
 
                                 NotebookResponse::KernelLaunched {
                                     kernel_type: resolved_kernel_type,


### PR DESCRIPTION
## Summary

- After `restart_kernel`, the daemon was unconditionally marking the environment as in-sync (`set_env_sync(true, ...)`) without checking whether the CRDT metadata had deps not yet installed in the venv
- Packages added via `add_dependency` silently disappeared after restart — the venv persisted but the hot-install drift watcher never fired because it was told everything was already synced
- Now both restart paths (in-place restart via runtime agent and fallback new-agent spawn) run `compute_env_sync_diff` against the current CRDT metadata, correctly marking out-of-sync when drift exists so `SyncEnvironment` hot-installs the missing packages

Found by gremlin validation during dx enrichment work (PR #1809) — the gremlin lost ~40 turns re-adding deps after each kernel restart.

## Test plan

- [x] `cargo test -p runtimed -- compute_env_sync_diff` — all 7 tests pass
- [x] `cargo test -p runtimed --test tokio_mutex_lint` — no locks held across await
- [x] `cargo xtask lint` clean
- [ ] Gremlin replay to confirm deps persist across restart