### PR TITLE
diag: slider-stall reproducer harness (headless)

### DIFF
--- a/e2e/slider-stall-repro.mjs
+++ b/e2e/slider-stall-repro.mjs
@@ -2,27 +2,44 @@
 /**
  * Widget-sync stall reproducer.
  *
- * Drives the same input pattern that reproduces the slider stall in
- * manual testing — a `matplotlib @interact FloatSlider` with rapid
- * arrow-key input — but does it headlessly via WebDriver so it can be
- * iterated on without someone sitting at a keyboard.
+ * Drives the slider-arrow-key input pattern that reproduces the
+ * widget-sync stall in manual testing, headlessly via WebDriver so
+ * it can be iterated on without someone at a keyboard.
+ *
+ * Scope:
+ *
+ *   This harness drives the *input* that causes the stall and
+ *   exits when the hammer phase completes. It does NOT try to
+ *   detect convergence itself. The diagnosis lives in the
+ *   `[frame-trace]` logs from the sibling instrumentation PRs
+ *   (#1884 app/webview/relay, #1886 daemon). After a run, grep
+ *   `notebook.log` + `runtimed.log` for `[frame-trace]` and
+ *   compare outbound vs inbound counts.
+ *
+ *   Why not detect convergence in-harness? The output widget is
+ *   rendered inside a sandboxed iframe (`allow-same-origin` is
+ *   specifically disallowed for security — see
+ *   `src/components/isolated/isolated-frame.tsx` SANDBOX_ATTRS).
+ *   Parent-side `contentDocument` access is blocked. WebDriver's
+ *   `switchToFrame` lets us click inside the iframe, but reliably
+ *   diffing "what the client thinks" vs "what the kernel produced"
+ *   from that vantage is fragile. Let the logs do the work.
  *
  * What it does:
  *
- * 1. Waits for the Tauri app + daemon + kernel to all be ready.
- * 2. Drops a `matplotlib @interact` cell into the first code cell.
- * 3. Executes the cell so the widget renders.
- * 4. Finds the FloatSlider thumb and hammers ArrowRight key presses
- *    at up to ~60Hz (matching OS key-repeat for arrow keys).
- * 5. Watches the rendered plot title (which shows `sin(X.YYx)`) and
- *    compares to the slider value. They should converge quickly
- *    after key presses stop. A gap that never closes is the stall.
+ *   1. Waits for the Tauri app + daemon + kernel to all be ready.
+ *   2. Rewrites the first cell to a minimal ipywidgets slider
+ *      scenario — no matplotlib, no numpy, no Agg backend. Just
+ *      a FloatSlider whose change handler prints a line, so we
+ *      know from the cell output whether the kernel is getting
+ *      updates at all.
+ *   3. Executes the cell so the widget renders.
+ *   4. switchToFrame into the output iframe, focuses the slider,
+ *      hammers ArrowRight key presses at ~60 Hz for the
+ *      configured duration, switches back.
+ *   5. Exits. Cell output + log traces tell you what happened.
  *
- * Paired with the `[frame-trace]` instrumentation in #1884 + #1886,
- * running this with `RUST_LOG=trace` gives a complete timeline of
- * where the stall happens when it does.
- *
- * Prereqs (see e2e/README.md for context):
+ * Prereqs:
  *
  *   # Build the app with the e2e-webdriver feature:
  *   cargo build --features e2e-webdriver -p notebook
@@ -30,26 +47,22 @@
  *   # Start the dev daemon (in a separate terminal):
  *   cargo xtask dev-daemon
  *
- *   # Start the app with a scratch notebook (in a separate terminal).
- *   # Path doesn't matter — we rewrite the first cell.
- *   RUST_LOG=trace ./target/debug/notebook notebooks/scratch.ipynb
+ *   # The target notebook's env must have ipywidgets. Scratch
+ *   # notebooks default to the prewarmed UV pool which does NOT
+ *   # include ipywidgets — either add it to the notebook's
+ *   # dependencies via the UI before running the harness, or use
+ *   # a notebook whose env already has it.
+ *
+ *   # Start the app with the target notebook (in a separate terminal).
+ *   RUST_LOG=trace ./target/debug/notebook <notebook.ipynb>
  *
  *   # Then run this harness:
  *   node e2e/slider-stall-repro.mjs
  *
  * Options:
  *
- *   --duration 30      How long to hammer the slider (seconds).
- *                      Default: 15.
- *   --presses-per-sec 60
- *                      Target arrow-key rate. Slower than real key
- *                      repeat to leave room for JS to process.
- *                      Default: 60.
- *   --converge-timeout 10
- *                      After the hammer phase ends, how long to
- *                      wait for the plot to catch up to the slider
- *                      value before declaring a stall.
- *                      Default: 10 seconds.
+ *   --duration 15        How long to hammer the slider (seconds).
+ *   --presses-per-sec 60 Target arrow-key rate.
  */
 
 import { remote } from "webdriverio";
@@ -57,34 +70,35 @@ import { remote } from "webdriverio";
 const WEBDRIVER_PORT = Number(process.env.WEBDRIVER_PORT || 4445);
 const DURATION_SECS = Number(argFlag("--duration", 15));
 const PRESSES_PER_SEC = Number(argFlag("--presses-per-sec", 60));
