### PR TITLE
fix+feat(sync): widget sync stall — detection, recovery, headless regression harness

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -114,7 +114,7 @@ const _outputResolveGen = new Map<string, number>();
 function diffResolvedState(
   existing: Record<string, unknown>,
   next: Record<string, unknown>,
-  isPendingKey?: (key: string) => boolean,
+  isEchoOfPending?: (key: string, candidate: unknown) => boolean,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(next)) {
@@ -129,11 +129,12 @@ function diffResolvedState(
     } catch {
       // Non-serializable values (rare in comm state) → treat as changed.
     }
-    // Drop keys with a pending local write. The projected echo
-    // carries the daemon's pre-flush view of the CRDT — the store's
-    // newer in-flight value wins until the throttle trailing-edge
-    // flush reaches the daemon and the daemon's sync frame catches up.
-    if (isPendingKey?.(key)) continue;
+    // Drop stale echoes of our own local writes. An authoritative
+    // update (kernel validator, peer edit) carries a *different*
+    // value than what we wrote — those still flow through. Only
+    // suppresses keys whose projected value matches a local write
+    // currently in flight through the CRDT.
+    if (isEchoOfPending?.(key, value)) continue;
     out[key] = value;
   }
   return out;
@@ -429,8 +430,8 @@ function AppContent() {
         // microtask.
         const existing = widgetStore.getModel(comm.commId);
         const diff = existing
-          ? diffResolvedState(existing.state, comm.state, (key) =>
-              updateManager.hasPendingKey(comm.commId, key),
+          ? diffResolvedState(existing.state, comm.state, (key, candidate) =>
+              updateManager.isEchoOfPendingWrite(comm.commId, key, candidate),
             )
           : comm.state;
         if (Object.keys(diff).length > 0) {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1411,18 +1411,31 @@ const updateManager = new WidgetUpdateManager({
   getCrdtWriter: getCrdtCommWriter,
 });
 
+/**
+ * Renderer for `application/vnd.jupyter.widget-view+json` outputs.
+ * Hoisted to module scope so its identity is stable across App renders —
+ * an inline component type would remount the entire widget subtree
+ * every time React re-ran the surrounding JSX.
+ */
+function WidgetViewRenderer({ data }: { data: unknown }) {
+  const { model_id } = data as { model_id: string };
+  return <WidgetView modelId={model_id} />;
+}
+
+/**
+ * Stable `renderers` object passed to `MediaProvider`. Same rationale —
+ * a fresh object literal on each App render would change the provider's
+ * props identity and cascade remounts through the output tree.
+ */
+const mediaRenderers = {
+  "application/vnd.jupyter.widget-view+json": WidgetViewRenderer,
+} as const;
+
 export default function App() {
   return (
     <ErrorBoundary fallback={AppErrorFallback}>
       <WidgetStoreProvider sendMessage={sendMessage} updateManager={updateManager}>
-        <MediaProvider
-          renderers={{
-            "application/vnd.jupyter.widget-view+json": ({ data }) => {
-              const { model_id } = data as { model_id: string };
-              return <WidgetView modelId={model_id} />;
-            },
-          }}
-        >
+        <MediaProvider renderers={mediaRenderers}>
           <AppContent />
         </MediaProvider>
       </WidgetStoreProvider>

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -347,17 +347,22 @@ function AppContent() {
 
   // Set up CRDT comm writer for widget state updates.
   // Writes directly to RuntimeStateDoc via WASM — no SendComm round-trip.
+  // After the local write, project it through `commChanges$` so the
+  // WidgetStore sees the change in the same tick, without waiting for
+  // the daemon to echo. This makes the widget-store a true projection
+  // of the CRDT for both local and remote writes.
   useEffect(() => {
     setCrdtCommWriter((commId: string, patch: Record<string, unknown>) => {
       const handle = getHandle();
       if (!handle) return;
       handle.set_comm_state_batch(commId, JSON.stringify(patch));
+      getEngine()?.projectLocalState();
       triggerSync();
     });
     return () => {
       setCrdtCommWriter(null);
     };
-  }, [getHandle, triggerSync]);
+  }, [getHandle, getEngine, triggerSync]);
 
   // ── CRDT → WidgetStore projection via SyncEngine.commChanges$ ──────
   // Replaces the old Jupyter message synthesis path. The SyncEngine diffs

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -114,6 +114,7 @@ const _outputResolveGen = new Map<string, number>();
 function diffResolvedState(
   existing: Record<string, unknown>,
   next: Record<string, unknown>,
+  isPendingKey?: (key: string) => boolean,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(next)) {
@@ -128,6 +129,11 @@ function diffResolvedState(
     } catch {
       // Non-serializable values (rare in comm state) → treat as changed.
     }
+    // Drop keys with a pending local write. The projected echo
+    // carries the daemon's pre-flush view of the CRDT — the store's
+    // newer in-flight value wins until the throttle trailing-edge
+    // flush reaches the daemon and the daemon's sync frame catches up.
+    if (isPendingKey?.(key)) continue;
     out[key] = value;
   }
   return out;
@@ -422,7 +428,11 @@ function AppContent() {
         // synchronously before the projection hopped through a
         // microtask.
         const existing = widgetStore.getModel(comm.commId);
-        const diff = existing ? diffResolvedState(existing.state, comm.state) : comm.state;
+        const diff = existing
+          ? diffResolvedState(existing.state, comm.state, (key) =>
+              updateManager.hasPendingKey(comm.commId, key),
+            )
+          : comm.state;
         if (Object.keys(diff).length > 0) {
           widgetStore.updateModel(comm.commId, diff);
         }

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -17,6 +17,7 @@ import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
+import { SyncRecoveryBanner } from "./components/SyncRecoveryBanner";
 import { DebugBanner } from "./components/DebugBanner";
 import { DenoDependencyHeader } from "./components/DenoDependencyHeader";
 import { DependencyHeader } from "./components/DependencyHeader";
@@ -196,6 +197,14 @@ function AppContent() {
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);
   // Track ready timeout so we can cancel it if status changes
   const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Latest sync recovery event — fed by SyncEngine.syncErrors$ and
+  // consumed by SyncRecoveryBanner. WASM auto-recovers on failed
+  // receive_sync_message; this surfaces the event so it doesn't happen
+  // silently.
+  const [syncRecoveryEvent, setSyncRecoveryEvent] = useState<
+    import("runtimed").SyncErrorEvent | null
+  >(null);
 
   // Pool state - prewarm pool errors from daemon (typo'd default packages, etc.)
   const {
@@ -420,6 +429,19 @@ function AppContent() {
       getEngine()?.reProjectComms();
     }
   }, [blobPort, getEngine]);
+
+  // Surface WASM sync recovery events in the top-level banner.
+  useEffect(() => {
+    const engine = getEngine();
+    if (!engine) return;
+    const sub = engine.syncErrors$.subscribe((ev) => {
+      logger.warn(
+        `[app] sync recovery: ${ev.doc} doc rebuilt (changed=${ev.changed}) at ${new Date(ev.ts).toISOString()}`,
+      );
+      setSyncRecoveryEvent(ev);
+    });
+    return () => sub.unsubscribe();
+  }, [getEngine]);
 
   // Split queue state into executing (currently running) and queued (waiting).
   const executingCellIds = new Set(queueState.executing ? [queueState.executing.cell_id] : []);
@@ -1149,6 +1171,10 @@ function AppContent() {
                 });
               });
           }}
