### PR TITLE
fix(mcpb-runt): prevent empty tool cache from poisoning disk

### DIFF
--- a/crates/mcpb-runt/src/main.rs
+++ b/crates/mcpb-runt/src/main.rs
@@ -224,24 +224,11 @@ async fn main() -> ExitCode {
         .set_upstream_identity(upstream_name, upstream_title)
         .await;
 
-    // Background: initialize child process
-    let proxy_for_init = proxy_ref.clone();
-    let peer = server.peer().clone();
-    tokio::spawn(async move {
-        if let Err(e) = proxy_for_init.init_child().await {
-            error!("Failed to initialize child: {e}");
-            return;
-        }
-
-        // Notify client that tools are available
-        if let Err(e) = peer.notify_tool_list_changed().await {
-            tracing::warn!("Failed to send tools/list_changed: {e}");
-        }
-        if let Err(e) = peer.notify_resource_list_changed().await {
-            tracing::warn!("Failed to send resources/list_changed: {e}");
-        }
-        info!("Child initialized, tools available");
-    });
+    // Child spawn and `tools/list_changed` / `resources/list_changed` notifications
+    // happen in `McpProxy::on_initialized`, after the client sends
+    // `notifications/initialized`. Firing them earlier races the MCP handshake —
+    // Claude Code drops notifications received before it has finished initializing,
+    // leaving its tool list empty.
 
     // Wait for client disconnect OR exit signal from incompatible tool divergence.
     let exit_signal = proxy_ref.exit_signal.clone();

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -14,7 +14,7 @@ use rmcp::model::{
     ListResourcesResult, ListToolsResult, ReadResourceRequestParams, ReadResourceResult,
     ServerCapabilities, ServerInfo, Tool,
 };
-use rmcp::service::{RequestContext, RoleServer};
+use rmcp::service::{NotificationContext, RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
 use tokio::sync::{mpsc, Mutex, Notify, RwLock};
 use tracing::{error, info, warn};
@@ -585,11 +585,19 @@ impl McpProxy {
     }
 
     /// Get the current child tools (live from child, or cached).
+    ///
+    /// Falls back to the cached list if the live query fails OR returns empty.
+    /// Empty-fallback matters when the child is alive but its daemon isn't —
+    /// a bare `runt mcp` against a missing daemon returns `{tools: []}`, and
+    /// without the fallback the MCP client would see zero tools and stick.
     pub async fn child_tools(&self) -> Vec<Tool> {
         let state = self.state.read().await;
         if let Some(ref client) = state.child_client {
             match client.list_tools(None).await {
-                Ok(result) => return result.tools,
+                Ok(result) if !result.tools.is_empty() => return result.tools,
+                Ok(_) => {
+                    warn!("Child returned empty tool list — falling back to cached tools");
+                }
                 Err(e) => {
                     warn!("Failed to list child tools: {e}");
                 }
@@ -713,10 +721,19 @@ impl McpProxy {
         if let Some(ref client) = state.child_client {
             match client.list_tools(None).await {
                 Ok(child_tools) => {
-                    if let Some(ref cache_dir) = self.config.cache_dir {
-                        tools::save_tool_cache(cache_dir, &child_tools.tools);
+                    // Never enshrine an empty list. An old/broken child that
+                    // transiently returns `{tools: []}` would otherwise poison
+                    // the on-disk cache — `load_cached_tools` treats an empty
+                    // file as valid, so every subsequent start would read
+                    // zero tools and skip the built-in fallback.
+                    if child_tools.tools.is_empty() {
+                        warn!("Child returned empty tool list — keeping prior cache");
+                    } else {
+                        if let Some(ref cache_dir) = self.config.cache_dir {
+                            tools::save_tool_cache(cache_dir, &child_tools.tools);
+                        }
+                        state.cached_tools = Some(child_tools.tools);
                     }
-                    state.cached_tools = Some(child_tools.tools);
                 }
                 Err(e) => {
                     warn!("Failed to refresh tool cache: {e}");
@@ -824,6 +841,31 @@ impl ServerHandler for McpProxy {
         }
 
         self.forward_tool_call(request).await
+    }
+
+    // Spawn the child only after the client has sent `notifications/initialized`.
+    // Per MCP spec, servers must not send notifications (tools/list_changed,
+    // resources/list_changed) before this point — Claude Code drops early ones,
+    // which leaves its tool list empty until a later refresh.
+    async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+        if self.state.read().await.child_client.is_some() {
+            return;
+        }
+        let proxy = self.clone();
+        let peer = context.peer;
+        tokio::spawn(async move {
+            if let Err(e) = proxy.init_child().await {
+                error!("Failed to initialize child: {e}");
+                return;
+            }
+            if let Err(e) = peer.notify_tool_list_changed().await {
+                warn!("Failed to send tools/list_changed: {e}");
+            }
+            if let Err(e) = peer.notify_resource_list_changed().await {
+                warn!("Failed to send resources/list_changed: {e}");
+            }
+            info!("Child initialized after client-initialized, tools available");
+        });
     }
 }
 

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -58,7 +58,15 @@ pub fn load_builtin_tools() -> Option<Vec<Tool>> {
 }
 
 /// Save child tool definitions to disk for optimistic serving on next startup.
+///
+/// Refuses to persist an empty list — an empty cache on disk outranks the
+/// built-in fallback in [`load_cached_tools`], so writing `[]` would poison
+/// every future start. Callers should treat empty results as "keep prior".
 pub fn save_tool_cache(cache_dir: &Path, tools: &[Tool]) {
+    if tools.is_empty() {
+        warn!("Refusing to save empty tool cache to disk");
+        return;
+    }
     let path = cache_dir.join(TOOL_CACHE_FILENAME);
     match serde_json::to_string_pretty(tools) {
         Ok(json) => {
@@ -301,12 +309,16 @@ mod tests {
     }
 
     #[test]
-    fn save_empty_cache() {
+    fn save_refuses_empty_cache() {
+        // Empty saves would poison future starts — `load_cached_tools` would
+        // hit the empty file and skip the built-in fallback.
         let dir = tempfile::tempdir().unwrap();
         let tools: Vec<Tool> = vec![];
         save_tool_cache(dir.path(), &tools);
-        let loaded = load_cached_tools(dir.path()).expect("should load empty cache");
-        assert!(loaded.is_empty());
+        assert!(
+            !dir.path().join(TOOL_CACHE_FILENAME).exists(),
+            "empty cache must not be persisted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fresh lab boxes were showing resources but no tools from the nightly `mcpb-runt`. Root cause: a single transient `{tools: []}` from the child could be persisted to `~/.cache/runt-nightly/mcpb/tool-cache.json`, and from then on every start read back the empty cache — the baked-in 26-tool fallback was unreachable because `load_cached_tools` only falls through when the file is *missing*.

Three overlapping guards, so one bad query can't permanently poison a box:

- `save_tool_cache` refuses to persist an empty list.
- `refresh_tool_cache_locked` keeps the prior cache when the child returns empty, instead of clobbering `cached_tools` with `vec![]`.
- `child_tools()` falls back to cache when the live child returns empty (not just on `Err`). A `runt mcp` whose daemon isn't reachable can legitimately reply empty; the MCP client should still see the cached list.

Also moves child spawn + `tools/list_changed` / `resources/list_changed` notifications into `McpProxy::on_initialized`. Per MCP spec, servers must not send notifications before the client's `notifications/initialized`. The prior `tokio::spawn` in `mcpb-runt/main.rs` could fire them during the handshake window, where Claude Code drops them.

## Test plan

- [x] `cargo build -p mcpb-runt -p runt-mcp-proxy`
- [x] `cargo test -p runt-mcp-proxy --lib` (92 pass, incl. new `save_refuses_empty_cache`)
- [x] `cargo xtask lint`
- [ ] Deploy to a fresh lab and confirm Claude Code sees the full tool list
- [ ] For any already-poisoned box: `rm ~/.cache/runt-nightly/mcpb/tool-cache.json` once (future bad queries won't recreate the poison file)