### PR TITLE
chore(xtask): pin cwd to workspace root + add sift-wasm Cargo metadata

### DIFF
--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "sift-wasm"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/sift-wasm/pkg/package.json
+++ b/crates/sift-wasm/pkg/package.json
@@ -3,6 +3,11 @@
   "type": "module",
   "description": "WASM bindings for nteract-predicate — used by @nteract/sift",
   "version": "0.1.0",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/desktop"
+  },
   "files": [
     "sift_wasm_bg.wasm",
     "sift_wasm.js",

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -8,10 +8,9 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
 /// Find the workspace root (nearest ancestor containing a Cargo.toml with
-/// a `[workspace]` section). Used to normalize the working directory at
-/// xtask startup so subprocesses that take repo-relative paths (notably
-/// `wasm-pack build crates/sift-wasm`) work regardless of where the user
-/// invoked `cargo xtask` from.
+/// a `[workspace]` section). Subcommands that need repo-relative paths
+/// can call `ensure_workspace_root_cwd()` from within the subcommand to
+/// `cd` there before shelling out.
 fn find_workspace_root() -> Option<PathBuf> {
     let mut dir = env::current_dir().ok()?;
     loop {
@@ -27,16 +26,21 @@ fn find_workspace_root() -> Option<PathBuf> {
     }
 }
 
-fn main() {
-    // Pin cwd to the workspace root before dispatching commands. Several
-    // subcommands (`wasm`, `renderer-plugins`, `mcpb`, …) spawn tools
-    // that take repo-relative paths; running xtask from `packages/sift`
-    // or any other subdir would otherwise fail with opaque errors like
-    // "crate directory is missing a Cargo.toml file".
+/// Change the process cwd to the workspace root. Scope this to the
+/// specific subcommands that need it — not the top of `main` — because
+/// several xtask subcommands accept user-supplied relative path arguments
+/// (`notebook foo.ipynb`, `icons ./src.png`, `mcpb --output dist/out.mcpb`,
+/// `e2e test-fixture fixture.ipynb spec.js`, `run notebook.ipynb`) and
+/// those must stay relative to the shell cwd where the user invoked
+/// `cargo xtask`. A global cd silently reinterprets those args against
+/// the workspace root and opens/writes the wrong files.
+fn ensure_workspace_root_cwd() {
     if let Some(root) = find_workspace_root() {
         let _ = env::set_current_dir(&root);
     }
+}
 
+fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
     if args.is_empty() {
@@ -1155,6 +1159,11 @@ fn cmd_e2e_test_all() {
 }
 
 fn cmd_wasm(target: Option<&str>) {
+    // `wasm-pack build crates/<name>` and the subsequent `fs::copy`/
+    // `fs::read_dir` calls here all use repo-relative paths. cd to the
+    // workspace root so this works whether the user invoked xtask from
+    // the root, from `packages/sift`, or from anywhere else.
+    ensure_workspace_root_cwd();
     require_tool("wasm-pack", WASM_PACK_INSTALL);
 
     // Default (no target) builds both. `sift` or `runtimed` pick just one.
@@ -1245,6 +1254,10 @@ fn cmd_wasm(target: Option<&str>) {
 }
 
 fn cmd_renderer_plugins() {
+    // The `node scripts/build-renderer-plugins.ts` call below resolves
+    // the script path against cwd — normalize it so this works from
+    // any subdirectory.
+    ensure_workspace_root_cwd();
     require_pnpm();
     println!("Building renderer plugins...");
     // Build both the notebook renderer plugins and the runt-mcp plugin assets.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,13 +1,42 @@
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{exit, Child, Command, ExitStatus, Stdio};
 use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
+/// Find the workspace root (nearest ancestor containing a Cargo.toml with
+/// a `[workspace]` section). Used to normalize the working directory at
+/// xtask startup so subprocesses that take repo-relative paths (notably
+/// `wasm-pack build crates/sift-wasm`) work regardless of where the user
+/// invoked `cargo xtask` from.
+fn find_workspace_root() -> Option<PathBuf> {
+    let mut dir = env::current_dir().ok()?;
+    loop {
+        let cargo = dir.join("Cargo.toml");
+        if cargo.exists() {
+            if let Ok(contents) = fs::read_to_string(&cargo) {
+                if contents.contains("[workspace]") {
+                    return Some(dir);
+                }
+            }
+        }
+        dir = dir.parent()?.to_path_buf();
+    }
+}
+
 fn main() {
+    // Pin cwd to the workspace root before dispatching commands. Several
+    // subcommands (`wasm`, `renderer-plugins`, `mcpb`, …) spawn tools
+    // that take repo-relative paths; running xtask from `packages/sift`
+    // or any other subdir would otherwise fail with opaque errors like
+    // "crate directory is missing a Cargo.toml file".
+    if let Some(root) = find_workspace_root() {
+        let _ = env::set_current_dir(&root);
+    }
+
     let args: Vec<String> = env::args().skip(1).collect();
 
     if args.is_empty() {


### PR DESCRIPTION
## Summary

Two small quality-of-life fixes around xtask.

### 1. xtask cwd

`cargo xtask wasm sift`, `cargo xtask renderer-plugins`, `cargo xtask mcpb` - any subcommand that shells out to a tool taking repo-relative paths - fail with opaque errors when invoked from a subdirectory:

```
$ cd packages/sift && cargo xtask wasm sift
Error: crate directory is missing a Cargo.toml file; is `crates/sift-wasm` the wrong directory?
```

Because xtask runs `wasm-pack build crates/sift-wasm`, which resolves `crates/sift-wasm` against the current working directory. Shelling out from `packages/sift` makes that `packages/sift/crates/sift-wasm`, which doesn't exist.

Fix: locate the workspace root at xtask startup (walk ancestors until a `Cargo.toml` contains `[workspace]`) and `cd` there before dispatching. Verified: `cd packages/sift && cargo xtask wasm sift` now runs successfully.

### 2. sift-wasm Cargo.toml metadata

wasm-pack has been warning on every sift build:

```
[INFO]: Optional fields missing from Cargo.toml: 'repository', 'license'.
```

Inherit those from the workspace (like every other crate in the tree), plus `edition.workspace = true` for consistency and `publish = false` to match the rest of the WASM/internal crates. Warning gone.

## Test plan

- [x] `cd packages/sift && cargo xtask wasm sift` succeeds from subdir
- [x] `cargo xtask lint` clean from workspace root and from subdir
- [x] `cargo check -p xtask` clean
- [x] `cargo check -p sift-wasm --target wasm32-unknown-unknown` clean

