### PR TITLE
fix(sift): render zero-width range filter as point marker

### DIFF
--- a/packages/sift/src/sparkline.test.ts
+++ b/packages/sift/src/sparkline.test.ts
@@ -28,17 +28,26 @@ describe("binOverlapsFilter", () => {
     expect(binOverlapsFilter(11, 11, 0, 10)).toBe(false);
   });
 
-  it("point-filter (min === max) is inclusive against the bin extent", () => {
+  it("point-filter (min === max) lands in one bin at interior boundaries", () => {
     // This is the #1860 case: user pinned a value while the column was
     // collapsed, then cleared the other filter so the column widened.
-    // A bin whose extent *contains* the pinned value should stay active.
-    expect(binOverlapsFilter(0, 10, 5, 5)).toBe(true);
-    // Pinned value at bin boundaries should still count.
-    expect(binOverlapsFilter(0, 10, 0, 0)).toBe(true);
-    expect(binOverlapsFilter(0, 10, 10, 10)).toBe(true);
-    // Pinned value outside the bin.
+    // Mirror the half-open [x0, x1) bucketing in NumericAccumulator —
+    // at an interior boundary (e.g. v = 10 for bins [0,10) and [10,20)),
+    // the pinned value should light the *upper* bin only, not both.
+    expect(binOverlapsFilter(0, 10, 5, 5)).toBe(true); // interior of bin
+    expect(binOverlapsFilter(0, 10, 0, 0)).toBe(true); // left edge (inclusive)
+    expect(binOverlapsFilter(0, 10, 10, 10)).toBe(false); // right edge — upper bin wins
+    expect(binOverlapsFilter(10, 20, 10, 10)).toBe(true); // same boundary from the upper side
     expect(binOverlapsFilter(0, 10, 11, 11)).toBe(false);
     expect(binOverlapsFilter(0, 10, -1, -1)).toBe(false);
+  });
+
+  it("point-filter hitting the last bin's upper edge stays inclusive", () => {
+    // `v === summary.max` clamps into the last bucket in the accumulator,
+    // so passing `isLastBin = true` makes the upper edge inclusive.
+    expect(binOverlapsFilter(90, 100, 100, 100, true)).toBe(true);
+    // Without the flag the last bin behaves like any interior bin.
+    expect(binOverlapsFilter(90, 100, 100, 100, false)).toBe(false);
   });
 
   it("point-bin and point-filter at the same value overlap", () => {

--- a/packages/sift/src/sparkline.test.ts
+++ b/packages/sift/src/sparkline.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+import { binOverlapsFilter } from "./sparkline";
+
+describe("binOverlapsFilter", () => {
+  it("treats overlapping ranges as active (normal case)", () => {
+    // Filter [5, 15] overlaps bin [0, 10] and bin [10, 20]
+    expect(binOverlapsFilter(0, 10, 5, 15)).toBe(true);
+    expect(binOverlapsFilter(10, 20, 5, 15)).toBe(true);
+  });
+
+  it("excludes bins that touch only at the boundary (strict)", () => {
+    // Filter [10, 20] and bin [0, 10]: x1 === filter.min, strict overlap is false
+    expect(binOverlapsFilter(0, 10, 10, 20)).toBe(false);
+    // Filter [0, 10] and bin [10, 20]: x0 === filter.max
+    expect(binOverlapsFilter(10, 20, 0, 10)).toBe(false);
+  });
+
+  it("excludes bins entirely outside the filter", () => {
+    expect(binOverlapsFilter(0, 5, 10, 20)).toBe(false);
+    expect(binOverlapsFilter(25, 30, 10, 20)).toBe(false);
+  });
+
+  it("point-bin (x0 === x1) is inclusive against the filter range", () => {
+    // Constant-slice histogram: bin collapses to a single value.
+    expect(binOverlapsFilter(7, 7, 0, 10)).toBe(true);
+    expect(binOverlapsFilter(0, 0, 0, 10)).toBe(true);
+    expect(binOverlapsFilter(10, 10, 0, 10)).toBe(true);
+    expect(binOverlapsFilter(11, 11, 0, 10)).toBe(false);
+  });
+
+  it("point-filter (min === max) is inclusive against the bin extent", () => {
+    // This is the #1860 case: user pinned a value while the column was
+    // collapsed, then cleared the other filter so the column widened.
+    // A bin whose extent *contains* the pinned value should stay active.
+    expect(binOverlapsFilter(0, 10, 5, 5)).toBe(true);
+    // Pinned value at bin boundaries should still count.
+    expect(binOverlapsFilter(0, 10, 0, 0)).toBe(true);
+    expect(binOverlapsFilter(0, 10, 10, 10)).toBe(true);
+    // Pinned value outside the bin.
+    expect(binOverlapsFilter(0, 10, 11, 11)).toBe(false);
+    expect(binOverlapsFilter(0, 10, -1, -1)).toBe(false);
+  });
+
+  it("point-bin and point-filter at the same value overlap", () => {
+    expect(binOverlapsFilter(5, 5, 5, 5)).toBe(true);
+    expect(binOverlapsFilter(5, 5, 6, 6)).toBe(false);
+  });
+});

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -21,6 +21,35 @@ type FilterCallback = (filter: ColumnFilter) => void;
 
 const CHART_HEIGHT = 48;
 
+/**
+ * Does a bin with range [x0, x1] overlap the active range filter?
+ *
+ * Uses strict inequality for the common case of two extents overlapping.
+ * The inclusive fallback handles two degenerate shapes that can arise
+ * from the constant-slice pin behavior (#1859 / #1860):
+ *
+ * - **Bin is a point** (`x0 === x1`): the bin collapsed to one value;
+ *   include it when the filter brackets that value.
+ * - **Filter is a point** (`filterMin === filterMax`): the user pinned
+ *   a value while the column was collapsed, and the column later
+ *   widened. Include any bin whose extent contains the pinned value so
+ *   the bar stays highlighted even with a zero-width filter.
+ */
+export function binOverlapsFilter(
+  x0: number,
+  x1: number,
+  filterMin: number,
+  filterMax: number,
+): boolean {
+  if (x0 === x1) {
+    return x0 >= filterMin && x0 <= filterMax;
+  }
+  if (filterMin === filterMax) {
+    return x0 <= filterMin && filterMin <= x1;
+  }
+  return x1 > filterMin && x0 < filterMax;
+}
+
 // --- Histogram brush layer ---
 
 function BrushLayer({
@@ -131,12 +160,24 @@ function BrushLayer({
     // a full-width overlay so the user still sees their filter is active.
     // Otherwise the filter has already excluded everything here (unlikely
     // but harmless), and a zero-width rect is fine.
+    //
+    // Separately, when the *filter* itself is a point (min === max — the
+    // pin created by the span-0 branch above) but the column has since
+    // widened, `valueToX(min) - valueToX(max)` is 0 pixels and the
+    // overlay disappears. Paint a 2px marker at the pinned value so the
+    // filter stays visible. Clamp so the marker sits flush against the
+    // right edge when the pin coincides with `max`.
+    const POINT_MARKER_WIDTH = 2;
     let x: number;
     let w: number;
     if (span <= 0) {
       const covered = activeFilter.min <= min && activeFilter.max >= max;
       x = 0;
       w = covered ? width : 0;
+    } else if (activeFilter.min === activeFilter.max) {
+      const center = valueToX(activeFilter.min);
+      x = Math.max(0, Math.min(width - POINT_MARKER_WIDTH, center - POINT_MARKER_WIDTH / 2));
+      w = POINT_MARKER_WIDTH;
     } else {
       x = valueToX(activeFilter.min);
       w = valueToX(activeFilter.max) - x;
@@ -207,9 +248,10 @@ function BinaryNumericRatioBar({
     : formatNum((highBin.x0 + highBin.x1) / 2);
 
   // Determine which segment is "active" based on range filter
-  const lowActive = !activeFilter || (lowBin.x1 > activeFilter.min && lowBin.x0 < activeFilter.max);
+  const lowActive =
+    !activeFilter || binOverlapsFilter(lowBin.x0, lowBin.x1, activeFilter.min, activeFilter.max);
   const highActive =
-    !activeFilter || (highBin.x1 > activeFilter.min && highBin.x0 < activeFilter.max);
+    !activeFilter || binOverlapsFilter(highBin.x0, highBin.x1, activeFilter.min, activeFilter.max);
 
   return (
     <div className="sift-bool-summary">
@@ -304,7 +346,7 @@ function LowCardinalityNumericBars({
       {items.map((item) => {
         // Highlight bar if its range overlaps the active range filter
         const isActive =
-          !activeFilter || (item.x1 > activeFilter.min && item.x0 < activeFilter.max);
+          !activeFilter || binOverlapsFilter(item.x0, item.x1, activeFilter.min, activeFilter.max);
         return (
           <div
             key={item.label}
@@ -413,17 +455,13 @@ function NumericHistogram({
               const x = i * (barW + gap);
               const h = (bin.count / maxCount) * CHART_HEIGHT;
               // Per-bin highlight: bins overlapping the filter range are bright, others dimmed.
-              // The zero-width bin case (x0 === x1, from the constant-slice fix) collapses
-              // to a single point and needs an inclusive point-in-range check; the regular
-              // overlap predicate uses strict inequality and would mark the bar inactive
-              // when the filter selects exactly that point.
+              // See `binOverlapsFilter` for the zero-width bin / zero-width filter cases
+              // that fall out of the constant-slice pin behavior (#1859 / #1860).
               let fill = baseFill;
               if (isFiltered) {
-                const binOverlaps =
-                  bin.x0 === bin.x1
-                    ? bin.x0 >= activeFilter.min && bin.x0 <= activeFilter.max
-                    : bin.x1 > activeFilter.min && bin.x0 < activeFilter.max;
-                fill = binOverlaps ? activeFill : dimFill;
+                fill = binOverlapsFilter(bin.x0, bin.x1, activeFilter.min, activeFilter.max)
+                  ? activeFill
+                  : dimFill;
               }
               return (
                 <rect
@@ -977,21 +1015,15 @@ function TimestampHistogram({
               if (bin.count <= 0) return null;
               const x = i * barW;
               const h = (bin.count / maxCount) * CHART_HEIGHT;
-              // Per-bin highlight for timestamp bins.
-              // When summary.min === summary.max (zero-span, constant-slice fix)
-              // binSpan collapses to 0 and both endpoints coincide at the single
-              // value, so switch to an inclusive point-in-range check; otherwise
-              // the strict inequalities dim the only visible bar even when the
-              // filter selects that exact instant.
+              // Per-bin highlight for timestamp bins. See `binOverlapsFilter` for
+              // the zero-span / zero-width-filter degenerate cases (#1859 / #1860).
               let fill = baseFill;
               if (isFiltered) {
                 const binStart = summary.min + i * binSpan;
                 const binEnd = binStart + binSpan;
-                const binOverlaps =
-                  binSpan === 0
-                    ? binStart >= activeFilter.min && binStart <= activeFilter.max
-                    : binEnd > activeFilter.min && binStart < activeFilter.max;
-                fill = binOverlaps ? activeFill : dimFill;
+                fill = binOverlapsFilter(binStart, binEnd, activeFilter.min, activeFilter.max)
+                  ? activeFill
+                  : dimFill;
               }
               return (
                 <rect

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -25,27 +25,33 @@ const CHART_HEIGHT = 48;
  * Does a bin with range [x0, x1] overlap the active range filter?
  *
  * Uses strict inequality for the common case of two extents overlapping.
- * The inclusive fallback handles two degenerate shapes that can arise
+ * The inclusive fallbacks handle two degenerate shapes that can arise
  * from the constant-slice pin behavior (#1859 / #1860):
  *
  * - **Bin is a point** (`x0 === x1`): the bin collapsed to one value;
  *   include it when the filter brackets that value.
  * - **Filter is a point** (`filterMin === filterMax`): the user pinned
  *   a value while the column was collapsed, and the column later
- *   widened. Include any bin whose extent contains the pinned value so
- *   the bar stays highlighted even with a zero-width filter.
+ *   widened. Use half-open `[x0, x1)` to mirror the actual bucketing
+ *   in `NumericAccumulator.snapshot` / `store_histogram` (values at
+ *   interior boundaries go to the upper bin via floor division). Pass
+ *   `isLastBin = true` for the final histogram bucket so `v === max`
+ *   still lights up the last bar — the bucketing code clamps that
+ *   index into the last bucket too.
  */
 export function binOverlapsFilter(
   x0: number,
   x1: number,
   filterMin: number,
   filterMax: number,
+  isLastBin: boolean = false,
 ): boolean {
   if (x0 === x1) {
     return x0 >= filterMin && x0 <= filterMax;
   }
   if (filterMin === filterMax) {
-    return x0 <= filterMin && filterMin <= x1;
+    const v = filterMin;
+    return isLastBin ? x0 <= v && v <= x1 : x0 <= v && v < x1;
   }
   return x1 > filterMin && x0 < filterMax;
 }
@@ -247,11 +253,21 @@ function BinaryNumericRatioBar({
     ? String(Math.round((highBin.x0 + highBin.x1) / 2))
     : formatNum((highBin.x0 + highBin.x1) / 2);
 
-  // Determine which segment is "active" based on range filter
+  // Determine which segment is "active" based on range filter. The high
+  // bin's right edge coincides with `summary.max`, so we mark it as the
+  // last bin so `v === max` pins keep it active (mirrors the bucketing
+  // clamp in `NumericAccumulator.snapshot`).
   const lowActive =
     !activeFilter || binOverlapsFilter(lowBin.x0, lowBin.x1, activeFilter.min, activeFilter.max);
   const highActive =
-    !activeFilter || binOverlapsFilter(highBin.x0, highBin.x1, activeFilter.min, activeFilter.max);
+    !activeFilter ||
+    binOverlapsFilter(
+      highBin.x0,
+      highBin.x1,
+      activeFilter.min,
+      activeFilter.max,
+      highBin.x1 === summary.max,
+    );
 
   return (
     <div className="sift-bool-summary">
@@ -344,9 +360,18 @@ function LowCardinalityNumericBars({
   return (
     <div className="sift-cat-summary">
       {items.map((item) => {
-        // Highlight bar if its range overlaps the active range filter
+        // Highlight bar if its range overlaps the active range filter.
+        // Mark the last bin (x1 === summary.max) so `v === max` pins
+        // stay lit; mirrors the bucketing clamp in the accumulator.
         const isActive =
-          !activeFilter || binOverlapsFilter(item.x0, item.x1, activeFilter.min, activeFilter.max);
+          !activeFilter ||
+          binOverlapsFilter(
+            item.x0,
+            item.x1,
+            activeFilter.min,
+            activeFilter.max,
+            item.x1 === summary.max,
+          );
         return (
           <div
             key={item.label}
@@ -459,7 +484,13 @@ function NumericHistogram({
               // that fall out of the constant-slice pin behavior (#1859 / #1860).
               let fill = baseFill;
               if (isFiltered) {
-                fill = binOverlapsFilter(bin.x0, bin.x1, activeFilter.min, activeFilter.max)
+                fill = binOverlapsFilter(
+                  bin.x0,
+                  bin.x1,
+                  activeFilter.min,
+                  activeFilter.max,
+                  i === numBins - 1,
+                )
                   ? activeFill
                   : dimFill;
               }
@@ -1021,7 +1052,13 @@ function TimestampHistogram({
               if (isFiltered) {
                 const binStart = summary.min + i * binSpan;
                 const binEnd = binStart + binSpan;
-                fill = binOverlapsFilter(binStart, binEnd, activeFilter.min, activeFilter.max)
+                fill = binOverlapsFilter(
+                  binStart,
+                  binEnd,
+                  activeFilter.min,
+                  activeFilter.max,
+                  i === numBins - 1,
+                )
                   ? activeFill
                   : dimFill;
               }


### PR DESCRIPTION
## Summary

Closes #1860. Follow-up to #1859.

When the user pins a numeric/timestamp filter on a collapsed column (`{min: v, max: v}`) and then clears the other filter so the column re-widens, two things went wrong:

1. `BrushLayer` computed the overlay rect as `valueToX(max) - valueToX(min) = 0` pixels wide, so the pin became visually invisible even though rows were still being filtered.
2. The bar-dimming logic in `BinaryNumericRatioBar`, `LowCardinalityNumericBars`, `NumericHistogram`, and `TimestampHistogram` used strict `>` / `<` overlap checks, which classify a zero-width filter as not overlapping anything and dim every bar.

## Fix

- Extract `binOverlapsFilter(x0, x1, filterMin, filterMax)` and use it from all four bar/histogram renderers. The helper widens the overlap predicate to inclusive `>=` / `<=` when **either** the bin or the filter has zero width. That subsumes the existing point-bin branch from #1859 and adds the symmetric point-filter branch for #1860.
- In `BrushLayer`, when the active filter is a point (`min === max`) and the column's span is nonzero, paint a 2px marker at `valueToX(v)` (clamped to the chart bounds) instead of a zero-width rect. The constant-slice `span === 0` branch is unchanged.

## Test plan

- [x] New `packages/sift/src/sparkline.test.ts` with six cases exercising `binOverlapsFilter`: normal overlap, strict boundary exclusion, non-overlap, point-bin, point-filter, and both-at-once.
- [x] `npm test` in `packages/sift` — 134 tests pass (6 new).
- [x] `cargo xtask lint --fix` — clean.
- [ ] Manual E2E against the Spotify demo using the repro steps in #1860: filter `track_id` to a repeated value, brush the now-collapsed `popularity` column, clear `track_id`, and confirm the overlay shows a 2px marker at the pinned value while the bin containing that value stays bright.