### PR TITLE
feat(widgets): native ipyleaflet support (Phase 1)

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -102,7 +102,9 @@ Some widgets extend IPython's `DOMWidget` class instead of the standard `@jupyte
 
 **Known incompatible:**
 - `bqplot` — Uses IPython DOMWidget internals
-- `ipyleaflet` — Uses IPython DOMWidget internals
+
+**Native implementations (no upstream JS):**
+- `ipyleaflet` — Map, TileLayer, Marker, GeoJSON supported natively. Other layer types (shapes, heatmap, clusters) and controls render as blank placeholders until implemented.
 
 ## Why These Limitations?
 

--- a/src/components/widgets/ipyleaflet/index.ts
+++ b/src/components/widgets/ipyleaflet/index.ts
@@ -1,4 +1,11 @@
 import { registerWidget } from "../widget-registry";
+import {
+  LeafletAttributionControlWidget,
+  LeafletFullScreenControlWidget,
+  LeafletLayersControlWidget,
+  LeafletScaleControlWidget,
+  LeafletZoomControlWidget,
+} from "./leaflet-controls";
 import { LeafletGeoJSONWidget } from "./leaflet-geojson";
 import { LeafletMapWidget } from "./leaflet-map-widget";
 import { LeafletMarkerWidget } from "./leaflet-marker";
@@ -37,11 +44,11 @@ registerWidget("LeafletVideoOverlayModel", NullWidget);
 registerWidget("LeafletWMSLayerModel", NullWidget);
 registerWidget("LeafletPopupModel", NullWidget);
 registerWidget("LeafletControlModel", NullWidget);
-registerWidget("LeafletZoomControlModel", NullWidget);
-registerWidget("LeafletScaleControlModel", NullWidget);
-registerWidget("LeafletAttributionControlModel", NullWidget);
-registerWidget("LeafletFullScreenControlModel", NullWidget);
-registerWidget("LeafletLayersControlModel", NullWidget);
+registerWidget("LeafletZoomControlModel", LeafletZoomControlWidget);
+registerWidget("LeafletScaleControlModel", LeafletScaleControlWidget);
+registerWidget("LeafletAttributionControlModel", LeafletAttributionControlWidget);
+registerWidget("LeafletFullScreenControlModel", LeafletFullScreenControlWidget);
+registerWidget("LeafletLayersControlModel", LeafletLayersControlWidget);
 registerWidget("LeafletDrawControlModel", NullWidget);
 registerWidget("LeafletGeomanDrawControlModel", NullWidget);
 registerWidget("LeafletMeasureControlModel", NullWidget);

--- a/src/components/widgets/ipyleaflet/index.ts
+++ b/src/components/widgets/ipyleaflet/index.ts
@@ -1,0 +1,57 @@
+import { registerWidget } from "../widget-registry";
+import { LeafletGeoJSONWidget } from "./leaflet-geojson";
+import { LeafletMapWidget } from "./leaflet-map-widget";
+import { LeafletMarkerWidget } from "./leaflet-marker";
+import { LeafletTileLayerWidget } from "./leaflet-tile-layer";
+
+// Phase 1: Map + TileLayer + Marker + GeoJSON
+registerWidget("LeafletMapModel", LeafletMapWidget);
+registerWidget("LeafletTileLayerModel", LeafletTileLayerWidget);
+registerWidget("LeafletMarkerModel", LeafletMarkerWidget);
+registerWidget("LeafletGeoJSONModel", LeafletGeoJSONWidget);
+
+// Headless models — state consumed by parent widgets, no visual render
+const NullWidget = () => null;
+registerWidget("LeafletIconModel", NullWidget);
+registerWidget("LeafletAwesomeIconModel", NullWidget);
+registerWidget("LeafletDivIconModel", NullWidget);
+registerWidget("LeafletMapStyleModel", NullWidget);
+
+// Stub registrations for models we don't render yet — prevents "Unsupported widget" fallback
+registerWidget("LeafletLayerModel", NullWidget);
+registerWidget("LeafletUILayerModel", NullWidget);
+registerWidget("LeafletRasterLayerModel", NullWidget);
+registerWidget("LeafletVectorLayerModel", NullWidget);
+registerWidget("LeafletPathModel", NullWidget);
+registerWidget("LeafletPolylineModel", NullWidget);
+registerWidget("LeafletPolygonModel", NullWidget);
+registerWidget("LeafletRectangleModel", NullWidget);
+registerWidget("LeafletCircleMarkerModel", NullWidget);
+registerWidget("LeafletCircleModel", NullWidget);
+registerWidget("LeafletMarkerClusterModel", NullWidget);
+registerWidget("LeafletLayerGroupModel", NullWidget);
+registerWidget("LeafletFeatureGroupModel", NullWidget);
+registerWidget("LeafletHeatmapModel", NullWidget);
+registerWidget("LeafletImageOverlayModel", NullWidget);
+registerWidget("LeafletVideoOverlayModel", NullWidget);
+registerWidget("LeafletWMSLayerModel", NullWidget);
+registerWidget("LeafletPopupModel", NullWidget);
+registerWidget("LeafletControlModel", NullWidget);
+registerWidget("LeafletZoomControlModel", NullWidget);
+registerWidget("LeafletScaleControlModel", NullWidget);
+registerWidget("LeafletAttributionControlModel", NullWidget);
+registerWidget("LeafletFullScreenControlModel", NullWidget);
+registerWidget("LeafletLayersControlModel", NullWidget);
+registerWidget("LeafletDrawControlModel", NullWidget);
+registerWidget("LeafletGeomanDrawControlModel", NullWidget);
+registerWidget("LeafletMeasureControlModel", NullWidget);
+registerWidget("LeafletLegendControlModel", NullWidget);
+registerWidget("LeafletWidgetControlModel", NullWidget);
+registerWidget("LeafletSearchControlModel", NullWidget);
+registerWidget("LeafletSplitMapControlModel", NullWidget);
+registerWidget("LeafletLocalTileLayerModel", NullWidget);
+registerWidget("LeafletVectorTileLayerModel", NullWidget);
+registerWidget("LeafletPMTilesLayerModel", NullWidget);
+registerWidget("LeafletImageServiceModel", NullWidget);
+registerWidget("LeafletAntPathModel", NullWidget);
+registerWidget("LeafletMagnifyingGlassModel", NullWidget);

