### PR TITLE
feat(xtask): add install-nightly for headless Linux first-install

### DIFF
--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -10,7 +10,7 @@ description: Develop, debug, and manage the runtimed daemon. Use when working on
 | Task | Command |
 |------|---------|
 | Start dev daemon | `cargo xtask dev-daemon` |
-| Install system daemon | `cargo xtask install-daemon` |
+| Install nightly (Linux/headless only) | `cargo xtask install-nightly` |
 | Check status | `./target/debug/runt daemon status` |
 | Check status (JSON) | `./target/debug/runt daemon status --json` |
 | Tail logs | `./target/debug/runt daemon logs -f` |
@@ -41,15 +41,17 @@ The daemon (`runtimed`) is a singleton process that communicates with notebook w
 
 The notebook app auto-connects to or starts the daemon. If unavailable, falls back to in-process prewarming.
 
-### Install from source
+### Install from source (Linux / headless)
 
-When you change daemon code and want the system service to pick it up:
+When you change daemon code and want the system service to pick it up on a cloud box or headless Linux machine:
 
 ```bash
-cargo xtask install-daemon
+cargo xtask install-nightly
 ```
 
-Builds release, stops old service, replaces binary, restarts. Verify: `cat ~/.cache/runt/daemon.json`.
+Builds runtimed + runt + runt-proxy (release), installs them to `~/.local/share/runt-nightly/bin/` with channel-suffixed names, writes + starts the systemd user unit on first install, upgrades in place on subsequent runs. On macOS it refuses by default — use the nteract Nightly app (it auto-updates). Pass `--on-macos` to override, `--replace-installed-app` if an app bundle is already present.
+
+Verify: `runt-nightly daemon status` or `cat ~/.cache/runt-nightly/daemon.json`.
 
 ### Fast iteration
 
@@ -272,7 +274,7 @@ Check that uv/conda are installed and working.
 **Never** use `pkill runtimed`, `killall runtimed`, or similar. These kill ALL runtimed processes system-wide, disrupting other agents and worktrees. Use:
 
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
-- `cargo xtask install-daemon` — gracefully reinstalls the system daemon
+- `cargo xtask install-nightly` — gracefully installs/reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
 
 ## Shipped App Behavior
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -193,8 +193,9 @@ The repo includes `.zed/tasks.json` with pre-configured tasks (use cmd-shift-t):
 
 **Daemon code changes not taking effect:**
 1. In dev mode: restart `cargo xtask dev-daemon`
-2. In production mode: run `cargo xtask install-daemon`
-3. Check which daemon: `./target/debug/runt daemon status`
+2. In production mode on macOS: reinstall the nteract Nightly .app (it auto-updates its daemon)
+3. In production mode on Linux / headless: run `cargo xtask install-nightly`
+4. Check which daemon: `./target/debug/runt daemon status`
 
 **App says "Dev daemon not running":**
 - You're in dev mode but haven't started the dev daemon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,10 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 **Critical:** The `env -i` wrapper on nteract-nightly and nteract is required to prevent direnv's env vars from leaking into these MCP servers. Without it, they will incorrectly connect to the dev daemon instead of the system daemon.
 
 **This system's nightly installation:**
-- Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly}`
-- Symlink: `/usr/local/bin/runt-nightly` → `~/.local/share/runt-nightly/bin/runt-nightly`
+- Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly,runt-proxy-nightly}`
+- Symlinks: `/usr/local/bin/{runtimed-nightly,runt-nightly,runt-proxy-nightly}` → the install dir
 - Daemon socket: `~/.cache/runt-nightly/runtimed.sock`
-- Install command: `cargo xtask build --release && cargo xtask install-daemon --channel nightly`
+- Install command: `cargo xtask install-nightly` (refuses on macOS and when an app bundle is installed — see § `install-nightly` below)
 - Version: Built from source, updated after each PR merge
 
 **Verification steps:** See `.claude/rules/mcp-servers.md` § Verifying Daemon Isolation.
@@ -409,7 +409,7 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask build-dmg` | Build a DMG bundle (CI/release packaging) |
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
 | | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
-| | `cargo xtask install-daemon` | Install runtimed as system daemon |
+| | `cargo xtask install-nightly` | Install runtimed + runt + runt-proxy as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
 | MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask dev-mcp` | Direct `runt mcp` (no proxy, no auto-restart) |
@@ -433,7 +433,7 @@ The daemon is a separate process from the notebook app. When you change code in 
 
 Use instead:
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
-- `cargo xtask install-daemon` — gracefully reinstalls the system daemon
+- `cargo xtask install-nightly` — gracefully installs or reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
 
 ### Per-Worktree Daemon Isolation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10874,6 +10874,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "runt-workspace",
+ "runtimed-client",
  "serde_json",
 ]
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo xtask dev
 | Lint (check) | `cargo xtask lint` | Check formatting and linting across Rust, JS/TS, Python |
 | Lint (fix) | `cargo xtask lint --fix` | Auto-fix formatting and linting |
 | Dev daemon | `cargo xtask dev-daemon` | Run per-worktree dev daemon |
