### PR TITLE
feat(notebook-sync): shared await_execution_terminal helper

### DIFF
--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -92,20 +92,13 @@ pub async fn await_execution_terminal(
         }
 
         if let Ok(state) = handle.get_runtime_state() {
-            // Kernel-level fault takes precedence over per-execution polling.
-            // Without this, a kernel crash mid-execution leaves us spinning
-            // until the outer timeout fires.
-            if state.kernel.status == "error" {
-                return Err(ExecutionTerminalError::KernelFailed {
-                    reason: "kernel error".to_string(),
-                });
-            }
-            if state.kernel.status == "shutdown" {
-                return Err(ExecutionTerminalError::KernelFailed {
-                    reason: "kernel shutdown".to_string(),
-                });
-            }
-
+            // Targeted execution wins over kernel-level status. When the
+            // daemon fails a kernel mid-run, it writes `set_execution_done`
+            // for pending executions *before* flipping `kernel.status` to
+            // `"error"`, so a late consumer (e.g. `Execution.result()`
+            // called after the fact) must be able to read a completed
+            // execution's real status/outputs rather than being handed a
+            // generic `KernelFailed`.
             if let Some(exec) = state.executions.get(execution_id) {
                 if exec.status == "done" || exec.status == "error" {
                     break ExecutionTerminalState {
@@ -115,6 +108,20 @@ pub async fn await_execution_terminal(
                         execution_count: exec.execution_count,
                     };
                 }
+            }
+
+            // Fallback: kernel fault aborts only if *this* execution is
+            // still non-terminal. Otherwise the caller would spin until
+            // the outer timeout fires.
+            if state.kernel.status == "error" {
+                return Err(ExecutionTerminalError::KernelFailed {
+                    reason: "kernel error".to_string(),
+                });
+            }
+            if state.kernel.status == "shutdown" {
+                return Err(ExecutionTerminalError::KernelFailed {
+                    reason: "kernel shutdown".to_string(),
+                });
             }
         }
 

--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -1,0 +1,151 @@
+//! Shared execution-completion helper.
+//!
+//! All consumers of the daemon — the Rust MCP server, the Python client,
+//! and any future tooling — need the same pattern to wait for a cell
+//! execution to reach terminal state and collect its outputs. This module
+//! centralises that pattern so behavior (and race handling) stays consistent.
+//!
+//! ## Why RuntimeStateDoc, not broadcasts
+//!
+//! The daemon writes `set_execution_done(execution_id, success)` *after* all
+//! output manifests for the execution are committed to the RuntimeStateDoc
+//! (`executions.{eid}.outputs`). Listening for the `ExecutionDone` broadcast
+//! and then reading outputs is racy: the broadcast arrives over a separate
+//! channel and the caller's Automerge replica may not have caught up on the
+//! final stream writes. Polling the RuntimeStateDoc is the authoritative
+//! path — by the time status transitions to `done`/`error`, outputs are in
+//! the same doc and visible after one more sync tick.
+//!
+//! ## Two phases
+//!
+//! 1. **Terminal wait.** Poll until `executions[eid].status` is `"done"` or
+//!    `"error"`.
+//! 2. **Output-sync grace.** If the terminal status is reached but the
+//!    output list is still empty on our replica, poll briefly (capped at
+//!    `output_sync_grace`) for the last sync frames to land.
+
+use std::time::{Duration, Instant};
+
+use crate::handle::DocHandle;
+
+/// Outcome of awaiting a single execution.
+#[derive(Debug, Clone)]
+pub struct ExecutionTerminalState {
+    /// `"done"` | `"error"` | `"timed_out"`.
+    pub status: String,
+    /// `true` when the kernel reported success. `false` on error or timeout.
+    pub success: bool,
+    /// Raw output manifest values from `RuntimeStateDoc::executions[eid].outputs`.
+    /// Empty when the execution produced no outputs or timed out before
+    /// sync caught up.
+    pub output_manifests: Vec<serde_json::Value>,
+    /// Execution count (`In[N]`), when reported by the kernel.
+    pub execution_count: Option<i64>,
+}
+
+/// Why an execution-wait returned early.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionTerminalError {
+    /// The deadline elapsed before terminal status was observed.
+    Timeout,
+    /// The kernel transitioned to `error` or `shutdown` while this execution
+    /// was pending, so there is no per-execution terminal state to report.
+    KernelFailed { reason: String },
+}
+
+/// Default output-sync grace period used by [`await_execution_terminal`] when
+/// the caller does not override it. Bounded so a genuinely output-free
+/// execution cannot block the caller indefinitely.
+pub const DEFAULT_OUTPUT_SYNC_GRACE: Duration = Duration::from_millis(500);
+
+/// Poll frequency while waiting for terminal status.
+const TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// Poll frequency during the output-sync grace window.
+const OUTPUT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Wait for a specific execution to reach terminal status in the
+/// `RuntimeStateDoc` and return the final outputs, execution count, and
+/// success flag.
+///
+/// `timeout` bounds the whole wait (both phases). `output_sync_grace` is
+/// clamped to the time remaining at the start of phase 2; pass `None` to
+/// use [`DEFAULT_OUTPUT_SYNC_GRACE`].
+///
+/// Returns an error only when:
+///
+/// * the deadline elapsed before terminal status was observed, or
+/// * the kernel itself transitioned to `error` / `shutdown` while this
+///   execution was still pending (in which case the caller can surface the
+///   kernel error rather than pretending this execution finished).
+pub async fn await_execution_terminal(
+    handle: &DocHandle,
+    execution_id: &str,
+    timeout: Duration,
+    output_sync_grace: Option<Duration>,
+) -> Result<ExecutionTerminalState, ExecutionTerminalError> {
+    let deadline = Instant::now() + timeout;
+
+    // ── Phase 1: wait for terminal status ───────────────────────────────
+    let mut final_state = loop {
+        if Instant::now() >= deadline {
+            return Err(ExecutionTerminalError::Timeout);
+        }
+
+        if let Ok(state) = handle.get_runtime_state() {
+            // Kernel-level fault takes precedence over per-execution polling.
+            // Without this, a kernel crash mid-execution leaves us spinning
+            // until the outer timeout fires.
+            if state.kernel.status == "error" {
+                return Err(ExecutionTerminalError::KernelFailed {
+                    reason: "kernel error".to_string(),
+                });
+            }
+            if state.kernel.status == "shutdown" {
+                return Err(ExecutionTerminalError::KernelFailed {
+                    reason: "kernel shutdown".to_string(),
+                });
+            }
+
+            if let Some(exec) = state.executions.get(execution_id) {
+                if exec.status == "done" || exec.status == "error" {
+                    break ExecutionTerminalState {
+                        status: exec.status.clone(),
+                        success: exec.success.unwrap_or(false),
+                        output_manifests: exec.outputs.clone(),
+                        execution_count: exec.execution_count,
+                    };
+                }
+            }
+        }
+
+        tokio::time::sleep(TERMINAL_POLL_INTERVAL).await;
+    };
+
+    // ── Phase 2: output-sync grace ──────────────────────────────────────
+    //
+    // The daemon commits outputs before `set_execution_done`, but sync
+    // frames can arrive in separate batches; our local replica may be a
+    // tick behind. Poll briefly for outputs to appear.
+    if final_state.output_manifests.is_empty() {
+        let grace = output_sync_grace.unwrap_or(DEFAULT_OUTPUT_SYNC_GRACE);
+        let remaining_until_deadline = deadline.saturating_duration_since(Instant::now());
+        let output_deadline = Instant::now() + grace.min(remaining_until_deadline);
+
+        while Instant::now() < output_deadline {
+            if let Ok(state) = handle.get_runtime_state() {
+                if let Some(exec) = state.executions.get(execution_id) {
+                    if !exec.outputs.is_empty() {
+                        final_state.output_manifests = exec.outputs.clone();
+                        if final_state.execution_count.is_none() {
+                            final_state.execution_count = exec.execution_count;
+                        }
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(OUTPUT_POLL_INTERVAL).await;
+        }
+    }
+
+    Ok(final_state)
+}

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -50,6 +50,7 @@
 pub mod broadcast;
 pub mod connect;
 pub mod error;
+pub mod execution_wait;
 pub mod handle;
 pub mod relay;
 pub mod relay_task;
@@ -59,6 +60,10 @@ pub mod sync_task;
 
 pub use broadcast::BroadcastReceiver;
 pub use error::SyncError;
+pub use execution_wait::{
+    await_execution_terminal, ExecutionTerminalError, ExecutionTerminalState,
+    DEFAULT_OUTPUT_SYNC_GRACE,
+};
 pub use handle::DocHandle;
 pub use relay::RelayHandle;
 pub use shared::SharedDocState;

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -582,6 +582,215 @@ mod tests {
         // Actor should still be the same
         assert_eq!(handle.get_actor_id().unwrap(), "agent:test:session1");
     }
+
+    // ── execution_wait ────────────────────────────────────────────────
+
+    /// Like [`test_handle`] but also returns the shared doc state so tests
+    /// can simulate daemon writes into the `RuntimeStateDoc`.
+    fn test_handle_with_shared() -> (
+        DocHandle,
+        Arc<Mutex<SharedDocState>>,
+        mpsc::UnboundedReceiver<()>,
+        mpsc::Receiver<crate::sync_task::SyncCommand>,
+    ) {
+        let nd = notebook_doc::NotebookDoc::new("test-notebook");
+        let doc = nd.into_inner();
+        let mut st = SharedDocState::new(doc, "test-notebook".into());
+        // Replace the unscaffolded RuntimeStateDoc with a fully initialized
+        // one so tests can write into the `executions` map directly.
+        st.state_doc =
+            notebook_doc::runtime_state::RuntimeStateDoc::new_with_actor("runtimed-sync-test");
+        let shared = Arc::new(Mutex::new(st));
+
+        let initial_snapshot = NotebookSnapshot::empty();
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+        let snapshot_tx = Arc::new(snapshot_tx);
+        let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+
+        let handle = DocHandle::new(
+            shared.clone(),
+            changed_tx,
+            cmd_tx,
+            snapshot_tx,
+            snapshot_rx,
+            "test-notebook".into(),
+        );
+
+        (handle, shared, changed_rx, cmd_rx)
+    }
+
+    /// Simulate the daemon writing an execution into the RuntimeStateDoc.
+    fn set_execution(
+        shared: &Arc<Mutex<SharedDocState>>,
+        execution_id: &str,
+        cell_id: &str,
+        status: &str,
+        outputs: &[serde_json::Value],
+        execution_count: Option<i64>,
+    ) {
+        let mut st = shared.lock().unwrap();
+        st.state_doc
+            .create_execution_with_source(execution_id, cell_id, "x = 1", 0);
+        st.state_doc.set_execution_running(execution_id);
+        if let Some(count) = execution_count {
+            st.state_doc.set_execution_count(execution_id, count);
+        }
+        for output in outputs {
+            st.state_doc.append_output(execution_id, output).unwrap();
+        }
+        if status == "done" {
+            st.state_doc.set_execution_done(execution_id, true);
+        } else if status == "error" {
+            st.state_doc.set_execution_done(execution_id, false);
+        }
+    }
+
+    #[tokio::test]
+    async fn await_execution_terminal_returns_once_status_done() {
+        use crate::execution_wait::{await_execution_terminal, ExecutionTerminalState};
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        let outputs = vec![serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": {"inline": "hello"},
+        })];
+
+        set_execution(&shared, "exec-1", "cell-1", "done", &outputs, Some(5));
+
+        let result =
+            await_execution_terminal(&handle, "exec-1", std::time::Duration::from_secs(1), None)
+                .await;
+
+        let ExecutionTerminalState {
+            status,
+            success,
+            output_manifests,
+            execution_count,
+        } = result.expect("terminal state");
+
+        assert_eq!(status, "done");
+        assert!(success);
+        assert_eq!(execution_count, Some(5));
+        assert_eq!(output_manifests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn await_execution_terminal_waits_for_transition() {
+        use crate::execution_wait::await_execution_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(&shared, "exec-1", "cell-1", "running", &[], None);
+
+        let shared_for_task = shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let outputs = vec![serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": {"inline": "ok"},
+            })];
+            set_execution(
+                &shared_for_task,
+                "exec-1",
+                "cell-1",
+                "done",
+                &outputs,
+                Some(3),
+            );
+        });
+
+        let state =
+            await_execution_terminal(&handle, "exec-1", std::time::Duration::from_secs(5), None)
+                .await
+                .expect("terminal state");
+
+        assert_eq!(state.status, "done");
+        assert_eq!(state.output_manifests.len(), 1);
+        assert_eq!(state.execution_count, Some(3));
+    }
+
+    #[tokio::test]
+    async fn await_execution_terminal_times_out_when_never_done() {
+        use crate::execution_wait::{await_execution_terminal, ExecutionTerminalError};
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(&shared, "exec-1", "cell-1", "running", &[], None);
+
+        let err = await_execution_terminal(
+            &handle,
+            "exec-1",
+            std::time::Duration::from_millis(300),
+            None,
+        )
+        .await
+        .expect_err("should time out");
+
+        assert_eq!(err, ExecutionTerminalError::Timeout);
+    }
+
+    #[tokio::test]
+    async fn await_execution_terminal_surfaces_kernel_error() {
+        use crate::execution_wait::{await_execution_terminal, ExecutionTerminalError};
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(&shared, "exec-1", "cell-1", "running", &[], None);
+        {
+            let mut st = shared.lock().unwrap();
+            st.state_doc.set_kernel_status("error");
+        }
+
+        let err =
+            await_execution_terminal(&handle, "exec-1", std::time::Duration::from_secs(5), None)
+                .await
+                .expect_err("should fail");
+
+        assert!(matches!(err, ExecutionTerminalError::KernelFailed { .. }));
+    }
+
+    #[tokio::test]
+    async fn await_execution_terminal_grace_catches_late_outputs() {
+        // Simulates the failing CI pattern: execution transitions to done
+        // with empty outputs on our replica, then output manifests land a
+        // few sync ticks later. The grace period must catch them.
+        use crate::execution_wait::await_execution_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(&shared, "exec-1", "cell-1", "done", &[], Some(7));
+
+        let shared_for_task = shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            let mut st = shared_for_task.lock().unwrap();
+            st.state_doc
+                .append_output(
+                    "exec-1",
+                    &serde_json::json!({
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": {"inline": "late-arriving"},
+                    }),
+                )
+                .unwrap();
+        });
+
+        let state = await_execution_terminal(
+            &handle,
+            "exec-1",
+            std::time::Duration::from_secs(5),
+            Some(std::time::Duration::from_millis(500)),
+        )
+        .await
+        .expect("terminal state");
+
+        assert_eq!(state.status, "done");
+        assert_eq!(state.output_manifests.len(), 1);
+        let text = state.output_manifests[0]["text"]["inline"]
+            .as_str()
+            .unwrap();
+        assert_eq!(text, "late-arriving");
+    }
 }
 
 // =========================================================================

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -750,6 +750,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn await_execution_terminal_prefers_done_over_kernel_error() {
+        // Regression: the daemon writes set_execution_done() for pending
+        // executions *before* flipping kernel.status to "error" on kernel
+        // death. A late consumer (e.g. Execution.result()) must return the
+        // execution's real terminal state rather than being handed a
+        // generic KernelFailed.
+        use crate::execution_wait::await_execution_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        let outputs = vec![serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": {"inline": "result data"},
+        })];
+        set_execution(&shared, "exec-1", "cell-1", "done", &outputs, Some(4));
+        // Kernel is now flagged as error AFTER the execution completed.
+        {
+            let mut st = shared.lock().unwrap();
+            st.state_doc.set_kernel_status("error");
+        }
+
+        let state =
+            await_execution_terminal(&handle, "exec-1", std::time::Duration::from_secs(5), None)
+                .await
+                .expect("should return completed execution, not KernelFailed");
+
+        assert_eq!(state.status, "done");
+        assert!(state.success);
+        assert_eq!(state.output_manifests.len(), 1);
+        assert_eq!(state.execution_count, Some(4));
+    }
+
+    #[tokio::test]
     async fn await_execution_terminal_grace_catches_late_outputs() {
         // Simulates the failing CI pattern: execution transitions to done
         // with empty outputs on our replica, then output manifests land a

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -9,6 +9,9 @@ use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
+use notebook_sync::execution_wait::{
+    await_execution_terminal, ExecutionTerminalError, ExecutionTerminalState,
+};
 use notebook_sync::handle::DocHandle;
 use runtimed_client::output_resolver;
 use runtimed_client::resolved_output::Output;
@@ -70,77 +73,46 @@ pub async fn execute_and_wait(
         }
     };
 
