### PR TITLE
refactor(runt-proxy): rename mcpb-runt to runt-proxy

### DIFF
--- a/.claude/plugins/nteract/.mcp.json
+++ b/.claude/plugins/nteract/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "nteract": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-mcpb-runt",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-runt-proxy",
       "args": [],
       "env": {
         "NTERACT_CHANNEL": "stable"

--- a/.claude/plugins/nteract/bin/nteract-runt-proxy
+++ b/.claude/plugins/nteract/bin/nteract-runt-proxy
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 channel="${NTERACT_CHANNEL:-stable}"
-binary_name="mcpb-runt"
+binary_name="runt-proxy"
 
 if [[ "$channel" == "nightly" ]]; then
   app_names=("nteract Nightly" "nteract-nightly" "nteract (Nightly)" "nteract")
@@ -29,7 +29,7 @@ case "$(uname -s)" in
     ;;
   MINGW*|MSYS*|CYGWIN*)
     local_app_data="${LOCALAPPDATA:-${HOME}/AppData/Local}"
-    binary_name="mcpb-runt.exe"
+    binary_name="runt-proxy.exe"
     for app_name in "${app_names[@]}"; do
       candidate_paths+=("${local_app_data}/${app_name}/${binary_name}")
       candidate_paths+=("${local_app_data}/Programs/${app_name}/${binary_name}")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,17 +271,17 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-            cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
+            cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-            cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
+            cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
           fi
 
       - name: Check tool caches are up to date
@@ -303,10 +303,10 @@ jobs:
           path: |
             target/release/runtimed
             target/release/runt
-            target/release/mcpb-runt
+            target/release/runt-proxy
             crates/notebook/binaries/runtimed-*
             crates/notebook/binaries/runt-*
-            crates/notebook/binaries/mcpb-runt-*
+            crates/notebook/binaries/runt-proxy-*
           retention-days: 1
 
       - name: Build Tauri E2E app
@@ -317,7 +317,7 @@ jobs:
           mkdir -p target/release/binaries
           cp crates/notebook/binaries/runtimed-* target/release/binaries/
           cp crates/notebook/binaries/runt-* target/release/binaries/
-          cp crates/notebook/binaries/mcpb-runt-* target/release/binaries/
+          cp crates/notebook/binaries/runt-proxy-* target/release/binaries/
 
       - name: Upload E2E app
         uses: actions/upload-artifact@v4
@@ -448,17 +448,17 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-            cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
+            cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-            cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
+            cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
           fi
 
       - name: Clippy

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -167,23 +167,23 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
 
           mkdir -p crates/notebook/binaries target/release/binaries
 
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
+          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
           cp target/release/runtimed "target/release/binaries/runtimed-$TARGET"
           cp target/release/runt "target/release/binaries/runt-$TARGET"
-          cp target/release/mcpb-runt "target/release/binaries/mcpb-runt-$TARGET"
+          cp target/release/runt-proxy "target/release/binaries/runt-proxy-$TARGET"
 
       - name: Build external binaries (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           $target = (rustc --print host-tuple).Trim()
 
           New-Item -ItemType Directory -Force crates/notebook/binaries | Out-Null
@@ -191,10 +191,10 @@ jobs:
 
           Copy-Item target/release/runtimed.exe "crates/notebook/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "crates/notebook/binaries/runt-$target.exe"
-          Copy-Item target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$target.exe"
+          Copy-Item target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$target.exe"
           Copy-Item target/release/runtimed.exe "target/release/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "target/release/binaries/runt-$target.exe"
-          Copy-Item target/release/mcpb-runt.exe "target/release/binaries/mcpb-runt-$target.exe"
+          Copy-Item target/release/runt-proxy.exe "target/release/binaries/runt-proxy-$target.exe"
 
       - name: Build notebook app (no bundle)
         working-directory: crates/notebook

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -291,12 +291,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
+          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -438,12 +438,12 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
           cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-          cp target/release/mcpb-runt.exe "crates/notebook/binaries/mcpb-runt-$TARGET.exe"
+          cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -562,12 +562,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p mcpb-runt
+          cargo build --release -p runtimed -p runt-cli -p runt-proxy
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/mcpb-runt "crates/notebook/binaries/mcpb-runt-$TARGET"
+          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs Sift (the `@nteract/sift` viewer; `nteract/dx` is the Python sender) |
 | `sift-wasm` | WASM bindings for `nteract-predicate` — used by `@nteract/sift` |
 | `mcp-supervisor` | `nteract-dev` MCP server — proxies `runt mcp` and adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) |