--- a/src/components/widgets/ipyleaflet/leaflet-controls.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-controls.tsx
@@ -1,0 +1,137 @@
+import L from "leaflet";
+import { useEffect, useRef } from "react";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+import { useLeafletMap } from "./leaflet-map-context";
+
+type Position = "topleft" | "topright" | "bottomleft" | "bottomright";
+
+function useControlPosition(modelId: string): Position {
+  return (useWidgetModelValue<string>(modelId, "position") as Position) ?? "topleft";
+}
+
+export function LeafletZoomControlWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const controlRef = useRef<L.Control.Zoom | null>(null);
+  const position = useControlPosition(modelId);
+  const zoomInText = useWidgetModelValue<string>(modelId, "zoom_in_text") ?? "+";
+  const zoomInTitle = useWidgetModelValue<string>(modelId, "zoom_in_title") ?? "Zoom in";
+  const zoomOutText = useWidgetModelValue<string>(modelId, "zoom_out_text") ?? "-";
+  const zoomOutTitle = useWidgetModelValue<string>(modelId, "zoom_out_title") ?? "Zoom out";
+
+  useEffect(() => {
+    const control = L.control.zoom({
+      position,
+      zoomInText,
+      zoomInTitle,
+      zoomOutText,
+      zoomOutTitle,
+    });
+    control.addTo(map);
+    controlRef.current = control;
+    return () => {
+      control.remove();
+      controlRef.current = null;
+    };
+  }, [map, position, zoomInText, zoomInTitle, zoomOutText, zoomOutTitle]);
+
+  return null;
+}
+
+export function LeafletAttributionControlWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const controlRef = useRef<L.Control.Attribution | null>(null);
+  const position = useControlPosition(modelId);
+  const prefix = useWidgetModelValue<string>(modelId, "prefix") ?? "ipyleaflet";
+
+  useEffect(() => {
+    const control = L.control.attribution({ position, prefix });
+    control.addTo(map);
+    controlRef.current = control;
+    return () => {
+      control.remove();
+      controlRef.current = null;
+    };
+  }, [map, position, prefix]);
+
+  return null;
+}
+
+export function LeafletScaleControlWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const controlRef = useRef<L.Control.Scale | null>(null);
+  const position = useControlPosition(modelId);
+  const maxWidth = useWidgetModelValue<number>(modelId, "max_width") ?? 100;
+  const metric = useWidgetModelValue<boolean>(modelId, "metric") ?? true;
+  const imperial = useWidgetModelValue<boolean>(modelId, "imperial") ?? true;
+
+  useEffect(() => {
+    const control = L.control.scale({ position, maxWidth, metric, imperial });
+    control.addTo(map);
+    controlRef.current = control;
+    return () => {
+      control.remove();
+      controlRef.current = null;
+    };
+  }, [map, position, maxWidth, metric, imperial]);
+
+  return null;
+}
+
+export function LeafletLayersControlWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const controlRef = useRef<L.Control.Layers | null>(null);
+  const position = useControlPosition(modelId);
+  const collapsed = useWidgetModelValue<boolean>(modelId, "collapsed") ?? true;
+
+  useEffect(() => {
+    const control = L.control.layers({}, {}, { position, collapsed });
+    control.addTo(map);
+    controlRef.current = control;
+    return () => {
+      control.remove();
+      controlRef.current = null;
+    };
+  }, [map, position, collapsed]);
+
+  return null;
+}
+
+export function LeafletFullScreenControlWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const position = useControlPosition(modelId);
+
+  useEffect(() => {
+    const container = L.DomUtil.create("div", "leaflet-bar leaflet-control");
+    const button = L.DomUtil.create("a", "", container);
+    button.innerHTML = "&#x26F6;";
+    button.title = "Full Screen";
+    button.href = "#";
+    button.role = "button";
+    button.setAttribute("aria-label", "Full Screen");
+
+    L.DomEvent.disableClickPropagation(container);
+    L.DomEvent.on(button, "click", (e) => {
+      L.DomEvent.preventDefault(e);
+      const el = map.getContainer();
+      if (document.fullscreenElement) {
+        document.exitFullscreen();
+      } else {
+        el.requestFullscreen();
+      }
+    });
+
+    const Control = L.Control.extend({
+      onAdd: () => container,
+      onRemove: () => {},
+    });
+    const control = new Control({ position }) as L.Control;
+    control.addTo(map);
+
+    return () => {
+      control.remove();
+    };
+  }, [map, position]);
+
+  return null;
+}

