### PR TITLE
docs(dx): rewrite README for PyPI display

### DIFF
--- a/python/dx/README.md
+++ b/python/dx/README.md
@@ -1,29 +1,47 @@
 # dx
 
-Efficient display and blob-store uploads for Python kernels running under nteract.
+**Smart DataFrame display for Jupyter, built for [nteract](https://nteract.io).**
 
-`dx` lets a Python kernel push bytes directly to the nteract daemon's blob store via a dedicated Jupyter comm, bypassing the IOPub "raw bytes" anti-pattern. Display bundles carry a tiny reference MIME (`application/vnd.nteract.blob-ref+json`) instead of megabytes of parquet/image/video data.
+`dx` upgrades how pandas and polars DataFrames render in a notebook. Instead of serializing megabytes of HTML into your output cells, dx hands the data to nteract's content-addressed blob store and renders it through a fast Arrow/parquet grid. Your `.ipynb` stays tiny, the cell stays snappy, and AI agents reading the notebook get a compact per-column summary — dtypes, ranges, distinct/top values, null counts — instead of raw bytes.
 
-## Usage
+## Install
+
+```bash
+# pandas
+pip install "dx[pandas]"
+
+# polars
+pip install "dx[polars]"
+
+# both
+pip install "dx[pandas,polars]"
+```
+
+Python 3.10+.
+
+## Use
 
 ```python
 import dx
 dx.install()
 
 import pandas as pd
-df = pd.read_parquet("big.parquet")
-df  # rendered via the sift parquet renderer from a blob reference
+df = pd.read_parquet("large-dataset.parquet")
+df  # rendered via nteract's sift grid — no base64 in your .ipynb
 ```
 
-Low-level:
+That's it. `dx.install()` is idempotent and automatically called by nteract's kernel bootstrap, so most nteract users never touch it directly. Calling it yourself is fine when you want the behavior in an environment nteract didn't configure for you (a standalone kernel, a test harness, etc.).
 
-```python
-ref = dx.put(open("image.png", "rb").read(), content_type="image/png")
-dx.display_blob_ref(ref, content_type="image/png")
-```
+## What you get
 
-See `docs/superpowers/specs/2026-04-13-nteract-dx-design.md` for the protocol.
+- **Fast rendering.** Large DataFrames stream through the blob store; the `.ipynb` payload stays small.
+- **AI-friendly summaries.** Every DataFrame ships a `text/llm+plain` column summary — dtypes, numeric ranges, string distinct/top values, null counts — so agents reason about the shape without materializing the whole table.
+- **Visualization integration.** [Altair](https://altair-viz.github.io) and [Plotly](https://plotly.com/python/) are automatically switched to their nteract renderers for interactive output that works inside nteract's isolated iframe sandbox.
+- **Narwhals-aware.** [narwhals](https://narwhals-dev.github.io/narwhals/)-wrapped DataFrames are unwrapped via `.to_native()` and dispatched through the pandas/polars path.
+- **Safe outside nteract.** When no nteract runtime is reachable, `dx.install()` is a no-op. `import dx` is safe from plain Python, vanilla Jupyter, scripts, CI.
 
-## In vanilla Jupyter or plain `python`
+## Links
 
-`dx.install()` is a no-op when no nteract runtime agent is reachable. `dx.display(df)` falls back to raw-bytes display, and `dx.put(...)` raises `DxNoAgentError`. The library is safe to import anywhere.
+- Homepage: <https://nteract.io>
+- Source & issues: <https://github.com/nteract/desktop>
+- License: BSD-3-Clause


### PR DESCRIPTION
Closes release-blocker #19 — the dx README is the primary artifact PyPI visitors see, and the old version read like internal design notes (led with "blob-store uploads via dedicated Jupyter comm," referenced removed low-level API like `dx.put`).

## Rewrite around user value

- Leads with what dx does for the user, not how it works under the hood
- Install instructions for the `[pandas]`, `[polars]`, and `[pandas,polars]` extras
- Minimal working example (`import dx; dx.install(); df` — that's the whole point)
- "What you get" bullet list: fast rendering, LLM summaries, viz integration, narwhals support, safe-outside-nteract fallback
- Links out: nteract homepage, GitHub source, BSD-3 license
- Drops the internal spec reference (`docs/superpowers/specs/...`) — that path works only on GitHub, was broken for PyPI readers. GitHub link lets anyone find it.

## Before / after

Before (29 lines):
> Efficient display and blob-store uploads for Python kernels running under nteract. `dx` lets a Python kernel push bytes directly to the nteract daemon's blob store via a dedicated Jupyter comm, bypassing the IOPub "raw bytes" anti-pattern…

After (47 lines):
> **Smart DataFrame display for Jupyter, built for [nteract](https://nteract.io).** `dx` upgrades how pandas and polars DataFrames render in a notebook. Instead of serializing megabytes of HTML into your output cells, dx hands the data to nteract's content-addressed blob store and renders it through a fast Arrow/parquet grid. Your `.ipynb` stays tiny, the cell stays snappy, and AI agents reading the notebook get a compact per-column summary…

## Verification

- `twine check dist/dx-2.0.0-py3-none-any.whl` → **PASSED** (confirms PyPI-compatible Markdown)
- Rendered locally, reads cleanly