### PR TITLE
Increase virtual scroll overscan buffer for better Safari compatibility

### DIFF
--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -144,9 +144,10 @@ const LINE_HEIGHT = 20;
 const CELL_PAD_H = 24; // 12px each side
 const CELL_PAD_V = 16; // 8px top + 8px bottom
 const MIN_COL_WIDTH = 60;
-const OVERSCAN = 40; // base buffer rows above/below viewport
+// Generous buffer: Safari fires scroll events ~2-3x less often than Chromium.
+const OVERSCAN = 80; // base buffer rows above/below viewport
 const OVERSCAN_VELOCITY_SCALE = 3; // extra rows per 10px of scroll delta
-const MAX_OVERSCAN = 120; // cap total overscan per side
+const MAX_OVERSCAN = 240; // cap total overscan per side
 
 // --- Table Engine ---
 


### PR DESCRIPTION
## Summary
Increased the virtual scrolling overscan buffer sizes to improve rendering performance and reduce flickering on Safari, which fires scroll events less frequently than Chromium-based browsers.

## Key Changes
- Doubled `OVERSCAN` from 40 to 80 rows to provide a more generous buffer above/below the viewport
- Doubled `MAX_OVERSCAN` from 120 to 240 rows to accommodate the increased base overscan with velocity scaling
- Added clarifying comment explaining the Safari scroll event frequency difference

## Implementation Details
Safari fires scroll events approximately 2-3x less frequently than Chromium browsers, which can cause visible gaps or flickering in virtualized tables when the overscan buffer is too small. By doubling both the base overscan and maximum overscan values, the table maintains a larger pre-rendered buffer that better handles Safari's scroll event behavior while still maintaining reasonable performance.