-const CONVERGE_TIMEOUT_SECS = Number(argFlag("--converge-timeout", 10));
 
 function argFlag(name, fallback) {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : fallback;
 }
 
+// Minimal widget that exercises the RuntimeStateSync path without
+// needing matplotlib, numpy, an interactive backend, or anything
+// else beyond ipywidgets. The on_change handler emits a print line
+// so the cell output itself tells us whether the kernel is getting
+// updates.
 const SLIDER_CELL_SOURCE = `
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
-from ipywidgets import interact, FloatSlider
+from ipywidgets import FloatSlider, Output
+from IPython.display import display
 
-@interact(freq=FloatSlider(min=0.5, max=5.0, step=0.01, value=1.0, description="Frequency"))
-def plot(freq):
-    x = np.linspace(0, 2 * np.pi, 200)
-    plt.figure(figsize=(8, 4))
-    plt.plot(x, np.sin(freq * x))
-    plt.title(f"sin({freq:.2f}x)")
-    plt.ylim(-1.5, 1.5)
-    plt.show()
+_slider = FloatSlider(min=0.0, max=1000.0, step=1.0, value=0.0, description="drive")
+_out = Output()
+
+@_out.capture(clear_output=True, wait=True)
+def _on_change(change):
+    print(f"kernel_saw={int(change['new'])}")
+
+_slider.observe(_on_change, names='value')
+display(_slider, _out)
 `.trim();
 
 async function main() {
   console.log(`[slider-stall] WebDriver on port ${WEBDRIVER_PORT}`);
   console.log(`[slider-stall] hammer: ${DURATION_SECS}s @ ${PRESSES_PER_SEC} Hz`);
-  console.log(`[slider-stall] converge timeout: ${CONVERGE_TIMEOUT_SECS}s`);
 
   const browser = await remote({
     hostname: "localhost",
@@ -118,7 +132,7 @@ async function main() {
     );
     console.log("[slider-stall] kernel ready");
 
-    // 3. Drop the slider cell into the first code cell
+    // 3. Drop the widget cell source into the first code cell.
     const setOk = await browser.execute((src) => {
       const cells = document.querySelectorAll('[data-cell-type="code"]');
       const cell = cells[0];
@@ -132,9 +146,7 @@ async function main() {
       });
       return true;
     }, SLIDER_CELL_SOURCE);
-    if (!setOk) {
-      throw new Error("failed to set cell source");
-    }
+    if (!setOk) throw new Error("failed to set cell source");
     console.log("[slider-stall] cell source set");
 
     // 4. Execute
@@ -147,138 +159,89 @@ async function main() {
     });
     if (!execOk) throw new Error("failed to click execute");
 
-    // 5. Wait for the slider widget to render inside the cell's output
-    //    iframe. The widget is rendered inside the isolated iframe;
-    //    we find it by the FloatSlider component's `role="slider"`
-    //    attribute (ipywidgets renders an <input type="range"> which
-    //    reports that role natively).
+    // 5. The widget lives inside an isolated iframe. We can't see its
+    //    DOM from the parent (`allow-same-origin` is intentionally
+    //    off), but WebDriver's `switchToFrame` is a driver-level
+    //    operation that works regardless of the sandbox.
+    //
+    //    Wait for an iframe to appear at all, then switch into it
+    //    and wait for the slider to render.
     await browser.waitUntil(
-      async () => {
-        return await browser.execute(() => {
-          // Search inside all iframes for a slider input.
-          // biome-ignore lint/suspicious/noExplicitAny: iframe contentWindow is platform
-          const iframes = document.querySelectorAll("iframe");
-          for (const f of iframes) {
-            try {
-              const doc = f.contentDocument;
-              if (!doc) continue;
-              const slider = doc.querySelector('input[type="range"], [role="slider"]');
-              if (slider) return true;
-            } catch {
-              // cross-origin iframe, skip
-            }
-          }
-          return false;
-        });
-      },
-      { timeout: 60000, interval: 500, timeoutMsg: "slider not rendered" },
+      async () => (await browser.$$("iframe")).length > 0,
+      { timeout: 60000, interval: 500, timeoutMsg: "no output iframe" },
     );
+    console.log("[slider-stall] iframe present");
+
+    // Try each iframe; the right one has the slider. Fail loudly if
+    // none have it after the timeout — most likely cause is
+    // ipywidgets not being installed in the notebook env.
+    const iframeHandles = await browser.$$("iframe");
+    let sliderFrame = null;
+    for (const frame of iframeHandles) {
+      try {
+        await browser.switchToFrame(frame);
+        const sliderExists = await browser.execute(
+          () => !!document.querySelector('input[type="range"], [role="slider"]'),
+        );
+        if (sliderExists) {
+          sliderFrame = frame;
+          break;
+        }
+      } catch {
+        // cross-origin, driver can sometimes refuse the switch
+      } finally {
+        await browser.switchToParentFrame();
+      }
+    }
+
+    if (!sliderFrame) {
+      // Widget didn't render. Read the cell output to surface
+      // whatever actually happened (usually ModuleNotFoundError).
+      const outputText = await browser.execute(() => {
+        const cells = document.querySelectorAll('[data-cell-type="code"]');
+        return cells[0]?.textContent?.slice(0, 500) ?? "";
+      });
+      throw new Error(
+        `slider did not render within 60s. First cell text: ${outputText}`,
+      );
+    }
     console.log("[slider-stall] slider rendered");
 
-    // 6. Focus the slider and hammer ArrowRight keypresses.
-    //    We use `view.actions()` style keydowns on the input element
-    //    for genuine key events (not synthetic dispatchEvent, which
-    //    bypasses the React handler the real UI uses).
-    await browser.execute(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: same escape hatch as above
-      const iframes = document.querySelectorAll("iframe");
-      for (const f of iframes) {
-        try {
-          const doc = f.contentDocument;
-          const slider = doc?.querySelector('input[type="range"], [role="slider"]');
-          if (slider instanceof HTMLElement) {
-            slider.focus();
-            return true;
-          }
-        } catch {}
-      }
-      return false;
-    });
+    // 6. Switch into the iframe, focus the slider, hammer keys.
+    await browser.switchToFrame(sliderFrame);
+    const sliderEl = await browser.$('input[type="range"], [role="slider"]');
+    await sliderEl.click();
 
     console.log("[slider-stall] hammer phase starting");
