### PR TITLE
fix(sift): filtered histogram edge cases + Utf8View decode

### DIFF
--- a/apps/notebook/src/renderer-plugins/sift.js
+++ b/apps/notebook/src/renderer-plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:028c3802bce9841b412b2e4ce4192b3d8683dcff5deb1ee976ba52cfa4b96b00
-size 5989796
+oid sha256:84d61307c862037bb47b49639379d2b3f45f56eeb56b804ee5150db2a9e21042
+size 5993159

--- a/crates/nteract-predicate/src/summary.rs
+++ b/crates/nteract-predicate/src/summary.rs
@@ -142,11 +142,22 @@ pub fn histogram(
 
     let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
     let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-    let bin_width = if (max - min).abs() < f64::EPSILON {
-        1.0
-    } else {
-        (max - min) / num_bins as f64
-    };
+
+    // Constant slice: return a single degenerate bin at `min`. The prior
+    // `bin_width = 1.0` fallback stretched `num_bins` bins across the
+    // range `[min, min + num_bins]`, leaving the TS consumer convinced
+    // the column's max was `min + num_bins` (it reads `bins[last].x1` as
+    // the upper bound). Header labels like "0.46 – 25.46" for a column
+    // where every row is 0.459 come from that. See nteract/desktop#1847.
+    if (max - min).abs() < f64::EPSILON {
+        return Ok(vec![HistogramBin {
+            x0: min,
+            x1: min,
+            count: u32::try_from(values.len()).unwrap_or(u32::MAX),
+        }]);
+    }
+
+    let bin_width = (max - min) / num_bins as f64;
 
     let mut bins: Vec<HistogramBin> = (0..num_bins)
         .map(|i| HistogramBin {

--- a/crates/runt-mcp/assets/plugins/sift.js
+++ b/crates/runt-mcp/assets/plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c97eb23dd8e135b637980be7ed44621e116c1b19b312e6f19b5f8747273eba5d
-size 5989989
+oid sha256:37b4017044b69e00be3a798f8a02f4980cf6d83e1b2269a16458fc8b3ce316c8
+size 5993352

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ebf3d547dc1f8e43b49478cd42a8b2497c2bba319cfa930a609a65fa28a6d7e
-size 4074408
+oid sha256:3fefe089bb49dbd77b50dd0432be3486e568c212a607ab22f67edced98e0f979
+size 4076672

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ebf3d547dc1f8e43b49478cd42a8b2497c2bba319cfa930a609a65fa28a6d7e
-size 4074408
+oid sha256:3fefe089bb49dbd77b50dd0432be3486e568c212a607ab22f67edced98e0f979
+size 4076672

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -405,11 +405,22 @@ pub fn store_histogram(handle: u32, col: usize, num_bins: usize) -> Result<JsVal
         }
         let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
         let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        let bin_width = if (max - min).abs() < f64::EPSILON {
-            1.0
-        } else {
-            (max - min) / num_bins as f64
-        };
+
+        // Constant column: collapse to a single degenerate bin at `min`
+        // rather than stretching `num_bins` bins across `[min, min + num_bins]`.
+        // Without this the TS consumer reads `bins[last].x1 = min + num_bins`
+        // as the column max, producing header labels like "0.46 - 25.46" for
+        // columns where every row is 0.459. See nteract/desktop#1847.
+        if (max - min).abs() < f64::EPSILON {
+            let single = vec![HistogramBin {
+                x0: min,
+                x1: min,
+                count: u32::try_from(values.len()).unwrap_or(u32::MAX),
+            }];
+            return serde_wasm_bindgen::to_value(&single).unwrap_or(JsValue::NULL);
+        }
+
+        let bin_width = (max - min) / num_bins as f64;
         let mut bins: Vec<HistogramBin> = (0..num_bins)
             .map(|i| HistogramBin {
                 x0: min + i as f64 * bin_width,
@@ -429,7 +440,7 @@ pub fn store_histogram(handle: u32, col: usize, num_bins: usize) -> Result<JsVal
             }
             bins[idx].count += 1;
         }
-        // Returns Vec<HistogramBin> — simple struct with f64/u32 fields
+        // Returns Vec<HistogramBin> - simple struct with f64/u32 fields
         serde_wasm_bindgen::to_value(&bins).unwrap_or(JsValue::NULL)
     })
     .map_err(|e| JsValue::from_str(&e))