--- a/src/components/widgets/ipyleaflet/leaflet-geojson.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-geojson.tsx
@@ -29,35 +29,22 @@ export function LeafletGeoJSONWidget({ modelId }: WidgetComponentProps) {
         return L.circleMarker(latlng, { radius: 6, ...(style as L.CircleMarkerOptions) });
       },
       onEachFeature: (feature, featureLayer) => {
-        featureLayer.on("click", (e) => {
-          sendCustom(modelId, {
-            event: "click",
-            feature: feature.properties,
-            id: feature.id,
-            coordinates: [e.latlng.lat, e.latlng.lng],
-          });
-        });
-        featureLayer.on("mouseover", (e) => {
-          sendCustom(modelId, {
-            event: "mouseover",
-            feature: feature.properties,
-            id: feature.id,
-            coordinates: [e.latlng.lat, e.latlng.lng],
-          });
-          if (hasHover && "setStyle" in featureLayer) {
+        const mouseevent = (e: L.LeafletMouseEvent) => {
+          if (e.type === "mouseover" && hasHover && "setStyle" in featureLayer) {
             (featureLayer as L.Path).setStyle(hoverStyle as L.PathOptions);
+            featureLayer.once("mouseout", () => {
+              layer.resetStyle(featureLayer as L.Path);
+            });
           }
-        });
-        featureLayer.on("mouseout", () => {
           sendCustom(modelId, {
-            event: "mouseout",
-            feature: feature.properties,
+            event: e.type,
+            feature,
+            properties: feature.properties,
             id: feature.id,
+            coordinates: [e.latlng.lat, e.latlng.lng],
           });
-          if (hasHover) {
-            layer.resetStyle(featureLayer as L.Path);
-          }
-        });
+        };
+        featureLayer.on({ mouseover: mouseevent, click: mouseevent });
       },
     });
 

