### PR TITLE
chore(dx): add datasets to dev deps and drop stale ty:ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "polars>=1.39.3",
     "plotly>=6.0",
     "nbformat>=5.0",
+    "datasets>=2.0",
 ]
 agents = [
     "claude-agent-sdk>=0.1.0",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -30,4 +30,5 @@ dev = [
     "polars>=0.20",
     "ipykernel>=6.0",
     "narwhals>=1.0",
+    "datasets>=2.0",
 ]

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -155,7 +155,7 @@ def install_formatters() -> None:
         pass
 
     try:
-        import datasets  # noqa: PLC0415  # ty: ignore[unresolved-import]
+        import datasets  # noqa: PLC0415
 
         mimebundle.for_type(datasets.Dataset, _dataset_mimebundle)
         ipython_display.for_type(datasets.Dataset, _dataset_ipython_display)

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -77,7 +77,7 @@ class TestDatasetEmitsDisplayDataWithSummary:
 
     def test_dataset_mimebundle_returns_llm_plain(self, monkeypatch):
         import dx._format_install as fi
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         monkeypatch.setattr(fi, "_INSTALLED", False)
         if hasattr(fi._pending, "buffers"):
@@ -96,7 +96,7 @@ class TestDatasetEmitsDisplayDataWithSummary:
     def test_dataset_mimebundle_no_parquet_ref(self, monkeypatch):
         """Dataset handler must NOT emit parquet ref MIME — keeps data lazy."""
         import dx._format_install as fi
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
         from dx._refs import BLOB_REF_MIME
 
         ds = Dataset.from_dict({"a": [1]})
@@ -106,7 +106,7 @@ class TestDatasetEmitsDisplayDataWithSummary:
 
     def test_dataset_handler_registered_on_install(self, monkeypatch):
         import dx._format_install as fi
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         monkeypatch.setattr(fi, "_INSTALLED", False)
         if hasattr(fi._pending, "buffers"):
@@ -139,7 +139,7 @@ class TestDatasetEmitsDisplayDataWithSummary:
 
     def test_dataset_ipython_display_publishes(self, monkeypatch):
         import dx._format_install as fi
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         ds = Dataset.from_dict({"text": ["hello"], "label": [1]})
 

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -83,8 +83,8 @@ def test_install_is_idempotent(monkeypatch):
     dx.install()
     dx.install()
     assert (
-        len(ip.display_formatter.mimebundle_formatter.registrations) <= 3
-    )  # pandas + optional polars + optional narwhals
+        len(ip.display_formatter.mimebundle_formatter.registrations) <= 4
+    )  # pandas + optional polars + optional narwhals + optional datasets
 
 
 def test_install_treats_display_formatter_as_attribute_not_method(monkeypatch):

--- a/python/dx/tests/test_summary_unit.py
+++ b/python/dx/tests/test_summary_unit.py
@@ -219,7 +219,7 @@ class TestDatasetSummary:
         pytest.importorskip("datasets")
 
     def test_dataset_summary_from_features_only(self):
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         ds = Dataset.from_dict({"text": ["hello", "world"], "label": [0, 1]})
         out = summarize_dataset(ds)
@@ -230,7 +230,7 @@ class TestDatasetSummary:
         assert "label" in out
 
     def test_dataset_summary_includes_sample_row(self):
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         ds = Dataset.from_dict({"name": ["alice"], "score": [0.95]})
         out = summarize_dataset(ds)
@@ -238,7 +238,7 @@ class TestDatasetSummary:
         assert "alice" in out
 
     def test_dataset_summary_empty(self):
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         ds = Dataset.from_dict({"a": [], "b": []})
         out = summarize_dataset(ds)
@@ -247,7 +247,7 @@ class TestDatasetSummary:
         assert "Sample" not in out
 
     def test_dataset_summary_truncates_long_values(self):
-        from datasets import Dataset  # ty: ignore[unresolved-import]
+        from datasets import Dataset
 
         ds = Dataset.from_dict({"bio": ["x" * 200]})
         out = summarize_dataset(ds)


### PR DESCRIPTION
## Summary

- Adds `datasets>=2.0` to the dx `[dependency-groups].dev` list in `python/dx/pyproject.toml` so both CI's `uv sync` and local dev envs resolve it.
- Strips `# ty: ignore[unresolved-import]` directives from `python/dx/tests/test_summary_unit.py`, `python/dx/tests/test_dx_integration.py`, and the one in `python/dx/src/dx/_format_install.py:158` (all flagged as `unused-ignore-comment` once datasets is declared).
- Bumps `test_install_is_idempotent`'s registration-count assertion from `<= 3` to `<= 4` since the Dataset handler now always registers in the dev env.

## Motivation / drift

The dx tests `from datasets import Dataset` in several places, and `_format_install.py` registers a handler for `datasets.Dataset` inside a try/except. But `datasets` was never declared in any `pyproject.toml` — it only worked locally for contributors who had it installed as a transitive leftover. CI's fresh `uv sync` didn't install it, so the imports carried `# ty: ignore[unresolved-import]` to keep `ty check python/` green.

That caused drift: on machines where `datasets` *was* installed, ty flagged every suppression as `unused-ignore-comment`. A previous attempt to strip the suppressions (#1824, closed) red-lit CI because `datasets` still wasn't declared. This PR declares it as a dev dep first, then strips the suppressions.

No change to public dx deps — datasets remains optional at runtime via the existing try/except in `_format_install.py`.

## Test plan

- [x] `cargo xtask lint` passes (ruff + ty + biome + rustfmt)
- [x] `uv run --package dx pytest python/dx/tests/` — 72 passed
- [ ] CI green