### PR TITLE
feat(outputs): detect and inject plotly.js for text/html outputs

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -346,8 +346,8 @@ export function OutputArea({
       }
     }
 
-    // Detect Plotly in text/html content from non-default renderers (e.g. "notebook",
-    // "iframe_connected") that emit only text/html without the structured MIME type.
+    // Detect Plotly in text/html content from non-default renderers (e.g. "notebook")
+    // that emit inline scripts without the structured MIME type.
     if (!pluginMimes.has("application/vnd.plotly.v1+json")) {
       for (const output of outputs) {
         if (

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -6,7 +6,11 @@ import {
   IsolatedFrame,
   type IsolatedFrameHandle,
 } from "@/components/isolated";
-import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
+import {
+  htmlNeedsPlotly,
+  injectPluginsForMimes,
+  needsPlugin,
+} from "@/components/isolated/iframe-libraries";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
@@ -338,6 +342,24 @@ export function OutputArea({
       if (output.output_type === "execute_result" || output.output_type === "display_data") {
         for (const mime of Object.keys(output.data)) {
           if (needsPlugin(mime)) pluginMimes.add(mime);
+        }
+      }
+    }
+
+    // Detect Plotly in text/html content from non-default renderers (e.g. "notebook",
+    // "iframe_connected") that emit only text/html without the structured MIME type.
+    if (!pluginMimes.has("application/vnd.plotly.v1+json")) {
+      for (const output of outputs) {
+        if (
+          (output.output_type === "execute_result" || output.output_type === "display_data") &&
+          output.data?.["text/html"]
+        ) {
+          const html = output.data["text/html"];
+          const htmlStr = Array.isArray(html) ? html.join("") : String(html);
+          if (htmlNeedsPlotly(htmlStr)) {
+            pluginMimes.add("application/vnd.plotly.v1+json");
+            break;
+          }
         }
       }
     }

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -58,7 +58,7 @@ const PLOTLY_HTML_RE =
  * `window.Plotly` or AMD `require("plotly")` to be available.
  *
  * Used to trigger plotly plugin injection for non-default Plotly renderers
- * (e.g. `notebook`, `iframe_connected`) that emit only text/html.
+ * (e.g. `notebook`) that emit inline scripts in text/html.
  */
 export function htmlNeedsPlotly(html: string): boolean {
   return PLOTLY_HTML_RE.test(html);

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -50,6 +50,20 @@ export function needsPlugin(mime: string): boolean {
   return mime in PLUGIN_MIME_TYPES || isVegaMimeType(mime);
 }
 
+const PLOTLY_HTML_RE =
+  /Plotly\s*\.\s*(?:newPlot|react|plot|relayout|restyle|update|animate)\s*\(|require\s*\(\s*[['"]\s*['"]?plotly/;
+
+/**
+ * Detect whether a text/html output contains Plotly scripts that expect
+ * `window.Plotly` or AMD `require("plotly")` to be available.
+ *
+ * Used to trigger plotly plugin injection for non-default Plotly renderers
+ * (e.g. `notebook`, `iframe_connected`) that emit only text/html.
+ */
+export function htmlNeedsPlotly(html: string): boolean {
+  return PLOTLY_HTML_RE.test(html);
+}
+
 /** Cache of plugin code promises, keyed by MIME type. */
 const pluginCache = new Map<string, Promise<PluginModule>>();
 

--- a/src/isolated-renderer/plotly-renderer.tsx
+++ b/src/isolated-renderer/plotly-renderer.tsx
@@ -135,8 +135,41 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
 
 // --- Plugin install ---
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const win = window as any;
+
 export function install(ctx: {
   register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
 }) {
   ctx.register(["application/vnd.plotly.v1+json"], PlotlyRenderer);
+
+  // Expose Plotly globally so text/html outputs that reference window.Plotly
+  // (from non-default renderers like "notebook" or "iframe_connected") work.
+  win.Plotly = Plotly;
+
+  // If RequireJS is already loaded (e.g. by a prior HTML output), register
+  // plotly as a named AMD module so require(["plotly"], cb) resolves.
+  if (typeof win.define === "function" && win.define.amd) {
+    win.define("plotly", [], () => Plotly);
+    win.define("plotly.js", [], () => Plotly);
+  }
+
+  // Otherwise install a minimal AMD/CJS require shim for Plotly's "notebook"
+  // renderer, which calls require(["plotly"], function(Plotly) { ... }).
+  if (typeof win.require !== "function") {
+    win.require = function require(
+      deps: string | string[],
+      callback?: (...modules: unknown[]) => void,
+    ) {
+      const resolve = (name: string) => {
+        if (name === "plotly" || name === "plotly.js") return Plotly;
+        throw new Error(`[plotly-shim] Unknown module: ${name}`);
+      };
+      if (typeof deps === "string") return resolve(deps);
+      if (Array.isArray(deps) && typeof callback === "function") {
+        callback(...deps.map(resolve));
+      }
+    };
+    win.require.amd = {};
+  }
 }

--- a/src/isolated-renderer/plotly-renderer.tsx
+++ b/src/isolated-renderer/plotly-renderer.tsx
@@ -144,7 +144,7 @@ export function install(ctx: {
   ctx.register(["application/vnd.plotly.v1+json"], PlotlyRenderer);
 
   // Expose Plotly globally so text/html outputs that reference window.Plotly
-  // (from non-default renderers like "notebook" or "iframe_connected") work.
+  // (from non-default renderers like "notebook") work.
   win.Plotly = Plotly;
 
   // If RequireJS is already loaded (e.g. by a prior HTML output), register


### PR DESCRIPTION
## Summary

When Plotly uses non-default renderers like `notebook`, it emits `text/html` containing inline scripts that reference `window.Plotly` or AMD `require("plotly")`. These silently fail because plotly.js is only injected when `application/vnd.plotly.v1+json` appears in the output MIME bundle.

This PR scans `text/html` content for Plotly signatures and triggers the plotly plugin injection, which now also exposes `window.Plotly` and an AMD `require` shim inside the sandboxed iframe.

### Changes

- **`iframe-libraries.ts`** — new `htmlNeedsPlotly()` function that regex-scans HTML for Plotly method calls and AMD require patterns
- **`OutputArea.tsx`** — after the existing MIME-based plugin scan, adds a content scan of `text/html` outputs; if Plotly signatures detected, triggers the plotly plugin load
- **`plotly-renderer.tsx`** — `install()` now exposes `window.Plotly` globally in the iframe, registers named AMD modules if RequireJS is present, and installs a minimal AMD/CJS `require` shim

### Timing

The plugin `install()` runs before `renderBatch()`, so `window.Plotly` is guaranteed to be set before any HTML scripts execute.

Closes #1533

## Verification

- [ ] Create a notebook, `import plotly.express as px`, set `plotly.io.renderers.default = "notebook"`, render a chart — it should display
- [ ] Default renderer (`plotly_mimetype`) still works as before
- [ ] Non-plotly `text/html` outputs (e.g. pandas DataFrames) do NOT trigger unnecessary plotly plugin loading (check console for `[iframe-libraries] installing renderer plugin` messages)

<!-- Screenshots/recordings of plotly notebook renderer working go here -->

_PR submitted by @rgbkrk's agent, Quill_