### PR TITLE
fix(runtimed): skip redundant dep bootstrap in auto_launch_kernel

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3739,13 +3739,24 @@ async fn auto_launch_kernel(
                     let deps = info.default_deps_snapshot();
                     if !deps.is_empty() {
                         let mut doc = room.doc.write().await;
+                        let mut changed = false;
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                            let pixi = snap.pixi_section_or_default();
-                            pixi.dependencies = deps;
-                            let _ = fork.set_metadata_snapshot(&snap);
+                            let current_deps = snap.runt.pixi.as_ref().map(|p| &p.dependencies);
+                            if current_deps.is_none_or(|d| d != &deps) {
+                                let pixi = snap.pixi_section_or_default();
+                                pixi.dependencies = deps;
+                                let _ = fork.set_metadata_snapshot(&snap);
+                                changed = true;
+                            }
                         });
-                        info!("[notebook-sync] Bootstrapped pixi.toml deps into CRDT");
+                        if changed {
+                            info!("[notebook-sync] Bootstrapped pixi.toml deps into CRDT");
+                        } else {
+                            debug!(
+                                "[notebook-sync] Pixi deps already current in CRDT, skipping write"
+                            );
+                        }
                     }
                 }
             }
@@ -3755,19 +3766,28 @@ async fn auto_launch_kernel(
                     let deps = extract_pyproject_deps(&content);
                     if !deps.is_empty() {
                         let mut doc = room.doc.write().await;
+                        let mut changed = false;
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-                            let uv = snap.runt.uv.get_or_insert_with(|| {
-                                notebook_doc::metadata::UvInlineMetadata {
-                                    dependencies: Vec::new(),
-                                    requires_python: None,
-                                    prerelease: None,
-                                }
-                            });
-                            uv.dependencies = deps;
-                            let _ = fork.set_metadata_snapshot(&snap);
+                            let current_deps = snap.runt.uv.as_ref().map(|u| &u.dependencies);
+                            if current_deps.is_none_or(|d| d != &deps) {
+                                let uv = snap.runt.uv.get_or_insert_with(|| {
+                                    notebook_doc::metadata::UvInlineMetadata {
+                                        dependencies: Vec::new(),
+                                        requires_python: None,
+                                        prerelease: None,
+                                    }
+                                });
+                                uv.dependencies = deps;
+                                let _ = fork.set_metadata_snapshot(&snap);
+                                changed = true;
+                            }
                         });
-                        info!("[notebook-sync] Bootstrapped pyproject.toml deps into CRDT");
+                        if changed {
+                            info!("[notebook-sync] Bootstrapped pyproject.toml deps into CRDT");
+                        } else {
+                            debug!("[notebook-sync] Pyproject deps already current in CRDT, skipping write");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

`auto_launch_kernel` unconditionally re-wrote project-file dependencies (pyproject.toml and pixi.toml) into the CRDT on every kernel launch — restart, reconnect, re-handshake. Even when deps hadn't changed, the Automerge `put()` calls created new CRDT operations that invalidated trust signatures and triggered env-sync drift UI flicker ("Restart and Run All" button highlighting).

Adds a comparison guard in both the pixi and pyproject bootstrap paths: reads current deps from the CRDT snapshot before writing, and skips the `set_metadata_snapshot` call when they already match. First-time bootstrap (when the dep section is absent) still proceeds.

Closes #1840

## Verification

- [ ] Create an untitled notebook in a directory with `pyproject.toml` containing dependencies
- [ ] Approve trust when prompted
- [ ] Restart the kernel via toolbar
- [ ] Verify: trust stays Approved, "Awaiting Approval" banner does **not** reappear
- [ ] Verify: "Restart and Run All" button does **not** highlight orange after restart
- [ ] Repeat with a `pixi.toml` project instead of `pyproject.toml`

_PR submitted by @rgbkrk's agent, Quill_