### PR TITLE
feat(runt-mcp): enrich create_notebook response, respect project env

### DIFF
--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -474,6 +474,14 @@ pub async fn sync_environment(
     }
 }
 
+/// Read dependencies for the detected package manager (pub for session.rs).
+pub(crate) fn get_deps_for_manager_pub(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: &str,
+) -> Vec<String> {
+    get_deps_for_manager(handle, manager)
+}
+
 /// Read dependencies for the detected package manager.
 fn get_deps_for_manager(handle: &notebook_sync::handle::DocHandle, manager: &str) -> Vec<String> {
     handle

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -393,7 +393,6 @@ pub async fn create_notebook(
     let working_dir = arg_str(request, "working_dir")
         .map(|s| PathBuf::from(resolve_path(s)))
         .or_else(|| std::env::current_dir().ok());
-    let working_dir_for_detection = working_dir.clone();
     let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 
     let prev = previous_notebook_id(server).await;
@@ -440,17 +439,9 @@ pub async fn create_notebook(
                 // Only override metadata when the user explicitly requested a
                 // package manager. When omitted, the daemon already set the
                 // correct metadata from default_python_env.
-                // Skip when a matching project file exists — the daemon already
-                // detected it and will bootstrap deps into CRDT.
                 if let Some(pm) = explicit_pkg_manager {
-                    let project_matches = working_dir_for_detection
-                        .as_ref()
-                        .and_then(|wd| crate::project_file::detect_project_file(wd))
-                        .is_some_and(|d| d.manager() == pm);
-                    if !project_matches {
-                        metadata_changed =
-                            super::deps::ensure_package_manager_metadata(&result.handle, pm);
-                    }
+                    metadata_changed =
+                        super::deps::ensure_package_manager_metadata(&result.handle, pm);
                 }
             }
 
@@ -529,10 +520,31 @@ pub async fn create_notebook(
                 }
             }
 
+            // Collect resolved runtime info for the response (env_source,
+            // kernel status, etc.) so agents know what environment they got.
+            let runtime_info = {
+                let guard = server.session.read().await;
+                if let Some(s) = guard.as_ref() {
+                    collect_runtime_info(&s.handle).await
+                } else {
+                    serde_json::json!({ "language": runtime })
+                }
+            };
+
+            // Read back the full dependency list (may include project deps
+            // that were already present before the agent's deps were added).
+            let all_deps = {
+                let guard = server.session.read().await;
+                guard.as_ref().map_or_else(Vec::new, |s| {
+                    super::deps::get_deps_for_manager_pub(&s.handle, &pkg_manager)
+                })
+            };
+
             let mut info = serde_json::json!({
                 "notebook_id": notebook_id,
-                "runtime": { "language": runtime },
-                "dependencies": deps,
+                "runtime": runtime_info,
+                "dependencies": all_deps,
+                "added_dependencies": deps,
                 "package_manager": pkg_manager,
                 "ephemeral": ephemeral,
             });


### PR DESCRIPTION
## Summary

Product direction from @rgbkrk on #1828: agents should respect the user's project environment, layer their deps on top, and get visibility into what was resolved.

- **Enriched \`create_notebook\` response**: now includes full runtime info (\`env_source\`, \`kernel_status\`, \`language\`), the complete dependency list (project + agent deps), and \`added_dependencies\` showing what the agent specifically requested
- **Removed project_matches gating**: when agent explicitly requests a \`package_manager\`, always ensure the metadata section exists — the daemon's auto-detection via project files still drives env resolution through \`auto:*\` env_source
- **\`kernel.rs\` and \`deps.rs\` already correct on main**: \`restart_kernel\` and \`add_dependency(after="restart")\` already use \`auto:*\` and respect project file detection

### Example response (before → after)

Before:
```json
{
  "runtime": { "language": "python" },
  "dependencies": ["pandas"]
}
```

After:
```json
{
  "runtime": {
    "kernel_status": "idle",
    "language": "python",
    "env_source": "uv:pyproject",
    "package_manager": "uv"
  },
  "dependencies": ["requests", "flask", "pandas"],
  "added_dependencies": ["pandas"]
}
```

Agents can now see: "I got the uv:pyproject env with 3 deps total, 1 of which I added."

## Context

Addresses feedback from #1828 (now closed, split into this PR + #1830 for the orthogonal .current_dir bug fix).

## Test plan

- [ ] `cargo build -p runt-mcp` compiles clean
- [ ] `cargo xtask lint` passes
- [ ] Gremlin suite confirms create_notebook with explicit deps still works
- [ ] Verify response includes env_source and full dependency list