### PR TITLE
feat(protocol): add correlation id envelope for NotebookRequest/Response

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -154,6 +154,12 @@ pub const PROTOCOL_V2: &str = "v2";
 
 /// Numeric protocol version for version negotiation.
 /// Increment this when making breaking protocol changes.
+///
+/// The request/response envelope change (`NotebookRequestEnvelope` /
+/// `NotebookResponseEnvelope` with an optional `id` correlation field)
+/// is JSON-wire-compatible — the id is `Option<String>` and serde
+/// ignores unknown fields by default — so mixed v2/new deployments
+/// interoperate. No version bump is needed for that change.
 pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Magic bytes identifying the runtimed protocol.

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -199,6 +199,36 @@ pub enum SaveErrorKind {
     Io { message: String },
 }
 
+/// Envelope around a `NotebookRequest` carrying a correlation id.
+///
+/// The id is echoed on the matching `NotebookResponseEnvelope` so the relay
+/// (or any future direct JS sender) can match responses to in-flight
+/// requests. Absent id == notification / fire-and-forget — not currently
+/// used but kept as a free escape hatch.
+///
+/// Wire shape is flattened: `{"id":"...","action":"execute_cell","cell_id":"..."}`.
+/// Introduced at `PROTOCOL_VERSION = 3`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookRequestEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(flatten)]
+    pub request: NotebookRequest,
+}
+
+/// Envelope around a `NotebookResponse` echoing the originating request id.
+///
+/// `id == None` is valid for out-of-band server-pushed responses that
+/// don't correspond to a specific client request (not currently emitted;
+/// reserved for future use).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookResponseEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(flatten)]
+    pub response: NotebookResponse,
+}
+
 /// Requests sent from notebook app to daemon for notebook operations.
 ///
 /// These are sent as JSON over the notebook sync connection alongside