-| Install daemon | `cargo xtask install-daemon` | Install daemon into the running service |
+| Install nightly (Linux/headless) | `cargo xtask install-nightly` | Build + install runtimed + runt + runt-proxy as the local nightly. Refuses on macOS and when an app bundle is installed. |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
 | Generate icons | `cargo xtask icons [source.png]` | Generate icon variants from source image |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -234,12 +234,15 @@ When you need to test the full production flow (daemon auto-install, upgrades, e
 unset RUNTIMED_DEV
 unset RUNTIMED_WORKSPACE_PATH
 
-# Rebuild and reinstall system daemon
-cargo xtask install-daemon
+# On macOS: install the nteract Nightly .app and let SMAppService manage the daemon.
+# On Linux / headless: rebuild and reinstall the full nightly stack from source:
+cargo xtask install-nightly
 
-# Run the app (it will connect to system daemon)
+# Run the app (it will connect to the system daemon)
 cargo xtask notebook
 ```
+
+Note: `cargo xtask install-nightly` refuses on macOS by default (the app bundle manages the daemon itself). Pass `--on-macos` if you really need to install out-of-bundle binaries, and `--replace-installed-app` if an app bundle is already present.
 
 ### Daemon logs
 
@@ -258,8 +261,9 @@ runt daemon logs -f | grep -i "kernel\|auto-detect"
 
 If your daemon code changes aren't taking effect:
 1. **In dev mode:** Did you restart `cargo xtask dev-daemon`?
-2. **In production mode:** Did you run `cargo xtask install-daemon`?
-3. Check which daemon is running: `runt daemon status`
+2. **In production mode (macOS):** Re-install the nteract Nightly .app (it auto-updates the bundled daemon).
+3. **In production mode (Linux / headless):** Did you run `cargo xtask install-nightly`?
+4. Check which daemon is running: `runt daemon status`
 
 If the app says "Dev daemon not running":
 - You're in dev mode but haven't started the dev daemon

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -6,7 +6,7 @@ The runtime daemon manages prewarmed Python environments, notebook document sync
 
 | Task | Command |
 |------|---------|
-| Install daemon from source | `cargo xtask install-daemon` |
+| Install nightly from source (Linux/headless) | `cargo xtask install-nightly` |
 | Run daemon | `cargo run -p runtimed` |
 | Run with debug logs | `RUST_LOG=debug cargo run -p runtimed` |
 | Check status | `cargo run -p runt-cli -- daemon status` |
@@ -92,19 +92,25 @@ The notebook app automatically connects to or starts the daemon on launch. The d
 
 The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `crates/notebook/src/lib.rs`) which takes a `tauri::AppHandle` and a progress callback to start and connect to the daemon.
 
-### Install daemon from source
+### Install the nightly stack from source (Linux / headless)
 
-When you change daemon code and want the installed service to pick it up:
+On Linux cloud boxes and headless dev environments:
 
 ```bash
-cargo xtask install-daemon
+cargo xtask install-nightly
 ```
 
-This builds runtimed in release mode, stops the running service, replaces the binary, and restarts it. You can verify the version with:
+This builds `runtimed`, `runt`, and `runt-proxy` in release mode and installs all three into `~/.local/share/runt-nightly/bin/` with channel-suffixed names (`runtimed-nightly`, `runt-nightly`, `runt-proxy-nightly`). On first run it writes the systemd user unit and starts it; on subsequent runs it upgrades in place. After the initial install the command prints the follow-up `sudo ln -sf` symlink commands for `/usr/local/bin/` and the `sudo loginctl enable-linger` step that keeps the user service alive across logout.
+
+It refuses by default on macOS (the desktop app manages its own daemon via SMAppService — reinstalling from source out of the app bundle is a footgun) and when an nteract app bundle is already installed on any platform. Override respectively with `--on-macos` and `--replace-installed-app` if you really mean it.
+
+Verify the running version with:
 
 ```bash
 cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
 ```
+
+For per-worktree daemon development (no system install involved), use `cargo xtask dev-daemon` instead — it runs the daemon out of the worktree with per-worktree socket isolation and no service files.
 
 ### Fast iteration: Daemon + bundled notebook
 

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -96,6 +96,13 @@ pub fn cli_command_name_for(channel: BuildChannel) -> &'static str {
     }
 }
 
+pub fn proxy_binary_basename_for(channel: BuildChannel) -> &'static str {
+    match channel {
+        BuildChannel::Stable => "runt-proxy",
+        BuildChannel::Nightly => "runt-proxy-nightly",
+    }
+}
+
 fn cli_notebook_alias_name_for(channel: BuildChannel) -> &'static str {
     match channel {
         BuildChannel::Stable => "nb",
@@ -141,6 +148,11 @@ pub fn daemon_launchd_label() -> &'static str {
 /// Channel-specific CLI command name.
 pub fn cli_command_name() -> &'static str {
     cli_command_name_for(build_channel())
+}
+
+/// Channel-specific runt-proxy binary base name (without extension).
+pub fn proxy_binary_basename() -> &'static str {
+    proxy_binary_basename_for(build_channel())
 }
 
 /// Channel-specific shorthand notebook command name.

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -12,4 +12,5 @@ workspace = true
 [dependencies]
 dirs = "6"
 runt-workspace = { path = "../runt-workspace" }
+runtimed-client = { path = "../runtimed-client" }
 serde_json.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1488,7 +1488,15 @@ fn cmd_install_nightly(args: &[String]) {
         exit(1);
     }
 
-    // ── Guard 2: existing app bundle detection (all platforms) ───────────
+    // ── Guard 2: existing app bundle detection (macOS only) ──────────────
+    // On macOS the .app bundle manages its own daemon via SMAppService —
+    // overwriting it from source is the specific footgun we're avoiding.
+    //
+    // On Linux, by contrast, replacing whatever's installed *is* the
+    // explicit goal of this command: cloud boxes and headless dev
+    // environments want to bring their source tree's build online as the
+    // running nightly, whether or not a prior .deb/AppImage put something
+    // there. So the installed-app guard is macOS-scoped intentionally.
     #[cfg(target_os = "macos")]
     if !replace_installed_app {
         if let Some((bundle_path, app_name)) = runt_workspace::find_any_installed_nteract_bundle() {
@@ -1507,8 +1515,7 @@ fn cmd_install_nightly(args: &[String]) {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        // App-bundle detection is macOS-specific; the flag is accepted silently
-        // on other platforms to keep CLI surface identical.
+        // Flag accepted silently on non-macOS so the CLI surface matches.
         let _ = replace_installed_app;
     }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1440,6 +1440,19 @@ fn cmd_install_nightly(args: &[String]) {
     let on_macos_override = args.iter().any(|a| a == "--on-macos");
     let replace_installed_app = args.iter().any(|a| a == "--replace-installed-app");
 
+    // ── Windows platform gate ────────────────────────────────────────────
+    // The atomic temp-file + rename helper below fails when the destination
+    // already exists on Windows, and the post-install symlink/linger
+    // guidance is Linux-specific. Installing the nightly daemon from source
+    // isn't a supported Windows workflow — users should install the app.
+    if cfg!(target_os = "windows") {
+        eprintln!("install-nightly is not supported on Windows.");
+        eprintln!();
+        eprintln!("Install the nteract Nightly app from https://nteract.io for the");
+        eprintln!("Windows daemon + CLI + runt-proxy bundle.");
+        exit(1);
+    }
+
     // ── Guard 0: xtask must itself be a nightly-channel build ───────────
     // `ServiceManager` and `runt_workspace::*` helpers derive service
     // names, binary basenames, and install paths from `build_channel()`,
@@ -1553,6 +1566,19 @@ fn cmd_install_nightly(args: &[String]) {
         }
     }
 
+    // ── Capture daemon.json pre-state (for restart verification) ─────────
+    // The post-start check needs to prove the *new* daemon wrote daemon.json,
+    // not just that *some* daemon.json exists. A previous daemon's file can
+    // linger (stale pid/version) when the restart fails. Record the mtime
+    // before starting so the verification loop can require a fresher write.
+    let daemon_json = dirs::cache_dir()
+        .unwrap_or_else(|| Path::new("/tmp").to_path_buf())
+        .join(runt_workspace::cache_namespace())
+        .join("daemon.json");
+    let pre_start_mtime = fs::metadata(&daemon_json)
+        .ok()
+        .and_then(|m| m.modified().ok());
+
     // ── Install the daemon via ServiceManager ────────────────────────────
     let mut manager = runtimed_client::service::ServiceManager::default();
     let was_installed = manager.is_installed();
@@ -1621,19 +1647,28 @@ fn cmd_install_nightly(args: &[String]) {
         println!("Installed {}", dest.display());
     }
 
-    // ── Verify the daemon is actually up ─────────────────────────────────
+    // ── Verify the daemon is actually up (fresh daemon.json write) ───────
     // systemctl returning success isn't quite enough — the daemon writes
-    // daemon.json on startup, so presence + parseable version is the best
-    // evidence we have that the new binary is serving. Poll with a short
-    // backoff (daemon.json write races with socket bind on a cold start).
-    let daemon_json = dirs::cache_dir()
-        .unwrap_or_else(|| Path::new("/tmp").to_path_buf())
-        .join(runt_workspace::cache_namespace())
-        .join("daemon.json");
-
+    // daemon.json on startup, so the combination of "file mtime advanced
+    // beyond our pre-start snapshot" AND "parseable version" proves the
+    // *new* daemon restarted and is serving. Without the mtime check, a
+    // stale daemon.json from a previous daemon (killed / crashed / never
+    // restarted) would satisfy the verification.
     let mut verified_version: Option<String> = None;
     for _ in 0..10 {
         std::thread::sleep(std::time::Duration::from_millis(500));
+        let Ok(meta) = fs::metadata(&daemon_json) else {
+            continue;
+        };
+        let Ok(mtime) = meta.modified() else {
+            continue;
+        };
+        if let Some(pre) = pre_start_mtime {
+            if mtime <= pre {
+                // Still the pre-start file — the new daemon hasn't written yet.
+                continue;
+            }
+        }
         if let Ok(contents) = fs::read_to_string(&daemon_json) {
             if let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) {
                 if let Some(version) = info.get("version").and_then(|v| v.as_str()) {
@@ -1670,10 +1705,12 @@ fn cmd_install_nightly(args: &[String]) {
 
 /// Atomic binary install: write to a temp sibling, set perms, rename into place.
 ///
-/// Mirrors the approach in `runtimed::service::ServiceManager::atomic_copy_binary`
+/// Mirrors the approach in `runtimed_client::service::ServiceManager::atomic_copy_binary`
 /// so upgrading a running `runt` or `runt-proxy` (e.g. the proxy being driven
 /// by a Claude Code session) doesn't corrupt a memory-mapped inode.
-#[allow(dead_code)] // used only on unix-like targets; the cfg gating keeps it quiet elsewhere
+///
+/// Unix only. Windows is refused at the top of `cmd_install_nightly` because
+/// `fs::rename` does not overwrite an existing destination on Windows.
 fn atomic_install(source: &Path, dest: &Path) -> std::io::Result<()> {
     let tmp = dest.with_extension("new");
     fs::copy(source, &tmp)?;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -49,7 +49,10 @@ fn main() {
         "build-e2e" => cmd_build_e2e(),
         "build-dmg" => cmd_build_dmg(),
         "build-app" => cmd_build_app(),
-        "install-daemon" => cmd_install_daemon(),
+        "install-nightly" => {
+            let sub_args: Vec<String> = args[1..].to_vec();
+            cmd_install_nightly(&sub_args);
+        }
         "dev-daemon" => {
             let release = args.iter().any(|a| a == "--release");
             cmd_dev_daemon(release);
@@ -123,7 +126,10 @@ Release:
   build-dmg                  Build DMG with icons (for CI)
 
 Daemon:
-  install-daemon             Build and install runtimed into the running service
+  install-nightly [FLAGS]    Build and install runtimed + runt + runt-proxy from this source
+                             tree as the local nightly install. Refuses on macOS (use the app)
+                             and when an nteract app bundle is present, unless overridden with
+                             --on-macos or --replace-installed-app.
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
 
 MCP:
@@ -1408,17 +1414,71 @@ fn generate_launch_agent_plist() {
     println!("Generated launch agent plist: {}", output_path.display());
 }
 
-/// Build runtimed and install it into the running launchd/systemd service.
+/// Build and install runtimed + runt + runt-proxy from this source tree
+/// as the local nightly install.
 ///
-/// This is the dev workflow for testing daemon changes:
-/// 1. Build runtimed in release mode
-/// 2. Stop the running service
-/// 3. Copy the new binary over the installed one
-/// 4. Restart the service
+/// This is the cloud-box / headless-Linux first-install flow. On macOS, the
+/// install pattern is the `.app` bundle — reinstalling from source out of
+/// bundle is a footgun, so we refuse by default (overridable with
+/// `--on-macos`). If an nteract app bundle is already installed on any
+/// platform we also refuse unless `--replace-installed-app` is passed, since
+/// the app auto-manages its own daemon.
+///
+/// What it does (once the guards pass):
+///
+/// 1. Build runtimed, runt-cli, runt-proxy (release)
+/// 2. Install the daemon via `ServiceManager::install()` (first-time) or
+///    `upgrade()` (when the service is already configured). This writes the
+///    systemd user unit or launchd plist, atomic-copies the binary, and
+///    starts the service.
+/// 3. Copy `runt` and `runt-proxy` into the same install dir, named after
+///    the channel (e.g. `runt-nightly`, `runt-proxy-nightly`).
+/// 4. Print follow-up steps (symlink into `/usr/local/bin`, `loginctl
+///    enable-linger`) — both require sudo, so we don't run them.
 #[allow(clippy::expect_used)] // xtask is a dev tool; panics with context are fine here
-fn cmd_install_daemon() {
-    // Guard: warn if running from a feature branch or worktree to prevent
-    // accidentally replacing the system daemon with a dev build.
+fn cmd_install_nightly(args: &[String]) {
+    let on_macos_override = args.iter().any(|a| a == "--on-macos");
+    let replace_installed_app = args.iter().any(|a| a == "--replace-installed-app");
+
+    // ── Guard 1: macOS platform gate ─────────────────────────────────────
+    if cfg!(target_os = "macos") && !on_macos_override {
+        eprintln!("Refusing to run on macOS by default.");
+        eprintln!();
+        eprintln!("macOS's install pattern is the nteract/nteract Nightly .app bundle,");
+        eprintln!("which manages its own daemon via SMAppService. Installing binaries");
+        eprintln!("out-of-bundle from source is a footgun and will diverge from the");
+        eprintln!("auto-update flow.");
+        eprintln!();
+        eprintln!("For local daemon development use:  cargo xtask dev-daemon");
+        eprintln!("To override anyway pass:           --on-macos");
+        exit(1);
+    }
+
+    // ── Guard 2: existing app bundle detection (all platforms) ───────────
+    #[cfg(target_os = "macos")]
+    if !replace_installed_app {
+        if let Some((bundle_path, app_name)) = runt_workspace::find_any_installed_nteract_bundle() {
+            eprintln!(
+                "Refusing to install: {app_name} is already installed at {}.",
+                bundle_path.display()
+            );
+            eprintln!();
+            eprintln!("That app auto-updates itself and manages its own daemon. Installing");
+            eprintln!("nightly binaries from this source tree will diverge from the app's");
+            eprintln!("copies and can cause confusing 'which one is running' situations.");
+            eprintln!();
+            eprintln!("To override anyway pass: --replace-installed-app");
+            exit(1);
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // App-bundle detection is macOS-specific; the flag is accepted silently
+        // on other platforms to keep CLI surface identical.
+        let _ = replace_installed_app;
+    }
+
+    // ── Branch warning ───────────────────────────────────────────────────
     if let Ok(branch) = std::process::Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .output()
@@ -1426,127 +1486,192 @@ fn cmd_install_daemon() {
         let branch = String::from_utf8_lossy(&branch.stdout).trim().to_string();
         if branch != "main" && !branch.is_empty() {
             eprintln!("⚠️  You are on branch '{branch}', not 'main'.");
-            eprintln!("   This will install your local build as the system daemon,");
-            eprintln!("   replacing the current nightly/release version.");
+            eprintln!("   This will install your local build as the nightly daemon,");
+            eprintln!("   replacing the current nightly install on this machine.");
             eprintln!();
-            eprintln!("   For development, use: cargo xtask dev-daemon");
+            eprintln!("   For per-worktree dev, use: cargo xtask dev-daemon");
             eprintln!("   Press Ctrl+C within 5 seconds to abort...");
             eprintln!();
             std::thread::sleep(Duration::from_secs(5));
         }
     }
 
-    println!("Building runtimed (release)...");
-    run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
+    // ── Build ────────────────────────────────────────────────────────────
+    println!("Building runtimed, runt-cli, runt-proxy (release)...");
+    run_cmd(
+        "cargo",
+        &[
+            "build",
+            "--release",
+            "-p",
+            "runtimed",
+            "-p",
+            "runt-cli",
+            "-p",
+            "runt-proxy",
+        ],
+    );
 
-    let source = if cfg!(windows) {
-        "target/release/runtimed.exe"
+    let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
+    let release_dir = Path::new("target/release");
+    let runtimed_source = release_dir.join(format!("runtimed{exe_suffix}"));
+    let runt_source = release_dir.join(format!("runt{exe_suffix}"));
+    let proxy_source = release_dir.join(format!("runt-proxy{exe_suffix}"));
+
+    for (label, path) in [
+        ("runtimed", &runtimed_source),
+        ("runt", &runt_source),
+        ("runt-proxy", &proxy_source),
+    ] {
+        if !path.exists() {
+            eprintln!(
+                "Build succeeded but {label} binary not found at {}",
+                path.display()
+            );
+            exit(1);
+        }
+    }
+
+    // ── Install the daemon via ServiceManager ────────────────────────────
+    let mut manager = runtimed_client::service::ServiceManager::default();
+    let was_installed = manager.is_installed();
+
+    if was_installed {
+        println!("Upgrading daemon service...");
+        if let Err(e) = manager.upgrade(&runtimed_source) {
+            eprintln!("Failed to upgrade daemon: {e}");
+            exit(1);
+        }
     } else {
-        "target/release/runtimed"
-    };
-
-    if !Path::new(source).exists() {
-        eprintln!("Build succeeded but binary not found at {source}");
-        exit(1);
+        println!("Installing daemon service (first time)...");
+        if let Err(e) = manager.install(&runtimed_source) {
+            eprintln!("Failed to install daemon: {e}");
+            exit(1);
+        }
+        if let Err(e) = manager.start() {
+            eprintln!("Warning: service installed but failed to start: {e}");
+            eprintln!("Start manually with: cargo xtask install-nightly (re-run) or systemctl --user start <unit>");
+        }
     }
 
-    // Use runtimed's own service manager to perform the upgrade.
-    // The `runtimed install` CLI already handles stop → copy → chmod → start.
-    // We call `runtimed upgrade --from <source>` if available, otherwise
-    // fall back to the manual stop/copy/start dance.
-    println!("Installing daemon...");
-
-    // Stop the running daemon gracefully
-    #[cfg(target_os = "macos")]
-    {
-        let _ = runt_workspace::launchd_stop();
-        // Brief pause for process cleanup
-        std::thread::sleep(std::time::Duration::from_secs(1));
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        let service = format!("{}.service", runt_workspace::daemon_service_basename());
-        let _ = Command::new("systemctl")
-            .args(["--user", "stop", &service])
-            .status();
-        std::thread::sleep(std::time::Duration::from_secs(1));
-    }
-
-    // Determine install path (matches runtimed::service::default_binary_path)
+    // ── Install runt + runt-proxy into the same bin dir ──────────────────
     let install_dir = dirs::data_local_dir()
         .expect("Could not determine data directory")
         .join(runt_workspace::cache_namespace())
         .join("bin");
-
-    let binary_name = runt_workspace::daemon_binary_basename();
-    let install_path = if cfg!(windows) {
-        install_dir.join(format!("{binary_name}.exe"))
-    } else {
-        install_dir.join(binary_name)
-    };
-
-    if !install_path.exists() {
+    fs::create_dir_all(&install_dir).unwrap_or_else(|e| {
         eprintln!(
-            "No existing daemon installation found at {}",
-            install_path.display()
+            "Failed to create install dir {}: {e}",
+            install_dir.display()
         );
-        eprintln!("Run the app once first to install the daemon service.");
-        exit(1);
-    }
-
-    // Copy new binary
-    fs::copy(source, &install_path).unwrap_or_else(|e| {
-        eprintln!("Failed to copy binary: {e}");
         exit(1);
     });
 
-    // Make executable on Unix
+    let runt_dest = install_dir.join(format!(
+        "{}{exe_suffix}",
+        runt_workspace::cli_command_name()
+    ));
+    let proxy_dest = install_dir.join(format!(
+        "{}{exe_suffix}",
+        runt_workspace::proxy_binary_basename()
+    ));
+
+    for (src, dest, label) in [
+        (&runt_source, &runt_dest, "runt"),
+        (&proxy_source, &proxy_dest, "runt-proxy"),
+    ] {
+        atomic_install(src, dest).unwrap_or_else(|e| {
+            eprintln!("Failed to install {label} to {}: {e}", dest.display());
+            exit(1);
+        });
+        println!("Installed {}", dest.display());
+    }
+
+    // ── Post-install guidance ────────────────────────────────────────────
+    println!();
+    println!("✓ nightly install complete");
+    println!();
+    print_post_install_guidance(&install_dir, was_installed);
+}
+
+/// Atomic binary install: write to a temp sibling, set perms, rename into place.
+///
+/// Mirrors the approach in `runtimed::service::ServiceManager::atomic_copy_binary`
+/// so upgrading a running `runt` or `runt-proxy` (e.g. the proxy being driven
+/// by a Claude Code session) doesn't corrupt a memory-mapped inode.
+#[allow(dead_code)] // used only on unix-like targets; the cfg gating keeps it quiet elsewhere
+fn atomic_install(source: &Path, dest: &Path) -> std::io::Result<()> {
+    let tmp = dest.with_extension("new");
+    fs::copy(source, &tmp)?;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&install_path, fs::Permissions::from_mode(0o755)).unwrap_or_else(|e| {
-            eprintln!("Failed to set permissions: {e}");
-            exit(1);
-        });
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))?;
     }
 
-    println!("Installed to {}", install_path.display());
+    fs::rename(&tmp, dest)?;
+    Ok(())
+}
 
-    // Restart the service
-    #[cfg(target_os = "macos")]
-    {
-        if let Err(e) = runt_workspace::launchd_start() {
-            eprintln!("Warning: failed to start launchd service: {e}");
-            eprintln!("Start manually with: {}", install_path.display());
+/// Print follow-up steps the user needs to take themselves (they require sudo).
+fn print_post_install_guidance(install_dir: &Path, was_upgrade: bool) {
+    let runt_name = runt_workspace::cli_command_name();
+    let proxy_name = runt_workspace::proxy_binary_basename();
+    let daemon_name = runt_workspace::daemon_binary_basename();
+
+    if !was_upgrade {
+        println!("First-time install — a few follow-up steps are needed:");
+        println!();
+
+        #[cfg(target_os = "linux")]
+        {
+            println!("  1. Put binaries on PATH (requires sudo):");
+            println!();
+            println!("     for bin in {daemon_name} {runt_name} {proxy_name}; do");
+            println!(
+                "       sudo ln -sf \"{}/$bin\" \"/usr/local/bin/$bin\"",
+                install_dir.display()
+            );
+            println!("     done");
+            println!();
+            println!("  2. Make the user service survive shell logout (requires sudo):");
+            println!();
+            println!("     sudo loginctl enable-linger \"$USER\"");
+            println!();
+            println!("  3. Verify the daemon is running:");
+            println!();
+            println!("     {runt_name} daemon status");
         }
-    }
 
-    #[cfg(target_os = "linux")]
-    {
-        let service = format!("{}.service", runt_workspace::daemon_service_basename());
-        run_cmd("systemctl", &["--user", "start", &service]);
-    }
-
-    // Wait briefly and verify
-    std::thread::sleep(std::time::Duration::from_secs(2));
-    let daemon_json = dirs::cache_dir()
-        .unwrap_or_else(|| Path::new("/tmp").to_path_buf())
-        .join(runt_workspace::cache_namespace())
-        .join("daemon.json");
-
-    if daemon_json.exists() {
-        if let Ok(contents) = fs::read_to_string(&daemon_json) {
-            if let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) {
-                if let Some(version) = info.get("version").and_then(|v| v.as_str()) {
-                    println!("Daemon running: version {version}");
-                    return;
-                }
-            }
+        #[cfg(target_os = "macos")]
+        {
+            println!("  1. Put binaries on PATH (requires sudo):");
+            println!();
+            println!("     for bin in {daemon_name} {runt_name} {proxy_name}; do");
+            println!(
+                "       sudo ln -sf \"{}/$bin\" \"/usr/local/bin/$bin\"",
+                install_dir.display()
+            );
+            println!("     done");
+            println!();
+            println!("  2. Verify the daemon is running:");
+            println!();
+            println!("     {runt_name} daemon status");
         }
-    }
 
-    println!("Daemon restarted (could not verify version from daemon.json)");
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let _ = (install_dir, daemon_name, runt_name, proxy_name);
+            println!("  Put binaries on PATH and verify with `{runt_name} daemon status`.");
+        }
+    } else {
+        // Upgrade path — symlinks and linger are already in place from the
+        // prior first-install. Just point at verification.
+        println!("Upgrade complete. Verify:");
+        println!();
+        println!("  {runt_name} daemon status");
+    }
 }
 
 /// Build and run runtimed in per-worktree development mode.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1440,6 +1440,27 @@ fn cmd_install_nightly(args: &[String]) {
     let on_macos_override = args.iter().any(|a| a == "--on-macos");
     let replace_installed_app = args.iter().any(|a| a == "--replace-installed-app");
 
+    // ── Guard 0: xtask must itself be a nightly-channel build ───────────
+    // `ServiceManager` and `runt_workspace::*` helpers derive service
+    // names, binary basenames, and install paths from `build_channel()`,
+    // which is baked into this xtask binary at compile time via
+    // `RUNT_BUILD_CHANNEL`. If someone built xtask with
+    // `RUNT_BUILD_CHANNEL=stable` (the release-validation path), running
+    // `install-nightly` would silently touch the stable namespace and
+    // potentially clobber a real stable install. Refuse loudly instead.
+    if runt_workspace::build_channel() != runt_workspace::BuildChannel::Nightly {
+        eprintln!(
+            "Refusing to run: this xtask was built with RUNT_BUILD_CHANNEL=stable, but \
+             `install-nightly` only targets the nightly channel."
+        );
+        eprintln!();
+        eprintln!("Re-run without the stable override so xtask is built as nightly:");
+        eprintln!();
+        eprintln!("    unset RUNT_BUILD_CHANNEL");
+        eprintln!("    cargo xtask install-nightly");
+        exit(1);
+    }
+
     // ── Guard 1: macOS platform gate ─────────────────────────────────────
     if cfg!(target_os = "macos") && !on_macos_override {
         eprintln!("Refusing to run on macOS by default.");
@@ -1549,8 +1570,21 @@ fn cmd_install_nightly(args: &[String]) {
             exit(1);
         }
         if let Err(e) = manager.start() {
-            eprintln!("Warning: service installed but failed to start: {e}");
-            eprintln!("Start manually with: cargo xtask install-nightly (re-run) or systemctl --user start <unit>");
+            eprintln!("Failed to start daemon service: {e}");
+            eprintln!();
+            eprintln!("The service file was written, but starting it failed. Common causes on");
+            eprintln!("a fresh Linux box:");
+            eprintln!();
+            eprintln!("  - `loginctl enable-linger $USER` hasn't been run yet, so the user");
+            eprintln!("    manager isn't available for a non-login session. Enable linger, then");
+            eprintln!("    re-run `cargo xtask install-nightly`.");
+            eprintln!("  - systemctl --user isn't reachable (no DBUS session).");
+            eprintln!();
+            eprintln!(
+                "Diagnose with: systemctl --user status {}",
+                runt_workspace::daemon_service_basename()
+            );
+            exit(1);
         }
     }
 
@@ -1587,9 +1621,49 @@ fn cmd_install_nightly(args: &[String]) {
         println!("Installed {}", dest.display());
     }
 
+    // ── Verify the daemon is actually up ─────────────────────────────────
+    // systemctl returning success isn't quite enough — the daemon writes
+    // daemon.json on startup, so presence + parseable version is the best
+    // evidence we have that the new binary is serving. Poll with a short
+    // backoff (daemon.json write races with socket bind on a cold start).
+    let daemon_json = dirs::cache_dir()
+        .unwrap_or_else(|| Path::new("/tmp").to_path_buf())
+        .join(runt_workspace::cache_namespace())
+        .join("daemon.json");
+
+    let mut verified_version: Option<String> = None;
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        if let Ok(contents) = fs::read_to_string(&daemon_json) {
+            if let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) {
+                if let Some(version) = info.get("version").and_then(|v| v.as_str()) {
+                    verified_version = Some(version.to_string());
+                    break;
+                }
+            }
+        }
+    }
+
     // ── Post-install guidance ────────────────────────────────────────────
     println!();
