### PR TITLE
diag: add daemon-side frame-trace

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2791,8 +2791,13 @@ where
                                 // arrow-key slider drags. If `lock_ms` is ever
                                 // seconds long, some other task is holding
                                 // `state_doc.write()` — that's the wedge site.
+                                //
+                                // The trace itself is emitted AFTER the write guard
+                                // drops so a slow tracing subscriber can't extend
+                                // the critical section and cause the contention it
+                                // was meant to diagnose.
                                 let stage_start = std::time::Instant::now();
-                                let reply_encoded = {
+                                let (reply_encoded, lock_ms, recv_ms) = {
                                     let mut state_doc = room.state_doc.write().await;
                                     let lock_ms = stage_start.elapsed().as_millis();
 
@@ -2804,12 +2809,6 @@ where
                                         )
                                     });
                                     let recv_ms = recv_started.elapsed().as_millis();
-                                    tracing::trace!(
-                                        "[frame-trace] daemon state-sync apply: peer={} lock_ms={} recv_ms={}",
-                                        peer_id,
-                                        lock_ms,
-                                        recv_ms,
-                                    );
                                     let had_changes = match recv_result {
                                         Ok(Ok(changed)) => changed,
                                         Ok(Err(e)) => {
@@ -2832,7 +2831,7 @@ where
                                         let _ = room.state_changed_tx.send(());
                                     }
 
-                                    match catch_automerge_panic("state-sync-reply", || {
+                                    let encoded = match catch_automerge_panic("state-sync-reply", || {
                                         state_doc
                                             .generate_sync_message(&mut state_peer_state)
                                             .map(|msg| msg.encode())
@@ -2846,8 +2845,17 @@ where
                                                 .generate_sync_message(&mut state_peer_state)
                                                 .map(|msg| msg.encode())
                                         }
-                                    }
+                                    };
+                                    (encoded, lock_ms, recv_ms)
                                 };
+                                // Emit apply-stage trace now that the write guard
+                                // has dropped (previous block closed).
+                                tracing::trace!(
+                                    "[frame-trace] daemon state-sync apply: peer={} lock_ms={} recv_ms={}",
+                                    peer_id,
+                                    lock_ms,
+                                    recv_ms,
+                                );
                                 if let Some(encoded) = reply_encoded {
                                     let send_started = std::time::Instant::now();
                                     connection::send_typed_frame(

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2357,7 +2357,7 @@ async fn run_sync_loop_v2<R, W>(
     writer: &mut W,
     room: &Arc<NotebookRoom>,
     _rooms: NotebookRooms,
-    _notebook_id: String,
+    notebook_id: String,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
     needs_load: Option<&Path>,
     peer_id: &str,
@@ -2559,6 +2559,17 @@ where
             result = connection::recv_typed_frame(reader) => {
                 match result? {
                     Some(frame) => {
+                        // Daemon-side frame-boundary trace. Paired with the
+                        // Tauri-side `[frame-trace] relay outbound socket write`
+                        // log; gap between those two means the frame is lost
+                        // between app socket write and daemon socket read.
+                        tracing::trace!(
+                            "[frame-trace] daemon recv: peer={} notebook={} type={:?} len={}",
+                            peer_id,
+                            notebook_id,
+                            frame.frame_type,
+                            frame.payload.len(),
+                        );
                         match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 // Handle Automerge sync message
@@ -2776,15 +2787,29 @@ where
                                 // to comms/*/state/* for widget state updates).
                                 let message = sync::Message::decode(&frame.payload)
                                     .map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
+                                // Per-stage trace for the frame type that stalls on
+                                // arrow-key slider drags. If `lock_ms` is ever
+                                // seconds long, some other task is holding
+                                // `state_doc.write()` — that's the wedge site.
+                                let stage_start = std::time::Instant::now();
                                 let reply_encoded = {
                                     let mut state_doc = room.state_doc.write().await;
+                                    let lock_ms = stage_start.elapsed().as_millis();
 
+                                    let recv_started = std::time::Instant::now();
                                     let recv_result = catch_automerge_panic("state-receive-sync", || {
                                         state_doc.receive_sync_message_with_changes(
                                             &mut state_peer_state,
                                             message,
                                         )
                                     });
+                                    let recv_ms = recv_started.elapsed().as_millis();
+                                    tracing::trace!(
+                                        "[frame-trace] daemon state-sync apply: peer={} lock_ms={} recv_ms={}",
+                                        peer_id,
+                                        lock_ms,
+                                        recv_ms,
+                                    );
                                     let had_changes = match recv_result {
                                         Ok(Ok(changed)) => changed,
                                         Ok(Err(e)) => {
@@ -2824,12 +2849,28 @@ where
                                     }
                                 };
                                 if let Some(encoded) = reply_encoded {
+                                    let send_started = std::time::Instant::now();
                                     connection::send_typed_frame(
                                         writer,
                                         NotebookFrameType::RuntimeStateSync,
                                         &encoded,
                                     )
                                     .await?;
+                                    tracing::trace!(
+                                        "[frame-trace] daemon state-sync reply sent: peer={} len={} write_ms={}",
+                                        peer_id,
+                                        encoded.len(),
+                                        send_started.elapsed().as_millis(),
+                                    );
+                                } else {
+                                    // Sync-protocol converged — nothing to reply with. If this
+                                    // fires while the client keeps sending, the daemon thinks
+                                    // we're in sync but the client doesn't. That's the
+                                    // "sent_hashes accumulating, daemon silent" shape.
+                                    tracing::trace!(
+                                        "[frame-trace] daemon state-sync no reply: peer={} (sync converged on receive)",
+                                        peer_id,
+                                    );
                                 }
                             }
 


### PR DESCRIPTION
Third layer of the frame-trace instrumentation. #1884 covered the Tauri app side (webview and relay); this adds the daemon side so the next widget-sync stall repro can be walked end-to-end.

## What

Three `tracing::trace!` lines inside `handle_notebook_sync_connection` and its sync loop:

- `[frame-trace] daemon recv` — any typed frame received from a client. Includes `peer`, `notebook`, frame type, payload length.
- `[frame-trace] daemon state-sync apply` — inside the `RuntimeStateSync` handler, reports `lock_ms` for the `state_doc.write()` acquisition and `recv_ms` for `receive_sync_message_with_changes`. High `lock_ms` localizes the wedge to lock contention against the state doc.
- `[frame-trace] daemon state-sync reply sent` / `no reply` — after the reply path completes. The `no reply` case is the specific shape we've been chasing: client keeps sending RuntimeStateSync frames, daemon thinks the protocol converged, so nothing goes back — matching the user's observation of outbound frames piling up with no inbound arriving.

## How to use with the other layers

This PR plus #1884 gives a complete timeline for each frame:

```
[frame-trace] js-out type=0xXX len=N          (webview)
[frame-trace] out window=... type=0xXX len=N  (Tauri command)
[frame-trace] relay forward_frame enter       (relay handle)
[frame-trace] relay forward_frame queued      (mpsc channel)
[frame-trace] relay outbound                  (relay task picks up)
[frame-trace] relay outbound socket write     (socket write complete)
[frame-trace] daemon recv                     (daemon read from socket)  ← this PR
[frame-trace] daemon state-sync apply         (daemon processed)         ← this PR
[frame-trace] daemon state-sync reply sent    (daemon wrote reply)       ← this PR
[frame-trace] relay inbound                   (Tauri relay pulled it)
[frame-trace] in window=... type=0xXX len=N   (Tauri emit to webview)
[frame-trace] js-in type=0xXX len=N           (webview listen callback)
```

Gaps between any two consecutive lines localize the wedge precisely.

## Enable

- **Daemon:** rebuild + `RUST_LOG=notebook_sync_server=trace` (or `RUST_LOG=trace`). Required because this is in the daemon binary.
- **Tauri app:** `RUST_LOG=trace` (already on for #1884's traces).
- **Webview:** `localStorage.setItem("nteract.frameTrace", "1")` + reload.

## Test plan

- [x] `cargo xtask lint` clean
- [x] `cargo check -p runtimed` clean
- [ ] Manual: with daemon rebuilt, reproduce the stall, grep `[frame-trace]` in `runtimed.log` and `notebook.log`, compare sequences.