-| `mcpb-runt` | MCPB binary — resilient proxy for `runt mcp` shipped in the `.mcpb` Claude Desktop extension |
+| `runt-proxy` | Resilient MCP proxy for `runt mcp` — shipped as a sidecar in the nteract desktop app and inside the `.mcpb` Claude Desktop extension |
 | `xtask` | Build system orchestration |
 
 ## Build System (`cargo xtask`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,20 +4092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mcpb-runt"
-version = "0.1.0"
-dependencies = [
- "dirs",
- "rmcp",
- "runt-mcp-proxy",
- "runt-workspace",
- "runtimed-client",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6851,6 +6837,20 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "runt-proxy"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "rmcp",
+ "runt-mcp-proxy",
+ "runt-workspace",
+ "runtimed-client",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
     "crates/mcp-supervisor",
     "crates/runt-mcp",
     "crates/runt-mcp-proxy",
-    "crates/mcpb-runt",
+    "crates/runt-proxy",
     "crates/repr-llm",
     "crates/nteract-predicate",
     "crates/sift-wasm",

--- a/crates/notebook/binaries/.gitignore
+++ b/crates/notebook/binaries/.gitignore
@@ -1,4 +1,3 @@
 # Ignore all external binaries (built by xtask)
 runtimed-*
 runt-*
-mcpb-runt-*

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -42,7 +42,7 @@ fn maybe_disable_external_bin_for_local_checks() {
     let expected_sidecars = [
         target_sidecar_path(&manifest_dir, &target, "runtimed"),
         target_sidecar_path(&manifest_dir, &target, "runt"),
-        target_sidecar_path(&manifest_dir, &target, "mcpb-runt"),
+        target_sidecar_path(&manifest_dir, &target, "runt-proxy"),
     ];
 
     for path in &expected_sidecars {

--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -1,7 +1,7 @@
 //! Build and install the nteract .mcpb (Claude Desktop extension) from the running app.
 //!
 //! Creates a `.mcpb` ZIP archive at runtime from embedded assets (manifest,
-//! icons, mcpb-runt binary), then opens it with the system handler so Claude
+//! icons, runt-proxy binary), then opens it with the system handler so Claude
 //! Desktop shows the install prompt.
 
 use std::fs;
@@ -57,14 +57,14 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         "license": "BSD-3-Clause",
         "server": {
             "type": "binary",
-            "entry_point": "server/mcpb-runt",
+            "entry_point": "server/runt-proxy",
             "mcp_config": {
-                "command": "${__dirname}/server/mcpb-runt",
+                "command": "${__dirname}/server/runt-proxy",
                 "args": [],
                 "env": { "NTERACT_CHANNEL": channel },
                 "platform_overrides": {
                     "win32": {
-                        "command": "${__dirname}/server/mcpb-runt.exe"
+                        "command": "${__dirname}/server/runt-proxy.exe"
                     }
                 }
             }
@@ -126,22 +126,22 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         format!("Failed to write manifest.json: {e}")
     })?;
 
-    // ── 4. Copy mcpb-runt binary from app sidecar ──────────────────────
+    // ── 4. Copy runt-proxy binary from app sidecar ─────────────────────
     let server_dir = staging.join("server");
     fs::create_dir_all(&server_dir).map_err(|e| {
         cleanup();
         format!("Failed to create server directory: {e}")
     })?;
 
-    let mcpb_runt_binary = get_bundled_mcpb_runt(app)?;
+    let runt_proxy_binary = get_bundled_runt_proxy(app)?;
     let binary_name = if cfg!(target_os = "windows") {
-        "mcpb-runt.exe"
+        "runt-proxy.exe"
     } else {
-        "mcpb-runt"
+        "runt-proxy"
     };
-    fs::copy(&mcpb_runt_binary, server_dir.join(binary_name)).map_err(|e| {
+    fs::copy(&runt_proxy_binary, server_dir.join(binary_name)).map_err(|e| {
         cleanup();
-        format!("Failed to copy mcpb-runt binary: {e}")
+        format!("Failed to copy runt-proxy binary: {e}")
     })?;
 
     // ── 5. Write icons (pre-sized 512x512, no runtime resize needed) ──
@@ -225,14 +225,14 @@ fn cli_on_path(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Find the bundled `mcpb-runt` binary in the app's sidecar directory.
-fn get_bundled_mcpb_runt(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+/// Find the bundled `runt-proxy` binary in the app's sidecar directory.
+fn get_bundled_runt_proxy(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     use tauri::Manager;
 
     let binary_name = if cfg!(target_os = "windows") {
-        "mcpb-runt.exe"
+        "runt-proxy.exe"
     } else {
-        "mcpb-runt"
+        "runt-proxy"
     };
 
     // Try the Tauri resource directory (where sidecars are bundled)
@@ -254,7 +254,7 @@ fn get_bundled_mcpb_runt(app: &tauri::AppHandle) -> Result<PathBuf, String> {
             return Ok(candidate);
         }
 
-        // macOS: Contents/MacOS/mcpb-runt
+        // macOS: Contents/MacOS/runt-proxy
         #[cfg(target_os = "macos")]
         {
             let candidate = exe_dir.join(binary_name);
@@ -264,8 +264,8 @@ fn get_bundled_mcpb_runt(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         }
     }
 
-    Err("mcpb-runt binary not found in app bundle. \
-         The app may need to be rebuilt with mcpb-runt as a sidecar."
+    Err("runt-proxy binary not found in app bundle. \
+         The app may need to be rebuilt with runt-proxy as a sidecar."
         .to_string())
 }
 

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -18,7 +18,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "externalBin": ["binaries/runtimed", "binaries/runt", "binaries/mcpb-runt"],
+    "externalBin": ["binaries/runtimed", "binaries/runt", "binaries/runt-proxy"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -4,7 +4,7 @@
 //! forwards MCP tools/resources, and handles transparent restart on child death.
 //!
 //! Used by:
-//! - `mcpb-runt` — lightweight MCPB binary for Claude Desktop
+//! - `runt-proxy` — shipped as a sidecar in the nteract app and inside the `.mcpb` Claude Desktop extension
 //! - `mcp-supervisor` — dev environment MCP proxy with file watching and build management
 
 pub mod child;

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1,7 +1,7 @@
 //! Core MCP proxy — spawns a child, forwards tools/resources, handles restarts.
 //!
 //! The `McpProxy` struct manages the child process lifecycle and provides the
-//! core forwarding logic. It can be used standalone (by `mcpb-runt`) or wrapped
+//! core forwarding logic. It can be used standalone (by `runt-proxy`) or wrapped
 //! by `mcp-supervisor` which adds dev-specific tools and file watching.
 
 use std::collections::HashMap;
@@ -337,7 +337,7 @@ impl McpProxy {
                                  Exiting so the MCP client can restart with the new tool set."
                             );
                             state.should_exit = true;
-                            // Signal the exit so mcpb-runt can shut down
+                            // Signal the exit so runt-proxy can shut down
                             self.exit_signal.notify_waiters();
                         }
                     }
@@ -744,10 +744,10 @@ impl McpProxy {
 }
 
 // ---------------------------------------------------------------------------
-// ServerHandler — used when McpProxy is the top-level MCP server (mcpb-runt)
+// ServerHandler — used when McpProxy is the top-level MCP server (runt-proxy)
 // ---------------------------------------------------------------------------
 
-/// Standalone ServerHandler for `McpProxy`. Used by `mcpb-runt` where the proxy
+/// Standalone ServerHandler for `McpProxy`. Used by `runt-proxy` where the proxy
 /// IS the MCP server. The supervisor wraps this with its own ServerHandler that
 /// adds supervisor_* tools.
 impl ServerHandler for McpProxy {

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -43,7 +43,7 @@ pub fn load_cached_tools(cache_dir: &Path) -> Option<Vec<Tool>> {
 }
 
 /// Load the built-in tool cache (compiled into the binary).
-/// Used when no cache_dir is configured (e.g., mcpb-runt).
+/// Used when no cache_dir is configured (e.g., runt-proxy).
 pub fn load_builtin_tools() -> Option<Vec<Tool>> {
     match serde_json::from_str::<Vec<Tool>>(BUILTIN_TOOL_CACHE) {
         Ok(tools) => {

--- a/crates/runt-proxy/Cargo.toml
+++ b/crates/runt-proxy/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "mcpb-runt"
+name = "runt-proxy"
 version = "0.1.0"
 edition.workspace = true
-description = "MCPB binary — resilient MCP proxy for runt mcp, ships in the .mcpb Claude Desktop extension"
+description = "Resilient MCP proxy for runt mcp. Ships as a sidecar in the nteract desktop app and inside the .mcpb Claude Desktop extension."
 repository.workspace = true
 license.workspace = true
 publish = false
 
 [[bin]]
-name = "mcpb-runt"
+name = "runt-proxy"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/runt-proxy/src/main.rs
+++ b/crates/runt-proxy/src/main.rs
@@ -1,7 +1,8 @@
-//! mcpb-runt — resilient MCP proxy for the nteract MCPB bundle.
+//! runt-proxy — resilient MCP proxy for `runt mcp`.
 //!
-//! Ships inside the `.mcpb` archive. Finds `runt` via `runt-workspace`,
-//! spawns `runt mcp` as a child, and proxies MCP over stdio with transparent
+//! Ships as a sidecar in the nteract desktop app and inside the `.mcpb`
+//! Claude Desktop extension. Finds `runt` via `runt-workspace`, spawns
+//! `runt mcp` as a child, and proxies MCP over stdio with transparent
 //! restart on child death (daemon upgrade, crash, etc.).
 
 use std::collections::HashMap;
@@ -139,7 +140,7 @@ async fn main() -> ExitCode {
     let binary_name = runt_workspace::cli_command_name();
 
     info!(
-        "mcpb-runt starting (channel={channel}, compiled={})",
+        "runt-proxy starting (channel={channel}, compiled={})",
         runt_workspace::channel_display_name()
     );
     if channel != runt_workspace::channel_display_name() {
@@ -187,7 +188,7 @@ async fn main() -> ExitCode {
         child_env,
         server_name: runt_workspace::desktop_product_name().to_string(),
         cache_dir: dirs::cache_dir().map(|d| {
-            let dir = d.join(runt_workspace::cache_namespace()).join("mcpb");
+            let dir = d.join(runt_workspace::cache_namespace()).join("proxy");
             let _ = std::fs::create_dir_all(&dir);
             dir
         }),

--- a/crates/runtimed-client/src/daemon_connection.rs
+++ b/crates/runtimed-client/src/daemon_connection.rs
@@ -8,7 +8,7 @@
 //! ground truth that the cached info is still valid.
 //!
 //! This supersedes per-lookup [`query_daemon_info`](crate::singleton::query_daemon_info)
-//! for long-running consumers (Tauri app, mcpb-runt, runt-mcp-proxy). One-
+//! for long-running consumers (Tauri app, runt-proxy, runt-mcp-proxy). One-
 //! shot CLI callers (e.g. `runt daemon status`) continue to use the
 //! existing helper.
 //!

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -750,7 +750,7 @@ impl Daemon {
 
         // Write `daemon.json` so older clients can still discover us.
         // Retained as a one-release compatibility shim for stale
-        // `runt-mcp` / `mcpb-runt` proxies that predate `GetDaemonInfo`.
+        // `runt-mcp` / `runt-proxy` proxies that predate `GetDaemonInfo`.
         // New consumers go through the socket (see
         // `runtimed_client::daemon_connection`). Target v2.4 for removal.
         if let Err(e) = self

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -729,7 +729,7 @@ fn cmd_build(rust_only: bool) {
     // anyway. By excluding notebook here, we still pre-warm the entire
     // dependency tree (all shared crates are built via the other targets),
     // and Phase 3 only needs to compile notebook + link.
-    println!("Building Rust targets (runtimed, runt, mcpb-runt, mcp-supervisor)...");
+    println!("Building Rust targets (runtimed, runt, runt-proxy, mcp-supervisor)...");
     run_cmd(
         "cargo",
         &[
@@ -739,7 +739,7 @@ fn cmd_build(rust_only: bool) {
             "-p",
             "runt-cli",
             "-p",
-            "mcpb-runt",
+            "runt-proxy",
             "-p",
             "mcp-supervisor",
         ],
@@ -748,7 +748,7 @@ fn cmd_build(rust_only: bool) {
     // Copy sidecar binaries for Tauri bundling
     copy_sidecar_binary("runtimed", false);
     copy_sidecar_binary("runt", false);
-    copy_sidecar_binary("mcpb-runt", false);
+    copy_sidecar_binary("runt-proxy", false);
 
     // Wait for pnpm install before starting frontend build
     if let Some(handle) = pnpm_handle {
@@ -2220,7 +2220,7 @@ fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
 fn build_runtimed_daemon(release: bool) {
     build_external_binary("runtimed", "runtimed", release);
     build_external_binary("runt-cli", "runt", release);
-    build_external_binary("mcpb-runt", "mcpb-runt", release);
+    build_external_binary("runt-proxy", "runt-proxy", release);
 }
 
 /// Build a binary and copy to binaries/ with target triple suffix for Tauri bundling.
@@ -2619,30 +2619,30 @@ fn cmd_mcpb(output: Option<&str>, variant: &str) {
     let dark_dest = staging_dir.join("icon-dark.png");
     resize_icon(dark_actual, &dark_dest.to_string_lossy());
 
-    // ── 4. Build and copy mcpb-runt binary ──────────────────────────────────
+    // ── 4. Build and copy runt-proxy binary ─────────────────────────────────
     // Set RUNT_BUILD_CHANNEL so the binary knows its channel at compile time.
     let build_channel = match variant {
         "stable" => "stable",
         _ => "nightly",
     };
-    println!("Building mcpb-runt (release, channel={build_channel})...");
+    println!("Building runt-proxy (release, channel={build_channel})...");
     let mut build_cmd = Command::new("cargo");
-    build_cmd.args(["build", "-p", "mcpb-runt", "--release"]);
+    build_cmd.args(["build", "-p", "runt-proxy", "--release"]);
     build_cmd.env("RUNT_BUILD_CHANNEL", build_channel);
     let build_status = build_cmd.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run cargo build -p mcpb-runt: {e}");
+        eprintln!("Failed to run cargo build -p runt-proxy: {e}");
         exit(1);
     });
     if !build_status.success() {
-        eprintln!("cargo build -p mcpb-runt --release failed");
+        eprintln!("cargo build -p runt-proxy --release failed");
         let _ = fs::remove_dir_all(&staging_dir);
         exit(1);
     }
 
     let binary_name = if cfg!(target_os = "windows") {
-        "mcpb-runt.exe"
+        "runt-proxy.exe"
     } else {
-        "mcpb-runt"
+        "runt-proxy"
     };
     let built_binary = Path::new("target/release").join(binary_name);
     if !built_binary.exists() {
@@ -2657,7 +2657,7 @@ fn cmd_mcpb(output: Option<&str>, variant: &str) {
         exit(1);
     });
     fs::copy(&built_binary, server_dir.join(binary_name)).unwrap_or_else(|e| {
-        eprintln!("Failed to copy mcpb-runt binary: {e}");
+        eprintln!("Failed to copy runt-proxy binary: {e}");
         exit(1);
     });
 

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -43,16 +43,16 @@
     "url": "https://github.com/nteract/desktop"
   },
   "server": {
-    "entry_point": "server/mcpb-runt",
+    "entry_point": "server/runt-proxy",
     "mcp_config": {
       "args": [],
-      "command": "${__dirname}/server/mcpb-runt",
+      "command": "${__dirname}/server/runt-proxy",
       "env": {
         "NTERACT_CHANNEL": "nightly"
       },
       "platform_overrides": {
         "win32": {
-          "command": "${__dirname}/server/mcpb-runt.exe"
+          "command": "${__dirname}/server/runt-proxy.exe"
         }
       }
     },

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -43,16 +43,16 @@
     "url": "https://github.com/nteract/desktop"
   },
   "server": {
-    "entry_point": "server/mcpb-runt",
+    "entry_point": "server/runt-proxy",
     "mcp_config": {
       "args": [],
-      "command": "${__dirname}/server/mcpb-runt",
+      "command": "${__dirname}/server/runt-proxy",
       "env": {
         "NTERACT_CHANNEL": "stable"
       },
       "platform_overrides": {
         "win32": {
-          "command": "${__dirname}/server/mcpb-runt.exe"
+          "command": "${__dirname}/server/runt-proxy.exe"
         }
       }
     },

--- a/plugins/nteract/.mcp.json
+++ b/plugins/nteract/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "nteract": {
-      "command": "./bin/nteract-mcpb-runt",
+      "command": "./bin/nteract-runt-proxy",
       "args": [],
       "env": {
         "NTERACT_CHANNEL": "stable"

--- a/plugins/nteract/bin/nteract-runt-proxy
+++ b/plugins/nteract/bin/nteract-runt-proxy
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 channel="${NTERACT_CHANNEL:-stable}"
-binary_name="mcpb-runt"
+binary_name="runt-proxy"
 
 if [[ "$channel" == "nightly" ]]; then
   app_names=("nteract Nightly" "nteract-nightly" "nteract (Nightly)" "nteract")
@@ -29,7 +29,7 @@ case "$(uname -s)" in
     ;;
   MINGW*|MSYS*|CYGWIN*)
     local_app_data="${LOCALAPPDATA:-${HOME}/AppData/Local}"
-    binary_name="mcpb-runt.exe"
+    binary_name="runt-proxy.exe"
     for app_name in "${app_names[@]}"; do
       candidate_paths+=("${local_app_data}/${app_name}/${binary_name}")
       candidate_paths+=("${local_app_data}/Programs/${app_name}/${binary_name}")


### PR DESCRIPTION
## Summary

Rename the `mcpb-runt` crate/binary to `runt-proxy`. Previously named after the `.mcpb` file format it shipped inside — a coupling that was misleading:

- The proxy is a general-purpose supervisor around `runt mcp`
- It ships as a **Tauri sidecar in the nteract desktop app** as well as inside the `.mcpb` Claude Desktop extension
- "mcpb" leaks Anthropic's format name into our crate namespace

## What changed

- **Crate**: `crates/mcpb-runt/` → `crates/runt-proxy/` (directory, `Cargo.toml` package + bin names, description)
- **Workspace member**: `Cargo.toml`
- **Tauri sidecar**: `tauri.conf.json` `externalBin` + `notebook/build.rs` + `notebook/binaries/.gitignore` (covered by existing `runt-*` glob)
- **Bundle installer**: `notebook/src/mcpb_install.rs` now copies `server/runt-proxy` (function renamed to `get_bundled_runt_proxy`)
- **MCPB manifests**: `mcpb/manifest.{stable,nightly}.json` `entry_point` + `command` paths
- **xtask**: build/copy calls in `cargo xtask build-app` and `cargo xtask mcpb`
- **CI**: `build.yml`, `release-common.yml`, `pr-binary-generation.yml` (18 references across macOS / Windows / Linux steps)
- **Plugin launchers**: `plugins/nteract/bin/nteract-mcpb-runt` → `nteract-runt-proxy` (+ same under `.claude/plugins/`) plus the `command` path in each `.mcp.json`
- **Doc comments**: `runt-mcp-proxy/{lib,proxy,tools}.rs`, `runtimed/daemon.rs`, `runtimed-client/daemon_connection.rs`
- **Docs**: `AGENTS.md` crate table (CLAUDE.md is a symlink to AGENTS.md)
- **Cache subdir**: `<cache>/runt*/mcpb/` → `<cache>/runt*/proxy/` (named after the binary; existing installs re-cache on first run — no user-visible breakage)

## What did NOT change

These refer to the Anthropic file format, not our binary:

- `.mcpb` file extension
- `mcpb/` manifest directory
- `crates/notebook/src/mcpb_install.rs` file name (it installs the `.mcpb` *bundle*)
- `cargo xtask mcpb` subcommand

## Test plan

- [x] `cargo build -p runt-proxy -p runt-mcp-proxy -p mcp-supervisor -p runtimed` — clean
- [x] `cargo test -p runt-mcp-proxy --lib` — all 94 tests pass
- [x] `cargo check -p notebook` — clean (Tauri sidecar wiring compiles)
- [x] `cargo xtask lint` — clean
- [ ] CI green (build.yml, release-common.yml artifacts upload with new names)
- [ ] Manual: `cargo xtask mcpb` produces a valid `.mcpb` archive containing `server/runt-proxy`
- [ ] Manual: after a fresh bundle install, Claude Desktop invokes `runt-proxy` and the nteract tools appear

## Migration notes for existing installs

- Claude Desktop users who already installed the `.mcpb` extension keep working with the old `mcpb-runt` binary packaged inside that older bundle. Reinstalling the extension (triggered from the nteract app) swaps in a new bundle with `runt-proxy`.
- Codex/Claude plugin users: `.mcp.json` command path changed from `./bin/nteract-mcpb-runt` to `./bin/nteract-runt-proxy`. Reinstalling the plugin picks up both changes atomically.

Depends on #1848 (merged).