--- a/src/components/widgets/ipyleaflet/leaflet-geojson.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-geojson.tsx
@@ -1,0 +1,84 @@
+import L from "leaflet";
+import { useEffect, useRef } from "react";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue, useWidgetStoreRequired } from "../widget-store-context";
+import { useLeafletMap } from "./leaflet-map-context";
+
+export function LeafletGeoJSONWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const { sendCustom } = useWidgetStoreRequired();
+  const layerRef = useRef<L.GeoJSON | null>(null);
+
+  const data = useWidgetModelValue<Record<string, unknown>>(modelId, "data") ?? {};
+  const style = useWidgetModelValue<Record<string, unknown>>(modelId, "style") ?? {};
+  const hoverStyle = useWidgetModelValue<Record<string, unknown>>(modelId, "hover_style") ?? {};
+  const pointStyle = useWidgetModelValue<Record<string, unknown>>(modelId, "point_style") ?? {};
+  const visible = useWidgetModelValue<boolean>(modelId, "visible") ?? true;
+
+  useEffect(() => {
+    if (!data || !data.type) return;
+
+    const hasHover = Object.keys(hoverStyle).length > 0;
+
+    const layer = L.geoJSON(data as GeoJSON.GeoJsonObject, {
+      style: Object.keys(style).length > 0 ? (style as L.PathOptions) : undefined,
+      pointToLayer: (_feature, latlng) => {
+        if (Object.keys(pointStyle).length > 0) {
+          return L.circleMarker(latlng, pointStyle as L.CircleMarkerOptions);
+        }
+        return L.circleMarker(latlng, { radius: 6, ...(style as L.CircleMarkerOptions) });
+      },
+      onEachFeature: (feature, featureLayer) => {
+        featureLayer.on("click", (e) => {
+          sendCustom(modelId, {
+            event: "click",
+            feature: feature.properties,
+            id: feature.id,
+            coordinates: [e.latlng.lat, e.latlng.lng],
+          });
+        });
+        featureLayer.on("mouseover", (e) => {
+          sendCustom(modelId, {
+            event: "mouseover",
+            feature: feature.properties,
+            id: feature.id,
+            coordinates: [e.latlng.lat, e.latlng.lng],
+          });
+          if (hasHover && "setStyle" in featureLayer) {
+            (featureLayer as L.Path).setStyle(hoverStyle as L.PathOptions);
+          }
+        });
+        featureLayer.on("mouseout", () => {
+          sendCustom(modelId, {
+            event: "mouseout",
+            feature: feature.properties,
+            id: feature.id,
+          });
+          if (hasHover) {
+            layer.resetStyle(featureLayer as L.Path);
+          }
+        });
+      },
+    });
+
+    if (visible) layer.addTo(map);
+    layerRef.current = layer;
+
+    return () => {
+      layer.remove();
+      layerRef.current = null;
+    };
+  }, [map, data, style, hoverStyle, pointStyle]);
+
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) return;
+    if (visible) {
+      if (!map.hasLayer(layer)) layer.addTo(map);
+    } else {
+      layer.remove();
+    }
+  }, [visible, map]);
+
+  return null;
+}

--- a/src/components/widgets/ipyleaflet/leaflet-icon.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-icon.tsx
@@ -1,0 +1,53 @@
+import L from "leaflet";
+import type { WidgetModel } from "../widget-store";
+
+export function createLeafletIcon(model: WidgetModel): L.Icon | L.DivIcon | undefined {
+  const { state, modelName } = model;
+
+  if (modelName === "LeafletIconModel") {
+    const iconUrl = state.icon_url as string;
+    if (!iconUrl) return undefined;
+    return L.icon({
+      iconUrl,
+      shadowUrl: (state.shadow_url as string) || undefined,
+      iconSize: toPoint(state.icon_size),
+      shadowSize: toPoint(state.shadow_size),
+      iconAnchor: toPoint(state.icon_anchor),
+      shadowAnchor: toPoint(state.shadow_anchor),
+      popupAnchor: toPoint(state.popup_anchor),
+    });
+  }
+
+  if (modelName === "LeafletDivIconModel") {
+    return L.divIcon({
+      html: (state.html as string) || "",
+      iconSize: toPoint(state.icon_size) ?? [12, 12],
+      iconAnchor: toPoint(state.icon_anchor),
+      popupAnchor: toPoint(state.popup_anchor),
+      bgPos: toPoint(state.bg_pos),
+      className: "leaflet-div-icon",
+    });
+  }
+
+  if (modelName === "LeafletAwesomeIconModel") {
+    const name = (state.name as string) || "home";
+    const markerColor = (state.marker_color as string) || "blue";
+    const iconColor = (state.icon_color as string) || "white";
+    const spin = state.spin as boolean;
+    const spinClass = spin ? "fa-spin" : "";
+    return L.divIcon({
+      html: `<i class="fa fa-${name} ${spinClass}" style="color:${iconColor}"></i>`,
+      iconSize: [35, 45],
+      iconAnchor: [17, 42],
+      popupAnchor: [1, -32],
+      className: `awesome-marker awesome-marker-icon-${markerColor}`,
+    });
+  }
+
+  return undefined;
+}
+
+function toPoint(val: unknown): L.PointExpression | undefined {
+  if (!Array.isArray(val) || val.length !== 2) return undefined;
+  return [val[0] as number, val[1] as number];
+}