-    println!("✓ nightly install complete");
+    match verified_version {
+        Some(version) => {
+            println!("✓ nightly install complete — daemon running: version {version}");
+        }
+        None => {
+            eprintln!(
+                "⚠️  Binaries installed and service command returned success, but could not \
+                 verify the daemon is running ({} did not appear within 5s).",
+                daemon_json.display()
+            );
+            eprintln!();
+            eprintln!(
+                "Check status with: systemctl --user status {}",
+                runt_workspace::daemon_service_basename()
+            );
+            exit(1);
+        }
+    }
     println!();
     print_post_install_guidance(&install_dir, was_installed);
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1531,20 +1531,34 @@ fn cmd_install_nightly(args: &[String]) {
     }
 
     // ── Build ────────────────────────────────────────────────────────────
-    println!("Building runtimed, runt-cli, runt-proxy (release)...");
-    run_cmd(
-        "cargo",
-        &[
-            "build",
-            "--release",
-            "-p",
-            "runtimed",
-            "-p",
-            "runt-cli",
-            "-p",
-            "runt-proxy",
-        ],
-    );
+    // Force RUNT_BUILD_CHANNEL=nightly for the child cargo build. Running
+    // the binary's guard already proved *this* xtask is a nightly build,
+    // but the child cargo inherits env from the caller — if the user has
+    // `RUNT_BUILD_CHANNEL=stable` exported for release validation, a naive
+    // `cargo build` would produce stable binaries that then get installed
+    // into the nightly namespace.
+    println!("Building runtimed, runt-cli, runt-proxy (release, channel=nightly)...");
+    let mut build_cmd = Command::new("cargo");
+    build_cmd.args([
+        "build",
+        "--release",
+        "-p",
+        "runtimed",
+        "-p",
+        "runt-cli",
+        "-p",
+        "runt-proxy",
+    ]);
+    build_cmd.env("RUNT_BUILD_CHANNEL", "nightly");
+    apply_sccache_env(&mut build_cmd);
+    let status = build_cmd.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run cargo build: {e}");
+        exit(1);
+    });
+    if !status.success() {
+        eprintln!("cargo build --release failed");
+        exit(status.code().unwrap_or(1));
+    }
 
     let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
     let release_dir = Path::new("target/release");