-    const intervalMs = Math.max(1, Math.floor(1000 / PRESSES_PER_SEC));
     const end = Date.now() + DURATION_SECS * 1000;
+    const intervalMs = Math.max(1, Math.floor(1000 / PRESSES_PER_SEC));
     let presses = 0;
     while (Date.now() < end) {
       await browser.keys(["ArrowRight"]);
       presses++;
-      // Yield so the event loop can drain React work between presses.
       if (presses % 10 === 0) await browser.pause(intervalMs);
     }
-    const hammerMs = Date.now() - (end - DURATION_SECS * 1000);
+    const hammerMs = DURATION_SECS * 1000;
     console.log(
       `[slider-stall] hammer done: ${presses} ArrowRight presses in ${hammerMs}ms` +
         ` (${((presses * 1000) / hammerMs).toFixed(1)} Hz)`,
     );
 
-    // 7. Convergence check. Read slider value + plot title. They
-    //    should match within a step or two of each other; if the
-    //    plot title is frozen at a low value while the slider is
-    //    high, the stall reproduced.
-    const readState = async () => {
-      return await browser.execute(() => {
-        // biome-ignore lint/suspicious/noExplicitAny: ditto
-        const iframes = document.querySelectorAll("iframe");
-        for (const f of iframes) {
-          try {
-            const doc = f.contentDocument;
-            if (!doc) continue;
-            const slider = doc.querySelector('input[type="range"], [role="slider"]');
-            if (!slider) continue;
-            const sliderValue = Number(
-              // biome-ignore lint/suspicious/noExplicitAny: ditto
-              (slider).getAttribute("aria-valuenow") ??
-                (slider).value ??
-                "NaN",
-            );
-            // Plot title rendered as SVG text usually; fall back to
-            // searching text content for "sin(".
-            const titleEl = doc.querySelector("svg text, .plot-title");
-            const titleText = titleEl?.textContent ?? doc.body?.textContent ?? "";
-            const match = titleText.match(/sin\(([-\d.]+)x\)/);
-            const plotValue = match ? Number(match[1]) : null;
-            return { sliderValue, plotValue, titleText: match?.[0] ?? null };
-          } catch {}
-        }
-        return null;
-      });
-    };
+    // Report the slider's post-hammer aria-valuenow for context.
+    const finalSliderValue = await browser.execute(() => {
+      const s = document.querySelector('input[type="range"], [role="slider"]');
+      // biome-ignore lint/suspicious/noExplicitAny: permissive DOM probe
+      return s?.getAttribute("aria-valuenow") ?? s?.value ?? null;
+    });
 
-    const convergeStart = Date.now();
-    const convergeDeadline = convergeStart + CONVERGE_TIMEOUT_SECS * 1000;
-    let lastState = null;
-    let converged = false;
-    while (Date.now() < convergeDeadline) {
-      const state = await readState();
-      if (state) {
-        lastState = state;
-        if (
-          state.plotValue != null &&
-          Math.abs(state.sliderValue - state.plotValue) < 0.05
-        ) {
-          converged = true;
-          break;
-        }
-      }
-      await browser.pause(100);
-    }
-    const convergeMs = Date.now() - convergeStart;
+    await browser.switchToParentFrame();
 
-    console.log("[slider-stall] ===================");
-    if (converged) {
-      console.log(
-        `[slider-stall] converged after ${convergeMs}ms: slider=${lastState?.sliderValue}, plot=${lastState?.plotValue}`,
-      );
-    } else {
-      console.log(
-        `[slider-stall] DID NOT CONVERGE within ${CONVERGE_TIMEOUT_SECS}s: ` +
-          `slider=${lastState?.sliderValue} plot=${lastState?.plotValue} title=${lastState?.titleText}`,
-      );
-      console.log(
-        "[slider-stall] this is the stall signature. Check runtimed.log + notebook.log for [frame-trace] lines.",
-      );
-      process.exitCode = 1;
-    }
+    console.log(
+      `[slider-stall] slider aria-valuenow after hammer: ${finalSliderValue}`,
+    );
+    console.log(
+      `[slider-stall] done. grep notebook.log + runtimed.log for '[frame-trace]' to see the sync traffic.`,
+    );
   } finally {
     await browser.deleteSession();
   }

