### PR TITLE
fix(build): sync mcpb_install.rs tool descriptions and handle escaped quotes

### DIFF
--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -71,7 +71,7 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         },
         "tools": [
             { "name": "list_active_notebooks", "description": "List running notebook sessions." },
-            { "name": "open_notebook", "description": "Open a notebook by path or session ID." },
+            { "name": "open_notebook", "description": "Open a notebook. Provide exactly one of: path (file path, e.g. \"~/analysis.ipynb\") or notebook_id (UUID from list_active_notebooks). Paths open the file from disk; notebook_id connects to a running session." },
             { "name": "create_notebook", "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist." },
             { "name": "save_notebook", "description": "Save notebook to disk." },
             { "name": "launch_app", "description": "Show the current notebook to the user." },

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2836,7 +2836,11 @@ fn cmd_sync_tool_cache(check: bool) {
             for tool in tools_arr {
                 let name = tool["name"].as_str().unwrap_or("");
                 let desc = tool["description"].as_str().unwrap_or("");
-                let needle = format!(r#""description": "{}""#, desc);
+                // The mcpb_install.rs source is Rust code with JSON inside a
+                // serde_json::json!() macro, so inner quotes appear as \"
+                // in the source file. Escape them in the needle to match.
+                let escaped_desc = desc.replace('"', r#"\""#);
+                let needle = format!(r#""description": "{}""#, escaped_desc);
                 if !source.contains(&needle) && source.contains(&format!(r#""name": "{}""#, name)) {
                     eprintln!(
                         "STALE: {} (description mismatch for tool '{}')",


### PR DESCRIPTION
## Summary

- Update `open_notebook` description in `mcpb_install.rs` to match the current tool definition after the UUID-first refactor (#1838) changed the param from `session_id` to `notebook_id`
- Fix `sync-tool-cache --check` to escape inner quotes when building the comparison needle, since `mcpb_install.rs` is Rust source where JSON quotes appear as `\"` inside the `serde_json::json!()` macro

## Why

CI was failing because:
1. The `open_notebook` tool description changed in #1838 but `mcpb_install.rs` wasn't updated
2. Even after updating, the check would still fail because descriptions containing quotes (e.g. `"~/analysis.ipynb"`) can never match — the source file has `\"` but the needle has raw `"`

## Test plan

- [x] `cargo xtask sync-tool-cache --check` passes
- [x] `cargo xtask lint` passes