### PR TITLE
fix(runt-mcp-proxy): declare type=object on reconnect tool inputSchema

### DIFF
--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -752,6 +752,12 @@ impl McpProxy {
 /// adds supervisor_* tools.
 impl ServerHandler for McpProxy {
     fn get_info(&self) -> ServerInfo {
+        // list_tools serves the cached tool set synchronously so the first
+        // client response is fast, then on_initialized spawns the child and
+        // fires tools/list_changed. Advertising listChanged tells the client
+        // to re-query when that notification arrives, so any drift between
+        // the cache and the live child (e.g. after a daemon upgrade) is
+        // reconciled without a reconnect.
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
@@ -764,6 +770,13 @@ impl ServerHandler for McpProxy {
             &self.config.server_name,
             env!("CARGO_PKG_VERSION"),
         ))
+        .with_instructions(
+            "nteract MCP server for Jupyter notebooks. \
+             Each connection has one active notebook session. \
+             Use list_active_notebooks to discover open notebooks, \
+             then open_notebook or create_notebook to set your active session. \
+             Calling these again switches your active session.",
+        )
     }
 
     async fn list_tools(
@@ -844,9 +857,8 @@ impl ServerHandler for McpProxy {
     }
 
     // Spawn the child only after the client has sent `notifications/initialized`.
-    // Per MCP spec, servers must not send notifications (tools/list_changed,
-    // resources/list_changed) before this point — Claude Code drops early ones,
-    // which leaves its tool list empty until a later refresh.
+    // Once the child is up, send tools/list_changed and resources/list_changed
+    // so the client re-queries and replaces the cached list with the live one.
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
         if self.state.read().await.child_client.is_some() {
             return;

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -875,14 +875,21 @@ const RECONNECT_TOOL_NAME: &str = "reconnect";
 /// Build the `reconnect` tool definition injected into the standalone
 /// `ServerHandler::list_tools` result.
 fn reconnect_tool() -> Tool {
-    let empty_schema: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    // Claude Code validates every tool's inputSchema as JSON Schema and rejects
+    // the entire tools/list response if any tool is missing `type: "object"`
+    // at the root — even for no-argument tools.
+    let mut schema: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    schema.insert(
+        "type".to_string(),
+        serde_json::Value::String("object".to_string()),
+    );
     Tool::new(
         RECONNECT_TOOL_NAME,
         "Restart the nteract MCP child process and reconnect to the daemon. \
          Use when tools are hanging, returning stale errors, or after a daemon \
          upgrade. Child-only — the daemon itself is managed by the installed \
          nteract app.",
-        empty_schema,
+        schema,
     )
 }
 
@@ -1440,6 +1447,11 @@ mod tests {
         assert!(
             desc.to_lowercase().contains("restart"),
             "reconnect tool description should mention restart: {desc}"
+        );
+        assert_eq!(
+            tool.input_schema.get("type").and_then(|v| v.as_str()),
+            Some("object"),
+            "reconnect tool inputSchema must declare type=object for Claude Code"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `type: "object"` to the `reconnect` tool's `inputSchema` root. Claude Code validates every tool's schema as strict JSON Schema and was rejecting the entire `tools/list` response because this one tool shipped an empty schema — the user-visible symptom was an empty nteract tool list in Claude Code.
- Wire `with_instructions(...)` into `get_info()` so MCP clients know the nteract session model up front (one active notebook per connection, `list_active_notebooks` → `open_notebook`/`create_notebook` to switch).
- Clarify comments around `get_info` / `on_initialized` to describe the cache→refresh flow (cached tools served synchronously for a fast first response, then `tools/list_changed` fires after the child is up so the client re-queries and replaces the cached list with the live one).

## Test plan

- [x] `cargo test -p runt-mcp-proxy --lib` — all 94 tests pass, including the new `reconnect tool inputSchema must declare type=object for Claude Code` assertion
- [x] `cargo xtask lint` clean
- [ ] Manual verification in Claude Code: tool list appears on first connection (previously empty)
- [ ] Manual verification that the reconnect tool is callable end-to-end after a daemon upgrade