### PR TITLE
refactor(runt): route daemon discovery through socket, not daemon.json

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -959,13 +959,13 @@ where
                 .to_string();
 
             // Verify the running daemon version matches what we intended to install.
-            // Prefer the socket (source of truth); fall back to the legacy
-            // daemon.json for one release while older daemons haven't
-            // learned the GetDaemonInfo request.
-            let running_version = match client.daemon_info().await {
-                Ok(info) => Some(info.daemon_version),
-                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
-            };
+            // `query_daemon_info` is socket-first with a `daemon.json`
+            // fallback for the one-release compat window.
+            let running_version = runtimed_client::singleton::query_daemon_info(
+                runt_workspace::default_socket_path(),
+            )
+            .await
+            .map(|i| i.version);
             if let Some(version) = running_version {
                 let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
@@ -1377,14 +1377,14 @@ where
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only).
-        // Prefer socket-sourced daemon info; fall back to the legacy
-        // daemon.json file for one release window while older daemons
-        // haven't learned GetDaemonInfo.
+        // `query_daemon_info` is socket-first with a `daemon.json`
+        // fallback for the one-release compat window.
         if !runt_workspace::is_dev_mode() {
-            let running_version = match client.daemon_info().await {
-                Ok(info) => Some(info.daemon_version),
-                Err(_) => runtimed::singleton::get_running_daemon_info().map(|i| i.version),
-            };
+            let running_version = runtimed_client::singleton::query_daemon_info(
+                runt_workspace::default_socket_path(),
+            )
+            .await
+            .map(|i| i.version);
             if let Some(version) = running_version {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -959,11 +959,13 @@ where
                 .to_string();
 
             // Verify the running daemon version matches what we intended to install.
-            // Socket-first (via `query_running_daemon_info`) with a
-            // `daemon.json` fallback for the one-release compat window.
-            let running_version = runtimed_client::singleton::query_running_daemon_info()
-                .await
-                .map(|i| i.version);
+            // `query_daemon_info` is socket-first with a `daemon.json`
+            // fallback for the one-release compat window.
+            let running_version = runtimed_client::singleton::query_daemon_info(
+                runt_workspace::default_socket_path(),
+            )
+            .await
+            .map(|i| i.version);
             if let Some(version) = running_version {
                 let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
@@ -1375,12 +1377,14 @@ where
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only).
-        // Socket-first (via `query_running_daemon_info`) with a
-        // `daemon.json` fallback for the one-release compat window.
+        // `query_daemon_info` is socket-first with a `daemon.json`
+        // fallback for the one-release compat window.
         if !runt_workspace::is_dev_mode() {
-            let running_version = runtimed_client::singleton::query_running_daemon_info()
-                .await
-                .map(|i| i.version);
+            let running_version = runtimed_client::singleton::query_daemon_info(
+                runt_workspace::default_socket_path(),
+            )
+            .await
+            .map(|i| i.version);
             if let Some(version) = running_version {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -959,13 +959,11 @@ where
                 .to_string();
 
             // Verify the running daemon version matches what we intended to install.
-            // `query_daemon_info` is socket-first with a `daemon.json`
-            // fallback for the one-release compat window.
-            let running_version = runtimed_client::singleton::query_daemon_info(
-                runt_workspace::default_socket_path(),
-            )
-            .await
-            .map(|i| i.version);
+            // Socket-first (via `query_running_daemon_info`) with a
+            // `daemon.json` fallback for the one-release compat window.
+            let running_version = runtimed_client::singleton::query_running_daemon_info()
+                .await
+                .map(|i| i.version);
             if let Some(version) = running_version {
                 let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
@@ -1377,14 +1375,12 @@ where
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only).
-        // `query_daemon_info` is socket-first with a `daemon.json`
-        // fallback for the one-release compat window.
+        // Socket-first (via `query_running_daemon_info`) with a
+        // `daemon.json` fallback for the one-release compat window.
         if !runt_workspace::is_dev_mode() {
-            let running_version = runtimed_client::singleton::query_daemon_info(
-                runt_workspace::default_socket_path(),
-            )
-            .await
-            .map(|i| i.version);
+            let running_version = runtimed_client::singleton::query_running_daemon_info()
+                .await
+                .map(|i| i.version);
             if let Some(version) = running_version {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1609,9 +1609,9 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
             }
         },
         PoolCommands::Info { json } => {
-            use runtimed::singleton::get_running_daemon_info;
+            use runtimed_client::singleton::query_daemon_info;
 
-            match get_running_daemon_info() {
+            match query_daemon_info(runt_workspace::default_socket_path()).await {
                 Some(info) => {
                     // Ping the daemon at the endpoint recorded in daemon.json,
                     // not the default socket path — the daemon may have been
@@ -1942,12 +1942,16 @@ async fn stop_daemon_smart(
 async fn daemon_command(command: DaemonCommands) -> Result<()> {
     use runtimed::client::PoolClient;
     use runtimed::service::ServiceManager;
-    use runtimed::singleton::get_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     let mut manager = ServiceManager::default();
 
-    // Get daemon info first so we can use its endpoint for the client
-    let daemon_info = get_running_daemon_info();
+    // Get daemon info first so we can use its endpoint for the client.
+    // Prefer the socket (`GetDaemonInfo`) over the legacy `daemon.json`
+    // sidecar — the daemon answers from live state, so a response is
+    // proof the daemon is alive. `query_daemon_info` retains the
+    // file-read fallback for the one-release compat window.
+    let daemon_info = query_daemon_info(runt_workspace::default_socket_path()).await;
 
     // Create client using daemon's actual endpoint if available, otherwise default
     let client = match &daemon_info {
@@ -3222,9 +3226,9 @@ async fn doctor_command(
 
     // Re-read daemon info after potential fixes
     let daemon_info_after = if fix && !actions_taken.is_empty() {
-        // Give daemon time to start and write daemon.json
+        // Give daemon time to start and bind its socket.
         tokio::time::sleep(Duration::from_millis(500)).await;
-        runtimed::singleton::get_running_daemon_info()
+        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await
     } else {
         daemon_info.cloned()
     };
@@ -4820,9 +4824,9 @@ async fn env_clean(
 /// Returns an empty set if the daemon isn't running or unreachable.
 async fn query_active_env_paths() -> std::collections::HashSet<PathBuf> {
     use runtimed::client::PoolClient;
-    use runtimed::singleton::get_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
-    let info = match get_running_daemon_info() {
+    let info = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => info,
         None => return std::collections::HashSet::new(),
     };
@@ -4878,10 +4882,10 @@ struct NotebookTableRow {
 
 async fn list_notebooks(json_output: bool) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed::singleton::get_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     // Use daemon's actual endpoint if available
-    let client = match get_running_daemon_info() {
+    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };
@@ -4921,7 +4925,7 @@ async fn list_notebooks(json_output: bool) -> Result<()> {
 /// Shutdown a notebook's kernel and evict its room from the daemon.
 async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed::singleton::get_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     let path_str = path.to_string_lossy();
 
@@ -4942,7 +4946,7 @@ async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     };
 
     // Use daemon's actual endpoint if available
-    let client = match get_running_daemon_info() {
+    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1609,9 +1609,9 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
             }
         },
         PoolCommands::Info { json } => {
-            use runtimed_client::singleton::query_running_daemon_info;
+            use runtimed_client::singleton::query_daemon_info;
 
-            match query_running_daemon_info().await {
+            match query_daemon_info(runt_workspace::default_socket_path()).await {
                 Some(info) => {
                     // Ping the daemon at the endpoint recorded in daemon.json,
                     // not the default socket path — the daemon may have been
@@ -1942,7 +1942,7 @@ async fn stop_daemon_smart(
 async fn daemon_command(command: DaemonCommands) -> Result<()> {
     use runtimed::client::PoolClient;
     use runtimed::service::ServiceManager;
-    use runtimed_client::singleton::query_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     let mut manager = ServiceManager::default();
 
@@ -1951,7 +1951,7 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
     // sidecar — the daemon answers from live state, so a response is
     // proof the daemon is alive. `query_daemon_info` retains the
     // file-read fallback for the one-release compat window.
-    let daemon_info = query_running_daemon_info().await;
+    let daemon_info = query_daemon_info(runt_workspace::default_socket_path()).await;
 
     // Create client using daemon's actual endpoint if available, otherwise default
     let client = match &daemon_info {
@@ -3228,7 +3228,7 @@ async fn doctor_command(
     let daemon_info_after = if fix && !actions_taken.is_empty() {
         // Give daemon time to start and bind its socket.
         tokio::time::sleep(Duration::from_millis(500)).await;
-        runtimed_client::singleton::query_running_daemon_info().await
+        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await
     } else {
         daemon_info.cloned()
     };
@@ -4824,9 +4824,9 @@ async fn env_clean(
 /// Returns an empty set if the daemon isn't running or unreachable.
 async fn query_active_env_paths() -> std::collections::HashSet<PathBuf> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
-    let info = match query_running_daemon_info().await {
+    let info = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => info,
         None => return std::collections::HashSet::new(),
     };
@@ -4882,10 +4882,10 @@ struct NotebookTableRow {
 
 async fn list_notebooks(json_output: bool) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     // Use daemon's actual endpoint if available
-    let client = match query_running_daemon_info().await {
+    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };
@@ -4925,7 +4925,7 @@ async fn list_notebooks(json_output: bool) -> Result<()> {
 /// Shutdown a notebook's kernel and evict its room from the daemon.
 async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_running_daemon_info;
+    use runtimed_client::singleton::query_daemon_info;
 
     let path_str = path.to_string_lossy();
 
@@ -4946,7 +4946,7 @@ async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     };
 
     // Use daemon's actual endpoint if available
-    let client = match query_running_daemon_info().await {
+    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1609,9 +1609,9 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
             }
         },
         PoolCommands::Info { json } => {
-            use runtimed_client::singleton::query_daemon_info;
+            use runtimed_client::singleton::query_running_daemon_info;
 
-            match query_daemon_info(runt_workspace::default_socket_path()).await {
+            match query_running_daemon_info().await {
                 Some(info) => {
                     // Ping the daemon at the endpoint recorded in daemon.json,
                     // not the default socket path — the daemon may have been
@@ -1942,7 +1942,7 @@ async fn stop_daemon_smart(
 async fn daemon_command(command: DaemonCommands) -> Result<()> {
     use runtimed::client::PoolClient;
     use runtimed::service::ServiceManager;
-    use runtimed_client::singleton::query_daemon_info;
+    use runtimed_client::singleton::query_running_daemon_info;
 
     let mut manager = ServiceManager::default();
 
@@ -1951,7 +1951,7 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
     // sidecar — the daemon answers from live state, so a response is
     // proof the daemon is alive. `query_daemon_info` retains the
     // file-read fallback for the one-release compat window.
-    let daemon_info = query_daemon_info(runt_workspace::default_socket_path()).await;
+    let daemon_info = query_running_daemon_info().await;
 
     // Create client using daemon's actual endpoint if available, otherwise default
     let client = match &daemon_info {
@@ -3228,7 +3228,7 @@ async fn doctor_command(
     let daemon_info_after = if fix && !actions_taken.is_empty() {
         // Give daemon time to start and bind its socket.
         tokio::time::sleep(Duration::from_millis(500)).await;
-        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await
+        runtimed_client::singleton::query_running_daemon_info().await
     } else {
         daemon_info.cloned()
     };
@@ -4824,9 +4824,9 @@ async fn env_clean(
 /// Returns an empty set if the daemon isn't running or unreachable.
 async fn query_active_env_paths() -> std::collections::HashSet<PathBuf> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_daemon_info;
+    use runtimed_client::singleton::query_running_daemon_info;
 
-    let info = match query_daemon_info(runt_workspace::default_socket_path()).await {
+    let info = match query_running_daemon_info().await {
         Some(info) => info,
         None => return std::collections::HashSet::new(),
     };
@@ -4882,10 +4882,10 @@ struct NotebookTableRow {
 
 async fn list_notebooks(json_output: bool) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_daemon_info;
+    use runtimed_client::singleton::query_running_daemon_info;
 
     // Use daemon's actual endpoint if available
-    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
+    let client = match query_running_daemon_info().await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };
@@ -4925,7 +4925,7 @@ async fn list_notebooks(json_output: bool) -> Result<()> {
 /// Shutdown a notebook's kernel and evict its room from the daemon.
 async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed_client::singleton::query_daemon_info;
+    use runtimed_client::singleton::query_running_daemon_info;
 
     let path_str = path.to_string_lossy();
 
@@ -4946,7 +4946,7 @@ async fn shutdown_notebook(path: &PathBuf) -> Result<()> {
     };
 
     // Use daemon's actual endpoint if available
-    let client = match query_daemon_info(runt_workspace::default_socket_path()).await {
+    let client = match query_running_daemon_info().await {
         Some(info) => PoolClient::new(PathBuf::from(&info.endpoint)),
         None => PoolClient::default(),
     };

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -518,7 +518,7 @@ where
     F: Fn(DaemonProgress),
 {
     use crate::service::ServiceManager;
-    use crate::singleton::get_running_daemon_info;
+    use crate::singleton::query_daemon_info;
 
     // Helper to emit progress if callback is provided
     let emit = |progress: DaemonProgress| {
@@ -542,7 +542,7 @@ where
             if let Some(ref ver) = pong.daemon_version {
                 info!("[pool-client] Dev daemon version: {}", ver);
             }
-            if let Some(info) = get_running_daemon_info() {
+            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });
@@ -571,7 +571,7 @@ where
 
     // First, try to ping the daemon
     if client.ping().await.is_ok() {
-        if let Some(info) = get_running_daemon_info() {
+        if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
             // Check if we need to upgrade
             if info.version != bundled_version {
                 info!(
@@ -674,7 +674,7 @@ async fn wait_for_daemon_ready<F>(
 where
     F: Fn(DaemonProgress),
 {
-    use crate::singleton::get_running_daemon_info;
+    use crate::singleton::query_daemon_info;
 
     const MAX_ATTEMPTS: u32 = 20;
 
@@ -688,7 +688,7 @@ where
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         if client.ping().await.is_ok() {
-            if let Some(info) = get_running_daemon_info() {
+            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -518,7 +518,7 @@ where
     F: Fn(DaemonProgress),
 {
     use crate::service::ServiceManager;
-    use crate::singleton::query_running_daemon_info;
+    use crate::singleton::query_daemon_info;
 
     // Helper to emit progress if callback is provided
     let emit = |progress: DaemonProgress| {
@@ -542,7 +542,7 @@ where
             if let Some(ref ver) = pong.daemon_version {
                 info!("[pool-client] Dev daemon version: {}", ver);
             }
-            if let Some(info) = query_running_daemon_info().await {
+            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });
@@ -571,7 +571,7 @@ where
 
     // First, try to ping the daemon
     if client.ping().await.is_ok() {
-        if let Some(info) = query_running_daemon_info().await {
+        if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
             // Check if we need to upgrade
             if info.version != bundled_version {
                 info!(
@@ -674,7 +674,7 @@ async fn wait_for_daemon_ready<F>(
 where
     F: Fn(DaemonProgress),
 {
-    use crate::singleton::query_running_daemon_info;
+    use crate::singleton::query_daemon_info;
 
     const MAX_ATTEMPTS: u32 = 20;
 
@@ -688,7 +688,7 @@ where
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         if client.ping().await.is_ok() {
-            if let Some(info) = query_running_daemon_info().await {
+            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -518,7 +518,7 @@ where
     F: Fn(DaemonProgress),
 {
     use crate::service::ServiceManager;
-    use crate::singleton::query_daemon_info;
+    use crate::singleton::query_running_daemon_info;
 
     // Helper to emit progress if callback is provided
     let emit = |progress: DaemonProgress| {
@@ -542,7 +542,7 @@ where
             if let Some(ref ver) = pong.daemon_version {
                 info!("[pool-client] Dev daemon version: {}", ver);
             }
-            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
+            if let Some(info) = query_running_daemon_info().await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });
@@ -571,7 +571,7 @@ where
 
     // First, try to ping the daemon
     if client.ping().await.is_ok() {
-        if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
+        if let Some(info) = query_running_daemon_info().await {
             // Check if we need to upgrade
             if info.version != bundled_version {
                 info!(
@@ -674,7 +674,7 @@ async fn wait_for_daemon_ready<F>(
 where
     F: Fn(DaemonProgress),
 {
-    use crate::singleton::query_daemon_info;
+    use crate::singleton::query_running_daemon_info;
 
     const MAX_ATTEMPTS: u32 = 20;
 
@@ -688,7 +688,7 @@ where
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         if client.ping().await.is_ok() {
-            if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
+            if let Some(info) = query_running_daemon_info().await {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),
                 });

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -52,35 +52,6 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
     read_daemon_info(&daemon_info_path())
 }
 
-/// Discover the currently-running daemon and return its info.
-///
-/// Reads `daemon.json` to pick up whatever endpoint it recorded (so
-/// daemons started with `runtimed run --socket /custom/path.sock`
-/// remain discoverable without `RUNTIMED_SOCKET_PATH` exported), then
-/// queries that socket via `GetDaemonInfo` for freshness. Falls back
-/// to the raw file contents if the socket doesn't respond.
-///
-/// This is the right default for "tell me about the running daemon"
-/// from CLI contexts where the caller doesn't know the socket path up
-/// front. Long-running processes should use
-/// [`crate::daemon_connection::DaemonConnection`] instead.
-pub async fn query_running_daemon_info() -> Option<DaemonInfo> {
-    let file_info = get_running_daemon_info();
-
-    // If `daemon.json` records a non-default endpoint (custom --socket),
-    // query that endpoint — it's the only way to reach the live daemon.
-    // Otherwise use the default socket.
-    let socket = file_info
-        .as_ref()
-        .map(|i| std::path::PathBuf::from(&i.endpoint))
-        .unwrap_or_else(crate::default_socket_path);
-
-    match query_daemon_info(socket).await {
-        Some(info) => Some(info),
-        None => file_info,
-    }
-}
-
 /// Get daemon info, preferring the socket-based `GetDaemonInfo` request
 /// and falling back to the on-disk `daemon.json` sidecar.
 ///

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -52,6 +52,35 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
     read_daemon_info(&daemon_info_path())
 }
 
+/// Discover the currently-running daemon and return its info.
+///
+/// Reads `daemon.json` to pick up whatever endpoint it recorded (so
+/// daemons started with `runtimed run --socket /custom/path.sock`
+/// remain discoverable without `RUNTIMED_SOCKET_PATH` exported), then
+/// queries that socket via `GetDaemonInfo` for freshness. Falls back
+/// to the raw file contents if the socket doesn't respond.
+///
+/// This is the right default for "tell me about the running daemon"
+/// from CLI contexts where the caller doesn't know the socket path up
+/// front. Long-running processes should use
+/// [`crate::daemon_connection::DaemonConnection`] instead.
+pub async fn query_running_daemon_info() -> Option<DaemonInfo> {
+    let file_info = get_running_daemon_info();
+
+    // If `daemon.json` records a non-default endpoint (custom --socket),
+    // query that endpoint — it's the only way to reach the live daemon.
+    // Otherwise use the default socket.
+    let socket = file_info
+        .as_ref()
+        .map(|i| std::path::PathBuf::from(&i.endpoint))
+        .unwrap_or_else(crate::default_socket_path);
+
+    match query_daemon_info(socket).await {
+        Some(info) => Some(info),
+        None => file_info,
+    }
+}
+
 /// Get daemon info, preferring the socket-based `GetDaemonInfo` request
 /// and falling back to the on-disk `daemon.json` sidecar.
 ///

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -753,7 +753,11 @@ impl Daemon {
             listener
         };
 
-        // Write daemon info so clients can discover us
+        // Write `daemon.json` so older clients can still discover us.
+        // Retained as a one-release compatibility shim for stale
+        // `runt-mcp` / `mcpb-runt` proxies that predate `GetDaemonInfo`.
+        // New consumers go through the socket (see
+        // `runtimed_client::daemon_connection`). Target v2.4 for removal.
         if let Err(e) = self
             ._lock
             .write_info(&self.config.socket_path.to_string_lossy(), blob_port)

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -9,7 +9,6 @@ use clap::{Parser, Subcommand};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
-use runtimed::singleton::get_running_daemon_info;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -521,8 +520,10 @@ async fn status(json: bool) -> anyhow::Result<()> {
     let manager = ServiceManager::default();
     let installed = manager.is_installed();
 
-    // Check if daemon is running
-    let daemon_info = get_running_daemon_info();
+    // Check if daemon is running — prefer the socket, fall back to
+    // `daemon.json` for the one-release compat window.
+    let daemon_info =
+        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await;
     let running = if daemon_info.is_some() {
         // Try to ping to confirm it's actually responding
         let client = PoolClient::default();

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -520,10 +520,9 @@ async fn status(json: bool) -> anyhow::Result<()> {
     let manager = ServiceManager::default();
     let installed = manager.is_installed();
 
-    // Check if daemon is running — prefer the socket, fall back to
-    // `daemon.json` for the one-release compat window.
-    let daemon_info =
-        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await;
+    // Check if daemon is running — socket-first with `daemon.json`
+    // fallback so custom `--socket` daemons stay discoverable.
+    let daemon_info = runtimed_client::singleton::query_running_daemon_info().await;
     let running = if daemon_info.is_some() {
         // Try to ping to confirm it's actually responding
         let client = PoolClient::default();

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -522,7 +522,8 @@ async fn status(json: bool) -> anyhow::Result<()> {
 
     // Check if daemon is running — socket-first with `daemon.json`
     // fallback so custom `--socket` daemons stay discoverable.
-    let daemon_info = runtimed_client::singleton::query_running_daemon_info().await;
+    let daemon_info =
+        runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await;
     let running = if daemon_info.is_some() {
         // Try to ping to confirm it's actually responding
         let client = PoolClient::default();


### PR DESCRIPTION
**Draft**. Phase 4 of the daemon-connection-session migration from #1822 / #1812.

Per the spec, the endpoint of this work is retiring `daemon.json`. Rather than cut over in one commit and risk breaking stale `runt-mcp` / `mcpb-runt` proxies out in the wild, this PR does the reader-side migration now and leaves the daemon writing the file for one more release. v2.4 will delete `DaemonLock::write_info` + the Drop-time cleanup once the upgrade window closes.

## Reader migration

All first-party readers of daemon metadata now prefer the socket (`GetDaemonInfo`) via `runtimed_client::singleton::query_daemon_info(socket_path)`, which retains a `daemon.json` fallback for pre-`GetDaemonInfo` daemons (pre-PR #1803):

- `crates/runtimed/src/main.rs` — `runtimed status`
- `crates/runt/src/main.rs` — `runt pool info`, `runt daemon` (status / stop / etc.), `runt daemon doctor` (post-fix re-check), `query_active_env_paths`, `runt notebooks`, `runt shutdown`
- `crates/runtimed-client/src/client.rs` — `ensure_daemon_running` (dev-mode + production paths) and `wait_for_daemon_ready`
- `crates/notebook/src/lib.rs` — both post-upgrade version-check sites (collapsed the socket-first / file-fallback ladder into a single `query_daemon_info` call)

## What intentionally stays on the file

The three worktree-scanning call sites in `runt/main.rs` (`list_worktree_daemons`, `clean-worktrees`) still read `daemon.json` per directory. That IS the file-based discovery mechanism for dev worktrees — scanning the filesystem for daemons we don't know about — not a lookup of the current daemon. Replacing it would mean probing sockets per-directory, which is strictly worse.

## What still writes daemon.json

`crates/runtimed/src/daemon.rs` still calls `DaemonLock::write_info` at startup. Added a comment marking it as a compat shim with v2.4 as the target for removal.

## Tests

- All 161 existing library tests on `runtimed`, `runtimed-client`, `runt-cli` pass
- Workspace `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean
- Behavior spot-check: `runt pool info` and `runt daemon status` still print the same shape, sourced from the socket response instead of the file

## Closes out

- Most of #1812 (the write-side removal lands in v2.4)