-    // Step 3: Poll RuntimeStateDoc for terminal execution status.
-    // The CRDT is the source of truth — no broadcast dependency.
+    // Step 3: Wait for terminal state via the shared helper. This uses
+    // the RuntimeStateDoc as the source of truth (no broadcast dependency)
+    // and applies a bounded output-sync grace period to catch the case
+    // where the last stream writes arrive in a sync frame after the
+    // status transition.
     let mut final_status = "running".to_string();
     let mut success = false;
     let mut output_manifests: Vec<serde_json::Value> = Vec::new();
-    let deadline = Instant::now() + timeout;
+    let mut execution_count_from_wait: Option<i64> = None;
 
     if let Some(ref eid) = execution_id {
-        // Phase 1: Wait for execution to reach terminal status.
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break;
+        match await_execution_terminal(handle, eid, timeout, None).await {
+            Ok(ExecutionTerminalState {
+                status,
+                success: s,
+                output_manifests: outs,
+                execution_count,
+            }) => {
+                final_status = status;
+                success = s;
+                output_manifests = outs;
+                execution_count_from_wait = execution_count;
             }
-
-            if let Ok(state) = handle.get_runtime_state() {
-                if let Some(exec) = state.executions.get(eid.as_str()) {
-                    if exec.status == "done" || exec.status == "error" {
-                        final_status = exec.status.clone();
-                        success = exec.success.unwrap_or(false);
-                        output_manifests = exec.outputs.clone();
-                        break;
-                    }
-                }
+            Err(ExecutionTerminalError::Timeout) => {
+                // Leave `running` and fall through — caller can surface
+                // timeout based on the status field.
             }
-
-            // Yield to the sync task so it can process incoming
-            // RuntimeStateDoc frames from the daemon.
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-
-        // Phase 2: If status is terminal but outputs are empty, poll briefly
-        // for output sync to catch up. The daemon writes outputs before
-        // set_execution_done, but they may arrive in separate sync frames.
-        // Cap at 500ms to avoid hanging on genuinely output-free executions.
-        if (final_status == "done" || final_status == "error") && output_manifests.is_empty() {
-            let output_deadline =
-                Instant::now() + Duration::from_millis(500).min(deadline - Instant::now());
-            while Instant::now() < output_deadline {
-                if let Ok(state) = handle.get_runtime_state() {
-                    if let Some(exec) = state.executions.get(eid.as_str()) {
-                        if !exec.outputs.is_empty() {
-                            output_manifests = exec.outputs.clone();
-                            break;
-                        }
-                    }
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+            Err(ExecutionTerminalError::KernelFailed { reason }) => {
+                warn!("kernel failed during execution: {reason}");
+                final_status = "error".to_string();
             }
         }
     }
 
     // Step 4: Collect outputs from CRDT.
-    // Prefer output hashes from RuntimeStateDoc (already synced above).
+    // Prefer output hashes from RuntimeStateDoc (already returned above).
     // Fall back to handle.get_cell() which reads via execution_id facade.
-
-    // Get execution_count from RuntimeStateDoc (the source of truth).
-    // The NotebookDoc cell's execution_count field is stale since execution
-    // state was moved to RuntimeStateDoc.
-    let execution_count = if let Some(ref eid) = execution_id {
-        handle
-            .get_runtime_state()
-            .ok()
-            .and_then(|state| {
-                state
-                    .executions
-                    .get(eid.as_str())
-                    .and_then(|e| e.execution_count)
-            })
-            .map(|c| c.to_string())
-    } else {
+    let execution_count = if let Some(count) = execution_count_from_wait {
+        Some(count.to_string())
+    } else if execution_id.is_none() {
         // Fallback: find most recent execution for this cell with an execution_count
         let ec = crate::tools::cell_read::get_cell_execution_count_from_runtime(handle, cell_id);
         if ec.is_empty() {
@@ -148,6 +120,8 @@ pub async fn execute_and_wait(
         } else {
             Some(ec)
         }
+    } else {
+        None
     };
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1229,8 +1229,14 @@ pub(crate) async fn queue_cell(
 
 /// Wait for execution to complete, then read outputs from the Automerge doc.
 ///
-/// Uses the broadcast stream only as a signal for when execution is done.
-/// The Automerge document is the source of truth for cell outputs.
+/// When an `execution_id` is provided, defers to
+/// [`notebook_sync::await_execution_terminal`] and reads outputs directly
+/// from the `RuntimeStateDoc` — the same path `runt-mcp` uses. This avoids
+/// the stream-output race where the `ExecutionDone` broadcast arrives
+/// before the final stream manifests have synced into our replica.
+///
+/// When `execution_id` is `None` (legacy callers), falls back to the older
+/// queue-presence polling + `NotebookDoc` cell snapshot read.
 pub(crate) async fn collect_outputs(
     state: &Arc<Mutex<SessionState>>,
     cell_id: &str,
@@ -1238,6 +1244,62 @@ pub(crate) async fn collect_outputs(
     blob_base_url: Option<String>,
     blob_store_path: Option<PathBuf>,
 ) -> PyResult<ExecutionResult> {
+    // ── Fast path: execution_id known — use the shared helper ─────────
+    if let Some(eid) = execution_id {
+        let handle = {
+            let st = state.lock().await;
+            st.handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?
+                .clone()
+        };
+
+        // No outer timeout here: the caller's tokio::time::timeout at
+        // execute_cell()/wait_for_execution() bounds the total wait. Pass
+        // a very long timeout so the helper only returns on terminal state
+        // or kernel failure.
+        let helper_timeout = std::time::Duration::from_secs(60 * 60 * 24);
+        let terminal =
+            notebook_sync::await_execution_terminal(&handle, eid, helper_timeout, None).await;
+
+        match terminal {
+            Ok(state) => {
+                let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
+                let outputs = output_resolver::resolve_cell_outputs(
+                    &state.output_manifests,
+                    &blob_base_url,
+                    &blob_store_path,
+                    comms.as_ref(),
+                )
+                .await;
+                let success = state.status == "done"
+                    && state.success
+                    && !outputs.iter().any(|o| o.output_type == "error");
+                return Ok(ExecutionResult {
+                    cell_id: cell_id.to_string(),
+                    outputs,
+                    success,
+                    execution_count: state.execution_count,
+                });
+            }
+            Err(notebook_sync::ExecutionTerminalError::KernelFailed { reason }) => {
+                return Ok(ExecutionResult {
+                    cell_id: cell_id.to_string(),
+                    outputs: vec![Output::error("KernelError", &reason, vec![])],
+                    success: false,
+                    execution_count: None,
+                });
+            }
+            Err(notebook_sync::ExecutionTerminalError::Timeout) => {
+                // Helper timeout is a day; reaching this means something
+                // drove us there intentionally (cancellation, outer abort).
+                return Err(to_py_err("Execution wait aborted"));
+            }
+        }
+    }
+
+    // ── Legacy path: no execution_id ─────────────────────────────────
+    // Falls through to queue-presence polling + NotebookDoc cell read.
     let mut kernel_error: Option<String> = None;
 
     // Phase 1: Wait for the cell to leave the execution queue.


### PR DESCRIPTION
## Summary

Lifts the `runt-mcp` execution-completion pattern into `notebook-sync` as a shared helper, then makes both `runt-mcp` and `runtimed-py` use it. This closes the stream-output race that caused `test_progress_bar_simulation` to flake on slow CI (got `Loading: 20%` instead of `Loading: 100%`) and also resolves the multi-client TODOs #1048 / #1066 flagged in `session_core.rs`.

## The race

Python's `collect_outputs` used to:

1. Break on the `ExecutionDone` broadcast.
2. Read outputs from the `NotebookDoc` cell snapshot via `get_cell(cell_id)`.

But outputs live in `RuntimeStateDoc::executions[eid].outputs`, not on the cell. On a slow runner the broadcast would land before the last stream manifests had synced into the Python replica, so the cell snapshot returned a stale view. `confirm_sync()` only guarantees the daemon has our changes, not that we have theirs.

`runt-mcp` already had the right pattern: poll the `RuntimeStateDoc` keyed by `execution_id` until status reaches `done`/`error`, then apply a bounded output-sync grace period for the last sync frames. This PR extracts that pattern.

## Changes

- **`notebook-sync`** — new `execution_wait` module exposing `await_execution_terminal(handle, execution_id, timeout, output_sync_grace)` and `ExecutionTerminalError::{Timeout, KernelFailed}`. Covers: terminal-status wait, kernel-error/shutdown fast-fail, bounded output-sync grace. 5 unit tests including the late-arriving-outputs scenario.
- **`runt-mcp::execute_and_wait`** — delegates to the shared helper. Net diff: +32 / −58.
- **`runtimed-py::session_core::collect_outputs`** — when an `execution_id` is present, delegates to the helper and reads outputs directly from `state.output_manifests` (the authoritative source). Legacy `execution_id=None` callers keep the old queue-presence polling for backward compatibility.

## Verification

- `cargo test -p notebook-sync --lib` — 36 passed, including 5 new `await_execution_terminal_*` tests.
- `cargo test -p runt-mcp --lib` — 66 passed.
- `cargo test -p runtimed-client --lib` — 165 passed.
- `cargo xtask lint` — clean.
- `pytest python/runtimed/tests/test_daemon_integration.py -k "Execution or TerminalEmulation or Stream"` — **28 passed including `test_progress_bar_simulation`**, which previously flaked on CI.

## Test plan

- [x] `cargo test -p notebook-sync --lib`
- [x] `cargo test -p runt-mcp --lib`
- [x] `cargo xtask lint`
- [x] Python integration — terminal emulation + execution scoping suites (28 passed)
- [ ] CI — watch `test_progress_bar_simulation` stability across reruns

## Follow-ups

- Legacy queue-presence fallback in `collect_outputs` is still there for `execution_id=None` callers. Worth auditing the callers and removing the fallback if they all pass an id (both in-repo callers do).
- Frontend remains reactive (no polling) — intentionally unchanged.