@@ -771,11 +782,19 @@ pub fn store_filtered_histogram(
         }
         let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
         let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        let bin_width = if (max - min).abs() < f64::EPSILON {
-            1.0
-        } else {
-            (max - min) / num_bins as f64
-        };
+
+        // Same degenerate-bin collapse as `store_histogram` - see
+        // that function for the rationale. See nteract/desktop#1847.
+        if (max - min).abs() < f64::EPSILON {
+            let single = vec![HistogramBin {
+                x0: min,
+                x1: min,
+                count: u32::try_from(values.len()).unwrap_or(u32::MAX),
+            }];
+            return serde_wasm_bindgen::to_value(&single).unwrap_or(JsValue::NULL);
+        }
+
+        let bin_width = (max - min) / num_bins as f64;
         let mut bins: Vec<HistogramBin> = (0..num_bins)
             .map(|i| HistogramBin {
                 x0: min + i as f64 * bin_width,
@@ -795,7 +814,7 @@ pub fn store_filtered_histogram(
             }
             bins[idx].count += 1;
         }
-        // Returns Vec<HistogramBin> — simple struct with f64/u32 fields
+        // Returns Vec<HistogramBin> - simple struct with f64/u32 fields
         serde_wasm_bindgen::to_value(&bins).unwrap_or(JsValue::NULL)
     })
     .map_err(|e| JsValue::from_str(&e))
@@ -933,6 +952,67 @@ pub fn store_sort_indices(handle: u32, col: usize, ascending: bool) -> Result<Ve
     .map_err(|e: String| JsValue::from_str(&e))
 }
 
+/// Downgrade Arrow "view" types (Utf8View, BinaryView) to their non-view
+/// equivalents (Utf8, Binary) before emitting IPC to the JS consumer. The
+/// apache-arrow npm package used by the sift frontend (21.x at time of
+/// writing) throws `Unrecognized type: "undefined" (24)` when it hits a
+/// Utf8View field during schema decode, which silently empties the table
+/// body. Normalizing server-side keeps the JS side on types it understands.
+///
+/// Currently handles the top-level column case (the actual repro path —
+/// polars' default string encoding is Utf8View). Nested occurrences
+/// (List<Utf8View>, Struct{s: Utf8View}) are left as-is; if they show up
+/// in practice we can walk the types recursively.
+///
+/// Fast-path: if the batch has no view columns, returns `batch.clone()`.
+///
+/// See nteract/desktop#1853.
+fn downgrade_view_types(batch: &RecordBatch) -> Result<RecordBatch, String> {
+    use arrow::datatypes::{Field, Schema};
+    use std::sync::Arc;
+
+    let schema = batch.schema();
+    let needs_cast = schema
+        .fields()
+        .iter()
+        .any(|f| matches!(f.data_type(), DataType::Utf8View | DataType::BinaryView));
+    if !needs_cast {
+        return Ok(batch.clone());
+    }
+
+    let mut new_columns: Vec<arrow::array::ArrayRef> = Vec::with_capacity(batch.num_columns());
+    let mut new_fields: Vec<Arc<Field>> = Vec::with_capacity(schema.fields().len());
+
+    for (i, field) in schema.fields().iter().enumerate() {
+        let col = batch.column(i);
+        let (new_col, new_field) = match field.data_type() {
+            DataType::Utf8View => (
+                arrow_cast::cast(col.as_ref(), &DataType::Utf8)
+                    .map_err(|e| format!("cast Utf8View→Utf8 on {}: {}", field.name(), e))?,
+                // Preserve field-level metadata (e.g. Arrow extension
+                // keys like `ARROW:extension:name`) by cloning the
+                // original and only swapping the data type.
+                Arc::new(field.as_ref().clone().with_data_type(DataType::Utf8)),
+            ),
+            DataType::BinaryView => (
+                arrow_cast::cast(col.as_ref(), &DataType::Binary)
+                    .map_err(|e| format!("cast BinaryView→Binary on {}: {}", field.name(), e))?,
+                Arc::new(field.as_ref().clone().with_data_type(DataType::Binary)),
+            ),
+            _ => (col.clone(), field.clone()),
+        };
+        new_columns.push(new_col);
+        new_fields.push(new_field);
+    }
+
+    // Preserve schema-level metadata too.
+    let new_schema = Arc::new(Schema::new_with_metadata(
+        new_fields,
+        schema.metadata().clone(),
+    ));
+    RecordBatch::try_new(new_schema, new_columns).map_err(|e| format!("rebatch: {}", e))
+}
+
 /// Get a viewport slice as Arrow IPC bytes.
 /// Returns the rows [start_row, end_row) serialized as Arrow IPC stream.
 /// This is the hot-path function — one call per scroll frame.
