### PR TITLE
refactor(build): use include_str! for git hash to avoid unnecessary recompilation

### DIFF
--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -78,29 +78,45 @@ fn maybe_disable_external_bin_for_local_checks() {
 }
 
 fn main() {
-    // Capture git metadata for About menu and version strings.
-    let branch = git_output(&["rev-parse", "--abbrev-ref", "HEAD"]);
-    let commit = git_output(&["rev-parse", "--short=7", "HEAD"]);
-    let release_date = git_output(&["show", "-s", "--format=%cs", "HEAD"]);
-
-    println!("cargo:rustc-env=GIT_BRANCH={branch}");
-    println!("cargo:rustc-env=GIT_COMMIT={commit}");
-    println!("cargo:rustc-env=GIT_COMMIT_DATE={release_date}");
+    // Write git metadata to $OUT_DIR files, skipping writes when content
+    // hasn't changed to avoid unnecessary recompilation.
+    write_git_metadata();
 
     // Re-run if frontend dist changes (ensures fresh frontend is embedded).
     // This is the only non-git watcher — Phase 2 builds the frontend, then
     // Phase 3 (cargo tauri build) picks up the updated dist/.
     println!("cargo:rerun-if-changed=../../apps/notebook/dist");
 
-    // We intentionally do NOT watch .git/HEAD, .git/index, or refs.
-    // That caused recompilation of notebook + all dependents on every
-    // commit, branch switch, pull, or fetch. The git metadata is refreshed
-    // whenever dist/ changes (every build) or this build script changes.
-    // CI always starts clean so release builds always get the right hash.
-
     maybe_disable_external_bin_for_local_checks();
 
     tauri_build::build()
+}
+
+/// Write git metadata to `$OUT_DIR/git_{hash,branch,date}.txt`, skipping
+/// writes when content hasn't changed. See `crates/runtimed/build.rs` for
+/// the rationale — this avoids recompilation when the metadata is unchanged.
+#[allow(clippy::unwrap_used)]
+fn write_git_metadata() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let hash = git_output(&["rev-parse", "--short=7", "HEAD"]);
+    let branch = git_output(&["rev-parse", "--abbrev-ref", "HEAD"]);
+    let date = git_output(&["show", "-s", "--format=%cs", "HEAD"]);
+
+    write_if_changed(&out_dir.join("git_hash.txt"), &hash);
+    write_if_changed(&out_dir.join("git_branch.txt"), &branch);
+    write_if_changed(&out_dir.join("git_date.txt"), &date);
+}
+
+#[allow(clippy::unwrap_used)]
+fn write_if_changed(path: &PathBuf, content: &str) {
+    let needs_write = match std::fs::read_to_string(path) {
+        Ok(existing) => existing != content,
+        Err(_) => true,
+    };
+    if needs_write {
+        std::fs::write(path, content).unwrap();
+    }
 }
 
 fn git_output(args: &[&str]) -> String {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -864,7 +864,11 @@ mod tests {
 /// Get the version string of the bundled daemon.
 /// Format: "{CARGO_PKG_VERSION}+{GIT_COMMIT}" e.g., "1.4.1+a1b2c3d"
 fn bundled_daemon_version() -> String {
-    format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT"))
+    format!(
+        "{}+{}",
+        env!("CARGO_PKG_VERSION"),
+        include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
+    )
 }
 
 /// Extract the commit hash from a version string.
@@ -1545,8 +1549,8 @@ async fn get_git_info() -> Option<GitInfo> {
             .filter(|s| !s.is_empty());
 
         Some(GitInfo {
-            branch: env!("GIT_BRANCH").to_string(),
-            commit: env!("GIT_COMMIT").to_string(),
+            branch: include_str!(concat!(env!("OUT_DIR"), "/git_branch.txt")).to_string(),
+            commit: include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt")).to_string(),
             description,
         })
     }

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -43,8 +43,8 @@ pub const MENU_CHECK_FOR_UPDATES: &str = "check_for_updates";
 pub const MENU_SETTINGS: &str = "settings";
 pub const MENU_SEND_FEEDBACK: &str = "send_feedback";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const APP_COMMIT_SHA: &str = env!("GIT_COMMIT");
-pub const APP_RELEASE_DATE: &str = env!("GIT_COMMIT_DATE");
+pub const APP_COMMIT_SHA: &str = include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"));
+pub const APP_RELEASE_DATE: &str = include_str!(concat!(env!("OUT_DIR"), "/git_date.txt"));
 
 pub const BUNDLED_SAMPLE_NOTEBOOK: BundledSampleNotebook = BundledSampleNotebook {
     title: "Open Sample",

--- a/crates/runt/build.rs
+++ b/crates/runt/build.rs
@@ -1,9 +1,8 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
-    let commit = git_commit_short();
-    println!("cargo:rustc-env=GIT_COMMIT={commit}");
-
     let variant = std::env::var("RUNT_VARIANT").unwrap_or_default();
     println!("cargo:rustc-env=RUNT_VARIANT={variant}");
     println!("cargo:rerun-if-env-changed=RUNT_VARIANT");
@@ -12,10 +11,26 @@ fn main() {
     // rerun-if-changed above, cargo won't use its default behavior).
     println!("cargo:rerun-if-changed=build.rs");
 
-    // We intentionally do NOT watch .git/HEAD or refs — that causes
-    // recompilation on every commit, branch switch, pull, or fetch.
-    // The hash is refreshed when build.rs or RUNT_VARIANT changes.
-    // CI always starts clean so release builds always get the right hash.
+    write_git_hash();
+}
+
+/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
+/// if the content hasn't changed. See `crates/runtimed/build.rs` for the
+/// rationale — this avoids recompilation when the hash doesn't change.
+#[allow(clippy::unwrap_used)]
+fn write_git_hash() {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let hash_file = out_dir.join("git_hash.txt");
+    let hash = git_commit_short();
+
+    let needs_write = match fs::read_to_string(&hash_file) {
+        Ok(existing) => existing != hash,
+        Err(_) => true,
+    };
+
+    if needs_write {
+        fs::write(&hash_file, &hash).unwrap();
+    }
 }
 
 fn git_commit_short() -> String {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -143,14 +143,20 @@ fn random_tagline() -> String {
     )
 }
 
+const GIT_COMMIT: &str = include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"));
+
 const fn runt_version_string() -> &'static str {
     if env!("RUNT_VARIANT").is_empty() {
-        concat!(env!("CARGO_PKG_VERSION"), "+", env!("GIT_COMMIT"))
+        concat!(
+            env!("CARGO_PKG_VERSION"),
+            "+",
+            include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
+        )
     } else {
         concat!(
             env!("CARGO_PKG_VERSION"),
             "+",
-            env!("GIT_COMMIT"),
+            include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt")),
             "-",
             env!("RUNT_VARIANT")
         )
@@ -3644,7 +3650,7 @@ fn collect_system_info() -> serde_json::Value {
         "arch": std::env::consts::ARCH,
         "os_version": os_version,
         "runt_version": env!("CARGO_PKG_VERSION"),
-        "runt_commit": env!("GIT_COMMIT"),
+        "runt_commit": GIT_COMMIT,
         "runt_variant": env!("RUNT_VARIANT"),
         "build_channel": format!("{:?}", runt_workspace::build_channel()),
         "dev_mode": runt_workspace::is_dev_mode(),

--- a/crates/runtimed-client/build.rs
+++ b/crates/runtimed-client/build.rs
@@ -1,17 +1,32 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
-    // Capture short commit hash for version-mismatch detection.
-    // This ensures the daemon gets restarted when the binary changes,
-    // even if the crate version (Cargo.toml) hasn't been bumped.
-    let commit = git_commit_short();
-    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    write_git_hash();
 
     // No rerun-if-changed directives — cargo's default behavior reruns
     // this script when any file in the package changes, which is exactly
-    // when we want a fresh commit hash. We intentionally do NOT watch
-    // .git/HEAD or refs — that causes recompilation of this crate (and
-    // all dependents) on every commit, branch switch, pull, or fetch.
+    // when we want a fresh commit hash check.
+}
+
+/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
+/// if the content hasn't changed. See `crates/runtimed/build.rs` for the
+/// rationale — this avoids recompilation when the hash doesn't change.
+#[allow(clippy::unwrap_used)]
+fn write_git_hash() {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let hash_file = out_dir.join("git_hash.txt");
+    let hash = git_commit_short();
+
+    let needs_write = match fs::read_to_string(&hash_file) {
+        Ok(existing) => existing != hash,
+        Err(_) => true,
+    };
+
+    if needs_write {
+        fs::write(&hash_file, &hash).unwrap();
+    }
 }
 
 fn git_commit_short() -> String {

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -567,7 +567,11 @@ where
     let mut manager = ServiceManager::default();
 
     // Version of the bundled/calling binary (includes git commit for dev builds)
-    let bundled_version = format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT"));
+    let bundled_version = format!(
+        "{}+{}",
+        env!("CARGO_PKG_VERSION"),
+        include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
+    );
 
     // First, try to ping the daemon
     if client.ping().await.is_ok() {

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
@@ -17,15 +19,35 @@ fn main() {
     // rerun-if-changed above, cargo won't use its default behavior).
     println!("cargo:rerun-if-changed=build.rs");
 
-    // Capture short commit hash for version-mismatch detection.
-    let commit = git_commit_short();
-    println!("cargo:rustc-env=GIT_COMMIT={commit}");
+    write_git_hash();
+}
 
-    // We intentionally do NOT watch .git/HEAD or refs — that causes
-    // recompilation of this crate and all dependents on every commit,
-    // branch switch, pull, or fetch. The hash is refreshed whenever
-    // this build script reruns (plugin asset change or build.rs edit).
-    // CI always starts clean so release builds always get the right hash.
+/// Write the git commit hash to `$OUT_DIR/git_hash.txt`, skipping the write
+/// if the content hasn't changed. Consumer code uses:
+///
+///     include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
+///
+/// Because cargo tracks file modification times on included files, an
+/// unchanged hash file means no recompilation — even after a rebase that
+/// doesn't touch this crate's source. This replaces the old
+/// `cargo:rustc-env=GIT_COMMIT=...` approach which forced recompilation
+/// every time the build script ran.
+#[allow(clippy::unwrap_used)]
+fn write_git_hash() {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let hash_file = out_dir.join("git_hash.txt");
+    let hash = git_commit_short();
+
+    // Only write if the content actually changed — preserves mtime so
+    // cargo's incremental compilation skips dependent rustc invocations.
+    let needs_write = match fs::read_to_string(&hash_file) {
+        Ok(existing) => existing != hash,
+        Err(_) => true,
+    };
+
+    if needs_write {
+        fs::write(&hash_file, &hash).unwrap();
+    }
 }
 
 fn git_commit_short() -> String {

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -45,5 +45,11 @@ pub mod terminal_size;
 /// Cached to avoid repeated allocations on hot paths.
 pub fn daemon_version() -> &'static str {
     static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    VERSION.get_or_init(|| format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT")))
+    VERSION.get_or_init(|| {
+        format!(
+            "{}+{}",
+            env!("CARGO_PKG_VERSION"),
+            include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
+        )
+    })
 }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 #[derive(Parser, Debug)]
 #[command(name = "runtimed")]
-#[command(version = concat!(env!("CARGO_PKG_VERSION"), "+", env!("GIT_COMMIT")))]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), "+", include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))))]
 #[command(about = "Runtime daemon for managing Jupyter environments")]
 struct Cli {
     #[command(subcommand)]
@@ -472,7 +472,7 @@ fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {
     println!(
         "Binary version: {}+{}",
         env!("CARGO_PKG_VERSION"),
-        env!("GIT_COMMIT")
+        include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))
     );
 
     let mut manager = ServiceManager::default();


### PR DESCRIPTION
## Summary

- Replace `cargo:rustc-env=GIT_COMMIT=...` with file-based git hash embedding across all 4 crates that embed commit hashes (`runtimed`, `runt`, `runtimed-client`, `notebook`)
- Each `build.rs` writes the hash to `$OUT_DIR/git_hash.txt` with a compare-before-write guard — the file is only touched when the hash actually changes
- Consumer code switches from `env!("GIT_COMMIT")` to `include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))`
- The `notebook` crate additionally gets `git_branch.txt` and `git_date.txt` for the About menu metadata

## Why

The old `cargo:rustc-env=GIT_COMMIT=...` approach sets the env var on every `build.rs` invocation. Even though we intentionally don't watch `.git/HEAD` (to avoid rebuild-on-every-commit), the env var mechanism can still trigger recompilation when the build script reruns for unrelated reasons (plugin asset changes, source edits in `runtimed-client`'s default rerun behavior).

With `include_str!`, cargo's file-based change detection means: same hash content → same mtime → no recompilation. This is especially noticeable during development when switching between branches that share the same commit at HEAD, or after rebases that don't change code.

## Test plan

- [x] `cargo build -p runtimed -p runt-cli -p runtimed-client` compiles clean
- [x] `runtimed --version` and `runt --version` show correct hash (`8b0368e`)
- [x] Second `cargo build` is instant (0.51s, no recompilation)
- [x] `cargo check -p notebook` compiles clean
- [x] `cargo xtask lint` passes (all checks green)
- [x] `cargo test -p runtimed --lib` — 308 tests pass
- [x] No remaining `env!("GIT_COMMIT")` references in source (verified via grep)