--- a/e2e/slider-stall-repro.mjs
+++ b/e2e/slider-stall-repro.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Widget-sync stall reproducer.
+ *
+ * Drives the same input pattern that reproduces the slider stall in
+ * manual testing — a `matplotlib @interact FloatSlider` with rapid
+ * arrow-key input — but does it headlessly via WebDriver so it can be
+ * iterated on without someone sitting at a keyboard.
+ *
+ * What it does:
+ *
+ * 1. Waits for the Tauri app + daemon + kernel to all be ready.
+ * 2. Drops a `matplotlib @interact` cell into the first code cell.
+ * 3. Executes the cell so the widget renders.
+ * 4. Finds the FloatSlider thumb and hammers ArrowRight key presses
+ *    at up to ~60Hz (matching OS key-repeat for arrow keys).
+ * 5. Watches the rendered plot title (which shows `sin(X.YYx)`) and
+ *    compares to the slider value. They should converge quickly
+ *    after key presses stop. A gap that never closes is the stall.
+ *
+ * Paired with the `[frame-trace]` instrumentation in #1884 + #1886,
+ * running this with `RUST_LOG=trace` gives a complete timeline of
+ * where the stall happens when it does.
+ *
+ * Prereqs (see e2e/README.md for context):
+ *
+ *   # Build the app with the e2e-webdriver feature:
+ *   cargo build --features e2e-webdriver -p notebook
+ *
+ *   # Start the dev daemon (in a separate terminal):
+ *   cargo xtask dev-daemon
+ *
+ *   # Start the app with a scratch notebook (in a separate terminal).
+ *   # Path doesn't matter — we rewrite the first cell.
+ *   RUST_LOG=trace ./target/debug/notebook notebooks/scratch.ipynb
+ *
+ *   # Then run this harness:
+ *   node e2e/slider-stall-repro.mjs
+ *
+ * Options:
+ *
+ *   --duration 30      How long to hammer the slider (seconds).
+ *                      Default: 15.
+ *   --presses-per-sec 60
+ *                      Target arrow-key rate. Slower than real key
+ *                      repeat to leave room for JS to process.
+ *                      Default: 60.
+ *   --converge-timeout 10
+ *                      After the hammer phase ends, how long to
+ *                      wait for the plot to catch up to the slider
+ *                      value before declaring a stall.
+ *                      Default: 10 seconds.
+ */
+
+import { remote } from "webdriverio";
+
+const WEBDRIVER_PORT = Number(process.env.WEBDRIVER_PORT || 4445);
+const DURATION_SECS = Number(argFlag("--duration", 15));
+const PRESSES_PER_SEC = Number(argFlag("--presses-per-sec", 60));
+const CONVERGE_TIMEOUT_SECS = Number(argFlag("--converge-timeout", 10));
+
+function argFlag(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const SLIDER_CELL_SOURCE = `
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from ipywidgets import interact, FloatSlider
+
+@interact(freq=FloatSlider(min=0.5, max=5.0, step=0.01, value=1.0, description="Frequency"))
+def plot(freq):
+    x = np.linspace(0, 2 * np.pi, 200)
+    plt.figure(figsize=(8, 4))
+    plt.plot(x, np.sin(freq * x))
+    plt.title(f"sin({freq:.2f}x)")
+    plt.ylim(-1.5, 1.5)
+    plt.show()
+`.trim();
+
+async function main() {
+  console.log(`[slider-stall] WebDriver on port ${WEBDRIVER_PORT}`);
+  console.log(`[slider-stall] hammer: ${DURATION_SECS}s @ ${PRESSES_PER_SEC} Hz`);
+  console.log(`[slider-stall] converge timeout: ${CONVERGE_TIMEOUT_SECS}s`);
+
+  const browser = await remote({
+    hostname: "localhost",
+    port: WEBDRIVER_PORT,
+    capabilities: {},
+    logLevel: "warn",
+  });
+
+  try {
+    // 1. App + sync
+    await browser.waitUntil(
+      () =>
+        browser.execute(() => {
+          const el = document.querySelector("[data-notebook-synced]");
+          return el?.getAttribute("data-notebook-synced") === "true";
+        }),
+      { timeout: 30000, interval: 500, timeoutMsg: "notebook not synced" },
+    );
+    console.log("[slider-stall] notebook synced");
+
+    // 2. Kernel
+    await browser.waitUntil(
+      async () => {
+        const status = await browser.execute(() => {
+          const el = document.querySelector("[data-testid='kernel-status']");
+          return el?.textContent?.toLowerCase() || "";
+        });
+        return status === "idle" || status === "busy";
+      },
+      { timeout: 120000, interval: 500, timeoutMsg: "kernel not ready" },
+    );
+    console.log("[slider-stall] kernel ready");
+
+    // 3. Drop the slider cell into the first code cell
+    const setOk = await browser.execute((src) => {
+      const cells = document.querySelectorAll('[data-cell-type="code"]');
+      const cell = cells[0];
+      if (!cell) return false;
+      const cm = cell.querySelector(".cm-content");
+      // biome-ignore lint/suspicious/noExplicitAny: CodeMirror view escape hatch
+      const view = cm?.cmView?.view;
+      if (!view) return false;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: src },
+      });
+      return true;
+    }, SLIDER_CELL_SOURCE);
+    if (!setOk) {
+      throw new Error("failed to set cell source");
+    }
+    console.log("[slider-stall] cell source set");
+
+    // 4. Execute
+    const execOk = await browser.execute(() => {
+      const cells = document.querySelectorAll('[data-cell-type="code"]');
+      const btn = cells[0].querySelector('[data-testid="execute-button"]');
+      if (!btn) return false;
+      btn.click();
+      return true;
+    });
+    if (!execOk) throw new Error("failed to click execute");
+
+    // 5. Wait for the slider widget to render inside the cell's output
+    //    iframe. The widget is rendered inside the isolated iframe;
+    //    we find it by the FloatSlider component's `role="slider"`
+    //    attribute (ipywidgets renders an <input type="range"> which
+    //    reports that role natively).
+    await browser.waitUntil(
+      async () => {
+        return await browser.execute(() => {
+          // Search inside all iframes for a slider input.
+          // biome-ignore lint/suspicious/noExplicitAny: iframe contentWindow is platform
+          const iframes = document.querySelectorAll("iframe");
+          for (const f of iframes) {
+            try {
+              const doc = f.contentDocument;
+              if (!doc) continue;
+              const slider = doc.querySelector('input[type="range"], [role="slider"]');
+              if (slider) return true;
+            } catch {
+              // cross-origin iframe, skip
+            }
+          }
+          return false;
+        });
+      },
+      { timeout: 60000, interval: 500, timeoutMsg: "slider not rendered" },
+    );
+    console.log("[slider-stall] slider rendered");
+
+    // 6. Focus the slider and hammer ArrowRight keypresses.
+    //    We use `view.actions()` style keydowns on the input element
+    //    for genuine key events (not synthetic dispatchEvent, which
+    //    bypasses the React handler the real UI uses).
+    await browser.execute(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: same escape hatch as above
+      const iframes = document.querySelectorAll("iframe");
+      for (const f of iframes) {
+        try {
+          const doc = f.contentDocument;
+          const slider = doc?.querySelector('input[type="range"], [role="slider"]');
+          if (slider instanceof HTMLElement) {
+            slider.focus();
+            return true;
+          }
+        } catch {}
+      }
+      return false;
+    });
+
+    console.log("[slider-stall] hammer phase starting");
+    const intervalMs = Math.max(1, Math.floor(1000 / PRESSES_PER_SEC));
+    const end = Date.now() + DURATION_SECS * 1000;
+    let presses = 0;
+    while (Date.now() < end) {
+      await browser.keys(["ArrowRight"]);
+      presses++;
+      // Yield so the event loop can drain React work between presses.
+      if (presses % 10 === 0) await browser.pause(intervalMs);
+    }
+    const hammerMs = Date.now() - (end - DURATION_SECS * 1000);
+    console.log(
+      `[slider-stall] hammer done: ${presses} ArrowRight presses in ${hammerMs}ms` +
+        ` (${((presses * 1000) / hammerMs).toFixed(1)} Hz)`,
+    );
+
+    // 7. Convergence check. Read slider value + plot title. They
+    //    should match within a step or two of each other; if the
+    //    plot title is frozen at a low value while the slider is
+    //    high, the stall reproduced.
+    const readState = async () => {
+      return await browser.execute(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: ditto
+        const iframes = document.querySelectorAll("iframe");
+        for (const f of iframes) {
+          try {
+            const doc = f.contentDocument;
+            if (!doc) continue;
+            const slider = doc.querySelector('input[type="range"], [role="slider"]');
+            if (!slider) continue;
+            const sliderValue = Number(
+              // biome-ignore lint/suspicious/noExplicitAny: ditto
+              (slider).getAttribute("aria-valuenow") ??
+                (slider).value ??
+                "NaN",
+            );
+            // Plot title rendered as SVG text usually; fall back to
+            // searching text content for "sin(".
+            const titleEl = doc.querySelector("svg text, .plot-title");
+            const titleText = titleEl?.textContent ?? doc.body?.textContent ?? "";
+            const match = titleText.match(/sin\(([-\d.]+)x\)/);
+            const plotValue = match ? Number(match[1]) : null;
+            return { sliderValue, plotValue, titleText: match?.[0] ?? null };
+          } catch {}
+        }
+        return null;
+      });
+    };
+
+    const convergeStart = Date.now();
+    const convergeDeadline = convergeStart + CONVERGE_TIMEOUT_SECS * 1000;
+    let lastState = null;
+    let converged = false;
+    while (Date.now() < convergeDeadline) {
+      const state = await readState();
+      if (state) {
+        lastState = state;
+        if (
+          state.plotValue != null &&
+          Math.abs(state.sliderValue - state.plotValue) < 0.05
+        ) {
+          converged = true;
+          break;
+        }
+      }
+      await browser.pause(100);
+    }
+    const convergeMs = Date.now() - convergeStart;
+
+    console.log("[slider-stall] ===================");
+    if (converged) {
+      console.log(
+        `[slider-stall] converged after ${convergeMs}ms: slider=${lastState?.sliderValue}, plot=${lastState?.plotValue}`,
+      );
+    } else {
+      console.log(
+        `[slider-stall] DID NOT CONVERGE within ${CONVERGE_TIMEOUT_SECS}s: ` +
+          `slider=${lastState?.sliderValue} plot=${lastState?.plotValue} title=${lastState?.titleText}`,
+      );
+      console.log(
+        "[slider-stall] this is the stall signature. Check runtimed.log + notebook.log for [frame-trace] lines.",
+      );
+      process.exitCode = 1;
+    }
+  } finally {
+    await browser.deleteSession();
+  }
+}
+
+main().catch((err) => {
+  console.error("[slider-stall] FAILED:", err?.message || err);
+  process.exit(1);
+});

