### PR TITLE
fix(sift): handle nested list values in table cells

### DIFF
--- a/packages/sift/src/accumulators.test.ts
+++ b/packages/sift/src/accumulators.test.ts
@@ -315,6 +315,10 @@ describe("formatCell", () => {
   it("preserves object structure", () => {
     expect(formatCell("categorical", { a: 1 })).toBe('{"a":1}');
   });
+
+  it("handles arrays containing bigint values", () => {
+    expect(formatCell("categorical", [1n, 2n, 3n])).toBe("[1,2,3]");
+  });
 });
 
 describe("isNullSentinel", () => {

--- a/packages/sift/src/accumulators.test.ts
+++ b/packages/sift/src/accumulators.test.ts
@@ -301,6 +301,20 @@ describe("formatCell", () => {
     expect(formatCell("numeric", 42)).toBe("42");
     expect(formatCell("categorical", "hello")).toBe("hello");
   });
+
+  it("preserves nested array structure", () => {
+    expect(formatCell("categorical", [["fast", "slow"], ["red"]])).toBe(
+      '[["fast","slow"],["red"]]',
+    );
+  });
+
+  it("preserves flat array structure", () => {
+    expect(formatCell("categorical", ["fast", "slow", "red"])).toBe('["fast","slow","red"]');
+  });
+
+  it("preserves object structure", () => {
+    expect(formatCell("categorical", { a: 1 })).toBe('{"a":1}');
+  });
 });
 
 describe("isNullSentinel", () => {

--- a/packages/sift/src/accumulators.ts
+++ b/packages/sift/src/accumulators.ts
@@ -87,7 +87,7 @@ export function refineColumnType(
 
   for (const val of sample) {
     if (val == null) continue;
-    const s = String(val);
+    const s = stringifyValue(val);
     if (NULL_SENTINELS.has(s)) {
       nullSentinelCount++;
       continue;
@@ -110,6 +110,13 @@ export function refineColumnType(
 
 // --- Cell formatting ---
 
+export function stringifyValue(val: unknown): string {
+  if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
+    return JSON.stringify(val);
+  }
+  return String(val);
+}
+
 export function formatCell(columnType: ColumnType, val: unknown): string {
   if (val == null) return "";
   switch (columnType) {
@@ -124,7 +131,7 @@ export function formatCell(columnType: ColumnType, val: unknown): string {
     case "boolean":
       return val ? "Yes" : "No";
     default:
-      return String(val);
+      return stringifyValue(val);
   }
 }
 

--- a/packages/sift/src/accumulators.ts
+++ b/packages/sift/src/accumulators.ts
@@ -112,7 +112,7 @@ export function refineColumnType(
 
 export function stringifyValue(val: unknown): string {
   if (Array.isArray(val) || (typeof val === "object" && val !== null)) {
-    return JSON.stringify(val);
+    return JSON.stringify(val, (_k, v) => (typeof v === "bigint" ? Number(v) : v));
   }
   return String(val);
 }

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -23,6 +23,7 @@ export {
   isNullSentinel,
   NumericAccumulator,
   refineColumnType,
+  stringifyValue,
   TimestampAccumulator,
 } from "./accumulators";
 export type {

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -670,6 +670,18 @@ h1 {
   font-style: italic;
 }
 
+.sift-badge-list-item {
+  background: color-mix(in srgb, var(--sift-accent) 10%, transparent);
+  color: color-mix(in srgb, var(--sift-accent) 80%, var(--sift-ink));
+}
+
+.sift-cell-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  align-items: center;
+}
+
 /* --- Boolean summary in header --- */
 
 .sift-bool-summary {

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1117,7 +1117,21 @@ export function createTable(
         break;
       }
       default:
-        cellEl.textContent = str;
+        if (
+          Array.isArray(raw) &&
+          raw.length > 0 &&
+          raw.every((item) => !Array.isArray(item) && (typeof item !== "object" || item === null))
+        ) {
+          cellEl.classList.add("sift-cell-list");
+          for (const item of raw) {
+            const badge = document.createElement("span");
+            badge.className = "sift-badge sift-badge-list-item";
+            badge.textContent = item == null ? "null" : String(item);
+            cellEl.appendChild(badge);
+          }
+        } else {
+          cellEl.textContent = str;
+        }
     }
   }
 
@@ -1386,6 +1400,18 @@ export function createTable(
         badge.className = raw ? "sift-badge sift-badge-true" : "sift-badge sift-badge-false";
         badge.textContent = raw ? "Yes" : "No";
         valueEl.appendChild(badge);
+      } else if (
+        Array.isArray(raw) &&
+        raw.length > 0 &&
+        raw.every((item) => !Array.isArray(item) && (typeof item !== "object" || item === null))
+      ) {
+        valueEl.classList.add("sift-cell-list");
+        for (const item of raw) {
+          const badge = document.createElement("span");
+          badge.className = "sift-badge sift-badge-list-item";
+          badge.textContent = item == null ? "null" : String(item);
+          valueEl.appendChild(badge);
+        }
       } else {
         valueEl.textContent = data.getCell(dataRow, c);
       }

--- a/packages/sift/src/wasm-table-data.ts
+++ b/packages/sift/src/wasm-table-data.ts
@@ -6,7 +6,7 @@
  * getCell/getCellRaw read from the JS-side cache — no per-cell FFI.
  */
 import { tableFromIPC } from "apache-arrow";
-import { formatCell } from "./accumulators";
+import { formatCell, stringifyValue } from "./accumulators";
 import { autoWidth } from "./auto-width";
 import type { FilterSpecJson } from "./predicate";
 import { getModuleSync } from "./predicate";
@@ -102,10 +102,10 @@ export function createWasmTableData(
           raws.push(numVal);
         } else if (colType === "numeric") {
           const numVal = typeof val === "bigint" ? Number(val) : Number(val);
-          strings.push(String(val));
+          strings.push(stringifyValue(val));
           raws.push(numVal);
         } else {
-          strings.push(String(val));
+          strings.push(stringifyValue(val));
           raws.push(val);
         }
       }


### PR DESCRIPTION
## Summary

`String()` flattens nested arrays — e.g. `String([["fast","slow"],["red"]])` produces `"fast,slow,red"`, breaking display for any Polars/Arrow column containing list-typed values.

This adds a `stringifyValue` helper that uses `JSON.stringify` for arrays/objects and `String()` for primitives, applied at all 4 call sites (`formatCell`, `refineColumnType`, and two paths in the WASM viewport cache). Flat arrays of primitives are also rendered as pill badges in table cells and the detail sheet, consistent with the existing badge pattern for booleans and nulls.

Closes #1841

## Changes

- **`accumulators.ts`** — new exported `stringifyValue()`, used in `formatCell` default case and `refineColumnType`
- **`wasm-table-data.ts`** — import and use `stringifyValue` in numeric and categorical viewport cache branches
- **`table.ts`** — detect flat primitive arrays in `renderCell` and detail sheet, render as `.sift-badge-list-item` pills; nested/complex arrays fall back to JSON string
- **`style.css`** — `.sift-badge-list-item` and `.sift-cell-list` styles
- **`index.ts`** — export `stringifyValue`
- **`accumulators.test.ts`** — tests for nested arrays, flat arrays, and objects

## Verification

- [ ] Open a notebook with a Polars DataFrame containing a list column (e.g. the reproducer from #1841) and confirm values render as pill badges
- [ ] Confirm nested lists (list of lists) display as JSON strings, not flattened
- [ ] Tap a row on narrow viewport to open detail sheet — list values should render as badges there too

<!-- Screenshots: add before/after of list column rendering -->

_PR submitted by @rgbkrk's agent, Quill_