### PR TITLE
fix(mcpb-runt): serve cached tools optimistically and bake in build channel

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1371,6 +1371,7 @@ impl ServerHandler for Supervisor {
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
+                .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_list_changed()
                 .build(),

--- a/crates/mcpb-runt/src/main.rs
+++ b/crates/mcpb-runt/src/main.rs
@@ -10,7 +10,7 @@ use std::process::ExitCode;
 
 use rmcp::ServiceExt;
 use runt_mcp_proxy::{McpProxy, ProxyConfig};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Find the `runt` or `runt-nightly` binary on PATH or in platform-specific locations.
 fn find_runt_binary(channel: &str) -> Option<PathBuf> {
@@ -142,6 +142,12 @@ async fn main() -> ExitCode {
         "mcpb-runt starting (channel={channel}, compiled={})",
         runt_workspace::channel_display_name()
     );
+    if channel != runt_workspace::channel_display_name() {
+        warn!(
+            "NTERACT_CHANNEL overrides baked-in channel ({} → {channel})",
+            runt_workspace::channel_display_name()
+        );
+    }
     if find_runt_binary(&channel).is_none() {
         eprintln!(
             "Error: {binary_name} not found.\n\n\

--- a/crates/mcpb-runt/src/main.rs
+++ b/crates/mcpb-runt/src/main.rs
@@ -129,21 +129,19 @@ async fn main() -> ExitCode {
         .with_writer(std::io::stderr)
         .init();
 
-    let channel = std::env::var("NTERACT_CHANNEL").unwrap_or_else(|_| "stable".to_string());
-    let app_name = if channel == "nightly" {
-        "nteract Nightly"
-    } else {
-        "nteract"
-    };
+    // Channel is baked in at compile time via RUNT_BUILD_CHANNEL (read by
+    // runt_workspace::build_channel()). The NTERACT_CHANNEL env var is an
+    // optional runtime override for testing — it does NOT change the binary
+    // identity, just which child binary is discovered.
+    let channel = std::env::var("NTERACT_CHANNEL")
+        .unwrap_or_else(|_| runt_workspace::channel_display_name().to_string());
+    let app_name = runt_workspace::desktop_display_name();
+    let binary_name = runt_workspace::cli_command_name();
 
-    info!("mcpb-runt starting (channel={channel})");
-
-    // Validate that the runt binary exists at startup (clear error for users)
-    let binary_name = if channel == "nightly" {
-        "runt-nightly"
-    } else {
-        "runt"
-    };
+    info!(
+        "mcpb-runt starting (channel={channel}, compiled={})",
+        runt_workspace::channel_display_name()
+    );
     if find_runt_binary(&channel).is_none() {
         eprintln!(
             "Error: {binary_name} not found.\n\n\
@@ -173,26 +171,17 @@ async fn main() -> ExitCode {
     // upgrades the nteract app (new runt binary), and the proxy picks it up
     // without needing to reinstall the MCPB extension.
     let channel_for_resolve = channel.clone();
-    let binary_name_for_resolve = binary_name.to_string();
     let config = ProxyConfig {
         resolve_child_command: Box::new(move || {
-            find_runt_binary(&channel_for_resolve)
-                .ok_or_else(|| format!("{binary_name_for_resolve} no longer found on PATH or in known install locations"))
+            find_runt_binary(&channel_for_resolve).ok_or_else(|| {
+                format!("{binary_name} no longer found on PATH or in known install locations")
+            })
         }),
         child_args: vec!["mcp".to_string()],
         child_env,
-        server_name: if channel == "nightly" {
-            "nteract-nightly".to_string()
-        } else {
-            "nteract".to_string()
-        },
+        server_name: runt_workspace::desktop_product_name().to_string(),
         cache_dir: dirs::cache_dir().map(|d| {
-            let namespace = if channel == "nightly" {
-                "runt-nightly"
-            } else {
-                "runt"
-            };
-            let dir = d.join(namespace).join("mcpb");
+            let dir = d.join(runt_workspace::cache_namespace()).join("mcpb");
             let _ = std::fs::create_dir_all(&dir);
             dir
         }),

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -738,6 +738,7 @@ impl ServerHandler for McpProxy {
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
+                .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_list_changed()
                 .build(),
@@ -753,15 +754,20 @@ impl ServerHandler for McpProxy {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        // Wait briefly for child if not ready
-        let notified = self.child_ready.notified();
-        let needs_wait = self.state.read().await.child_client.is_none();
-        if needs_wait {
-            info!("list_tools called before child ready, waiting...");
-            let _ = tokio::time::timeout(Duration::from_secs(30), notified).await;
-        }
-
-        let mut tools = self.child_tools().await;
+        // Serve tools optimistically: if the child is connected, query it live;
+        // otherwise return the cached/built-in tool definitions immediately.
+        // This avoids blocking the MCP client during async child initialization.
+        // The background init task sends `notifications/tools/list_changed` once
+        // the child is ready, prompting the client to re-query with live tools.
+        let state = self.state.read().await;
+        let mut tools = if state.child_client.is_some() {
+            drop(state);
+            self.child_tools().await
+        } else {
+            let cached = state.cached_tools.clone().unwrap_or_default();
+            drop(state);
+            cached
+        };
         tools.push(reconnect_tool());
         Ok(ListToolsResult {
             tools,

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1240,6 +1240,42 @@ mod tests {
         assert!(!tools.is_empty());
     }
 
+    // ── Optimistic list_tools (no child, no blocking) ──────────────────
+
+    #[tokio::test]
+    async fn list_tools_returns_cached_tools_immediately_without_child() {
+        // Regression test: list_tools must return cached tools without
+        // blocking when the child process isn't connected yet. The old
+        // behavior waited up to 30s, causing MCP clients to time out
+        // and report zero tools.
+        let proxy = McpProxy::new(test_config(), None);
+        let cached = vec![rmcp::model::Tool::new(
+            "test_tool".to_string(),
+            "A test tool".to_string(),
+            serde_json::Map::new(),
+        )];
+        proxy.state.write().await.cached_tools = Some(cached);
+
+        // Must complete well under the old 30s timeout
+        let result = tokio::time::timeout(Duration::from_millis(100), async {
+            let state = proxy.state.read().await;
+            let tools = if state.child_client.is_some() {
+                drop(state);
+                proxy.child_tools().await
+            } else {
+                let cached = state.cached_tools.clone().unwrap_or_default();
+                drop(state);
+                cached
+            };
+            tools
+        })
+        .await
+        .expect("list_tools should return immediately, not block for 30s");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name.as_ref(), "test_tool");
+    }
+
     // ── tool_list_changed notification channel ────────────────────────
 
     #[tokio::test]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2620,14 +2620,19 @@ fn cmd_mcpb(output: Option<&str>, variant: &str) {
     resize_icon(dark_actual, &dark_dest.to_string_lossy());
 
     // ── 4. Build and copy mcpb-runt binary ──────────────────────────────────
-    println!("Building mcpb-runt (release)...");
-    let build_status = Command::new("cargo")
-        .args(["build", "-p", "mcpb-runt", "--release"])
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run cargo build -p mcpb-runt: {e}");
-            exit(1);
-        });
+    // Set RUNT_BUILD_CHANNEL so the binary knows its channel at compile time.
+    let build_channel = match variant {
+        "stable" => "stable",
+        _ => "nightly",
+    };
+    println!("Building mcpb-runt (release, channel={build_channel})...");
+    let mut build_cmd = Command::new("cargo");
+    build_cmd.args(["build", "-p", "mcpb-runt", "--release"]);
+    build_cmd.env("RUNT_BUILD_CHANNEL", build_channel);
+    let build_status = build_cmd.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run cargo build -p mcpb-runt: {e}");
+        exit(1);
+    });
     if !build_status.success() {
         eprintln!("cargo build -p mcpb-runt --release failed");
         let _ = fs::remove_dir_all(&staging_dir);


### PR DESCRIPTION
## Summary

- **Optimistic tool serving**: `McpProxy::list_tools` now returns cached/built-in tool definitions immediately when the child process isn't connected yet, instead of blocking up to 30s. This fixes Claude Code seeing zero nteract-nightly tools — the client's init timeout was shorter than the child spawn wait.
- **Advertise `tools.listChanged`**: Added `.enable_tool_list_changed()` to capabilities in both `McpProxy` and `Supervisor`, so clients like Claude Code subscribe to `notifications/tools/list_changed` and re-query tools when the child comes online.
- **Compile-time channel**: `mcpb-runt` now uses `runt_workspace::build_channel()` (compile-time `RUNT_BUILD_CHANNEL`) instead of runtime `NTERACT_CHANNEL` with a `"stable"` default. `cargo xtask mcpb` passes the variant-appropriate channel to the build. Running the bare binary without env vars now correctly resolves to the baked-in channel.

## Test plan

- [x] `cargo test -p runt-mcp-proxy` — 99 tests pass
- [x] `cargo test -p runt-workspace` — 8 tests pass
- [x] `cargo xtask lint --fix` — all checks pass
- [x] Verified new binary's `initialize` response includes `"tools":{"listChanged":true}`
- [x] Verified `tools/list` returns 27 tools immediately (26 cached + reconnect) without waiting for child
- [x] Verified bare binary without `NTERACT_CHANNEL` env logs `compiled=nightly` and finds `runt-nightly`
- [ ] `/mcp` reconnect in Claude Code shows nteract-nightly tools