@@ -1726,13 +1740,43 @@ fn atomic_install(source: &Path, dest: &Path) -> std::io::Result<()> {
 }
 
 /// Print follow-up steps the user needs to take themselves (they require sudo).
+///
+/// `was_upgrade` is taken from `ServiceManager::is_installed()`, which only
+/// tells us whether the service config existed before this run — it doesn't
+/// guarantee the user ever completed the sudo follow-up steps (`ln -sf` into
+/// `/usr/local/bin`, `loginctl enable-linger`). To avoid leaving someone
+/// stuck on a half-finished install that reports success, inspect the
+/// expected symlinks and always print guidance when any are missing.
 fn print_post_install_guidance(install_dir: &Path, was_upgrade: bool) {
     let runt_name = runt_workspace::cli_command_name();
     let proxy_name = runt_workspace::proxy_binary_basename();
     let daemon_name = runt_workspace::daemon_binary_basename();
 
-    if !was_upgrade {
-        println!("First-time install — a few follow-up steps are needed:");
+    let symlinks_complete = {
+        let expected = [daemon_name, runt_name, proxy_name];
+        expected.iter().all(|name| {
+            let link = Path::new("/usr/local/bin").join(name);
+            fs::symlink_metadata(&link)
+                .ok()
+                .and_then(|m| if m.is_symlink() { Some(()) } else { None })
+                .is_some()
+        })
+    };
+
+    // Show the full guidance on first install, or on any subsequent run
+    // where the expected `/usr/local/bin` symlinks don't all resolve —
+    // the prior install may have aborted before the user ran the sudo
+    // step, and we don't want a retry to silently stop at a working
+    // daemon with a still-missing CLI on PATH.
+    if !was_upgrade || !symlinks_complete {
+        if was_upgrade {
+            println!(
+                "Upgrade complete — but /usr/local/bin/{daemon_name}, /{runt_name}, or /{proxy_name} \
+                 is missing, so finish the setup now:"
+            );
+        } else {
+            println!("First-time install — a few follow-up steps are needed:");
+        }
         println!();
 
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Replaces `cargo xtask install-daemon` with `cargo xtask install-nightly`. The old command was narrow (runtimed only), required an existing service config, and silently did the wrong thing on macOS where the `.app` bundle manages its own daemon via SMAppService.

`install-nightly` is the cloud-box / headless-Linux first-install flow. Clone the repo, run one command, get `runtimed` + `runt` + `runt-proxy` installed as the local nightly with a working systemd user unit.

## Behavior

- Builds `runtimed`, `runt-cli`, `runt-proxy` in release mode
- Uses `ServiceManager::install()` when service config is missing (first install — writes unit/plist, atomic-copies binary, starts service) or `upgrade()` when it already exists (atomic swap + restart)
- Drops `runt` and `runt-proxy` into `~/.local/share/runt-nightly/bin/` with channel-suffixed names, via atomic temp-file + rename so upgrading a running proxy doesn't corrupt a memory-mapped inode
- Prints the follow-up sudo steps (symlinks into `/usr/local/bin`, `loginctl enable-linger`) rather than running them — xtask stays out of sudo

## Guards

Agents running `install-nightly` on dev machines would be destructive, so:

- **Refuses on macOS** by default → override with `--on-macos`. Rationale: the nteract/nteract Nightly `.app` bundle manages its own daemon via SMAppService; installing out-of-bundle diverges from the auto-update flow.
- **Refuses when an nteract app bundle is installed** on any platform → override with `--replace-installed-app`. Rationale: the app auto-updates itself; out-of-bundle binaries cause "which one is running" confusion.
- Keeps the existing 5-second countdown when not on `main`.

Both refusals exit 1 with an actionable message pointing at `cargo xtask dev-daemon` for local dev or the override flag for the rare legitimate case.

## New helper

`runt_workspace::proxy_binary_basename[_for]` — channel-aware `runt-proxy` / `runt-proxy-nightly`, mirroring the existing `daemon_binary_basename` and `cli_command_name` helpers.

## Docs

Updated `AGENTS.md`, `README.md`, `contributing/development.md`, `contributing/runtimed.md`, `.claude/skills/daemon-dev/SKILL.md`, and `.claude/skills/frontend-dev/SKILL.md` to reflect the rename and the macOS refusal.

## Test plan

- [x] `cargo check -p xtask -p notebook` clean
- [x] `cargo xtask lint` clean
- [x] `cargo test -p runt-workspace --lib` (8 pass)
- [x] Manually verified the macOS refusal path exits with code 1 and the expected message
- [ ] Linux cloud-box smoke test: fresh ubuntu, `cargo xtask install-nightly` installs daemon + runt + runt-proxy, systemd unit comes up, `runt-nightly daemon status` shows a running daemon
- [ ] Re-run `cargo xtask install-nightly` on a box that already has the nightly installed → upgrade path fires (service is already configured, so `ServiceManager::upgrade` runs)

## Follow-up

Downstream consumers with cloud-init or bespoke install scripts that build runtimed/runt/runt-proxy by hand can collapse to a single `cargo xtask install-nightly` call.
