### PR TITLE
feat(dx): use text/plain directly for small DataFrames

### DIFF
--- a/python/dx/src/dx/_summary.py
+++ b/python/dx/src/dx/_summary.py
@@ -12,6 +12,10 @@ from typing import Any
 # Cap the number of columns in the summary to keep it compact.
 _MAX_SUMMARY_COLUMNS = 40
 
+# Maximum byte length for using the library's text/plain directly as the LLM
+# summary.  Matches the CRDT inline threshold (1 KB).
+_MAX_TEXT_PLAIN_BYTES = 1024
+
 
 def _format_int(n: int) -> str:
     return f"{n:,}"
@@ -35,6 +39,15 @@ def _detect_flavor(df: Any) -> str:
     if mod in ("pandas", "polars"):
         return mod
     return "unknown"
+
+
+def _text_plain(df: Any, flavor: str) -> str:
+    """Return the library's native text/plain for *df*."""
+    if flavor == "pandas":
+        return df.to_string(index=False)
+    if flavor == "polars":
+        return str(df)
+    return repr(df)
 
 
 # ── Per-column stat extractors ──────────────────────────────────────
@@ -289,8 +302,16 @@ def summarize_dataframe(
     explicitly calls that out.
     """
     flavor = _detect_flavor(df)
+    n_cols = len(df.columns) if hasattr(df, "columns") else 0
 
-    # Extract per-column stats
+    # ── Fast path: small DataFrames use text/plain directly ────────
+    if not (sampled and total_rows != included_rows) and n_cols <= _MAX_SUMMARY_COLUMNS:
+        text_plain = _text_plain(df, flavor)
+        if len(text_plain.encode("utf-8")) <= _MAX_TEXT_PLAIN_BYTES:
+            header = f"DataFrame ({flavor}): {_format_int(included_rows)} rows × {n_cols} columns"
+            return f"{header}\n\n{text_plain}"
+
+    # ── Rich path: per-column stats + head preview ─────────────────
     if flavor == "pandas":
         col_stats = _pandas_column_stats(df)
     elif flavor == "polars":
@@ -298,11 +319,11 @@ def summarize_dataframe(
     else:
         col_stats = []
 
-    n_cols = len(col_stats) if col_stats else (len(df.columns) if hasattr(df, "columns") else 0)
+    rich_n_cols = len(col_stats) if col_stats else n_cols
     lines: list[str] = []
 
     # Header
-    header = f"DataFrame ({flavor}): {_format_int(included_rows)} rows × {n_cols} columns"
+    header = f"DataFrame ({flavor}): {_format_int(included_rows)} rows × {rich_n_cols} columns"
     if sampled and total_rows != included_rows:
         header += f" (sampled from {_format_int(total_rows)} total rows)"
     lines.append(header)

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -51,7 +51,10 @@ class TestEmitDataFrameFallbackWithoutPyarrow:
             lambda df, max_bytes: (_ for _ in ()).throw(ImportError("No module named 'pyarrow'")),
         )
 
-        df = pd.DataFrame({"score": [0.1, 0.5, 0.9], "name": ["a", "b", "c"]})
+        data: dict = {"score": [0.1, 0.5, 0.9], "name": ["a", "b", "c"]}
+        for j in range(30):
+            data[f"_pad{j}"] = ["padding_value_long_string"] * 3
+        df = pd.DataFrame(data)
         bundle = fi._emit_dataframe(df, total_rows=3)
 
         assert bundle is not None

--- a/python/dx/tests/test_summary.py
+++ b/python/dx/tests/test_summary.py
@@ -20,14 +20,20 @@ def test_summarize_pandas_sampled_mentions_sampling():
 
 
 def test_summarize_pandas_includes_dtypes():
-    df = pd.DataFrame({"i": [1, 2], "s": ["a", "b"]})
+    data: dict = {"i": [1, 2], "s": ["a", "b"]}
+    for j in range(30):
+        data[f"_pad{j}"] = ["padding_value_long_string"] * 2
+    df = pd.DataFrame(data)
     out = summarize_dataframe(df, total_rows=2, included_rows=2, sampled=False)
     assert "int" in out.lower()
     assert "object" in out.lower() or "str" in out.lower()
 
 
 def test_summarize_pandas_includes_null_counts():
-    df = pd.DataFrame({"a": [1.0, None, 3.0], "b": [None, None, "x"]})
+    data: dict = {"a": [1.0, None, 3.0], "b": [None, None, "x"]}
+    for j in range(20):
+        data[f"_pad{j}"] = ["padding_value"] * 3
+    df = pd.DataFrame(data)
     out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
     assert "null" in out.lower()
 

--- a/python/dx/tests/test_summary_unit.py
+++ b/python/dx/tests/test_summary_unit.py
@@ -7,10 +7,21 @@ HuggingFace Dataset summaries.
 import pandas as pd
 import pytest
 from dx._summary import (
+    _MAX_TEXT_PLAIN_BYTES,
     _truncate_cell,
     summarize_dataframe,
     summarize_dataset,
 )
+
+
+def _pad_pandas(df: pd.DataFrame) -> pd.DataFrame:
+    """Add padding columns so the text/plain exceeds the fast-path threshold."""
+    while len(df.to_string(index=False).encode("utf-8")) <= _MAX_TEXT_PLAIN_BYTES:
+        df[f"_pad{len(df.columns)}"] = ["padding_value"] * len(df)
+    return df
+
+
+_pad_to_force_rich_path = _pad_pandas
 
 # ── Truncation ──────────────────────────────────────────────────────
 
@@ -40,14 +51,14 @@ class TestTruncateCell:
 
 class TestPandasNumericRange:
     def test_includes_numeric_range(self):
-        df = pd.DataFrame({"score": [0.12, 0.5, 0.99]})
+        df = _pad_to_force_rich_path(pd.DataFrame({"score": [0.12, 0.5, 0.99]}))
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "range" in out
         assert "0.120" in out
         assert "0.990" in out
 
     def test_integer_range(self):
-        df = pd.DataFrame({"id": [1, 500, 1200]})
+        df = _pad_to_force_rich_path(pd.DataFrame({"id": [1, 500, 1200]}))
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "range" in out
         assert "1" in out
@@ -59,14 +70,17 @@ class TestPandasNumericRange:
 
 class TestPandasStringStats:
     def test_includes_string_distinct_and_top(self):
-        df = pd.DataFrame({"name": ["alice", "bob", "carol", "alice", "bob"]})
-        out = summarize_dataframe(df, total_rows=5, included_rows=5, sampled=False)
+        df = _pad_to_force_rich_path(
+            pd.DataFrame({"name": ["alice", "bob", "carol", "alice", "bob"]})
+        )
+        n = len(df)
+        out = summarize_dataframe(df, total_rows=n, included_rows=n, sampled=False)
         assert "distinct" in out
         assert "top:" in out
         assert '"alice"' in out or '"bob"' in out
 
     def test_single_value_column(self):
-        df = pd.DataFrame({"status": ["ok"] * 10})
+        df = _pad_to_force_rich_path(pd.DataFrame({"status": ["ok"] * 10}))
         out = summarize_dataframe(df, total_rows=10, included_rows=10, sampled=False)
         assert "1 distinct" in out
         assert '"ok"' in out
@@ -96,12 +110,12 @@ class TestTruncationIntegration:
 
 class TestNullHandling:
     def test_all_null_column(self):
-        df = pd.DataFrame({"empty": [None, None, None]})
+        df = _pad_to_force_rich_path(pd.DataFrame({"empty": [None, None, None]}))
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "all null" in out
 
     def test_partial_null_with_percentage(self):
-        df = pd.DataFrame({"a": [1.0, None, 3.0]})
+        df = _pad_to_force_rich_path(pd.DataFrame({"a": [1.0, None, 3.0]}))
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "null" in out
         assert "%" in out
@@ -143,7 +157,10 @@ class TestPolars:
     def test_polars_numeric_range(self):
         import polars as pl
 
-        df = pl.DataFrame({"val": [10, 20, 30]})
+        data: dict = {"val": [10, 20, 30]}
+        for i in range(20):
+            data[f"_pad{i}"] = ["padding_value"] * 3
+        df = pl.DataFrame(data)
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "range" in out
         assert "10" in out
@@ -152,7 +169,10 @@ class TestPolars:
     def test_polars_string_distinct(self):
         import polars as pl
 
-        df = pl.DataFrame({"name": ["alice", "bob", "carol"]})
+        data: dict = {"name": ["alice", "bob", "carol"]}
+        for i in range(20):
+            data[f"_pad{i}"] = ["padding_value"] * 3
+        df = pl.DataFrame(data)
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "distinct" in out
 
@@ -189,7 +209,12 @@ class TestPolars:
     def test_polars_all_null(self):
         import polars as pl
 
-        df = pl.DataFrame({"x": [None, None, None]}, schema={"x": pl.Int64})
+        schema: dict = {"x": pl.Int64}
+        data: dict = {"x": [None, None, None]}
+        for i in range(20):
+            data[f"_pad{i}"] = ["padding_value"] * 3
+            schema[f"_pad{i}"] = pl.Utf8
+        df = pl.DataFrame(data, schema=schema)
         out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
         assert "all null" in out
 
@@ -198,8 +223,13 @@ class TestPolars:
         equivalent structural elements."""
         import polars as pl
 
-        pd_df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        pl_df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        pd_data: dict = {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+        pl_data: dict = {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+        for i in range(20):
+            pd_data[f"_pad{i}"] = ["padding_value"] * 3
+            pl_data[f"_pad{i}"] = ["padding_value"] * 3
+        pd_df = pd.DataFrame(pd_data)
+        pl_df = pl.DataFrame(pl_data)
 
         pd_out = summarize_dataframe(pd_df, total_rows=3, included_rows=3, sampled=False)
         pl_out = summarize_dataframe(pl_df, total_rows=3, included_rows=3, sampled=False)
@@ -253,3 +283,52 @@ class TestDatasetSummary:
         out = summarize_dataset(ds)
         assert "…" in out
         assert "chars]" in out
+
+
+# ── Small DataFrame text/plain fast path ───────────────────────────
+
+
+class TestSmallDataFrameTextPlainPath:
+    """When a DataFrame's native text/plain fits under 1 KB, summarize_dataframe
+    should return it directly instead of running the stat-rich path."""
+
+    def test_small_pandas_uses_text_plain(self):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert out.startswith("DataFrame (pandas): 3 rows × 2 columns")
+        assert "Columns:" not in out
+        assert "Head (" not in out
+        # Should contain the actual cell values
+        assert "x" in out and "y" in out and "z" in out
+
+    def test_small_polars_uses_text_plain(self):
+        pl = pytest.importorskip("polars")
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        out = summarize_dataframe(df, total_rows=3, included_rows=3, sampled=False)
+        assert out.startswith("DataFrame (polars): 3 rows × 2 columns")
+        assert "Columns:" not in out
+        assert "Head (" not in out
+
+    def test_large_pandas_uses_rich_path(self):
+        df = pd.DataFrame({"text": ["word " * 40] * 100})
+        out = summarize_dataframe(df, total_rows=100, included_rows=100, sampled=False)
+        assert "Columns:" in out
+        assert "Head (" in out
+
+    def test_sampled_frame_uses_rich_path(self):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        out = summarize_dataframe(df, total_rows=1000, included_rows=3, sampled=True)
+        assert "Columns:" in out
+        assert "(sampled from" in out
+
+    def test_wide_frame_uses_rich_path(self):
+        data = {f"c{i}": [i] for i in range(50)}
+        df = pd.DataFrame(data)
+        out = summarize_dataframe(df, total_rows=1, included_rows=1, sampled=False)
+        assert "Columns:" in out
+
+    def test_sampled_but_equal_totals_uses_text_plain(self):
+        df = pd.DataFrame({"a": [1, 2]})
+        out = summarize_dataframe(df, total_rows=2, included_rows=2, sampled=True)
+        assert "Columns:" not in out
+        assert "Head (" not in out


### PR DESCRIPTION
## Summary

For DataFrames whose native `text/plain` fits under 1 KB, skip the stat-rich `summarize_dataframe` path and use the library's own tabular repr (`df.to_string()` for pandas, `str(df)` for polars) directly as `text/llm+plain`. This avoids unnecessary stat extraction, head-preview formatting, and per-cell truncation for the common "few rows, narrow columns" case where the agent can just read the actual values.

Downsampled frames (`sampled=True` with different row counts) and wide frames (>40 columns) still use the rich path with per-column stats.

Closes #1811

## Verification

- [ ] Small pandas DataFrame (e.g. 3×2) summary shows raw tabular output, not column stats
- [ ] Small polars DataFrame summary shows polars box-formatted table
- [ ] Large DataFrame (>1 KB text/plain) still shows rich summary with "Columns:" and "Head ()"
- [ ] Downsampled frame always shows rich summary with "(sampled from N total rows)"
- [ ] Wide frame (50+ columns) uses rich summary path

_PR submitted by @rgbkrk's agent, Quill_