@@ -789,5 +819,90 @@ mod tests {
         let json = serde_json::to_string(&entry).expect("serialize");
         let parsed: QueueEntry = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(entry, parsed);
+    }
+
+    #[test]
+    fn request_envelope_flattens_and_round_trips() {
+        let env = NotebookRequestEnvelope {
+            id: Some("req-1".into()),
+            request: NotebookRequest::ExecuteCell {
+                cell_id: "cell-42".into(),
+            },
+        };
+        let json = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(json["id"], "req-1");
+        assert_eq!(json["action"], "execute_cell");
+        assert_eq!(json["cell_id"], "cell-42");
+        let parsed: NotebookRequestEnvelope = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed.id.as_deref(), Some("req-1"));
+        assert!(matches!(
+            parsed.request,
+            NotebookRequest::ExecuteCell { cell_id } if cell_id == "cell-42"
+        ));
+    }
+
+    /// Legacy v2 payload (no `id` field) must deserialize as an envelope
+    /// with `id = None`. This lets a new daemon accept requests from an
+    /// old client that hasn't learned about the correlation id yet.
+    #[test]
+    fn request_envelope_accepts_legacy_v2_payload() {
+        let legacy = serde_json::json!({
+            "action": "execute_cell",
+            "cell_id": "cell-legacy",
+        });
+        let parsed: NotebookRequestEnvelope =
+            serde_json::from_value(legacy).expect("legacy payload deserializes");
+        assert!(parsed.id.is_none());
+        assert!(matches!(
+            parsed.request,
+            NotebookRequest::ExecuteCell { cell_id } if cell_id == "cell-legacy"
+        ));
+    }
+
+    /// A `NotebookRequestEnvelope` sent to a legacy v2 parser (which
+    /// deserializes into the bare `NotebookRequest` enum) must still work
+    /// — serde ignores unknown fields by default, so the `id` field is
+    /// harmlessly dropped. This lets a new client talk to an old daemon.
+    #[test]
+    fn legacy_v2_parser_accepts_envelope_payload() {
+        let envelope = NotebookRequestEnvelope {
+            id: Some("req-1".into()),
+            request: NotebookRequest::InterruptExecution {},
+        };
+        let json = serde_json::to_string(&envelope).expect("serialize");
+        let parsed: NotebookRequest =
+            serde_json::from_str(&json).expect("v2 parser accepts envelope");
+        assert!(matches!(parsed, NotebookRequest::InterruptExecution {}));
+    }
+
+    #[test]
+    fn response_envelope_flattens_and_round_trips() {
+        let env = NotebookResponseEnvelope {
+            id: Some("req-1".into()),
+            response: NotebookResponse::CellQueued {
+                cell_id: "cell-42".into(),
+                execution_id: "exec-abc".into(),
+            },
+        };
+        let json = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(json["id"], "req-1");
+        assert_eq!(json["result"], "cell_queued");
+        assert_eq!(json["cell_id"], "cell-42");
+        let parsed: NotebookResponseEnvelope = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed.id.as_deref(), Some("req-1"));
+    }
+
+    /// A legacy v2 response parser must accept the new response envelope
+    /// (id field is unknown-and-ignored by default serde behavior).
+    #[test]
+    fn legacy_v2_response_parser_accepts_envelope() {
+        let envelope = NotebookResponseEnvelope {
+            id: Some("req-1".into()),
+            response: NotebookResponse::Ok {},
+        };
+        let json = serde_json::to_string(&envelope).expect("serialize");
+        let parsed: NotebookResponse =
+            serde_json::from_str(&json).expect("v2 parser accepts response envelope");
+        assert!(matches!(parsed, NotebookResponse::Ok {}));
     }
 }

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -178,9 +178,19 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     request: &notebook_protocol::protocol::NotebookRequest,
     notebook_id: &str,
 ) -> Result<NotebookResponse, SyncError> {
-    // Serialize and send the request
+    // Wrap the request in a correlation envelope. The daemon echoes the
+    // id on the response envelope. The relay currently serializes requests
+    // (one in flight per room), so the correlation id is redundant here —
+    // but it's part of the wire protocol at `PROTOCOL_VERSION = 3`, and a
+    // later PR (direct JS sendRequest) will use the id to dispatch
+    // concurrent responses via a pending map.
+    let expected_id = uuid::Uuid::new_v4().to_string();
+    let envelope = notebook_protocol::protocol::NotebookRequestEnvelope {
+        id: Some(expected_id.clone()),
+        request: request.clone(),
+    };
     let payload =
-        serde_json::to_vec(request).map_err(|e| SyncError::Serialization(e.to_string()))?;
+        serde_json::to_vec(&envelope).map_err(|e| SyncError::Serialization(e.to_string()))?;
     connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
         .await
         .map_err(SyncError::Io)?;
@@ -199,7 +209,13 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
     let result = tokio::time::timeout(
         Duration::from_secs(timeout_secs),
-        wait_for_response(reader, frame_tx, req_broadcast_tx, notebook_id),
+        wait_for_response(
+            reader,
+            frame_tx,
+            req_broadcast_tx,
+            notebook_id,
+            &expected_id,
+        ),
     )
     .await;
 
@@ -229,6 +245,7 @@ async fn wait_for_response<R: AsyncRead + Unpin>(
     frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
     req_broadcast_tx: Option<&tokio::sync::broadcast::Sender<NotebookBroadcast>>,
     _notebook_id: &str,
+    expected_id: &str,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = connection::recv_typed_frame(reader)
@@ -238,9 +255,23 @@ async fn wait_for_response<R: AsyncRead + Unpin>(
 
         match frame.frame_type {
             NotebookFrameType::Response => {
-                let response: NotebookResponse = serde_json::from_slice(&frame.payload)
-                    .map_err(|e| SyncError::Serialization(e.to_string()))?;
-                return Ok(response);
+                let envelope: notebook_protocol::protocol::NotebookResponseEnvelope =
+                    serde_json::from_slice(&frame.payload)
+                        .map_err(|e| SyncError::Serialization(e.to_string()))?;
+                // Relay serializes requests per room, so the id we're waiting
+                // for should always match. A mismatch means a stale response
+                // leaked past a timeout or a protocol bug — warn and keep
+                // reading so we eventually land on ours.
+                if let Some(id) = envelope.id.as_deref() {
+                    if id != expected_id {
+                        warn!(
+                            "[relay] Ignoring response with id {:?}, waiting for {:?}",
+                            id, expected_id
+                        );
+                        continue;
+                    }
+                }
+                return Ok(envelope.response);
             }
 
             NotebookFrameType::Broadcast => {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2651,19 +2651,30 @@ where
                             }
 
                             NotebookFrameType::Request => {
-                                // Handle NotebookRequest
-                                let request: NotebookRequest = serde_json::from_slice(&frame.payload)?;
-                                let response =
-                                    handle_notebook_request(room, request, daemon.clone()).await;
+                                // Decode the envelope, dispatch the inner request,
+                                // echo the id on the response envelope so the caller
+                                // can correlate multiple in-flight requests.
+                                let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
+                                    serde_json::from_slice(&frame.payload)?;
+                                let response = handle_notebook_request(
+                                    room,
+                                    envelope.request,
+                                    daemon.clone(),
+                                )
+                                .await;
 
                                 // Promotion from untitled → file-backed is now handled
                                 // entirely inside handle_notebook_request (SaveNotebook arm).
                                 // Save path update is handled inside handle_notebook_request.
 
+                                let reply = notebook_protocol::protocol::NotebookResponseEnvelope {
+                                    id: envelope.id,
+                                    response,
+                                };
                                 connection::send_typed_json_frame(
                                     writer,
                                     NotebookFrameType::Response,
-                                    &response,
+                                    &reply,
                                 )
                                 .await?;
                             }


### PR DESCRIPTION
## Summary

Adds `NotebookRequestEnvelope` / `NotebookResponseEnvelope` carrying an optional `id: Option<String>` correlation field. The daemon echoes the id back on responses, so callers can match responses to in-flight requests.

Wire shape stays flat via `#[serde(flatten)]`:

```json
{"id": "uuid-...", "action": "execute_cell", "cell_id": "..."}
{"id": "uuid-...", "result": "cell_queued", "cell_id": "...", "execution_id": "..."}
```

**No `PROTOCOL_VERSION` bump.** The envelope is JSON-wire-compatible with existing v2 peers:

- `id` is optional, so a v2 client sending `{"action":"execute_cell",...}` deserializes cleanly as an envelope with `id = None`.
- Serde ignores unknown fields by default, so a v2 daemon parsing a new envelope payload as bare `NotebookRequest` harmlessly drops the `id` field and still sees the inner request.

Five tests in `notebook-protocol` lock in both directions of cross-version compat — an accidental `#[serde(deny_unknown_fields)]` addition would surface as a test failure.

## Why

Prep for a follow-up PR that exposes `NotebookRequest` / `NotebookResponse` to the frontend via `sendFrame(0x01)` + `notebook:frame` routing, eliminating the ~15 `*_via_daemon` Tauri commands. JS needs to correlate responses to concurrent requests without a separate command per request type; the relay's current serialized-request model won't carry over.

The relay still serializes requests per room today, so the id is redundant on that path. The pending-map dispatch + JS `sendRequest` lands in the follow-up.

## Design decisions

- **Correlation via JSON `id` field**, not strict JSON-RPC 2.0. Standard JSON-RPC mandates `jsonrpc: "2.0"` (noise) and `method`/`params` (invasive refactor of all daemon handlers). The envelope with `#[serde(flatten)]` keeps our tagged-enum shape and adds `id` with zero handler changes.
- **Stays on JSON, not CBOR**. Requests are low-rate — user actions, kernel lifecycle, save. JSON overhead per request is sub-millisecond. CBOR would cost debuggability (can't `grep` a wire capture) to optimize something that isn't hot. Presence uses CBOR because it's high-rate; requests aren't.
- **Reuses frame types `0x01`/`0x02`** instead of introducing new types. Only the daemon and the Tauri relay's `send_request_impl` parse those frames today — no external consumers.
- **No PROTOCOL_VERSION bump** (addressed codex R1/P1) — because the JSON envelope is cross-version compatible, a version bump would gratuitously hard-reject mixed-version client/daemon deployments during rollout.
- **`id` is `Option<String>`**. `None` = notification (no response expected). Not currently used but reserved.

## Files

- `crates/notebook-protocol/src/protocol.rs` — envelope types + 5 cross-version compat tests.
- `crates/notebook-protocol/src/connection.rs` — comment explaining why PROTOCOL_VERSION stays at 2.
- `crates/runtimed/src/notebook_sync_server.rs` — deserialize envelope on `0x01`, call existing `handle_notebook_request` with the inner request, serialize the response envelope with echoed id.
- `crates/notebook-sync/src/relay_task.rs` — wrap outgoing requests with a fresh uuid, compare the echoed id on the response envelope (warn + keep reading if a mismatch slips through — defensive; shouldn't happen with serialized requests).

## Codex review

R1 / P1: gratuitous PROTOCOL_VERSION bump would break mixed-version deploys. **Fixed** — reverted to v2 with comment explaining why. R2 clean.

## Test plan

- [x] `cargo test -p notebook-protocol --lib` — 36 pass (+5 new compat tests).
- [x] `cargo test -p notebook-sync --lib` — 37 pass.
- [x] `cargo test --workspace --lib --exclude runtimed-wasm` — all green.
- [x] `pnpm test` — 1054 pass.
- [x] `cargo xtask lint` — clean.
- [ ] `cargo xtask integration` — running.

## Follow-up PR (not here)

Frontend `transport.sendRequest` routing via frames:
- Allow `0x01` in the outgoing frame path.
- Route `0x02` responses to the frontend as `notebook:frame` events.
- `TauriTransport.sendRequest` becomes: encode envelope, `sendFrame(0x01)`, register pending Map entry, wait.
- Relay gains a pending map keyed by request id instead of serialized `send_request_impl`.
- Drop the 15 `*_via_daemon` Tauri commands.

With this PR landed, Electron just opens the socket and speaks the protocol — no per-request wrappers to port.