### PR TITLE
fix(widgets): await <link> load before rendering anywidget

### DIFF
--- a/src/components/widgets/__tests__/anywidget-view.test.ts
+++ b/src/components/widgets/__tests__/anywidget-view.test.ts
@@ -1,9 +1,11 @@
 /**
  * Tests for anywidget-view helpers that don't require the full iframe +
  * Jupyter comm pipeline. Focused on `injectCSS` because it grew a URL
- * branch (see PR that restores `_css` URL passthrough). Other exports
- * like `loadESM` rely on dynamic `import()` and are better covered by
- * integration tests in the isolated iframe harness.
+ * branch (see PR that restores `_css` URL passthrough) plus an async
+ * `ready` signal so callers can wait for the stylesheet to apply before
+ * rendering. Other exports like `loadESM` rely on dynamic `import()`
+ * and are better covered by integration tests in the isolated iframe
+ * harness.
  */
 
 import { afterEach, describe, expect, it } from "vite-plus/test";
@@ -15,7 +17,7 @@ describe("injectCSS", () => {
   });
 
   it("renders raw CSS into a <style> element and cleans up on dispose", () => {
-    const cleanup = injectCSS("m1", ".foo { color: red; }");
+    const { cleanup } = injectCSS("m1", ".foo { color: red; }");
     const el = document.head.querySelector<HTMLStyleElement>('style[data-widget-id="m1"]');
     expect(el).not.toBeNull();
     expect(el?.textContent).toBe(".foo { color: red; }");
@@ -23,9 +25,16 @@ describe("injectCSS", () => {
     expect(document.head.querySelector('[data-widget-id="m1"]')).toBeNull();
   });
 
+  it("raw CSS ready promise resolves synchronously", async () => {
+    const { ready, cleanup } = injectCSS("m1b", ".foo {}");
+    // Inline <style> applies synchronously; ready should already be resolved.
+    await expect(ready).resolves.toBeUndefined();
+    cleanup();
+  });
+
   it("renders http:// URL as a <link rel=stylesheet> and cleans up", () => {
     const url = "http://127.0.0.1:1234/blob/cafebabe";
-    const cleanup = injectCSS("m2", url);
+    const { cleanup } = injectCSS("m2", url);
     const el = document.head.querySelector<HTMLLinkElement>('link[data-widget-id="m2"]');
     expect(el).not.toBeNull();
     expect(el?.rel).toBe("stylesheet");
@@ -38,10 +47,28 @@ describe("injectCSS", () => {
 
   it("renders https:// URL as a <link rel=stylesheet>", () => {
     const url = "https://cdn.example.com/widget.css";
-    const cleanup = injectCSS("m3", url);
+    const { cleanup } = injectCSS("m3", url);
     const el = document.head.querySelector<HTMLLinkElement>('link[data-widget-id="m3"]');
     expect(el).not.toBeNull();
     expect(el?.href).toBe(url);
+    cleanup();
+  });
+
+  it("URL ready resolves on <link> load event", async () => {
+    const { ready, cleanup } = injectCSS("m3b", "http://127.0.0.1:1234/blob/load");
+    const link = document.head.querySelector<HTMLLinkElement>('link[data-widget-id="m3b"]');
+    expect(link).not.toBeNull();
+    link!.dispatchEvent(new Event("load"));
+    await expect(ready).resolves.toBeUndefined();
+    cleanup();
+  });
+
+  it("URL ready resolves on <link> error event (missing stylesheet doesn't block widget)", async () => {
+    const { ready, cleanup } = injectCSS("m3c", "http://127.0.0.1:1234/blob/missing");
+    const link = document.head.querySelector<HTMLLinkElement>('link[data-widget-id="m3c"]');
+    expect(link).not.toBeNull();
+    link!.dispatchEvent(new Event("error"));
+    await expect(ready).resolves.toBeUndefined();
     cleanup();
   });
 
@@ -50,9 +77,9 @@ describe("injectCSS", () => {
     const c2 = injectCSS("m5", "http://x/blob/h");
     expect(document.head.querySelector('style[data-widget-id="m4"]')).not.toBeNull();
     expect(document.head.querySelector('link[data-widget-id="m5"]')).not.toBeNull();
-    c1();
+    c1.cleanup();
     expect(document.head.querySelector('[data-widget-id="m4"]')).toBeNull();
     expect(document.head.querySelector('link[data-widget-id="m5"]')).not.toBeNull();
-    c2();
+    c2.cleanup();
   });
 });

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -111,6 +111,31 @@ export async function loadESM(esm: string): Promise<AnyWidgetModule> {
 // === CSS Injection ===
 
 /**
+ * Injected CSS handle.
+ *
+ * `ready` resolves when the stylesheet is parsed and its rules have
+ * applied to the document — resolved synchronously for the raw-text
+ * branch, and on the `<link>`'s `load` / `error` event for the URL
+ * branch. Callers that measure layout (anywidget `initialize` /
+ * `render`) should await `ready` before measuring so the widget
+ * doesn't mount against unstyled geometry.
+ *
+ * `cleanup` removes the injected element.
+ */
+export interface InjectedCSS {
+  ready: Promise<void>;
+  cleanup: () => void;
+}
+
+/**
+ * How long to wait for a `<link rel="stylesheet">` to load before
+ * letting the widget render anyway. 5s is long enough for slow
+ * networks (remote CDN stylesheets) and short enough that a broken
+ * blob server never silently blocks a widget forever.
+ */
+const CSS_LOAD_TIMEOUT_MS = 5_000;
+
+/**
  * Inject CSS into the document head for a widget.
  *
  * Accepts either raw CSS text (rendered into a `<style>`) or an
@@ -118,23 +143,49 @@ export async function loadESM(esm: string): Promise<AnyWidgetModule> {
  * form is preferred when the daemon keeps `_css` as a blob URL —
  * it avoids a redundant round-trip fetch in the sync engine and lets
  * the browser cache the stylesheet.
- *
- * @returns Cleanup function to remove the injected element.
  */
-export function injectCSS(modelId: string, css: string): () => void {
+export function injectCSS(modelId: string, css: string): InjectedCSS {
   const isUrl = css.startsWith("http://") || css.startsWith("https://");
   if (isUrl) {
     const link = document.createElement("link");
     link.rel = "stylesheet";
     link.href = css;
     link.setAttribute("data-widget-id", modelId);
-    link.onerror = () => {
-      // Don't throw — widget can still render without its CSS.
-      console.warn(`[anywidget] failed to load CSS: ${css}`);
+
+    let readyResolve: () => void = () => {};
+    const ready = new Promise<void>((resolve) => {
+      readyResolve = resolve;
+    });
+
+    // Resolve on the first of load / error / timeout so the widget is
+    // never blocked on a missing stylesheet. `onload` fires after the
+    // rules are parsed and applied; `onerror` fires for 404s / network
+    // failures. The timeout is a last-resort guard against a browser
+    // that never signals either (e.g. the blob server hangs the
+    // connection open).
+    const timeoutId = window.setTimeout(() => {
+      console.warn(`[anywidget] CSS load timed out after ${CSS_LOAD_TIMEOUT_MS}ms: ${css}`);
+      readyResolve();
+    }, CSS_LOAD_TIMEOUT_MS);
+
+    link.onload = () => {
+      window.clearTimeout(timeoutId);
+      readyResolve();
     };
+    link.onerror = () => {
+      window.clearTimeout(timeoutId);
+      console.warn(`[anywidget] failed to load CSS: ${css}`);
+      readyResolve();
+    };
+
     document.head.appendChild(link);
-    return () => {
-      link.remove();
+
+    return {
+      ready,
+      cleanup: () => {
+        window.clearTimeout(timeoutId);
+        link.remove();
+      },
     };
   }
 
@@ -143,8 +194,12 @@ export function injectCSS(modelId: string, css: string): () => void {
   style.textContent = css;
   document.head.appendChild(style);
 
-  return () => {
-    style.remove();
+  return {
+    // Inline <style> applies synchronously — no wait needed.
+    ready: Promise.resolve(),
+    cleanup: () => {
+      style.remove();
+    },
   };
 }
 
@@ -470,9 +525,16 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
           containerRef.current.innerHTML = "";
         }
 
-        // Inject CSS if provided
+        // Inject CSS if provided. The URL branch returns a pending
+        // `ready` promise (resolves on the `<link>`'s load/error or
+        // after a timeout); the inline branch resolves synchronously.
+        // We start CSS injection before loading the ESM so both fetches
+        // run in parallel, then await `ready` before `render` so the
+        // widget never measures against unstyled geometry.
+        let cssHandle: InjectedCSS | undefined;
         if (css) {
-          cleanupRef.current.css = injectCSS(modelId, css);
+          cssHandle = injectCSS(modelId, css);
+          cleanupRef.current.css = cssHandle.cleanup;
         }
 
         // Load the ESM module
@@ -480,6 +542,13 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
 
         // Check if cancelled after async load
         if (isCancelled) return;
+
+        // Wait for the stylesheet to apply before rendering so
+        // layout-sensitive anywidgets don't measure unstyled DOM.
+        if (cssHandle) {
+          await cssHandle.ready;
+          if (isCancelled) return;
+        }
 
         // Create the AFM model proxy using refs for stable references
         const modelProxy = createAFMModelProxy(


### PR DESCRIPTION
## Summary

Follow-up to #1866. When `_css` arrives as a URL, `injectCSS` renders a `<link rel=stylesheet>` which loads async. `mount()` previously dropped straight into `loadESM` + `render` after `injectCSS`, so layout-sensitive anywidgets could mount and measure against unstyled geometry (codex review flagged this as a P2 race).

- `injectCSS` now returns `{ ready, cleanup }` instead of a bare cleanup fn.
- URL branch resolves `ready` on the `<link>`'s `load`/`error` event, or after a 5s timeout as a last-resort guard.
- Raw-text branch resolves `ready` synchronously (inline `<style>` applies immediately).
- `mount()` kicks CSS injection before `loadESM` so both fetches overlap, then awaits `ready` between `loadESM` and `render` so widgets never measure unstyled DOM.

## Test plan

- [x] `pnpm vp test run src/components/widgets/__tests__/anywidget-view.test.ts` — 7 tests pass
  - Inline `<style>` branch: element + cleanup behavior + synchronous `ready`
  - URL `<link>` branch: `http://`/`https://` rendering, `ready` resolves on `load`, `ready` resolves on `error`
  - Distinct model ids stay independent
- [x] `pnpm vp test run src/components/widgets` — 145 tests pass (no regressions in the broader widget suite)
- [x] `cargo xtask lint --fix` — clean
- [ ] Manual E2E with an anywidget carrying a large external `_css` URL — verify no unstyled flash before first render