### PR TITLE
fix(notebook): sync daemon:ready cache on save-as too

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2030,6 +2030,7 @@ async fn save_notebook_as(
     path: String,
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
+    sync_ready: tauri::State<'_, SyncReadyState>,
 ) -> Result<(), String> {
     info!(
         "[save] save_notebook_as command invoked by window {} with path {:?}",
@@ -2082,6 +2083,11 @@ async fn save_notebook_as(
         );
         *p = Some(saved_path.clone());
     }
+    // Keep the cached `daemon:ready` payload's path in sync so a React
+    // remount (HMR, error boundary) after this save-as sees the new path
+    // via `get_daemon_ready_info` instead of replaying the old untitled
+    // payload. Mirrors the same update in `apply_path_changed`.
+    sync_ready.update_cached_path(window.label(), Some(&saved_path.to_string_lossy()));
     dirty.store(false, Ordering::SeqCst);
 
     refresh_native_menu(window.app_handle(), registry.inner());


### PR DESCRIPTION
## Summary

Follow-up to #1890. The cached `daemon:ready` payload is kept in sync on `apply_path_changed` but not on `save_notebook_as`. If a React remount (HMR, error boundary) happens in the narrow window between `NotebookResponse::NotebookSaved` and the broadcast subscriber firing `host.notebook.applyPathChanged`, `get_daemon_ready_info` replays the old `ephemeral=true` / untitled payload and the titlebar reverts to `* Untitled.ipynb` until the next daemon reconnect.

Adds the same `SyncReadyState::update_cached_path` call at the end of `save_notebook_as`, mirroring the pattern already in `apply_path_changed`.

Narrow race — dev-only in practice, caught by codex during review. Belt-and-suspenders because the frontend `path_changed` handler already walks through `apply_path_changed` and keeps things consistent. Cost is two lines plus a doc comment.

## Test plan

- [x] `cargo check -p notebook` — clean
- [x] `cargo xtask lint` — clean
- [ ] Manual: Save As on an untitled notebook, then trigger HMR (edit a React component). Title should stay on the new filename; asterisk clears.