### PR TITLE
feat(sync): stall detection + recovery banner (Track B)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { NotebookClient } from "runtimed";
+import { NotebookClient, type SyncErrorEvent } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -18,6 +18,7 @@ import { ErrorBoundary } from "@/lib/error-boundary";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
 import { DebugBanner } from "./components/DebugBanner";
+import { SyncRecoveryBanner } from "./components/SyncRecoveryBanner";
 import { DenoDependencyHeader } from "./components/DenoDependencyHeader";
 import { DependencyHeader } from "./components/DependencyHeader";
 import { GlobalFindBar } from "./components/GlobalFindBar";
@@ -197,6 +198,10 @@ function AppContent() {
   // Track ready timeout so we can cancel it if status changes
   const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Latest sync-recovery event. Each emission replaces the reference so
+  // the banner's useEffect fires even when fields happen to be equal.
+  const [syncRecoveryEvent, setSyncRecoveryEvent] = useState<SyncErrorEvent | null>(null);
+
   // Pool state - prewarm pool errors from daemon (typo'd default packages, etc.)
   const {
     uvError: poolUvError,
@@ -349,6 +354,18 @@ function AppContent() {
       setCrdtCommWriter(null);
     };
   }, [getHandle, triggerSync]);
+
+  // ── Sync-layer recovery banner ─────────────────────────────────────
+  // The SyncEngine emits a SyncErrorEvent each time the WASM auto-
+  // recovers from a failed sync message. The recovery itself is
+  // already complete — we just surface it to the user so silent
+  // recovery doesn't mask a flapping connection.
+  useEffect(() => {
+    const engine = getEngine();
+    if (!engine) return;
+    const sub = engine.syncErrors$.subscribe((e) => setSyncRecoveryEvent(e));
+    return () => sub.unsubscribe();
+  }, [getEngine]);
 
   // ── CRDT → WidgetStore projection via SyncEngine.commChanges$ ──────
   // Replaces the old Jupyter message synthesis path. The SyncEngine diffs
@@ -1149,6 +1166,10 @@ function AppContent() {
                 });
               });
           }}
+        />
+        <SyncRecoveryBanner
+          event={syncRecoveryEvent}
+          onDismiss={() => setSyncRecoveryEvent(null)}
         />
         <PoolErrorBanner
           uvError={poolUvError}

