### PR TITLE
fix(runt-mcp): use inline env_source when deps are pre-declared

### DIFF
--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -166,6 +166,9 @@ pub async fn prepare_environment_in(
 
     let mut venv_cmd = tokio::process::Command::new(&uv_path);
     venv_cmd.arg("venv").arg(&venv_path);
+    // Set explicit cwd so `uv` doesn't fail when the daemon's inherited cwd
+    // has been deleted (e.g. a cleaned-up gremlin temp directory).
+    venv_cmd.current_dir(cache_dir);
 
     if let Some(ref py_version) = deps.requires_python {
         let version = py_version
@@ -234,6 +237,7 @@ pub async fn prepare_environment_in(
 
     let offline_output = tokio::process::Command::new(&uv_path)
         .args(&offline_args)
+        .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -268,6 +272,7 @@ pub async fn prepare_environment_in(
 
     let install_output = tokio::process::Command::new(&uv_path)
         .args(&install_args)
+        .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -287,6 +292,7 @@ pub async fn prepare_environment_in(
         retry_args.insert(2, "--refresh".to_string());
         tokio::process::Command::new(&uv_path)
             .args(&retry_args)
+            .current_dir(cache_dir)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
@@ -352,8 +358,13 @@ pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<(
     // Insert --offline after "pip install" (index 2)
     offline_args.insert(2, "--offline".to_string());
 
+    // Use the venv's parent directory as cwd so `uv` doesn't fail when the
+    // daemon's inherited cwd has been deleted.
+    let cwd = env.venv_path.parent().unwrap_or_else(|| Path::new("/tmp"));
+
     let offline_output = tokio::process::Command::new(&uv_path)
         .args(&offline_args)
+        .current_dir(cwd)
         .output()
         .await?;
 
@@ -370,6 +381,7 @@ pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<(
 
     let output = tokio::process::Command::new(&uv_path)
         .args(&install_args)
+        .current_dir(cwd)
         .output()
         .await?;
 
@@ -422,6 +434,9 @@ pub async fn create_prewarmed_environment_in(
     let venv_output = tokio::process::Command::new(&uv_path)
         .arg("venv")
         .arg(&venv_path)
+        // Set explicit cwd so `uv` doesn't fail when the daemon's inherited cwd
+        // has been deleted (e.g. a cleaned-up gremlin temp directory).
+        .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -467,6 +482,7 @@ pub async fn create_prewarmed_environment_in(
 
     let offline_output = tokio::process::Command::new(&uv_path)
         .args(&offline_args)
+        .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -504,6 +520,7 @@ pub async fn create_prewarmed_environment_in(
 
     let install_output = tokio::process::Command::new(&uv_path)
         .args(&install_args)
+        .current_dir(cache_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -78,6 +78,24 @@ pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) 
     "uv".to_string()
 }
 
+/// Check if the notebook metadata has any non-empty inline dependency section.
+pub(crate) fn has_any_inline_deps(meta: &notebook_doc::metadata::NotebookMetadataSnapshot) -> bool {
+    meta.runt
+        .uv
+        .as_ref()
+        .is_some_and(|u| !u.dependencies.is_empty())
+        || meta
+            .runt
+            .conda
+            .as_ref()
+            .is_some_and(|c| !c.dependencies.is_empty())
+        || meta
+            .runt
+            .pixi
+            .as_ref()
+            .is_some_and(|p| !p.dependencies.is_empty())
+}
+
 /// Ensure the notebook metadata has the correct package manager section.
 ///
 /// The daemon creates metadata based on `default_python_env`, which may
@@ -155,6 +173,54 @@ pub(crate) fn ensure_package_manager_metadata(
         return false;
     }
     true
+}
+
+/// Replace the dependency list with the given deps for the specified package manager.
+/// Used by `create_notebook` to set exact deps, overriding any auto-bootstrapped deps.
+pub(crate) fn set_deps_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    deps: &[String],
+    manager: &str,
+) {
+    let mut snapshot = handle.get_notebook_metadata().unwrap_or_default();
+    match manager {
+        "conda" => {
+            let conda = snapshot.runt.conda.get_or_insert_with(|| {
+                notebook_doc::metadata::CondaInlineMetadata {
+                    dependencies: Vec::new(),
+                    channels: vec!["conda-forge".to_string()],
+                    python: None,
+                }
+            });
+            conda.dependencies = deps.to_vec();
+        }
+        "pixi" => {
+            let pixi = snapshot.runt.pixi.get_or_insert_with(|| {
+                notebook_doc::metadata::PixiInlineMetadata {
+                    dependencies: Vec::new(),
+                    pypi_dependencies: Vec::new(),
+                    channels: vec!["conda-forge".to_string()],
+                    python: None,
+                }
+            });
+            pixi.dependencies = deps.to_vec();
+        }
+        _ => {
+            let uv =
+                snapshot
+                    .runt
+                    .uv
+                    .get_or_insert_with(|| notebook_doc::metadata::UvInlineMetadata {
+                        dependencies: Vec::new(),
+                        requires_python: None,
+                        prerelease: None,
+                    });
+            uv.dependencies = deps.to_vec();
+        }
+    }
+    if let Err(e) = handle.set_metadata_snapshot(&snapshot) {
+        tracing::warn!("Failed to set dependency list: {e}");
+    }
 }
 
 /// Add a dependency using the appropriate package manager, return error string on failure.
@@ -286,18 +352,30 @@ pub async fn add_dependency(
             }
         }
         "restart" => {
-            // Shutdown + relaunch with scoped auto-detect to preserve the
-            // package manager family (auto:uv, auto:conda, auto:pixi)
+            // Shutdown + relaunch after adding a dependency.
+            // Since we just added an inline dep, use the exact inline source
+            // to skip project-file detection (which can pick up an unrelated
+            // pyproject.toml from the MCP server's working directory).
+            // For non-prewarmed sources that already have the right env_source
+            // (e.g. uv:inline, conda:inline), keep as-is.
             let restart_env_source = match handle
                 .get_runtime_state()
                 .ok()
                 .map(|s| s.kernel.env_source.clone())
                 .as_deref()
             {
-                Some("uv:prewarmed") => "auto:uv".to_string(),
-                Some("conda:prewarmed") => "auto:conda".to_string(),
-                Some("pixi:prewarmed") => "auto:pixi".to_string(),
-                Some("") | None => "auto".to_string(),
+                Some("uv:prewarmed") => "uv:inline".to_string(),
+                Some("conda:prewarmed") => "conda:inline".to_string(),
+                Some("pixi:prewarmed") => "pixi:inline".to_string(),
+                Some("") | None => {
+                    // No previous env_source — detect from metadata
+                    let detected = detect_package_manager(&handle);
+                    match detected.as_str() {
+                        "conda" => "conda:inline".to_string(),
+                        "pixi" => "pixi:inline".to_string(),
+                        _ => "uv:inline".to_string(),
+                    }
+                }
                 Some(s) => s.to_string(),
             };
             // Derive notebook_path for project-file-backed envs (uv:pyproject, pixi:toml, etc.)

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -175,54 +175,6 @@ pub(crate) fn ensure_package_manager_metadata(
     true
 }
 
-/// Replace the dependency list with the given deps for the specified package manager.
-/// Used by `create_notebook` to set exact deps, overriding any auto-bootstrapped deps.
-pub(crate) fn set_deps_for_manager(
-    handle: &notebook_sync::handle::DocHandle,
-    deps: &[String],
-    manager: &str,
-) {
-    let mut snapshot = handle.get_notebook_metadata().unwrap_or_default();
-    match manager {
-        "conda" => {
-            let conda = snapshot.runt.conda.get_or_insert_with(|| {
-                notebook_doc::metadata::CondaInlineMetadata {
-                    dependencies: Vec::new(),
-                    channels: vec!["conda-forge".to_string()],
-                    python: None,
-                }
-            });
-            conda.dependencies = deps.to_vec();
-        }
-        "pixi" => {
-            let pixi = snapshot.runt.pixi.get_or_insert_with(|| {
-                notebook_doc::metadata::PixiInlineMetadata {
-                    dependencies: Vec::new(),
-                    pypi_dependencies: Vec::new(),
-                    channels: vec!["conda-forge".to_string()],
-                    python: None,
-                }
-            });
-            pixi.dependencies = deps.to_vec();
-        }
-        _ => {
-            let uv =
-                snapshot
-                    .runt
-                    .uv
-                    .get_or_insert_with(|| notebook_doc::metadata::UvInlineMetadata {
-                        dependencies: Vec::new(),
-                        requires_python: None,
-                        prerelease: None,
-                    });
-            uv.dependencies = deps.to_vec();
-        }
-    }
-    if let Err(e) = handle.set_metadata_snapshot(&snapshot) {
-        tracing::warn!("Failed to set dependency list: {e}");
-    }
-}
-
 /// Add a dependency using the appropriate package manager, return error string on failure.
 pub(crate) fn add_dep_for_manager(
     handle: &notebook_sync::handle::DocHandle,
@@ -353,11 +305,10 @@ pub async fn add_dependency(
         }
         "restart" => {
             // Shutdown + relaunch after adding a dependency.
-            // Since we just added an inline dep, use the exact inline source
-            // to skip project-file detection (which can pick up an unrelated
-            // pyproject.toml from the MCP server's working directory).
-            // For non-prewarmed sources that already have the right env_source
-            // (e.g. uv:inline, conda:inline), keep as-is.
+            // For prewarmed envs, switch to inline since prewarmed means
+            // no project file was found. For project-backed envs (uv:pyproject,
+            // pixi:toml, etc.), keep the same source. For unknown/empty,
+            // use auto-detect so the daemon resolves project files if present.
             let restart_env_source = match handle
                 .get_runtime_state()
                 .ok()
@@ -368,12 +319,13 @@ pub async fn add_dependency(
                 Some("conda:prewarmed") => "conda:inline".to_string(),
                 Some("pixi:prewarmed") => "pixi:inline".to_string(),
                 Some("") | None => {
-                    // No previous env_source — detect from metadata
+                    // No previous env_source — use auto-detect so the daemon
+                    // resolves project files if present.
                     let detected = detect_package_manager(&handle);
                     match detected.as_str() {
-                        "conda" => "conda:inline".to_string(),
-                        "pixi" => "pixi:inline".to_string(),
-                        _ => "uv:inline".to_string(),
+                        "conda" => "auto:conda".to_string(),
+                        "pixi" => "auto:pixi".to_string(),
+                        _ => "auto:uv".to_string(),
                     }
                 }
                 Some(s) => s.to_string(),
@@ -550,6 +502,14 @@ pub async fn sync_environment(
         Ok(_) => tool_success(&serde_json::json!({ "success": true }).to_string()),
         Err(e) => tool_error(&format!("Failed to sync environment: {e}")),
     }
+}
+
+/// Read dependencies for the detected package manager (pub for session.rs).
+pub(crate) fn get_deps_for_manager_pub(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: &str,
+) -> Vec<String> {
+    get_deps_for_manager(handle, manager)
 }
 
 /// Read dependencies for the detected package manager.

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -110,24 +110,15 @@ pub async fn restart_kernel(
             }
             Some(s) if !s.is_empty() => s.to_string(),
             _ => {
-                // No previous env_source — fall back to metadata-based detection.
-                // Use inline source when deps exist to avoid project-file detection.
+                // No previous env_source — use auto-detect so the daemon
+                // resolves project files (pyproject.toml, pixi.toml, etc.)
+                // if present. Inline deps in metadata will be picked up
+                // by the daemon's resolution pipeline regardless.
                 let detected_manager = super::deps::detect_package_manager(&handle);
-                let has_inline_deps = handle
-                    .get_notebook_metadata()
-                    .is_some_and(|m| super::deps::has_any_inline_deps(&m));
-                if has_inline_deps {
-                    match detected_manager.as_str() {
-                        "pixi" => "pixi:inline".to_string(),
-                        "conda" => "conda:inline".to_string(),
-                        _ => "uv:inline".to_string(),
-                    }
-                } else {
-                    match detected_manager.as_str() {
-                        "pixi" => "auto:pixi".to_string(),
-                        "conda" => "auto:conda".to_string(),
-                        _ => "auto:uv".to_string(),
-                    }
+                match detected_manager.as_str() {
+                    "pixi" => "auto:pixi".to_string(),
+                    "conda" => "auto:conda".to_string(),
+                    _ => "auto:uv".to_string(),
                 }
             }
         };

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -64,10 +64,16 @@ pub async fn restart_kernel(
     }
 
     // Step 2: Determine kernel type and env_source.
-    // Use metadata-based detection (not RuntimeState env_source) to scope the
-    // auto-detect. This ensures the correct package manager pool is used even
-    // if the previous kernel was launched with a different env (e.g., UV default
-    // when the notebook metadata says pixi). See #1605.
+    // Re-use the previous env_source from RuntimeState so we restart into the
+    // same environment.  Non-prewarmed sources (uv:inline, uv:pyproject, etc.)
+    // are kept as-is to avoid the daemon re-resolving to a different source
+    // based on working_dir project files (which caused "Kernel process exited
+    // immediately" when the working_dir had an unrelated/broken pyproject.toml).
+    //
+    // Prewarmed sources need special handling: if inline deps were added since
+    // launch (via add_dependency), re-detect so the daemon picks them up.
+    // Otherwise keep the exact prewarmed source to avoid project-file
+    // mis-resolution.
     let (kernel_type, env_source) = {
         let state = handle.get_runtime_state().ok();
         let kernel_type = state
@@ -81,12 +87,49 @@ pub async fn restart_kernel(
                 }
             })
             .unwrap_or_else(|| "python".to_string());
-        // Scope auto-detect based on notebook metadata, not stale env_source
-        let detected_manager = super::deps::detect_package_manager(&handle);
-        let env_source = match detected_manager.as_str() {
-            "pixi" => "auto:pixi".to_string(),
-            "conda" => "auto:conda".to_string(),
-            _ => "auto:uv".to_string(),
+        let prev_env_source = state.as_ref().map(|s| s.kernel.env_source.as_str());
+        let env_source = match prev_env_source {
+            Some(s @ ("uv:prewarmed" | "conda:prewarmed" | "pixi:prewarmed")) => {
+                // Check if inline deps were added since the prewarmed kernel launched.
+                // If so, use the exact inline source to skip project-file detection
+                // (which can pick up an unrelated pyproject.toml from the MCP server's
+                // working directory). Otherwise keep the exact prewarmed source.
+                let has_inline_deps = handle
+                    .get_notebook_metadata()
+                    .is_some_and(|m| super::deps::has_any_inline_deps(&m));
+                if has_inline_deps {
+                    match s {
+                        "uv:prewarmed" => "uv:inline",
+                        "conda:prewarmed" => "conda:inline",
+                        _ => "pixi:inline",
+                    }
+                    .to_string()
+                } else {
+                    s.to_string()
+                }
+            }
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => {
+                // No previous env_source — fall back to metadata-based detection.
+                // Use inline source when deps exist to avoid project-file detection.
+                let detected_manager = super::deps::detect_package_manager(&handle);
+                let has_inline_deps = handle
+                    .get_notebook_metadata()
+                    .is_some_and(|m| super::deps::has_any_inline_deps(&m));
+                if has_inline_deps {
+                    match detected_manager.as_str() {
+                        "pixi" => "pixi:inline".to_string(),
+                        "conda" => "conda:inline".to_string(),
+                        _ => "uv:inline".to_string(),
+                    }
+                } else {
+                    match detected_manager.as_str() {
+                        "pixi" => "auto:pixi".to_string(),
+                        "conda" => "auto:conda".to_string(),
+                        _ => "auto:uv".to_string(),
+                    }
+                }
+            }
         };
         (kernel_type, env_source)
     };

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -452,11 +452,16 @@ pub async fn create_notebook(
                 .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
 
             if runtime != "deno" && !deps.is_empty() {
-                // When explicit deps are provided, **replace** the dependency list
-                // rather than appending. The auto-launch may have bootstrapped deps
-                // from an unrelated project file (e.g. pyproject.toml in the MCP
-                // server's working directory), and we want only the user's deps.
-                super::deps::set_deps_for_manager(&result.handle, &deps, &pkg_manager);
+                // Add agent-requested deps on top of whatever the daemon already
+                // resolved (e.g. project pyproject.toml deps). This respects the
+                // user's project environment while layering explicit deps on top.
+                for dep in &deps {
+                    if let Err(e) =
+                        super::deps::add_dep_for_manager(&result.handle, dep, &pkg_manager)
+                    {
+                        tracing::warn!("Failed to add dependency '{}': {}", dep, e);
+                    }
+                }
             }
 
             let session = NotebookSession {
@@ -479,24 +484,15 @@ pub async fn create_notebook(
                         tracing::warn!("confirm_sync failed before create_notebook relaunch: {e}");
                     }
 
-                    // Determine the env_source for the relaunch.
-                    // When deps were explicitly added, use the exact inline source
-                    // to skip project-file detection (which can pick up an unrelated
-                    // pyproject.toml from the MCP server's working directory).
-                    // When only the package manager metadata was changed (no deps),
-                    // use scoped auto-detect so the daemon re-resolves correctly.
-                    let scoped_env_source = if !deps.is_empty() {
-                        match pkg_manager.as_str() {
-                            "pixi" => "pixi:inline",
-                            "conda" => "conda:inline",
-                            _ => "uv:inline",
-                        }
-                    } else {
-                        match pkg_manager.as_str() {
-                            "pixi" => "auto:pixi",
-                            "conda" => "auto:conda",
-                            _ => "auto:uv",
-                        }
+                    // Use auto-detect so the daemon resolves the right
+                    // environment: project file (pyproject.toml, pixi.toml,
+                    // environment.yml) if present, inline deps otherwise.
+                    // Agent-requested deps were already added to metadata above
+                    // and will be picked up by whichever env resolution path wins.
+                    let scoped_env_source = match pkg_manager.as_str() {
+                        "pixi" => "auto:pixi",
+                        "conda" => "auto:conda",
+                        _ => "auto:uv",
                     };
                     let _ = s
                         .handle
@@ -532,10 +528,31 @@ pub async fn create_notebook(
                 }
             }
 
+            // Collect resolved runtime info for the response (env_source,
+            // kernel status, etc.) so agents know what environment they got.
+            let runtime_info = {
+                let guard = server.session.read().await;
+                if let Some(s) = guard.as_ref() {
+                    collect_runtime_info(&s.handle).await
+                } else {
+                    serde_json::json!({ "language": runtime })
+                }
+            };
+
+            // Read back the full dependency list (may include project deps
+            // that were already present before the agent's deps were added).
+            let all_deps = {
+                let guard = server.session.read().await;
+                guard.as_ref().map_or_else(Vec::new, |s| {
+                    super::deps::get_deps_for_manager_pub(&s.handle, &pkg_manager)
+                })
+            };
+
             let mut info = serde_json::json!({
                 "notebook_id": notebook_id,
-                "runtime": { "language": runtime },
-                "dependencies": deps,
+                "runtime": runtime_info,
+                "dependencies": all_deps,
+                "added_dependencies": deps,
                 "package_manager": pkg_manager,
                 "ephemeral": ephemeral,
             });

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -393,7 +393,6 @@ pub async fn create_notebook(
     let working_dir = arg_str(request, "working_dir")
         .map(|s| PathBuf::from(resolve_path(s)))
         .or_else(|| std::env::current_dir().ok());
-    let working_dir_for_detection = working_dir.clone();
     let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 
     let prev = previous_notebook_id(server).await;
@@ -440,17 +439,9 @@ pub async fn create_notebook(
                 // Only override metadata when the user explicitly requested a
                 // package manager. When omitted, the daemon already set the
                 // correct metadata from default_python_env.
-                // Skip when a matching project file exists — the daemon already
-                // detected it and will bootstrap deps into CRDT.
                 if let Some(pm) = explicit_pkg_manager {
-                    let project_matches = working_dir_for_detection
-                        .as_ref()
-                        .and_then(|wd| crate::project_file::detect_project_file(wd))
-                        .is_some_and(|d| d.manager() == pm);
-                    if !project_matches {
-                        metadata_changed =
-                            super::deps::ensure_package_manager_metadata(&result.handle, pm);
-                    }
+                    metadata_changed =
+                        super::deps::ensure_package_manager_metadata(&result.handle, pm);
                 }
             }
 
@@ -460,10 +451,12 @@ pub async fn create_notebook(
                 .map(String::from)
                 .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
 
-            if runtime != "deno" {
-                for dep in &deps {
-                    let _ = super::deps::add_dep_for_manager(&result.handle, dep, &pkg_manager);
-                }
+            if runtime != "deno" && !deps.is_empty() {
+                // When explicit deps are provided, **replace** the dependency list
+                // rather than appending. The auto-launch may have bootstrapped deps
+                // from an unrelated project file (e.g. pyproject.toml in the MCP
+                // server's working directory), and we want only the user's deps.
+                super::deps::set_deps_for_manager(&result.handle, &deps, &pkg_manager);
             }
 
             let session = NotebookSession {
@@ -486,14 +479,24 @@ pub async fn create_notebook(
                         tracing::warn!("confirm_sync failed before create_notebook relaunch: {e}");
                     }
 
-                    // Shutdown and relaunch with scoped auto-detect so the daemon
-                    // uses the correct package manager pool (not the system default).
-                    // "auto:pixi" → pixi pool/inline, "auto:conda" → conda pool/inline,
-                    // "auto" → follows default_python_env (which may differ from requested).
-                    let scoped_env_source = match pkg_manager.as_str() {
-                        "pixi" => "auto:pixi",
-                        "conda" => "auto:conda",
-                        _ => "auto:uv",
+                    // Determine the env_source for the relaunch.
+                    // When deps were explicitly added, use the exact inline source
+                    // to skip project-file detection (which can pick up an unrelated
+                    // pyproject.toml from the MCP server's working directory).
+                    // When only the package manager metadata was changed (no deps),
+                    // use scoped auto-detect so the daemon re-resolves correctly.
+                    let scoped_env_source = if !deps.is_empty() {
+                        match pkg_manager.as_str() {
+                            "pixi" => "pixi:inline",
+                            "conda" => "conda:inline",
+                            _ => "uv:inline",
+                        }
+                    } else {
+                        match pkg_manager.as_str() {
+                            "pixi" => "auto:pixi",
+                            "conda" => "auto:conda",
+                            _ => "auto:uv",
+                        }
                     };
                     let _ = s
                         .handle


### PR DESCRIPTION
## Summary

- When `create_notebook(package_manager="uv", dependencies=["pandas"])` runs from a directory with an unrelated `pyproject.toml`, the daemon's auto-launch resolves to `uv:pyproject` via `room.working_dir` project-file detection. This causes the kernel to fail (e.g. hash mismatch on local wheel deps), bootstraps 25+ wrong deps into the CRDT, and the MCP relaunch with `auto:uv` re-detects the same project file.
- Fix: when inline deps exist, all three MCP tool paths (`create_notebook`, `restart_kernel`, `add_dependency(after="restart")`) now use `*:inline` instead of `auto:*`, skipping project-file detection entirely.
- Also replaces (rather than appends) the dep list in `create_notebook` to override any auto-bootstrapped pyproject deps.

## Reproduction

The nightly gremlin test suite (run from `/home/ubuntu/projects/nightly-tester/`, which has its own `pyproject.toml` with 25+ deps) consistently hit:
1. `create_notebook(package_manager="uv", dependencies=["pandas", "numpy"])` → kernel never launches (`has_kernel: false`)
2. `execute_cell` hangs (kernel status stuck at `not_started`)
3. `restart_kernel` fails with "Kernel process exited immediately: exit status: 1"

Root cause: the MCP server inherits the gremlin harness's cwd. The daemon detects the harness's `pyproject.toml` → `uv:pyproject` → `uv run --with ipykernel` fails on a `dx` wheel with stale hash → exit status 1.

## Changes

| File | Change |
|------|--------|
| `session.rs` | `create_notebook` relaunch uses `*:inline` when deps provided; `set_deps_for_manager()` replaces bootstrapped deps |
| `kernel.rs` | `restart_kernel` maps prewarmed→`*:inline` when inline deps exist; fallback also checks inline deps |
| `deps.rs` | `add_dependency(after="restart")` maps prewarmed→`*:inline`; new `has_any_inline_deps()` and `set_deps_for_manager()` helpers |

## Test plan

- [x] E2E test via MCP subprocess from problematic cwd (`/home/ubuntu/projects/nightly-tester/`):
  - `create_notebook` returns `deps=["pandas","numpy"]` (not 25+ pyproject deps)
  - `execute_cell` succeeds with `uv:inline` kernel
  - `restart_kernel` uses `uv:inline` (not `auto:uv`)
  - `execute_cell` after restart succeeds
- [x] Daemon logs confirm: auto-launch → `uv:pyproject` (fails), MCP relaunch → `uv:inline` (succeeds)
- [ ] Nightly gremlin suite validation (experiments-manager)