### PR TITLE
fix(notebook-sync): defensive cell-count guard in rebuild_from_save

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1012,11 +1012,25 @@ impl NotebookDoc {
     /// and `load()` reconstructs all internal data structures from scratch.
     /// This is the document-level equivalent of automerge-repo's
     /// `decodeSyncState(encodeSyncState(state))` round-trip hack.
+    ///
+    /// Includes a defensive cell-count guard: if the rebuilt doc would have
+    /// fewer cells, the rebuild is skipped to prevent silent cell loss when
+    /// `save()` on a panic-corrupted doc drops ops from the serialized bytes.
     pub fn rebuild_from_save(&mut self) -> bool {
         let actor = self.doc.get_actor().clone();
+        let pre_cell_count = self.cell_count();
         let bytes = self.doc.save();
         match AutoCommit::load(&bytes) {
             Ok(mut doc) => {
+                let post_cell_count = get_cells_from_doc(&doc).len();
+                if post_cell_count < pre_cell_count {
+                    #[cfg(feature = "persistence")]
+                    warn!(
+                        "[notebook-doc] rebuild_from_save would lose cells ({} → {}), skipping",
+                        pre_cell_count, post_cell_count
+                    );
+                    return false;
+                }
                 doc.set_actor(actor);
                 self.doc = doc;
                 true

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -38,11 +38,27 @@ use crate::snapshot::NotebookSnapshot;
 /// Rebuild a `SharedDocState` after an automerge panic by round-tripping
 /// save→load to clear corrupted internal indices, then resetting the
 /// peer sync state to force a fresh handshake with the daemon.
+///
+/// Includes a defensive cell-count guard: if the rebuilt doc would have
+/// fewer cells than the original, the rebuild is skipped (only sync state
+/// is reset). This prevents silent cell loss when `save()` on a
+/// panic-corrupted doc drops ops from the serialized bytes.
 fn rebuild_shared_doc_state(state: &mut SharedDocState) {
     let actor = state.doc.get_actor().clone();
+    let pre_cell_count = notebook_doc::get_cells_from_doc(&state.doc).len();
     let bytes = state.doc.save();
     match AutoCommit::load(&bytes) {
         Ok(mut doc) => {
+            let post_cell_count = notebook_doc::get_cells_from_doc(&doc).len();
+            if post_cell_count < pre_cell_count {
+                warn!(
+                    "[notebook-sync] rebuild_shared_doc_state would lose cells \
+                     ({} → {}), keeping original doc and resetting sync state only",
+                    pre_cell_count, post_cell_count
+                );
+                state.peer_state = sync::State::new();
+                return;
+            }
             doc.set_actor(actor);
             state.doc = doc;
             state.peer_state = sync::State::new();
@@ -50,6 +66,7 @@ fn rebuild_shared_doc_state(state: &mut SharedDocState) {
         }
         Err(e) => {
             warn!("[notebook-sync] Failed to rebuild doc after panic: {}", e);
+            state.peer_state = sync::State::new();
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2393,10 +2393,15 @@ where
             Ok(encoded) => encoded,
             Err(e) => {
                 warn!("{}", e);
-                doc.rebuild_from_save();
                 peer_state = sync::State::new();
-                doc.generate_sync_message(&mut peer_state)
-                    .map(|msg| msg.encode())
+                if doc.rebuild_from_save() {
+                    doc.generate_sync_message(&mut peer_state)
+                        .map(|msg| msg.encode())
+                } else {
+                    // Cell-count guard prevented rebuild — skip sync message,
+                    // fresh peer_state will trigger full re-sync on next exchange
+                    None
+                }
             }
         }
     };
@@ -2564,10 +2569,13 @@ where
                                         Ok(encoded) => encoded,
                                         Err(e) => {
                                             warn!("{}", e);
-                                            doc.rebuild_from_save();
                                             peer_state = sync::State::new();
-                                            doc.generate_sync_message(&mut peer_state)
-                                                .map(|reply| reply.encode())
+                                            if doc.rebuild_from_save() {
+                                                doc.generate_sync_message(&mut peer_state)
+                                                    .map(|reply| reply.encode())
+                                            } else {
+                                                None
+                                            }
                                         }
                                     };
 
@@ -2906,10 +2914,13 @@ where
                         Ok(encoded) => encoded,
                         Err(e) => {
                             warn!("{}", e);
-                            doc.rebuild_from_save();
                             peer_state = sync::State::new();
-                            doc.generate_sync_message(&mut peer_state)
-                                .map(|msg| msg.encode())
+                            if doc.rebuild_from_save() {
+                                doc.generate_sync_message(&mut peer_state)
+                                    .map(|msg| msg.encode())
+                            } else {
+                                None
+                            }
                         }
                     }
                 };


### PR DESCRIPTION
## Summary

- Adds a cell-count guard to `rebuild_from_save` (daemon-side) and `rebuild_shared_doc_state` (MCP client-side) that prevents Automerge save→load round-trips from silently dropping cells
- When the rebuilt doc has fewer cells than the original, the rebuild is skipped and only sync state is reset — a fresh sync handshake from the daemon recovers correct state
- Addresses intermittent cell-loss pattern during `sync_environment` / `add_dependency(after=restart)` caused by Automerge 0.8.0 MissingOps panic corrupting the op-set index during high-frequency sync bursts

### Root cause

`rebuild_from_save` / `rebuild_shared_doc_state` do a `doc.save()` → `AutoCommit::load()` round-trip to clear corrupted Automerge internal indices after catching a `MissingOps` panic. If the panic interrupted `receive_sync_message` midway, the save can lose partially-applied ops — including cell creation ops. The sync burst during kernel restart (new runtime agent connecting as a fresh peer) makes MissingOps more likely.

### Performance

`get_cells_from_doc()` is an O(n) scan of the cells map but n is the cell count (typically <100). The rebuild path itself is already O(doc_size) due to `save()` + `load()`, so the guard adds negligible overhead. Called only on panic recovery, not on any hot path.

## Test plan

- [ ] Cargo check passes for all affected crates (`notebook-doc`, `notebook-sync`, `runtimed`)
- [ ] All runtimed tests pass
- [ ] Lint clean
- [ ] Gremlin validation: deploy locally, run suite targeting the cell-loss pattern (create cell → sync_environment → verify cell exists), confirm 0% cell-loss rate vs previous ~27%