### PR TITLE
feat(notebook-host): HostWindow + onFocusChange

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,5 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { NotebookClient } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
@@ -42,6 +40,7 @@ import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
 import { getBlobPort, useBlobPort } from "./lib/blob-port";
+import { subscribeBroadcast } from "./lib/notebook-frame-bus";
 import {
   flushCellUIState,
   setExecutingCellIds as storeSetExecutingCellIds,
@@ -126,6 +125,7 @@ function resolveCommOutputs(
 }
 
 function AppContent() {
+  const host = useNotebookHost();
   const gitInfo = useGitInfo();
   const daemonInfo = useDaemonInfo();
 
@@ -151,8 +151,8 @@ function AppContent() {
   // Re-establish CodeMirror input context on window reactivation.
   // Without this, WKWebView may drop the first few keystrokes after Cmd+Tab.
   useEffect(() => {
-    return startWindowFocusHandler();
-  }, []);
+    return startWindowFocusHandler(host);
+  }, [host]);
 
   const {
     cellIds,
@@ -230,6 +230,19 @@ function AppContent() {
   const [runtimeHint, setRuntimeHint] = useState<string | null>(null);
   const runtime = detectedRuntime ?? runtimeHint;
 
+  // `true` when the room is in-memory only (untitled); reported by the daemon
+  // via `daemon:ready`. Drives the always-dirty titlebar asterisk. Null until
+  // the first ready event lands — treated conservatively as "unknown, assume
+  // persisted" so we don't flash an asterisk on open-from-disk notebooks.
+  const [ephemeral, setEphemeral] = useState<boolean | null>(null);
+
+  // Canonical window-title base. Bootstrapped from the host on mount (Rust
+  // sets it to the filename or "Untitled.ipynb" at window creation), then
+  // updated on `path_changed` broadcasts. Used to compute the title asterisk
+  // without a getTitle-then-setTitle round-trip that would race with the
+  // concurrent Rust-side title update from `applyPathChanged`.
+  const [titleBase, setTitleBase] = useState<string | null>(null);
+
   // Auto-clear justSynced after 3 seconds
   useEffect(() => {
     if (!justSynced) return;
@@ -292,7 +305,6 @@ function AppContent() {
   // NotebookClient for sending kernel commands via transport. The host's
   // transport is the single instance shared with the SyncEngine in
   // useAutomergeNotebook — no more separate connection per consumer.
-  const host = useNotebookHost();
   const notebookClient = useMemo(() => new NotebookClient({ transport: host.transport }), [host]);
 
   // Daemon-owned kernel execution
@@ -834,28 +846,43 @@ function AppContent() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [save]);
 
-  // Show asterisk in window title when notebook has unsaved changes.
-  // Untitled notebooks (no file path) always show the asterisk.
+  // Derive a filename + ephemeral flag from a path (or its absence). Shared
+  // between the mount-time `getReadyInfo` pull, the `daemon:ready` event, and
+  // the `path_changed` broadcast. Keeping all three paths identical prevents
+  // "one of them forgot to update titleBase" bugs.
+  const applyNotebookPath = useCallback((path: string | null | undefined) => {
+    if (path) {
+      const parts = path.split(/[\\/]/);
+      setTitleBase(parts[parts.length - 1] || "Untitled.ipynb");
+      setEphemeral(false);
+    } else {
+      setTitleBase("Untitled.ipynb");
+      setEphemeral(true);
+    }
+  }, []);
+
+  // Path transitions. `path_changed` with a non-null path means the room is
+  // now file-backed — flip ephemeral false and update the title base. A null
+  // path puts the room back into untitled state.
   useEffect(() => {
-    let cancelled = false;
-    const win = getCurrentWindow();
-    (async () => {
-      try {
-        const currentTitle = await win.title();
-        if (cancelled) return;
-        const base = currentTitle.replace(/^\* /, "");
-        const hasPath = await invoke<boolean>("has_notebook_path");
-        if (cancelled) return;
-        const showDirty = dirty || !hasPath;
-        await win.setTitle(showDirty ? `* ${base}` : base);
-      } catch {
-        // Window may have been closed between rapid dirty toggles
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [dirty]);
+    return subscribeBroadcast((payload) => {
+      const b = payload as { event?: string; path?: string | null };
+      if (b.event !== "path_changed") return;
+      applyNotebookPath(b.path);
+    });
+  }, [applyNotebookPath]);
+
+  // Render the asterisk purely from frontend state. `titleBase` is the
+  // filename, `dirty || ephemeral` adds the prefix. One setTitle per change;
+  // no read-then-write race against `applyPathChanged`.
+  useEffect(() => {
+    if (titleBase == null) return;
+    const showDirty = dirty || ephemeral === true;
+    const next = showDirty ? `* ${titleBase}` : titleBase;
+    host.window.setTitle(next).catch(() => {
+      // Window may have been closed between rapid dirty toggles
+    });
+  }, [host, dirty, ephemeral, titleBase]);
 
   // Cmd+F to open global find
   useEffect(() => {
@@ -996,16 +1023,40 @@ function AppContent() {
       });
     });
 
-    // Listen for daemon ready (reconnection success)
-    const unlistenReady = host.daemonEvents.onReady((payload) => {
-      // Clear any status banner when daemon reconnects (failed, checking, etc.)
+    // Shared handler for both the live event and the cached backfill below.
+    // Factored out so the two paths can never drift.
+    const handleReady = (
+      payload:
+        | {
+            runtime?: string;
+            ephemeral?: boolean;
+            notebook_path?: string | null;
+          }
+        | null
+        | undefined,
+    ) => {
       cancelReadyTimeout();
       setDaemonStatus(null);
       // Set or clear the runtime hint — clearing prevents stale hints
       // when a window is reused to open a different notebook (Open path
       // sends runtime: null).
       setRuntimeHint(payload?.runtime ?? null);
-    });
+      // Sync titlebar: derive filename + ephemeral from the path carried
+      // on the ready payload.
+      if (payload) {
+        if (typeof payload.ephemeral === "boolean") {
+          applyNotebookPath(payload.ephemeral ? null : (payload.notebook_path ?? null));
+        } else if (payload.notebook_path !== undefined) {
+          applyNotebookPath(payload.notebook_path);
+        }
+      }
+    };
+
+    // Listen for daemon ready (reconnection success, Finder-reuse of an
+    // untitled window into a file-backed one, etc.). `onReady` internally
+    // also backfills from the Rust-side cache, so a `daemon:ready` that
+    // fired before this subscription still hydrates the state.
+    const unlistenReady = host.daemonEvents.onReady(handleReady);
 
     // Check daemon status on mount (in case events fired before React was ready)
     // Small delay to let initial events settle
@@ -1034,7 +1085,7 @@ function AppContent() {
       unlistenUnavailable();
       unlistenReady();
     };
-  }, [host]);
+  }, [host, applyNotebookPath]);
 
   // Cmd+Shift+I to toggle isolation test panel (dev only)
   useEffect(() => {

--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -19,8 +19,8 @@
  * flicker (no paint occurs between the synchronous blur and focus calls).
  */
 
+import type { NotebookHost } from "@nteract/notebook-host";
 import { EditorView } from "@codemirror/view";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { logger } from "./logger";
 
 // ── State ────────────────────────────────────────────────────────────
@@ -168,7 +168,7 @@ function restoreEditorFocus(): void {
  * Call once at app startup. Returns a cleanup function.
  * Follows the same pattern as {@link startCursorDispatch}.
  */
-export function startWindowFocusHandler(): () => void {
+export function startWindowFocusHandler(host: NotebookHost): () => void {
   // Track which CM editor has focus (capture phase for earliest signal).
   document.addEventListener("focusin", trackEditorFocus, true);
 
@@ -178,18 +178,13 @@ export function startWindowFocusHandler(): () => void {
   window.addEventListener("focus", handleWindowFocus);
   window.addEventListener("blur", handleWindowBlur);
 
-  // Tauri-specific window focus signal as a belt-and-suspenders layer.
-  // Goes through the IPC bridge so it may arrive slightly after the DOM
-  // events, but it's authoritative for Tauri-managed windows.
-  const tauriUnlistenPromise = getCurrentWindow().onFocusChanged(
-    ({ payload: focused }) => {
-      if (focused) {
-        handleWindowFocus();
-      } else {
-        handleWindowBlur();
-      }
-    },
-  );
+  // Host-level focus signal as a belt-and-suspenders layer. May arrive
+  // slightly after the DOM events (IPC hop) but is authoritative for
+  // OS-managed window focus, including transitions DOM events miss.
+  const hostUnlisten = host.window.onFocusChange((focused) => {
+    if (focused) handleWindowFocus();
+    else handleWindowBlur();
+  });
 
   // Visibility change covers minimize / restore and (on some platforms)
   // Mission Control transitions that don't fire window blur/focus.
@@ -209,7 +204,7 @@ export function startWindowFocusHandler(): () => void {
     window.removeEventListener("focus", handleWindowFocus);
     window.removeEventListener("blur", handleWindowBlur);
     document.removeEventListener("visibilitychange", handleVisibility);
-    tauriUnlistenPromise.then((fn) => fn()).catch(() => {});
+    hostUnlisten();
     savedView = null;
     savedSelection = null;
     logger.info("[window-focus] Handler stopped");

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -178,9 +178,16 @@ struct DaemonStatusState(Arc<Mutex<Option<runtimed::client::DaemonProgress>>>);
 ///
 /// On the first connection the relay blocks until the JS calls `notify_sync_ready`.
 /// On reconnection the flag is already `true`, so frames flow immediately.
+///
+/// Also caches the most-recent `daemon:ready` payload per window so that
+/// `notify_sync_ready` can re-emit it for late-mounted JS listeners. Tauri
+/// webview events aren't sticky — if Rust emits `daemon:ready` before the
+/// React tree has called `host.daemonEvents.onReady(...)`, the event is lost.
+/// Re-emitting on sync-ready closes that race.
 #[derive(Clone, Default)]
 struct SyncReadyState {
     senders: Arc<Mutex<HashMap<String, tokio::sync::watch::Sender<bool>>>>,
+    last_ready: Arc<Mutex<HashMap<String, DaemonReadyPayload>>>,
 }
 
 impl SyncReadyState {
@@ -219,6 +226,53 @@ impl SyncReadyState {
             .or_insert_with(|| tokio::sync::watch::channel(false).0);
         tx.subscribe()
     }
+
+    /// Record the most-recent `daemon:ready` payload for this window, so
+    /// late-mounted JS listeners can pull it via `get_daemon_ready_info`.
+    fn record_ready(&self, label: &str, payload: DaemonReadyPayload) {
+        let mut cache = match self.last_ready.lock() {
+            Ok(c) => c,
+            Err(e) => e.into_inner(),
+        };
+        cache.insert(label.to_string(), payload);
+    }
+
+    /// Look up the cached payload on demand. Idempotent — multiple callers
+    /// during startup all see the same value.
+    fn get_cached_ready(&self, label: &str) -> Option<DaemonReadyPayload> {
+        let cache = match self.last_ready.lock() {
+            Ok(c) => c,
+            Err(e) => e.into_inner(),
+        };
+        cache.get(label).cloned()
+    }
+
+    /// Update the cached payload's `ephemeral` + `notebook_path` fields to
+    /// reflect a path transition. Called from `apply_path_changed` so a
+    /// React remount (error boundary, HMR) that hits `get_daemon_ready_info`
+    /// after a save-as/rename sees the *current* path instead of the one
+    /// that happened to be authoritative at initial connect.
+    fn update_cached_path(&self, label: &str, path: Option<&str>) {
+        let mut cache = match self.last_ready.lock() {
+            Ok(c) => c,
+            Err(e) => e.into_inner(),
+        };
+        if let Some(p) = cache.get_mut(label) {
+            p.notebook_path = path.map(|s| s.to_string());
+            p.ephemeral = path.is_none();
+        }
+    }
+
+    /// Drop the cached payload for this window. Called on daemon disconnect
+    /// so a late-mounting `host.daemonEvents.onReady` doesn't see a stale
+    /// "ready" payload while the relay is actually down.
+    fn clear_cached_ready(&self, label: &str) {
+        let mut cache = match self.last_ready.lock() {
+            Ok(c) => c,
+            Err(e) => e.into_inner(),
+        };
+        cache.remove(label);
+    }
 }
 
 use std::path::{Path, PathBuf};
@@ -235,6 +289,16 @@ struct DaemonReadyPayload {
     notebook_id: String,
     cell_count: usize,
     needs_trust_approval: bool,
+    /// Whether this notebook is in-memory only (no on-disk path).
+    /// Drives the always-dirty titlebar asterisk for untitled notebooks
+    /// without a Tauri round-trip.
+    ephemeral: bool,
+    /// On-disk path if the notebook is file-backed. Used by the frontend
+    /// to derive the titlebar filename, including after a Finder-reuse flow
+    /// (macOS opens a file into an existing untitled window — no
+    /// `PathChanged` broadcast fires because the path was set before the
+    /// room was reconnected).
+    notebook_path: Option<String>,
     /// Runtime hint so the frontend can show the correct UI before metadata syncs.
     /// Only set for Create (where we know the exact runtime); None for Open
     /// (where the actual runtime is determined from the file's metadata).
@@ -596,6 +660,7 @@ async fn initialize_notebook_sync_open(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
+    let path_for_payload = path.to_string_lossy().to_string();
     let result = notebook_sync::connect::connect_open_relay(socket_path, path, frame_tx)
         .await
         .map_err(|e| format!("sync connect (open): {}", e))?;
@@ -617,6 +682,8 @@ async fn initialize_notebook_sync_open(
         notebook_id: info.notebook_id.clone(),
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
+        ephemeral: info.ephemeral,
+        notebook_path: Some(path_for_payload),
         runtime: None,
     };
 
@@ -687,6 +754,10 @@ async fn initialize_notebook_sync_create(
         notebook_id: info.notebook_id.clone(),
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
+        ephemeral: info.ephemeral,
+        // Create mode has no on-disk path. If the room was created from a
+        // restored untitled-session snapshot it still has no file backing.
+        notebook_path: None,
         runtime: Some(runtime),
     };
 
@@ -809,6 +880,13 @@ async fn setup_sync_receivers(
                 notebook_id_for_relay, current_generation,
             );
             *notebook_sync_for_disconnect.lock().await = None;
+            // Invalidate the cached `daemon:ready` payload so that a React
+            // remount (HMR / error boundary) while disconnected can't pull
+            // a stale "everything's fine" payload via `get_daemon_ready_info`.
+            window
+                .app_handle()
+                .state::<SyncReadyState>()
+                .clear_cached_ready(window.label());
             if let Err(e) =
                 emit_to_label::<_, _, _>(&window, window.label(), "daemon:disconnected", ())
             {
@@ -826,6 +904,14 @@ async fn setup_sync_receivers(
         "[notebook-sync] Sync receivers established for {}",
         notebook_id,
     );
+
+    // Stash the payload so `notify_sync_ready` can re-emit it for late JS
+    // listeners (Tauri webview events aren't sticky — if `daemon:ready` fires
+    // before React has attached its `onReady` handler, the event is lost).
+    window_for_ready
+        .app_handle()
+        .state::<SyncReadyState>()
+        .record_ready(window_for_ready.label(), ready_payload.clone());
 
     // Emit daemon:ready with connection info so frontend can show loading state / trust prompt
     if let Err(e) = emit_to_label::<_, _, _>(
@@ -1821,6 +1907,7 @@ fn apply_path_changed(
     path: Option<String>,
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
+    sync_ready: tauri::State<'_, SyncReadyState>,
 ) -> Result<(), String> {
     info!(
         "[path-changed] apply_path_changed invoked: path={:?} window={}",
@@ -1840,13 +1927,17 @@ fn apply_path_changed(
         *p = new_path.clone();
     }
 
-    // Update window title to match the new path (or "Untitled" if cleared).
-    let title = new_path
-        .as_deref()
-        .and_then(|p| p.file_name())
-        .and_then(|n| n.to_str())
-        .unwrap_or("Untitled.ipynb");
-    let _ = window.set_title(title);
+    // Keep the cached `daemon:ready` payload's `notebook_path` + `ephemeral`
+    // fields in sync with the new path. Without this, a React remount (error
+    // boundary, HMR) after a save-as would pull stale "untitled" state from
+    // `get_daemon_ready_info` and flip the titlebar back to Untitled.ipynb.
+    sync_ready.update_cached_path(window.label(), path.as_deref());
+
+    // Note: the window title is owned by the frontend (computed from
+    // `titleBase` + `dirty` / `ephemeral` state). We intentionally do NOT
+    // touch `window.set_title(...)` here — a Rust-side write would race
+    // against the frontend's concurrent title update from the same
+    // `path_changed` broadcast and could clobber the dirty asterisk.
 
     Ok(())
 }
@@ -1978,13 +2069,10 @@ async fn save_notebook_as(
         }
     };
 
-    // Update local state — the room is the same, just aliased to a file path now.
-    let filename = saved_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("Untitled.ipynb");
-    let _ = window.set_title(filename);
-
+    // Note: the window title is owned by the frontend — see the
+    // `apply_path_changed` command for the rationale. The frontend's
+    // `path_changed` broadcast subscriber updates `titleBase` and the
+    // title-render effect writes the correct dirty-adjusted title.
     if let Ok(mut p) = context_path.lock() {
         info!(
             "[save-as] context.path mutation: {:?} -> {:?} (window={})",
@@ -2969,6 +3057,24 @@ fn notify_sync_ready(window: tauri::Window, sync_ready: tauri::State<'_, SyncRea
         window.label()
     );
     sync_ready.set_ready(window.label());
+    // Note: we do NOT re-emit `daemon:ready` here. `notifySyncReady()` is
+    // called from `useAutomergeNotebook`, whose useEffect runs BEFORE the
+    // App.tsx useEffects that subscribe to `host.daemonEvents.onReady(...)`.
+    // Replaying on this path would still miss late-mounted listeners.
+    // Instead, `get_daemon_ready_info` lets the frontend pull the cached
+    // payload on demand, after the listener is attached.
+}
+
+/// Returns the most-recent cached `daemon:ready` payload for this window.
+/// Used by the frontend on mount to backfill `ephemeral` / runtime hint /
+/// trust-approval state that may have been emitted before any JS listener
+/// was attached (Tauri webview events are not sticky).
+#[tauri::command]
+fn get_daemon_ready_info(
+    window: tauri::Window,
+    sync_ready: tauri::State<'_, SyncReadyState>,
+) -> Option<DaemonReadyPayload> {
+    sync_ready.get_cached_ready(window.label())
 }
 
 /// Send a typed frame to the daemon.
@@ -4321,6 +4427,7 @@ pub fn run(
             complete_via_daemon,
             reconnect_to_daemon,
             notify_sync_ready,
+            get_daemon_ready_info,
             send_frame,
             // App update support
             begin_upgrade,

--- a/packages/notebook-host/src/index.ts
+++ b/packages/notebook-host/src/index.ts
@@ -13,6 +13,7 @@ export type {
   HostRelay,
   HostSystem,
   HostTrust,
+  HostWindow,
   NotebookHost,
   TrustInfo,
   TyposquatWarning,

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -15,6 +15,7 @@
 
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   attachConsole as pluginAttachConsole,
   debug as pluginDebug,
@@ -42,6 +43,7 @@ import type {
   HostRelay,
   HostSystem,
   HostTrust,
+  HostWindow,
   NotebookHost,
   TrustInfo,
   TyposquatWarning,
@@ -96,6 +98,9 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     async getInfo() {
       return invoke<DaemonInfo | null>("get_daemon_info");
     },
+    async getReadyInfo() {
+      return invoke<DaemonReadyPayload | null>("get_daemon_ready_info");
+    },
   };
 
   const blobs: HostBlobs = {
@@ -120,7 +125,37 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   };
 
   const daemonEvents: HostDaemonEvents = {
-    onReady: (cb) => listenWebview<DaemonReadyPayload>("daemon:ready", cb),
+    // `onReady` subscribes to future emissions AND backfills from the
+    // Rust-side cache. Tauri webview events aren't sticky — if the Rust
+    // sync task emitted `daemon:ready` before this listener was attached,
+    // that specific event is lost. The cache (populated by
+    // `setup_sync_receivers` before emit, and refreshed on path changes)
+    // lets late subscribers catch up.
+    //
+    // Both IPCs are queued on the same channel: `webview.listen(...)`
+    // issues `invoke("plugin:event|listen", ...)` which Rust processes
+    // before the subsequent `get_daemon_ready_info`. By the time the
+    // cached value reaches us, the listener is attached, so a live event
+    // can't land in a gap and be dropped.
+    onReady: (cb) => {
+      // Track cancellation across both the live-event subscription and the
+      // cache backfill. If the subscriber unmounts before either async
+      // operation resolves, neither path invokes the callback on a dead
+      // component. React StrictMode's double-mount exercises this path.
+      let cancelled = false;
+      const unlistenLive = listenWebview<DaemonReadyPayload>("daemon:ready", (p) => {
+        if (!cancelled) cb(p);
+      });
+      invoke<DaemonReadyPayload | null>("get_daemon_ready_info")
+        .then((info) => {
+          if (!cancelled && info) cb(info);
+        })
+        .catch(() => {});
+      return () => {
+        cancelled = true;
+        unlistenLive();
+      };
+    },
     onProgress: (cb) => listenWebview<DaemonProgressPayload>("daemon:progress", cb),
     onDisconnected: (cb) => listenWebview<void>("daemon:disconnected", () => cb()),
     onUnavailable: (cb) => listenWebview<DaemonUnavailablePayload>("daemon:unavailable", cb),
@@ -138,6 +173,35 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     },
     async markClean() {
       await invoke("mark_notebook_clean");
+    },
+  };
+
+  const windowNs: HostWindow = {
+    async getTitle() {
+      return getCurrentWindow().title();
+    },
+    async setTitle(title) {
+      await getCurrentWindow().setTitle(title);
+    },
+    onFocusChange(cb) {
+      let unlisten: Unlisten | null = null;
+      let cancelled = false;
+      getCurrentWindow()
+        .onFocusChanged(({ payload: focused }) => {
+          cb(focused);
+        })
+        .then((fn) => {
+          if (cancelled) fn();
+          else unlisten = fn;
+        })
+        .catch(() => {});
+      return () => {
+        cancelled = true;
+        if (unlisten) {
+          unlisten();
+          unlisten = null;
+        }
+      };
     },
   };
 
@@ -185,6 +249,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     trust,
     deps,
     notebook,
+    window: windowNs,
     system,
     commands,
     log,

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -60,6 +60,13 @@ export interface TyposquatWarning {
 }
 
 export interface DaemonReadyPayload {
+  notebook_id?: string;
+  cell_count?: number;
+  needs_trust_approval?: boolean;
+  /** In-memory-only notebook (no on-disk path). Drives the always-dirty asterisk. */
+  ephemeral?: boolean;
+  /** On-disk path if the notebook is file-backed. Derives the titlebar filename. */
+  notebook_path?: string | null;
   runtime?: string;
 }
 
@@ -87,6 +94,13 @@ export interface HostDaemon {
   reconnect(): Promise<void>;
   /** Daemon diagnostics for banners / debug UI. */
   getInfo(): Promise<DaemonInfo | null>;
+  /**
+   * Pull the most-recent `daemon:ready` payload for this window, or null if
+   * one hasn't landed yet. Used by late-mounted consumers to backfill state
+   * that was emitted before any JS listener was attached — Tauri webview
+   * events aren't sticky, so the event-based path can miss the first fire.
+   */
+  getReadyInfo(): Promise<DaemonReadyPayload | null>;
 }
 
 /** Blob store — the daemon's HTTP blob server port. */
@@ -141,12 +155,37 @@ export interface HostRelay {
   notifySyncReady(): Promise<void>;
 }
 
-/** Notebook-scoped state transitions the UI sometimes has to announce to the host. */
+/**
+ * Notebook-scoped state transitions the UI sometimes has to announce to the host.
+ *
+ * NOTE: the `applyPathChanged` / `markClean` pair is a legacy shadow of state
+ * the daemon already owns (last-saved heads vs current heads for dirty; the
+ * `NotebookSession` for path). We keep them on the host for now because the
+ * Tauri Rust side still maintains a `WindowNotebookRegistry` that the window
+ * title setter reads from. Once the frontend reads path + dirty directly from
+ * daemon state / RuntimeStateDoc, these two methods and their Tauri commands
+ * (`apply_path_changed`, `mark_notebook_clean`, `has_notebook_path`) all go.
+ */
 export interface HostNotebook {
   /** Daemon's path for this room changed (save / save-as); flushed to window state. */
   applyPathChanged(path: string): Promise<void>;
   /** Daemon autosaved the doc; clear frontend dirty marker. */
   markClean(): Promise<void>;
+}
+
+/**
+ * OS window chrome. Read/write the title (for the dirty asterisk) and
+ * subscribe to focus changes (for keyboard-input-context restoration on
+ * WKWebView reactivation).
+ *
+ * `onFocusChange` is the host-level / OS-attributed focus signal. The
+ * frontend also listens to the DOM-level `window.addEventListener("focus")`
+ * for a fast path; these are belt-and-suspenders layers.
+ */
+export interface HostWindow {
+  getTitle(): Promise<string>;
+  setTitle(title: string): Promise<void>;
+  onFocusChange(cb: (focused: boolean) => void): Unlisten;
 }
 
 /** Non-specific system metadata. */
@@ -190,6 +229,7 @@ export interface NotebookHost {
   readonly trust: HostTrust;
   readonly deps: HostDeps;
   readonly notebook: HostNotebook;
+  readonly window: HostWindow;
   readonly system: HostSystem;
   /**
    * Typed action bus shared between host UI surfaces (menus, keyboard,

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -33,6 +33,15 @@ vi.mock("@tauri-apps/api/core", () => ({
         return Promise.resolve([]);
       case "get_username":
         return Promise.resolve("kyle");
+      case "get_daemon_ready_info":
+        return Promise.resolve({
+          notebook_id: "nb-1",
+          cell_count: 2,
+          needs_trust_approval: false,
+          ephemeral: true,
+          notebook_path: null,
+          runtime: "python",
+        });
       default:
         return Promise.resolve(undefined);
     }
@@ -47,6 +56,23 @@ vi.mock("@tauri-apps/api/webview", () => ({
       return mockUnlisten;
     }),
     setZoom: vi.fn(),
+  }),
+}));
+
+const mockWindowUnlisten = vi.fn();
+let capturedFocusCb: ((ev: { payload: boolean }) => void) | null = null;
+let mockWindowTitle = "notebook";
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    title: vi.fn(async () => mockWindowTitle),
+    setTitle: vi.fn(async (t: string) => {
+      mockWindowTitle = t;
+    }),
+    onFocusChanged: vi.fn(async (cb: (ev: { payload: boolean }) => void) => {
+      capturedFocusCb = cb;
+      return mockWindowUnlisten;
+    }),
   }),
 }));
 
@@ -85,6 +111,9 @@ beforeEach(() => {
   capturedListens.length = 0;
   pluginLogCalls.length = 0;
   mockUnlisten.mockReset();
+  mockWindowUnlisten.mockReset();
+  capturedFocusCb = null;
+  mockWindowTitle = "notebook";
 });
 
 describe("createTauriHost()", () => {
@@ -115,6 +144,15 @@ describe("createTauriHost()", () => {
       is_dev_mode: true,
     });
     expect(capturedInvokes.at(-1)?.cmd).toBe("get_daemon_info");
+  });
+
+  it("routes daemon.getReadyInfo to get_daemon_ready_info and passes ephemeral + path through", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const info = await host.daemon.getReadyInfo();
+    expect(capturedInvokes.at(-1)?.cmd).toBe("get_daemon_ready_info");
+    expect(info?.ephemeral).toBe(true);
+    expect(info?.notebook_path).toBe(null);
+    expect(info?.runtime).toBe("python");
   });
 
   it("routes blobs.port to get_blob_port", async () => {
@@ -175,10 +213,59 @@ describe("createTauriHost()", () => {
     const entry = capturedListens.find((x) => x.event === "daemon:ready");
     expect(entry).toBeTruthy();
     entry?.cb({ payload: { runtime: "python" } });
-    expect(received).toEqual([{ runtime: "python" }]);
+    expect(received).toContainEqual({ runtime: "python" });
     unlisten();
     await Promise.resolve();
     expect(mockUnlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("daemonEvents.onReady also backfills cached payload from get_daemon_ready_info", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const received: unknown[] = [];
+    host.daemonEvents.onReady((p) => received.push(p));
+    // Let both the listen() promise and the get_daemon_ready_info invoke
+    // settle. Two awaits covers the two-step promise chain inside onReady.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Mock returns the canned ready info (ephemeral=true, runtime=python).
+    expect(received).toContainEqual({
+      notebook_id: "nb-1",
+      cell_count: 2,
+      needs_trust_approval: false,
+      ephemeral: true,
+      notebook_path: null,
+      runtime: "python",
+    });
+  });
+
+  it("daemonEvents.onReady drops the cached backfill when unlistened before resolution", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const received: unknown[] = [];
+    const unlisten = host.daemonEvents.onReady((p) => received.push(p));
+    // Unlisten BEFORE any promises resolve. StrictMode's double-mount
+    // dispose exercises exactly this timing.
+    unlisten();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(received).toEqual([]);
+  });
+
+  it("daemonEvents.onReady ignores live emissions after unlisten", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const received: unknown[] = [];
+    const unlisten = host.daemonEvents.onReady((p) => received.push(p));
+    // Let both the cache backfill and listen() promise settle before the
+    // interesting part of the test.
+    await Promise.resolve();
+    await Promise.resolve();
+    const entry = capturedListens.find((x) => x.event === "daemon:ready");
+    // Reset before testing post-unlisten behavior specifically.
+    const countBefore = received.length;
+    unlisten();
+    // Simulate a late live emission (Tauri-side unlisten hasn't been
+    // processed yet). The JS-side wrapper must gate on `cancelled`.
+    entry?.cb({ payload: { runtime: "deno" } });
+    expect(received.length).toBe(countBefore);
   });
 
   it("relay.notifySyncReady invokes notify_sync_ready (not on daemonEvents)", async () => {
@@ -241,6 +328,28 @@ describe("createTauriHost()", () => {
     // Let the async run() call settle.
     await Promise.resolve();
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("window.getTitle / setTitle route to getCurrentWindow", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    await expect(host.window.getTitle()).resolves.toBe("notebook");
+    await host.window.setTitle("* notebook");
+    await expect(host.window.getTitle()).resolves.toBe("* notebook");
+  });
+
+  it("window.onFocusChange forwards focused boolean and returns a working unlisten", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const seen: boolean[] = [];
+    const unlisten = host.window.onFocusChange((focused) => seen.push(focused));
+    // Flush the onFocusChanged() promise so the cb is registered.
+    await Promise.resolve();
+    expect(capturedFocusCb).toBeTruthy();
+    capturedFocusCb?.({ payload: true });
+    capturedFocusCb?.({ payload: false });
+    expect(seen).toEqual([true, false]);
+    unlisten();
+    await Promise.resolve();
+    expect(mockWindowUnlisten).toHaveBeenCalledTimes(1);
   });
 
   it("host.log forwards each level to plugin-log", () => {


### PR DESCRIPTION
## Summary

Adds `host.window` (`getTitle` / `setTitle` / `onFocusChange`) and plumbs the daemon-owned `ephemeral` + `notebook_path` state to the frontend so the titlebar dirty-asterisk can be driven without the Tauri shadow-state round-trip (`has_notebook_path`).

**Explicitly excludes** `HostNotebook.hasPath()` (an earlier draft had it). Path + dirty state lives on the daemon side already (`NotebookSession` owns path; last-saved heads tracks dirty; `PathChanged` broadcast communicates transitions). Baking a `has_notebook_path` into the host interface would codify the shadow rather than remove it. A follow-up PR moves path + dirty onto daemon-managed state and deletes `has_notebook_path` / `mark_notebook_clean` / `apply_path_changed` / `WindowNotebookRegistry` entirely — see [`.context/tauri-daemon-audit.md`](https://github.com/nteract/desktop/blob/feat/notebook-host-window/.context/tauri-daemon-audit.md) for the full shadow-state audit.

## What's here

**`host.window`**
- `getTitle()` / `setTitle()` — wrap `getCurrentWindow().title()` / `.setTitle()`.
- `onFocusChange(cb)` — wraps `getCurrentWindow().onFocusChanged(...)` with sync-unlisten semantics.

**`host.daemon.getReadyInfo()`** (new pull API)
- Returns the most-recent cached `daemon:ready` payload for this window, or `null` if one hasn't landed yet.
- Internally used by `onReady` to backfill late subscribers — each `host.daemonEvents.onReady(cb)` call now ALSO pulls the cache and replays to `cb` if present. Tauri webview events aren't sticky, so this closes the "daemon:ready fired before React mounted" gap.

**`DaemonReadyPayload` extensions (Rust + TS)**
- `ephemeral: bool` — from `NotebookConnectionInfo.ephemeral`. Drives the always-dirty asterisk on untitled rooms.
- `notebook_path: Option<String>` — from the room's on-disk path. Lets the frontend derive the filename without reading the live window title (and covers Finder-reuse, which doesn't emit `PathChanged`).

**Titlebar ownership moved to the frontend**
- `AppContent` owns the title end-to-end via a shared `applyNotebookPath(path)` helper called from two entry points (`daemon:ready` event — which also delivers the cached backfill — and `path_changed` broadcast). Both paths derive filename + ephemeral identically.
- Render effect writes `titleBase` / `* titleBase` from first principles — no `getTitle`-then-`setTitle` read-modify-write that can race against concurrent Rust-side title updates.
- Rust-side `apply_path_changed` / `save_notebook_as` no longer call `window.set_title()`. Race gone.

**Cache consistency**
- `SyncReadyState.last_ready` stores the per-window payload.
- `setup_sync_receivers` records before emitting.
- `apply_path_changed` updates `notebook_path` + `ephemeral` so a React remount (error boundary, HMR) after save-as doesn't resurrect "untitled" state.
- Cache is **invalidated on disconnect** so a remount during an outage can't replay the last-known-good ready payload and hide the failure.

**Cancellation**
- The cache-backfill invoke inside `onReady` is now guarded by a `cancelled` flag shared with the live-event listener. Subscribers that unmount before the backfill resolves (StrictMode double-mount) don't fire their callback against a dead component.

**`window-focus.ts`** — accepts `NotebookHost`, uses `host.window.onFocusChange`. Zero Tauri imports.

**`App.tsx`** — Zero Tauri imports. `useNotebookHost()` hoisted to the top so the early `window-focus` effect can see it.

## Codex review

Six rounds of `codex review --base main` against this branch. Every finding addressed:

| Round | Severity | Finding | Fix |
|-------|----------|---------|-----|
| R1 | P2 | `ephemeral` never set when `daemon:ready` fires before React mounts | Rust caches payload; frontend pulls via `getReadyInfo` |
| R1 | P2 | `getTitle`-then-`setTitle` race against `apply_path_changed` title updates | Frontend owns title end-to-end; Rust `set_title` calls removed |
| R2 | P2 | `notify_sync_ready` replay was still too early for React's effect order | `getReadyInfo` pull model instead |
| R2 | P3 | Finder-reuse opens a file without `path_changed` broadcast | `notebook_path` carried on `daemon:ready` |
| R3 | P3 | Cached ready payload stale after save-as on remount | `update_cached_path` from `apply_path_changed` |
| R5 | P2 | `onReady()` listener not synchronously attached before `getReadyInfo()` | Cache backfill moved inside `onReady` so both IPCs ride the same serialized queue |
| R6 | P2 | Cache not cleared on disconnect — remount during outage replays stale "ready" | `SyncReadyState::clear_cached_ready` on `daemon:disconnected` |
| R6 | P3 | Cache-backfill callback uncancellable (StrictMode) | Shared `cancelled` flag across live + backfill paths |

Final round (R8) returned clean: "I did not find any discrete correctness issues in this diff."

## Test plan

- [x] `pnpm test` — **1038** pass (+4 new on `tauri-host.test.ts`: getTitle/setTitle round-trip, onFocusChange listener + unlisten, getReadyInfo routing, onReady cache-backfill delivery, onReady unlisten cancellation)
- [x] `npx tsc --noEmit -p apps/notebook` — clean
- [x] `cargo xtask lint` — clean
- [x] `cargo check -p notebook` — clean
- [ ] **Manual**: `cargo xtask notebook` —
  - Titled notebook: asterisk flips on edit / clears on autosave.
  - Untitled notebook: asterisk persists through all edits until save-as.
  - Save-As on untitled: title updates to filename, asterisk clears, no `Untitled.ipynb` flash.
  - Cmd+Tab in/out still preserves first keystrokes in CodeMirror.

## Stacked follow-up

**#1891** (feat(notebook-host): HostDialog + HostExternalLinks) is stacked on this branch — once this lands, that one rebases onto main.

Further follow-ups sequenced in `.context/tauri-daemon-audit.md`:

1. Move path + dirty onto daemon-managed state (deletes `has_notebook_path`, `mark_notebook_clean`, `apply_path_changed`, `WindowNotebookRegistry`).
2. Direct-transport `NotebookRequest` dispatch (15 `*_via_daemon` wrappers → `transport.sendRequest(req)`).
3. `HostDeps` extension + env detection in daemon.
4. `createElectronHost()` — the original goal.