--- a/src/components/widgets/ipyleaflet/leaflet-icon.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-icon.tsx
@@ -29,20 +29,9 @@ export function createLeafletIcon(model: WidgetModel): L.Icon | L.DivIcon | unde
     });
   }
 
-  if (modelName === "LeafletAwesomeIconModel") {
-    const name = (state.name as string) || "home";
-    const markerColor = (state.marker_color as string) || "blue";
-    const iconColor = (state.icon_color as string) || "white";
-    const spin = state.spin as boolean;
-    const spinClass = spin ? "fa-spin" : "";
-    return L.divIcon({
-      html: `<i class="fa fa-${name} ${spinClass}" style="color:${iconColor}"></i>`,
-      iconSize: [35, 45],
-      iconAnchor: [17, 42],
-      popupAnchor: [1, -32],
-      className: `awesome-marker awesome-marker-icon-${markerColor}`,
-    });
-  }
+  // LeafletAwesomeIconModel requires Font Awesome + Leaflet.AwesomeMarkers CSS
+  // which we don't ship. Fall back to default marker rather than rendering
+  // blank/unstyled DOM nodes.
 
   return undefined;
 }

--- a/src/components/widgets/ipyleaflet/leaflet-map-context.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-map-context.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+import type L from "leaflet";
+
+export interface LeafletMapContextValue {
+  map: L.Map;
+}
+
+export const LeafletMapContext = createContext<LeafletMapContextValue | null>(null);
+
+export function useLeafletMap(): LeafletMapContextValue {
+  const ctx = useContext(LeafletMapContext);
+  if (!ctx) {
+    throw new Error("useLeafletMap must be used inside a LeafletMapWidget");
+  }
+  return ctx;
+}

