### PR TITLE
docs: mark blob GC and ipynb blob-ref specs as shipped

### DIFF
--- a/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
+++ b/docs/superpowers/specs/2026-04-14-blob-gc-correctness-design.md
@@ -1,6 +1,6 @@
 # Blob GC correctness
 
-**Status:** Design
+**Status:** Shipped (#1770)
 **Date:** 2026-04-14
 **Related:** #1762 (dx), [spec: ipynb save without base64 inlining](./2026-04-14-ipynb-save-blob-refs-design.md)
 

--- a/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
+++ b/docs/superpowers/specs/2026-04-14-ipynb-save-blob-refs-design.md
@@ -1,6 +1,6 @@
 # `.ipynb` save: external blob refs instead of base64 inlining
 
-**Status:** Design
+**Status:** Shipped (#1769)
 **Date:** 2026-04-14
 **Related:** #1762 (dx), [spec: blob GC correctness](./2026-04-14-blob-gc-correctness-design.md)
 


### PR DESCRIPTION
## Summary

Audited issue #1818 (align notebook-docs retention with blob grace window) and confirmed the underlying problem is fully resolved by Spec 1 (#1770) and Spec 2 (#1769). Both spec docs still said `Status: Design` — updated them to `Shipped`.

Closes #1818

## Verification

* [ ] Spec status fields show `Shipped` with correct PR numbers
* [ ] No other spec docs reference these as "Design" or "pending"

_PR submitted by @rgbkrk's agent, Quill_