--- a/e2e/slider-stall-repro.mjs
+++ b/e2e/slider-stall-repro.mjs
@@ -132,31 +132,65 @@ async function main() {
     );
     console.log("[slider-stall] kernel ready");
 
-    // 3. Drop the widget cell source into the first code cell.
-    const setOk = await browser.execute((src) => {
-      const cells = document.querySelectorAll('[data-cell-type="code"]');
-      const cell = cells[0];
-      if (!cell) return false;
-      const cm = cell.querySelector(".cm-content");
-      // biome-ignore lint/suspicious/noExplicitAny: CodeMirror view escape hatch
-      const view = cm?.cmView?.view;
-      if (!view) return false;
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: src },
-      });
-      return true;
-    }, SLIDER_CELL_SOURCE);
+    // 3. Find the visually-topmost code cell and hold onto its
+    //    `data-cell-id`. NotebookView keeps DOM order stable by
+    //    cell id (for iframe-reload avoidance) and uses CSS
+    //    `order` for the visual position the user sees, so
+    //    NodeList index is NOT the visual order. Additionally, if
+    //    the notebook starts with a markdown cell, the code cell
+    //    is not the first `<div>` sibling — `:first-of-type`
+    //    selectors won't match. Scope everything by cell id
+    //    instead so the rewrite, execute, and iframe lookup all
+    //    target the same cell.
+    const targetCellId = await browser.execute(() => {
+      const codeCells = Array.from(
+        document.querySelectorAll('[data-cell-type="code"]'),
+      );
+      if (codeCells.length === 0) return null;
+      // Pick the lowest CSS `order` value. Ties break by DOM order.
+      const withOrder = codeCells.map((el, i) => ({
+        id: el.getAttribute("data-cell-id"),
+        order: Number.parseInt(getComputedStyle(el).order, 10) || 0,
+        i,
+      }));
+      withOrder.sort((a, b) => a.order - b.order || a.i - b.i);
+      return withOrder[0]?.id ?? null;
+    });
+    if (!targetCellId) {
+      throw new Error("no code cells found");
+    }
+    console.log(`[slider-stall] target cell: ${targetCellId}`);
+
+    const cellSelector = `[data-cell-id="${targetCellId}"]`;
+
+    // Drop the widget cell source into the target cell.
+    const setOk = await browser.execute(
+      (sel, src) => {
+        const cell = document.querySelector(sel);
+        if (!cell) return false;
+        const cm = cell.querySelector(".cm-content");
+        // biome-ignore lint/suspicious/noExplicitAny: CodeMirror view escape hatch
+        const view = cm?.cmView?.view;
+        if (!view) return false;
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: src },
+        });
+        return true;
+      },
+      cellSelector,
+      SLIDER_CELL_SOURCE,
+    );
     if (!setOk) throw new Error("failed to set cell source");
     console.log("[slider-stall] cell source set");
 
     // 4. Execute