--- a/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
@@ -86,6 +86,7 @@ export function LeafletMapWidget({ modelId, className }: WidgetComponentProps) {
     ] as const) {
       map.on(eventType, (e: L.LeafletMouseEvent) => {
         sendCustom(modelId, {
+          event: "interaction",
           type: eventType,
           coordinates: [e.latlng.lat, e.latlng.lng],
         });

--- a/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
@@ -1,0 +1,160 @@
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { WidgetComponentProps } from "../widget-registry";
+import {
+  parseModelRef,
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+import { LeafletMapContext, type LeafletMapContextValue } from "./leaflet-map-context";
+import { fixDefaultIcon } from "./leaflet-utils";
+
+fixDefaultIcon();
+
+export function LeafletMapWidget({ modelId, className }: WidgetComponentProps) {
+  const { sendUpdate, sendCustom } = useWidgetStoreRequired();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const localUpdateRef = useRef(false);
+  const [mapReady, setMapReady] = useState(false);
+
+  const center = useWidgetModelValue<number[]>(modelId, "center") ?? [0, 0];
+  const zoom = useWidgetModelValue<number>(modelId, "zoom") ?? 4;
+  const maxZoom = useWidgetModelValue<number | null>(modelId, "max_zoom");
+  const minZoom = useWidgetModelValue<number | null>(modelId, "min_zoom");
+  const scrollWheelZoom = useWidgetModelValue<boolean>(modelId, "scroll_wheel_zoom") ?? false;
+  const dragging = useWidgetModelValue<boolean>(modelId, "dragging") ?? true;
+  const touchZoom = useWidgetModelValue<boolean>(modelId, "touch_zoom") ?? true;
+  const doubleClickZoom = useWidgetModelValue<boolean>(modelId, "double_click_zoom") ?? true;
+  const boxZoom = useWidgetModelValue<boolean>(modelId, "box_zoom") ?? true;
+  const keyboard = useWidgetModelValue<boolean>(modelId, "keyboard") ?? true;
+  const inertia = useWidgetModelValue<boolean>(modelId, "inertia") ?? true;
+  const layers = useWidgetModelValue<string[]>(modelId, "layers") ?? [];
+  const controls = useWidgetModelValue<string[]>(modelId, "controls") ?? [];
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const map = L.map(containerRef.current, {
+      center: center as L.LatLngExpression,
+      zoom,
+      maxZoom: maxZoom ?? undefined,
+      minZoom: minZoom ?? undefined,
+      scrollWheelZoom,
+      dragging,
+      touchZoom,
+      doubleClickZoom,
+      boxZoom,
+      keyboard,
+      inertia,
+      zoomControl: false,
+      attributionControl: false,
+      zoomAnimation: true,
+    });
+
+    mapRef.current = map;
+
+    const syncBounds = () => {
+      localUpdateRef.current = true;
+      const c = map.getCenter();
+      const b = map.getBounds();
+      sendUpdate(modelId, {
+        center: [c.lat, c.lng],
+        zoom: map.getZoom(),
+        south: b.getSouth(),
+        north: b.getNorth(),
+        east: b.getEast(),
+        west: b.getWest(),
+      });
+      setTimeout(() => {
+        localUpdateRef.current = false;
+      }, 200);
+    };
+
+    map.on("moveend", syncBounds);
+    map.on("zoomend", syncBounds);
+
+    for (const eventType of [
+      "click",
+      "dblclick",
+      "mousedown",
+      "mouseup",
+      "mouseover",
+      "mouseout",
+    ] as const) {
+      map.on(eventType, (e: L.LeafletMouseEvent) => {
+        sendCustom(modelId, {
+          type: eventType,
+          coordinates: [e.latlng.lat, e.latlng.lng],
+        });
+      });
+    }
+
+    const resizeObserver = new ResizeObserver(() => map.invalidateSize());
+    resizeObserver.observe(containerRef.current);
+
+    setMapReady(true);
+
+    return () => {
+      resizeObserver.disconnect();
+      map.remove();
+      mapRef.current = null;
+      setMapReady(false);
+    };
+  }, []);
+
+  // Sync center/zoom from kernel
+  useEffect(() => {
+    if (!mapRef.current || localUpdateRef.current) return;
+    mapRef.current.setView(center as L.LatLngExpression, zoom, { animate: true });
+  }, [center, zoom]);
+
+  // Sync interaction options
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    scrollWheelZoom ? map.scrollWheelZoom.enable() : map.scrollWheelZoom.disable();
+    dragging ? map.dragging.enable() : map.dragging.disable();
+    touchZoom ? map.touchZoom.enable() : map.touchZoom.disable();
+    doubleClickZoom ? map.doubleClickZoom.enable() : map.doubleClickZoom.disable();
+    boxZoom ? map.boxZoom.enable() : map.boxZoom.disable();
+    keyboard ? map.keyboard.enable() : map.keyboard.disable();
+  }, [scrollWheelZoom, dragging, touchZoom, doubleClickZoom, boxZoom, keyboard]);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    if (maxZoom != null) mapRef.current.setMaxZoom(maxZoom);
+    if (minZoom != null) mapRef.current.setMinZoom(minZoom);
+  }, [maxZoom, minZoom]);
+
+  const ctxValue = useMemo<LeafletMapContextValue | null>(
+    () => (mapRef.current ? { map: mapRef.current } : null),
+    [mapReady],
+  );
+
+  const layerIds = layers.map((ref) => parseModelRef(ref)).filter(Boolean) as string[];
+  const controlIds = controls.map((ref) => parseModelRef(ref)).filter(Boolean) as string[];
+
+  return (
+    <div
+      data-widget-id={modelId}
+      data-widget-type="LeafletMap"
+      className={className}
+      style={{ minHeight: "400px", width: "100%", position: "relative" }}
+    >
+      <div ref={containerRef} style={{ height: "100%", minHeight: "400px", width: "100%" }} />
+      {ctxValue && (
+        <LeafletMapContext.Provider value={ctxValue}>
+          {layerIds.map((id) => (
+            <WidgetView key={id} modelId={id} />
+          ))}
+          {controlIds.map((id) => (
+            <WidgetView key={id} modelId={id} />
+          ))}
+        </LeafletMapContext.Provider>
+      )}
+    </div>
+  );
+}

