### PR TITLE
diag: trace every frame crossing the Tauri/webview boundary

### DIFF
--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -15,6 +15,25 @@ import type {
 } from "runtimed";
 import { logger } from "./logger";
 
+/**
+ * Frame-boundary tracing. OFF by default: `logger.debug` would
+ * otherwise fire an IPC to the Tauri log plugin for every frame,
+ * roughly doubling the hot-path cost on a hammered slider and
+ * potentially introducing the sync stalls this trace exists to
+ * diagnose. Enable per-session by setting
+ * `localStorage.setItem("nteract.frameTrace", "1")` in devtools
+ * and reloading. Runs alongside Rust-side `[frame-trace]` logs
+ * (controlled via `RUST_LOG=debug`) so the two can be correlated
+ * across the boundary.
+ */
+const FRAME_TRACE_ENABLED: boolean = (() => {
+  try {
+    return typeof localStorage !== "undefined" && localStorage.getItem("nteract.frameTrace") === "1";
+  } catch {
+    return false;
+  }
+})();
+
 export class TauriTransport implements NotebookTransport {
   private _connected = true;
   private unlisteners: Array<() => void> = [];
@@ -27,14 +46,16 @@ export class TauriTransport implements NotebookTransport {
     const frame = new Uint8Array(1 + payload.length);
     frame[0] = frameType;
     frame.set(payload, 1);
-    // Frame-boundary trace (JS outbound). Pairs with Rust's
-    // `[frame-trace] out` in `send_frame_bytes`. If this log fires
-    // but the Rust log doesn't, the break is in the Tauri invoke
-    // path itself. `len` is the full frame byte count so it
-    // compares directly across both sides of the boundary.
-    logger.debug(
-      `[frame-trace] js-out type=0x${frameType.toString(16).padStart(2, "0")} len=${frame.length}`,
-    );
+    if (FRAME_TRACE_ENABLED) {
+      // Frame-boundary trace (JS outbound). Pairs with Rust's
+      // `[frame-trace] out` in `send_frame_bytes`. If this log fires
+      // but the Rust log doesn't, the break is in the Tauri invoke
+      // path itself. `len` is the full frame byte count so it
+      // compares directly across both sides of the boundary.
+      logger.debug(
+        `[frame-trace] js-out type=0x${frameType.toString(16).padStart(2, "0")} len=${frame.length}`,
+      );
+    }
     return invoke("send_frame", frame);
   }
 
@@ -57,17 +78,19 @@ export class TauriTransport implements NotebookTransport {
     const unlistenPromise = webview.listen<number[]>(
       "notebook:frame",
       (event) => {
-        // Frame-boundary trace (JS inbound). Pairs with Rust's
-        // `[frame-trace] in` in the relay's emit loop. If the Rust
-        // log fires but this one doesn't, the break is between
-        // Tauri's event emit and the webview's listen delivery.
-        // Log before entering the try/catch so an exception thrown
-        // by the downstream handler doesn't hide the arrival.
         const payload = event.payload;
-        const frameType = payload.length > 0 ? payload[0] : 0xff;
-        logger.debug(
-          `[frame-trace] js-in type=0x${frameType.toString(16).padStart(2, "0")} len=${payload.length}`,
-        );
+        if (FRAME_TRACE_ENABLED) {
+          // Frame-boundary trace (JS inbound). Pairs with Rust's
+          // `[frame-trace] in` in the relay's emit loop. If the Rust
+          // log fires but this one doesn't, the break is between
+          // Tauri's event emit and the webview's listen delivery.
+          // Log before entering the try/catch so an exception thrown
+          // by the downstream handler doesn't hide the arrival.
+          const frameType = payload.length > 0 ? payload[0] : 0xff;
+          logger.debug(
+            `[frame-trace] js-in type=0x${frameType.toString(16).padStart(2, "0")} len=${payload.length}`,
+          );
+        }
         try {
           callback(payload);
         } catch (err) {

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -27,6 +27,14 @@ export class TauriTransport implements NotebookTransport {
     const frame = new Uint8Array(1 + payload.length);
     frame[0] = frameType;
     frame.set(payload, 1);
+    // Frame-boundary trace (JS outbound). Pairs with Rust's
+    // `[frame-trace] out` in `send_frame_bytes`. If this log fires
+    // but the Rust log doesn't, the break is in the Tauri invoke
+    // path itself. `len` is the full frame byte count so it
+    // compares directly across both sides of the boundary.
+    logger.debug(
+      `[frame-trace] js-out type=0x${frameType.toString(16).padStart(2, "0")} len=${frame.length}`,
+    );
     return invoke("send_frame", frame);
   }
 
@@ -49,8 +57,19 @@ export class TauriTransport implements NotebookTransport {
     const unlistenPromise = webview.listen<number[]>(
       "notebook:frame",
       (event) => {
+        // Frame-boundary trace (JS inbound). Pairs with Rust's
+        // `[frame-trace] in` in the relay's emit loop. If the Rust
+        // log fires but this one doesn't, the break is between
+        // Tauri's event emit and the webview's listen delivery.
+        // Log before entering the try/catch so an exception thrown
+        // by the downstream handler doesn't hide the arrival.
+        const payload = event.payload;
+        const frameType = payload.length > 0 ? payload[0] : 0xff;
+        logger.debug(
+          `[frame-trace] js-in type=0x${frameType.toString(16).padStart(2, "0")} len=${payload.length}`,
+        );
         try {
-          callback(event.payload);
+          callback(payload);
         } catch (err) {
           logger.error("[tauri-transport] notebook:frame handler threw:", err);
         }

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -160,7 +160,20 @@ impl RelayHandle {
     /// decoding or processing it. Used for Automerge sync messages and
     /// presence frames originating from the WASM frontend.
     pub async fn forward_frame(&self, frame_type: u8, payload: Vec<u8>) -> Result<(), SyncError> {
+        // Frame-boundary trace (relay layer). Paired with the
+        // `[frame-trace] relay` logs in relay_task. Shows up at
+        // `trace!` level only — no cost in normal dev mode.
+        let payload_len = payload.len();
+        let queue_cap = self.cmd_tx.capacity();
         let (reply_tx, reply_rx) = oneshot::channel();
+        log::trace!(
+            "[frame-trace] relay forward_frame enter: type=0x{:02x} len={} queue_cap={}",
+            frame_type,
+            payload_len,
+            queue_cap,
+        );
+
+        let send_started = std::time::Instant::now();
         self.cmd_tx
             .send(RelayCommand::ForwardFrame {
                 frame_type,
@@ -169,6 +182,24 @@ impl RelayHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        let send_elapsed = send_started.elapsed();
+        log::trace!(
+            "[frame-trace] relay forward_frame queued: type=0x{:02x} len={} send_wait_ms={}",
+            frame_type,
+            payload_len,
+            send_elapsed.as_millis(),
+        );
+
+        let reply_started = std::time::Instant::now();
+        let result = reply_rx.await.map_err(|_| SyncError::Disconnected)?;
+        let reply_elapsed = reply_started.elapsed();
+        log::trace!(
+            "[frame-trace] relay forward_frame done: type=0x{:02x} len={} reply_wait_ms={} ok={}",
+            frame_type,
+            payload_len,
+            reply_elapsed.as_millis(),
+            result.is_ok(),
+        );
+        result
     }
 }

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -106,7 +106,17 @@ where
                     payload,
                     reply,
                 } => {
+                    // Frame-boundary trace (relay task, outbound arm).
+                    // Logs before and after the socket write so a stall
+                    // on the daemon-side pipe is attributable here.
+                    let payload_len = payload.len();
+                    log::trace!(
+                        "[frame-trace] relay outbound: type=0x{:02x} len={}",
+                        frame_type,
+                        payload_len,
+                    );
                     let ft = NotebookFrameType::try_from(frame_type);
+                    let write_started = std::time::Instant::now();
                     let result = match ft {
                         Ok(ft) => connection::send_typed_frame(&mut writer, ft, &payload)
                             .await
@@ -116,12 +126,29 @@ where
                             frame_type,
                         ))),
                     };
+                    log::trace!(
+                        "[frame-trace] relay outbound socket write: type=0x{:02x} len={} write_ms={} ok={}",
+                        frame_type,
+                        payload_len,
+                        write_started.elapsed().as_millis(),
+                        result.is_ok(),
+                    );
                     let _ = reply.send(result);
                 }
             },
 
             // ─── Incoming frame from daemon → pipe to frontend ─────────
             SelectResult::Frame(Ok(Some(frame))) => {
+                // Frame-boundary trace (relay task, inbound arm).
+                // Logs what the relay received from the daemon socket
+                // before it's piped to the frontend's `notebook:frame`
+                // event. Use this to distinguish "daemon isn't sending"
+                // from "Tauri isn't delivering to webview."
+                log::trace!(
+                    "[frame-trace] relay inbound: type={:?} len={}",
+                    frame.frame_type,
+                    frame.payload.len(),
+                );
                 pipe_frame(&config.frame_tx, &frame);
             }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -791,14 +791,17 @@ async fn setup_sync_receivers(
                 );
                 break;
             }
-            // Frame-boundary trace. Enabled with `RUST_LOG=debug`; grep
-            // `[frame-trace] in` to see every inbound frame emitted to
-            // the webview. Widget-sync stall investigation uses these
-            // logs paired with the JS-side counter to localize which
-            // side of the Tauri boundary stops moving.
+            // Frame-boundary trace. Emitted at `trace!` level so the
+            // nightly default `LevelFilter::Debug` does NOT enable
+            // this — it would otherwise run on every inbound frame
+            // for every session and create the IPC/log overhead the
+            // JS-side gate avoids. Enable explicitly with
+            // `RUST_LOG=trace` (or a narrower target filter once we
+            // wire EnvFilter). Grep `[frame-trace] in` in
+            // `notebook.log` to see every inbound frame.
             let frame_type = frame_bytes.first().copied().unwrap_or(0xff);
             let frame_len = frame_bytes.len();
-            debug!(
+            log::trace!(
                 "[frame-trace] in window={} type=0x{:02x} len={}",
                 window.label(),
                 frame_type,
@@ -3039,11 +3042,13 @@ async fn send_frame_bytes(
     let frame_type = frame_data[0];
     let payload = &frame_data[1..];
 
-    // Frame-boundary trace (outbound). Pairs with `[frame-trace] in`
-    // on inbound and the JS-side counters. `RUST_LOG=debug` to see.
-    // `len` is the full frame byte count including the type prefix so
-    // it directly compares to `[frame-trace] in` on the other side.
-    debug!(
+    // Frame-boundary trace (outbound). At `trace!` level — OFF
+    // under the nightly `LevelFilter::Debug` default. Enable with
+    // `RUST_LOG=trace`. Pairs with `[frame-trace] in` on inbound
+    // and the JS-side counters. `len` is the full frame byte count
+    // including the type prefix so it compares directly across both
+    // sides of the boundary.
+    log::trace!(
         "[frame-trace] out window={} type=0x{:02x} len={}",
         window.label(),
         frame_type,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -791,10 +791,26 @@ async fn setup_sync_receivers(
                 );
                 break;
             }
+            // Frame-boundary trace. Enabled with `RUST_LOG=debug`; grep
+            // `[frame-trace] in` to see every inbound frame emitted to
+            // the webview. Widget-sync stall investigation uses these
+            // logs paired with the JS-side counter to localize which
+            // side of the Tauri boundary stops moving.
+            let frame_type = frame_bytes.first().copied().unwrap_or(0xff);
+            let frame_len = frame_bytes.len();
+            debug!(
+                "[frame-trace] in window={} type=0x{:02x} len={}",
+                window.label(),
+                frame_type,
+                frame_len,
+            );
             if let Err(e) =
                 emit_to_label::<_, _, _>(&window, window.label(), "notebook:frame", &frame_bytes)
             {
-                warn!("[notebook-sync] Failed to emit notebook:frame: {}", e);
+                warn!(
+                    "[notebook-sync] Failed to emit notebook:frame (type=0x{:02x} len={}): {}",
+                    frame_type, frame_len, e,
+                );
             }
         }
         warn!(
@@ -3022,6 +3038,17 @@ async fn send_frame_bytes(
 
     let frame_type = frame_data[0];
     let payload = &frame_data[1..];
+
+    // Frame-boundary trace (outbound). Pairs with `[frame-trace] in`
+    // on inbound and the JS-side counters. `RUST_LOG=debug` to see.
+    // `len` is the full frame byte count including the type prefix so
+    // it directly compares to `[frame-trace] in` on the other side.
+    debug!(
+        "[frame-trace] out window={} type=0x{:02x} len={}",
+        window.label(),
+        frame_type,
+        frame_data.len(),
+    );
 
     match frame_type {
         frame_types::AUTOMERGE_SYNC


### PR DESCRIPTION
Trace instrumentation for the Tauri ↔ daemon frame pipe. No behavior change; opt-in tracing only. Goal is to localize where the sync stall reported in recent reproductions is actually wedging.

## What

Seven matched trace lines across four layers, all at `trace!` / `logger.debug` level and off by default.

**Webview (`apps/notebook/src/lib/tauri-transport.ts`):**
- `[frame-trace] js-out` — at the `invoke("send_frame")` call site.
- `[frame-trace] js-in` — at the `listen("notebook:frame")` callback, before the try/catch.

**Tauri command layer (`crates/notebook/src/lib.rs`):**
- `[frame-trace] out` — enters `send_frame_bytes` before forwarding.
- `[frame-trace] in` — in the relay's emit loop, before `emit_to_label`.

**Relay handle (`crates/notebook-sync/src/relay.rs`):**
- `relay forward_frame enter` — before sending to the bounded command channel. Includes `queue_cap` (available slots in the 32-slot channel; falling toward 0 means backpressure).
- `relay forward_frame queued` — after the command channel `send` resolves; `send_wait_ms`.
- `relay forward_frame done` — after the relay task's reply resolves; `reply_wait_ms` + ok flag.

**Relay task (`crates/notebook-sync/src/relay_task.rs`):**
- `relay outbound` — before `send_typed_frame` to the daemon socket.
- `relay outbound socket write` — after the socket write; `write_ms` + ok.
- `relay inbound` — on every frame pulled off the daemon socket; `frame_type` + `len`.

## Enable

- **Rust:** `RUST_LOG=trace` (or `RUST_LOG=notebook=trace,notebook_sync=trace` to scope).
- **Webview:** `localStorage.setItem("nteract.frameTrace", "1")` in devtools + reload. Gated locally because `logger.debug` fires an IPC per call regardless of Rust-side level.

No daemon rebuild required — all traces are on the Tauri-app side of the socket.

## What the traces can distinguish

| Observation | Likely failure location |
|---|---|
| `js-out` fires, no `out` | Tauri invoke path |
| `out` fires, no `forward_frame enter` | Never reached the relay handle (impossible given the code, but worth confirming) |
| `forward_frame enter` fires, no `queued` | Bounded mpsc channel full; relay task stalled. `queue_cap` will show 0. |
| `queued` fires, no `done` | Relay task picked it up but the socket write or daemon response didn't complete |
| `done` fires quickly, but no `relay inbound` | Daemon is accepting but has stopped sending back |
| `relay inbound` fires, no `in` | Impossible — `pipe_frame` synchronously emits |
| `in` fires, no `js-in` | Tauri event emit is losing frames to the webview |

## Test plan

- [x] `cargo xtask lint` clean
- [x] `pnpm test:run` passes
- [ ] Manual: reproduce the slider stall with tracing on; grep `[frame-trace]` and localize the break.