-    const execOk = await browser.execute(() => {
-      const cells = document.querySelectorAll('[data-cell-type="code"]');
-      const btn = cells[0].querySelector('[data-testid="execute-button"]');
+    const execOk = await browser.execute((sel) => {
+      const cell = document.querySelector(sel);
+      const btn = cell?.querySelector('[data-testid="execute-button"]');
       if (!btn) return false;
       btn.click();
       return true;
-    });
+    }, cellSelector);
     if (!execOk) throw new Error("failed to click execute");
 
     // 5. The widget lives inside an isolated iframe. We can't see its
@@ -171,9 +205,11 @@ async function main() {
     const deadline = Date.now() + 60000;
     let sliderFrame = null;
     while (Date.now() < deadline) {
-      const cellIframes = await browser.$$(
-        '[data-cell-type="code"]:first-of-type iframe',
-      );
+      // Scope strictly to the cell we just rewrote — not by DOM
+      // position (`:first-of-type` fails when a non-code cell
+      // precedes this one) or global iframe scan (could pick up a
+      // stale render from another cell).
+      const cellIframes = await browser.$$(`${cellSelector} iframe`);
       for (const frame of cellIframes) {
         try {
           await browser.switchToFrame(frame);
@@ -196,19 +232,21 @@ async function main() {
     }
 
     if (!sliderFrame) {
-      // Widget didn't render in the first cell. Read the cell text
+      // Widget didn't render in the target cell. Read the cell text
       // to surface whatever actually happened (usually
       // ModuleNotFoundError for ipywidgets).
-      const outputText = await browser.execute(() => {
-        const cells = document.querySelectorAll('[data-cell-type="code"]');
-        return cells[0]?.textContent?.slice(0, 500) ?? "";
-      });
+      const outputText = await browser.execute((sel) => {
+        const cell = document.querySelector(sel);
+        return cell?.textContent?.slice(0, 500) ?? "";
+      }, cellSelector);
       throw new Error(
-        `slider did not render within 60s in the first cell. ` +
+        `slider did not render within 60s in target cell ${targetCellId}. ` +
           `Cell text: ${outputText}`,
       );
     }
-    console.log("[slider-stall] slider rendered (in first cell's iframe)");
+    console.log(
+      `[slider-stall] slider rendered (inside cell ${targetCellId}'s iframe)`,
+    );
 
     // 6. Focus the slider, hammer keys. Already in the iframe
     //    context from the discovery loop above.

--- a/e2e/slider-stall-repro.mjs
+++ b/e2e/slider-stall-repro.mjs
@@ -164,62 +164,72 @@ async function main() {
     //    off), but WebDriver's `switchToFrame` is a driver-level
     //    operation that works regardless of the sandbox.
     //
-    //    Wait for an iframe to appear at all, then switch into it
-    //    and wait for the slider to render.
-    await browser.waitUntil(
-      async () => (await browser.$$("iframe")).length > 0,
-      { timeout: 60000, interval: 500, timeoutMsg: "no output iframe" },
-    );
-    console.log("[slider-stall] iframe present");
-
-    // Try each iframe; the right one has the slider. Fail loudly if
-    // none have it after the timeout — most likely cause is
-    // ipywidgets not being installed in the notebook env.
-    const iframeHandles = await browser.$$("iframe");
+    //    Look specifically inside the FIRST cell (the one we just
+    //    rewrote + executed). Scanning the global iframe list can
+    //    pick up stale outputs from other cells if the notebook
+    //    already had widget renders before we overwrote the cell.
+    const deadline = Date.now() + 60000;
     let sliderFrame = null;
-    for (const frame of iframeHandles) {
-      try {
-        await browser.switchToFrame(frame);
-        const sliderExists = await browser.execute(
-          () => !!document.querySelector('input[type="range"], [role="slider"]'),
-        );
-        if (sliderExists) {
-          sliderFrame = frame;
-          break;
+    while (Date.now() < deadline) {
+      const cellIframes = await browser.$$(
+        '[data-cell-type="code"]:first-of-type iframe',
+      );
+      for (const frame of cellIframes) {
+        try {
+          await browser.switchToFrame(frame);
+          const sliderExists = await browser.execute(
+            () =>
+              !!document.querySelector('input[type="range"], [role="slider"]'),
+          );
+          if (sliderExists) {
+            sliderFrame = frame;
+            break;
+          }
+        } catch {
+          // driver may refuse switch on some frames; skip
+        } finally {
+          if (!sliderFrame) await browser.switchToParentFrame();
         }
-      } catch {
-        // cross-origin, driver can sometimes refuse the switch
-      } finally {
-        await browser.switchToParentFrame();
       }
+      if (sliderFrame) break;
+      await browser.pause(300);
     }
 
     if (!sliderFrame) {
-      // Widget didn't render. Read the cell output to surface
-      // whatever actually happened (usually ModuleNotFoundError).
+      // Widget didn't render in the first cell. Read the cell text
+      // to surface whatever actually happened (usually
+      // ModuleNotFoundError for ipywidgets).
       const outputText = await browser.execute(() => {
         const cells = document.querySelectorAll('[data-cell-type="code"]');
         return cells[0]?.textContent?.slice(0, 500) ?? "";
       });
       throw new Error(
-        `slider did not render within 60s. First cell text: ${outputText}`,
+        `slider did not render within 60s in the first cell. ` +
+          `Cell text: ${outputText}`,
       );
     }
-    console.log("[slider-stall] slider rendered");
+    console.log("[slider-stall] slider rendered (in first cell's iframe)");
 
-    // 6. Switch into the iframe, focus the slider, hammer keys.
-    await browser.switchToFrame(sliderFrame);
+    // 6. Focus the slider, hammer keys. Already in the iframe
+    //    context from the discovery loop above.
     const sliderEl = await browser.$('input[type="range"], [role="slider"]');
     await sliderEl.click();
 
     console.log("[slider-stall] hammer phase starting");
     const end = Date.now() + DURATION_SECS * 1000;
-    const intervalMs = Math.max(1, Math.floor(1000 / PRESSES_PER_SEC));
+    const intervalMs = 1000 / PRESSES_PER_SEC;
+    // Target-time pacing so the actual rate matches --presses-per-sec
+    // regardless of WebDriver latency (up to a ceiling of "as fast
+    // as WebDriver can go"). Without this, sleeping every N
+    // iterations undershoots the target rate by a factor of N.
+    let nextTick = Date.now();
     let presses = 0;
     while (Date.now() < end) {
       await browser.keys(["ArrowRight"]);
       presses++;
-      if (presses % 10 === 0) await browser.pause(intervalMs);
+      nextTick += intervalMs;
+      const wait = nextTick - Date.now();
+      if (wait > 0) await browser.pause(wait);
     }
     const hammerMs = DURATION_SECS * 1000;
     console.log(

--- a/e2e/slider-stall-repro.mjs
+++ b/e2e/slider-stall-repro.mjs
@@ -81,11 +81,16 @@ function argFlag(name, fallback) {
 // else beyond ipywidgets. The on_change handler emits a print line
 // so the cell output itself tells us whether the kernel is getting
 // updates.
+// Slider range is generous so long runs (`--duration` * `--presses-per-sec`)
+// don't saturate the max and fall off the end of the widget's range,
+// which would stop generating CRDT writes and look like a stall.
+const SLIDER_MAX = 1_000_000;
+
 const SLIDER_CELL_SOURCE = `
 from ipywidgets import FloatSlider, Output
 from IPython.display import display
 
-_slider = FloatSlider(min=0.0, max=1000.0, step=1.0, value=0.0, description="drive")
+_slider = FloatSlider(min=0.0, max=${SLIDER_MAX}.0, step=1.0, value=0.0, description="drive")
 _out = Output()
 
 @_out.capture(clear_output=True, wait=True)
@@ -163,14 +168,17 @@ async function main() {
 
     const cellSelector = `[data-cell-id="${targetCellId}"]`;
 
-    // Drop the widget cell source into the target cell.
+    // Drop the widget cell source into the target cell. CM6 attaches
+    // the `EditorView` to `.cm-content.cmTile.view` (not `.cmView.view`
+    // — that path exists in some older snippets but is not what's
+    // wired up here, see `e2e/helpers.js` `setCellSource`).
     const setOk = await browser.execute(
       (sel, src) => {
         const cell = document.querySelector(sel);
         if (!cell) return false;
-        const cm = cell.querySelector(".cm-content");
+        const cm = cell.querySelector(".cm-content[contenteditable]");
         // biome-ignore lint/suspicious/noExplicitAny: CodeMirror view escape hatch
-        const view = cm?.cmView?.view;
+        const view = cm?.cmTile?.view;
         if (!view) return false;
         view.dispatch({
           changes: { from: 0, to: view.state.doc.length, insert: src },
@@ -192,6 +200,32 @@ async function main() {
       return true;
     }, cellSelector);
     if (!execOk) throw new Error("failed to click execute");
+
+    // Wait for the kernel to actually run the cell (busy → idle). If
+    // the cell had a stale widget iframe, it'll be cleared on
+    // execution start, so after this wait the iframe we find is
+    // guaranteed to be fresh.
+    await browser.waitUntil(
+      async () => {
+        const status = await browser.execute(() => {
+          const el = document.querySelector("[data-testid='kernel-status']");
+          return el?.textContent?.toLowerCase() || "";
+        });
+        return status === "busy";
+      },
+      { timeout: 30000, interval: 200, timeoutMsg: "kernel didn't go busy" },
+    );
+    await browser.waitUntil(
+      async () => {
+        const status = await browser.execute(() => {
+          const el = document.querySelector("[data-testid='kernel-status']");
+          return el?.textContent?.toLowerCase() || "";
+        });
+        return status === "idle";
+      },
+      { timeout: 60000, interval: 200, timeoutMsg: "kernel didn't go idle" },
+    );
+    console.log("[slider-stall] cell executed (kernel busy → idle)");
 
     // 5. The widget lives inside an isolated iframe. We can't see its
     //    DOM from the parent (`allow-same-origin` is intentionally


### PR DESCRIPTION
Headless harness I can iterate with to reproduce the widget-sync stall — so diagnosis stops depending on someone at a keyboard.

## What

`e2e/slider-stall-repro.mjs` — standalone WebDriverIO script in the same style as `e2e/stress-sync.mjs`. Drives the Tauri app via the `e2e-webdriver` feature's built-in WebDriver server on port 4445.

Steps:

1. Waits for the notebook + kernel to be ready.
2. Rewrites the first cell to a matplotlib `@interact FloatSlider` scenario.
3. Executes the cell → slider renders inside the output iframe.
4. Focuses the slider, hammers `ArrowRight` at ~60 Hz for a configurable duration.
5. Reads both the slider value and the plot title (`sin(X.YYx)`) from the iframe DOM. They should converge within a step after hammering ends. A persistent gap is the stall signature.

Exit code is `1` on non-convergence, so a CI job or a watch loop can detect it.

## How to run

Prereqs in `e2e/README.md` apply. Quick form:

```bash
cargo build --features e2e-webdriver -p notebook
cargo xtask dev-daemon                                     # terminal 1
RUST_LOG=trace ./target/debug/notebook <scratch.ipynb>     # terminal 2
node e2e/slider-stall-repro.mjs                            # terminal 3
```

Pairs with the frame-trace instrumentation in #1884 (app/webview) and #1886 (daemon). With `RUST_LOG=trace` on both sides, running this harness produces an end-to-end `[frame-trace]` timeline in the logs that localizes the stall.

## Why standalone (not a WebdriverIO spec)

Same reasoning as `stress-sync.mjs`: it's a reproducer, not a correctness regression. Running it via the full `pnpm test:e2e:native` would miss the point — we want to poke at it, tweak parameters, watch logs.

## Test plan

- [x] `cargo xtask lint` clean
- [ ] Run once end-to-end against a live app to confirm it reaches all the waits and produces either converged or stall output.

## Follow-ups if useful

- A flag to dump the `[frame-trace]` counts from the logs alongside the convergence result, so the script output is self-contained rather than needing log grepping.
- A "no kernel" variant that creates a dummy widget via direct RuntimeStateDoc writes — narrower test of just the sync path, faster feedback loop.