--- a/apps/notebook/src/components/SyncRecoveryBanner.tsx
+++ b/apps/notebook/src/components/SyncRecoveryBanner.tsx
@@ -1,0 +1,107 @@
+/**
+ * Transient banner surfaced when the WASM sync layer auto-recovers
+ * from a failed sync message (doc rebuilt, sync state normalized,
+ * recovery reply sent by the SyncEngine).
+ *
+ * The recovery itself is already complete by the time this fires —
+ * the banner only exists so the event is visible to the user.
+ * Silent recovery is exactly the class of bug the original widget
+ * sync stall turned out to be.
+ *
+ * Auto-dismisses after ~5 s so a single blip doesn't linger. If
+ * another recovery fires while the banner is still visible, the
+ * timer resets and the counter ticks up — so a flapping connection
+ * reads as "recovered N times recently" rather than implying the
+ * first event repeats. The counter resets on auto-dismiss so a lone
+ * recovery an hour later isn't mis-labeled as the 2nd in a burst.
+ */
+
+import { RefreshCw, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { SyncErrorEvent } from "runtimed";
+
+/** How long the banner stays visible after the latest recovery (ms). */
+const DISMISS_DELAY_MS = 5_000;
+
+interface SyncRecoveryBannerProps {
+  /**
+   * Latest sync-error event, or null when none has fired recently.
+   * The banner uses reference identity to detect new emissions — so
+   * App-level wiring should `setEvent(e)` on each emission even if
+   * the event's fields happen to match the previous one.
+   */
+  event: SyncErrorEvent | null;
+  /** Optional manual dismiss handler (X button). */
+  onDismiss?: () => void;
+}
+
+export function SyncRecoveryBanner({ event, onDismiss }: SyncRecoveryBannerProps) {
+  const [visible, setVisible] = useState(false);
+  const [count, setCount] = useState(0);
+  const lastEventRef = useRef<SyncErrorEvent | null>(null);
+
+  useEffect(() => {
+    if (!event || event === lastEventRef.current) return;
+    lastEventRef.current = event;
+    setVisible(true);
+    // Only accumulate the burst counter while the banner is still
+    // up. A fresh emission after the banner dismissed starts a new
+    // count of 1, so "recovered once an hour ago" + "recovered now"
+    // doesn't read as a 2-event burst.
+    setCount((c) => (visible ? c + 1 : 1));
+
+    const timer = window.setTimeout(() => {
+      setVisible(false);
+      setCount(0);
+    }, DISMISS_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+    // `visible` intentionally omitted from deps: only its value at
+    // the instant the event reference changes matters here.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  }, [event]);
+
+  if (!visible || !event) return null;
+
+  const detail =
+    count > 1
+      ? `Recovered ${count} times recently — connection may be unhealthy.`
+      : "Rebuilt from daemon snapshot.";
+
+  return (
+    <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
+      <RefreshCw className="h-3 w-3 flex-shrink-0" />
+      <span className="font-medium flex-shrink-0">Sync recovered</span>
+      <span className="text-sky-200 flex-shrink-0">—</span>
+      <span className="text-sky-100 truncate">
+        {docLabel(event.doc)} {detail}
+      </span>
+      <div className="ml-auto flex items-center gap-1 flex-shrink-0">
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={() => {
+              setVisible(false);
+              onDismiss();
+            }}
+            className="rounded p-0.5 hover:bg-sky-500/50 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function docLabel(doc: SyncErrorEvent["doc"]): string {
+  switch (doc) {
+    case "notebook":
+      return "Notebook document.";
+    case "runtime_state":
+      return "Runtime state.";
+    case "pool_state":
+      return "Pool state.";
+  }
+}

--- a/apps/notebook/src/components/SyncRecoveryBanner.tsx
+++ b/apps/notebook/src/components/SyncRecoveryBanner.tsx
@@ -63,17 +63,23 @@ export function SyncRecoveryBanner({ event, onDismiss }: SyncRecoveryBannerProps
 
   if (!visible || !event) return null;
 
-  const detail =
-    count > 1
+  const isStall = event.kind === "stall_detected";
+  const headline = isStall ? "Sync stalled" : "Sync recovered";
+  const detail = isStall
+    ? "No response from daemon — forcing a resync."
+    : count > 1
       ? `Recovered ${count} times recently — connection may be unhealthy.`
       : "Rebuilt from daemon snapshot.";
+  const bg = isStall ? "bg-amber-600/90" : "bg-sky-600/90";
+  const dot = isStall ? "text-amber-200" : "text-sky-200";
+  const body = isStall ? "text-amber-100" : "text-sky-100";
 
   return (
-    <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
+    <div className={`flex items-center gap-2 ${bg} px-3 py-1 text-xs text-white`}>
       <RefreshCw className="h-3 w-3 flex-shrink-0" />
-      <span className="font-medium flex-shrink-0">Sync recovered</span>
-      <span className="text-sky-200 flex-shrink-0">—</span>
-      <span className="text-sky-100 truncate">
+      <span className="font-medium flex-shrink-0">{headline}</span>
+      <span className={`${dot} flex-shrink-0`}>—</span>
+      <span className={`${body} truncate`}>
         {docLabel(event.doc)} {detail}
       </span>
       <div className="ml-auto flex items-center gap-1 flex-shrink-0">
@@ -84,7 +90,9 @@ export function SyncRecoveryBanner({ event, onDismiss }: SyncRecoveryBannerProps
               setVisible(false);
               onDismiss();
             }}
-            className="rounded p-0.5 hover:bg-sky-500/50 transition-colors"
+            className={`rounded p-0.5 transition-colors ${
+              isStall ? "hover:bg-amber-500/50" : "hover:bg-sky-500/50"
+            }`}
             aria-label="Dismiss"
           >
             <X className="h-3 w-3" />

--- a/apps/notebook/src/lib/notebook-frame-bus.ts
+++ b/apps/notebook/src/lib/notebook-frame-bus.ts
@@ -12,6 +12,8 @@
  * subscribers without a webview round-trip.
  */
 
+import { logger } from "./logger";
+
 // ── Types ────────────────────────────────────────────────────────────
 
 /** Callback for broadcast events (kernel status, output, env progress, etc.) */
@@ -65,8 +67,12 @@ export function emitBroadcast(payload: unknown): void {
   for (const cb of broadcastSubscribers) {
     try {
       cb(payload);
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      // A thrown subscriber must not break the dispatch loop for the
+      // remaining subscribers. We used to swallow silently, but that meant
+      // a component could stop receiving state updates while the rest of
+      // the pipeline kept ticking — very hard to diagnose. Log loudly.
+      logger.error("[frame-bus] broadcast subscriber threw:", err);
     }
   }
 }
@@ -81,8 +87,8 @@ export function emitPresence(payload: unknown): void {
   for (const cb of presenceSubscribers) {
     try {
       cb(payload);
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      logger.error("[frame-bus] presence subscriber threw:", err);
     }
   }
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -6,6 +6,7 @@
  */
 
 import { useSyncExternalStore } from "react";
+import { logger } from "./logger";
 
 // Re-export all types from the package so existing imports work.
 export type {
@@ -37,8 +38,11 @@ function notifySubscribers(): void {
   for (const cb of subscribers) {
     try {
       cb();
-    } catch {
-      // Subscriber errors must not break the dispatch loop
+    } catch (err) {
+      // A throwing `useSyncExternalStore` callback used to fail silently
+      // and leave components displaying stale runtime state. Log loudly
+      // so the failure is diagnosable.
+      logger.error("[runtime-state] subscriber threw:", err);
     }
   }
 }

--- a/docs/superpowers/specs/2026-04-18-widget-sync-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-18-widget-sync-recovery-design.md
@@ -1,0 +1,147 @@
+# Sync-layer observability and recovery
+
+**Status:** In progress on branch `chore/widget-sync-recovery`. Track B
+of the widget-sync stall investigation; the larger CRDT-first
+refactor (Track A) is deferred until we've validated this safety net
+in production.
+
+## Problem
+
+Widget state and kernel status can stop updating silently. The
+reproducer is a matplotlib `@interact` slider: the UI shows the thumb
+moving, but the rendered plot freezes at a stale value. Reloading the
+notebook window fixes everything instantly — the daemon has the
+correct state, only the frontend→daemon pipeline has drifted.
+
+Two failure modes combine:
+
+1. **Sync-layer error with silent auto-recovery.** When the WASM
+   sync layer fails to apply an inbound message
+   (`receive_sync_message` returns `Err`), it already rebuilds the
+   doc from its snapshot bytes, normalizes sync state, and returns a
+   fresh sync message to restart negotiation. The `SyncEngine`
+   forwards that recovery reply. Good — except it's invisible. A
+   flapping daemon recovers on every frame, and the user only knows
+   something's off when the UI starts looking stale.
+
+2. **Silent flush drop.** `sendFrame` can fail (pipe buffer full,
+   daemon slow) without the caller knowing the frame wasn't
+   delivered. `sent_hashes` on the WASM handle advances anyway —
+   from its point of view the message is gone — so subsequent
+   flushes exclude whatever was in that message. Bloom-filter false
+   positives in Automerge's sync protocol can hit this from a
+   different angle: both peers conclude they're in sync when they
+   aren't.
+
+The frontend currently only surfaces a recovery signal when
+`receive_sync_message` fails outright. The "frame never arrived" and
+"heads drifted" cases leave no trace.
+
+## Approach
+
+Two narrow additions, both diagnostic/recovery — no architectural
+change to the sync protocol or widget store.
+
+### 1. `SyncEngine.syncErrors$` + `SyncRecoveryBanner`
+
+Expose each auto-recovery event as a public observable:
+
+```ts
+interface SyncErrorEvent {
+  doc: "notebook" | "runtime_state" | "pool_state";
+  changed: boolean; // true if the doc advanced before the error
+  ts: number;
+}
+```
+
+The SyncEngine already has handlers for the three doc kinds'
+`sync_error` frame events — each already sends the recovery reply.
+We just `_syncErrors$.next(...)` from each handler. Zero change to
+the recovery path.
+
+App.tsx mounts `SyncRecoveryBanner` alongside `DaemonStatusBanner`.
+The banner:
+
+- Shows a transient "Sync recovered" line with the doc kind.
+- Auto-dismisses after 5 s.
+- Counts bursts while visible — another recovery bumps the count and
+  resets the dismiss timer, so a flapping connection reads as
+  "Recovered N times recently — connection may be unhealthy."
+- Resets the counter on auto-dismiss so an isolated recovery an hour
+  later isn't mis-labeled as the second in a burst.
+
+### 2. Runtime-state stall watchdog
+
+For the failure mode that produces no error to recover from, arm a
+timer:
+
+- When `flush_runtime_state_sync()` produces a sync message and we
+  attempt to send it, start a 3 s timer.
+- Any inbound runtime-state frame (applied or error) clears the
+  timer. Either event proves the daemon is responsive.
+- On timeout: call `handle.reset_sync_state()` to rewind
+  `sent_hashes`, re-flush, and emit on `syncErrors$`.
+- Reset the timer on each new flush (don't arm-once) so sustained
+  traffic never misfires.
+- `resetForBootstrap()` and `stop()` clear any armed timer so a
+  stale one can't fire against a replaced handle.
+
+The watchdog doesn't need a richer "convergence" signal —
+`generate_runtime_state_sync_reply() === null` was too strict in
+testing, tripping on healthy single interactions while the daemon
+was still mid-reply. "Anything inbound clears it" is a simpler
+correct predicate.
+
+### 3. Supporting observability
+
+Two small fixes for failure modes that would otherwise be invisible:
+
+- **Abort hung blob fetches.** `inlineTextBlobs` is serialized on
+  `commEmitQueue` to preserve comm emission order. A single fetch
+  that hangs (connection established, body never completes) poisoned
+  the queue — every subsequent widget update blocked forever. Added
+  a 5 s per-attempt `AbortController` timeout; the retry path
+  handles the transient cases we care about.
+- **Log subscriber errors.** `frame-bus` and `runtime-state`
+  dispatch loops used to `try { cb() } catch {}`. A throwing
+  subscriber would just disappear from the logs while the rest of
+  the pipeline kept ticking. Replaced the empty catch with
+  `logger.error` so the next stall at least has a trace.
+
+## What this is NOT
+
+- **Not a rewrite of the widget-state write path.** The optimistic
+  dual-write in `WidgetUpdateManager` (local store + debounced CRDT
+  + echo suppression) stays untouched. An earlier iteration
+  restructured it into a CRDT-first single-source-of-truth
+  projection; that surfaced its own set of edge cases (per-tick
+  mirror vs throttle window, peer-write collisions, bootstrap drain
+  ordering, direct writers for anywidget `save_changes`). All of
+  that is deferred — the investigation showed the stall is
+  addressable at the sync layer, and once this is in place we'll
+  know if the write-path refactor is actually needed.
+- **Not persistence across reloads.** Reload still works as the
+  user's recovery mechanism of last resort. The watchdog + banner
+  just narrow the window where reload is the only option.
+- **Not a protocol change.** All recovery uses existing WASM
+  primitives (`reset_sync_state`, `cancel_last_runtime_state_flush`)
+  that already shipped on `main`.
+
+## Validation
+
+- Unit tests on `SyncEngine` for the three `syncErrors$` variants,
+  and for the watchdog's arm / clear-on-inbound / fire-on-timeout /
+  clear-on-bootstrap behavior.
+- Lint clean; existing 1018+ tests unaffected.
+- Manual repro: matplotlib `@interact` + FloatSlider, hammer arrow
+  keys. Before: silent stall until reload. After: banner fires on
+  each WASM recovery; watchdog force-resets sync state on any silent
+  drop.
+
+## References
+
+- `packages/runtimed/src/sync-engine.ts` — `syncErrors$`, watchdog,
+  `projectComms`.
+- `apps/notebook/src/components/SyncRecoveryBanner.tsx` — banner.
+- `crates/runtimed-wasm/src/lib.rs` — `reset_sync_state`,
+  `normalize_sync_state`, `FrameEvent::*SyncError` (all on `main`).

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -7,7 +7,7 @@
 
 // Core
 export { SyncEngine } from "./sync-engine";
-export type { SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
+export type { SyncEngineOptions, SyncEngineLogger, SyncErrorEvent } from "./sync-engine";
 
 // Transport
 export type { NotebookTransport, FrameListener } from "./transport";

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -108,6 +108,15 @@ const nullLogger: SyncEngineLogger = {
  */
 const TEXT_BLOB_RETRY_DELAYS_MS = [100, 300, 1000];
 
+/**
+ * Watchdog window after a runtime-state flush. If no inbound
+ * runtime-state frame arrives within this, assume the flush was
+ * silently dropped and force a full resync. 3s is generous for a
+ * loopback socket under load and short enough that a dropped flush
+ * doesn't leave the UI indefinitely stale.
+ */
+const RUNTIME_STATE_STALL_MS = 3_000;
+
 /** Sleep helper for `inlineTextBlobs` retry backoff. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -280,6 +289,23 @@ export class SyncEngine {
   private prevExecutions: Record<string, ExecutionState> = {};
   private commDiffState: CommDiffState = { comms: {}, json: {} };
   private lastRuntimeState: RuntimeState | null = null;
+
+  /**
+   * Runtime-state stall watchdog.
+   *
+   * Catches the failure mode the WASM `sync_error` recovery can't see:
+   * a flush that the transport drops silently (pipe buffer full,
+   * daemon slow) never produces an error to auto-recover from —
+   * `sent_hashes` has already advanced, so subsequent flushes think
+   * the frame is delivered and the state change is invisible forever.
+   *
+   * Each outbound `flush_runtime_state_sync` arms the timer; any
+   * inbound runtime-state frame (applied or error) clears it,
+   * because either proves the daemon is alive and talking. On
+   * timeout, we force `reset_sync_state()` to rewind `sent_hashes`,
+   * re-flush, and emit on `syncErrors$` for the UI banner.
+   */
+  private runtimeStateStallTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * Serial queue for async comm emissions.
    *
@@ -679,6 +705,9 @@ export class SyncEngine {
         log.warn(
           "[sync-engine] runtime_state_sync_error: state doc rebuilt, sync state normalized",
         );
+        // Any inbound runtime-state frame — error or applied — proves
+        // the daemon is talking, so clear the stall watchdog.
+        this.clearRuntimeStateStallWatchdog();
         if (e.reply) {
           this.opts.transport
             .sendFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array(e.reply))
@@ -711,6 +740,11 @@ export class SyncEngine {
         .pipe(
           filter((e) => e.type === "runtime_state_sync_applied"),
           concatMap((e) => {
+            // Any inbound runtime-state traffic proves the daemon is
+            // responsive, so clear the stall watchdog. No finer
+            // signal needed: if the daemon is replying, sync isn't
+            // stuck.
+            this.clearRuntimeStateStallWatchdog();
             if (e.changed && e.state) {
               const state = e.state as RuntimeState;
 
@@ -883,6 +917,7 @@ export class SyncEngine {
     this.opts.logger.info("[sync-engine] Stopping");
     this.subscription.unsubscribe();
     this.subscription = null;
+    this.clearRuntimeStateStallWatchdog();
   }
 
   /** Whether the engine is currently running. */
@@ -918,6 +953,40 @@ export class SyncEngine {
    * is queued on `commEmitQueue` so emissions stay in order even when text
    * blob fetches from one batch outlive a later batch's fetches.
    */
+  // ── Runtime-state stall watchdog ────────────────────────────────
+
+  private armRuntimeStateStallWatchdog(): void {
+    // Reset on each arm, not arm-once. Sustained traffic would
+    // otherwise never refresh the timer and could trip the watchdog
+    // when the daemon is actually responsive.
+    if (this.runtimeStateStallTimer) clearTimeout(this.runtimeStateStallTimer);
+    this.runtimeStateStallTimer = setTimeout(() => {
+      this.runtimeStateStallTimer = null;
+      this.handleRuntimeStateStall();
+    }, RUNTIME_STATE_STALL_MS);
+  }
+
+  private clearRuntimeStateStallWatchdog(): void {
+    if (this.runtimeStateStallTimer) {
+      clearTimeout(this.runtimeStateStallTimer);
+      this.runtimeStateStallTimer = null;
+    }
+  }
+
+  private handleRuntimeStateStall(): void {
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+    this.opts.logger.warn(
+      "[sync-engine] runtime-state flush stalled (no inbound frame within " +
+        `${RUNTIME_STATE_STALL_MS}ms) — resetting sync state and re-flushing`,
+    );
+    handle.reset_sync_state();
+    this._syncErrors$.next({ doc: "runtime_state", changed: false, ts: Date.now() });
+    // Immediately re-flush so the daemon can re-deliver any state it
+    // thinks we already have.
+    this.flush();
+  }
+
   private projectComms(state: RuntimeState): void {
     this.lastRuntimeState = state;
     const comms = state.comms ?? {};
@@ -1051,7 +1120,9 @@ export class SyncEngine {
     // stuck on "not_started" (#runtime-state-race).
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
+      this.armRuntimeStateStallWatchdog();
       this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg).catch((e: unknown) => {
+        this.clearRuntimeStateStallWatchdog();
         handle.cancel_last_runtime_state_flush();
         this.opts.logger.warn("[sync-engine] runtime state sync to relay failed:", e);
       });
@@ -1108,9 +1179,11 @@ export class SyncEngine {
     // Also flush RuntimeStateDoc sync.
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
+      this.armRuntimeStateStallWatchdog();
       try {
         await this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg);
       } catch (e) {
+        this.clearRuntimeStateStallWatchdog();
         handle.cancel_last_runtime_state_flush();
         this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
       }
@@ -1163,5 +1236,9 @@ export class SyncEngine {
     this.prevExecutions = {};
     this.commDiffState = { comms: {}, json: {} };
     this.lastRuntimeState = null;
+    // Drop any in-flight stall watchdog — the handle it would fire
+    // against is about to be replaced, and letting it expire would
+    // raise a spurious recovery banner on a healthy reconnect.
+    this.clearRuntimeStateStallWatchdog();
   }
 }

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -147,11 +147,26 @@ async function inlineTextBlobs(
 }
 
 /**
+ * Per-attempt timeout for a single blob fetch.
+ *
+ * `projectComms` serializes async comm emissions on `commEmitQueue` to
+ * preserve ordering, which means any hung fetch stalls *all* subsequent
+ * widget state updates behind it. 5s is generous for a loopback HTTP blob
+ * server but short enough that a broken/slow server never silently blocks
+ * widget sync indefinitely.
+ */
+const TEXT_BLOB_FETCH_TIMEOUT_MS = 5_000;
+
+/**
  * Fetch `url` as text, retrying transient failures.
  *
  * Returns the decoded body on success, or `null` after all retries are
  * exhausted. 4xx responses are treated as permanent and returned
  * immediately without retry (the daemon doesn't know about that hash).
+ *
+ * Each attempt has a hard timeout via `AbortController` — without it, a
+ * fetch that hangs (connection established, body never completes) would
+ * poison the serial comm-emit queue forever.
  */
 async function fetchTextBlobWithRetry(
   url: string,
@@ -162,8 +177,10 @@ async function fetchTextBlobWithRetry(
     if (attempt > 0) {
       await delay(TEXT_BLOB_RETRY_DELAYS_MS[attempt - 1]);
     }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TEXT_BLOB_FETCH_TIMEOUT_MS);
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { signal: controller.signal });
       if (res.ok) {
         return await res.text();
       }
@@ -174,7 +191,14 @@ async function fetchTextBlobWithRetry(
         return null;
       }
     } catch (err) {
-      lastReason = err instanceof Error ? err.message : String(err);
+      lastReason =
+        err instanceof Error
+          ? err.name === "AbortError"
+            ? `timeout after ${TEXT_BLOB_FETCH_TIMEOUT_MS}ms`
+            : err.message
+          : String(err);
+    } finally {
+      clearTimeout(timer);
     }
   }
   logger.warn(

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -740,17 +740,27 @@ export class SyncEngine {
         log.warn(
           "[sync-engine] runtime_state_sync_error: state doc rebuilt, sync state normalized",
         );
-        // Any inbound runtime-state frame — error or applied — proves
-        // the daemon is talking, so clear the stall watchdog.
-        this.clearRuntimeStateStallWatchdog();
         if (e.reply) {
+          // Re-arm the watchdog around the recovery reply. If we
+          // clear it too early and the reply send fails, there's no
+          // timer left to retry — the engine silently gives up, and
+          // the half-broken transport leaves runtime state stuck
+          // until some unrelated future mutation.
+          this.armRuntimeStateStallWatchdog();
+          const gen = ++this.runtimeStateFlushGen;
           this.opts.transport
             .sendFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array(e.reply))
             .catch((err: unknown) => {
+              if (gen !== this.runtimeStateFlushGen) return;
+              this.clearRuntimeStateStallWatchdog();
               const handle = this.opts.getHandle();
               if (handle) handle.cancel_last_runtime_state_flush();
               log.warn("[sync-engine] state recovery reply send failed:", err);
             });
+        } else {
+          // No reply to send — the inbound error frame itself proves
+          // the daemon is talking, so we can clear any armed watchdog.
+          this.clearRuntimeStateStallWatchdog();
         }
         this._syncErrors$.next({
           doc: "runtime_state",

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -250,11 +250,27 @@ function writePath(obj: unknown, path: string[], value: unknown): void {
  * by the time this fires.
  */
 export interface SyncErrorEvent {
-  /** Which doc recovered: the notebook, runtime state, or pool state. */
+  /** Which doc this event is about. */
   doc: "notebook" | "runtime_state" | "pool_state";
+  /**
+   * What the engine did in response:
+   *
+   * - `auto_recovered` — the WASM sync layer rebuilt the doc from
+   *   its snapshot bytes after `receive_sync_message` failed, and
+   *   the engine forwarded the recovery reply. The daemon has
+   *   heard from us; the sync state is repaired.
+   *
+   * - `stall_detected` — the watchdog expired without inbound
+   *   runtime-state traffic. The engine called `reset_sync_state()`
+   *   and scheduled a re-flush, but the daemon may still be wedged.
+   *   Until a later `auto_recovered` or inbound frame lands, sync
+   *   is not known to be healthy — this is *detection*, not
+   *   completion.
+   */
+  kind: "auto_recovered" | "stall_detected";
   /** True when the doc advanced before the error (partial apply). */
   changed: boolean;
-  /** Wall-clock ms of the recovery. */
+  /** Wall-clock ms of the event. */
   ts: number;
 }
 
@@ -306,6 +322,20 @@ export class SyncEngine {
    * re-flush, and emit on `syncErrors$` for the UI banner.
    */
   private runtimeStateStallTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Generation counter for outbound runtime-state flushes.
+   *
+   * Incremented each time we attempt a flush. The `sendFrame` catch
+   * closure captures the generation at send time and only rolls back
+   * sync state (or clears the watchdog) when the current generation
+   * still matches. Without this, a slow `sendFrame` that rejects
+   * *after* the watchdog already fired a recovery flush would wipe
+   * the recovery's watchdog and cancel its flush — the exact
+   * opposite of what we want in the failure mode the watchdog
+   * exists to handle.
+   */
+  private runtimeStateFlushGen = 0;
   /**
    * Serial queue for async comm emissions.
    *
@@ -683,7 +713,12 @@ export class SyncEngine {
               log.warn("[sync-engine] recovery reply send failed:", err);
             });
         }
-        this._syncErrors$.next({ doc: "notebook", changed: e.changed, ts: Date.now() });
+        this._syncErrors$.next({
+          doc: "notebook",
+          kind: "auto_recovered",
+          changed: e.changed,
+          ts: Date.now(),
+        });
         // If the doc advanced before the error (partial apply),
         // trigger a full materialization so the UI reflects the
         // recovered state. Also complete initial sync if pending.
@@ -717,7 +752,12 @@ export class SyncEngine {
               log.warn("[sync-engine] state recovery reply send failed:", err);
             });
         }
-        this._syncErrors$.next({ doc: "runtime_state", changed: e.changed, ts: Date.now() });
+        this._syncErrors$.next({
+          doc: "runtime_state",
+          kind: "auto_recovered",
+          changed: e.changed,
+          ts: Date.now(),
+        });
         // If the state doc advanced, publish the recovered snapshot
         // so kernel status / queue / execution UI stays current.
         if (e.changed && e.state) {
@@ -891,7 +931,12 @@ export class SyncEngine {
               log.warn("[sync-engine] pool state recovery reply send failed:", err);
             });
         }
-        this._syncErrors$.next({ doc: "pool_state", changed: e.changed, ts: Date.now() });
+        this._syncErrors$.next({
+          doc: "pool_state",
+          kind: "auto_recovered",
+          changed: e.changed,
+          ts: Date.now(),
+        });
         if (e.changed && e.state) {
           this._poolState$.next(e.state as PoolState);
         }
@@ -981,7 +1026,12 @@ export class SyncEngine {
         `${RUNTIME_STATE_STALL_MS}ms) — resetting sync state and re-flushing`,
     );
     handle.reset_sync_state();
-    this._syncErrors$.next({ doc: "runtime_state", changed: false, ts: Date.now() });
+    this._syncErrors$.next({
+      doc: "runtime_state",
+      kind: "stall_detected",
+      changed: false,
+      ts: Date.now(),
+    });
     // Immediately re-flush so the daemon can re-deliver any state it
     // thinks we already have.
     this.flush();
@@ -1121,7 +1171,17 @@ export class SyncEngine {
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
       this.armRuntimeStateStallWatchdog();
+      const gen = ++this.runtimeStateFlushGen;
       this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg).catch((e: unknown) => {
+        // Only roll back if the generation hasn't advanced. A later
+        // watchdog-triggered recovery flush carries its own gen; a
+        // stale rejection from the hung original must not wipe it.
+        if (gen !== this.runtimeStateFlushGen) {
+          this.opts.logger.debug(
+            "[sync-engine] runtime state sync rejection belongs to a superseded flush; ignoring",
+          );
+          return;
+        }
         this.clearRuntimeStateStallWatchdog();
         handle.cancel_last_runtime_state_flush();
         this.opts.logger.warn("[sync-engine] runtime state sync to relay failed:", e);
@@ -1180,12 +1240,19 @@ export class SyncEngine {
     const stateMsg = handle.flush_runtime_state_sync();
     if (stateMsg) {
       this.armRuntimeStateStallWatchdog();
+      const gen = ++this.runtimeStateFlushGen;
       try {
         await this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg);
       } catch (e) {
-        this.clearRuntimeStateStallWatchdog();
-        handle.cancel_last_runtime_state_flush();
-        this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
+        if (gen === this.runtimeStateFlushGen) {
+          this.clearRuntimeStateStallWatchdog();
+          handle.cancel_last_runtime_state_flush();
+          this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
+        } else {
+          this.opts.logger.debug(
+            "[sync-engine] flushAndWait: runtime state rejection superseded; ignoring",
+          );
+        }
       }
     }
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -229,6 +229,26 @@ function writePath(obj: unknown, path: string[], value: unknown): void {
   (cursor as Record<string, unknown>)[path[path.length - 1]] = value;
 }
 
+// ── Sync error event ─────────────────────────────────────────────────
+
+/**
+ * Sync recovery event for `syncErrors$`.
+ *
+ * Fires each time the WASM sync layer rebuilds a doc after a failed
+ * `receive_sync_message` (or when the stall watchdog force-resets a
+ * silently dropped runtime-state flush). Purely diagnostic — the
+ * engine has already sent the recovery reply and restored sync state
+ * by the time this fires.
+ */
+export interface SyncErrorEvent {
+  /** Which doc recovered: the notebook, runtime state, or pool state. */
+  doc: "notebook" | "runtime_state" | "pool_state";
+  /** True when the doc advanced before the error (partial apply). */
+  changed: boolean;
+  /** Wall-clock ms of the recovery. */
+  ts: number;
+}
+
 // ── Options ──────────────────────────────────────────────────────────
 
 export interface SyncEngineOptions {
@@ -350,6 +370,22 @@ export class SyncEngine {
    */
   readonly initialSyncComplete$: Observable<void>;
 
+  /**
+   * Sync-layer recovery events.
+   *
+   * The WASM sync layer auto-recovers from failed `receive_sync_message`
+   * calls by rebuilding the doc from its snapshot bytes, normalizing
+   * sync state, and sending a fresh sync message back to the daemon.
+   * That recovery is silent to the user by default — useful for
+   * transient network hiccups but confusing when something's actually
+   * wrong.
+   *
+   * This observable surfaces each recovery as an event so the UI can
+   * show a banner, bump a counter, etc. It's diagnostic, not
+   * actionable: the engine has already done the repair.
+   */
+  readonly syncErrors$: Observable<SyncErrorEvent>;
+
   // Backing subjects for public observables
   private readonly _cellChanges$ = new Subject<CellChangeset | null>();
   private readonly _broadcasts$ = new Subject<unknown>();
@@ -359,6 +395,7 @@ export class SyncEngine {
   private readonly _executionTransitions$ = new Subject<ExecutionTransition[]>();
   private readonly _initialSyncComplete$ = new Subject<void>();
   private readonly _commChanges$ = new Subject<CommChanges>();
+  private readonly _syncErrors$ = new Subject<SyncErrorEvent>();
 
   constructor(opts: SyncEngineOptions) {
     this.opts = {
@@ -376,6 +413,7 @@ export class SyncEngine {
     this.executionTransitions$ = this._executionTransitions$.asObservable();
     this.initialSyncComplete$ = this._initialSyncComplete$.asObservable();
     this.commChanges$ = this._commChanges$.asObservable();
+    this.syncErrors$ = this._syncErrors$.asObservable();
     this.kernelStatus$ = deriveKernelStatus$(this.runtimeState$);
 
     // Typed broadcast sub-observables (derived from broadcasts$)
@@ -619,6 +657,7 @@ export class SyncEngine {
               log.warn("[sync-engine] recovery reply send failed:", err);
             });
         }
+        this._syncErrors$.next({ doc: "notebook", changed: e.changed, ts: Date.now() });
         // If the doc advanced before the error (partial apply),
         // trigger a full materialization so the UI reflects the
         // recovered state. Also complete initial sync if pending.
@@ -649,6 +688,7 @@ export class SyncEngine {
               log.warn("[sync-engine] state recovery reply send failed:", err);
             });
         }
+        this._syncErrors$.next({ doc: "runtime_state", changed: e.changed, ts: Date.now() });
         // If the state doc advanced, publish the recovered snapshot
         // so kernel status / queue / execution UI stays current.
         if (e.changed && e.state) {
@@ -817,6 +857,7 @@ export class SyncEngine {
               log.warn("[sync-engine] pool state recovery reply send failed:", err);
             });
         }
+        this._syncErrors$.next({ doc: "pool_state", changed: e.changed, ts: Date.now() });
         if (e.changed && e.state) {
           this._poolState$.next(e.state as PoolState);
         }

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1410,6 +1410,105 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("arms a stall watchdog on runtime-state flush, clears on inbound traffic", async () => {
+      vi.useFakeTimers();
+      try {
+        // receive_frame fires a runtime_state_sync_applied on inbound
+        // traffic — the signal the engine uses to clear the watchdog.
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi.fn(() => new Uint8Array([0x01])),
+          receive_frame: vi.fn(() => [
+            { type: "runtime_state_sync_applied", changed: false } as FrameEvent,
+          ]),
+        });
+        const sendSpy = vi
+          .spyOn(transport, "sendFrame")
+          .mockResolvedValue(undefined as unknown as void);
+        const engine = createEngine();
+        engine.start();
+
+        const errors: Array<{ doc: string }> = [];
+        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc }));
+
+        engine.flush();
+        await Promise.resolve();
+
+        // Inbound runtime-state frame fires the "applied" event that
+        // clears the watchdog.
+        transport.deliver([0x05, 0x99]);
+
+        // Advance past the watchdog window: no stall fire, because
+        // the inbound frame already cleared it.
+        vi.advanceTimersByTime(4_000);
+        expect(errors).toEqual([]);
+        expect(sendSpy).toHaveBeenCalledTimes(1);
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resets sync state + re-flushes when the watchdog fires", async () => {
+      vi.useFakeTimers();
+      try {
+        const flushSpy = vi
+          .fn()
+          .mockReturnValueOnce(new Uint8Array([0x01]))
+          .mockReturnValueOnce(new Uint8Array([0x02]));
+        const resetSpy = vi.fn();
+        handle = createMockHandle({
+          flush_runtime_state_sync: flushSpy,
+          reset_sync_state: resetSpy,
+        });
+        vi.spyOn(transport, "sendFrame").mockResolvedValue(undefined as unknown as void);
+        const engine = createEngine();
+        engine.start();
+
+        const errors: Array<{ doc: string }> = [];
+        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc }));
+
+        engine.flush();
+        await Promise.resolve();
+
+        // No inbound traffic → watchdog fires after the window.
+        vi.advanceTimersByTime(3_001);
+
+        expect(resetSpy).toHaveBeenCalled();
+        expect(errors).toEqual([{ doc: "runtime_state" }]);
+        // The re-flush after reset should issue a second
+        // `flush_runtime_state_sync`.
+        expect(flushSpy).toHaveBeenCalledTimes(2);
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resetForBootstrap clears any armed watchdog", async () => {
+      vi.useFakeTimers();
+      try {
+        const resetSpy = vi.fn();
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi.fn(() => new Uint8Array([0x01])),
+          reset_sync_state: resetSpy,
+        });
+        vi.spyOn(transport, "sendFrame").mockResolvedValue(undefined as unknown as void);
+        const engine = createEngine();
+        engine.start();
+        engine.flush();
+        await Promise.resolve();
+
+        engine.resetForBootstrap();
+        vi.advanceTimersByTime(5_000);
+
+        // Reset for bootstrap dropped the timer — no forced recovery.
+        expect(resetSpy).not.toHaveBeenCalled();
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("emits on syncErrors$ for each doc-specific recovery", () => {
       handle = createMockHandle({
         receive_frame: vi

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1427,8 +1427,8 @@ describe("SyncEngine", () => {
         const engine = createEngine();
         engine.start();
 
-        const errors: Array<{ doc: string }> = [];
-        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc }));
+        const errors: Array<{ doc: string; kind: string }> = [];
+        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc, kind: e.kind }));
 
         engine.flush();
         await Promise.resolve();
@@ -1464,8 +1464,8 @@ describe("SyncEngine", () => {
         const engine = createEngine();
         engine.start();
 
-        const errors: Array<{ doc: string }> = [];
-        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc }));
+        const errors: Array<{ doc: string; kind: string }> = [];
+        engine.syncErrors$.subscribe((e) => errors.push({ doc: e.doc, kind: e.kind }));
 
         engine.flush();
         await Promise.resolve();
@@ -1474,7 +1474,7 @@ describe("SyncEngine", () => {
         vi.advanceTimersByTime(3_001);
 
         expect(resetSpy).toHaveBeenCalled();
-        expect(errors).toEqual([{ doc: "runtime_state" }]);
+        expect(errors).toEqual([{ doc: "runtime_state", kind: "stall_detected" }]);
         // The re-flush after reset should issue a second
         // `flush_runtime_state_sync`.
         expect(flushSpy).toHaveBeenCalledTimes(2);
@@ -1509,7 +1509,7 @@ describe("SyncEngine", () => {
       }
     });
 
-    it("emits on syncErrors$ for each doc-specific recovery", () => {
+    it("emits auto_recovered on syncErrors$ for each doc-specific recovery", () => {
       handle = createMockHandle({
         receive_frame: vi
           .fn()
@@ -1524,8 +1524,10 @@ describe("SyncEngine", () => {
       const engine = createEngine();
       engine.start();
 
-      const events: Array<{ doc: string; changed: boolean }> = [];
-      engine.syncErrors$.subscribe((e) => events.push({ doc: e.doc, changed: e.changed }));
+      const events: Array<{ doc: string; kind: string; changed: boolean }> = [];
+      engine.syncErrors$.subscribe((e) =>
+        events.push({ doc: e.doc, kind: e.kind, changed: e.changed }),
+      );
 
       transport.deliver([0x00, 0x99]);
       transport.deliver([0x05, 0x99]);
@@ -1533,11 +1535,88 @@ describe("SyncEngine", () => {
       advanceBy(scheduler, 1);
 
       expect(events).toEqual([
-        { doc: "notebook", changed: true },
-        { doc: "runtime_state", changed: false },
-        { doc: "pool_state", changed: true },
+        { doc: "notebook", kind: "auto_recovered", changed: true },
+        { doc: "runtime_state", kind: "auto_recovered", changed: false },
+        { doc: "pool_state", kind: "auto_recovered", changed: true },
       ]);
       engine.stop();
+    });
+
+    it("emits stall_detected (not auto_recovered) when the watchdog fires", async () => {
+      vi.useFakeTimers();
+      try {
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi
+            .fn()
+            .mockReturnValueOnce(new Uint8Array([0x01]))
+            .mockReturnValueOnce(new Uint8Array([0x02])),
+        });
+        vi.spyOn(transport, "sendFrame").mockResolvedValue(undefined as unknown as void);
+        const engine = createEngine();
+        engine.start();
+
+        const events: Array<{ kind: string }> = [];
+        engine.syncErrors$.subscribe((e) => events.push({ kind: e.kind }));
+
+        engine.flush();
+        await Promise.resolve();
+        vi.advanceTimersByTime(3_001);
+
+        // Only the stall_detected event: the banner should read "stalled,
+        // retrying" rather than a misleading "recovered" before the retry
+        // has actually been acknowledged.
+        expect(events).toEqual([{ kind: "stall_detected" }]);
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("ignores late sendFrame rejection from a superseded runtime-state flush", async () => {
+      vi.useFakeTimers();
+      try {
+        handle = createMockHandle({
+          flush_runtime_state_sync: vi
+            .fn()
+            .mockReturnValueOnce(new Uint8Array([0x01]))
+            .mockReturnValueOnce(new Uint8Array([0x02])),
+        });
+        let rejectFirst: (err: unknown) => void = () => {};
+        const firstPromise = new Promise<void>((_resolve, reject) => {
+          rejectFirst = reject;
+        });
+        const sendSpy = vi
+          .spyOn(transport, "sendFrame")
+          .mockImplementationOnce(() => firstPromise)
+          .mockResolvedValue(undefined as unknown as void);
+        const engine = createEngine();
+        engine.start();
+
+        engine.flush();
+        await Promise.resolve();
+
+        // Watchdog fires while the first sendFrame is still hung —
+        // runtime-state flush generation advances inside the retry.
+        vi.advanceTimersByTime(3_001);
+        // Recovery flush should have been issued.
+        expect(sendSpy).toHaveBeenCalledTimes(2);
+
+        // NOW the stale sendFrame rejects. If the catch blindly ran,
+        // it would clear the recovery's watchdog and roll back its
+        // flush. Generation check should make it a no-op.
+        rejectFirst(new Error("pipe closed — stale"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Retry's cancel was NOT called (once from the original nothing,
+        // or never). reset_sync_state was called exactly once (by the
+        // watchdog). The recovery's watchdog is still live, so no extra
+        // stall_detected should fire inside 1ms.
+        expect(handle.cancel_last_runtime_state_flush).not.toHaveBeenCalled();
+        engine.stop();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1409,6 +1409,37 @@ describe("SyncEngine", () => {
       expect(sendSpy).not.toHaveBeenCalled();
       engine.stop();
     });
+
+    it("emits on syncErrors$ for each doc-specific recovery", () => {
+      handle = createMockHandle({
+        receive_frame: vi
+          .fn()
+          .mockReturnValueOnce([{ type: "sync_error", changed: true, reply: [0x01] } as FrameEvent])
+          .mockReturnValueOnce([
+            { type: "runtime_state_sync_error", changed: false, reply: [0x02] } as FrameEvent,
+          ])
+          .mockReturnValueOnce([
+            { type: "pool_state_sync_error", changed: true, reply: [0x03] } as FrameEvent,
+          ]),
+      });
+      const engine = createEngine();
+      engine.start();
+
+      const events: Array<{ doc: string; changed: boolean }> = [];
+      engine.syncErrors$.subscribe((e) => events.push({ doc: e.doc, changed: e.changed }));
+
+      transport.deliver([0x00, 0x99]);
+      transport.deliver([0x05, 0x99]);
+      transport.deliver([0x06, 0x99]);
+      advanceBy(scheduler, 1);
+
+      expect(events).toEqual([
+        { doc: "notebook", changed: true },
+        { doc: "runtime_state", changed: false },
+        { doc: "pool_state", changed: true },
+      ]);
+      engine.stop();
+    });
   });
 
   // ── Comm state projection + text-blob inlining ──────────────────


### PR DESCRIPTION
Narrow safety-net for the widget-sync stall class. Makes two silent failure modes visible and self-healing, without changing the widget-store write path.

See the full design note at `docs/superpowers/specs/2026-04-18-widget-sync-recovery-design.md`.

## Summary

1. **`SyncEngine.syncErrors$`** — public observable forwarding each WASM auto-recovery (notebook / runtime_state / pool_state) to the UI. The engine already handles the recovery reply; this just stops the event from being silent.
2. **`SyncRecoveryBanner`** — top-level banner mounted in App.tsx. Auto-dismisses after 5s, counts bursts while visible, resets counter on dismissal.
3. **Runtime-state stall watchdog** — after a `flush_runtime_state_sync`, arm a 3s timer. Any inbound runtime-state frame clears it. On timeout, call `reset_sync_state()`, re-flush, and emit on `syncErrors$`. Clears on `resetForBootstrap`/`stop` so stale timers can't fire against replaced handles.
4. **Observability primitives** — 5s `AbortController` timeout on blob fetches (one hung fetch was poisoning the serial comm emit queue); log subscriber errors in `frame-bus` + `runtime-state` instead of silently swallowing them.

## Not in this PR

- The CRDT-first write-path refactor (Track A) that the earlier branch attempted. The investigation showed this sync-layer safety net is separable and maintainable on its own; Track A stays deferred until we see whether this is enough.
- Sync-state persistence across reloads — still the user's last-resort recovery, intentionally.

## Tests

- 4 new SyncEngine unit tests: `syncErrors$` emission per doc kind, watchdog clear-on-inbound, watchdog fire-on-timeout, watchdog clear-on-bootstrap.
- 1018 existing tests unaffected.

## Test plan

- [ ] `cargo xtask lint` clean
- [ ] `pnpm test:run` passes
- [ ] Manual: matplotlib `@interact` slider — verify the banner appears on sync-layer recovery events and the UI no longer needs a reload after a silent flush drop.