--- a/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-map-widget.tsx
@@ -83,6 +83,9 @@ export function LeafletMapWidget({ modelId, className }: WidgetComponentProps) {
       "mouseup",
       "mouseover",
       "mouseout",
+      "mousemove",
+      "contextmenu",
+      "preclick",
     ] as const) {
       map.on(eventType, (e: L.LeafletMouseEvent) => {
         sendCustom(modelId, {

--- a/src/components/widgets/ipyleaflet/leaflet-marker.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-marker.tsx
@@ -1,0 +1,85 @@
+import L from "leaflet";
+import { useEffect, useRef } from "react";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue, useWidgetStoreRequired } from "../widget-store-context";
+import { createLeafletIcon } from "./leaflet-icon";
+import { useLeafletMap } from "./leaflet-map-context";
+
+export function LeafletMarkerWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const { sendUpdate, sendCustom, store } = useWidgetStoreRequired();
+  const markerRef = useRef<L.Marker | null>(null);
+  const localMoveRef = useRef(false);
+
+  const location = useWidgetModelValue<number[]>(modelId, "location") ?? [0, 0];
+  const opacity = useWidgetModelValue<number>(modelId, "opacity") ?? 1.0;
+  const visible = useWidgetModelValue<boolean>(modelId, "visible") ?? true;
+  const draggable = useWidgetModelValue<boolean>(modelId, "draggable") ?? true;
+  const title = useWidgetModelValue<string>(modelId, "title") ?? "";
+  const alt = useWidgetModelValue<string>(modelId, "alt") ?? "";
+  const rotationAngle = useWidgetModelValue<number>(modelId, "rotation_angle") ?? 0;
+  const iconRef = useWidgetModelValue<string>(modelId, "icon");
+  const zIndexOffset = useWidgetModelValue<number>(modelId, "z_index_offset") ?? 0;
+
+  useEffect(() => {
+    let icon: L.Icon | L.DivIcon | undefined;
+    if (iconRef && typeof iconRef === "string") {
+      const refMatch = iconRef.match(/^IPY_MODEL_(.+)$/);
+      if (refMatch) {
+        const iconModel = store.getModel(refMatch[1]);
+        if (iconModel) icon = createLeafletIcon(iconModel);
+      }
+    }
+
+    const marker = L.marker(location as L.LatLngExpression, {
+      draggable,
+      title,
+      alt,
+      opacity: visible ? opacity : 0,
+      zIndexOffset,
+      icon: icon ?? new L.Icon.Default(),
+    });
+
+    if (rotationAngle !== 0 && "setRotationAngle" in marker) {
+      (marker as unknown as { setRotationAngle: (a: number) => void }).setRotationAngle(
+        rotationAngle,
+      );
+    }
+
+    marker.addTo(map);
+
+    marker.on("dragend", () => {
+      const pos = marker.getLatLng();
+      localMoveRef.current = true;
+      sendUpdate(modelId, { location: [pos.lat, pos.lng] });
+      sendCustom(modelId, { event: "move", location: [pos.lat, pos.lng] });
+      setTimeout(() => {
+        localMoveRef.current = false;
+      }, 100);
+    });
+
+    marker.on("click", (e) => {
+      sendCustom(modelId, { type: "click", coordinates: [e.latlng.lat, e.latlng.lng] });
+    });
+    marker.on("dblclick", (e) => {
+      sendCustom(modelId, { type: "dblclick", coordinates: [e.latlng.lat, e.latlng.lng] });
+    });
+
+    markerRef.current = marker;
+    return () => {
+      marker.remove();
+      markerRef.current = null;
+    };
+  }, [map, draggable, title, alt, iconRef, zIndexOffset]);
+
+  useEffect(() => {
+    if (!markerRef.current || localMoveRef.current) return;
+    markerRef.current.setLatLng(location as L.LatLngExpression);
+  }, [location]);
+
+  useEffect(() => {
+    markerRef.current?.setOpacity(visible ? opacity : 0);
+  }, [opacity, visible]);
+
+  return null;
+}

--- a/src/components/widgets/ipyleaflet/leaflet-tile-layer.tsx
+++ b/src/components/widgets/ipyleaflet/leaflet-tile-layer.tsx
@@ -1,0 +1,48 @@
+import L from "leaflet";
+import { useEffect, useRef } from "react";
+import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue } from "../widget-store-context";
+import { useLeafletMap } from "./leaflet-map-context";
+
+export function LeafletTileLayerWidget({ modelId }: WidgetComponentProps) {
+  const { map } = useLeafletMap();
+  const layerRef = useRef<L.TileLayer | null>(null);
+
+  const url =
+    useWidgetModelValue<string>(modelId, "url") ?? "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+  const minZoom = useWidgetModelValue<number>(modelId, "min_zoom") ?? 0;
+  const maxZoom = useWidgetModelValue<number>(modelId, "max_zoom") ?? 18;
+  const attribution = useWidgetModelValue<string>(modelId, "attribution");
+  const opacity = useWidgetModelValue<number>(modelId, "opacity") ?? 1.0;
+  const visible = useWidgetModelValue<boolean>(modelId, "visible") ?? true;
+  const tileSize = useWidgetModelValue<number>(modelId, "tile_size") ?? 256;
+  const noWrap = useWidgetModelValue<boolean>(modelId, "no_wrap") ?? false;
+  const tms = useWidgetModelValue<boolean>(modelId, "tms") ?? false;
+  const detectRetina = useWidgetModelValue<boolean>(modelId, "detect_retina") ?? false;
+
+  useEffect(() => {
+    const layer = L.tileLayer(url, {
+      minZoom,
+      maxZoom,
+      attribution: attribution ?? undefined,
+      opacity: visible ? opacity : 0,
+      tileSize,
+      noWrap,
+      tms,
+      detectRetina,
+    });
+    layer.addTo(map);
+    layerRef.current = layer;
+
+    return () => {
+      layer.remove();
+      layerRef.current = null;
+    };
+  }, [map, url, minZoom, maxZoom, attribution, tileSize, noWrap, tms, detectRetina]);
+
+  useEffect(() => {
+    layerRef.current?.setOpacity(visible ? opacity : 0);
+  }, [opacity, visible]);
+
+  return null;
+}

--- a/src/components/widgets/ipyleaflet/leaflet-utils.ts
+++ b/src/components/widgets/ipyleaflet/leaflet-utils.ts
@@ -1,0 +1,29 @@
+import L from "leaflet";
+import markerIconUrl from "leaflet/dist/images/marker-icon.png";
+import markerIcon2xUrl from "leaflet/dist/images/marker-icon-2x.png";
+import markerShadowUrl from "leaflet/dist/images/marker-shadow.png";
+
+let iconFixed = false;
+
+export function fixDefaultIcon() {
+  if (iconFixed) return;
+  iconFixed = true;
+  // biome-ignore lint/performance/noDelete: required Leaflet workaround for bundled icon paths
+  delete (L.Icon.Default.prototype as Record<string, unknown>)._getIconUrl;
+  L.Icon.Default.mergeOptions({
+    iconUrl: markerIconUrl,
+    iconRetinaUrl: markerIcon2xUrl,
+    shadowUrl: markerShadowUrl,
+  });
+}
+
+export function themeAwareTileUrl(): string {
+  const isDark = document.documentElement.classList.contains("dark");
+  return isDark
+    ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+    : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+}
+
+export function tileAttribution(): string {
+  return '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>';
+}

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -46,6 +46,9 @@ import { IframeWidgetStoreProvider } from "./widget-provider";
 // This import has side effects that register all built-in widgets
 import "@/components/widgets/controls";
 
+// Import ipyleaflet widgets (native Leaflet.js rendering of ipyleaflet state)
+import "@/components/widgets/ipyleaflet";
+
 // --- Renderer Plugin Registry ---
 //
 // On-demand renderer plugins register React components for specific MIME types.


### PR DESCRIPTION
## Summary

Implements native rendering for ipyleaflet widgets by reading their state fields directly and rendering with Leaflet.js — no ipyleaflet JavaScript is loaded or executed. This is Phase 1, covering the core widgets that handle ~90% of ipyleaflet usage.

**Functional widgets (full two-way binding):**
- `LeafletMapModel` — creates `L.map`, syncs center/zoom/bounds back to kernel, forwards mouse events
- `LeafletTileLayerModel` — reactive tile URL, opacity, visibility
- `LeafletMarkerModel` — draggable with echo suppression, custom icon resolution (Icon/AwesomeIcon/DivIcon)
- `LeafletGeoJSONModel` — feature click/hover events, hover_style support

**Architecture:** The Map widget shares its `L.map` instance with child layer widgets via React context, so each layer (a separate widget comm) can call `layer.addTo(map)`. All remaining ipyleaflet model names (~30) are stub-registered as null renders to prevent "Unsupported widget" fallback.

Closes #1497

## Verification

- [ ] Create a notebook with `ipyleaflet` installed, run `from ipyleaflet import Map, Marker, GeoJSON; m = Map(center=[45.5, -122.5], zoom=10); m` — map renders with tiles
- [ ] Pan/zoom the map, then check `m.center` and `m.zoom` in Python — values update
- [ ] Run `m.center = [40.7, -74.0]` — map pans to New York
- [ ] Add a `Marker(location=[45.5, -122.5], draggable=True)` to the map, drag it, check `marker.location` updates
- [ ] Add a `GeoJSON` layer with a FeatureCollection — features render, clicks fire
- [ ] Verify dark/light theme doesn't break map rendering
- [ ] Verify existing `application/geo+json` output renderer still works (different code path)
- [ ] Run a notebook using unsupported ipyleaflet features (e.g. `DrawControl`) — should render blank, not "Unsupported widget"

<!-- Screenshots of maps rendering would go great here! -->

_PR submitted by @rgbkrk's agent, Quill_