### PR TITLE
docs: sync agent + contributor docs to current architecture

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -10,34 +10,32 @@ Three nteract MCP servers may be available. Always use the right one:
 
 | Server | What it is | When to use |
 |--------|-----------|-------------|
-| `nteract-dev` | Dev MCP server with supervisor tools (`up`, `down`, `status`, `logs`, `vite_logs`). Manages a per-worktree dev daemon, hot-reloads on code changes. | **Default for all development work.** Use this for notebook interaction, daemon lifecycle, building, and testing. |
+| `nteract-dev` | Dev MCP server. Adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) on top of the proxied `runt mcp` toolset. Manages a per-worktree dev daemon, hot-reloads on code changes. | **Default for all development work.** Use this for notebook interaction, daemon lifecycle, building, and testing. |
 | `nteract-nightly` | System-installed nightly release daemon | Diagnostics and inspection of the installed nightly app. Do NOT use for development. |
 | `nteract` | System-installed stable release daemon (nteract.app) | Diagnostics and inspection of the installed stable app. Do NOT use for development. |
 
 **Rules:**
 
-1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes supervisor tools for managing the build/daemon lifecycle.
+1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes the dev tools for managing the build/daemon lifecycle.
 2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
 3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
-4. The supervisor tools are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
+4. The dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) live on the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
 
-## Supervisor tool surface (nteract-dev)
+## nteract-dev tool surface
 
-Consolidated around two verbs plus three read-only tools:
+Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` toolset:
 
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent "bring the dev environment to a working state." Sweeps zombie Vite processes, ensures the daemon is running, ensures the MCP child is healthy. Optional args: `vite=true` to also start Vite, `rebuild=true` to rebuild daemon + Python bindings first, `mode='debug'\|'release'` to switch build mode. Safe to call repeatedly — this is the first thing to reach for when things feel off. |
 | `down` | Stop the managed Vite dev server. Leaves the daemon running by default (launchd / the installed app may own it). Pass `daemon=true` to also stop the managed daemon process. |
-| `status` | Read-only report of supervisor, child, daemon, and managed-process state. |
+| `status` | Read-only report of `nteract-dev`, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log. Arg: `lines` (default 50). |
 | `vite_logs` | Tail the Vite dev server log. Arg: `lines` (default 50). |
 
-The older `supervisor_*` names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases. Prefer the new names.
-
 ## MCP Server
 
-The supervisor always uses `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
+`nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
 
 ## System daemon CLI (`runt` / `runt-nightly`)
 
@@ -62,7 +60,7 @@ For the dev daemon, use `./target/debug/runt` directly (no `env -i` needed — d
 After setting up direnv, verify that the three MCP servers connect to the correct daemons:
 
 ```bash
-# 1. Check nteract-dev supervisor status (should show worktrees/ socket)
+# 1. Check nteract-dev status (should show worktrees/ socket)
 status
 # Expected socket: ~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock
 

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -79,8 +79,8 @@ Python packages. The major architectural seams are:
 - `runt-workspace`: Per-worktree daemon socket isolation
 - `runt`: CLI binary (daemon management, kernel control, notebook launching, MCP server)
 - `runtimed-client`: Shared client library (output resolution, daemon paths, pool client)
-- `runt-mcp`: Rust-native MCP server (27 tools for notebook interaction)
-- `mcp-supervisor`: nteract-dev MCP supervisor proxy, daemon/vite lifecycle
+- `runt-mcp`: Rust-native MCP server (26 tools for notebook interaction)
+- `mcp-supervisor`: `nteract-dev` MCP server (proxies `runt mcp`, manages daemon/vite lifecycle)
 - `repr-llm`: LLM-friendly text summaries of visualization specs
 - `notebook`: Tauri desktop app (main GUI, bundles daemon+CLI as sidecars)
 

--- a/.claude/skills/diagnostics/SKILL.md
+++ b/.claude/skills/diagnostics/SKILL.md
@@ -7,7 +7,7 @@ description: Collect and analyze nteract diagnostic logs. Use when debugging iss
 
 ## Why `env -i`?
 
-In the dev environment, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` are set (by direnv, xtask, or the supervisor). These cause `runt` to target the per-worktree dev daemon. System diagnostics need to target the **system-installed** daemon, so we use `env -i` to strip all env vars except `PATH` and `HOME`.
+In the dev environment, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` are set (by direnv, xtask, or `nteract-dev`). These cause `runt` to target the per-worktree dev daemon. System diagnostics need to target the **system-installed** daemon, so we use `env -i` to strip all env vars except `PATH` and `HOME`.
 
 The repo-local `bin/runt` wrapper is first in `$PATH` — it runs `./target/debug/runt`, which is the dev build. That's fine for quick checks, but for true system diagnostics, call the system binary by its channel-specific name (`runt` for stable, `runt-nightly` for nightly) via `env -i` so dev env vars don't leak through.
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -17,7 +17,7 @@ description: Run the notebook app in dev mode with hot reload. Use when starting
 | Run bundled binary | `cargo xtask run` |
 | One-shot setup | `cargo xtask dev` |
 | Lint/format | `cargo xtask lint --fix` |
-| MCP supervisor | `cargo xtask run-mcp` |
+| nteract-dev MCP server | `cargo xtask run-mcp` |
 
 ## `cargo xtask notebook` — Hot Reload
 
@@ -118,13 +118,13 @@ RUNTIMED_DEV=1 cargo xtask notebook      # Terminal 2
 
 ## MCP Server Development
 
-### nteract-dev Supervisor (recommended)
+### nteract-dev (recommended)
 
 ```bash
 cargo xtask run-mcp
 ```
 
-Starts the dev daemon, launches the dev-only `nteract-dev` supervisor, spawns a child `runt mcp`, proxies notebook tool calls, watches for file changes, and hot-reloads. Python bindings are rebuilt when the watched Rust paths require it.
+Starts the dev daemon, launches `nteract-dev` (the dev-only MCP server for this source tree), spawns a child `runt mcp`, proxies notebook tool calls, watches for file changes, and hot-reloads. Python bindings are rebuilt when the watched Rust paths require it.
 
 For editor config:
 
@@ -150,7 +150,7 @@ Use `nteract-dev` as the repo-local MCP server name so it stays distinct from an
 }
 ```
 
-### Direct Mode (no supervisor)
+### Direct Mode (no proxy)
 
 ```bash
 # Terminal 1: start dev daemon
