### PR TITLE
fix(runtimed): evict re-keyed rooms by Arc pointer, not stale key

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2118,18 +2118,24 @@ where
             // BEFORE async teardown. Holding the lock across runtime agent
             // shutdown RPCs causes a convoy deadlock when the agent is
             // unresponsive — all notebook operations block on the lock.
+            //
+            // Look up the room by Arc pointer, not by the captured notebook_id,
+            // because rekey_ephemeral_room may have moved the room to a new key
+            // (UUID → file path) after the eviction timer was scheduled.
             let should_teardown = {
                 let mut rooms_guard = rooms_for_eviction.lock().await;
                 if room_for_eviction.active_peers.load(Ordering::Relaxed) == 0 {
-                    if rooms_guard
-                        .get(&notebook_id_for_eviction)
-                        .is_some_and(|r| Arc::ptr_eq(r, &room_for_eviction))
-                    {
-                        rooms_guard.remove(&notebook_id_for_eviction);
+                    // Find the room's current key by Arc pointer (stable across re-keys)
+                    let current_key = rooms_guard
+                        .iter()
+                        .find(|(_, r)| Arc::ptr_eq(r, &room_for_eviction))
+                        .map(|(k, _)| k.clone());
+                    if let Some(key) = current_key {
+                        rooms_guard.remove(&key);
                         true
                     } else {
                         debug!(
-                            "[notebook-sync] Eviction skipped for {} (room was replaced)",
+                            "[notebook-sync] Eviction skipped for {} (room already removed)",
                             notebook_id_for_eviction
                         );
                         false

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -11491,6 +11491,101 @@ mod tests {
         );
     }
 
+    // ── Regression test: eviction finds re-keyed room by Arc pointer ─────
+
+    /// Verify that when a room is re-keyed from UUID → file path and the
+    /// eviction timer fires under the old UUID key, the room is still found
+    /// and removed from the rooms map via Arc pointer comparison.
+    ///
+    /// This is the exact scenario that caused zombie rooms before the fix:
+    /// UUID eviction timer → `rooms.get(uuid)` returns None → eviction
+    /// skipped → room lives forever under the path key.
+    #[tokio::test(start_paused = true)]
+    async fn test_eviction_finds_rekeyed_room_by_arc_pointer() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let blob_store = test_blob_store(&tmp);
+        let docs_dir = tmp.path().join("docs");
+        std::fs::create_dir_all(&docs_dir).unwrap();
+
+        // 1. Create an ephemeral room with a UUID notebook_id
+        let uuid_id = "11111111-2222-3333-4444-555555555555";
+        let room = Arc::new(NotebookRoom::new_fresh(
+            uuid_id, &docs_dir, blob_store, false,
+        ));
+
+        // Add a cell so save produces valid .ipynb
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "cell-1", "code").unwrap();
+            doc.update_source("cell-1", "x = 1").unwrap();
+        }
+
+        // 2. Insert into rooms map and simulate a connected peer
+        let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        rooms.lock().await.insert(uuid_id.to_string(), room.clone());
+        room.active_peers.fetch_add(1, Ordering::Relaxed);
+        room.had_peers.store(true, Ordering::Relaxed);
+
+        // 3. Save to disk and re-key from UUID → file path
+        let save_path = tmp.path().join("rekeyed.ipynb");
+        let result = save_notebook_to_disk(&room, Some(save_path.to_str().unwrap())).await;
+        assert!(result.is_ok());
+
+        let new_id =
+            rekey_ephemeral_room(&rooms, uuid_id, save_path.to_str().unwrap(), &room).await;
+        assert!(new_id.is_some());
+        let path_key = new_id.unwrap();
+
+        // Verify: UUID key gone, path key present, same Arc
+        {
+            let guard = rooms.lock().await;
+            assert!(!guard.contains_key(uuid_id));
+            assert!(guard.contains_key(&path_key));
+            assert!(Arc::ptr_eq(guard.get(&path_key).unwrap(), &room));
+        }
+
+        // 4. Simulate peer disconnect — active_peers drops to 0
+        room.active_peers.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
+
+        // 5. Simulate the eviction timer firing with the OLD UUID key.
+        //    This is what the disconnect handler captures before re-key.
+        let rooms_for_eviction = rooms.clone();
+        let room_for_eviction = room.clone();
+        let notebook_id_for_eviction = uuid_id.to_string(); // stale UUID key!
+
+        // Run the exact eviction logic from the disconnect handler
+        let should_teardown = {
+            let mut rooms_guard = rooms_for_eviction.lock().await;
+            if room_for_eviction.active_peers.load(Ordering::Relaxed) == 0 {
+                let current_key = rooms_guard
+                    .iter()
+                    .find(|(_, r)| Arc::ptr_eq(r, &room_for_eviction))
+                    .map(|(k, _)| k.clone());
+                if let Some(key) = current_key {
+                    rooms_guard.remove(&key);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        assert!(
+            should_teardown,
+            "Eviction should succeed even though the room was re-keyed from {} to {}",
+            notebook_id_for_eviction, path_key
+        );
+
+        // 6. Verify room was removed from the map
+        assert!(
+            rooms.lock().await.is_empty(),
+            "Room should be removed from the map after eviction"
+        );
+    }
+
     // ── compute_env_sync_diff tests ───────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes room eviction leak where rooms re-keyed by `rekey_ephemeral_room` (UUID → file path) were never evicted, leaking fds indefinitely
- The eviction timer now finds the room in the rooms map by `Arc` pointer comparison instead of the captured `notebook_id` key, which becomes stale after re-keying

### Root cause

When `rekey_ephemeral_room` moves a room from UUID → file path key, the eviction timer scheduled under the old UUID key fires 30s later and looks up `rooms_guard.get(&uuid_key)`. Since the UUID was removed from the map (replaced by the path key), the lookup returns `None` and eviction is skipped. No new eviction timer is ever scheduled under the new path key. The room lives forever with its kernel, runtime agent socket, file watcher, and autosave debouncer.

### Evidence from production daemon (7h uptime)

| Metric | Count |
|--------|-------|
| Rooms created | 237 |
| Eviction timers scheduled | 248 |
| **Eviction skipped (stale key after re-key)** | **163** |
| Actually evicted | 81 |
| Cancelled (peers reconnected) | 4 |
| **Zombie rooms (0 peers, idle kernel)** | **144** |
| Daemon fds | 695/1024 (68%) |

### Fix

The eviction timer closure now iterates the rooms map to find the entry matching the captured `Arc<NotebookRoom>` by pointer. The `Arc` is stable across re-keying since `rekey_ephemeral_room` moves the same `Arc` to the new key. This is O(n) in room count but runs at most once per room disconnect — negligible vs the existing O(doc_size) teardown work.

## Test plan

- [ ] All runtimed tests pass (25/25)
- [ ] Lint clean, tokio mutex lint passes
- [ ] Deploy locally, verify zombie rooms are evicted after 30s idle timeout
- [ ] Monitor fd count — should stabilize instead of monotonically increasing