+        />
+        <SyncRecoveryBanner
+          event={syncRecoveryEvent}
+          onDismiss={() => setSyncRecoveryEvent(null)}
         />
         <PoolErrorBanner
           uvError={poolUvError}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -396,6 +396,14 @@ function AppContent() {
     setCrdtCommWriter((commId: string, patch: Record<string, unknown>) => {
       const handle = getHandle();
       if (!handle) return;
+      // Record the write against the echo-suppression history
+      // regardless of whether the caller went through
+      // `WidgetUpdateManager.updateAndPersist` (normal widgets) or
+      // reached the writer directly (anywidget `save_changes`). The
+      // subsequent `projectLocalState` emission is always one of
+      // our own local writes, so it must be consumable by the
+      // pending-write filter.
+      updateManager.recordLocalWrite(commId, patch);
       handle.set_comm_state_batch(commId, JSON.stringify(patch));
       getEngine()?.projectLocalState();
       triggerSync();

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -100,6 +100,40 @@ async function sendMessage(message: unknown): Promise<void> {
 const _outputResolveGen = new Map<string, number>();
 
 /**
+ * Compute the diff of `next` relative to `existing` — returns only
+ * the keys whose values aren't already current in `existing`.
+ *
+ * Used by the `commChanges$` subscriber to avoid firing duplicate
+ * `change` notifications when a synchronous caller (anywidget
+ * `save_changes`, etc.) wrote the value into the store immediately
+ * and the subsequent projection's resolved state carries the same
+ * bytes. Equality is by reference OR by stringified JSON — shallow
+ * comparison would miss structurally-equal objects arriving through
+ * the WASM resolver as fresh references.
+ */
+function diffResolvedState(
+  existing: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(next)) {
+    const prev = existing[key];
+    if (prev === value) continue;
+    // Cheap path: referential match. Otherwise fall back to JSON.
+    // For widget state (mostly scalars and small arrays/objects)
+    // this is fast and avoids the subtleties of deep equality with
+    // mixed reference identities from the WASM resolver.
+    try {
+      if (JSON.stringify(prev) === JSON.stringify(value)) continue;
+    } catch {
+      // Non-serializable values (rare in comm state) → treat as changed.
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
  * Resolve Output widget manifests and update the WidgetStore.
  *
  * When SyncEngine.commChanges$ emits a comm with `unresolvedOutputs`,
@@ -380,12 +414,18 @@ function AppContent() {
         }
       }
       for (const comm of changes.updated) {
-        // CRDT is the single source of truth — no echo suppression
-        // needed (see Track A in the widget-sync stall design doc).
-        // Local writes flow through the same pipeline via
-        // `engine.projectLocalState()`, so every update visible to
-        // the user is also visible in this emission.
-        widgetStore.updateModel(comm.commId, comm.state);
+        // CRDT is the single source of truth. The commChanges$
+        // emission re-delivers the full resolved state; filter out
+        // keys whose values already match the store before calling
+        // `updateModel`, to avoid double `change` notifications when
+        // a caller (anywidget `save_changes`, etc.) wrote the value
+        // synchronously before the projection hopped through a
+        // microtask.
+        const existing = widgetStore.getModel(comm.commId);
+        const diff = existing ? diffResolvedState(existing.state, comm.state) : comm.state;
+        if (Object.keys(diff).length > 0) {
+          widgetStore.updateModel(comm.commId, diff);
+        }
         if (comm.unresolvedOutputs) {
           resolveCommOutputs(comm.commId, comm.unresolvedOutputs, widgetStore);
         }

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -380,12 +380,12 @@ function AppContent() {
         }
       }
       for (const comm of changes.updated) {
-        // Suppress CRDT echoes for keys with pending optimistic values
-        // (e.g. slider being dragged — don't clobber with stale echo).
-        const filtered = updateManager.shouldSuppressEcho(comm.commId, comm.state);
-        if (filtered) {
-          widgetStore.updateModel(comm.commId, filtered);
-        }
+        // CRDT is the single source of truth — no echo suppression
+        // needed (see Track A in the widget-sync stall design doc).
+        // Local writes flow through the same pipeline via
+        // `engine.projectLocalState()`, so every update visible to
+        // the user is also visible in this emission.
+        widgetStore.updateModel(comm.commId, comm.state);
         if (comm.unresolvedOutputs) {
           resolveCommOutputs(comm.commId, comm.unresolvedOutputs, widgetStore);
         }

--- a/apps/notebook/src/components/SyncRecoveryBanner.tsx
+++ b/apps/notebook/src/components/SyncRecoveryBanner.tsx
@@ -41,15 +41,26 @@ export function SyncRecoveryBanner({ event, onDismiss }: SyncRecoveryBannerProps
     if (!event || event === lastEventRef.current) return;
     lastEventRef.current = event;
     setVisible(true);
-    setCount((c) => c + 1);
+    // Only accumulate the burst counter while the banner is still
+    // visible. A fresh emission after the banner has dismissed
+    // restarts the counter — otherwise a one-off recovery hours
+    // earlier would make a new one-off recovery report itself as
+    // the second in a burst.
+    setCount((c) => (visible ? c + 1 : 1));
 
     const timer = window.setTimeout(() => {
       setVisible(false);
+      // Reset the burst counter on dismissal so the next emission
+      // starts fresh.
+      setCount(0);
     }, DISMISS_DELAY_MS);
 
     return () => {
       window.clearTimeout(timer);
     };
+    // `visible` intentionally omitted from deps: we only care about
+    // its value at the instant the event changes.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   }, [event]);
 
   if (!visible || !event) return null;

--- a/apps/notebook/src/components/SyncRecoveryBanner.tsx
+++ b/apps/notebook/src/components/SyncRecoveryBanner.tsx
@@ -1,0 +1,99 @@
+/**
+ * Transient banner surfaced when the WASM sync layer auto-recovers
+ * from a failed `receive_sync_message` (doc rebuilt, sync state
+ * normalized, recovery reply sent).
+ *
+ * The recovery itself is already handled inside the SyncEngine — this
+ * component only exists so the event is visible to the user. Silent
+ * recovery would otherwise be invisible, exactly the class of bug
+ * that the widget-sync stall investigation was chasing down.
+ *
+ * Auto-dismisses after ~5 s so a lone blip doesn't linger. If another
+ * recovery fires while the banner is up, the timer resets and the
+ * count ticks up — a visible "this connection is unhealthy" signal.
+ */
+
+import { RefreshCw, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { SyncErrorEvent } from "runtimed";
+
+/** How long the banner stays up after the latest recovery (ms). */
+const DISMISS_DELAY_MS = 5_000;
+
+interface SyncRecoveryBannerProps {
+  /**
+   * Latest sync-error event, or null when none has fired recently.
+   * Each emission replaces this reference; the banner uses the
+   * reference identity to reset its auto-dismiss timer so a burst
+   * keeps it visible.
+   */
+  event: SyncErrorEvent | null;
+  /** Manual dismiss handler (X button). */
+  onDismiss?: () => void;
+}
+
+export function SyncRecoveryBanner({ event, onDismiss }: SyncRecoveryBannerProps) {
+  const [visible, setVisible] = useState(false);
+  const [count, setCount] = useState(0);
+  const lastEventRef = useRef<SyncErrorEvent | null>(null);
+
+  useEffect(() => {
+    if (!event || event === lastEventRef.current) return;
+    lastEventRef.current = event;
+    setVisible(true);
+    setCount((c) => c + 1);
+
+    const timer = window.setTimeout(() => {
+      setVisible(false);
+    }, DISMISS_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [event]);
+
+  if (!visible || !event) return null;
+
+  const label = docLabel(event.doc);
+  const detail =
+    count > 1
+      ? `Recovered ${count} times recently — connection may be unhealthy.`
+      : "Rebuilt from daemon snapshot.";
+
+  return (
+    <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
+      <RefreshCw className="h-3 w-3 flex-shrink-0" />
+      <span className="font-medium flex-shrink-0">Sync recovered</span>
+      <span className="text-sky-200 flex-shrink-0">—</span>
+      <span className="text-sky-100 truncate">
+        {label} {detail}
+      </span>
+      <div className="ml-auto flex items-center gap-1 flex-shrink-0">
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={() => {
+              setVisible(false);
+              onDismiss();
+            }}
+            className="rounded p-0.5 hover:bg-sky-500/50 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function docLabel(doc: SyncErrorEvent["doc"]): string {
+  switch (doc) {
+    case "notebook":
+      return "Notebook document.";
+    case "runtime_state":
+      return "Runtime state.";
+    case "pool_state":
+      return "Pool state.";
+  }
+}

--- a/apps/notebook/src/lib/notebook-frame-bus.ts
+++ b/apps/notebook/src/lib/notebook-frame-bus.ts
@@ -12,6 +12,8 @@
  * subscribers without a webview round-trip.
  */
 
+import { logger } from "./logger";
+
 // ── Types ────────────────────────────────────────────────────────────
 
 /** Callback for broadcast events (kernel status, output, env progress, etc.) */
@@ -65,8 +67,12 @@ export function emitBroadcast(payload: unknown): void {
   for (const cb of broadcastSubscribers) {
     try {
       cb(payload);
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      // A thrown subscriber must not break the dispatch loop for the
+      // remaining subscribers. We used to swallow silently, but that meant
+      // a component could stop receiving state updates while the rest of
+      // the pipeline kept ticking — very hard to diagnose. Log loudly.
+      logger.error("[frame-bus] broadcast subscriber threw:", err);
     }
   }
 }
@@ -81,8 +87,8 @@ export function emitPresence(payload: unknown): void {
   for (const cb of presenceSubscribers) {
     try {
       cb(payload);
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      logger.error("[frame-bus] presence subscriber threw:", err);
     }
   }
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -6,6 +6,7 @@
  */
 
 import { useSyncExternalStore } from "react";
+import { logger } from "./logger";
 
 // Re-export all types from the package so existing imports work.
 export type {
@@ -37,8 +38,11 @@ function notifySubscribers(): void {
   for (const cb of subscribers) {
     try {
       cb();
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      // A throwing `useSyncExternalStore` callback used to fail silently
+      // and leave components displaying stale runtime state. Log loudly
+      // so the failure is diagnosable.
+      logger.error("[runtime-state] subscriber threw:", err);
     }
   }
 }

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -337,6 +337,24 @@ export class NotebookHandle {
      */
     constructor(notebook_id: string);
     /**
+     * Open a comm in the local RuntimeStateDoc — **test harnesses only**.
+     *
+     * Production code must not call this: comms are opened by the daemon
+     * in response to kernel `comm_open` IOPub messages. Exposing it here
+     * lets the WASM-backed sync harness simulate the daemon side end to
+     * end (push a comm_open, then drive comm_msg updates) without a real
+     * kernel. Without this, `set_comm_state_batch` is a no-op because
+     * the comm entry doesn't exist yet.
+     *
+     * Replaces the fresh RuntimeStateDoc on first call so the scaffolded
+     * `comms`/`queue`/`executions` maps are present — the WASM handle
+     * normally receives scaffolding over sync from the daemon.
+     *
+     * `state_json` must be a JSON object string of the initial widget
+     * state (same shape the daemon would receive from the kernel).
+     */
+    put_comm_for_test(comm_id: string, target_name: string, model_module: string, model_name: string, state_json: string, seq: number): void;
+    /**
      * Receive a typed frame from the daemon, demux by type byte, return events for the frontend.
      *
      * The input is the raw frame bytes from the `notebook:frame` Tauri event:
@@ -644,6 +662,7 @@ export interface InitOutput {
     readonly notebookhandle_load_state_doc: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_move_cell: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_new: (a: number, b: number) => number;
+    readonly notebookhandle_put_comm_for_test: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number) => void;
     readonly notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
     readonly notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_remove_conda_dependency: (a: number, b: number, c: number, d: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -1111,6 +1111,52 @@ export class NotebookHandle {
         return this;
     }
     /**
+     * Open a comm in the local RuntimeStateDoc — **test harnesses only**.
+     *
+     * Production code must not call this: comms are opened by the daemon
+     * in response to kernel `comm_open` IOPub messages. Exposing it here
+     * lets the WASM-backed sync harness simulate the daemon side end to
+     * end (push a comm_open, then drive comm_msg updates) without a real
+     * kernel. Without this, `set_comm_state_batch` is a no-op because
+     * the comm entry doesn't exist yet.
+     *
+     * Replaces the fresh RuntimeStateDoc on first call so the scaffolded
+     * `comms`/`queue`/`executions` maps are present — the WASM handle
+     * normally receives scaffolding over sync from the daemon.
+     *
+     * `state_json` must be a JSON object string of the initial widget
+     * state (same shape the daemon would receive from the kernel).
+     * @param {string} comm_id
+     * @param {string} target_name
+     * @param {string} model_module
+     * @param {string} model_name
+     * @param {string} state_json
+     * @param {number} seq
+     */
+    put_comm_for_test(comm_id, target_name, model_module, model_name, state_json, seq) {
+        try {
+            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+            const ptr0 = passStringToWasm0(comm_id, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+            const len0 = WASM_VECTOR_LEN;
+            const ptr1 = passStringToWasm0(target_name, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+            const len1 = WASM_VECTOR_LEN;
+            const ptr2 = passStringToWasm0(model_module, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+            const len2 = WASM_VECTOR_LEN;
+            const ptr3 = passStringToWasm0(model_name, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+            const len3 = WASM_VECTOR_LEN;
+            const ptr4 = passStringToWasm0(state_json, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+            const len4 = WASM_VECTOR_LEN;
+            wasm.notebookhandle_put_comm_for_test(retptr, this.__wbg_ptr, ptr0, len0, ptr1, len1, ptr2, len2, ptr3, len3, ptr4, len4, seq);
+            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+            if (r1) {
+                throw takeObject(r0);
+            }
+        } finally {
+            wasm.__wbindgen_add_to_stack_pointer(16);
+        }
+    }
+    /**
      * Receive a typed frame from the daemon, demux by type byte, return events for the frontend.
      *
      * The input is the raw frame bytes from the `notebook:frame` Tauri event:

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0e3063f0248acf1f1f3debf8349dfdb02486399284c5947ced43e96c42eb3be
-size 1668157
+oid sha256:755e5d2b20eba504fb0c5e811333ac3f016d9754da806a04c90fc589269a88e8
+size 1677372

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -59,6 +59,7 @@ export const notebookhandle_load: (a: number, b: number, c: number) => void;
 export const notebookhandle_load_state_doc: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_move_cell: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_new: (a: number, b: number) => number;
+export const notebookhandle_put_comm_for_test: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number) => void;
 export const notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
 export const notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_remove_conda_dependency: (a: number, b: number, c: number, d: number) => void;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1240,6 +1240,65 @@ impl NotebookHandle {
         any_written
     }
 
+    /// Open a comm in the local RuntimeStateDoc — **test harnesses only**.
+    ///
+    /// Production code must not call this: comms are opened by the daemon
+    /// in response to kernel `comm_open` IOPub messages. Exposing it here
+    /// lets the WASM-backed sync harness simulate the daemon side end to
+    /// end (push a comm_open, then drive comm_msg updates) without a real
+    /// kernel. Without this, `set_comm_state_batch` is a no-op because
+    /// the comm entry doesn't exist yet.
+    ///
+    /// Replaces the fresh RuntimeStateDoc on first call so the scaffolded
+    /// `comms`/`queue`/`executions` maps are present — the WASM handle
+    /// normally receives scaffolding over sync from the daemon.
+    ///
+    /// `state_json` must be a JSON object string of the initial widget
+    /// state (same shape the daemon would receive from the kernel).
+    pub fn put_comm_for_test(
+        &mut self,
+        comm_id: &str,
+        target_name: &str,
+        model_module: &str,
+        model_name: &str,
+        state_json: &str,
+        seq: u32,
+    ) -> Result<(), JsError> {
+        let state: serde_json::Value = serde_json::from_str(state_json)
+            .map_err(|e| JsError::new(&format!("invalid state_json: {}", e)))?;
+        // If the state_doc is still the empty bootstrap, swap it for a
+        // fully-scaffolded doc so `put_comm` can find the `comms` map.
+        use automerge::ReadDoc;
+        if self
+            .state_doc
+            .doc_mut()
+            .get(automerge::ROOT, "comms")
+            .ok()
+            .flatten()
+            .is_none()
+        {
+            let mut scaffolded = RuntimeStateDoc::new();
+            scaffolded
+                .doc_mut()
+                .merge(self.state_doc.doc_mut())
+                .map_err(|e| JsError::new(&format!("scaffold merge failed: {}", e)))?;
+            self.state_doc = scaffolded;
+            // The sync state is tied to the previous doc's history — reset
+            // so the next flush generates a fresh sync message against the
+            // scaffolded doc.
+            self.state_sync_state = automerge::sync::State::new();
+        }
+        self.state_doc.put_comm(
+            comm_id,
+            target_name,
+            model_module,
+            model_name,
+            &state,
+            seq as u64,
+        );
+        Ok(())
+    }
+
     /// Generate a sync reply for the RuntimeStateDoc.
     /// Called immediately after each `RuntimeStateSyncApplied` event
     /// so the daemon knows which state the client has received.

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -1,0 +1,164 @@
+# Widget sync stall — detection, recovery, and CRDT-first projection
+
+**Status:** In progress. Track B (detection + recovery) shipping on branch `chore/widget-sync-tracing`. Track A (architectural refactor) planned.
+
+## Problem
+
+ipywidgets in an active notebook sporadically stop reflecting kernel-side
+state changes. Symptoms reproduced with a minimal matplotlib `@interact`
+FloatSlider:
+
+- User drags the slider with arrow keys.
+- The slider thumb moves in the UI (optimistic local update).
+- The matplotlib image embedded in the `Output` widget freezes at a
+  stale value — plot title says `sin(1.5x)` while the slider sits at
+  `2.70`.
+- New `execute_cell` requests dispatched to the daemon appear to
+  complete on the daemon side (log shows kernel processed them, CRDT
+  has up-to-date state) but produce no visible change in the UI.
+- **Reloading the notebook window fixes everything instantly.**
+
+That last bit is load-bearing: the CRDT has the correct final state.
+The stall is entirely frontend-side — the daemon→frontend pipeline
+stops delivering updates the UI can render, silently.
+
+## Root-cause surface
+
+Two architectural choices combine to produce the stall:
+
+### 1. Two sources of truth for widget state
+
+The `WidgetStore` is updated from two independent paths:
+
+- **Optimistic** (`WidgetUpdateManager.updateAndPersist` → `store.updateModel`):
+  every user interaction synchronously mutates the store for instant UI
+  feedback, then writes to the CRDT on a 50 ms debounce.
+- **CRDT projection** (`SyncEngine.commChanges$` → App.tsx subscriber
+  → `store.updateModel`): every sync frame from the daemon runs through
+  `projectComms` and pushes the resolved state back into the store.
+
+An echo-suppression layer (`WidgetUpdateManager.shouldSuppressEcho`)
+filters optimistic keys out of incoming CRDT projections so a stale
+kernel echo doesn't clobber an in-flight drag. Under rapid input the
+suppression's bookkeeping gets stuck — `optimisticKeys` are tracked
+per-comm with no bounded lifetime and a `!writer` early-return in
+`flushComm` can leave them populated indefinitely, silently dropping
+every subsequent echo for that comm.
+
+### 2. Silent sync-layer failures
+
+Even without the echo-suppression tangle, the Automerge sync layer can
+drift silently:
+
+- `sendFrame` can fail (pipe buffer full, daemon slow) without the
+  caller knowing the frame wasn't delivered. The `sent_hashes` state
+  on the WASM handle advances anyway, permanently filtering the change.
+- Bloom-filter false positives convince both peers they're in sync
+  when they aren't.
+- The frontend only surfaces a recovery signal when
+  `receive_sync_message` fails outright — the "frame never arrived" and
+  "heads drifted" failure modes are invisible.
+
+## Fix strategy
+
+Two tracks. They compose but ship independently.
+
+### Track B — safety net (no architecture change)
+
+Makes existing failure modes visible and recoverable.
+
+1. **SyncError observability** (`SyncEngine.syncErrors$`). WASM already
+   auto-recovers from failed `receive_sync_message`; the engine already
+   forwards the recovery reply. Surface it via a top-level banner
+   (`SyncRecoveryBanner`) so silent recovery becomes visible. Arms a
+   transient "Sync recovered" message; recurring recoveries bump a
+   counter ("recovered N times recently — connection may be unhealthy").
+2. **Runtime-state stall watchdog**. After an outbound
+   `RUNTIME_STATE_SYNC` flush, start a 3 s timer. Clear only when
+   `generate_runtime_state_sync_reply()` returns `null` (the precise
+   "daemon has fully caught up with our writes" signal — not mere
+   inbound traffic, which fires constantly during kernel execution).
+   On timeout: log, `handle.reset_sync_state()`, re-flush, emit on
+   `syncErrors$`.
+3. **Observability primitives** already landed: abort hung blob fetches
+   (so one stuck fetch doesn't poison the serial `commEmitQueue`), and
+   log (instead of silently swallow) subscriber errors in the frame bus
+   and runtime-state store.
+
+### Track A — architectural refactor (CRDT-first)
+
+Eliminates the drift class entirely by collapsing two sources of truth
+into one.
+
+1. **Route local writes through `projectComms`**. Today `projectComms`
+   only runs on inbound `runtime_state_sync_applied`. After
+   `set_comm_state_batch` on the local handle, fire a synthetic event
+   (or call `projectComms` directly) so the WidgetStore updates from
+   the same pipeline regardless of whether the change originated
+   locally or arrived from the daemon. Paves the way for A2.
+2. **Remove the optimistic path**. `WidgetUpdateManager.updateAndPersist`
+   stops calling `store.updateModel` synchronously. All store updates
+   come from `projectComms`. Delete `shouldSuppressEcho`,
+   `optimisticKeys`, the `!writer` retry loop. The remaining
+   `WidgetUpdateManager` collapses to ~50 lines of debounced CRDT
+   writes. Single source of truth.
+3. **jslink re-derivation**. Today `link-subscriptions.ts` propagates
+   source→target synchronously via `store.updateModel`. After A2,
+   instead of snapshotting, the subscription runs inside each
+   `projectComms` emission: read source from CRDT, write derived value
+   to target. Same behavior, different source. Custom messages
+   (buttons, `model.send()`) and the canvas manager router are on a
+   separate broadcast pipeline (`commBroadcasts$`) and don't change.
+
+### Supporting work
+
+- **Real-WASM test harness** (`packages/runtimed/tests/wasm-harness.ts`
+  + `widget-sync-stall.test.ts`). Scripts the `@interact` scenario
+  headlessly: two `NotebookHandle`s (server + client) connected via
+  `DirectTransport`, real RuntimeStateDoc sync, assertions on
+  `commChanges$` emissions. Lets every subsequent refactor validate
+  against the exact stall case without manual slider-dragging.
+- **`put_comm_for_test`** on the WASM. The real daemon opens comms
+  on kernel `comm_open`; exposing the same operation as a clearly
+  test-only method lets the harness simulate the daemon end to end.
+- **Move more logic into shared `runtimed-js` / `runtimed-wasm`**. The
+  `commChanges$` subscriber loop, `resolveCommOutputs`, and
+  `WidgetUpdateManager` are all framework-agnostic today but live in
+  `apps/notebook`. As Track A lands, push each into the shared library
+  so Deno harnesses, Python clients, and future frontends wire up
+  identically. Each commit in Track A naturally produces a candidate.
+
+## What this is NOT
+
+- Not persisting the sync state across reloads (would be nice; deferred).
+- Not a full reconnect on stall — `reset_sync_state` is cheaper and
+  sufficient for the observed failure modes.
+- Not a full rewrite of the widget store — the store itself is fine;
+  only the dual-write dispatch path on top of it is the problem.
+
+## Validation
+
+- Unit tests in `sync-engine.test.ts` cover the `syncErrors$` observable
+  and the stall watchdog (fires on timeout, clears only on true
+  convergence, re-arms correctly).
+- Real-WASM tests in `widget-sync-stall.test.ts` lock in the expected
+  `commChanges$` emission shape for the `@interact` scenario. These
+  are the invariants Track A must preserve.
+- Manual repro: matplotlib `@interact` + FloatSlider, hammer arrow
+  keys. Before Track B: silent stall. After Track B: banner fires on
+  recovery, watchdog resets the sync state if the pipe dropped a
+  frame. After Track A: no drift possible; optimistic path and
+  suppression heuristic both deleted.
+
+## References
+
+- `crates/runtimed-wasm/src/lib.rs` — `receive_frame`, `reset_sync_state`,
+  `normalize_sync_state`, `put_comm_for_test`.
+- `packages/runtimed/src/sync-engine.ts` — stall watchdog, `syncErrors$`,
+  `projectComms`.
+- `src/components/widgets/widget-update-manager.ts` — current dual-write
+  path (target for deletion in A2).
+- `src/components/widgets/link-subscriptions.ts` — jslink (A3 target).
+- `~/code/src/github.com/automerge/automerge-repo/packages/automerge-repo/src/DocHandle.ts:241-260`
+  — canonical headsAreSame short-circuit, ours at
+  `crates/runtimed-wasm/src/lib.rs:1604-1605`.

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -150,6 +150,49 @@ into one.
   frame. After Track A: no drift possible; optimistic path and
   suppression heuristic both deleted.
 
+## How we got here — jslink archaeology
+
+The optimistic dual-write was introduced in
+[PR #1580](https://github.com/nteract/desktop/pull/1580)
+(`feat(widgets): debounced CRDT writes + jslink echo suppression`).
+`WidgetUpdateManager` landed as part of that PR with three concurrent
+goals:
+
+1. **Slider flooding**: raw slider drags generated ~60 CRDT writes/sec.
+   Debouncing to 50 ms per comm cut that to ~20/sec — healthier sync
+   traffic without losing interactivity.
+2. **Instant UI feedback**: waiting for a round-trip echo before
+   showing the new slider value would feel laggy. Synchronous
+   `store.updateModel` gives the user unmistakable feedback during a
+   drag.
+3. **jslink feedback loops**: two linked widgets (e.g., paired
+   min/max sliders) used to oscillate because each local change
+   echoed back through the CRDT and re-triggered the link handler.
+   `shouldSuppressEcho` filters the echo of optimistic keys out of the
+   incoming CRDT projection so the link doesn't bounce.
+
+All three are legitimate concerns. Track A doesn't retreat on any of
+them — it addresses them from a different angle:
+
+1. Slider flooding → the debounce stays (pure outbound coalescer), it
+   just loses the reconciliation bookkeeping it currently does against
+   the optimistic store.
+2. Instant UI feedback → achieved by making the local CRDT write fire
+   `projectComms` synchronously in the same tick (Track A1). The UI
+   updates from the same pipeline as remote changes, at local-write
+   speed.
+3. jslink loops → solved by deriving targets from the CRDT on each
+   `projectComms` emission rather than cascading through the store.
+   The source's CRDT value is the single source of truth for the
+   link's computation; no oscillation possible because there's no
+   parallel optimistic state to drift from.
+
+The stall that motivated this investigation isn't a regression in
+#1580 — it's an emergent interaction between the echo-suppression's
+bookkeeping and edge cases (silent sync failures, `!writer` early
+returns leaving `optimisticKeys` populated indefinitely). The fix is
+to remove the need for the bookkeeping entirely, not to patch it.
+
 ## References
 
 - `crates/runtimed-wasm/src/lib.rs` — `receive_frame`, `reset_sync_state`,

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -141,6 +141,22 @@ into one.
   drop an inbound key if its value matches a recently-written local
   value within some tombstone window. Deferred.
 
+- **iframe jslink targets don't propagate to other views of the same
+  widget.** Each output iframe runs its own `WidgetStore` shadow
+  (see `src/isolated-renderer/widget-provider.tsx`) that the parent
+  `CommBridgeManager` syncs into. jslink is frontend-only by
+  ipywidgets semantics, so its target writes deliberately skip the
+  kernel — but they currently also skip the parent store. If the
+  same model is rendered in multiple cells (multiple iframes), only
+  the iframe where the source tick fired sees the target update.
+  The shipping compromise: iframe-local-only is correct for the
+  common case (one cell per model) and matches how Jupyter Lab
+  handles jslink within a single output area. A cross-iframe fix
+  would need either a new "local-only" bridge RPC that updates the
+  parent store without forwarding to the kernel, or routing jslink
+  through the CRDT (blocked on the throttle-stutter follow-up
+  above). Deferred.
+
 ## What this is NOT
 
 - Not persisting the sync state across reloads (would be nice; deferred).

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -128,6 +128,19 @@ into one.
   so Deno harnesses, Python clients, and future frontends wire up
   identically. Each commit in Track A naturally produces a candidate.
 
+## Known limitations (follow-up)
+
+- **Linked widget targets tick at the throttle rate, not per-event.**
+  With CRDT writes throttled to 50 ms per comm for outbound flood
+  control, `widgets.jslink` / `widgets.jsdlink` targets update at
+  ~20 Hz during a continuous slider drag — pre-A2 they tracked every
+  tick because the source's store was written per-tick. A naive fix
+  (per-tick `store.updateModel`) reintroduces the echo-clobbering
+  class: stale kernel echoes overwrite in-flight drag values. A
+  proper fix likely requires an "acknowledge by value" filter —
+  drop an inbound key if its value matches a recently-written local
+  value within some tombstone window. Deferred.
+
 ## What this is NOT
 
 - Not persisting the sync state across reloads (would be nice; deferred).

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -147,22 +147,6 @@ into one.
   earlier design pre-empted this class with explicit echo suppression
   bookkeeping (`optimisticKeys`), which we removed in Track A.
 
-- **iframe jslink targets don't propagate to other views of the same
-  widget.** Each output iframe runs its own `WidgetStore` shadow
-  (see `src/isolated-renderer/widget-provider.tsx`) that the parent
-  `CommBridgeManager` syncs into. jslink is frontend-only by
-  ipywidgets semantics, so its target writes deliberately skip the
-  kernel — but they currently also skip the parent store. If the
-  same model is rendered in multiple cells (multiple iframes), only
-  the iframe where the source tick fired sees the target update.
-  The shipping compromise: iframe-local-only is correct for the
-  common case (one cell per model) and matches how Jupyter Lab
-  handles jslink within a single output area. A cross-iframe fix
-  would need either a new "local-only" bridge RPC that updates the
-  parent store without forwarding to the kernel, or routing jslink
-  through the CRDT (blocked on the throttle-stutter follow-up
-  above). Deferred.
-
 ## What this is NOT
 
 - Not persisting the sync state across reloads (would be nice; deferred).

--- a/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
+++ b/docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md
@@ -130,16 +130,22 @@ into one.
 
 ## Known limitations (follow-up)
 
-- **Linked widget targets tick at the throttle rate, not per-event.**
-  With CRDT writes throttled to 50 ms per comm for outbound flood
-  control, `widgets.jslink` / `widgets.jsdlink` targets update at
-  ~20 Hz during a continuous slider drag — pre-A2 they tracked every
-  tick because the source's store was written per-tick. A naive fix
-  (per-tick `store.updateModel`) reintroduces the echo-clobbering
-  class: stale kernel echoes overwrite in-flight drag values. A
-  proper fix likely requires an "acknowledge by value" filter —
-  drop an inbound key if its value matches a recently-written local
-  value within some tombstone window. Deferred.
+- **Rare echo-clobber from validator widgets.**
+  The local store is mirrored on every tick in
+  `WidgetUpdateManager.updateAndPersist` so slider thumbs move
+  smoothly even when CRDT writes are throttled to 50 ms/comm.
+  `projectLocalState → commChanges$ → diffResolvedState` makes the
+  normal round-trip a no-op against what we already wrote. If a
+  validator widget on the kernel side rewrites the incoming value
+  (e.g., clamps `value=150` to `max=100`), the kernel echo lands in
+  the CRDT as a distinct Automerge write and projects back through
+  `commChanges$` with a *different* value than the local store — so
+  the diff is non-empty and the user sees a momentary snap to the
+  validated value mid-drag. This is the expected correction in
+  practice; the only surprise is that it reaches the UI immediately
+  rather than after the drag settles. Documented here because the
+  earlier design pre-empted this class with explicit echo suppression
+  bookkeeping (`optimisticKeys`), which we removed in Track A.
 
 - **iframe jslink targets don't propagate to other views of the same
   widget.** Each output iframe runs its own `WidgetStore` shadow

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -42,6 +42,20 @@ export interface ServerHandle {
 
   /** Reset sync state (for reconnection simulation). */
   reset_sync_state(): void;
+
+  /**
+   * Generate a RuntimeStateDoc sync message for pending comm/queue/exec
+   * changes. Optional — only needed by tests that exercise widget sync.
+   */
+  flush_runtime_state_sync?(): Uint8Array | null | undefined;
+
+  /**
+   * Apply an inbound frame (typed 1-byte prefix + payload) from the
+   * client side. Optional — only needed by tests that exercise runtime
+   * state sync, since the client's initial flush sends a handshake that
+   * the server has to apply before it can reply.
+   */
+  receive_frame?(frame: Uint8Array): unknown;
 }
 
 // ── DirectTransport ──────────────────────────────────────────────────
@@ -101,8 +115,16 @@ export class DirectTransport implements NotebookTransport {
     // Route to server based on frame type.
     if (frameType === FrameType.AUTOMERGE_SYNC) {
       this.server.receive_sync_message(payload);
+    } else if (frameType === FrameType.RUNTIME_STATE_SYNC && this.server.receive_frame) {
+      // Forward RuntimeStateDoc sync by reconstructing the typed frame
+      // (1-byte prefix + payload) and dispatching via receive_frame. The
+      // server handle demuxes by frame type the same way the client does.
+      const frame = new Uint8Array(1 + payload.length);
+      frame[0] = FrameType.RUNTIME_STATE_SYNC;
+      frame.set(payload, 1);
+      this.server.receive_frame(frame);
     }
-    // RUNTIME_STATE_SYNC, PRESENCE, etc. — just record, no server action.
+    // POOL_STATE_SYNC, PRESENCE, etc. — just record, no server action.
   }
 
   onFrame(callback: FrameListener): () => void {
@@ -144,6 +166,28 @@ export class DirectTransport implements NotebookTransport {
     frame.set(msg, 1);
 
     // Deliver as number[] to match Tauri's event payload format.
+    this.deliver(Array.from(frame));
+    return true;
+  }
+
+  /**
+   * Push the server's pending RuntimeStateDoc changes to all client
+   * subscribers as a RUNTIME_STATE_SYNC frame (0x05).
+   *
+   * Mirrors `pushServerChanges()` for the runtime-state doc: generates
+   * a sync message from the server handle's runtime-state sync state
+   * and delivers it to subscribers. Returns true if a message was
+   * generated (server had changes to send).
+   */
+  pushServerRuntimeStateChanges(): boolean {
+    const flush = this.server.flush_runtime_state_sync;
+    if (!flush) return false;
+    const msg = flush.call(this.server);
+    if (!msg) return false;
+
+    const frame = new Uint8Array(1 + msg.length);
+    frame[0] = FrameType.RUNTIME_STATE_SYNC;
+    frame.set(msg, 1);
     this.deliver(Array.from(frame));
     return true;
   }

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -111,6 +111,18 @@ export interface SyncableHandle {
   cell_count(): number;
 
   /**
+   * Read the current local `RuntimeState` snapshot as a native JS
+   * object (same shape consumed by `RuntimeStateSyncApplied` events).
+   *
+   * Optional — implementations that don't support runtime-state
+   * projection (e.g. minimal test mocks) may omit this method. The
+   * sync engine uses it to re-run `projectComms` after a
+   * frontend-initiated `set_comm_state_batch`, so the widget store
+   * sees local writes without waiting for a daemon round-trip.
+   */
+  get_runtime_state?(): unknown;
+
+  /**
    * Resolve ContentRef values in a comm's state.
    *
    * Returns `{ state, buffer_paths, text_paths }` where blob ContentRefs are

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -7,7 +7,7 @@
 
 // Core
 export { SyncEngine } from "./sync-engine";
-export type { SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
+export type { SyncEngineOptions, SyncEngineLogger, SyncErrorEvent } from "./sync-engine";
 
 // Transport
 export type { NotebookTransport, FrameListener } from "./transport";

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -66,6 +66,30 @@ import {
 import { FrameType } from "./transport";
 import type { NotebookTransport } from "./transport";
 
+// ── SyncError event ──────────────────────────────────────────────────
+
+/**
+ * Emitted on `syncErrors$` whenever WASM auto-recovers from a failed
+ * `receive_sync_message` on one of the three synced docs.
+ *
+ * The engine has already forwarded the recovery reply and republished
+ * the resulting state before this fires — consumers only need to
+ * surface a UI signal that a reset happened. A burst of events in
+ * quick succession probably means the connection is unhealthy;
+ * consumers may want to debounce.
+ */
+export interface SyncErrorEvent {
+  /** Which of the three synced documents hit the error. */
+  doc: "notebook" | "runtime_state" | "pool_state";
+  /**
+   * Whether the doc's heads advanced before the error (partial apply).
+   * When true, the engine has already republished the recovered state.
+   */
+  changed: boolean;
+  /** Unix ms timestamp of when the error event fired. */
+  ts: number;
+}
+
 // ── Constants ────────────────────────────────────────────────────────
 
 /** Coalescing window for incoming sync frames (ms). */
@@ -350,6 +374,19 @@ export class SyncEngine {
    */
   readonly initialSyncComplete$: Observable<void>;
 
+  /**
+   * Fires when WASM auto-recovers from a failed `receive_sync_message`.
+   *
+   * The WASM layer rebuilds the doc + normalizes the sync state and
+   * returns a fresh sync reply as a `FrameEvent::*SyncError`. The engine
+   * already forwards the reply to the daemon and republishes the
+   * recovered state; this observable exists so the UI can surface a
+   * transient "sync recovered" signal — silent recovery would otherwise
+   * be invisible, exactly the class of bug the widget-sync stall
+   * investigation was trying to chase down.
+   */
+  readonly syncErrors$: Observable<SyncErrorEvent>;
+
   // Backing subjects for public observables
   private readonly _cellChanges$ = new Subject<CellChangeset | null>();
   private readonly _broadcasts$ = new Subject<unknown>();
@@ -359,6 +396,7 @@ export class SyncEngine {
   private readonly _executionTransitions$ = new Subject<ExecutionTransition[]>();
   private readonly _initialSyncComplete$ = new Subject<void>();
   private readonly _commChanges$ = new Subject<CommChanges>();
+  private readonly _syncErrors$ = new Subject<SyncErrorEvent>();
 
   constructor(opts: SyncEngineOptions) {
     this.opts = {
@@ -376,6 +414,7 @@ export class SyncEngine {
     this.executionTransitions$ = this._executionTransitions$.asObservable();
     this.initialSyncComplete$ = this._initialSyncComplete$.asObservable();
     this.commChanges$ = this._commChanges$.asObservable();
+    this.syncErrors$ = this._syncErrors$.asObservable();
     this.kernelStatus$ = deriveKernelStatus$(this.runtimeState$);
 
     // Typed broadcast sub-observables (derived from broadcasts$)
@@ -610,6 +649,7 @@ export class SyncEngine {
     sub.add(
       frameEvents$.pipe(filter((e) => e.type === "sync_error")).subscribe((e) => {
         log.warn("[sync-engine] sync_error: doc rebuilt, sync state normalized");
+        this._syncErrors$.next({ doc: "notebook", changed: e.changed ?? false, ts: Date.now() });
         if (e.reply) {
           this.opts.transport
             .sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(e.reply))
@@ -640,6 +680,11 @@ export class SyncEngine {
         log.warn(
           "[sync-engine] runtime_state_sync_error: state doc rebuilt, sync state normalized",
         );
+        this._syncErrors$.next({
+          doc: "runtime_state",
+          changed: e.changed ?? false,
+          ts: Date.now(),
+        });
         if (e.reply) {
           this.opts.transport
             .sendFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array(e.reply))
@@ -808,6 +853,11 @@ export class SyncEngine {
     sub.add(
       frameEvents$.pipe(filter((e) => e.type === "pool_state_sync_error")).subscribe((e) => {
         log.warn("[sync-engine] pool_state_sync_error: pool doc rebuilt, sync state normalized");
+        this._syncErrors$.next({
+          doc: "pool_state",
+          changed: e.changed ?? false,
+          ts: Date.now(),
+        });
         if (e.reply) {
           this.opts.transport
             .sendFrame(FrameType.POOL_STATE_SYNC, new Uint8Array(e.reply))

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1005,11 +1005,17 @@ export class SyncEngine {
    * three peer states) but reliably unsticks widget updates.
    */
   private armRuntimeStateStallWatchdog(): void {
+    // Each new outbound flush resets the deadline. A sustained burst of
+    // local writes (slider drag, play-widget loop, anywidget traits
+    // streaming) produces more outbound than the daemon can reply-null
+    // to; we'd rather give each new write a fresh 3s window than fire
+    // on a healthy-but-busy session. The stall case we do want to
+    // catch — pipe drops the frame, daemon panics, bloom filter false
+    // positive — shows up as "no more outbound to reset the timer
+    // AND no inbound arriving" within 3s of the last flush, which
+    // this still detects.
     if (this.runtimeStateStallTimer) {
-      // Already armed — don't reset. A burst of outbound writes should
-      // all land within a single watchdog window; resetting on each
-      // write would hide the stall.
-      return;
+      clearTimeout(this.runtimeStateStallTimer);
     }
     this.runtimeStateStallTimer = setTimeout(() => {
       this.runtimeStateStallTimer = null;

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -147,11 +147,26 @@ async function inlineTextBlobs(
 }
 
 /**
+ * Per-attempt timeout for a single blob fetch.
+ *
+ * `projectComms` serializes async comm emissions on `commEmitQueue` to
+ * preserve ordering, which means any hung fetch stalls *all* subsequent
+ * widget state updates behind it. 5s is generous for a loopback HTTP blob
+ * server but short enough that a broken/slow server never silently blocks
+ * widget sync indefinitely.
+ */
+const TEXT_BLOB_FETCH_TIMEOUT_MS = 5_000;
+
+/**
  * Fetch `url` as text, retrying transient failures.
  *
  * Returns the decoded body on success, or `null` after all retries are
  * exhausted. 4xx responses are treated as permanent and returned
  * immediately without retry (the daemon doesn't know about that hash).
+ *
+ * Each attempt has a hard timeout via `AbortController` — without it, a
+ * fetch that hangs (connection established, body never completes) would
+ * poison the serial comm-emit queue forever.
  */
 async function fetchTextBlobWithRetry(
   url: string,
@@ -162,8 +177,10 @@ async function fetchTextBlobWithRetry(
     if (attempt > 0) {
       await delay(TEXT_BLOB_RETRY_DELAYS_MS[attempt - 1]);
     }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TEXT_BLOB_FETCH_TIMEOUT_MS);
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { signal: controller.signal });
       if (res.ok) {
         return await res.text();
       }
@@ -174,7 +191,14 @@ async function fetchTextBlobWithRetry(
         return null;
       }
     } catch (err) {
-      lastReason = err instanceof Error ? err.message : String(err);
+      lastReason =
+        err instanceof Error
+          ? err.name === "AbortError"
+            ? `timeout after ${TEXT_BLOB_FETCH_TIMEOUT_MS}ms`
+            : err.message
+          : String(err);
+    } finally {
+      clearTimeout(timer);
     }
   }
   logger.warn(

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1305,5 +1305,9 @@ export class SyncEngine {
     this.prevExecutions = {};
     this.commDiffState = { comms: {}, json: {} };
     this.lastRuntimeState = null;
+    // Drop any in-flight stall watchdog — the fresh handle it would
+    // have fired against is now gone, and letting it expire would
+    // raise a spurious sync-recovery banner during a healthy reconnect.
+    this.clearRuntimeStateStallWatchdog();
   }
 }

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -813,18 +813,21 @@ export class SyncEngine {
               this.projectComms(state);
             }
 
-            // Send sync reply so the daemon knows our heads.
-            //
-            // `generate_runtime_state_sync_reply` returns `null` IFF
-            // we and the daemon have fully converged — nothing left to
-            // send in either direction. That's the precise signal we
-            // want for the stall watchdog: clear it only when our own
-            // outstanding writes have been incorporated, not on every
-            // inbound runtime-state frame (which fires often for
-            // daemon-authored queue / execution / status changes even
-            // when our widget update was silently dropped).
+            // Any inbound runtime-state frame proves the daemon is
+            // responsive, so clear the stall watchdog. Earlier
+            // iterations tried a stricter signal (clear only when
+            // `generate_runtime_state_sync_reply()` returns null =
+            // fully converged) but that fires the watchdog after
+            // every normal single interaction: daemon applies our
+            // write, responds once, then goes quiet — and our ack
+            // reply is non-null so the watchdog stays armed. The
+            // weaker "any inbound clears" heuristic misses the
+            // narrow case where the daemon is busy with unrelated
+            // traffic AND our specific write was dropped, but that's
+            // preferable to spurious resets on every widget click.
             const handle = this.opts.getHandle();
             if (handle) {
+              this.clearRuntimeStateStallWatchdog();
               try {
                 const reply = handle.generate_runtime_state_sync_reply();
                 if (reply) {
@@ -836,7 +839,6 @@ export class SyncEngine {
                       ),
                   );
                 }
-                this.clearRuntimeStateStallWatchdog();
               } catch (err) {
                 log.warn("[sync-engine] generate_runtime_state_sync_reply failed:", err);
               }

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -740,10 +740,6 @@ export class SyncEngine {
         .pipe(
           filter((e) => e.type === "runtime_state_sync_applied"),
           concatMap((e) => {
-            // Any inbound runtime-state sync frame acknowledges the
-            // daemon is responsive — even if nothing changed (pure
-            // convergence ack), that's still a liveness signal.
-            this.clearRuntimeStateStallWatchdog();
             if (e.changed && e.state) {
               const state = e.state as RuntimeState;
 
@@ -817,7 +813,16 @@ export class SyncEngine {
               this.projectComms(state);
             }
 
-            // Send sync reply so the daemon knows our heads
+            // Send sync reply so the daemon knows our heads.
+            //
+            // `generate_runtime_state_sync_reply` returns `null` IFF
+            // we and the daemon have fully converged — nothing left to
+            // send in either direction. That's the precise signal we
+            // want for the stall watchdog: clear it only when our own
+            // outstanding writes have been incorporated, not on every
+            // inbound runtime-state frame (which fires often for
+            // daemon-authored queue / execution / status changes even
+            // when our widget update was silently dropped).
             const handle = this.opts.getHandle();
             if (handle) {
               try {
@@ -831,6 +836,7 @@ export class SyncEngine {
                       ),
                   );
                 }
+                this.clearRuntimeStateStallWatchdog();
               } catch (err) {
                 log.warn("[sync-engine] generate_runtime_state_sync_reply failed:", err);
               }

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -98,6 +98,16 @@ const COALESCE_MS = 32;
 /** Timeout before retrying sync if initial sync hasn't produced cells (ms). */
 const SYNC_RETRY_MS = 3000;
 
+/**
+ * Watchdog: after sending an outbound RUNTIME_STATE_SYNC frame, how
+ * long do we wait for a corresponding inbound `runtime_state_sync_applied`
+ * (or `_error`) event before declaring the sync stalled and forcing a
+ * reset. Widget state updates normally round-trip under 100ms; even
+ * under heavy load a few hundred ms is plenty. 3s is a generous cap
+ * before we assume something silent has broken in the pipe or daemon.
+ */
+const RUNTIME_STATE_STALL_MS = 3000;
+
 /** Debounce interval for outbound source sync (ms). */
 const FLUSH_DEBOUNCE_MS = 20;
 
@@ -398,6 +408,16 @@ export class SyncEngine {
   private readonly _commChanges$ = new Subject<CommChanges>();
   private readonly _syncErrors$ = new Subject<SyncErrorEvent>();
 
+  /**
+   * Watchdog for an outstanding RUNTIME_STATE_SYNC flush. Armed when
+   * we send an outbound frame, cleared on any inbound
+   * `runtime_state_sync_applied` or `runtime_state_sync_error` event.
+   * If it fires, the daemon hasn't acknowledged our change in
+   * `RUNTIME_STATE_STALL_MS` — we assume silent failure in the pipe
+   * or daemon, reset the sync state, and re-flush.
+   */
+  private runtimeStateStallTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(opts: SyncEngineOptions) {
     this.opts = {
       ...opts,
@@ -680,6 +700,10 @@ export class SyncEngine {
         log.warn(
           "[sync-engine] runtime_state_sync_error: state doc rebuilt, sync state normalized",
         );
+        // Error-recovery also counts as a response from the daemon —
+        // the WASM already did its own recovery. Clear the watchdog so
+        // we don't stack our reset on top.
+        this.clearRuntimeStateStallWatchdog();
         this._syncErrors$.next({
           doc: "runtime_state",
           changed: e.changed ?? false,
@@ -716,6 +740,10 @@ export class SyncEngine {
         .pipe(
           filter((e) => e.type === "runtime_state_sync_applied"),
           concatMap((e) => {
+            // Any inbound runtime-state sync frame acknowledges the
+            // daemon is responsive — even if nothing changed (pure
+            // convergence ack), that's still a liveness signal.
+            this.clearRuntimeStateStallWatchdog();
             if (e.changed && e.state) {
               const state = e.state as RuntimeState;
 
@@ -890,6 +918,7 @@ export class SyncEngine {
   stop(): void {
     if (!this.subscription) return;
     this.opts.logger.info("[sync-engine] Stopping");
+    this.clearRuntimeStateStallWatchdog();
     this.subscription.unsubscribe();
     this.subscription = null;
   }
@@ -927,6 +956,63 @@ export class SyncEngine {
    * is queued on `commEmitQueue` so emissions stay in order even when text
    * blob fetches from one batch outlive a later batch's fetches.
    */
+  // ── Runtime-state stall watchdog ─────────────────────────────────
+
+  /**
+   * Start (or extend) the runtime-state stall watchdog.
+   *
+   * Called when we send an outbound RUNTIME_STATE_SYNC frame. If the
+   * watchdog fires before the corresponding inbound applied/error event
+   * clears it, we assume the sync is silently stalled — the pipe dropped
+   * the frame, the daemon panicked mid-apply, or bloom-filter false
+   * positives convinced both sides they were in sync when they weren't.
+   * Recovery: `reset_sync_state` + flush. Heavy-handed (it blanks all
+   * three peer states) but reliably unsticks widget updates.
+   */
+  private armRuntimeStateStallWatchdog(): void {
+    if (this.runtimeStateStallTimer) {
+      // Already armed — don't reset. A burst of outbound writes should
+      // all land within a single watchdog window; resetting on each
+      // write would hide the stall.
+      return;
+    }
+    this.runtimeStateStallTimer = setTimeout(() => {
+      this.runtimeStateStallTimer = null;
+      this.handleRuntimeStateStall();
+    }, RUNTIME_STATE_STALL_MS);
+  }
+
+  private clearRuntimeStateStallWatchdog(): void {
+    if (this.runtimeStateStallTimer) {
+      clearTimeout(this.runtimeStateStallTimer);
+      this.runtimeStateStallTimer = null;
+    }
+  }
+
+  private handleRuntimeStateStall(): void {
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+    this.opts.logger.warn(
+      `[sync-engine] runtime-state sync stall — no daemon response within ${RUNTIME_STATE_STALL_MS}ms. Resetting sync state and re-flushing.`,
+    );
+    // Blow away the peer state so the next flush renegotiates from
+    // scratch. This is the WASM equivalent of automerge-repo's "fresh
+    // peer" recovery — cheaper than reconnecting but guaranteed to
+    // produce a full sync message that includes anything the daemon
+    // claims to already have but actually doesn't.
+    handle.reset_sync_state();
+    // Emit on syncErrors$ so the UI surfaces a recovery signal
+    // consistent with WASM's own receive_sync_message recoveries.
+    this._syncErrors$.next({
+      doc: "runtime_state",
+      changed: false,
+      ts: Date.now(),
+    });
+    // Immediately re-flush so the daemon can re-deliver any state it
+    // thinks we already have.
+    this.flush();
+  }
+
   private projectComms(state: RuntimeState): void {
     this.lastRuntimeState = state;
     const comms = state.comms ?? {};
@@ -1060,7 +1146,9 @@ export class SyncEngine {
     // stuck on "not_started" (#runtime-state-race).
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
+      this.armRuntimeStateStallWatchdog();
       this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg).catch((e: unknown) => {
+        this.clearRuntimeStateStallWatchdog();
         handle.cancel_last_runtime_state_flush();
         this.opts.logger.warn("[sync-engine] runtime state sync to relay failed:", e);
       });
@@ -1117,9 +1205,11 @@ export class SyncEngine {
     // Also flush RuntimeStateDoc sync.
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
+      this.armRuntimeStateStallWatchdog();
       try {
         await this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg);
       } catch (e) {
+        this.clearRuntimeStateStallWatchdog();
         handle.cancel_last_runtime_state_flush();
         this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
       }

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -952,6 +952,35 @@ export class SyncEngine {
   }
 
   /**
+   * Project local comm state after a frontend-initiated write.
+   *
+   * The widget store is a projection of RuntimeStateDoc. Remote changes
+   * land via `runtime_state_sync_applied` → `projectComms` → emit on
+   * `commChanges$`. Local writes (user drags a slider, sets an
+   * anywidget trait) mutate the WASM state doc directly via
+   * `set_comm_state_batch` — they don't go through `receive_frame`, so
+   * the projection pipeline never fires and the widget store only
+   * observes the change once the daemon's echo makes the round trip.
+   *
+   * Call this immediately after a local `set_comm_state_batch` to run
+   * the same projection step against the handle's current state. The
+   * UI sees the change in the same tick, from the same pipeline as
+   * remote changes — a single source of truth. Closes the gap that
+   * today's optimistic store writes bridge via a separate dual-write
+   * path.
+   */
+  projectLocalState(): void {
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+    // `get_runtime_state` returns the full native-object snapshot the
+    // same way `RuntimeStateSyncApplied` does — feed it to the same
+    // projection used for remote inbound frames.
+    const state = handle.get_runtime_state?.() as RuntimeState | undefined;
+    if (!state) return;
+    this.projectComms(state);
+  }
+
+  /**
    * Project comm state from a RuntimeState snapshot.
    *
    * Diffs against previous state, resolves ContentRefs via the WASM handle,

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1705,6 +1705,96 @@ describe("SyncEngine", () => {
       }
     });
   });
+
+  // ── Runtime-state stall watchdog ───────────────────────────────
+
+  describe("runtime-state stall watchdog", () => {
+    it("resets sync state + re-flushes when daemon doesn't ack within 3s", () => {
+      vi.useFakeTimers();
+      try {
+        const stateMsg = new Uint8Array([0xaa, 0xbb]);
+        const flushSpy = vi.fn(() => stateMsg);
+        handle = createMockHandle({
+          flush_runtime_state_sync: flushSpy,
+        });
+        const sendSpy = vi.spyOn(transport, "sendFrame");
+        const engine = createEngine();
+        engine.start();
+
+        // Manual flush — arms the watchdog.
+        engine.flush();
+        expect(sendSpy).toHaveBeenCalledWith(FrameType.RUNTIME_STATE_SYNC, stateMsg);
+        const initialFlushCount = flushSpy.mock.calls.length;
+
+        // Advance past the 3s watchdog window without any inbound frame.
+        vi.advanceTimersByTime(3100);
+
+        expect(handle.reset_sync_state).toHaveBeenCalled();
+        // handleRuntimeStateStall kicks another flush to renegotiate.
+        expect(flushSpy.mock.calls.length).toBeGreaterThan(initialFlushCount);
+
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears the watchdog when a runtime_state_sync_applied event arrives", () => {
+      vi.useFakeTimers();
+      try {
+        const stateMsg = new Uint8Array([0xaa, 0xbb]);
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi.fn(() => stateMsg),
+          receive_frame: vi.fn(() => [
+            { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
+          ]),
+        });
+        const engine = createEngine();
+        engine.start();
+
+        engine.flush();
+        // Deliver an inbound frame — clears the watchdog.
+        transport.deliver([0x05, 0x01]);
+
+        vi.advanceTimersByTime(3100);
+
+        expect(handle.reset_sync_state).not.toHaveBeenCalled();
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("watchdog re-arms on later flushes after the first one was cleared", () => {
+      vi.useFakeTimers();
+      try {
+        const stateMsg = new Uint8Array([0xaa]);
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi.fn(() => stateMsg),
+          receive_frame: vi.fn(() => [
+            { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
+          ]),
+        });
+        const engine = createEngine();
+        engine.start();
+
+        // First round: flush, ack, watchdog cleared.
+        engine.flush();
+        transport.deliver([0x05, 0x01]);
+        vi.advanceTimersByTime(500);
+        expect(handle.reset_sync_state).not.toHaveBeenCalled();
+
+        // Second round: flush again, NO ack, watchdog fires.
+        engine.flush();
+        vi.advanceTimersByTime(3100);
+        expect(handle.reset_sync_state).toHaveBeenCalled();
+
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });
 
 // ── DirectTransport tests ──────────────────────────────────────────

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1739,137 +1739,42 @@ describe("SyncEngine", () => {
       }
     });
 
-    it("clears the watchdog only when the daemon has fully ack'd our writes", async () => {
-      // Regression: inbound RuntimeStateDoc traffic from the daemon
-      // (queue / execution / status changes) must NOT count as an ack
-      // for a previously-sent client flush. The real signal is that
-      // `generate_runtime_state_sync_reply()` returns null — meaning
-      // both peers are fully converged.
+    it("any inbound runtime-state frame clears the watchdog", async () => {
+      // The watchdog's job is to detect a dead pipe / unresponsive
+      // daemon — not "daemon hasn't caught up yet." Any inbound
+      // frame proves the daemon is alive, so clear. The stricter
+      // "wait for full convergence" variant fired the watchdog
+      // after every normal single interaction: daemon applies our
+      // write, responds once, then goes quiet while our ack reply
+      // is still non-null, leaving the timer running.
       vi.useFakeTimers();
       try {
         const stateMsg = new Uint8Array([0xaa, 0xbb]);
-        // Reply returns non-null (still pending) for the first two
-        // calls, then null (converged) on the third.
-        const replies: (Uint8Array | null)[] = [
-          new Uint8Array([0x11]),
-          new Uint8Array([0x22]),
-          null,
-        ];
-        const replyFn = vi.fn(() => replies.shift() ?? null);
         handle = createMockHandle({
           flush_runtime_state_sync: vi.fn(() => stateMsg),
-          generate_runtime_state_sync_reply: replyFn,
+          // Reply always non-null (single healthy round: daemon
+          // applied, sent us a state update, and we need to ack).
+          generate_runtime_state_sync_reply: vi.fn(() => new Uint8Array([0x11])),
           receive_frame: vi.fn(() => [
-            {
-              type: "runtime_state_sync_applied",
-              changed: true,
-              state: {
-                kernel: {
-                  status: "idle",
-                  starting_phase: "",
-                  name: "",
-                  language: "",
-                  env_source: "",
-                },
-                queue: {
-                  executing: null,
-                  executing_execution_id: null,
-                  queued: [],
-                  queued_execution_ids: [],
-                },
-                env: { in_sync: true, added: [], removed: [] },
-                trust: { status: "trusted", needs_approval: false },
-                last_saved: null,
-                executions: {},
-                comms: {},
-              },
-            } as FrameEvent,
+            { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
           ]),
         });
         const engine = createEngine();
         engine.start();
 
-        // Outbound flush arms the watchdog.
         engine.flush();
 
-        // First inbound: reply is non-null (daemon hasn't caught up
-        // yet). Watchdog should stay armed.
+        // One inbound arrives — clears the watchdog regardless of
+        // whether our ack reply is null or non-null.
         transport.deliver([0x05, 0x01]);
         await vi.advanceTimersByTimeAsync(100);
         expect(handle.reset_sync_state).not.toHaveBeenCalled();
 
-        // Second inbound: reply still non-null. Still armed.
-        transport.deliver([0x05, 0x01]);
-        await vi.advanceTimersByTimeAsync(100);
-        expect(handle.reset_sync_state).not.toHaveBeenCalled();
-
-        // Third inbound: reply is null — converged. Clear watchdog.
-        transport.deliver([0x05, 0x01]);
-        await vi.advanceTimersByTimeAsync(10);
-
+        // Daemon goes quiet. No further frames. Watchdog should not
+        // fire — the interaction completed cleanly.
         await vi.advanceTimersByTimeAsync(3100);
         expect(handle.reset_sync_state).not.toHaveBeenCalled();
-        engine.stop();
-      } finally {
-        vi.useRealTimers();
-      }
-    });
 
-    it("inbound traffic without full convergence does NOT clear the watchdog", async () => {
-      // The active-kernel case codex flagged: the daemon emits
-      // unrelated runtime-state frames (execution status, queue) that
-      // advance the doc but don't ack the client's widget patch.
-      // `generate_runtime_state_sync_reply()` still returns non-null
-      // in that case because our local change isn't in shared_heads
-      // yet. The watchdog must still fire.
-      vi.useFakeTimers();
-      try {
-        const stateMsg = new Uint8Array([0xaa]);
-        handle = createMockHandle({
-          flush_runtime_state_sync: vi.fn(() => stateMsg),
-          // Reply always non-null — daemon never catches up with us.
-          generate_runtime_state_sync_reply: vi.fn(() => new Uint8Array([0x99])),
-          receive_frame: vi.fn(() => [
-            {
-              type: "runtime_state_sync_applied",
-              changed: true,
-              state: {
-                kernel: {
-                  status: "idle",
-                  starting_phase: "",
-                  name: "",
-                  language: "",
-                  env_source: "",
-                },
-                queue: {
-                  executing: null,
-                  executing_execution_id: null,
-                  queued: [],
-                  queued_execution_ids: [],
-                },
-                env: { in_sync: true, added: [], removed: [] },
-                trust: { status: "trusted", needs_approval: false },
-                last_saved: null,
-                executions: {},
-                comms: {},
-              },
-            } as FrameEvent,
-          ]),
-        });
-        const engine = createEngine();
-        engine.start();
-
-        engine.flush();
-
-        // Several rounds of daemon traffic — but our reply is still
-        // pending, so none of them ack our write.
-        for (let i = 0; i < 3; i++) {
-          transport.deliver([0x05, 0x01]);
-          await vi.advanceTimersByTimeAsync(500);
-        }
-
-        await vi.advanceTimersByTimeAsync(2000);
-        expect(handle.reset_sync_state).toHaveBeenCalled();
         engine.stop();
       } finally {
         vi.useRealTimers();

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1270,6 +1270,30 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("emits syncErrors$ for notebook, runtime_state, and pool_state recoveries", () => {
+      handle = createMockHandle({
+        receive_frame: vi.fn(() => [
+          { type: "sync_error", changed: false } as FrameEvent,
+          { type: "runtime_state_sync_error", changed: true } as FrameEvent,
+          { type: "pool_state_sync_error", changed: false } as FrameEvent,
+        ]),
+      });
+      const engine = createEngine();
+      engine.start();
+      const events: { doc: string; changed: boolean }[] = [];
+      engine.syncErrors$.subscribe((ev) => events.push({ doc: ev.doc, changed: ev.changed }));
+
+      transport.deliver([0x00, 0x99]);
+      advanceBy(scheduler, 1);
+
+      expect(events).toEqual([
+        { doc: "notebook", changed: false },
+        { doc: "runtime_state", changed: true },
+        { doc: "pool_state", changed: false },
+      ]);
+      engine.stop();
+    });
+
     it("triggers full materialization when sync_error has changed=true", () => {
       handle = createMockHandle({
         receive_frame: vi.fn(() => [

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1739,25 +1739,75 @@ describe("SyncEngine", () => {
       }
     });
 
-    it("clears the watchdog when a runtime_state_sync_applied event arrives", () => {
+    it("clears the watchdog only when the daemon has fully ack'd our writes", async () => {
+      // Regression: inbound RuntimeStateDoc traffic from the daemon
+      // (queue / execution / status changes) must NOT count as an ack
+      // for a previously-sent client flush. The real signal is that
+      // `generate_runtime_state_sync_reply()` returns null — meaning
+      // both peers are fully converged.
       vi.useFakeTimers();
       try {
         const stateMsg = new Uint8Array([0xaa, 0xbb]);
+        // Reply returns non-null (still pending) for the first two
+        // calls, then null (converged) on the third.
+        const replies: (Uint8Array | null)[] = [
+          new Uint8Array([0x11]),
+          new Uint8Array([0x22]),
+          null,
+        ];
+        const replyFn = vi.fn(() => replies.shift() ?? null);
         handle = createMockHandle({
           flush_runtime_state_sync: vi.fn(() => stateMsg),
+          generate_runtime_state_sync_reply: replyFn,
           receive_frame: vi.fn(() => [
-            { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
+            {
+              type: "runtime_state_sync_applied",
+              changed: true,
+              state: {
+                kernel: {
+                  status: "idle",
+                  starting_phase: "",
+                  name: "",
+                  language: "",
+                  env_source: "",
+                },
+                queue: {
+                  executing: null,
+                  executing_execution_id: null,
+                  queued: [],
+                  queued_execution_ids: [],
+                },
+                env: { in_sync: true, added: [], removed: [] },
+                trust: { status: "trusted", needs_approval: false },
+                last_saved: null,
+                executions: {},
+                comms: {},
+              },
+            } as FrameEvent,
           ]),
         });
         const engine = createEngine();
         engine.start();
 
+        // Outbound flush arms the watchdog.
         engine.flush();
-        // Deliver an inbound frame — clears the watchdog.
+
+        // First inbound: reply is non-null (daemon hasn't caught up
+        // yet). Watchdog should stay armed.
         transport.deliver([0x05, 0x01]);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(handle.reset_sync_state).not.toHaveBeenCalled();
 
-        vi.advanceTimersByTime(3100);
+        // Second inbound: reply still non-null. Still armed.
+        transport.deliver([0x05, 0x01]);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(handle.reset_sync_state).not.toHaveBeenCalled();
 
+        // Third inbound: reply is null — converged. Clear watchdog.
+        transport.deliver([0x05, 0x01]);
+        await vi.advanceTimersByTimeAsync(10);
+
+        await vi.advanceTimersByTimeAsync(3100);
         expect(handle.reset_sync_state).not.toHaveBeenCalled();
         engine.stop();
       } finally {
@@ -1765,12 +1815,77 @@ describe("SyncEngine", () => {
       }
     });
 
-    it("watchdog re-arms on later flushes after the first one was cleared", () => {
+    it("inbound traffic without full convergence does NOT clear the watchdog", async () => {
+      // The active-kernel case codex flagged: the daemon emits
+      // unrelated runtime-state frames (execution status, queue) that
+      // advance the doc but don't ack the client's widget patch.
+      // `generate_runtime_state_sync_reply()` still returns non-null
+      // in that case because our local change isn't in shared_heads
+      // yet. The watchdog must still fire.
       vi.useFakeTimers();
       try {
         const stateMsg = new Uint8Array([0xaa]);
         handle = createMockHandle({
           flush_runtime_state_sync: vi.fn(() => stateMsg),
+          // Reply always non-null — daemon never catches up with us.
+          generate_runtime_state_sync_reply: vi.fn(() => new Uint8Array([0x99])),
+          receive_frame: vi.fn(() => [
+            {
+              type: "runtime_state_sync_applied",
+              changed: true,
+              state: {
+                kernel: {
+                  status: "idle",
+                  starting_phase: "",
+                  name: "",
+                  language: "",
+                  env_source: "",
+                },
+                queue: {
+                  executing: null,
+                  executing_execution_id: null,
+                  queued: [],
+                  queued_execution_ids: [],
+                },
+                env: { in_sync: true, added: [], removed: [] },
+                trust: { status: "trusted", needs_approval: false },
+                last_saved: null,
+                executions: {},
+                comms: {},
+              },
+            } as FrameEvent,
+          ]),
+        });
+        const engine = createEngine();
+        engine.start();
+
+        engine.flush();
+
+        // Several rounds of daemon traffic — but our reply is still
+        // pending, so none of them ack our write.
+        for (let i = 0; i < 3; i++) {
+          transport.deliver([0x05, 0x01]);
+          await vi.advanceTimersByTimeAsync(500);
+        }
+
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(handle.reset_sync_state).toHaveBeenCalled();
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("watchdog re-arms on later flushes after the first one was cleared", async () => {
+      vi.useFakeTimers();
+      try {
+        const stateMsg = new Uint8Array([0xaa]);
+        // First round: reply converges on inbound (clears watchdog).
+        // Second round: no inbound at all (watchdog should fire).
+        const replies: (Uint8Array | null)[] = [null];
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi.fn(() => stateMsg),
+          generate_runtime_state_sync_reply: vi.fn(() => replies.shift() ?? null),
           receive_frame: vi.fn(() => [
             { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
           ]),
@@ -1778,15 +1893,15 @@ describe("SyncEngine", () => {
         const engine = createEngine();
         engine.start();
 
-        // First round: flush, ack, watchdog cleared.
+        // First round: flush, inbound, reply null → watchdog cleared.
         engine.flush();
         transport.deliver([0x05, 0x01]);
-        vi.advanceTimersByTime(500);
+        await vi.advanceTimersByTimeAsync(500);
         expect(handle.reset_sync_state).not.toHaveBeenCalled();
 
-        // Second round: flush again, NO ack, watchdog fires.
+        // Second round: flush again, NO inbound, watchdog fires.
         engine.flush();
-        vi.advanceTimersByTime(3100);
+        await vi.advanceTimersByTimeAsync(3100);
         expect(handle.reset_sync_state).toHaveBeenCalled();
 
         engine.stop();

--- a/packages/runtimed/tests/wasm-harness.ts
+++ b/packages/runtimed/tests/wasm-harness.ts
@@ -79,6 +79,14 @@ class WasmServerHandle implements ServerHandle {
   reset_sync_state(): void {
     this.handle.reset_sync_state();
   }
+
+  flush_runtime_state_sync(): Uint8Array | null {
+    return this.handle.flush_runtime_state_sync() ?? null;
+  }
+
+  receive_frame(frame: Uint8Array): unknown {
+    return this.handle.receive_frame(frame);
+  }
 }
 
 // ── Test harness ─────────────────────────────────────────────────────
@@ -105,10 +113,48 @@ export interface WasmHarness {
   serverClearOutputs(cellId: string): void;
 
   /**
+   * Open a comm on the server (daemon) side. Mirrors the daemon's
+   * reaction to a kernel `comm_open` IOPub message — creates the
+   * `doc.comms.<commId>` entry with metadata + initial state.
+   */
+  serverOpenComm(
+    commId: string,
+    opts: {
+      targetName: string;
+      modelModule: string;
+      modelName: string;
+      state: Record<string, unknown>;
+      seq?: number;
+    },
+  ): void;
+
+  /**
+   * Apply a widget-state patch on the server (daemon) side. The comm
+   * must already be opened via `serverOpenComm`. Mirrors how the real
+   * daemon writes kernel `comm_msg(update)` traffic into
+   * `doc.comms.<commId>.state`.
+   */
+  serverSetCommState(commId: string, patch: Record<string, unknown>): void;
+
+  /**
    * Push server changes to the client via the transport.
    * Returns true if a sync message was delivered.
    */
   pushToClient(): boolean;
+
+  /**
+   * Push the server's pending RuntimeStateDoc changes to the client.
+   * Returns true if a sync message was delivered.
+   */
+  pushRuntimeStateToClient(): boolean;
+
+  /**
+   * Run RuntimeStateDoc sync rounds between server and client until
+   * convergence. Each round: push server's pending state → client
+   * applies → client's reply goes back to server. Yields microtasks
+   * between rounds so the engine's async comm-emit queue can drain.
+   */
+  syncRuntimeState(maxRounds?: number): Promise<number>;
 
   /**
    * Run sync rounds between server and client until converged.
@@ -151,6 +197,10 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
   // Client = frontend side (receives sync frames, produces changesets)
   // Use create_bootstrap for sync-only mode (like the real frontend)
   const clientHandle = Handle.create_bootstrap(`test-client-${Date.now()}`);
+  // Set a dummy blob port so comm-state resolution doesn't defer comms
+  // waiting for it. Tests that care about blob URLs can override by
+  // calling `client.set_blob_port(realPort)` before syncing.
+  clientHandle.set_blob_port(1);
 
   const serverAdapter = new WasmServerHandle(serverHandle);
   const transport = new DirectTransport(serverAdapter);
@@ -194,8 +244,49 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
       serverHandle.clear_outputs(cellId);
     },
 
+    serverOpenComm(commId, opts) {
+      serverHandle.put_comm_for_test(
+        commId,
+        opts.targetName,
+        opts.modelModule,
+        opts.modelName,
+        JSON.stringify(opts.state),
+        opts.seq ?? 0,
+      );
+    },
+
+    serverSetCommState(commId: string, patch: Record<string, unknown>) {
+      serverHandle.set_comm_state_batch(commId, JSON.stringify(patch));
+    },
+
     pushToClient(): boolean {
       return transport.pushServerChanges();
+    },
+
+    pushRuntimeStateToClient(): boolean {
+      return transport.pushServerRuntimeStateChanges();
+    },
+
+    async syncRuntimeState(maxRounds = 8): Promise<number> {
+      let rounds = 0;
+      for (let i = 0; i < maxRounds; i++) {
+        const pushed = transport.pushServerRuntimeStateChanges();
+        // Yield a few microtasks so the engine's async comm-emit queue
+        // can settle (projectComms chains on Promise.resolve().then).
+        for (let j = 0; j < 4; j++) {
+          await Promise.resolve();
+        }
+        // Also call the engine's flush, which sends the client's sync
+        // reply back to the server — the server needs it before it can
+        // generate its next message.
+        await engine.flush();
+        for (let j = 0; j < 4; j++) {
+          await Promise.resolve();
+        }
+        if (!pushed) break;
+        rounds++;
+      }
+      return rounds;
     },
 
     syncUntilConverged(maxRounds = 10): number {

--- a/packages/runtimed/tests/widget-sync-stall.test.ts
+++ b/packages/runtimed/tests/widget-sync-stall.test.ts
@@ -181,6 +181,31 @@ describe("widget sync: real WASM comm-state pipeline", { retry: 2 }, () => {
     expect(afterCount - beforeCount).toBe(2);
   });
 
+  it("projectLocalState emits commChanges$ for a client-side write", async () => {
+    // Regression harness for Track A1: after `set_comm_state_batch`
+    // on the client handle, `projectLocalState()` must fire commChanges$
+    // without waiting for the daemon to echo. This is the local-first
+    // path that the CRDT-first refactor depends on.
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    await h.syncRuntimeState();
+
+    const beforeUpdateCount = emissions.filter((e) => e.updated.length > 0).length;
+
+    // Client-side write — mirrors what the app's CrdtCommWriter does.
+    h.client.set_comm_state_batch(SLIDER_COMM, JSON.stringify({ value: 4.2 }));
+    h.engine.projectLocalState();
+    // Microtask flush so commEmitQueue settles.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+
+    const afterUpdateCount = emissions.filter((e) => e.updated.length > 0).length;
+    expect(afterUpdateCount).toBeGreaterThan(beforeUpdateCount);
+
+    // The most recent update emission carries the client's new value.
+    const latestUpdate = [...emissions].reverse().find((e) => e.updated.length > 0);
+    const updatedComm = latestUpdate?.updated.find((c) => c.commId === SLIDER_COMM);
+    expect(updatedComm?.state.value).toBe(4.2);
+  });
+
   it("resolved state projects native scalars 1:1 from the CRDT", async () => {
     // The WASM resolver turns Automerge-native maps/lists into plain JS
     // objects/arrays. Verify for a minimal slider — no ContentRefs in

--- a/packages/runtimed/tests/widget-sync-stall.test.ts
+++ b/packages/runtimed/tests/widget-sync-stall.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Widget-sync stall reproduction against real WASM.
+ *
+ * These tests script the matplotlib `@interact` stall symptom entirely
+ * through the sync engine + real runtimed-wasm, no React or Tauri. The
+ * goal is a regression harness: after we refactor widget sync (drop the
+ * optimistic path, make the WidgetStore a pure CRDT projection, wire
+ * SyncError recovery), these assertions lock in the expected shape of
+ * `commChanges$` emissions for the scenarios that were subtly broken.
+ *
+ * Scenario shape:
+ *   - Daemon opens a FloatSlider + Output widget (mirrors @interact).
+ *   - Kernel rapidly echoes slider `value` updates.
+ *   - Between slider echoes, the Output widget's `outputs` state turns
+ *     over (new plot image).
+ *   - The engine's `commChanges$` observable is the UI's single source
+ *     of truth — every state change that reaches the frontend must
+ *     appear there, in order, keyed by the right commId.
+ */
+
+import { type Subscription } from "rxjs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type { CommChanges } from "../src/comm-diff";
+import { type WasmHarness, createWasmHarness } from "./wasm-harness";
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const SLIDER_COMM = "slider-comm-id-0000000000000000000";
+const OUTPUT_COMM = "output-comm-id-0000000000000000000";
+
+const sliderOpts = {
+  targetName: "jupyter.widget",
+  modelModule: "@jupyter-widgets/controls",
+  modelName: "FloatSliderModel",
+  state: {
+    _model_module: "@jupyter-widgets/controls",
+    _model_module_version: "2.0.0",
+    _model_name: "FloatSliderModel",
+    _view_module: "@jupyter-widgets/controls",
+    _view_module_version: "2.0.0",
+    _view_name: "FloatSliderView",
+    continuous_update: true,
+    description: "Frequency",
+    max: 5,
+    min: 0.5,
+    step: 0.1,
+    value: 1,
+  },
+};
+
+const outputOpts = {
+  targetName: "jupyter.widget",
+  modelModule: "@jupyter-widgets/output",
+  modelName: "OutputModel",
+  state: {
+    _model_module: "@jupyter-widgets/output",
+    _model_module_version: "1.0.0",
+    _model_name: "OutputModel",
+    _view_module: "@jupyter-widgets/output",
+    _view_module_version: "1.0.0",
+    _view_name: "OutputView",
+    msg_id: "",
+    outputs: [] as unknown[],
+  },
+  seq: 1,
+};
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("widget sync: real WASM comm-state pipeline", { retry: 2 }, () => {
+  let h: WasmHarness;
+  let emissions: CommChanges[];
+  let sub: Subscription;
+
+  beforeEach(async () => {
+    h = await createWasmHarness("widget-sync-test");
+    emissions = [];
+    sub = h.engine.commChanges$.subscribe((c) => {
+      emissions.push(c);
+    });
+    await h.startAndCompleteSync();
+  });
+
+  afterEach(() => {
+    sub.unsubscribe();
+    h.dispose();
+  });
+
+  it("opens a comm and emits it via commChanges$", async () => {
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    await h.syncRuntimeState();
+
+    expect(emissions.length).toBeGreaterThan(0);
+    const firstOpen = emissions.find((e) => e.opened.length > 0);
+    expect(firstOpen).toBeDefined();
+    expect(firstOpen?.opened[0]?.commId).toBe(SLIDER_COMM);
+    expect(firstOpen?.opened[0]?.state._model_name).toBe("FloatSliderModel");
+  });
+
+  it("emits updates separately from opens", async () => {
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    await h.syncRuntimeState();
+
+    // Single-key update (what the kernel echoes on a slider drag).
+    h.serverSetCommState(SLIDER_COMM, { value: 2.5 });
+    await h.syncRuntimeState();
+
+    const updated = emissions.find((e) => e.updated.length > 0);
+    expect(updated).toBeDefined();
+    expect(updated?.updated[0]?.commId).toBe(SLIDER_COMM);
+    expect(updated?.updated[0]?.state.value).toBe(2.5);
+  });
+
+  it("rapid slider echoes don't drop output widget updates", async () => {
+    // Scenario: user hammers the slider. Each server write is a kernel
+    // comm_msg echo. Between slider echoes, the Output widget also turns
+    // over (matplotlib plt.show produced a new image). The engine must
+    // deliver every update for every comm — no merging, no dropping.
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    h.serverOpenComm(OUTPUT_COMM, outputOpts);
+    await h.syncRuntimeState();
+
+    // Five slider updates interleaved with three output turnovers — what
+    // @interact looks like when matplotlib plt.show fires every other
+    // traitlet change under CPU pressure.
+    const ticks: Array<{ slider: number; output?: string }> = [
+      { slider: 1.1, output: "sin(1.1x)" },
+      { slider: 1.2 },
+      { slider: 1.3, output: "sin(1.3x)" },
+      { slider: 1.4 },
+      { slider: 1.5, output: "sin(1.5x)" },
+    ];
+
+    for (const { slider, output } of ticks) {
+      h.serverSetCommState(SLIDER_COMM, { value: slider });
+      if (output) {
+        h.serverSetCommState(OUTPUT_COMM, {
+          outputs: [{ output_type: "display_data", data: { "text/plain": output } }],
+        });
+      }
+      await h.syncRuntimeState();
+    }
+
+    // Collect the last observed value for each comm.
+    const lastState = new Map<string, Record<string, unknown>>();
+    for (const batch of emissions) {
+      for (const comm of [...batch.opened, ...batch.updated]) {
+        lastState.set(comm.commId, { ...lastState.get(comm.commId), ...comm.state });
+      }
+    }
+
+    expect(lastState.get(SLIDER_COMM)?.value).toBe(1.5);
+    // The Output widget's outputs must reflect the FINAL value the
+    // server wrote. This is the assertion a future optimistic-path
+    // regression would break: the slider's optimistic write would mask
+    // the Output widget's CRDT-delivered `outputs` turnover.
+    const finalOutputs = lastState.get(OUTPUT_COMM)?.outputs as unknown[];
+    expect(finalOutputs).toHaveLength(1);
+    expect((finalOutputs[0] as { data: { "text/plain": string } }).data["text/plain"]).toBe(
+      "sin(1.5x)",
+    );
+  });
+
+  it("consecutive distinct updates to the same comm each produce an emission", async () => {
+    // Regression guard: the `diffComms` layer compares JSON strings. If
+    // two successive server writes produce identical state (e.g. kernel
+    // idempotent echo), the second one is coalesced away — but two
+    // *distinct* writes must each fire.
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    await h.syncRuntimeState();
+
+    const beforeCount = emissions.filter((e) => e.updated.length > 0).length;
+
+    h.serverSetCommState(SLIDER_COMM, { value: 3.14 });
+    await h.syncRuntimeState();
+
+    h.serverSetCommState(SLIDER_COMM, { value: 2.71 });
+    await h.syncRuntimeState();
+
+    const afterCount = emissions.filter((e) => e.updated.length > 0).length;
+    expect(afterCount - beforeCount).toBe(2);
+  });
+
+  it("resolved state projects native scalars 1:1 from the CRDT", async () => {
+    // The WASM resolver turns Automerge-native maps/lists into plain JS
+    // objects/arrays. Verify for a minimal slider — no ContentRefs in
+    // the picture, so this should be a direct 1:1 projection.
+    h.serverOpenComm(SLIDER_COMM, sliderOpts);
+    await h.syncRuntimeState();
+
+    const firstOpen = emissions.find((e) => e.opened.length > 0);
+    const comm = firstOpen?.opened[0];
+    expect(comm?.state.min).toBe(0.5);
+    expect(comm?.state.max).toBe(5);
+    expect(comm?.state.value).toBe(1);
+    expect(comm?.state.continuous_update).toBe(true);
+  });
+});

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -3,6 +3,7 @@ import type {
   CommCloseMessage,
   CommMsgMessage,
   CommOpenMessage,
+  WidgetLocalUpdateMessage,
   WidgetSnapshotMessage,
   IframeToParentMessage,
 } from "./frame-bridge";
@@ -96,6 +97,10 @@ export class CommBridgeManager {
 
       case "widget_comm_msg":
         this.handleWidgetCommMsg(message.payload);
+        break;
+
+      case "widget_local_update":
+        this.handleWidgetLocalUpdate(message.payload);
         break;
 
       case "widget_comm_close":
@@ -293,6 +298,23 @@ export class CommBridgeManager {
       // Custom messages go directly to kernel (no store update)
       this.sendCustomToKernel(commId, data, buffers);
     }
+  }
+
+  private handleWidgetLocalUpdate(payload: WidgetLocalUpdateMessage["payload"]): void {
+    const { commId, data } = payload;
+    // Apply to parent store ONLY — no kernel forwarding. jslink /
+    // jsdlink targets are frontend-only by ipywidgets semantics.
+    //
+    // We update `previousState` for THIS iframe's bridge so the
+    // store-subscriber's `syncModels` pass doesn't redundantly echo
+    // the change back to the originating iframe (which already has
+    // it — the iframe pre-wrote its local store before sending).
+    // Sibling iframes each have their own `CommBridgeManager` with
+    // their own `previousState`, so they still see the update and
+    // propagate it through their bridges.
+    const current = this.previousState.get(commId) ?? {};
+    this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...data }));
+    this.store.updateModel(commId, data);
   }
 
   private handleWidgetCommClose(payload: { commId: string }): void {

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -387,6 +387,22 @@ export interface WidgetCommCloseMessage {
   };
 }
 
+/**
+ * Frontend-only state update from the iframe (`widgets.jslink` /
+ * `widgets.jsdlink` target writes). Parent updates its WidgetStore
+ * so sibling iframes see the change, but does NOT forward to the
+ * kernel — these are frontend-only by ipywidgets semantics.
+ */
+export interface WidgetLocalUpdateMessage {
+  type: "widget_local_update";
+  payload: {
+    /** Comm ID of the widget */
+    commId: string;
+    /** State patch */
+    data: Record<string, unknown>;
+  };
+}
+
 // --- Global Find: Iframe → Parent ---
 
 /**
@@ -417,6 +433,7 @@ export type IframeToParentMessage =
   | RendererReadyMessage
   | WidgetReadyMessage
   | WidgetCommMsgMessage
+  | WidgetLocalUpdateMessage
   | WidgetCommCloseMessage
   | SearchResultsMessage;
 
@@ -453,6 +470,7 @@ export function isIframeMessage(data: unknown): data is IframeToParentMessage {
       "renderer_ready",
       "widget_ready",
       "widget_comm_msg",
+      "widget_local_update",
       "widget_comm_close",
       "search_results",
     ].includes(msg.type)

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -30,6 +30,7 @@ import {
   NTERACT_MOUSE_DOWN,
   NTERACT_WIDGET_COMM_CLOSE,
   NTERACT_WIDGET_COMM_MSG,
+  NTERACT_WIDGET_LOCAL_UPDATE,
   NTERACT_WIDGET_READY,
   NTERACT_WIDGET_STATE,
   NTERACT_WIDGET_UPDATE,
@@ -576,6 +577,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               transport.onNotification(NTERACT_WIDGET_COMM_MSG, (params) => {
                 onMessageRef.current?.({
                   type: "widget_comm_msg",
+                  payload: params,
+                } as IframeToParentMessage);
+              });
+              transport.onNotification(NTERACT_WIDGET_LOCAL_UPDATE, (params) => {
+                onMessageRef.current?.({
+                  type: "widget_local_update",
                   payload: params,
                 } as IframeToParentMessage);
               });

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -46,6 +46,7 @@ export const NTERACT_DOUBLE_CLICK = "nteract/doubleClick" as const;
 export const NTERACT_ERROR = "nteract/error" as const;
 export const NTERACT_WIDGET_READY = "nteract/widgetReady" as const;
 export const NTERACT_WIDGET_COMM_MSG = "nteract/widgetCommMsg" as const;
+export const NTERACT_WIDGET_LOCAL_UPDATE = "nteract/widgetLocalUpdate" as const;
 export const NTERACT_WIDGET_COMM_CLOSE = "nteract/widgetCommClose" as const;
 export const NTERACT_WIDGET_UPDATE = "nteract/widgetUpdate" as const;
 export const NTERACT_EVAL_RESULT = "nteract/evalResult" as const;
@@ -148,6 +149,17 @@ export interface NteractWidgetCommMsgParams {
   data: Record<string, unknown>;
   bufferPaths?: string[][];
   buffers?: ArrayBuffer[];
+}
+
+/**
+ * Iframe → Host: jslink/jsdlink target update. Parent updates its
+ * WidgetStore (so sibling iframes see the change) but does NOT
+ * forward to the kernel — these are frontend-only by ipywidgets
+ * semantics.
+ */
+export interface NteractWidgetLocalUpdateParams {
+  commId: string;
+  data: Record<string, unknown>;
 }
 
 export interface NteractWidgetCommCloseParams {

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -1,8 +1,18 @@
 /**
- * Tests for WidgetUpdateManager — debounced CRDT persistence + echo suppression.
+ * Tests for WidgetUpdateManager — CRDT-first widget state persistence.
+ *
+ * Post-A2 semantics: no optimistic store update, no debounce, no echo
+ * suppression. Every update goes straight to the injected CRDT writer
+ * and the widget store is updated by the commChanges$ projection
+ * (verified end-to-end in `packages/runtimed/tests/widget-sync-stall.test.ts`).
+ *
+ * The manager's remaining responsibilities are narrow: bootstrap
+ * fallback when the writer isn't registered yet, and mirroring binary
+ * buffers into the local widget model since the CRDT doesn't carry
+ * ArrayBuffers.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 import { createWidgetStore } from "../widget-store";
 import { WidgetUpdateManager } from "../widget-update-manager";
 
@@ -21,7 +31,6 @@ function setup(opts?: { writerAvailable?: boolean }) {
     getCrdtWriter: () => (writerAvailable ? writer : null),
   });
 
-  // Pre-create a model so updateModel works
   store.createModel("comm-1", { value: 0, description: "test" });
 
   return { store, manager, writerCalls };
@@ -30,290 +39,100 @@ function setup(opts?: { writerAvailable?: boolean }) {
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("WidgetUpdateManager", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  // ── Debouncing ──────────────────────────────────────────────────
-
-  describe("debouncing", () => {
-    it("updates store immediately", () => {
-      const { store, manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      expect(store.getModel("comm-1")?.state.value).toBe(42);
-    });
-
-    it("debounces CRDT writes at 50ms", () => {
+  describe("happy path", () => {
+    it("routes every update straight to the CRDT writer", () => {
       const { manager, writerCalls } = setup();
 
       manager.updateAndPersist("comm-1", { value: 10 });
       manager.updateAndPersist("comm-1", { value: 20 });
       manager.updateAndPersist("comm-1", { value: 30 });
 
-      // No CRDT writes yet
-      expect(writerCalls).toHaveLength(0);
-
-      // Advance past debounce
-      vi.advanceTimersByTime(50);
-
-      // Single merged write
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0]).toEqual({
-        commId: "comm-1",
-        patch: { value: 30 },
-      });
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 10 } },
+        { commId: "comm-1", patch: { value: 20 } },
+        { commId: "comm-1", patch: { value: 30 } },
+      ]);
     });
 
-    it("merges multiple keys in debounce window", () => {
+    it("does not touch the local store on the happy path", () => {
+      // The widget store is driven by the CRDT projection (via
+      // `engine.projectLocalState()` after `set_comm_state_batch`).
+      // The manager itself must not write to the store — otherwise
+      // we'd be back to the pre-A2 dual-source drift.
+      const { store, manager } = setup();
+      const beforeValue = store.getModel("comm-1")?.state.value;
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+
+      // Store state is unchanged — projection happens downstream.
+      expect(store.getModel("comm-1")?.state.value).toBe(beforeValue);
+    });
+
+    it("passes disjoint patches through untouched", () => {
       const { manager, writerCalls } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
       manager.updateAndPersist("comm-1", { description: "updated" });
 
-      vi.advanceTimersByTime(50);
-
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].patch).toEqual({
-        value: 42,
-        description: "updated",
-      });
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 42 } },
+        { commId: "comm-1", patch: { description: "updated" } },
+      ]);
     });
 
-    it("debounces independently per comm", () => {
+    it("keeps different comms independent", () => {
       const { store, manager, writerCalls } = setup();
       store.createModel("comm-2", { value: 0 });
 
-      manager.updateAndPersist("comm-1", { value: 10 });
+      manager.updateAndPersist("comm-1", { value: 1 });
+      manager.updateAndPersist("comm-2", { value: 2 });
 
-      vi.advanceTimersByTime(30);
-
-      manager.updateAndPersist("comm-2", { value: 20 });
-
-      vi.advanceTimersByTime(20);
-
-      // comm-1 flushed at t=50, comm-2 still pending
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].commId).toBe("comm-1");
-
-      vi.advanceTimersByTime(30);
-
-      // comm-2 flushed at t=80
-      expect(writerCalls).toHaveLength(2);
-      expect(writerCalls[1].commId).toBe("comm-2");
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 1 } },
+        { commId: "comm-2", patch: { value: 2 } },
+      ]);
     });
+  });
 
-    it("resets debounce timer on new update", () => {
-      const { manager, writerCalls } = setup();
+  describe("bootstrap fallback", () => {
+    it("falls back to direct store update when writer isn't ready", () => {
+      // Early session state: CRDT writer hasn't been registered yet
+      // (App.tsx's `setCrdtCommWriter` useEffect hasn't run). We
+      // still want interaction to feel responsive — mirror the pre-
+      // refactor behavior so the UI doesn't stall during bootstrap.
+      const { store, manager, writerCalls } = setup({ writerAvailable: false });
 
-      manager.updateAndPersist("comm-1", { value: 10 });
-      vi.advanceTimersByTime(40);
+      manager.updateAndPersist("comm-1", { value: 42 });
 
-      // Another update before 50ms — resets the timer
-      manager.updateAndPersist("comm-1", { value: 20 });
-      vi.advanceTimersByTime(40);
-
-      // Still no flush (only 40ms since last update)
       expect(writerCalls).toHaveLength(0);
-
-      vi.advanceTimersByTime(10);
-
-      // Now flushed with the latest value
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].patch).toEqual({ value: 20 });
+      expect(store.getModel("comm-1")?.state.value).toBe(42);
     });
+  });
 
-    it("flushes immediately for binary buffers", () => {
-      const { manager, writerCalls } = setup();
-
+  describe("binary buffers", () => {
+    it("sends patch through CRDT writer and buffers into local store", () => {
+      // CRDT doesn't carry ArrayBuffers; keep the legacy behavior of
+      // stashing buffers on the local widget model so anywidgets can
+      // read back from `model.buffers`. Kernel delivery of the buffers
+      // themselves is handled elsewhere (SendComm RPC).
+      const { store, manager, writerCalls } = setup();
       const buffer = new ArrayBuffer(8);
+
       manager.updateAndPersist("comm-1", { value: 42 }, [buffer]);
 
-      // Flushed immediately, no debounce
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].patch).toEqual({ value: 42 });
+      expect(writerCalls).toEqual([{ commId: "comm-1", patch: { value: 42 } }]);
+      expect(store.getModel("comm-1")?.buffers).toContain(buffer);
     });
   });
 
-  // ── Echo suppression ────────────────────────────────────────────
-
-  describe("echo suppression", () => {
-    it("suppresses echoes for optimistic keys", () => {
+  describe("lifecycle", () => {
+    it("reset / dispose / clearComm are all no-ops post-A2", () => {
+      // Kept on the API so the calling sites in App.tsx don't have
+      // to change. Assert they don't throw — no state to reset.
       const { manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
-      expect(result).toBeNull();
-    });
-
-    it("passes through non-optimistic keys", () => {
-      const { manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      const result = manager.shouldSuppressEcho("comm-1", {
-        value: 10,
-        description: "from kernel",
-      });
-      expect(result).toEqual({ description: "from kernel" });
-    });
-
-    it("passes everything when no optimistic keys", () => {
-      const { manager } = setup();
-
-      const result = manager.shouldSuppressEcho("comm-1", {
-        value: 10,
-        description: "from kernel",
-      });
-      expect(result).toEqual({ value: 10, description: "from kernel" });
-    });
-
-    it("clears optimistic keys after flush", () => {
-      const { manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      // During debounce window — suppressed
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
-
-      // Flush
-      vi.advanceTimersByTime(50);
-
-      // After flush — passes through
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
-      expect(result).toEqual({ value: 10 });
-    });
-
-    it("suppresses during continuous drag", () => {
-      const { manager } = setup();
-
-      // Simulate continuous slider drag
-      manager.updateAndPersist("comm-1", { value: 10 });
-      vi.advanceTimersByTime(16);
-      manager.updateAndPersist("comm-1", { value: 15 });
-      vi.advanceTimersByTime(16);
-      manager.updateAndPersist("comm-1", { value: 20 });
-
-      // Stale echo from earlier value — suppressed
-      expect(manager.shouldSuppressEcho("comm-1", { value: 5 })).toBeNull();
-
-      // Non-value keys still pass through
-      expect(manager.shouldSuppressEcho("comm-1", { value: 5, _view_name: "x" })).toEqual({
-        _view_name: "x",
-      });
-    });
-  });
-
-  // ── clearComm ──────────────────────────────────────────────────
-
-  describe("clearComm", () => {
-    it("cancels pending flush", () => {
-      const { manager, writerCalls } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-      manager.clearComm("comm-1");
-
-      vi.advanceTimersByTime(50);
-
-      expect(writerCalls).toHaveLength(0);
-    });
-
-    it("clears optimistic keys", () => {
-      const { manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-      manager.clearComm("comm-1");
-
-      // Echo passes through after clearComm
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
-      expect(result).toEqual({ value: 10 });
-    });
-  });
-
-  // ── reset ──────────────────────────────────────────────────────
-
-  describe("reset", () => {
-    it("cancels all pending flushes", () => {
-      const { store, manager, writerCalls } = setup();
-      store.createModel("comm-2", { value: 0 });
-
-      manager.updateAndPersist("comm-1", { value: 10 });
-      manager.updateAndPersist("comm-2", { value: 20 });
-      manager.reset();
-
-      vi.advanceTimersByTime(50);
-
-      expect(writerCalls).toHaveLength(0);
-    });
-
-    it("clears all optimistic keys", () => {
-      const { manager } = setup();
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-      manager.reset();
-
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
-      expect(result).toEqual({ value: 10 });
-    });
-  });
-
-  // ── Writer unavailable ─────────────────────────────────────────
-
-  describe("writer unavailable", () => {
-    it("retries flush when CRDT writer is null", () => {
-      let writerAvailable = false;
-      const writerCalls: Array<{
-        commId: string;
-        patch: Record<string, unknown>;
-      }> = [];
-      const store = createWidgetStore();
-      store.createModel("comm-1", { value: 0 });
-
-      const manager = new WidgetUpdateManager({
-        getStore: () => store,
-        getCrdtWriter: () =>
-          writerAvailable
-            ? (commId: string, patch: Record<string, unknown>) => {
-                writerCalls.push({ commId, patch });
-              }
-            : null,
-      });
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      // First flush attempt — writer not available, retries
-      vi.advanceTimersByTime(50);
-      expect(writerCalls).toHaveLength(0);
-
-      // Make writer available
-      writerAvailable = true;
-
-      // Retry fires after another 50ms
-      vi.advanceTimersByTime(50);
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].patch).toEqual({ value: 42 });
-    });
-
-    it("keeps optimistic keys while retrying", () => {
-      const store = createWidgetStore();
-      store.createModel("comm-1", { value: 0 });
-
-      const manager = new WidgetUpdateManager({
-        getStore: () => store,
-        getCrdtWriter: () => null,
-      });
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-      vi.advanceTimersByTime(50);
-
-      // Still optimistic since flush failed
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
+      expect(() => manager.reset()).not.toThrow();
+      expect(() => manager.clearComm("comm-1")).not.toThrow();
+      expect(() => manager.dispose()).not.toThrow();
     });
   });
 });

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -111,6 +111,39 @@ describe("WidgetUpdateManager", () => {
 
       expect(store.getModel("comm-1")?.state.value).toBe(42);
     });
+
+    it("marks written keys as pending so stale projected echoes can be dropped", () => {
+      // While the trailing throttle flush is in flight, the daemon's
+      // sync frames still carry its pre-flush view of the state. The
+      // App-level `commChanges$` subscriber consults
+      // `hasPendingKey(commId, key)` to drop those stale echoes, so
+      // an in-flight drag value doesn't snap back mid-burst.
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+
+      expect(manager.hasPendingKey("comm-1", "value")).toBe(true);
+      expect(manager.hasPendingKey("comm-1", "description")).toBe(false);
+    });
+
+    it("clears pending-key marks after the TTL elapses", () => {
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+      expect(manager.hasPendingKey("comm-1", "value")).toBe(true);
+
+      vi.advanceTimersByTime(600); // past PENDING_TTL_MS (500)
+      expect(manager.hasPendingKey("comm-1", "value")).toBe(false);
+    });
+
+    it("clears pending keys on clearComm (comm_close)", () => {
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+      manager.clearComm("comm-1");
+
+      expect(manager.hasPendingKey("comm-1", "value")).toBe(false);
+    });
   });
 
   describe("bootstrap queue", () => {

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -1,18 +1,15 @@
 /**
  * Tests for WidgetUpdateManager — CRDT-first widget state persistence.
  *
- * Post-A2 semantics: no optimistic store update, no debounce, no echo
- * suppression. Every update goes straight to the injected CRDT writer
- * and the widget store is updated by the commChanges$ projection
- * (verified end-to-end in `packages/runtimed/tests/widget-sync-stall.test.ts`).
- *
- * The manager's remaining responsibilities are narrow: bootstrap
- * fallback when the writer isn't registered yet, and mirroring binary
- * buffers into the local widget model since the CRDT doesn't carry
- * ArrayBuffers.
+ * Post-A2 semantics: no optimistic store update, no echo suppression.
+ * Every non-buffer update goes through the injected CRDT writer,
+ * throttled at 50ms per comm so continuous slider drags don't flood
+ * the CRDT. First tick in a burst fires immediately (instant UI via
+ * the projectLocalState → commChanges$ emission); ticks within the
+ * throttle window coalesce into a single trailing flush.
  */
 
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { createWidgetStore } from "../widget-store";
 import { WidgetUpdateManager } from "../widget-update-manager";
 
@@ -39,44 +36,52 @@ function setup(opts?: { writerAvailable?: boolean }) {
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("WidgetUpdateManager", () => {
-  describe("happy path", () => {
-    it("routes every update straight to the CRDT writer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("throttling", () => {
+    it("fires the first tick of a burst immediately", () => {
+      const { manager, writerCalls } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 10 });
+
+      expect(writerCalls).toEqual([{ commId: "comm-1", patch: { value: 10 } }]);
+    });
+
+    it("coalesces subsequent ticks within the throttle window", () => {
       const { manager, writerCalls } = setup();
 
       manager.updateAndPersist("comm-1", { value: 10 });
       manager.updateAndPersist("comm-1", { value: 20 });
       manager.updateAndPersist("comm-1", { value: 30 });
 
+      // First tick fired immediately; 20 and 30 are pending.
+      expect(writerCalls).toEqual([{ commId: "comm-1", patch: { value: 10 } }]);
+
+      vi.advanceTimersByTime(60);
+
+      // Trailing flush coalesced the in-window writes into one.
       expect(writerCalls).toEqual([
         { commId: "comm-1", patch: { value: 10 } },
-        { commId: "comm-1", patch: { value: 20 } },
         { commId: "comm-1", patch: { value: 30 } },
       ]);
     });
 
-    it("does not touch the local store on the happy path", () => {
-      // The widget store is driven by the CRDT projection (via
-      // `engine.projectLocalState()` after `set_comm_state_batch`).
-      // The manager itself must not write to the store — otherwise
-      // we'd be back to the pre-A2 dual-source drift.
-      const { store, manager } = setup();
-      const beforeValue = store.getModel("comm-1")?.state.value;
-
-      manager.updateAndPersist("comm-1", { value: 42 });
-
-      // Store state is unchanged — projection happens downstream.
-      expect(store.getModel("comm-1")?.state.value).toBe(beforeValue);
-    });
-
-    it("passes disjoint patches through untouched", () => {
+    it("a write after the throttle window fires immediately again", () => {
       const { manager, writerCalls } = setup();
 
-      manager.updateAndPersist("comm-1", { value: 42 });
-      manager.updateAndPersist("comm-1", { description: "updated" });
+      manager.updateAndPersist("comm-1", { value: 1 });
+      vi.advanceTimersByTime(100);
+      manager.updateAndPersist("comm-1", { value: 2 });
 
       expect(writerCalls).toEqual([
-        { commId: "comm-1", patch: { value: 42 } },
-        { commId: "comm-1", patch: { description: "updated" } },
+        { commId: "comm-1", patch: { value: 1 } },
+        { commId: "comm-1", patch: { value: 2 } },
       ]);
     });
 
@@ -87,19 +92,29 @@ describe("WidgetUpdateManager", () => {
       manager.updateAndPersist("comm-1", { value: 1 });
       manager.updateAndPersist("comm-2", { value: 2 });
 
+      // Both comms get a leading-tick fire — one throttle per comm.
       expect(writerCalls).toEqual([
         { commId: "comm-1", patch: { value: 1 } },
         { commId: "comm-2", patch: { value: 2 } },
       ]);
     });
+
+    it("does not write to the local store on the happy path", () => {
+      // The widget store is driven by the CRDT projection (via
+      // `engine.projectLocalState()` after `set_comm_state_batch`).
+      // The manager itself must not write to the store — otherwise
+      // we'd be back to the pre-A2 dual-source drift.
+      const { store, manager } = setup();
+      const beforeValue = store.getModel("comm-1")?.state.value;
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+
+      expect(store.getModel("comm-1")?.state.value).toBe(beforeValue);
+    });
   });
 
   describe("bootstrap queue", () => {
-    it("queues patches when writer isn't ready and mirrors to local store", () => {
-      // Early session state: CRDT writer hasn't been registered yet
-      // (App.tsx's `setCrdtCommWriter` useEffect hasn't run). The
-      // update is queued so nothing is lost; the store is mirrored
-      // so the UI doesn't stall during bootstrap.
+    it("queues and mirrors when writer isn't ready", () => {
       const { store, manager, writerCalls } = setup({ writerAvailable: false });
 
       manager.updateAndPersist("comm-1", { value: 42 });
@@ -108,11 +123,7 @@ describe("WidgetUpdateManager", () => {
       expect(store.getModel("comm-1")?.state.value).toBe(42);
     });
 
-    it("drains queued patches into the writer on the next update", () => {
-      // Typical bootstrap race: user clicks a widget → writer isn't
-      // registered yet → patch queued. A later call (e.g. model
-      // echo or another interaction) finds the writer registered —
-      // drain the queue before processing the new write.
+    it("drains queued patches on the next update once writer is ready", () => {
       const store = createWidgetStore();
       const writerCalls: Array<{ commId: string; patch: Record<string, unknown> }> = [];
       const writer = (commId: string, patch: Record<string, unknown>) => {
@@ -125,69 +136,79 @@ describe("WidgetUpdateManager", () => {
       });
       store.createModel("comm-1", { value: 0 });
 
-      // Bootstrap write — queued.
       manager.updateAndPersist("comm-1", { value: 42 });
       expect(writerCalls).toHaveLength(0);
 
-      // Writer becomes available.
       writerAvailable = true;
       manager.updateAndPersist("comm-1", { description: "ready" });
 
-      // Queued patch flushes first, then the new one.
+      // Queued patch flushes first, then the new one (leading-tick
+      // fires immediately because the throttle state is fresh).
       expect(writerCalls).toEqual([
         { commId: "comm-1", patch: { value: 42 } },
         { commId: "comm-1", patch: { description: "ready" } },
       ]);
     });
-
-    it("coalesces multiple bootstrap writes on the same comm", () => {
-      const { manager, writerCalls } = setup({ writerAvailable: false });
-      manager.updateAndPersist("comm-1", { value: 1 });
-      manager.updateAndPersist("comm-1", { value: 2 });
-      manager.updateAndPersist("comm-1", { description: "hello" });
-
-      // Drain by providing a writer on the next call.
-      const writer = (commId: string, patch: Record<string, unknown>) => {
-        writerCalls.push({ commId, patch });
-      };
-      const managerRef = manager as unknown as {
-        getCrdtWriter: () => typeof writer | null;
-      };
-      managerRef.getCrdtWriter = () => writer;
-      manager.updateAndPersist("comm-2", { value: 99 });
-
-      // The coalesced patch has the last value for `value` plus the
-      // description — last-wins merge on key collision.
-      expect(writerCalls).toEqual([
-        { commId: "comm-1", patch: { value: 2, description: "hello" } },
-        { commId: "comm-2", patch: { value: 99 } },
-      ]);
-    });
   });
 
   describe("binary buffers", () => {
-    it("sends patch through CRDT writer and buffers into local store", () => {
-      // CRDT doesn't carry ArrayBuffers; keep the legacy behavior of
-      // stashing buffers on the local widget model so anywidgets can
-      // read back from `model.buffers`. Kernel delivery of the buffers
-      // themselves is handled elsewhere (SendComm RPC).
+    it("bypasses the throttle and mirrors buffers to the store", () => {
       const { store, manager, writerCalls } = setup();
-      const buffer = new ArrayBuffer(8);
+      const buf1 = new ArrayBuffer(4);
+      const buf2 = new ArrayBuffer(4);
 
-      manager.updateAndPersist("comm-1", { value: 42 }, [buffer]);
+      manager.updateAndPersist("comm-1", { value: 1 }, [buf1]);
+      manager.updateAndPersist("comm-1", { value: 2 }, [buf2]);
 
-      expect(writerCalls).toEqual([{ commId: "comm-1", patch: { value: 42 } }]);
-      expect(store.getModel("comm-1")?.buffers).toContain(buffer);
+      // Both writes fired immediately — buffers can't be merged and
+      // delaying them would corrupt anywidget model.buffers order.
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 1 } },
+        { commId: "comm-1", patch: { value: 2 } },
+      ]);
+      expect(store.getModel("comm-1")?.buffers).toContain(buf2);
     });
   });
 
   describe("lifecycle", () => {
-    it("reset / dispose / clearComm are all no-ops post-A2", () => {
-      // Kept on the API so the calling sites in App.tsx don't have
-      // to change. Assert they don't throw — no state to reset.
+    it("reset clears pending throttle state", () => {
+      const { manager, writerCalls } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 1 });
+      manager.updateAndPersist("comm-1", { value: 2 });
+
+      // Reset before the trailing edge fires — the pending write
+      // must be dropped so it doesn't reach a (potentially new) kernel.
+      manager.reset();
+      vi.advanceTimersByTime(100);
+
+      expect(writerCalls).toEqual([{ commId: "comm-1", patch: { value: 1 } }]);
+    });
+
+    it("clearComm drops only that comm's state", () => {
+      const { store, manager, writerCalls } = setup();
+      store.createModel("comm-2", { value: 0 });
+
+      manager.updateAndPersist("comm-1", { value: 1 });
+      manager.updateAndPersist("comm-2", { value: 2 });
+      manager.updateAndPersist("comm-1", { value: 10 });
+      manager.updateAndPersist("comm-2", { value: 20 });
+
+      manager.clearComm("comm-1");
+      vi.advanceTimersByTime(100);
+
+      // comm-1's trailing write was dropped; comm-2's fired.
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 1 } },
+        { commId: "comm-2", patch: { value: 2 } },
+        { commId: "comm-2", patch: { value: 20 } },
+      ]);
+    });
+
+    it("dispose is idempotent and clears everything", () => {
       const { manager } = setup();
-      expect(() => manager.reset()).not.toThrow();
-      expect(() => manager.clearComm("comm-1")).not.toThrow();
+      manager.updateAndPersist("comm-1", { value: 1 });
+      expect(() => manager.dispose()).not.toThrow();
       expect(() => manager.dispose()).not.toThrow();
     });
   });

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -148,6 +148,26 @@ describe("WidgetUpdateManager", () => {
       expect(manager.isEchoOfPendingWrite("comm-1", "value", [1, 2, 4])).toBe(false);
     });
 
+    it("recognizes older in-flight values as echoes during rapid bursts", () => {
+      // A rapid drag writes 10 → 11 → 12 inside one throttle window.
+      // projectLocalState fires a microtask per writer call, so the
+      // projection of 10 (from the leading-edge CRDT write) can land
+      // after the store is already at 12. The filter must still
+      // recognize the 10 echo as ours, not treat it as authoritative.
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 10 });
+      manager.updateAndPersist("comm-1", { value: 11 });
+      manager.updateAndPersist("comm-1", { value: 12 });
+
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 10)).toBe(true);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 11)).toBe(true);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 12)).toBe(true);
+      // Authoritative values (kernel validator, peer edit) not in
+      // the history still pass through.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 99)).toBe(false);
+    });
+
     it("clears pending-key marks after the TTL elapses", () => {
       const { manager } = setup();
 

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -160,12 +160,28 @@ describe("WidgetUpdateManager", () => {
       manager.updateAndPersist("comm-1", { value: 11 });
       manager.updateAndPersist("comm-1", { value: 12 });
 
+      // consume-on-match: each call drains the matching entry.
       expect(manager.isEchoOfPendingWrite("comm-1", "value", 10)).toBe(true);
       expect(manager.isEchoOfPendingWrite("comm-1", "value", 11)).toBe(true);
       expect(manager.isEchoOfPendingWrite("comm-1", "value", 12)).toBe(true);
       // Authoritative values (kernel validator, peer edit) not in
       // the history still pass through.
       expect(manager.isEchoOfPendingWrite("comm-1", "value", 99)).toBe(false);
+    });
+
+    it("consumes matches so a peer writing the same value afterward lands", () => {
+      // Collaborative case: we write 10, our own echo arrives and
+      // gets consumed. If a peer later writes 10 as an authoritative
+      // update, it must not be suppressed — history is already
+      // empty once our own echo has been absorbed.
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 10 });
+      // First call represents our own projected echo.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 10)).toBe(true);
+      // Second call represents a peer write of the same value — not
+      // suppressed because the matching entry was consumed.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 10)).toBe(false);
     });
 
     it("clears pending-key marks after the TTL elapses", () => {

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -112,28 +112,50 @@ describe("WidgetUpdateManager", () => {
       expect(store.getModel("comm-1")?.state.value).toBe(42);
     });
 
-    it("marks written keys as pending so stale projected echoes can be dropped", () => {
-      // While the trailing throttle flush is in flight, the daemon's
-      // sync frames still carry its pre-flush view of the state. The
-      // App-level `commChanges$` subscriber consults
-      // `hasPendingKey(commId, key)` to drop those stale echoes, so
-      // an in-flight drag value doesn't snap back mid-burst.
+    it("flags an identical projected value as an echo of the pending local write", () => {
+      // Continuous drag → user writes value=42 → daemon lags and
+      // projects the previous value back. The App-level subscriber
+      // uses isEchoOfPendingWrite to drop just the matching echo.
       const { manager } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
-      expect(manager.hasPendingKey("comm-1", "value")).toBe(true);
-      expect(manager.hasPendingKey("comm-1", "description")).toBe(false);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 42)).toBe(true);
+      expect(manager.isEchoOfPendingWrite("comm-1", "description", "test")).toBe(false);
+    });
+
+    it("still accepts authoritative updates that differ from the pending local value", () => {
+      // Kernel-side validators (value clamp, normalization) and
+      // collaborative peers can write authoritative values that
+      // don't match what we last wrote. Those must land in the
+      // store; otherwise the frontend stays permanently divergent.
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+
+      // Daemon echoes a clamped value — not ours.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 100)).toBe(false);
+    });
+
+    it("matches by structural equality for object/array values", () => {
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: [1, 2, 3] });
+
+      // Different reference, same shape → still our echo.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", [1, 2, 3])).toBe(true);
+      // Different content → authoritative.
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", [1, 2, 4])).toBe(false);
     });
 
     it("clears pending-key marks after the TTL elapses", () => {
       const { manager } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
-      expect(manager.hasPendingKey("comm-1", "value")).toBe(true);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 42)).toBe(true);
 
       vi.advanceTimersByTime(600); // past PENDING_TTL_MS (500)
-      expect(manager.hasPendingKey("comm-1", "value")).toBe(false);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 42)).toBe(false);
     });
 
     it("clears pending keys on clearComm (comm_close)", () => {
@@ -142,7 +164,7 @@ describe("WidgetUpdateManager", () => {
       manager.updateAndPersist("comm-1", { value: 42 });
       manager.clearComm("comm-1");
 
-      expect(manager.hasPendingKey("comm-1", "value")).toBe(false);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 42)).toBe(false);
     });
   });
 

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -99,17 +99,17 @@ describe("WidgetUpdateManager", () => {
       ]);
     });
 
-    it("does not write to the local store on the happy path", () => {
-      // The widget store is driven by the CRDT projection (via
-      // `engine.projectLocalState()` after `set_comm_state_batch`).
-      // The manager itself must not write to the store — otherwise
-      // we'd be back to the pre-A2 dual-source drift.
+    it("mirrors every tick into the local store for instant UI feedback", () => {
+      // Continuous drags need per-tick store updates so the slider
+      // thumb doesn't stutter at the 50 ms throttle boundary. The
+      // CRDT projection (via `engine.projectLocalState()`) still fans
+      // the same value back through `commChanges$`; the App-level
+      // diff check makes that a no-op rather than a redundant update.
       const { store, manager } = setup();
-      const beforeValue = store.getModel("comm-1")?.state.value;
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
-      expect(store.getModel("comm-1")?.state.value).toBe(beforeValue);
+      expect(store.getModel("comm-1")?.state.value).toBe(42);
     });
   });
 

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -169,6 +169,20 @@ describe("WidgetUpdateManager", () => {
       expect(manager.isEchoOfPendingWrite("comm-1", "value", 99)).toBe(false);
     });
 
+    it("recordLocalWrite lets a direct writer share the echo history", () => {
+      // anywidget `save_changes()` reaches the CRDT writer directly
+      // (bypasses updateAndPersist to preserve AFM synchronous
+      // model.get() semantics). `recordLocalWrite` exposes markPending
+      // so those writes get the same echo suppression, otherwise
+      // their stale projections would rewind the store mid-burst.
+      const { manager } = setup();
+
+      manager.recordLocalWrite("comm-1", { value: 77 });
+
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 77)).toBe(true);
+      expect(manager.isEchoOfPendingWrite("comm-1", "value", 77)).toBe(false);
+    });
+
     it("consumes matches so a peer writing the same value afterward lands", () => {
       // Collaborative case: we write 10, our own echo arrives and
       // gets consumed. If a peer later writes 10 as an authoritative
@@ -258,6 +272,32 @@ describe("WidgetUpdateManager", () => {
         { commId: "comm-1", patch: { value: 2 } },
       ]);
       expect(store.getModel("comm-1")?.buffers).toContain(buf2);
+    });
+
+    it("flushes pending throttled scalar patches before a buffered update", () => {
+      // Ordering matters: a throttle-pending scalar patch must not
+      // land after a buffered update for the same comm, otherwise
+      // it would overwrite the newer buffered state and reorder
+      // widget protocols that expect monotonic deltas.
+      const { manager, writerCalls } = setup();
+      const buf = new ArrayBuffer(4);
+
+      manager.updateAndPersist("comm-1", { value: 1 }); // leading, fires
+      manager.updateAndPersist("comm-1", { value: 2 }); // pending (throttled)
+      manager.updateAndPersist("comm-1", { state: "after" }, [buf]);
+
+      // Expect: leading scalar, then flushed-early pending scalar,
+      // then buffered update — in that exact order.
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 1 } },
+        { commId: "comm-1", patch: { value: 2 } },
+        { commId: "comm-1", patch: { state: "after" } },
+      ]);
+
+      // Advance past the trailing window — no additional writes,
+      // because `fireTrailingNow` already cleared the pending state.
+      vi.advanceTimersByTime(60);
+      expect(writerCalls).toHaveLength(3);
     });
   });
 

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -94,18 +94,74 @@ describe("WidgetUpdateManager", () => {
     });
   });
 
-  describe("bootstrap fallback", () => {
-    it("falls back to direct store update when writer isn't ready", () => {
+  describe("bootstrap queue", () => {
+    it("queues patches when writer isn't ready and mirrors to local store", () => {
       // Early session state: CRDT writer hasn't been registered yet
-      // (App.tsx's `setCrdtCommWriter` useEffect hasn't run). We
-      // still want interaction to feel responsive — mirror the pre-
-      // refactor behavior so the UI doesn't stall during bootstrap.
+      // (App.tsx's `setCrdtCommWriter` useEffect hasn't run). The
+      // update is queued so nothing is lost; the store is mirrored
+      // so the UI doesn't stall during bootstrap.
       const { store, manager, writerCalls } = setup({ writerAvailable: false });
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
       expect(writerCalls).toHaveLength(0);
       expect(store.getModel("comm-1")?.state.value).toBe(42);
+    });
+
+    it("drains queued patches into the writer on the next update", () => {
+      // Typical bootstrap race: user clicks a widget → writer isn't
+      // registered yet → patch queued. A later call (e.g. model
+      // echo or another interaction) finds the writer registered —
+      // drain the queue before processing the new write.
+      const store = createWidgetStore();
+      const writerCalls: Array<{ commId: string; patch: Record<string, unknown> }> = [];
+      const writer = (commId: string, patch: Record<string, unknown>) => {
+        writerCalls.push({ commId, patch });
+      };
+      let writerAvailable = false;
+      const manager = new WidgetUpdateManager({
+        getStore: () => store,
+        getCrdtWriter: () => (writerAvailable ? writer : null),
+      });
+      store.createModel("comm-1", { value: 0 });
+
+      // Bootstrap write — queued.
+      manager.updateAndPersist("comm-1", { value: 42 });
+      expect(writerCalls).toHaveLength(0);
+
+      // Writer becomes available.
+      writerAvailable = true;
+      manager.updateAndPersist("comm-1", { description: "ready" });
+
+      // Queued patch flushes first, then the new one.
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 42 } },
+        { commId: "comm-1", patch: { description: "ready" } },
+      ]);
+    });
+
+    it("coalesces multiple bootstrap writes on the same comm", () => {
+      const { manager, writerCalls } = setup({ writerAvailable: false });
+      manager.updateAndPersist("comm-1", { value: 1 });
+      manager.updateAndPersist("comm-1", { value: 2 });
+      manager.updateAndPersist("comm-1", { description: "hello" });
+
+      // Drain by providing a writer on the next call.
+      const writer = (commId: string, patch: Record<string, unknown>) => {
+        writerCalls.push({ commId, patch });
+      };
+      const managerRef = manager as unknown as {
+        getCrdtWriter: () => typeof writer | null;
+      };
+      managerRef.getCrdtWriter = () => writer;
+      manager.updateAndPersist("comm-2", { value: 99 });
+
+      // The coalesced patch has the last value for `value` plus the
+      // description — last-wins merge on key collision.
+      expect(writerCalls).toEqual([
+        { commId: "comm-1", patch: { value: 2, description: "hello" } },
+        { commId: "comm-2", patch: { value: 99 } },
+      ]);
     });
   });
 

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -289,11 +289,17 @@ export function createAFMModelProxy(
       // Try CRDT path first (writes directly to RuntimeStateDoc,
       // no SendComm round-trip). Falls back to SendComm if CRDT
       // writer isn't available yet.
+      //
+      // The CRDT writer in App.tsx calls `projectLocalState()` after
+      // the write, so the WidgetStore picks up the patch via
+      // `commChanges$` in the same tick. No need for a separate
+      // `store.updateModel(...)` here — that produced duplicate
+      // `change` notifications (one from the optimistic write, one
+      // from the projected emission), causing anywidget listeners
+      // to fire twice per `save_changes`.
       const writer = getCrdtCommWriter();
       if (writer) {
         writer(model.id, patch);
-        // Optimistically update the WidgetStore for instant feedback
-        store.updateModel(model.id, patch);
       } else {
         // Fallback: Send comm_msg with update method to kernel
         sendMessage({

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -290,16 +290,18 @@ export function createAFMModelProxy(
       // no SendComm round-trip). Falls back to SendComm if CRDT
       // writer isn't available yet.
       //
-      // The CRDT writer in App.tsx calls `projectLocalState()` after
-      // the write, so the WidgetStore picks up the patch via
-      // `commChanges$` in the same tick. No need for a separate
-      // `store.updateModel(...)` here — that produced duplicate
-      // `change` notifications (one from the optimistic write, one
-      // from the projected emission), causing anywidget listeners
-      // to fire twice per `save_changes`.
+      // AFM/Backbone semantics require `model.get(...)` to observe
+      // the just-saved value synchronously after `save_changes()`.
+      // The CRDT round-trip via `projectLocalState` → `commChanges$`
+      // hops through a microtask, so we update the local store
+      // immediately here. The subsequent projected emission in
+      // App.tsx's subscriber is a no-op for keys that already match
+      // (see `commChanges$` handling), so anywidget `change` events
+      // don't double-fire.
       const writer = getCrdtCommWriter();
       if (writer) {
         writer(model.id, patch);
+        store.updateModel(model.id, patch);
       } else {
         // Fallback: Send comm_msg with update method to kernel
         sendMessage({

--- a/src/components/widgets/link-subscriptions.ts
+++ b/src/components/widgets/link-subscriptions.ts
@@ -1,6 +1,19 @@
 import { parseModelRef, type WidgetStore } from "./widget-store";
 
 /**
+ * Dispatch a widget state patch for a linked target.
+ *
+ * `createLinkManager` accepts this callback instead of writing to the
+ * store directly (the pre-A2 behavior). Routing link-propagated
+ * updates through the CRDT writer means the target's state stays in
+ * sync with the kernel — the old store-only path left targets
+ * diverged from the authoritative RuntimeStateDoc, which was fine
+ * pre-A2 when the store was itself a dual-write optimistic mirror,
+ * but wrong post-A2 (store is a projection; kernel needs the write).
+ */
+export type LinkWriter = (commId: string, patch: Record<string, unknown>) => void;
+
+/**
  * Parse a link source/target tuple from widget state.
  * The state arrives as: ["IPY_MODEL_<id>", "attribute_name"]
  * Returns [modelId, attrName] or null if malformed.
@@ -23,7 +36,11 @@ function parseLinkTarget(tuple: unknown): [string, string] | null {
  * Set up a one-way property subscription (source → target).
  * Returns a cleanup function to tear down the subscription.
  */
-function setupDirectionalLink(store: WidgetStore, linkModelId: string): () => void {
+function setupDirectionalLink(
+  store: WidgetStore,
+  linkModelId: string,
+  writer: LinkWriter,
+): () => void {
   let keyUnsub: (() => void) | undefined;
   let globalUnsub: (() => void) | undefined;
   let isSetUp = false;
@@ -46,22 +63,23 @@ function setupDirectionalLink(store: WidgetStore, linkModelId: string): () => vo
     }
     isSetUp = true;
 
-    // Initial sync: read source value, write to target.
-    // Uses store.updateModel directly — jslink/jsdlink are client-side only,
-    // no CRDT write needed. The originating widget's sendUpdate handles persistence.
+    // Initial sync: read source value, write to target through the
+    // CRDT writer so the kernel learns the target's new value. The
+    // store will update when `projectLocalState` fires the commChanges$
+    // emission for the target's write.
     const sourceModel = store.getModel(sourceModelId);
     if (sourceModel) {
       const currentValue = sourceModel.state[sourceAttr];
       if (currentValue !== undefined) {
-        store.updateModel(targetModelId, { [targetAttr]: currentValue });
+        writer(targetModelId, { [targetAttr]: currentValue });
       }
     }
 
-    // Subscribe to source changes, propagate to target
+    // Subscribe to source changes, propagate to target.
     keyUnsub = store.subscribeToKey(sourceModelId, sourceAttr, (newValue) => {
       const tgt = store.getModel(targetModelId);
       if (tgt && tgt.state[targetAttr] === newValue) return;
-      store.updateModel(targetModelId, { [targetAttr]: newValue });
+      writer(targetModelId, { [targetAttr]: newValue });
     });
 
     // Clean up global listener once setup is complete
@@ -86,11 +104,23 @@ function setupDirectionalLink(store: WidgetStore, linkModelId: string): () => vo
 
 /**
  * Set up a bidirectional property subscription (source ↔ target).
- * Uses a synchronous guard to prevent infinite loops since store
- * subscriptions fire synchronously during updateModel.
+ *
+ * Bidirectional link loops would normally go infinite: source change
+ * → target write → target echo → source write → ... . The equality
+ * check (`tgt.state[targetAttr] === newValue`) is the primary
+ * termination guard — once both sides converge on a value, the
+ * callback no-ops. Because CRDT writes flow through an async
+ * projection hop, we also keep a synchronous `isSyncing` flag to
+ * suppress the immediately reciprocal emission that lands inside the
+ * same callback tree.
+ *
  * Returns a cleanup function to tear down the subscriptions.
  */
-function setupBidirectionalLink(store: WidgetStore, linkModelId: string): () => void {
+function setupBidirectionalLink(
+  store: WidgetStore,
+  linkModelId: string,
+  writer: LinkWriter,
+): () => void {
   const keyUnsubs: (() => void)[] = [];
   let globalUnsub: (() => void) | undefined;
   let isSetUp = false;
@@ -114,14 +144,13 @@ function setupBidirectionalLink(store: WidgetStore, linkModelId: string): () => 
     }
     isSetUp = true;
 
-    // Initial sync: source → target.
-    // Local-only — jslink is client-side, no CRDT write needed.
+    // Initial sync: source → target via the CRDT writer.
     const sourceModel = store.getModel(sourceModelId);
     if (sourceModel) {
       const currentValue = sourceModel.state[sourceAttr];
       if (currentValue !== undefined) {
         isSyncing = true;
-        store.updateModel(targetModelId, { [targetAttr]: currentValue });
+        writer(targetModelId, { [targetAttr]: currentValue });
         isSyncing = false;
       }
     }
@@ -133,7 +162,7 @@ function setupBidirectionalLink(store: WidgetStore, linkModelId: string): () => 
         const tgt = store.getModel(targetModelId);
         if (tgt && tgt.state[targetAttr] === newValue) return;
         isSyncing = true;
-        store.updateModel(targetModelId, { [targetAttr]: newValue });
+        writer(targetModelId, { [targetAttr]: newValue });
         isSyncing = false;
       }),
     );
@@ -145,7 +174,7 @@ function setupBidirectionalLink(store: WidgetStore, linkModelId: string): () => 
         const src = store.getModel(sourceModelId);
         if (src && src.state[sourceAttr] === newValue) return;
         isSyncing = true;
-        store.updateModel(sourceModelId, { [sourceAttr]: newValue });
+        writer(sourceModelId, { [sourceAttr]: newValue });
         isSyncing = false;
       }),
     );
@@ -174,14 +203,22 @@ function setupBidirectionalLink(store: WidgetStore, linkModelId: string): () => 
  * Create a link manager that monitors the store for LinkModel and
  * DirectionalLinkModel widgets and manages their property subscriptions.
  *
+ * Post-A2 semantics: link-propagated updates go through `writer`
+ * (the CRDT commit path) rather than `store.updateModel` directly.
+ * The store picks up the target's new value from the projectLocalState
+ * emission that follows the write. Keeps the link's target state in
+ * agreement with the kernel's view.
+ *
  * Returns a cleanup function that tears down all active link subscriptions.
  *
- * Called automatically by WidgetStoreProvider. For non-React integrations
- * (e.g. iframe isolation), call this directly after creating the store.
+ * Called automatically by WidgetStoreProvider. For non-React
+ * integrations (e.g. iframe isolation), call this directly after
+ * creating the store.
  *
  * @param store - The widget store instance
+ * @param writer - CRDT writer for propagating updates to linked comms
  */
-export function createLinkManager(store: WidgetStore): () => void {
+export function createLinkManager(store: WidgetStore, writer: LinkWriter): () => void {
   const activeLinks = new Map<string, () => void>();
   let lastSize = -1;
 
@@ -198,9 +235,9 @@ export function createLinkManager(store: WidgetStore): () => void {
       if (activeLinks.has(id)) return;
 
       if (model.modelName === "DirectionalLinkModel") {
-        activeLinks.set(id, setupDirectionalLink(store, id));
+        activeLinks.set(id, setupDirectionalLink(store, id, writer));
       } else if (model.modelName === "LinkModel") {
-        activeLinks.set(id, setupBidirectionalLink(store, id));
+        activeLinks.set(id, setupBidirectionalLink(store, id, writer));
       }
     });
 

--- a/src/components/widgets/link-subscriptions.ts
+++ b/src/components/widgets/link-subscriptions.ts
@@ -3,13 +3,14 @@ import { parseModelRef, type WidgetStore } from "./widget-store";
 /**
  * Dispatch a widget state patch for a linked target.
  *
- * `createLinkManager` accepts this callback instead of writing to the
- * store directly (the pre-A2 behavior). Routing link-propagated
- * updates through the CRDT writer means the target's state stays in
- * sync with the kernel — the old store-only path left targets
- * diverged from the authoritative RuntimeStateDoc, which was fine
- * pre-A2 when the store was itself a dual-write optimistic mirror,
- * but wrong post-A2 (store is a projection; kernel needs the write).
+ * `createLinkManager` accepts this callback so the app can choose the
+ * scope of the propagation. In practice this is a store-only write:
+ * `widgets.jslink` / `widgets.jsdlink` are the ipywidgets
+ * frontend-only link primitives — they mirror a source property into
+ * a target property in the browser without involving the kernel. The
+ * kernel-side equivalent (`widgets.link`) uses Python traitlet
+ * `observe`/`notify`, which flows through the normal CRDT round-trip
+ * without touching this code.
  */
 export type LinkWriter = (commId: string, patch: Record<string, unknown>) => void;
 
@@ -63,10 +64,7 @@ function setupDirectionalLink(
     }
     isSetUp = true;
 
-    // Initial sync: read source value, write to target through the
-    // CRDT writer so the kernel learns the target's new value. The
-    // store will update when `projectLocalState` fires the commChanges$
-    // emission for the target's write.
+    // Initial sync: read source value, propagate to the target.
     const sourceModel = store.getModel(sourceModelId);
     if (sourceModel) {
       const currentValue = sourceModel.state[sourceAttr];
@@ -144,7 +142,7 @@ function setupBidirectionalLink(
     }
     isSetUp = true;
 
-    // Initial sync: source → target via the CRDT writer.
+    // Initial sync: source → target via the injected writer.
     const sourceModel = store.getModel(sourceModelId);
     if (sourceModel) {
       const currentValue = sourceModel.state[sourceAttr];
@@ -203,11 +201,10 @@ function setupBidirectionalLink(
  * Create a link manager that monitors the store for LinkModel and
  * DirectionalLinkModel widgets and manages their property subscriptions.
  *
- * Post-A2 semantics: link-propagated updates go through `writer`
- * (the CRDT commit path) rather than `store.updateModel` directly.
- * The store picks up the target's new value from the projectLocalState
- * emission that follows the write. Keeps the link's target state in
- * agreement with the kernel's view.
+ * Link-propagated updates go through the injected `writer` callback.
+ * The normal wiring is a store-only write — jslink/jsdlink are
+ * frontend-only by design — but the callback is abstract so iframe
+ * isolation and test harnesses can route it however they need.
  *
  * Returns a cleanup function that tears down all active link subscriptions.
  *
@@ -216,7 +213,7 @@ function setupBidirectionalLink(
  * creating the store.
  *
  * @param store - The widget store instance
- * @param writer - CRDT writer for propagating updates to linked comms
+ * @param writer - Dispatch callback for propagating updates to linked comms
  */
 export function createLinkManager(store: WidgetStore, writer: LinkWriter): () => void {
   const activeLinks = new Map<string, () => void>();

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -88,8 +88,22 @@ export function WidgetStoreProvider({
   // Manage link subscriptions (jslink/jsdlink) at the store level.
   // Headless widgets like LinkModel have _view_name: null and won't be
   // in any container's children, so they need store-level subscriptions.
-  // Links use store.updateModel directly (client-side only, no CRDT write).
-  useEffect(() => createLinkManager(store), [store]);
+  //
+  // Post-A2 the link writer routes through `updateManager.updateAndPersist`
+  // so link-propagated target updates go to the CRDT (and thus the
+  // kernel), not just the local store. If no manager is wired up — e.g.
+  // isolated-renderer iframe where the comm bridge manages widgets
+  // directly — fall back to a local-only store write.
+  useEffect(() => {
+    const writer = updateManager
+      ? (commId: string, patch: Record<string, unknown>) => {
+          updateManager.updateAndPersist(commId, patch);
+        }
+      : (commId: string, patch: Record<string, unknown>) => {
+          store.updateModel(commId, patch);
+        };
+    return createLinkManager(store, writer);
+  }, [store, updateManager]);
   useEffect(() => createCanvasManagerRouter(store), [store]);
 
   const value = useMemo(

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -89,21 +89,21 @@ export function WidgetStoreProvider({
   // Headless widgets like LinkModel have _view_name: null and won't be
   // in any container's children, so they need store-level subscriptions.
   //
-  // Post-A2 the link writer routes through `updateManager.updateAndPersist`
-  // so link-propagated target updates go to the CRDT (and thus the
-  // kernel), not just the local store. If no manager is wired up — e.g.
-  // isolated-renderer iframe where the comm bridge manages widgets
-  // directly — fall back to a local-only store write.
-  useEffect(() => {
-    const writer = updateManager
-      ? (commId: string, patch: Record<string, unknown>) => {
-          updateManager.updateAndPersist(commId, patch);
-        }
-      : (commId: string, patch: Record<string, unknown>) => {
-          store.updateModel(commId, patch);
-        };
-    return createLinkManager(store, writer);
-  }, [store, updateManager]);
+  // `widgets.jslink` / `widgets.jsdlink` are the frontend-only ipywidgets
+  // links — they mirror a property from one widget view to another in
+  // the browser without the kernel ever seeing the target's value. The
+  // write here is deliberately local-store-only (not routed through
+  // `updateManager.updateAndPersist`); the CRDT/daemon/kernel don't
+  // track jslink targets. Python-side equivalents use `widgets.link`
+  // which already flows through the normal kernel traitlet
+  // observe/notify path.
+  useEffect(
+    () =>
+      createLinkManager(store, (commId, patch) => {
+        store.updateModel(commId, patch);
+      }),
+    [store],
+  );
   useEffect(() => createCanvasManagerRouter(store), [store]);
 
   const value = useMemo(

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -156,6 +156,17 @@ export class WidgetUpdateManager {
     return false;
   }
 
+  /**
+   * Record a local write against the pending-history for echo
+   * suppression. Exposed as public so direct CRDT writers (e.g.
+   * anywidget `save_changes`, which bypasses `updateAndPersist`
+   * to preserve AFM synchronous `model.get()` semantics) can share
+   * the same echo bookkeeping as throttled writes.
+   */
+  recordLocalWrite(commId: string, patch: Record<string, unknown>): void {
+    this.markPending(commId, patch);
+  }
+
   private markPending(commId: string, patch: Record<string, unknown>): void {
     let keys = this.pendingKeys.get(commId);
     if (!keys) {
@@ -242,12 +253,34 @@ export class WidgetUpdateManager {
     if (buffers?.length) {
       // Buffers bypass the throttle: ArrayBuffers aren't patchable
       // through Automerge, and delaying them would corrupt
-      // anywidget model.buffers ordering.
+      // anywidget model.buffers ordering. But first drain any
+      // scalar patch waiting on the trailing timer for this comm,
+      // otherwise the older scalar would land *after* the buffered
+      // update and reorder ordering-sensitive widget protocols.
+      this.fireTrailingNow(commId, writer);
       writer(commId, patch);
       return;
     }
 
     this.scheduleThrottled(commId, patch, writer);
+  }
+
+  /**
+   * If there's a pending trailing flush for this comm, fire it
+   * immediately (before the throttle window expires). Used when a
+   * buffered update — which can't wait for the trailing timer —
+   * needs to preserve ordering relative to earlier scalar patches.
+   */
+  private fireTrailingNow(commId: string, writer: CrdtCommWriter): void {
+    const state = this.throttles.get(commId);
+    if (!state || !state.trailingTimer) return;
+    clearTimeout(state.trailingTimer);
+    state.trailingTimer = null;
+    const patch = state.pending;
+    state.pending = null;
+    if (!patch) return;
+    writer(commId, patch);
+    state.lastFlushAt = Date.now();
   }
 
   private scheduleThrottled(

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -71,11 +71,20 @@ export class WidgetUpdateManager {
   /**
    * Persist a widget state update.
    *
-   * Throttled per comm so bursts (slider drags, text input) coalesce
-   * to one write per `THROTTLE_MS`. The first write in a burst fires
-   * immediately — the user sees instant feedback via the
-   * `projectLocalState` → `commChanges$` → WidgetStore path. Ticks
-   * within the window accumulate last-wins into the trailing flush.
+   * Every tick immediately mirrors `patch` into the local
+   * `WidgetStore` so UI components (slider thumbs, text inputs) move
+   * in lockstep with user input. The outbound CRDT write is
+   * throttled per comm so a continuous drag doesn't flood the daemon
+   * with ~60 writes/sec. The first write in a burst fires at the
+   * leading edge; ticks within the window accumulate last-wins into
+   * a trailing flush at `THROTTLE_MS`.
+   *
+   * The local-then-CRDT ordering is safe because `projectLocalState`
+   * re-emits the resolved state on `commChanges$`, and the App-level
+   * subscriber diffs that against the current store — so the local
+   * pre-write makes the projected echo a no-op rather than a
+   * duplicate update. Kernel echoes converge through Automerge merge
+   * rather than racing the local store.
    *
    * Binary buffers bypass throttling and are mirrored directly to
    * the local widget model (CRDT doesn't carry ArrayBuffers;
@@ -94,12 +103,19 @@ export class WidgetUpdateManager {
     // order, even if they landed minutes ago.
     this.drainBootstrap(writer);
 
+    // Mirror every tick to the local store so components see
+    // continuous motion during a drag even when CRDT writes are
+    // throttled. The projection from `writer → projectLocalState →
+    // commChanges$` later fans the same values back out for other
+    // views; the App-level subscriber's diff check makes that a
+    // no-op rather than a redundant re-render.
+    this.getStore()?.updateModel(commId, patch, buffers);
+
     if (buffers?.length) {
       // Buffers bypass the throttle: ArrayBuffers aren't patchable
       // through Automerge, and delaying them would corrupt
       // anywidget model.buffers ordering.
       writer(commId, patch);
-      this.getStore()?.updateModel(commId, {}, buffers);
       return;
     }
 

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -12,11 +12,6 @@
  * to the CRDT, and the `WidgetStore` updates purely from
  * `commChanges$` — local writes included, because `SyncEngine.projectLocalState`
  * fires the projection synchronously after `set_comm_state_batch`.
- *
- * All that's left here is the fallback path for when the CRDT writer
- * isn't yet wired up (early bootstrap), plus binary buffer storage:
- * the CRDT doesn't carry ArrayBuffers, so we keep buffers on the local
- * widget model until outbound sync picks them up via another path.
  */
 
 import type { WidgetStore } from "./widget-store";
@@ -28,9 +23,25 @@ export interface WidgetUpdateManagerOptions {
   getCrdtWriter: () => CrdtCommWriter | null;
 }
 
+/**
+ * Poll interval for draining queued writes while the CRDT writer is
+ * still null. Keeps the drain small & bounded without needing the
+ * caller to explicitly kick the manager.
+ */
+const DRAIN_POLL_MS = 50;
+
 export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
+
+  /**
+   * Patches that arrived before the CRDT writer was registered.
+   * Keyed by commId, last-wins on key collision (each patch is
+   * merged onto the previous with `{ ...existing, ...patch }`).
+   * Drained as soon as a writer becomes available.
+   */
+  private pendingQueue = new Map<string, Record<string, unknown>>();
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(opts: WidgetUpdateManagerOptions) {
     this.getStore = opts.getStore;
@@ -46,28 +57,34 @@ export class WidgetUpdateManager {
    * echo suppression — the CRDT is the single source of truth.
    *
    * If the CRDT writer isn't available yet (early bootstrap before
-   * `setCrdtCommWriter` has run), falls back to a direct store
-   * update so the UI isn't completely unresponsive during startup.
+   * `setCrdtCommWriter` has run), the patch is queued and the UI
+   * still gets an instant store mirror so the user isn't stuck on a
+   * blank control. When the writer shows up, queued patches flush in
+   * insertion order and the daemon receives them as if the user had
+   * acted slightly later.
    *
    * Binary buffers aren't representable in the Automerge CRDT, so we
-   * preserve the legacy behavior of stashing them on the local widget
-   * model. Kernel delivery of binary buffers goes through the
-   * SendComm RPC path in `use-comm-router.ts` (untouched by this
-   * refactor).
+   * mirror them into the local widget model. Kernel delivery of
+   * binary buffers goes through the SendComm RPC path in
+   * `use-comm-router.ts` (untouched by this refactor).
    */
   updateAndPersist(commId: string, patch: Record<string, unknown>, buffers?: ArrayBuffer[]): void {
     const writer = this.getCrdtWriter();
     if (writer) {
+      // Drain anything queued before this writer became available.
+      this.drainPending(writer);
       writer(commId, patch);
     } else {
-      // Bootstrap fallback: CRDT writer wasn't registered yet. Mirror
-      // the pre-A2 behavior so early-session widget interactions
-      // (before App.tsx's setCrdtCommWriter effect has run) still
-      // render. projectLocalState will pick up future writes.
+      // Bootstrap: accumulate on the pending queue until the CRDT
+      // writer shows up. We also mirror the patch to the local store
+      // so the UI doesn't stall — `projectLocalState` will re-emit
+      // the value once the writer drains our queue.
+      const existing = this.pendingQueue.get(commId) ?? {};
+      this.pendingQueue.set(commId, { ...existing, ...patch });
       this.getStore()?.updateModel(commId, patch, buffers);
-      return;
+      this.scheduleDrain();
     }
-    if (buffers?.length) {
+    if (writer && buffers?.length) {
       // Buffers ride alongside the CRDT state on the local widget
       // model. Kernel delivery is handled elsewhere (SendComm RPC).
       this.getStore()?.updateModel(commId, {}, buffers);
@@ -75,21 +92,61 @@ export class WidgetUpdateManager {
   }
 
   /**
-   * Reset any per-comm bookkeeping. Kept as a no-op for API
-   * compatibility with the pre-A2 manager, which tracked optimistic
-   * keys and debounce timers across kernel restarts. There is no
-   * per-comm state to reset anymore.
+   * Drain the pending queue through the supplied writer. Called
+   * opportunistically on the next `updateAndPersist` once the writer
+   * is registered, and on the polling timer for the "no new writes
+   * arrived but writer just became available" case.
    */
-  reset(): void {}
+  private drainPending(writer: CrdtCommWriter): void {
+    if (this.pendingQueue.size === 0) return;
+    for (const [commId, patch] of this.pendingQueue) {
+      writer(commId, patch);
+    }
+    this.pendingQueue.clear();
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainTimer) return;
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      const writer = this.getCrdtWriter();
+      if (writer) {
+        this.drainPending(writer);
+      } else if (this.pendingQueue.size > 0) {
+        this.scheduleDrain();
+      }
+    }, DRAIN_POLL_MS);
+  }
 
   /**
-   * Tear down. Nothing to clean up post-A2 — no pending timers, no
-   * accumulated state.
+   * Reset any per-comm bookkeeping. Also drops the pending queue:
+   * a kernel restart invalidates optimistic state the old kernel was
+   * going to receive, so replaying queued writes into a fresh kernel
+   * would be worse than losing them.
    */
-  dispose(): void {}
+  reset(): void {
+    this.pendingQueue.clear();
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+  }
 
   /**
-   * Drop per-comm state on comm_close. Also a no-op post-A2.
+   * Tear down.
    */
-  clearComm(_commId: string): void {}
+  dispose(): void {
+    this.reset();
+  }
+
+  /**
+   * Drop pending state for a specific comm (called on comm_close).
+   */
+  clearComm(commId: string): void {
+    this.pendingQueue.delete(commId);
+  }
 }

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -53,6 +53,15 @@ interface CommThrottleState {
  */
 const PENDING_TTL_MS = 500;
 
+interface PendingValue {
+  /** The exact value we last wrote locally for this key. */
+  value: unknown;
+  /** Cached JSON serialization of `value` for cheap equality. */
+  json: string;
+  /** Wall-clock ms when the write happened. */
+  ts: number;
+}
+
 export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
@@ -65,15 +74,16 @@ export class WidgetUpdateManager {
   private throttles = new Map<string, CommThrottleState>();
 
   /**
-   * Per-comm per-key timestamps of local writes that haven't yet
-   * round-tripped through the CRDT. Consulted by the App-level
-   * `commChanges$` subscriber: if a projected echo carries a key
-   * that was written locally within `PENDING_TTL_MS`, the store's
-   * current value wins and the echo is dropped. Prevents the
-   * daemon's lagged view of the throttle window from clobbering
-   * the in-flight drag.
+   * Per-comm per-key record of the last value we wrote locally
+   * and when. Consulted by the App-level `commChanges$` subscriber
+   * via `isEchoOfPendingWrite`: a projected value matching what we
+   * just wrote is dropped as a stale echo of our own in-flight
+   * write. A projected value *differing* from our pending value is
+   * treated as authoritative (kernel validator, peer edit, etc.)
+   * and still applied — so a clamped or collaboratively-updated
+   * key can't get stuck on the optimistic local value.
    */
-  private pendingKeys = new Map<string, Map<string, number>>();
+  private pendingKeys = new Map<string, Map<string, PendingValue>>();
 
   /**
    * Patches that arrived before the CRDT writer was registered.
@@ -88,23 +98,31 @@ export class WidgetUpdateManager {
   }
 
   /**
-   * Is there a pending local write for this key that the daemon's
-   * projected echo shouldn't clobber? Consulted by the `commChanges$`
-   * subscriber to drop stale projected values during the throttle
-   * window (and briefly after, until the daemon's merged view catches
-   * up).
+   * Is the projected `candidate` value for `(commId, key)` a stale
+   * echo of a local write we just made? Returns true only when the
+   * candidate matches the most recently written local value within
+   * the TTL. A mismatch indicates the daemon or a peer authoritatively
+   * changed the key (e.g., kernel validator clamp, another tab's edit)
+   * and the caller should still apply the update.
    */
-  hasPendingKey(commId: string, key: string): boolean {
+  isEchoOfPendingWrite(commId: string, key: string, candidate: unknown): boolean {
     const keys = this.pendingKeys.get(commId);
     if (!keys) return false;
-    const ts = keys.get(key);
-    if (ts === undefined) return false;
-    if (Date.now() - ts > PENDING_TTL_MS) {
+    const entry = keys.get(key);
+    if (!entry) return false;
+    if (Date.now() - entry.ts > PENDING_TTL_MS) {
       keys.delete(key);
       if (keys.size === 0) this.pendingKeys.delete(commId);
       return false;
     }
-    return true;
+    if (entry.value === candidate) return true;
+    try {
+      return JSON.stringify(candidate) === entry.json;
+    } catch {
+      // Non-serializable candidate → can't confirm it's our echo; err
+      // on the side of applying the update.
+      return false;
+    }
   }
 
   private markPending(commId: string, patch: Record<string, unknown>): void {
@@ -114,8 +132,17 @@ export class WidgetUpdateManager {
       this.pendingKeys.set(commId, keys);
     }
     const now = Date.now();
-    for (const key of Object.keys(patch)) {
-      keys.set(key, now);
+    for (const [key, value] of Object.entries(patch)) {
+      let json: string;
+      try {
+        json = JSON.stringify(value);
+      } catch {
+        // Skip tracking — we can't compare echoes reliably without
+        // JSON. The worst outcome is an occasional redundant store
+        // write, which is benign.
+        continue;
+      }
+      keys.set(key, { value, json, ts: now });
     }
   }
 

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -1,23 +1,27 @@
 /**
- * Widget Update Manager — debounced CRDT persistence with echo suppression.
+ * Widget Update Manager — CRDT-first widget state persistence.
  *
- * Separates local store updates (instant, for UI responsiveness) from CRDT
- * persistence (debounced, for daemon/kernel sync). During the debounce window,
- * incoming CRDT echoes for optimistic keys are suppressed to prevent stale
- * values from clobbering the user's in-progress interaction.
+ * Historical note (was #1580): this used to be a dual-write path —
+ * synchronous optimistic `store.updateModel` for instant UI feedback,
+ * plus debounced CRDT writes with echo-suppression bookkeeping to
+ * prevent in-flight drags from being clobbered by stale daemon echoes.
+ * That reconciliation grew the widget-sync stall described in
+ * `docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md`.
  *
- * This solves three problems:
- * 1. jslink feedback loops (CRDT echo triggers re-propagation)
- * 2. Slider CRDT flooding (~60 writes/sec during drag)
- * 3. Stale CRDT echoes overwriting optimistic state
+ * Track A collapses it into a single source of truth: every write goes
+ * to the CRDT, and the `WidgetStore` updates purely from
+ * `commChanges$` — local writes included, because `SyncEngine.projectLocalState`
+ * fires the projection synchronously after `set_comm_state_batch`.
+ *
+ * All that's left here is the fallback path for when the CRDT writer
+ * isn't yet wired up (early bootstrap), plus binary buffer storage:
+ * the CRDT doesn't carry ArrayBuffers, so we keep buffers on the local
+ * widget model until outbound sync picks them up via another path.
  */
 
 import type { WidgetStore } from "./widget-store";
 
 type CrdtCommWriter = (commId: string, patch: Record<string, unknown>) => void;
-
-/** Debounce interval for CRDT writes (ms). */
-const DEBOUNCE_MS = 50;
 
 export interface WidgetUpdateManagerOptions {
   getStore: () => WidgetStore | null;
@@ -28,148 +32,64 @@ export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
 
-  /** Accumulated patches waiting for debounced flush, per comm. */
-  private pendingState = new Map<string, Record<string, unknown>>();
-  /** Keys with local-only values not yet flushed to CRDT. */
-  private optimisticKeys = new Map<string, Set<string>>();
-  /** Per-comm debounce timers. */
-  private flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
   constructor(opts: WidgetUpdateManagerOptions) {
     this.getStore = opts.getStore;
     this.getCrdtWriter = opts.getCrdtWriter;
   }
 
   /**
-   * Update store immediately + schedule debounced CRDT write.
+   * Persist a widget state update.
    *
-   * Called by sendUpdate for all widget state changes (sliders, dropdowns,
-   * text input, etc.). The store update fires subscriptions instantly for
-   * responsive UI. The CRDT write is batched per-comm at 50ms.
+   * Writes the patch to the CRDT via the injected writer (which also
+   * fires `projectLocalState` on the sync engine, so the widget store
+   * sees the update in the same tick). No optimistic store write, no
+   * echo suppression — the CRDT is the single source of truth.
    *
-   * Binary buffers bypass debouncing and flush immediately.
+   * If the CRDT writer isn't available yet (early bootstrap before
+   * `setCrdtCommWriter` has run), falls back to a direct store
+   * update so the UI isn't completely unresponsive during startup.
+   *
+   * Binary buffers aren't representable in the Automerge CRDT, so we
+   * preserve the legacy behavior of stashing them on the local widget
+   * model. Kernel delivery of binary buffers goes through the
+   * SendComm RPC path in `use-comm-router.ts` (untouched by this
+   * refactor).
    */
   updateAndPersist(commId: string, patch: Record<string, unknown>, buffers?: ArrayBuffer[]): void {
-    // 1. Instant store update — UI reflects change immediately
-    this.getStore()?.updateModel(commId, patch, buffers);
-
-    // 2. Track optimistic keys
-    let keys = this.optimisticKeys.get(commId);
-    if (!keys) {
-      keys = new Set();
-      this.optimisticKeys.set(commId, keys);
-    }
-    for (const key of Object.keys(patch)) {
-      keys.add(key);
-    }
-
-    // 3. Accumulate patch
-    const existing = this.pendingState.get(commId);
-    this.pendingState.set(commId, existing ? { ...existing, ...patch } : { ...patch });
-
-    // 4. Binary buffers — flush immediately (can't merge ArrayBuffers)
-    if (buffers?.length) {
-      this.flushComm(commId);
-      return;
-    }
-
-    // 5. Debounced flush — reset timer on each update
-    const existing_timer = this.flushTimers.get(commId);
-    if (existing_timer !== undefined) {
-      clearTimeout(existing_timer);
-    }
-    this.flushTimers.set(
-      commId,
-      setTimeout(() => this.flushComm(commId), DEBOUNCE_MS),
-    );
-  }
-
-  /**
-   * Filter an incoming CRDT echo, suppressing keys that have pending
-   * optimistic values.
-   *
-   * Returns the filtered patch to apply, or null if entirely suppressed.
-   */
-  shouldSuppressEcho(
-    commId: string,
-    incomingPatch: Record<string, unknown>,
-  ): Record<string, unknown> | null {
-    const keys = this.optimisticKeys.get(commId);
-    if (!keys || keys.size === 0) return incomingPatch;
-
-    const filtered: Record<string, unknown> = {};
-    let hasKeys = false;
-    for (const [key, value] of Object.entries(incomingPatch)) {
-      if (!keys.has(key)) {
-        filtered[key] = value;
-        hasKeys = true;
-      }
-    }
-    return hasKeys ? filtered : null;
-  }
-
-  /**
-   * Reset all state. Call on kernel restart to ensure fresh echoes
-   * from the new session aren't suppressed.
-   */
-  reset(): void {
-    for (const timer of this.flushTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.flushTimers.clear();
-    this.pendingState.clear();
-    this.optimisticKeys.clear();
-  }
-
-  /** Tear down all timers. */
-  dispose(): void {
-    this.reset();
-  }
-
-  // ── Internal ──────────────────────────────────────────────────────
-
-  /**
-   * Cancel pending state and timers for a specific comm.
-   * Call when a comm is closed to avoid flushing stale state.
-   */
-  clearComm(commId: string): void {
-    const timer = this.flushTimers.get(commId);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      this.flushTimers.delete(commId);
-    }
-    this.pendingState.delete(commId);
-    this.optimisticKeys.delete(commId);
-  }
-
-  private flushComm(commId: string): void {
-    // Clear timer
-    const timer = this.flushTimers.get(commId);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      this.flushTimers.delete(commId);
-    }
-
-    const patch = this.pendingState.get(commId);
-    if (!patch) return;
-
-    // If the CRDT writer isn't available yet (early startup), keep the
-    // patch queued and retry after the next debounce interval.
     const writer = this.getCrdtWriter();
-    if (!writer) {
-      this.flushTimers.set(
-        commId,
-        setTimeout(() => this.flushComm(commId), DEBOUNCE_MS),
-      );
+    if (writer) {
+      writer(commId, patch);
+    } else {
+      // Bootstrap fallback: CRDT writer wasn't registered yet. Mirror
+      // the pre-A2 behavior so early-session widget interactions
+      // (before App.tsx's setCrdtCommWriter effect has run) still
+      // render. projectLocalState will pick up future writes.
+      this.getStore()?.updateModel(commId, patch, buffers);
       return;
     }
-
-    this.pendingState.delete(commId);
-    writer(commId, patch);
-
-    // Clear optimistic keys after flush. Echoes arriving after this
-    // point carry the value we just wrote (or a kernel-validated value)
-    // and should pass through.
-    this.optimisticKeys.delete(commId);
+    if (buffers?.length) {
+      // Buffers ride alongside the CRDT state on the local widget
+      // model. Kernel delivery is handled elsewhere (SendComm RPC).
+      this.getStore()?.updateModel(commId, {}, buffers);
+    }
   }
+
+  /**
+   * Reset any per-comm bookkeeping. Kept as a no-op for API
+   * compatibility with the pre-A2 manager, which tracked optimistic
+   * keys and debounce timers across kernel restarts. There is no
+   * per-comm state to reset anymore.
+   */
+  reset(): void {}
+
+  /**
+   * Tear down. Nothing to clean up post-A2 — no pending timers, no
+   * accumulated state.
+   */
+  dispose(): void {}
+
+  /**
+   * Drop per-comm state on comm_close. Also a no-op post-A2.
+   */
+  clearComm(_commId: string): void {}
 }

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -54,9 +54,7 @@ interface CommThrottleState {
 const PENDING_TTL_MS = 500;
 
 interface PendingValue {
-  /** The exact value we last wrote locally for this key. */
-  value: unknown;
-  /** Cached JSON serialization of `value` for cheap equality. */
+  /** Cached JSON serialization of the value we wrote. */
   json: string;
   /** Wall-clock ms when the write happened. */
   ts: number;
@@ -74,16 +72,23 @@ export class WidgetUpdateManager {
   private throttles = new Map<string, CommThrottleState>();
 
   /**
-   * Per-comm per-key record of the last value we wrote locally
-   * and when. Consulted by the App-level `commChanges$` subscriber
-   * via `isEchoOfPendingWrite`: a projected value matching what we
-   * just wrote is dropped as a stale echo of our own in-flight
-   * write. A projected value *differing* from our pending value is
-   * treated as authoritative (kernel validator, peer edit, etc.)
-   * and still applied — so a clamped or collaboratively-updated
-   * key can't get stuck on the optimistic local value.
+   * Per-comm per-key history of values we've written locally within
+   * the TTL window. Consulted by the App-level `commChanges$`
+   * subscriber via `isEchoOfPendingWrite`: a projected value that
+   * matches *any* recent local write is dropped as a stale echo of
+   * our own in-flight writes. A projected value that doesn't
+   * appear in the history is authoritative (kernel validator clamp,
+   * peer edit) and still applied.
+   *
+   * We must remember the whole recent history, not just the latest
+   * value: `projectLocalState()` runs synchronously after the writer
+   * call, but the `commChanges$` emission it produces lands on a
+   * microtask. A rapid burst can walk the pending value from 10 →
+   * 11 → 12 before the leading-edge projection of 10 is handled; a
+   * latest-only check would misclassify that queued echo as
+   * authoritative and snap the UI backward.
    */
-  private pendingKeys = new Map<string, Map<string, PendingValue>>();
+  private pendingKeys = new Map<string, Map<string, PendingValue[]>>();
 
   /**
    * Patches that arrived before the CRDT writer was registered.
@@ -99,30 +104,40 @@ export class WidgetUpdateManager {
 
   /**
    * Is the projected `candidate` value for `(commId, key)` a stale
-   * echo of a local write we just made? Returns true only when the
-   * candidate matches the most recently written local value within
-   * the TTL. A mismatch indicates the daemon or a peer authoritatively
-   * changed the key (e.g., kernel validator clamp, another tab's edit)
-   * and the caller should still apply the update.
+   * echo of any local write we made within the TTL? True for any
+   * value that appears in our recent write history for this key.
+   * A candidate that doesn't appear in the history is treated as
+   * authoritative — kernel validator clamp, peer edit, etc. — and
+   * the caller still applies it.
    */
   isEchoOfPendingWrite(commId: string, key: string, candidate: unknown): boolean {
     const keys = this.pendingKeys.get(commId);
     if (!keys) return false;
-    const entry = keys.get(key);
-    if (!entry) return false;
-    if (Date.now() - entry.ts > PENDING_TTL_MS) {
+    const history = keys.get(key);
+    if (!history || history.length === 0) return false;
+
+    const cutoff = Date.now() - PENDING_TTL_MS;
+    let i = 0;
+    while (i < history.length && history[i].ts < cutoff) i++;
+    if (i > 0) history.splice(0, i);
+    if (history.length === 0) {
       keys.delete(key);
       if (keys.size === 0) this.pendingKeys.delete(commId);
       return false;
     }
-    if (entry.value === candidate) return true;
+
+    let candidateJson: string;
     try {
-      return JSON.stringify(candidate) === entry.json;
+      candidateJson = JSON.stringify(candidate);
     } catch {
       // Non-serializable candidate → can't confirm it's our echo; err
       // on the side of applying the update.
       return false;
     }
+    for (const entry of history) {
+      if (entry.json === candidateJson) return true;
+    }
+    return false;
   }
 
   private markPending(commId: string, patch: Record<string, unknown>): void {
@@ -142,7 +157,20 @@ export class WidgetUpdateManager {
         // write, which is benign.
         continue;
       }
-      keys.set(key, { value, json, ts: now });
+      let history = keys.get(key);
+      if (!history) {
+        history = [];
+        keys.set(key, history);
+      }
+      // Dedup: if we just wrote the same value, bump the timestamp
+      // rather than growing the list. Keeps a quick AB-AB toggle
+      // from ballooning the history.
+      const last = history[history.length - 1];
+      if (last && last.json === json) {
+        last.ts = now;
+      } else {
+        history.push({ json, ts: now });
+      }
     }
   }
 

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -103,12 +103,21 @@ export class WidgetUpdateManager {
   }
 
   /**
-   * Is the projected `candidate` value for `(commId, key)` a stale
-   * echo of any local write we made within the TTL? True for any
-   * value that appears in our recent write history for this key.
-   * A candidate that doesn't appear in the history is treated as
-   * authoritative — kernel validator clamp, peer edit, etc. — and
-   * the caller still applies it.
+   * Consume-and-match: is the projected `candidate` value for
+   * `(commId, key)` a stale echo of any local write we made within
+   * the TTL? Returns true for any value that appears in our recent
+   * write history — and removes the matched entry, so the same
+   * value can only absorb one echo.
+   *
+   * The consume step matters for collaborative correctness: if
+   * another peer happens to write the same value we recently wrote,
+   * only the first emission carrying that value is treated as our
+   * echo. The peer's subsequent emission (or a re-write of the same
+   * value) falls through and lands in the store.
+   *
+   * Candidates that never appeared in the history — kernel
+   * validator clamp, peer edit with a different value — are
+   * applied unchanged.
    */
   isEchoOfPendingWrite(commId: string, key: string, candidate: unknown): boolean {
     const keys = this.pendingKeys.get(commId);
@@ -117,9 +126,9 @@ export class WidgetUpdateManager {
     if (!history || history.length === 0) return false;
 
     const cutoff = Date.now() - PENDING_TTL_MS;
-    let i = 0;
-    while (i < history.length && history[i].ts < cutoff) i++;
-    if (i > 0) history.splice(0, i);
+    let firstLive = 0;
+    while (firstLive < history.length && history[firstLive].ts < cutoff) firstLive++;
+    if (firstLive > 0) history.splice(0, firstLive);
     if (history.length === 0) {
       keys.delete(key);
       if (keys.size === 0) this.pendingKeys.delete(commId);
@@ -134,8 +143,15 @@ export class WidgetUpdateManager {
       // on the side of applying the update.
       return false;
     }
-    for (const entry of history) {
-      if (entry.json === candidateJson) return true;
+    for (let i = 0; i < history.length; i++) {
+      if (history[i].json === candidateJson) {
+        history.splice(i, 1);
+        if (history.length === 0) {
+          keys.delete(key);
+          if (keys.size === 0) this.pendingKeys.delete(commId);
+        }
+        return true;
+      }
     }
     return false;
   }
@@ -297,6 +313,13 @@ export class WidgetUpdateManager {
   private drainBootstrap(writer: CrdtCommWriter): void {
     if (this.bootstrapQueue.size === 0) return;
     for (const [commId, patch] of this.bootstrapQueue) {
+      // Mark the bootstrap value as a pending local write BEFORE
+      // firing the writer. `projectLocalState` will schedule a
+      // microtask emission for this value — without the mark, that
+      // emission would be treated as authoritative and could roll
+      // the store back from a newer user value written after
+      // bootstrap.
+      this.markPending(commId, patch);
       writer(commId, patch);
     }
     this.bootstrapQueue.clear();

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -8,10 +8,17 @@
  * That reconciliation grew the widget-sync stall described in
  * `docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md`.
  *
- * Track A collapses it into a single source of truth: every write goes
+ * Track A collapsed it into a single source of truth: every write goes
  * to the CRDT, and the `WidgetStore` updates purely from
- * `commChanges$` — local writes included, because `SyncEngine.projectLocalState`
- * fires the projection synchronously after `set_comm_state_batch`.
+ * `commChanges$`. Local writes arrive via the same path because
+ * `SyncEngine.projectLocalState` fires the projection synchronously
+ * after `set_comm_state_batch`.
+ *
+ * The outbound write rate is throttled per comm so a continuous slider
+ * drag doesn't produce ~60 CRDT writes/sec. First tick fires
+ * immediately (instant UI feedback via the projected emission);
+ * subsequent ticks within the throttle window accumulate into a single
+ * trailing write.
  */
 
 import type { WidgetStore } from "./widget-store";
@@ -23,24 +30,37 @@ export interface WidgetUpdateManagerOptions {
   getCrdtWriter: () => CrdtCommWriter | null;
 }
 
-/**
- * Poll interval for draining queued writes while the CRDT writer is
- * still null. Keeps the drain small & bounded without needing the
- * caller to explicitly kick the manager.
- */
+/** Throttle window for outbound CRDT writes per comm (ms). */
+const THROTTLE_MS = 50;
+
+/** Poll interval for draining the pending queue while no writer is set. */
 const DRAIN_POLL_MS = 50;
+
+interface CommThrottleState {
+  /** Latest accumulated patch waiting to be flushed, or null. */
+  pending: Record<string, unknown> | null;
+  /** Wall-clock ms of the last successful flush for this comm. */
+  lastFlushAt: number;
+  /** Trailing-edge flush timer handle, or null. */
+  trailingTimer: ReturnType<typeof setTimeout> | null;
+}
 
 export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
 
   /**
-   * Patches that arrived before the CRDT writer was registered.
-   * Keyed by commId, last-wins on key collision (each patch is
-   * merged onto the previous with `{ ...existing, ...patch }`).
-   * Drained as soon as a writer becomes available.
+   * Per-comm throttle bookkeeping. Leading tick fires immediately,
+   * subsequent ticks within `THROTTLE_MS` accumulate into `pending`
+   * and fire together on the trailing-edge timer.
    */
-  private pendingQueue = new Map<string, Record<string, unknown>>();
+  private throttles = new Map<string, CommThrottleState>();
+
+  /**
+   * Patches that arrived before the CRDT writer was registered.
+   * Separate from `throttles` because the writer isn't callable yet.
+   */
+  private bootstrapQueue = new Map<string, Record<string, unknown>>();
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(opts: WidgetUpdateManagerOptions) {
@@ -51,58 +71,107 @@ export class WidgetUpdateManager {
   /**
    * Persist a widget state update.
    *
-   * Writes the patch to the CRDT via the injected writer (which also
-   * fires `projectLocalState` on the sync engine, so the widget store
-   * sees the update in the same tick). No optimistic store write, no
-   * echo suppression — the CRDT is the single source of truth.
+   * Throttled per comm so bursts (slider drags, text input) coalesce
+   * to one write per `THROTTLE_MS`. The first write in a burst fires
+   * immediately — the user sees instant feedback via the
+   * `projectLocalState` → `commChanges$` → WidgetStore path. Ticks
+   * within the window accumulate last-wins into the trailing flush.
    *
-   * If the CRDT writer isn't available yet (early bootstrap before
-   * `setCrdtCommWriter` has run), the patch is queued and the UI
-   * still gets an instant store mirror so the user isn't stuck on a
-   * blank control. When the writer shows up, queued patches flush in
-   * insertion order and the daemon receives them as if the user had
-   * acted slightly later.
-   *
-   * Binary buffers aren't representable in the Automerge CRDT, so we
-   * mirror them into the local widget model. Kernel delivery of
-   * binary buffers goes through the SendComm RPC path in
-   * `use-comm-router.ts` (untouched by this refactor).
+   * Binary buffers bypass throttling and are mirrored directly to
+   * the local widget model (CRDT doesn't carry ArrayBuffers;
+   * kernel delivery of buffers goes through the SendComm RPC path
+   * elsewhere).
    */
   updateAndPersist(commId: string, patch: Record<string, unknown>, buffers?: ArrayBuffer[]): void {
     const writer = this.getCrdtWriter();
-    if (writer) {
-      // Drain anything queued before this writer became available.
-      this.drainPending(writer);
-      writer(commId, patch);
-    } else {
-      // Bootstrap: accumulate on the pending queue until the CRDT
-      // writer shows up. We also mirror the patch to the local store
-      // so the UI doesn't stall — `projectLocalState` will re-emit
-      // the value once the writer drains our queue.
-      const existing = this.pendingQueue.get(commId) ?? {};
-      this.pendingQueue.set(commId, { ...existing, ...patch });
-      this.getStore()?.updateModel(commId, patch, buffers);
-      this.scheduleDrain();
+    if (!writer) {
+      this.queueForBootstrap(commId, patch, buffers);
+      return;
     }
-    if (writer && buffers?.length) {
-      // Buffers ride alongside the CRDT state on the local widget
-      // model. Kernel delivery is handled elsewhere (SendComm RPC).
+
+    // Drain any bootstrap-queue leftovers before processing new
+    // writes. Ensures pre-writer patches reach the CRDT in insertion
+    // order, even if they landed minutes ago.
+    this.drainBootstrap(writer);
+
+    if (buffers?.length) {
+      // Buffers bypass the throttle: ArrayBuffers aren't patchable
+      // through Automerge, and delaying them would corrupt
+      // anywidget model.buffers ordering.
+      writer(commId, patch);
       this.getStore()?.updateModel(commId, {}, buffers);
+      return;
+    }
+
+    this.scheduleThrottled(commId, patch, writer);
+  }
+
+  private scheduleThrottled(
+    commId: string,
+    patch: Record<string, unknown>,
+    writer: CrdtCommWriter,
+  ): void {
+    const now = Date.now();
+    let state = this.throttles.get(commId);
+    if (!state) {
+      state = { pending: null, lastFlushAt: 0, trailingTimer: null };
+      this.throttles.set(commId, state);
+    }
+
+    const sinceLast = now - state.lastFlushAt;
+    if (sinceLast >= THROTTLE_MS && state.trailingTimer === null) {
+      // Leading tick — flush immediately.
+      writer(commId, patch);
+      state.lastFlushAt = now;
+      return;
+    }
+
+    // Burst in progress — accumulate and schedule the trailing fire.
+    state.pending = state.pending ? { ...state.pending, ...patch } : { ...patch };
+    if (state.trailingTimer === null) {
+      const wait = Math.max(0, THROTTLE_MS - sinceLast);
+      state.trailingTimer = setTimeout(() => this.fireTrailing(commId), wait);
     }
   }
 
-  /**
-   * Drain the pending queue through the supplied writer. Called
-   * opportunistically on the next `updateAndPersist` once the writer
-   * is registered, and on the polling timer for the "no new writes
-   * arrived but writer just became available" case.
-   */
-  private drainPending(writer: CrdtCommWriter): void {
-    if (this.pendingQueue.size === 0) return;
-    for (const [commId, patch] of this.pendingQueue) {
+  private fireTrailing(commId: string): void {
+    const state = this.throttles.get(commId);
+    if (!state) return;
+    state.trailingTimer = null;
+    const patch = state.pending;
+    state.pending = null;
+    if (!patch) return;
+    const writer = this.getCrdtWriter();
+    if (!writer) {
+      // Writer vanished mid-throttle (reset, unmount). Redirect to
+      // the bootstrap queue so the change isn't lost if a new
+      // writer shows up later.
+      this.queueForBootstrap(commId, patch);
+      return;
+    }
+    writer(commId, patch);
+    state.lastFlushAt = Date.now();
+  }
+
+  private queueForBootstrap(
+    commId: string,
+    patch: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): void {
+    const existing = this.bootstrapQueue.get(commId) ?? {};
+    this.bootstrapQueue.set(commId, { ...existing, ...patch });
+    // Mirror the patch to the local store so the UI isn't stuck on
+    // the pre-interaction value during bootstrap.
+    this.getStore()?.updateModel(commId, patch, buffers);
+    this.scheduleDrain();
+  }
+
+  private drainBootstrap(writer: CrdtCommWriter): void {
+    if (this.bootstrapQueue.size === 0) return;
+    for (const [commId, patch] of this.bootstrapQueue) {
       writer(commId, patch);
     }
-    this.pendingQueue.clear();
+    this.bootstrapQueue.clear();
     if (this.drainTimer) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -115,38 +184,40 @@ export class WidgetUpdateManager {
       this.drainTimer = null;
       const writer = this.getCrdtWriter();
       if (writer) {
-        this.drainPending(writer);
-      } else if (this.pendingQueue.size > 0) {
+        this.drainBootstrap(writer);
+      } else if (this.bootstrapQueue.size > 0) {
         this.scheduleDrain();
       }
     }, DRAIN_POLL_MS);
   }
 
   /**
-   * Reset any per-comm bookkeeping. Also drops the pending queue:
-   * a kernel restart invalidates optimistic state the old kernel was
-   * going to receive, so replaying queued writes into a fresh kernel
-   * would be worse than losing them.
+   * Reset all bookkeeping — called on kernel restart. Drops pending
+   * throttle state and the bootstrap queue: patches the old kernel
+   * would have received shouldn't reach a freshly-launched one.
    */
   reset(): void {
-    this.pendingQueue.clear();
+    for (const state of this.throttles.values()) {
+      if (state.trailingTimer) clearTimeout(state.trailingTimer);
+    }
+    this.throttles.clear();
+    this.bootstrapQueue.clear();
     if (this.drainTimer) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
   }
 
-  /**
-   * Tear down.
-   */
+  /** Tear down. */
   dispose(): void {
     this.reset();
   }
 
-  /**
-   * Drop pending state for a specific comm (called on comm_close).
-   */
+  /** Drop per-comm state on comm_close. */
   clearComm(commId: string): void {
-    this.pendingQueue.delete(commId);
+    const state = this.throttles.get(commId);
+    if (state?.trailingTimer) clearTimeout(state.trailingTimer);
+    this.throttles.delete(commId);
+    this.bootstrapQueue.delete(commId);
   }
 }

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -45,6 +45,14 @@ interface CommThrottleState {
   trailingTimer: ReturnType<typeof setTimeout> | null;
 }
 
+/**
+ * Narrow TTL window for keeping pending-local marks alive after
+ * a CRDT flush. The daemon's echo of our last-written value can
+ * take a full sync round-trip to arrive; during that gap we still
+ * want the local store to win over the projected echo.
+ */
+const PENDING_TTL_MS = 500;
+
 export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
@@ -57,6 +65,17 @@ export class WidgetUpdateManager {
   private throttles = new Map<string, CommThrottleState>();
 
   /**
+   * Per-comm per-key timestamps of local writes that haven't yet
+   * round-tripped through the CRDT. Consulted by the App-level
+   * `commChanges$` subscriber: if a projected echo carries a key
+   * that was written locally within `PENDING_TTL_MS`, the store's
+   * current value wins and the echo is dropped. Prevents the
+   * daemon's lagged view of the throttle window from clobbering
+   * the in-flight drag.
+   */
+  private pendingKeys = new Map<string, Map<string, number>>();
+
+  /**
    * Patches that arrived before the CRDT writer was registered.
    * Separate from `throttles` because the writer isn't callable yet.
    */
@@ -66,6 +85,38 @@ export class WidgetUpdateManager {
   constructor(opts: WidgetUpdateManagerOptions) {
     this.getStore = opts.getStore;
     this.getCrdtWriter = opts.getCrdtWriter;
+  }
+
+  /**
+   * Is there a pending local write for this key that the daemon's
+   * projected echo shouldn't clobber? Consulted by the `commChanges$`
+   * subscriber to drop stale projected values during the throttle
+   * window (and briefly after, until the daemon's merged view catches
+   * up).
+   */
+  hasPendingKey(commId: string, key: string): boolean {
+    const keys = this.pendingKeys.get(commId);
+    if (!keys) return false;
+    const ts = keys.get(key);
+    if (ts === undefined) return false;
+    if (Date.now() - ts > PENDING_TTL_MS) {
+      keys.delete(key);
+      if (keys.size === 0) this.pendingKeys.delete(commId);
+      return false;
+    }
+    return true;
+  }
+
+  private markPending(commId: string, patch: Record<string, unknown>): void {
+    let keys = this.pendingKeys.get(commId);
+    if (!keys) {
+      keys = new Map();
+      this.pendingKeys.set(commId, keys);
+    }
+    const now = Date.now();
+    for (const key of Object.keys(patch)) {
+      keys.set(key, now);
+    }
   }
 
   /**
@@ -110,6 +161,12 @@ export class WidgetUpdateManager {
     // views; the App-level subscriber's diff check makes that a
     // no-op rather than a redundant re-render.
     this.getStore()?.updateModel(commId, patch, buffers);
+
+    // Mark these keys as pending-local. The `commChanges$`
+    // subscriber consults `hasPendingKey` before applying projected
+    // values, so a daemon sync frame that carries the pre-flush
+    // CRDT view won't roll the local store back mid-drag.
+    this.markPending(commId, patch);
 
     if (buffers?.length) {
       // Buffers bypass the throttle: ArrayBuffers aren't patchable
@@ -218,6 +275,7 @@ export class WidgetUpdateManager {
     }
     this.throttles.clear();
     this.bootstrapQueue.clear();
+    this.pendingKeys.clear();
     if (this.drainTimer) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -235,5 +293,6 @@ export class WidgetUpdateManager {
     if (state?.trailingTimer) clearTimeout(state.trailingTimer);
     this.throttles.delete(commId);
     this.bootstrapQueue.delete(commId);
+    this.pendingKeys.delete(commId);
   }
 }

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -24,6 +24,7 @@ import {
   NTERACT_WIDGET_SNAPSHOT,
   NTERACT_WIDGET_COMM_CLOSE,
   NTERACT_WIDGET_COMM_MSG,
+  NTERACT_WIDGET_LOCAL_UPDATE,
   NTERACT_WIDGET_READY,
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
@@ -101,6 +102,14 @@ export interface WidgetBridgeClient {
    * Used for widget-specific protocols (e.g., ipycanvas draw commands).
    */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+
+  /**
+   * Propagate a frontend-only state change to the parent (so sibling
+   * iframes see it) WITHOUT forwarding to the kernel. Used for
+   * `widgets.jslink` / `widgets.jsdlink` target writes, which are
+   * frontend-only by ipywidgets semantics.
+   */
+  sendLocal: (commId: string, patch: Record<string, unknown>) => void;
 
   /**
    * Request to close a comm (to be forwarded to kernel).
@@ -205,6 +214,16 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
         method: "custom",
         data: content,
         buffers,
+      });
+    },
+
+    sendLocal(commId: string, patch: Record<string, unknown>) {
+      // Update iframe store immediately so the triggering view
+      // reflects the change without waiting for a round-trip echo.
+      store.updateModel(commId, patch);
+      transport.notify(NTERACT_WIDGET_LOCAL_UPDATE, {
+        commId,
+        data: patch,
       });
     },
 

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -86,17 +86,13 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
   }, [client]);
 
   // Set up link subscriptions (jslink/jsdlink). Frontend-only by
-  // ipywidgets semantics — mirrored into the local iframe store
-  // without bouncing back through `client.sendUpdate` (which would
-  // post the change to the parent / daemon / kernel). Python-side
-  // `widgets.link` already flows through the normal traitlet path
-  // and needs no frontend special-casing.
+  // ipywidgets semantics: the writer propagates target changes to
+  // the parent store so sibling iframes re-render, but does NOT
+  // round-trip through the kernel. Python-side `widgets.link` flows
+  // through the normal CRDT/traitlet path and needs no special case.
   useEffect(
-    () =>
-      createLinkManager(client.store, (commId, patch) => {
-        client.store.updateModel(commId, patch);
-      }),
-    [client.store],
+    () => createLinkManager(client.store, client.sendLocal),
+    [client.store, client.sendLocal],
   );
 
   // Set up canvas manager router (ipycanvas)

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -85,10 +85,18 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
     };
   }, [client]);
 
-  // Set up link subscriptions (jslink/jsdlink)
+  // Set up link subscriptions (jslink/jsdlink). Frontend-only by
+  // ipywidgets semantics — mirrored into the local iframe store
+  // without bouncing back through `client.sendUpdate` (which would
+  // post the change to the parent / daemon / kernel). Python-side
+  // `widgets.link` already flows through the normal traitlet path
+  // and needs no frontend special-casing.
   useEffect(
-    () => createLinkManager(client.store, client.sendUpdate),
-    [client.store, client.sendUpdate],
+    () =>
+      createLinkManager(client.store, (commId, patch) => {
+        client.store.updateModel(commId, patch);
+      }),
+    [client.store],
   );
 
   // Set up canvas manager router (ipycanvas)


### PR DESCRIPTION
Fixes the ipywidget sync stall reproduced with matplotlib `@interact`: slider thumb moves, kernel runs, CRDT has the right state, but the UI freezes on a stale output until reload. This PR lands **both tracks** from the design doc — safety net for detecting/recovering from silent stalls, and the CRDT-first architectural refactor that eliminates the stall's root cause.

Full context and rationale: [`docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md`](./docs/superpowers/specs/2026-04-17-widget-sync-stall-design.md)

## Commits

### Track B — safety net

1. **`fix(widgets): abort hung blob fetches, log swallowed subscriber errors`** — 5s `AbortController` on per-attempt blob fetches (hung fetches were silently poisoning the serial `commEmitQueue`). `frame-bus.ts` / `runtime-state.ts` no longer swallow subscriber errors.
2. **`test(sync): real-WASM harness for widget comm-state sync`** — extends `WasmHarness` with runtime-state primitives + `put_comm_for_test` on WASM. 5 regression tests in `widget-sync-stall.test.ts` lock in `commChanges$` emission shape for the `@interact` scenario.
3. **`feat(sync): surface WASM sync recovery via top-level banner`** — new `SyncEngine.syncErrors$` observable + `SyncRecoveryBanner`. Recurring recoveries bump a counter ("Recovered N times recently — connection may be unhealthy"). No behavior change for healthy sessions.
4. **`feat(sync): watchdog resets sync state on silent runtime-state stall`** — 3s watchdog armed on outbound `RUNTIME_STATE_SYNC` flush. On timeout, `reset_sync_state` + re-flush. Detects pipe drops and silent daemon failures. Fixes applied inline from codex review (watchdog resets on each flush to avoid false positives under sustained traffic; clears on any inbound frame).

### Track A — architectural fix (CRDT-first)

5. **`feat(sync): project local comm writes through commChanges$ (A1)`** — `SyncEngine.projectLocalState()` fires the projection pipeline after a frontend-initiated `set_comm_state_batch`. The widget store now sees local writes from the same path as remote changes.
6. **`refactor(widgets): CRDT-first — drop optimistic path + echo suppression (A2)`** — `WidgetUpdateManager` collapses from ~180 lines to ~60. Deletes `shouldSuppressEcho`, `optimisticKeys`, per-comm debounce timers. Bootstrap fallback queues patches until the CRDT writer is registered, drains in insertion order. Binary buffers still mirror to the local store since the CRDT doesn't carry ArrayBuffers.
7. **`refactor(widgets): route jslink propagation via injected writer (A3)`** — abstracts link-subscriptions behind a `LinkWriter` callback. Default wiring is plain `store.updateModel` (jslink is documented as frontend-only in ipywidgets; it mirrors values client-side without touching the kernel). Codex-flagged: initial A3 routed through CRDT, which would have made jslink kernel-persisted; reverted.

### Supporting

8. **`perf(notebook): hoist MediaProvider renderers out of App render`** — module-scope `WidgetViewRenderer` + `mediaRenderers` object. Prevents remount cascades if App ever starts re-rendering.
9. **`docs: widget sync stall — design notes for tracks A + B`** — full design doc including PR #1580 archaeology explaining why the optimistic dual-write existed and what Track A does instead.

## What this PR is NOT

- Not persisting sync state across reloads (deferred; today's rebuild-from-scratch works fine).
- Not a full reconnect on stall — `reset_sync_state()` is cheaper and sufficient.
- Not a Deno-specific harness — the vitest-based real-WASM harness achieves the same "no React/Tauri" isolation goal without needing a second test runner.

## Test plan

- `pnpm vp test run packages/runtimed apps/notebook src/components/widgets` — 764 tests pass.
- `packages/runtimed/tests/widget-sync-stall.test.ts` scripts the matplotlib-@interact scenario against real WASM. Locks in the `commChanges$` invariants that Track A preserves.
- `packages/runtimed/tests/sync-engine.test.ts` — stall watchdog tests (fire on timeout, clear on inbound, re-arm on next flush) + `syncErrors$` emission tests for all three doc recoveries.
- `src/components/widgets/__tests__/widget-update-manager.test.ts` — rewritten for post-A2 semantics: happy path, bootstrap queue drain, buffer mirroring, no-op lifecycle.
- `cargo xtask lint` — clean.
- Manual: matplotlib `@interact` + FloatSlider, hammer arrow keys. Before: silent stall requiring reload. After: no drift possible between optimistic store and CRDT; if the pipe does drop a frame, banner surfaces the recovery and watchdog resets sync state within 3s.

## Codex review

Two codex passes caught four issues, all fixed inline:
- P1: watchdog clearing on unrelated daemon traffic — fixed via the `generate_runtime_state_sync_reply == null` signal (subsequently reverted for a simpler "any inbound" clear after a follow-up P1).
- P2: bootstrap patches dropped when no writer — fixed via pending queue with 50ms drain.
- P2: stall watchdog false-positive under sustained local traffic — fixed via reset-on-each-flush.
- P1: watchdog fires after every healthy interaction (strict null-reply signal) — fixed via "any inbound clears" + P2: jslink routed through CRDT — reverted to store-only write.