@@ -160,7 +160,7 @@ cargo xtask dev-daemon
 cargo xtask dev-mcp
 ```
 
-### Supervisor Tools
+### nteract-dev Tools
 
 | Tool | Purpose |
 |------|---------|
@@ -169,8 +169,6 @@ cargo xtask dev-mcp
 | `status` | Read-only report of child, daemon, managed processes, build mode |
 | `logs` | Tail daemon log file |
 | `vite_logs` | Tail Vite dev server log file |
-
-The older `supervisor_*` names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases.
 
 ### Hot Reload
 

--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -185,21 +185,23 @@ runt mcp
 # Or via the Python wrapper
 uv run nteract
 
-# Via nteract-dev supervisor (recommended for development, handles lifecycle)
+# Via nteract-dev (recommended for development, handles lifecycle)
 cargo xtask run-mcp
 ```
 
-### nteract MCP Tools (27 tools)
+### nteract MCP Tools (26 tools)
 
 | Category | Tools |
 |----------|-------|
-| Session | `list_active_notebooks`, `show_notebook`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook` |
+| Session | `list_active_notebooks`, `open_notebook`, `create_notebook`, `save_notebook`, `launch_app` |
 | Kernel | `interrupt_kernel`, `restart_kernel` |
 | Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
-| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell` |
+| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs` |
 | Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
-| Find/Replace | `replace_match`, `replace_regex` |
-| Execution | `execute_cell`, `run_all_cells`, `clear_outputs` |
+| Editing | `replace_match`, `replace_regex` |
+| Execution | `execute_cell`, `run_all_cells` |
+
+`join_notebook` is accepted as a backward-compat alias for `open_notebook`.
 
 Three packages are workspace members:
 
@@ -230,4 +232,4 @@ cd crates/runtimed-py
 VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
-Or if using nteract-dev supervisor, call `up rebuild=true`.
+Or if using nteract-dev, call `up rebuild=true`.

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -24,16 +24,16 @@ Run `git diff --name-only` to see changed files and match them to the table belo
 | `crates/runt/src/**` | `cargo test -p runt` |
 | `crates/runt-workspace/src/**` | `cargo test -p runt-workspace` |
 | `crates/runtimed-py/src/**` | `up rebuild=true` (rebuilds Python bindings) |
-| `python/nteract/src/**` | Supervisor auto-restarts; no explicit test needed |
-| `python/runtimed/src/**` | Supervisor auto-restarts; run `pytest python/runtimed/tests/test_session_unit.py -v` |
+| `python/nteract/src/**` | `nteract-dev` auto-restarts; no explicit test needed |
+| `python/runtimed/src/**` | `nteract-dev` auto-restarts; run `pytest python/runtimed/tests/test_session_unit.py -v` |
 | `apps/notebook/src/**` | `pnpm test:run` |
 | `crates/runtimed-wasm/**` | `cargo xtask wasm` then `deno test --allow-read --allow-env --no-check` |
 
 If multiple crates changed, run tests for each: `cargo test -p runtimed -p notebook-doc`.
 
-## Step 3: MCP Live Verification (when supervisor tools are available)
+## Step 3: MCP Live Verification (when nteract-dev tools are available)
 
-If narrow tests pass and you have the nteract-dev supervisor (`up`/`down`/`status`) and `open_notebook`/`execute_cell` tools, do a live check:
+If narrow tests pass and you have `nteract-dev` (`up`/`down`/`status`) and `open_notebook`/`execute_cell` tools, do a live check:
 
 ### For daemon/kernel changes (`crates/runtimed/`, `crates/runtimed-py/`):
 
@@ -79,7 +79,7 @@ Run the setup cell first, then run any metric cell. Each metric cell is self-con
 - Uses the **project venv** (no inline dependencies) — `runtimed` and `matplotlib` are both project dev deps
 - Imports `runtimed.Client` directly for inline async measurements (no subprocess needed)
 - Loads `baseline.json` from the notebook's own directory (`scripts/metrics/`)
-- The daemon socket is discovered automatically via `RUNTIMED_SOCKET_PATH` env var (set by the daemon/supervisor)
+- The daemon socket is discovered automatically via `RUNTIMED_SOCKET_PATH` env var (set by the daemon or `nteract-dev`)
 
 **Three measurement cells:**
 - **Execution latency** — cold start + warm p50/p95 distribution, compared to baseline

--- a/.codex/skills/nteract-daemon-dev/SKILL.md
+++ b/.codex/skills/nteract-daemon-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nteract-daemon-dev
-description: Work with the per-worktree runtimed daemon in the nteract desktop repo. Use when changing `crates/runtimed/**`, debugging daemon-backed notebook behavior, deriving `RUNTIMED_SOCKET_PATH`, checking daemon logs/status, running daemon-backed tests or reviews, or deciding whether to use `supervisor_*` tools versus manual `cargo xtask dev-daemon` commands.
+description: Work with the per-worktree runtimed daemon in the nteract desktop repo. Use when changing `crates/runtimed/**`, debugging daemon-backed notebook behavior, deriving `RUNTIMED_SOCKET_PATH`, checking daemon logs/status, running daemon-backed tests or reviews, or deciding whether to use the `nteract-dev` MCP tools (`up`/`down`/`status`/`logs`/`vite_logs`) versus manual `cargo xtask dev-daemon` commands.
 ---
 
 # nteract Daemon Dev
@@ -9,7 +9,7 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 
 ## Workflow
 
-1. Prefer `supervisor_*` tools when they are available.
+1. Prefer the `nteract-dev` MCP tools (`up`, `down`, `status`, `logs`, `vite_logs`) when they are available.
 2. Decide whether you are validating the default nightly source flow or an explicit stable flow. Source builds are nightly unless `RUNT_BUILD_CHANNEL=stable`.
 3. Otherwise, treat the worktree daemon as mandatory for daemon-backed verification.
 4. Export `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` before any manual `runt` command.
@@ -27,6 +27,6 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 
 ## Quick Start
 
-If you have supervisor tools, use them for daemon lifecycle and logs.
+If you have `nteract-dev` tools, use them for daemon lifecycle and logs.
 
 If you do not, read [references/daemon-workflows.md](references/daemon-workflows.md) and follow the manual command sequence there.

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -58,9 +58,9 @@ Start or restart the worktree daemon when:
 - You are verifying MCP server behavior against local Rust changes
 - You are comparing behavior across worktrees and need isolation
 
-## Prefer supervisor tools when available
+## Prefer nteract-dev tools when available
 
-If the nteract-dev MCP supervisor is available, prefer:
+If `nteract-dev` is available, prefer:
 
 - `up` — idempotent "bring the dev environment up". Ensures daemon + child are healthy. Args: `vite=true`, `rebuild=true`, `mode="debug"|"release"`
 - `down` — stop the managed Vite dev server. `daemon=true` also stops the daemon
@@ -68,7 +68,7 @@ If the nteract-dev MCP supervisor is available, prefer:
 - `logs` — tail daemon logs
 - `vite_logs` — tail Vite dev server logs when you need the Vite side of a hot-reload session
 
-These avoid manual env-var mistakes. The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases.
+These avoid manual env-var mistakes.
 
 ## Safety rules
 

--- a/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
+++ b/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
@@ -58,7 +58,7 @@ The MCP server is `runt mcp` (Rust, shipped with the desktop app). For developme
 uv run nteract
 ```
 
-If the MCP supervisor is available, prefer `cargo xtask run-mcp` or the supervisor tools instead of a manual launch.
+If `nteract-dev` is available, prefer `cargo xtask run-mcp` or its tools (`up`, `down`, `status`, `logs`, `vite_logs`) instead of a manual launch.
 
 Use `default_socket_path()` for current-process resolution. Use `socket_path_for_channel("stable"|"nightly")` only when you need an explicit channel path that ignores `RUNTIMED_SOCKET_PATH`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,25 +49,25 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 **Three MCP servers** should be configured:
 
 1. **nteract-dev** (development, per-worktree daemon)
-   - Command: `cargo xtask run-mcp` or `/path/to/repo/target/debug/mcp-supervisor`
+   - Command: `cargo xtask run-mcp` (builds and runs the local `mcp-supervisor` binary)
    - Working directory: `/path/to/nteract/desktop`
    - Env vars: Inherits from shell (direnv provides RUNTIMED_DEV, RUNTIMED_WORKSPACE_PATH)
    - Socket: `~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock`
-   - Tools: 27 nteract tools + 8 supervisor tools
+   - Tools: 26 nteract tools (proxied from `runt mcp`) + 5 dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
 
 2. **nteract-nightly** (system nightly daemon, for testing releases)
    - Command: `env -i HOME=$HOME /usr/local/bin/runt-nightly mcp`
    - Working directory: Can be anywhere (no repo dependency)
    - Env vars: **MUST use `env -i`** to strip RUNTIMED_DEV and RUNTIMED_WORKSPACE_PATH
    - Socket: `~/.cache/runt-nightly/runtimed.sock` (system socket, NOT worktrees/)
-   - Tools: 27 nteract tools (no supervisor tools)
+   - Tools: 26 nteract tools (no dev tools)
 
 3. **nteract** (system stable daemon, for testing stable releases)
    - Command: `env -i HOME=$HOME /usr/local/bin/runt mcp`
    - Working directory: Can be anywhere
    - Env vars: **MUST use `env -i`** to strip dev env vars
    - Socket: `~/.cache/runt/runtimed.sock`
-   - Tools: 27 nteract tools (no supervisor tools)
+   - Tools: 26 nteract tools (no dev tools)
 
 **Critical:** The `env -i` wrapper on nteract-nightly and nteract is required to prevent direnv's env vars from leaking into these MCP servers. Without it, they will incorrectly connect to the dev daemon instead of the system daemon.
 
@@ -84,7 +84,7 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 
 ### If you have `up` / `down` / `status` tools — use them
 
-If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (the nteract-dev supervisor surface), **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
+If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (provided by `nteract-dev`), **prefer those over manual terminal commands**. `nteract-dev` manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
 **Claude Code has nteract-dev locally** — the local dev environment connects Claude Code to the repo-local `nteract-dev` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose these tools, use the manual `cargo xtask` commands below.
 
@@ -97,11 +97,9 @@ If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (the nte
 | `cargo xtask vite` | `up vite=true` |
 | `cargo xtask notebook` (stop dev processes) | `down` (stops Vite; `daemon=true` also stops daemon) |
 
-The supervisor automatically handles per-worktree isolation, env var plumbing, zombie Vite cleanup, health probes, and lockfile-drift re-installs. You only need the manual commands below when the supervisor isn't available (e.g. cloud sessions, CI).
+`nteract-dev` automatically handles per-worktree isolation, env var plumbing, zombie Vite cleanup, health probes, and lockfile-drift re-installs. You only need the manual commands below when `nteract-dev` isn't available (e.g. cloud sessions, CI).
 
-The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases — prefer the new ones.
-
-### Manual commands (when supervisor is not available)
+### Manual commands (when nteract-dev is not available)
 
 For raw terminal commands, opt into dev mode explicitly. `RUNTIMED_DEV=1` is what enables per-worktree daemon isolation. `RUNTIMED_WORKSPACE_PATH` is the safest way to pin the current worktree, though binaries launched from the repo root can also discover the worktree via git.
 
@@ -158,12 +156,12 @@ python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_un
 
 **Do not launch the notebook app from an agent terminal.** The app is a GUI process that blocks until the user quits it (⌘Q), and the agent will misinterpret the exit. Let the human launch it from their own terminal or Zed task.
 
-With supervisor tools, the daemon and vite are already managed — the human just runs:
+With `nteract-dev`, the daemon and vite are already managed — the human just runs:
 ```bash
 cargo xtask notebook
 ```
 
-Without supervisor (human runs both):
+Without `nteract-dev` (human runs both):
 ```bash
 # Terminal 1: Start dev daemon
 cargo xtask dev-daemon
@@ -296,10 +294,10 @@ If you must write a `.ipynb` file directly (e.g., test fixtures), dependencies g
 
 ## MCP Server (Local Development)
 
-### nteract-dev — MCP Supervisor
+### nteract-dev
 
 ```bash
-# Build and run the supervisor (starts daemon if needed)
+# Build and run nteract-dev (starts daemon if needed)
 cargo xtask run-mcp
 
 # Or print config JSON for your MCP client
@@ -308,49 +306,49 @@ cargo xtask run-mcp --print-config
 
 Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
 
-For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server using the `nteract-dev` entry name.
+For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same server using the `nteract-dev` entry name.
 
 ### MCP Server
 
-The supervisor always uses the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload.
+`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload.
 
-`runt mcp` can also be run standalone (no supervisor): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
+`runt mcp` can also be run standalone (no proxy): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
 
 For the installed app, `runt mcp` ships as a sidecar binary alongside `runtimed`, so MCP clients can use it directly without Python or uv.
 
-### Supervisor Tools (from nteract-dev / `mcp-supervisor`)
+### nteract-dev Tools
 
-Consolidated around two verbs plus three read-only tools:
+Two verbs plus three read-only tools layered on top of the proxied `runt mcp` toolset:
 
 | Tool | Purpose |
 |------|---------|
 | `up` | Idempotent "bring the dev environment to a working state". Sweeps zombie Vite processes, ensures daemon is running, ensures the MCP child is healthy. Args: `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild daemon + Python bindings first, `mode="debug"\|"release"` to switch build mode. Safe to call repeatedly. |
 | `down` | Stop the managed Vite dev server. Leaves the daemon alone by default (launchd / installed app may own it). Pass `daemon=true` to also stop the managed daemon. |
-| `status` | Read-only report of supervisor, child, daemon, and managed-process state. |
+| `status` | Read-only report of `nteract-dev`, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log file. |
 | `vite_logs` | Tail the Vite dev server log file. |
 
-The older `supervisor_*` names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases.
+### nteract MCP Tools (26 tools for notebook interaction)
 
-### nteract MCP Tools (27 tools for notebook interaction)
-
-When nteract-dev is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
+When `nteract-dev` is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
 
 | Category | Tools |
 |----------|-------|
-| Session | `list_active_notebooks`, `show_notebook`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook` |
+| Session | `list_active_notebooks`, `open_notebook`, `create_notebook`, `save_notebook`, `launch_app` |
 | Kernel | `interrupt_kernel`, `restart_kernel` |
 | Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
-| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell` |
+| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs` |
 | Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
-| Find/Replace | `replace_match`, `replace_regex` |
-| Execution | `execute_cell`, `run_all_cells`, `clear_outputs` |
+| Editing | `replace_match`, `replace_regex` |
+| Execution | `execute_cell`, `run_all_cells` |
+
+`join_notebook` is accepted as a backward-compat alias that routes to `open_notebook`.
 
 **Audit workflow example:** After modifying daemon or kernel code, use `open_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
 
 ### Hot reload
 
-The supervisor watches source directories and auto-restarts the child on changes:
+`nteract-dev` watches source directories and auto-restarts the child on changes:
 - **`crates/runt-mcp/src/`** → `cargo build -p runt-cli` + restart (Rust MCP mode)
 - **`crates/runtimed-client/src/`** → `cargo build -p runt-cli` + `maturin develop` + restart (shared code)
 - **`crates/runtimed-py/src/`, `crates/runtimed/src/`** → `maturin develop` + `cargo build` + restart
@@ -358,13 +356,13 @@ The supervisor watches source directories and auto-restarts the child on changes
 
 ### Tool availability
 
-- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. nteract-dev exposes `up` / `down` / `status` / `logs` / `vite_logs` (plus the older `supervisor_*` aliases) and the proxied nteract notebook tools. **Prefer these for daemon lifecycle** — they handle env vars and isolation automatically.
-- **Environments without supervisor tools** → use `cargo xtask` commands directly for build, daemon, and testing.
-- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no supervisor surface. Use manual terminal commands for daemon management.
+- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. It exposes `up` / `down` / `status` / `logs` / `vite_logs` plus the proxied nteract notebook tools. **Prefer these for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Environments without `nteract-dev`** → use `cargo xtask` commands directly for build, daemon, and testing.
+- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no dev tools. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
-- **Dev daemon not running** → call `up` — nteract-dev starts it if missing
+- **Dev daemon not running** → call `up` — `nteract-dev` starts it if missing
 
-## Workspace Crates (17)
+## Workspace Crates (21)
 
 | Crate | Purpose |
 |-------|---------|
@@ -376,14 +374,18 @@ The supervisor watches source directories and auto-restarts the child on changes
 | `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723, MIME classification |
 | `notebook-protocol` | Wire types — requests, responses, broadcasts |
 | `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
-| `runt` | CLI — daemon management, kernel control, notebook launching, MCP server |
-| `runt-mcp` | Rust-native MCP server — 27 tools for notebook interaction via `runt mcp` |
+| `runt-cli` | CLI (`runt` binary) — daemon management, kernel control, notebook launching, MCP server |
+| `runt-mcp` | Rust-native MCP server — 26 tools for notebook interaction via `runt mcp` |
+| `runt-mcp-proxy` | Resilient proxy for `runt mcp` — child supervision, restart-with-retry, session tracking |
 | `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |
 | `runt-workspace` | Per-worktree daemon isolation, socket path management |
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
 | `repr-llm` | LLM-friendly text summaries of visualization specs incl. GeoJSON (`text/llm+plain` synthesis) |
-| `mcp-supervisor` | nteract-dev — MCP supervisor proxy, daemon/vite lifecycle management |
+| `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs `@nteract/sift` and `nteract/dx` |
+| `sift-wasm` | WASM bindings for `nteract-predicate` — used by `@nteract/sift` |
+| `mcp-supervisor` | `nteract-dev` MCP server — proxies `runt mcp` and adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) |
+| `mcpb-runt` | MCPB binary — resilient proxy for `runt mcp` shipped in the `.mcpb` Claude Desktop extension |
 | `xtask` | Build system orchestration |
 
 ## Build System (`cargo xtask`)
@@ -408,9 +410,9 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
 | | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
 | | `cargo xtask install-daemon` | Install runtimed as system daemon |
-| MCP | `cargo xtask run-mcp` | nteract-dev supervisor (daemon + MCP + auto-restart) |
+| MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
-| | `cargo xtask dev-mcp` | Direct nteract MCP (no supervisor) |
+| | `cargo xtask dev-mcp` | Direct `runt mcp` (no proxy, no auto-restart) |
 | | `cargo xtask dev-mcp --print-config` | Print direct MCP client config JSON |
 | | `cargo xtask mcp-inspector` | Launch MCP Inspector UI for testing runt mcp |
 | Lint | `cargo xtask lint` | Check formatting (Rust, JS/TS, Python) |
@@ -435,9 +437,9 @@ Use instead:
 
 ### Per-Worktree Daemon Isolation
 
-Each git worktree runs its own isolated daemon in dev mode. If you have supervisor tools, the daemon is managed for you — use `up` to start it (idempotent), and `status` to check it.
+Each git worktree runs its own isolated daemon in dev mode. With `nteract-dev` available, the daemon is managed for you — use `up` to start it (idempotent), and `status` to check it.
 
-Without supervisor (manual two-terminal workflow):
+Without `nteract-dev` (manual two-terminal workflow):
 
 ```bash
 # Terminal 1: Start dev daemon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
 | `repr-llm` | LLM-friendly text summaries of visualization specs incl. GeoJSON (`text/llm+plain` synthesis) |
-| `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs `@nteract/sift` and `nteract/dx` |
+| `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs Sift (the `@nteract/sift` viewer; `nteract/dx` is the Python sender) |
 | `sift-wasm` | WASM bindings for `nteract-predicate` — used by `@nteract/sift` |
 | `mcp-supervisor` | `nteract-dev` MCP server — proxies `runt mcp` and adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) |
 | `mcpb-runt` | MCPB binary — resilient proxy for `runt mcp` shipped in the `.mcpb` Claude Desktop extension |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ nteract/desktop
 │   ├── runtimed-client/   # Shared client library for daemon communication
 │   ├── repr-llm/          # LLM-friendly text summaries of visualization specs
 │   ├── xtask/             # Build automation tasks
-│   └── mcp-supervisor/    # nteract-dev MCP supervisor for dev workflows
+│   └── mcp-supervisor/    # nteract-dev MCP server (proxies runt mcp + adds dev tools)
 ├── python/                 # Python packages
 │   ├── runtimed/          # PyPI: runtimed (Python bindings for daemon)
 │   ├── nteract/           # PyPI: nteract (MCP server)

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -72,6 +72,8 @@ Cell outputs are stored as content-addressed blobs with manifest references. Thi
 - Manifest format allows lazy loading and deduplication
 - Large outputs don't block document sync
 
+**On `.ipynb` save** the daemon still inlines most outputs as base64 — the same as vanilla Jupyter — so other tools can read the file. A small whitelist of nteract-specific MIMEs (currently just `application/vnd.apache.parquet`, the format the Sift dataframe viewer round-trips through) is externalized as a `BLOB_REF_MIME` entry pointing at the local blob store, keeping `.ipynb` size bounded for outputs that would otherwise serialize tens or hundreds of MiB. The Python `nteract/dx` package is the helper that produces those parquet payloads from a kernel. See `crates/runtimed/src/output_store.rs` (`should_externalize_mime_on_save`) and `docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md`.
+
 **Implementation details:**
 
 The blob store uses content-addressed storage at `~/.cache/runt/blobs/`. Each blob is identified by its SHA-256 hash and stored in a two-level shard directory:
@@ -102,7 +104,7 @@ Jupyter kernels send binary data (images) as base64-encoded strings on the wire.
 
 #### The `is_binary_mime` Contract
 
-One canonical Rust implementation in `notebook-doc::mime` is the single source of truth. All Rust crates use this module — the old per-crate copies have been deleted. On the TypeScript side, `isBinaryMime()` has been deleted from `manifest-resolution.ts`. WASM now owns MIME classification end-to-end — it resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly.
+One canonical Rust implementation in `notebook-doc::mime` is the single source of truth. All Rust crates use this module — the old per-crate copies have been deleted. WASM owns MIME classification end-to-end and resolves `ContentRef`s to `Inline`/`Url`/`Blob` variants directly, so the frontend never has to classify MIMEs itself. The `looksLikeBinaryMime()` helper in `apps/notebook/src/lib/manifest-resolution.ts` is a thin cold-start safety net that runs before WASM is ready and is intentionally not the source of truth.
 
 | Location | Function |
 |----------|----------|
@@ -143,7 +145,7 @@ Key files:
 - `crates/runtimed/src/blob_store.rs` — Content-addressed storage with atomic writes
 - `crates/runtimed/src/blob_server.rs` — HTTP server (`GET /blob/{hash}`, serves raw bytes with correct `Content-Type`)
 - `crates/runtimed-client/src/output_resolver.rs` — Shared Rust manifest resolution, Python/MCP consumers
-- `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution (`isBinaryMime()` deleted, WASM resolves `ContentRef` directly)
+- `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution (WASM resolves `ContentRef` directly; `looksLikeBinaryMime()` is only the cold-start fallback)
 - `apps/notebook/src/lib/materialize-cells.ts` — Assembles cells with resolved outputs
 
 ### 6. Process-Isolated Kernel Execution
@@ -276,7 +278,7 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
 - `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`
 - `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame` accepts raw binary via `tauri::ipc::Request`, `setup_sync_receivers`)
-- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x05)
+- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x06)
 - `apps/notebook/src/lib/frame-types.ts` — Frame type constants + `sendFrame()` binary IPC helper
 - `apps/notebook/src/hooks/useAutomergeNotebook.ts` — WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch
 - `apps/notebook/src/lib/materialize-cells.ts` — `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full)

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -14,9 +14,9 @@
 | Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
 | Build release .app | `cargo xtask build-app` |
 | Build release DMG | `cargo xtask build-dmg` |
-| MCP supervisor (nteract-dev) | `cargo xtask run-mcp` |
+| nteract-dev MCP server | `cargo xtask run-mcp` |
 | MCP config JSON | `cargo xtask run-mcp --print-config` |
-| MCP server (no supervisor) | `cargo xtask dev-mcp` |
+| Direct `runt mcp` (no proxy) | `cargo xtask dev-mcp` |
 | Lint (check mode) | `cargo xtask lint` |
 | Lint (auto-fix) | `cargo xtask lint --fix` |
 
@@ -176,9 +176,9 @@ If you have the repo-local `nteract-dev` MCP entry configured, the daemon is man
 - `logs` — tail daemon logs.
 - `vite_logs` — tail the Vite dev server log file.
 
-No env vars or extra terminals needed. nteract-dev handles per-worktree isolation automatically. The older `supervisor_*` names still work as aliases.
+No env vars or extra terminals needed. `nteract-dev` handles per-worktree isolation automatically.
 
-**Two-terminal workflow (without supervisor):**
+**Two-terminal workflow (without nteract-dev):**
 
 ```bash
 # Terminal 1: Start the dev daemon (stays running)
@@ -310,10 +310,9 @@ test-only venv).
 uv run nteract
 ```
 
-### nteract-dev supervisor (recommended)
+### nteract-dev (recommended)
 
-The **nteract-dev** MCP supervisor (`crates/mcp-supervisor/`) is a stable Rust
-process that proxies to `runt mcp`. It handles daemon
+`nteract-dev` (the dev MCP server, built from `crates/mcp-supervisor/`) proxies `runt mcp` and adds dev tools on top. It handles daemon
 lifecycle, auto-restart on crash, and hot-reload on file changes — one command,
 everything works:
 
@@ -324,7 +323,7 @@ cargo xtask run-mcp
 This:
 1. Starts the dev daemon if not running
 2. Builds `runt-cli` and spawns `runt mcp` as a child process
-3. Proxies all tool calls + injects `supervisor_*` management tools
+3. Proxies all tool calls + adds the dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
 4. Watches source files and hot-reloads on changes
 
 For your MCP client config (Zed, Claude Desktop, Codex, etc.):
@@ -335,7 +334,7 @@ cargo xtask run-mcp --print-config
 
 Use `nteract-dev` as the server name for this source tree so it stays distinct from any global/system `nteract` MCP entry.
 
-Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes one that mirrors the same supervisor setup:
+Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes one that mirrors the same setup:
 
 ```toml
 [mcp_servers.nteract-dev]
@@ -360,11 +359,11 @@ Or configure `.zed/settings.json` directly (gitignored):
 }
 ```
 
-In clients that namespace tools by server name, this keeps repo-local notebook tools separate from the global install while still exposing the same notebook APIs plus the extra supervisor tools.
+In clients that namespace tools by server name, this keeps repo-local notebook tools separate from the global install while still exposing the same notebook APIs plus the extra dev tools.
 
-#### Supervisor tools
+#### nteract-dev tools
 
-These tools are always available, even when the child MCP is down:
+These tools are always available, even when the child `runt mcp` is down:
 
 | Tool | Purpose |
 |------|---------|
@@ -374,11 +373,9 @@ These tools are always available, even when the child MCP is down:
 | `logs` | Tail the daemon log file. |
 | `vite_logs` | Tail the Vite dev server log file. |
 
-The older names (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) still work as aliases for backward compatibility.
-
 #### Hot reload
 
-The supervisor watches `crates/runt-mcp/src/`, `crates/runtimed-client/src/`,
+`nteract-dev` watches `crates/runt-mcp/src/`, `crates/runtimed-client/src/`,
 `python/nteract/src/`, `python/runtimed/src/`, `crates/runtimed-py/src/`, and
 `crates/runtimed/src/`:
 
@@ -389,10 +386,10 @@ The supervisor watches `crates/runt-mcp/src/`, `crates/runtimed-client/src/`,
 - **Behavior changes** take effect immediately on the next tool call
 - **New/removed tools** may take a moment for the client to discover
 
-### Direct mode (no supervisor)
+### Direct mode (no proxy)
 
-If you don't need auto-restart or file watching, `dev-mcp` runs the nteract
-server directly:
+If you don't need auto-restart or file watching, `dev-mcp` runs `runt mcp`
+directly:
 
 ```bash
 # Terminal 1: start the dev daemon
@@ -404,18 +401,17 @@ cargo xtask dev-mcp
 
 ### How it works
 
-`nteract-dev` is the **dev-only supervisor server** for this source tree. It
-exposes the supervisor tools (`up`, `down`, `status`, `logs`, `vite_logs`, plus
-the older `supervisor_*` aliases) itself, then proxies the regular notebook
-tools from a child `runt mcp` process launched inside the supervisor. That
-child is the Rust-native MCP implementation from `crates/runt-mcp/`, not a
-Python MCP server.
+`nteract-dev` is the **dev-only MCP server** for this source tree. It
+exposes the dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
+itself, then proxies the regular notebook tools from a child `runt mcp`
+process. That child is the Rust-native MCP implementation from
+`crates/runt-mcp/`, not a Python MCP server.
 
-The Python workspace packages still matter for local development: `python/runtimed/`
-provides the PyO3 bindings, and `python/nteract/` is the convenience wrapper that
-finds and launches `runt mcp` outside the supervisor flow. Both are workspace
-members of the repo-root `pyproject.toml`, so `uv sync` installs them into `.venv`
-at the repo root.
+The Python workspace packages still matter for local development:
+`python/runtimed/` provides the PyO3 bindings, and `python/nteract/` is a
+convenience wrapper that finds and launches `runt mcp` (still shipped, not
+the recommended path). Both are workspace members of the repo-root
+`pyproject.toml`, so `uv sync` installs them into `.venv` at the repo root.
 
 ## Before You Commit
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -91,8 +91,10 @@ import { useDaemonKernel } from "~/hooks/useDaemonKernel";  // app-specific
 CodeMirror integration with Jupyter-specific extensions:
 - `codemirror-editor.tsx` — Main editor component
 - `extensions.ts` — Keybindings, line numbers, bracket matching
-- `languages.ts` — Python, Markdown, SQL syntax
-- `themes.ts` — Light and dark themes
+- `languages.ts` — Python, Markdown, SQL syntax (Lezer parsers; replaced Prism in #1742)
+- `themes.ts` — Light and dark themes (in-tree, no external CodeMirror theme dependency)
+
+Markdown rendering uses the same Lezer parsers for static highlighting of code fences, so the editor and the rendered preview agree on tokens without bundling a second highlighter.
 
 ### Outputs (`src/components/outputs/`)
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -146,6 +146,7 @@ After the handshake, frames are typed by their first byte:
 | `0x03`    | NotebookBroadcast  | JSON |
 | `0x04`    | Presence           | Binary (CBOR, see `notebook_doc::presence`) |
 | `0x05`    | RuntimeStateSync   | Binary (raw Automerge sync for per-notebook `RuntimeStateDoc`) |
+| `0x06`    | PoolStateSync      | Binary (raw Automerge sync for the per-daemon `PoolDoc`) |
 
 ## Automerge Sync
 
@@ -359,7 +360,7 @@ Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes com
 | `crates/runtimed-wasm/src/lib.rs` | WASM bindings: cell mutations, sync, per-cell accessors, `CellChangeset` |
 | `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset`: structural diff from Automerge patches |
-| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x05) |
+| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x06) |
 | `crates/notebook-doc/src/runtime_state.rs` | `RuntimeStateDoc`: per-notebook daemon-authoritative state (kernel, queue, env sync) |
 | `apps/notebook/src/lib/runtime-state.ts` | Frontend runtime state store + `useRuntimeState()` hook |
 | `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -9,7 +9,7 @@ The repo keeps a shared semver source version across its release inputs, but CI 
 | Artifact | Where | Version source |
 |---|---|---|
 | nteract desktop app | GitHub Releases | `crates/notebook/tauri.conf.json` |
-| `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` |
+| `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` (package name `runt-cli`) |
 | `runtimed` daemon | Bundled in app + Python wheel | `crates/runtimed/Cargo.toml` |
 | `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
 | `nteract` Python package | PyPI | `python/nteract/pyproject.toml` |
@@ -147,6 +147,17 @@ Desktop version is computed as `{runt-cli version}-{suffix}.{timestamp}` where s
 ### Trusted Publishing
 
 PyPI publishing uses OIDC trusted publishing (no API tokens). The GitHub Actions workflow identity is registered as a trusted publisher on PyPI for the `runtimed` package. Both `release-common.yml` and `python-package.yml` use this.
+
+## Local Validation
+
+To exercise the release packaging path without tagging:
+
+```bash
+cargo xtask build-app   # build the .app bundle with icons
+cargo xtask build-dmg   # build the DMG used by stable/nightly releases (macOS only)
+```
+
+These produce the same artifacts CI publishes, minus signing/notarization. Useful when changing build dependencies, sidecar binaries, or `tauri.conf.json`.
 
 ## Checklist
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -108,17 +108,15 @@ cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
 
 When iterating on daemon code, you often want to test changes in the notebook app without rebuilding the frontend.
 
-**With nteract-dev supervisor** (if you have `up` / `down` / `status` MCP tools — e.g. in Zed or Claude Code):
+**With nteract-dev** (if you have `up` / `down` / `status` MCP tools — e.g. in Zed or Claude Code):
 
-The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
+`nteract-dev` manages the dev daemon for you. No env vars or extra terminals needed.
 
 - `up` — idempotent "bring the dev environment up". Ensures the daemon is running and the MCP child is healthy. Pass `vite=true` to also start Vite (health-probed), `rebuild=true` to rebuild the daemon binary + Python bindings first, `mode="debug"|"release"` to switch build mode.
 - `down` — stop the managed Vite dev server. Pass `daemon=true` to also stop the daemon.
 - `status` — read-only report (child, daemon, managed processes, build mode).
 - `logs` — tail the daemon log file.
 - `vite_logs` — tail the Vite dev server log file.
-
-The older `supervisor_*` names (`supervisor_restart`, `supervisor_rebuild`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`, `supervisor_status`, `supervisor_logs`, `supervisor_vite_logs`) still work as aliases.
 
 Then build and run the app normally:
 ```bash
@@ -127,7 +125,7 @@ cargo xtask build --rust-only     # Fast rebuild (reuses frontend assets)
 cargo xtask run                   # Run the bundled binary
 ```
 
-**Without supervisor** (manual two-terminal workflow):
+**Without nteract-dev** (manual two-terminal workflow):
 
 ```bash
 # Terminal 1: Run dev daemon (restart when you change daemon code)

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -74,13 +74,15 @@ Execution is CRDT-driven — the coordinator writes execution entries (with sour
 |-----------|---------|----------|
 | Unix socket | IPC endpoint | `~/Library/Caches/<cache_namespace>/runtimed.sock` (macOS) / `~/.cache/<cache_namespace>/runtimed.sock` (Linux) |
 | Lock file | Singleton guarantee | `~/Library/Caches/<cache_namespace>/daemon.lock` (macOS) / `~/.cache/<cache_namespace>/daemon.lock` (Linux) |
-| Info file | Discovery (PID, endpoint) | `~/Library/Caches/<cache_namespace>/daemon.json` (macOS) / `~/.cache/<cache_namespace>/daemon.json` (Linux) |
+| Info file (legacy) | Pre-socket discovery fallback | `~/Library/Caches/<cache_namespace>/daemon.json` (macOS) / `~/.cache/<cache_namespace>/daemon.json` (Linux) |
 | Environments | Prewarmed venvs | `~/Library/Caches/<cache_namespace>/envs/` (macOS) / `~/.cache/<cache_namespace>/envs/` (Linux) |
 | Blob store | Content-addressed outputs | `~/Library/Caches/<cache_namespace>/blobs/` (macOS) / `~/.cache/<cache_namespace>/blobs/` (Linux) |
 | Notebook docs | Persisted Automerge docs | `~/Library/Caches/<cache_namespace>/notebook-docs/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/` (Linux) |
 | Snapshots | Pre-delete safety copies | `~/Library/Caches/<cache_namespace>/notebook-docs/snapshots/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/snapshots/` (Linux) |
 
 `<cache_namespace>` is `runt` for stable builds and `runt-nightly` for nightly builds. Source builds default to nightly unless `RUNT_BUILD_CHANNEL=stable`.
+
+**Daemon discovery is socket-first.** Clients connect to the socket and send a `GetDaemonInfo` request; the daemon answers from live state. The on-disk `daemon.json` exists only as a fallback for older daemons that don't recognise the request — it will be removed once every daemon in the wild speaks `GetDaemonInfo`. New code should not depend on `daemon.json`. See `crates/runtimed-client/src/singleton.rs::query_daemon_info`.
 
 ## Development Workflow
 
@@ -437,8 +439,8 @@ python -c "import asyncio, runtimed; asyncio.run(runtimed.Client().ping())"
 
 ```bash
 # Check what's holding the lock
-cat ~/.cache/<cache_namespace>/daemon.json
 lsof ~/.cache/<cache_namespace>/daemon.lock
+./target/debug/runt daemon status --json   # asks the running daemon directly
 
 # If stale (crashed daemon), remove manually
 rm ~/.cache/<cache_namespace>/daemon.lock ~/.cache/<cache_namespace>/daemon.json
@@ -532,7 +534,7 @@ systemctl --user start runtimed.service
 | Installed binary | `~/Library/Application Support/<cache_namespace>/bin/<daemon_binary_basename>` |
 | Service config | `~/Library/LaunchAgents/<daemon_launchd_label>.plist` |
 | Socket | `~/Library/Caches/<cache_namespace>/runtimed.sock` |
-| Daemon info | `~/Library/Caches/<cache_namespace>/daemon.json` |
+| Daemon info (legacy fallback) | `~/Library/Caches/<cache_namespace>/daemon.json` |
 | Logs | `~/Library/Caches/<cache_namespace>/runtimed.log` |
 
 For stable, these expand to `runt`, `runtimed`, and `io.nteract.runtimed`. For nightly, they expand to `runt-nightly`, `runtimed-nightly`, and `io.nteract.runtimed.nightly`.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -97,11 +97,13 @@ See [Settings](settings.md) for how to change these defaults.
 
 When you open a notebook with dependencies for the first time, nteract Desktop may show a trust dialog asking you to approve the dependency installation. This happens because:
 
-- Dependencies are signed with a per-machine key
+- Dependencies are signed with a per-machine HMAC-SHA256 key
 - Notebooks from other machines (shared by a colleague, cloned from a repo) have a different signature
 - nteract Desktop asks you to verify the dependencies before installing anything
 
-After you approve, the notebook is re-signed with your machine's key and won't prompt again.
+After you approve, the notebook is re-signed with your machine's key and won't prompt again — unless the dependency list changes, which invalidates the signature and re-prompts.
+
+The key lives at `~/.config/runt/trust-key` (Linux), `~/Library/Application Support/runt/trust-key` (macOS), or the platform equivalent — file mode `0600`. It's created on first run and never sent off the machine.
 
 ## Cache and Cleanup
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -2,6 +2,8 @@
 
 The `runtimed` Python package provides programmatic access to the notebook daemon. Use it to execute code, manage kernels, and interact with notebooks from Python scripts, agents, or automation workflows.
 
+> **Looking for an MCP server?** `runt mcp` (Rust, shipped as a sidecar of the desktop app) is the canonical MCP path — you do not need Python or uv for it. The Python `nteract` package that launches `runt mcp` still ships, but these bindings are for programmatic use, not MCP integration.
+
 ## Installation
 
 ```bash

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -55,6 +55,10 @@ The notebook lives alongside a project file (`pyproject.toml`, `environment.yml`
 
 When you open a notebook with inline dependencies from another machine, nteract Desktop shows a trust dialog. This is a security measure — it prevents notebooks from silently installing arbitrary packages.
 
-The dialog shows what dependencies the notebook wants to install. After you approve, nteract Desktop signs the notebook with your machine's key and won't ask again for that notebook (unless the dependencies change).
+The dialog shows what dependencies the notebook wants to install. After you approve, nteract Desktop signs the notebook with your machine's HMAC-SHA256 key (stored at `~/.config/runt/trust-key` or the platform equivalent) and won't ask again for that notebook. Editing the dependency list invalidates the signature and re-prompts.
 
 Project-file-based environments (pyproject.toml, environment.yml, pixi.toml) don't trigger the trust dialog because the dependencies come from files you can inspect in the repository, not from embedded notebook metadata.
+
+## Notebook File Format
+
+Saved `.ipynb` files are standard Jupyter notebooks. Most outputs are inlined as base64 (the same as vanilla Jupyter), so any tool that reads `.ipynb` will see them. Large nteract-specific outputs like `application/vnd.apache.parquet` (the format Sift, the nteract dataframe viewer, uses to round-trip tabular data) are externalized as small blob references — the file stays small, and reopening the notebook in nteract Desktop rehydrates the data from the local blob store. Other tools see a placeholder MIME but still get the standard `text/html` and `text/plain` representations of the same output.


### PR DESCRIPTION
## Summary

Sweep of stale docs against the current code. Three commits, organized by area.

**Factual corrections (CLAUDE.md/AGENTS.md):**
- Workspace crates: 21 (was 17). Added `runt-mcp-proxy`, `nteract-predicate`, `sift-wasm`, `mcpb-runt`. Renamed the `runt` row to `runt-cli` (the actual package name).
- nteract MCP tools: 26 (was 27). Tool name is `launch_app` (was incorrectly listed as `show_notebook`, which is the internal handler). `clear_outputs` moved to Cell CRUD; `join_notebook` documented as a backward-compat alias.

**Terminology cleanup — drop "supervisor":**
- User-facing prose now says `nteract-dev` (the registered MCP server name) or names the actual tools (`up`, `down`, `status`, `logs`, `vite_logs`).
- The literal `mcp-supervisor` crate name is preserved where it refers to the actual Cargo package.
- Touched: `AGENTS.md`, `.claude/rules/mcp-servers.md`, `README.md`, `contributing/runtimed.md`, `contributing/development.md`, `.codex/skills/nteract-daemon-dev/{SKILL.md,references/daemon-workflows.md}`, `.codex/skills/nteract-python-bindings/references/bindings-workflows.md`, `.claude/skills/{python-bindings,diagnostics,frontend-dev,verify-changes,architecture-review}/SKILL.md`.

**Architecture/protocol updates:**
- `contributing/runtimed.md` + `contributing/protocol.md`: `daemon.json` is a legacy fallback for pre-`GetDaemonInfo` daemons; the socket is the source of truth. Added frame type `0x06 PoolStateSync` to the protocol frame table.
- `contributing/architecture.md`: nuanced the `isBinaryMime` story (the TS `looksLikeBinaryMime()` helper is a cold-start safety net, not a parallel implementation). Documented that `.ipynb` save inlines most outputs as base64 (vanilla Jupyter compat) and only externalizes a small whitelist (currently `application/vnd.apache.parquet`) as `BLOB_REF_MIME` entries.
- `contributing/frontend-architecture.md`: Lezer parsers replaced Prism for static highlighting (#1742).

**User-facing docs:**
- `docs/python-bindings.md`: `runt mcp` is the canonical MCP path (Rust sidecar). The Python `nteract` wrapper still ships but isn't required.
- `docs/sharing.md`, `docs/environments.md`: trust signing is HMAC-SHA256, key location named, and the new ipynb save shape (mostly base64 with parquet externalized) is documented.
- `contributing/releasing.md`: added a Local Validation section pointing at `cargo xtask build-app` / `build-dmg`. Did not add `install-daemon` — that's not a release path.

**Brand correction:**
- The dataframe viewer is "Sift" / the nteract dataframe viewer. The `nteract/dx` Python package is the helper that produces parquet payloads consumed by it (not "the dx viewer").

## Test plan

- [ ] CI passes (`cargo xtask lint` ran clean locally)
- [ ] Skim a few touched docs for any surviving "supervisor" prose: `grep -ri supervisor *.md contributing/ docs/ .claude/ .codex/`
- [ ] Verify the crate table in `AGENTS.md` matches `ls crates/`