### PR TITLE
fix(build): use cocoa::base::YES for macOS x86_64 BOOL compatibility

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3632,14 +3632,19 @@ fn open_notebook_from_menu_without_window(
     log::info!("[menu] File > Open triggered with no windows open");
 
     // On macOS, activate the app to ensure the file dialog is visible
-    // when the app has no windows but is still running
+    // when the app has no windows but is still running.
+    //
+    // Use `cocoa::base::YES` rather than a raw `true`: Objective-C's `BOOL`
+    // is `bool` on aarch64 Apple targets but `i8` on x86_64 (see
+    // `objc::runtime::BOOL`), and the cocoa 0.26 shim follows suit. The
+    // `YES` constant is the portable spelling across both archs.
     #[cfg(target_os = "macos")]
     #[allow(deprecated)]
     unsafe {
         use cocoa::appkit::NSApplication;
-        use cocoa::base::nil;
+        use cocoa::base::{nil, YES};
         let ns_app = NSApplication::sharedApplication(nil);
-        ns_app.activateIgnoringOtherApps_(true);
+        ns_app.activateIgnoringOtherApps_(YES);
     }
 
     let app_handle = app.clone();


### PR DESCRIPTION
## Summary

The nightly release failed on macOS x86_64 with:

\`\`\`
error[E0308]: mismatched types
    --> crates/notebook/src/lib.rs:3642:43
     |
3642 |         ns_app.activateIgnoringOtherApps_(true);
     |                -------------------------- ^^^^ expected \`i8\`, found \`bool\`
\`\`\`

Objective-C's \`BOOL\` maps to \`bool\` on aarch64 Apple targets but \`c_schar\` (\`i8\`) on x86_64 — see [\`objc::runtime::BOOL\`](https://docs.rs/objc/0.2.7/objc/runtime/type.BOOL.html). The cocoa 0.26 shim re-exports the same split type. Raw \`true\` compiles on arm64 but not on x86_64.

Fix: use the portable \`cocoa::base::YES\` constant, which is defined per-arch as \`1_i8\` or \`true\`.

## Test plan

- [x] \`rustup target add x86_64-apple-darwin && cargo check -p notebook --target x86_64-apple-darwin\` — clean.
- [x] \`cargo check -p notebook --target aarch64-apple-darwin\` — clean (previously passing, unchanged behavior on arm64).
- [ ] Kick off another nightly build after merge to confirm the x86_64 job completes.