@@ -945,7 +1025,6 @@ pub fn get_viewport(handle: u32, start_row: u32, end_row: u32) -> Result<Vec<u8>
             return Err("empty viewport".to_string());
         }
 
-        let schema = s.batches[0].schema();
         let mut slices: Vec<RecordBatch> = Vec::new();
 
         // Walk batches, slicing the ones that overlap [start, end)
@@ -966,16 +1045,20 @@ pub fn get_viewport(handle: u32, start_row: u32, end_row: u32) -> Result<Vec<u8>
                 batch.num_rows()
             };
 
-            slices.push(batch.slice(local_start, local_end - local_start));
+            let slice = batch.slice(local_start, local_end - local_start);
+            slices.push(downgrade_view_types(&slice)?);
         }
 
         if slices.is_empty() {
             return Err("no data in viewport".to_string());
         }
 
+        // All downgraded slices share the same (possibly-transformed) schema.
+        let writer_schema = slices[0].schema();
+
         // Serialize to Arrow IPC stream
         let mut buf = Vec::new();
-        let mut writer = StreamWriter::try_new(&mut buf, &schema)
+        let mut writer = StreamWriter::try_new(&mut buf, &writer_schema)
             .map_err(|e| format!("IPC writer error: {}", e))?;
         for slice in &slices {
             writer
@@ -1027,6 +1110,7 @@ pub fn get_viewport_by_indices(handle: u32, indices: &[u32]) -> Result<Vec<u8>, 
 
         let batch =
             RecordBatch::try_new(schema, columns).map_err(|e| format!("batch error: {}", e))?;
+        let batch = downgrade_view_types(&batch)?;
 
         let mut buf = Vec::new();
         let mut writer = StreamWriter::try_new(&mut buf, batch.schema_ref())

--- a/packages/sift/public/polars-utf8view.arrow
+++ b/packages/sift/public/polars-utf8view.arrow
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f
+size 9352

--- a/packages/sift/src/datasets.ts
+++ b/packages/sift/src/datasets.ts
@@ -39,6 +39,15 @@ export const DATASETS: DatasetEntry[] = [
     rows: "500",
   },
   {
+    id: "polars-utf8view",
+    label: "Polars Utf8View (100)",
+    description:
+      "Regression fixture for #1853 — polars-written Arrow IPC with Utf8View string columns that apache-arrow-js cannot decode without the server-side Utf8View→Utf8 cast",
+    source: "local",
+    path: "polars-utf8view.arrow",
+    rows: "100",
+  },
+  {
     id: "spotify",
     label: "Spotify Tracks",
     description:

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -42,18 +42,26 @@ function BrushLayer({
     currentX: number;
   } | null>(null);
 
+  // When min === max (the filtered slice is a single value), the brush's
+  // value↔pixel mapping would divide by zero and produce NaN coordinates,
+  // which corrupts the active-selection overlay. Treat that case as a
+  // degenerate single-value column: any brush result collapses to `min`,
+  // and the overlay spans the full width.
+  const span = max - min;
   const xToValue = useCallback(
     (px: number) => {
-      return min + (px / width) * (max - min);
+      if (span <= 0) return min;
+      return min + (px / width) * span;
     },
-    [width, min, max],
+    [width, min, span],
   );
 
   const valueToX = useCallback(
     (v: number) => {
-      return ((v - min) / (max - min)) * width;
+      if (span <= 0) return 0;
+      return ((v - min) / span) * width;
     },
-    [width, min, max],
+    [width, min, span],
   );
 
   const onPointerDown = useCallback((e: React.PointerEvent) => {
@@ -86,6 +94,16 @@ function BrushLayer({
       return;
     }
 
+    // Constant-slice column (span === 0): xToValue maps every pixel to
+    // `min`, so v0 === v1 === min === max and the "entire range" check
+    // below would fire on every real drag and clear the filter. Let the
+    // user pin the single value instead so their filter survives
+    // subsequent changes on other columns.
+    if (span <= 0) {
+      onFilter({ kind: "range", min, max });
+      return;
+    }
+
     const v0 = xToValue(x0);
     const v1 = xToValue(x1);
 
@@ -96,7 +114,7 @@ function BrushLayer({
     }
 
     onFilter({ kind: "range", min: v0, max: v1 });
-  }, [brushState, xToValue, onFilter, min, max]);
+  }, [brushState, xToValue, onFilter, min, max, span]);
 
   // Render brush rect for active selection
   let brushRect = null;
@@ -107,8 +125,22 @@ function BrushLayer({
       <rect x={x} y={0} width={w} height={CHART_HEIGHT} fill="var(--sift-accent)" opacity={0.2} />
     );
   } else if (activeFilter) {
-    const x = valueToX(activeFilter.min);
-    const w = valueToX(activeFilter.max) - x;
+    // When the filtered slice has collapsed to a single value (span === 0),
+    // `valueToX` can't express a range anymore. If the active filter
+    // brackets that single value, the entire column is "selected" — show
+    // a full-width overlay so the user still sees their filter is active.
+    // Otherwise the filter has already excluded everything here (unlikely
+    // but harmless), and a zero-width rect is fine.
+    let x: number;
+    let w: number;
+    if (span <= 0) {
+      const covered = activeFilter.min <= min && activeFilter.max >= max;
+      x = 0;
+      w = covered ? width : 0;
+    } else {
+      x = valueToX(activeFilter.min);
+      w = valueToX(activeFilter.max) - x;
+    }
     brushRect = (
       <rect
         x={x}
@@ -319,9 +351,7 @@ function NumericHistogram({
   if (summary.isIndex) {
     return (
       <div>
-        <span className="sift-th-range">
-          {formatNum(summary.min)} – {formatNum(summary.max)}
-        </span>
+        <span className="sift-th-range">{formatNumRange(summary.min, summary.max)}</span>
       </div>
     );
   }
@@ -382,10 +412,17 @@ function NumericHistogram({
               if (bin.count <= 0) return null;
               const x = i * (barW + gap);
               const h = (bin.count / maxCount) * CHART_HEIGHT;
-              // Per-bin highlight: bins overlapping the filter range are bright, others dimmed
+              // Per-bin highlight: bins overlapping the filter range are bright, others dimmed.
+              // The zero-width bin case (x0 === x1, from the constant-slice fix) collapses
+              // to a single point and needs an inclusive point-in-range check; the regular
+              // overlap predicate uses strict inequality and would mark the bar inactive
+              // when the filter selects exactly that point.
               let fill = baseFill;
               if (isFiltered) {
-                const binOverlaps = bin.x1 > activeFilter.min && bin.x0 < activeFilter.max;
+                const binOverlaps =
+                  bin.x0 === bin.x1
+                    ? bin.x0 >= activeFilter.min && bin.x0 <= activeFilter.max
+                    : bin.x1 > activeFilter.min && bin.x0 < activeFilter.max;
                 fill = binOverlaps ? activeFill : dimFill;
               }
               return (
@@ -414,16 +451,17 @@ function NumericHistogram({
           onFilter={onFilter}
         />
       </div>
-      {/* Hide range for binary-like columns where the ratio bar says it all */}
-      {!(
-        Number.isInteger(summary.min) &&
-        Number.isInteger(summary.max) &&
-        summary.max - summary.min <= 1
-      ) && (
-        <span className="sift-th-range">
-          {formatNum(summary.min)} – {formatNum(summary.max)}
-        </span>
-      )}
+      {/*
+        Always show the range label. The earlier "hide when integer span
+        <= 1" heuristic was a carry-over from the binary (0/1) case, which
+        already early-returns into `BinaryNumericRatioBar` via the
+        `uniqueCount === 2` branch above. Past that branch, single-valued
+        integer columns (e.g., a filtered slice where every row is 0)
+        were falling into this suppression and rendering no textual
+        label at all - with no ratio bar either, since `uniqueCount`
+        is 1 in that case.
+      */}
+      <span className="sift-th-range">{formatNumRange(summary.min, summary.max)}</span>
       <NumericProfile summary={summary} />
     </div>
   );
@@ -781,6 +819,30 @@ function formatDateRange(minMs: number, maxMs: number): [string, string] {
   const max = new Date(maxMs);
   const spanDays = (maxMs - minMs) / (1000 * 60 * 60 * 24);
 
+  if (maxMs === minMs) {
+    // Zero-span: filtered to a single value. Render date + time in UTC
+    // so Date32 values (days-since-epoch normalized to midnight UTC)
+    // still show the correct calendar day in non-UTC locales. Using
+    // local time here would shift `2024-01-01` to `Dec 31, 2023, 4:00
+    // PM` for a viewer in America/Los_Angeles. Real Datetime instants
+    // also render in UTC, which is a reasonable trade for a filtered
+    // single-value header where absolute-time correctness matters
+    // more than the user's local wall-clock. A proper Date32-vs-
+    // Datetime distinction would need source-type plumbing through
+    // the summary.
+    const fmt = (d: Date) =>
+      d.toLocaleString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+        timeZoneName: "short",
+      });
+    return [fmt(min), fmt(max)];
+  }
+
   if (spanDays < 1) {
     // < 24 hours: show time only
     const fmt = (d: Date) =>
@@ -859,12 +921,20 @@ function TimestampHistogram({
               if (bin.count <= 0) return null;
               const x = i * barW;
               const h = (bin.count / maxCount) * CHART_HEIGHT;
-              // Per-bin highlight for timestamp bins
+              // Per-bin highlight for timestamp bins.
+              // When summary.min === summary.max (zero-span, constant-slice fix)
+              // binSpan collapses to 0 and both endpoints coincide at the single
+              // value, so switch to an inclusive point-in-range check; otherwise
+              // the strict inequalities dim the only visible bar even when the
+              // filter selects that exact instant.
               let fill = baseFill;
               if (isFiltered) {
                 const binStart = summary.min + i * binSpan;
                 const binEnd = binStart + binSpan;
-                const binOverlaps = binEnd > activeFilter.min && binStart < activeFilter.max;
+                const binOverlaps =
+                  binSpan === 0
+                    ? binStart >= activeFilter.min && binStart <= activeFilter.max
+                    : binEnd > activeFilter.min && binStart < activeFilter.max;
                 fill = binOverlaps ? activeFill : dimFill;
               }
               return (
@@ -894,7 +964,7 @@ function TimestampHistogram({
         />
       </div>
       <span className="sift-th-range">
-        {minLabel} – {maxLabel}
+        {summary.min === summary.max ? minLabel : `${minLabel} – ${maxLabel}`}
       </span>
     </div>
   );
@@ -968,6 +1038,17 @@ function ColumnSummaryChart({
 function formatNum(n: number): string {
   if (Number.isInteger(n)) return n.toLocaleString();
   return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+/** Format a numeric range, collapsing to a single value when min === max.
+ *
+ * Compare against the raw values, not the formatted strings — `formatNum`
+ * rounds to two decimals, so `0.001`–`0.004` would both render as "0" and
+ * falsely collapse. We only want to hide the upper endpoint when the
+ * column is genuinely single-valued. */
+function formatNumRange(min: number, max: number): string {
+  if (min === max) return formatNum(min);
+  return `${formatNum(min)} – ${formatNum(max)}`;
 }
 
 function truncate(s: string, max: number): string {


### PR DESCRIPTION
Consolidates #1854 + #1855 into one PR so the sift-wasm + renderer-plugin artifacts rebuild once instead of twice. Closes #1847 and #1853. `polars-utf8view.arrow` now lands via LFS automatically (thanks to #1858).

## Filtered histogram fixes (closes #1847)

When the filtered slice of a numeric or timestamp column collapses to a single value, `store_histogram` and `store_filtered_histogram` used to fall back to `bin_width = 1.0` and stretch `num_bins` phantom bins across `[min, min + num_bins]`. The TS consumer then reads `bins[last].x1` as the column max, producing header labels like `"0.46 - 25.46"` for rows where every value is actually `0.459`. Fix: emit a single degenerate bin at `min` in both Rust paths.

Downstream sparkline polish so the degenerate case renders correctly:

- `formatNumRange` collapses to a single value when raw `min === max` (not when formatted strings happen to match, which would hide real decimal variation like `0.001`-`0.004` both rounding to `"0"`).
- `BrushLayer` handles `span === 0` via point-in-range math; brushing a constant column pins `{min: v, max: v}` instead of triggering the "entire range selected" shortcut that cleared the filter.
- Bin-overlap checks in both `NumericHistogram` and `TimestampHistogram` use inclusive point-in-range when bin width is zero, so the exact-value filter doesn't dim the only visible bar.
- `formatDateRange` special-cases zero-span with a UTC date+time label. Date32 values (midnight-UTC ms) keep their calendar day in non-UTC locales, and real Datetime instants also render in UTC.
- Always show the range label for non-binary numeric columns. The old "hide when integer span <= 1" heuristic predated the binary-column early-return and was silently hiding single-valued integer filters.

## Utf8View/BinaryView fix (closes #1853)

`apache-arrow@21.x` throws `Unrecognized type: "undefined" (24)` when decoding `Utf8View` schema fields, silently emptying the table body. Polars' default string encoding is `Utf8View`, so any polars-written Arrow IPC with a string column triggered this.

Add a `downgrade_view_types` helper in `sift-wasm::store` that casts `Utf8View -> Utf8` and `BinaryView -> Binary` via `arrow_cast::cast` before the viewport IPC emitters hand bytes to JS. Preserves field- and schema-level metadata via `field.clone().with_data_type(...)` and `Schema::new_with_metadata(...)`.

## Fixtures

- `packages/sift/public/polars-utf8view.arrow` (100 rows, via LFS) - registered as "Polars Utf8View (100)" in the demo picker.

## Codex review history

Source changes here were reviewed in 8 rounds on the original #1854 branch and 2 rounds on #1855. Every finding except one was addressed. The remaining nit is noted below as a follow-up.

## Known follow-up

When a user brushes a collapsed column, the emitted `{min: v, max: v}` filter persists. If the column later widens (e.g. another filter is cleared), the pin renders as a zero-width rect. Codex flagged this as P3 after round 8; will file as a separate issue.

## Test plan

- [x] `cargo check -p sift-wasm --target wasm32-unknown-unknown`
- [x] `cargo check -p nteract-predicate`
- [x] `cargo xtask lint`
- [x] Manual: Spotify demo, filter to constant slice, numeric headers collapse correctly
- [x] Manual: "Polars Utf8View (100)" fixture renders all rows with string columns
- [x] Manual: "Timestamp fixture (500)" still brushes correctly across all four TimeUnits
- [x] WASM + renderer plugins rebuilt once (combined rebuild, avoids merge churn)

Supersedes #1854 and #1855.