### PR TITLE
feat(transport): frame-based direct request/response via correlation id

### DIFF
--- a/apps/notebook/src/hooks/useHistorySearch.ts
+++ b/apps/notebook/src/hooks/useHistorySearch.ts
@@ -1,11 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useRef, useState } from "react";
+import { useNotebookHost } from "@nteract/notebook-host";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { NotebookClient } from "runtimed";
+import type { HistoryEntry } from "runtimed";
 
-export interface HistoryEntry {
-  session: number;
-  line: number;
-  source: string;
-}
+export type { HistoryEntry };
 
 // MRU cache for search queries (pattern -> entries)
 // Uses Map iteration order: oldest at start, newest at end
@@ -48,57 +46,51 @@ function getTailCache(): HistoryEntry[] {
 }
 
 export function useHistorySearch() {
+  const host = useNotebookHost();
+  const client = useMemo(() => new NotebookClient({ transport: host.transport }), [host]);
   const [entries, setEntries] = useState<HistoryEntry[]>(getTailCache);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Track the current search pattern to avoid race conditions
   const currentSearchRef = useRef<string | undefined>(undefined);
 
-  const searchHistory = useCallback(async (pattern?: string) => {
-    // Track this search request
-    currentSearchRef.current = pattern;
+  const searchHistory = useCallback(
+    async (pattern?: string) => {
+      currentSearchRef.current = pattern;
 
-    // Check cache first - if we have results, show them immediately
-    const cached = getCachedResult(pattern);
-    if (cached) {
-      setEntries(cached);
-      // Still fetch fresh results in background, but don't show loading
-      // This gives instant feedback for typo corrections / backspace
-    }
+      const cached = getCachedResult(pattern);
+      if (cached) {
+        setEntries(cached);
+      }
 
-    setIsLoading(true);
-    setError(null);
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      const results = await invoke<HistoryEntry[]>("get_history_via_daemon", {
-        pattern: pattern || null,
-        n: 100,
-      });
+      try {
+        const results = await client.getHistory(pattern || null, 100, true);
 
-      // Only update if this is still the current search (avoid race conditions)
-      if (currentSearchRef.current === pattern) {
-        // Don't replace good entries with empty kernel results — the kernel
-        // glob search may legitimately return nothing for very narrow patterns
-        // while client-side filtering of the tail still has useful matches.
-        if (results.length > 0 || !pattern) {
-          setEntries(results);
-          setCacheResult(pattern, results);
+        if (currentSearchRef.current === pattern) {
+          // Don't replace good entries with empty kernel results — the kernel
+          // glob search may legitimately return nothing for very narrow patterns
+          // while client-side filtering of the tail still has useful matches.
+          if (results.length > 0 || !pattern) {
+            setEntries(results);
+            setCacheResult(pattern, results);
+          }
+        }
+      } catch (e) {
+        const errorMsg = e instanceof Error ? e.message : String(e);
+        if (currentSearchRef.current === pattern) {
+          setError(errorMsg);
+        }
+      } finally {
+        if (currentSearchRef.current === pattern) {
+          setIsLoading(false);
         }
       }
-    } catch (e) {
-      const errorMsg = e instanceof Error ? e.message : String(e);
-      // Only update error if this is still the current search
-      if (currentSearchRef.current === pattern) {
-        setError(errorMsg);
-        // Don't clear entries on error - keep showing what we have
-      }
-    } finally {
-      // Only clear loading if this is still the current search
-      if (currentSearchRef.current === pattern) {
-        setIsLoading(false);
-      }
-    }
-  }, []);
+    },
+    [client],
+  );
 
   const clearEntries = useCallback(() => {
     // Reset to tail cache (or empty if no cache)

--- a/apps/notebook/src/lib/kernel-completion.ts
+++ b/apps/notebook/src/lib/kernel-completion.ts
@@ -4,59 +4,49 @@ import {
   type CompletionResult,
 } from "@codemirror/autocomplete";
 import type { Extension } from "@codemirror/state";
-import { invoke } from "@tauri-apps/api/core";
+import type { NotebookHost } from "@nteract/notebook-host";
+import { NotebookClient } from "runtimed";
 
-/** A single completion item (LSP-ready structure). */
-interface CompletionItem {
-  label: string;
-  /** Kind: "function", "variable", "class", "module", etc. */
-  kind?: string;
-  /** Short type annotation. */
-  detail?: string;
-  /** Source: "kernel" now, "ruff"/"basedpyright" later. */
-  source?: string;
-}
+/** Module-level reference to the host — set once from `main.tsx`. */
+let _host: NotebookHost | null = null;
+let _client: NotebookClient | null = null;
 
-interface KernelCompletionResult {
-  items: CompletionItem[];
-  cursor_start: number;
-  cursor_end: number;
+/**
+ * Register the `NotebookHost` used for kernel completions. Called once
+ * from `main.tsx` after `createTauriHost()`. Matches the pattern used by
+ * `logger`, `blob-port`, and `open-url` for non-React helpers.
+ */
+export function setKernelCompletionHost(host: NotebookHost | null): void {
+  _host = host;
+  _client = host ? new NotebookClient({ transport: host.transport }) : null;
 }
 
 /**
- * CodeMirror completion source that queries the Jupyter kernel
- * for code completions via the `complete_request` message.
+ * CodeMirror completion source that queries the Jupyter kernel for code
+ * completions via the `complete` request.
  *
- * Only activates on explicit request (Ctrl+Space / Tab) to avoid
- * per-keystroke kernel round-trips that thrash busy→idle status
- * and generate excessive Automerge sync traffic.
+ * Only activates on explicit request (Ctrl+Space / Tab) to avoid per-
+ * keystroke kernel round-trips that thrash busy→idle status and
+ * generate excessive Automerge sync traffic.
  */
 async function kernelCompletionSource(
   context: CompletionContext,
 ): Promise<CompletionResult | null> {
-  // Only trigger on explicit activation (Ctrl+Space / Tab) — never on
-  // keystroke. This avoids per-character kernel round-trips that thrash
-  // busy→idle status and generate excessive Automerge sync traffic.
   if (!context.explicit) return null;
+  if (!_client || !_host) return null;
 
   const code = context.state.doc.toString();
   const cursorPos = context.pos;
 
   try {
-    const result = await invoke<KernelCompletionResult>("complete_via_daemon", {
-      code,
-      cursorPos,
-    });
+    const result = await _client.complete(code, cursorPos);
 
-    // Discard stale response if the user has moved on
     if (context.aborted) return null;
     if (!result.items || result.items.length === 0) return null;
 
-    // Use kernel-reported cursor range — it knows the correct span
-    // even for contexts without a local token (e.g. `from os import |`)
     return {
-      from: result.cursor_start,
-      to: result.cursor_end,
+      from: result.cursorStart,
+      to: result.cursorEnd,
       options: result.items.map((item) => ({ label: item.label })),
     };
   } catch {

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import "./index.css";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import { setBlobPortHost } from "./lib/blob-port";
+import { setKernelCompletionHost } from "./lib/kernel-completion";
 import { setLoggerHost } from "./lib/logger";
 import { setMetadataTransport } from "./lib/notebook-metadata";
 import { setOpenUrlHost } from "./lib/open-url";
@@ -38,6 +39,7 @@ setMetadataTransport(host.transport);
 setBlobPortHost(host);
 setLoggerHost(host);
 setOpenUrlHost(host);
+setKernelCompletionHost(host);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -905,4 +905,89 @@ mod tests {
             serde_json::from_str(&json).expect("v2 parser accepts response envelope");
         assert!(matches!(parsed, NotebookResponse::Ok {}));
     }
+
+    /// Locks in the exact JSON wire shape that the TypeScript frontend
+    /// emits for each `NotebookRequest` variant. The TS `NotebookRequest`
+    /// union's discriminator field names must match the Rust variant's
+    /// snake_cased name — the frame-based `TauriTransport.sendRequest`
+    /// translates TS's `type:` into the envelope's `action:` key verbatim,
+    /// so a mismatched name produces an unparseable request on the
+    /// daemon side (silent wire error + failed interrupt / execute / etc.).
+    ///
+    /// Adding a new variant on the Rust side? Extend this test with the
+    /// JSON shape the TS caller sends. Renaming a Rust variant? This
+    /// test will flag the mismatch.
+    #[test]
+    fn wire_action_names_match_ts_discriminators() {
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "launch_kernel",
+                serde_json::json!({
+                    "action": "launch_kernel",
+                    "kernel_type": "python",
+                    "env_source": "uv:inline",
+                }),
+            ),
+            (
+                "execute_cell",
+                serde_json::json!({ "action": "execute_cell", "cell_id": "c1" }),
+            ),
+            (
+                "clear_outputs",
+                serde_json::json!({ "action": "clear_outputs", "cell_id": "c1" }),
+            ),
+            (
+                "interrupt_execution",
+                serde_json::json!({ "action": "interrupt_execution" }),
+            ),
+            (
+                "shutdown_kernel",
+                serde_json::json!({ "action": "shutdown_kernel" }),
+            ),
+            (
+                "sync_environment",
+                serde_json::json!({ "action": "sync_environment" }),
+            ),
+            (
+                "run_all_cells",
+                serde_json::json!({ "action": "run_all_cells" }),
+            ),
+            (
+                "get_history",
+                serde_json::json!({
+                    "action": "get_history",
+                    "pattern": null,
+                    "n": 100,
+                    "unique": false,
+                }),
+            ),
+            (
+                "complete",
+                serde_json::json!({
+                    "action": "complete",
+                    "code": "import os\nos.",
+                    "cursor_pos": 13,
+                }),
+            ),
+        ];
+
+        for (name, json) in cases {
+            // Also validate the envelope form (with an id), which is what
+            // the frame-based path actually sends.
+            let mut with_id = json.clone();
+            if let serde_json::Value::Object(ref mut map) = with_id {
+                map.insert("id".into(), serde_json::Value::String("req-1".into()));
+            }
+            let _: NotebookRequestEnvelope = serde_json::from_value(with_id.clone())
+                .unwrap_or_else(|e| {
+                    panic!("envelope with action {:?} failed to deserialize: {e}", name)
+                });
+            let _: NotebookRequest = serde_json::from_value(json).unwrap_or_else(|e| {
+                panic!(
+                    "bare request with action {:?} failed to deserialize: {e}",
+                    name
+                )
+            });
+        }
+    }
 }

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -30,13 +30,24 @@ use crate::error::SyncError;
 /// so there are no mutation or sync confirmation commands.
 pub enum RelayCommand {
     /// Send a request to the daemon and wait for a response.
+    ///
+    /// The caller generates the correlation `id` so it can later send a
+    /// matching `CancelRequest` if the wait times out — otherwise the
+    /// pending entry would linger in the relay's `HashMap` forever.
     SendRequest {
+        id: String,
         request: NotebookRequest,
         reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
         /// Optional broadcast sender for delivering broadcasts during long-running
         /// requests (e.g., LaunchKernel with environment progress updates).
         broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
     },
+
+    /// Evict a pending request whose caller has given up (e.g., timed
+    /// out). Stops future responses for `id` from being delivered to a
+    /// dead `oneshot` and keeps the pending map from accumulating
+    /// abandoned entries across a long-lived relay.
+    CancelRequest { id: String },
 
     /// Forward a typed frame from the frontend to the daemon.
     ///
@@ -116,20 +127,13 @@ impl RelayHandle {
     ///
     /// This is async because it involves socket I/O. The request is sent
     /// to the daemon via the relay task, which handles the wire protocol.
+    /// The per-request-type timeout (see `relay_task::request_timeout`) is
+    /// enforced here; an overrun returns `SyncError::Timeout`.
     pub async fn send_request(
         &self,
         request: NotebookRequest,
     ) -> Result<NotebookResponse, SyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.cmd_tx
-            .send(RelayCommand::SendRequest {
-                request,
-                reply: reply_tx,
-                broadcast_tx: None,
-            })
-            .await
-            .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        self.send_request_inner(request, None).await
     }
 
     /// Send a request with a broadcast channel for real-time progress updates.
@@ -142,16 +146,39 @@ impl RelayHandle {
         request: NotebookRequest,
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     ) -> Result<NotebookResponse, SyncError> {
+        self.send_request_inner(request, Some(broadcast_tx)).await
+    }
+
+    async fn send_request_inner(
+        &self,
+        request: NotebookRequest,
+        broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
+    ) -> Result<NotebookResponse, SyncError> {
+        let timeout = crate::relay_task::request_timeout(&request);
+        // Generate the id here so we can send a matching CancelRequest on
+        // timeout — otherwise the pending map inside the relay task would
+        // accumulate abandoned entries across a long-lived connection.
+        let id = uuid::Uuid::new_v4().to_string();
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
             .send(RelayCommand::SendRequest {
+                id: id.clone(),
                 request,
                 reply: reply_tx,
-                broadcast_tx: Some(broadcast_tx),
+                broadcast_tx,
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        match tokio::time::timeout(timeout, reply_rx).await {
+            Ok(Ok(inner)) => inner,
+            Ok(Err(_)) => Err(SyncError::Disconnected),
+            Err(_) => {
+                // Fire-and-forget eviction. If the relay has already shut
+                // down (cmd_tx closed), there's nothing to clean up.
+                let _ = self.cmd_tx.send(RelayCommand::CancelRequest { id }).await;
+                Err(SyncError::Timeout)
+            }
+        }
     }
 
     /// Forward a typed frame from the frontend to the daemon.

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -8,19 +8,40 @@
 //!
 //! Two arms:
 //! 1. **Commands** from `RelayHandle` — send requests, forward frames
-//! 2. **Incoming daemon frames** — pipe to frontend via `frame_tx`
+//! 2. **Incoming daemon frames** — route via pending map or pipe to frontend
 //!
-//! No `changed_rx` (no local doc to sync). No snapshot publishing.
-//! No `FrameForwarder` conditionals — the relay always pipes.
+//! ## Request/response correlation
+//!
+//! Requests carry a correlation id (see `NotebookRequestEnvelope`). When a
+//! Rust-side caller issues `SendRequest`, the relay:
+//! 1. Generates a uuid id.
+//! 2. Registers a `PendingEntry { reply, broadcast_tx }` in the pending map.
+//! 3. Writes the `0x01` request envelope (with id) to the daemon socket.
+//!
+//! When a `0x02` response arrives on the socket, the relay parses the
+//! envelope and looks up the id in the pending map. If a Rust caller
+//! registered, the response is delivered via their oneshot. If the id is
+//! unknown, the raw frame is piped to the frontend — a frontend-originated
+//! request was waiting for it. This lets Rust and JS share the socket for
+//! request/response without per-type Tauri commands.
+//!
+//! JS-originated requests arrive via `RelayCommand::ForwardFrame` with
+//! frame type `0x01`; the relay forwards them unchanged and never looks at
+//! the id. The frontend maintains its own pending map and matches responses
+//! via the `notebook:frame` event stream.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use notebook_protocol::connection::{self, NotebookFrameType};
-use notebook_protocol::protocol::{NotebookBroadcast, NotebookResponse};
+use notebook_protocol::protocol::{
+    NotebookBroadcast, NotebookRequest, NotebookRequestEnvelope, NotebookResponse,
+    NotebookResponseEnvelope,
+};
 
 use crate::error::SyncError;
 use crate::relay::RelayCommand;
@@ -38,13 +59,18 @@ pub struct RelayTaskConfig {
     pub notebook_id: String,
 }
 
+/// A Rust-side caller awaiting a response for a specific correlation id.
+struct PendingEntry {
+    reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+    /// Progress broadcasts to deliver while the request is in flight
+    /// (e.g., LaunchKernel env-creation progress). Optional.
+    broadcast_tx: Option<tokio::sync::broadcast::Sender<NotebookBroadcast>>,
+}
+
 /// Run the relay task.
 ///
-/// This is spawned as a background tokio task. It runs until the socket
-/// closes or all handles are dropped (command channel closes).
-///
-/// The relay has no local document, no mutex, no snapshot publishing.
-/// It is a transparent byte pipe with request/response support.
+/// Spawned as a background tokio task. Runs until the socket closes or all
+/// handles are dropped (command channel closes).
 pub async fn run<R, W>(mut config: RelayTaskConfig, reader: R, writer: W)
 where
     R: AsyncRead + Unpin,
@@ -54,6 +80,7 @@ where
     let mut writer = tokio::io::BufWriter::new(writer);
 
     let notebook_id = &config.notebook_id;
+    let mut pending: HashMap<String, PendingEntry> = HashMap::new();
 
     info!("[relay] Started for {}", notebook_id);
 
@@ -65,17 +92,15 @@ where
 
         let select_result = tokio::select! {
             biased;
-            // Prioritize incoming daemon frames (sync, broadcast, presence)
-            // over outgoing commands.  Keeping sync frames flowing prevents
-            // head divergence; commands can wait a tick.
+            // Prioritize incoming daemon frames (sync, broadcast, presence,
+            // responses) over outgoing commands. Keeping frames flowing
+            // prevents head divergence; commands can wait a tick.
             frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
         };
 
         match select_result {
-            // ─── Command from handle ───────────────────────────────────
             SelectResult::Command(None) => {
-                // All handles dropped — shut down
                 info!(
                     "[relay] All handles dropped for {}, shutting down",
                     notebook_id
@@ -85,20 +110,26 @@ where
 
             SelectResult::Command(Some(cmd)) => match cmd {
                 RelayCommand::SendRequest {
+                    id,
                     request,
                     reply,
                     broadcast_tx,
                 } => {
-                    let result = send_request_impl(
-                        &mut reader,
+                    handle_send_request(
                         &mut writer,
-                        &config.frame_tx,
-                        broadcast_tx.as_ref(),
-                        &request,
-                        notebook_id,
+                        &mut pending,
+                        id,
+                        request,
+                        reply,
+                        broadcast_tx,
                     )
                     .await;
-                    let _ = reply.send(result);
+                }
+
+                RelayCommand::CancelRequest { id } => {
+                    // Caller gave up (timeout). Drop the pending entry so
+                    // the map doesn't accumulate abandoned senders.
+                    pending.remove(&id);
                 }
 
                 RelayCommand::ForwardFrame {
@@ -120,9 +151,8 @@ where
                 }
             },
 
-            // ─── Incoming frame from daemon → pipe to frontend ─────────
             SelectResult::Frame(Ok(Some(frame))) => {
-                pipe_frame(&config.frame_tx, &frame);
+                route_incoming_frame(&frame, &mut pending, &config.frame_tx);
             }
 
             SelectResult::Frame(Ok(None)) => {
@@ -137,159 +167,150 @@ where
         }
     }
 
+    // Any Rust callers still waiting get a Disconnected error so they
+    // don't hang on a channel that will never deliver.
+    for (_, entry) in pending.drain() {
+        let _ = entry.reply.send(Err(SyncError::Disconnected));
+    }
+
     info!("[relay] Stopped for {}", notebook_id);
+}
+
+/// Register a Rust-side request in the pending map and write the envelope
+/// to the daemon. If the write fails, the entry is evicted and the error
+/// is delivered on the caller's oneshot.
+async fn handle_send_request<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    pending: &mut HashMap<String, PendingEntry>,
+    id: String,
+    request: NotebookRequest,
+    reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+    broadcast_tx: Option<tokio::sync::broadcast::Sender<NotebookBroadcast>>,
+) {
+    let envelope = NotebookRequestEnvelope {
+        id: Some(id.clone()),
+        request,
+    };
+
+    let payload = match serde_json::to_vec(&envelope) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = reply.send(Err(SyncError::Serialization(e.to_string())));
+            return;
+        }
+    };
+
+    // Register BEFORE sending so a fast daemon response can't arrive before
+    // the pending entry is in place.
+    pending.insert(
+        id.clone(),
+        PendingEntry {
+            reply,
+            broadcast_tx,
+        },
+    );
+
+    if let Err(e) = connection::send_typed_frame(writer, NotebookFrameType::Request, &payload).await
+    {
+        if let Some(entry) = pending.remove(&id) {
+            let _ = entry.reply.send(Err(SyncError::Io(e)));
+        }
+    }
+}
+
+/// Dispatch an incoming frame from the daemon.
+///
+/// Response frames with a known correlation id are delivered to the
+/// matching Rust caller. Response frames with no id, or with an id we
+/// didn't register, are piped to the frontend — a JS caller is the likely
+/// owner. Broadcast frames are both delivered to any subscribed request
+/// (for progress updates on long-running calls) and piped to the frontend.
+/// Everything else is piped to the frontend.
+fn route_incoming_frame(
+    frame: &connection::TypedNotebookFrame,
+    pending: &mut HashMap<String, PendingEntry>,
+    frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
+) {
+    match frame.frame_type {
+        NotebookFrameType::Response => {
+            match serde_json::from_slice::<NotebookResponseEnvelope>(&frame.payload) {
+                Ok(envelope) => {
+                    let entry = envelope.id.as_deref().and_then(|id| pending.remove(id));
+                    if let Some(entry) = entry {
+                        let _ = entry.reply.send(Ok(envelope.response));
+                    } else {
+                        // Unknown id (or missing) — must belong to a frontend
+                        // request. Pipe the whole frame so the frontend's pending
+                        // map can match on the envelope's id.
+                        pipe_frame(frame_tx, frame);
+                    }
+                }
+                Err(e) => {
+                    warn!("[relay] Malformed response envelope: {}", e);
+                    // Pipe anyway so the frontend can surface / log it.
+                    pipe_frame(frame_tx, frame);
+                }
+            }
+        }
+
+        NotebookFrameType::Broadcast => {
+            // If any in-flight request subscribed to progress broadcasts,
+            // deliver there too (e.g., LaunchKernel env-creation phases).
+            let broadcast: Option<NotebookBroadcast> = serde_json::from_slice(&frame.payload).ok();
+            if let Some(bc) = broadcast.as_ref() {
+                for entry in pending.values() {
+                    if let Some(tx) = &entry.broadcast_tx {
+                        let _ = tx.send(bc.clone());
+                    }
+                }
+            }
+            pipe_frame(frame_tx, frame);
+        }
+
+        _ => pipe_frame(frame_tx, frame),
+    }
 }
 
 /// Pipe a daemon frame to the frontend.
 ///
-/// Only sync, broadcast, and presence frames are forwarded. Response and
-/// request frames are internal to the protocol and must not reach the frontend.
+/// Forwards sync, broadcast, presence, runtime-state, pool-state, AND
+/// response (`0x02`) frames. Frontend requests rely on `0x02` reaching the
+/// JS side so the frontend's pending map can correlate the response.
+///
+/// Request frames (`0x01`) are never piped outbound to the frontend — the
+/// frontend sends them; the daemon never emits them to a client.
 fn pipe_frame(frame_tx: &mpsc::UnboundedSender<Vec<u8>>, frame: &connection::TypedNotebookFrame) {
     match frame.frame_type {
         NotebookFrameType::AutomergeSync
         | NotebookFrameType::Broadcast
         | NotebookFrameType::Presence
         | NotebookFrameType::RuntimeStateSync
-        | NotebookFrameType::PoolStateSync => {
+        | NotebookFrameType::PoolStateSync
+        | NotebookFrameType::Response => {
             let mut bytes = vec![frame.frame_type as u8];
             bytes.extend_from_slice(&frame.payload);
             let _ = frame_tx.send(bytes);
         }
-        _ => {
+        NotebookFrameType::Request => {
             debug!(
-                "[relay] Not piping {:?} frame ({} bytes)",
-                frame.frame_type,
+                "[relay] Not piping Request frame (outbound only) — {} bytes",
                 frame.payload.len()
             );
         }
     }
 }
 
-/// Send a request to the daemon and wait for the response.
-///
-/// While waiting, non-response frames are piped to the frontend.
-/// This ensures the WASM frontend doesn't miss sync/broadcast/presence
-/// frames that arrive during a request/response cycle.
-async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    reader: &mut R,
-    writer: &mut W,
-    frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
-    req_broadcast_tx: Option<&tokio::sync::broadcast::Sender<NotebookBroadcast>>,
-    request: &notebook_protocol::protocol::NotebookRequest,
-    notebook_id: &str,
-) -> Result<NotebookResponse, SyncError> {
-    // Wrap the request in a correlation envelope. The daemon echoes the
-    // id on the response envelope. The relay currently serializes requests
-    // (one in flight per room), so the correlation id is redundant here —
-    // but it's part of the wire protocol at `PROTOCOL_VERSION = 3`, and a
-    // later PR (direct JS sendRequest) will use the id to dispatch
-    // concurrent responses via a pending map.
-    let expected_id = uuid::Uuid::new_v4().to_string();
-    let envelope = notebook_protocol::protocol::NotebookRequestEnvelope {
-        id: Some(expected_id.clone()),
-        request: request.clone(),
-    };
-    let payload =
-        serde_json::to_vec(&envelope).map_err(|e| SyncError::Serialization(e.to_string()))?;
-    connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
-        .await
-        .map_err(SyncError::Io)?;
-
-    // Determine timeout based on request type.
-    // Completions use 7s — the daemon's kernel-level timeout is 5s, so the
-    // daemon always responds within ~5s. The extra 2s margin ensures the
-    // relay never independently times out during normal operation (only on
-    // daemon crash/hang). A long wait blocks the entire relay.
-    let timeout_secs = match request {
-        notebook_protocol::protocol::NotebookRequest::LaunchKernel { .. } => 300,
-        notebook_protocol::protocol::NotebookRequest::SyncEnvironment { .. } => 300,
-        notebook_protocol::protocol::NotebookRequest::Complete { .. } => 7,
+/// Per-request-type timeouts — exported so `RelayHandle::send_request` can
+/// wrap its oneshot await in the same bound that the old inline read loop
+/// used to enforce.
+pub fn request_timeout(request: &NotebookRequest) -> Duration {
+    let secs = match request {
+        NotebookRequest::LaunchKernel { .. } => 300,
+        NotebookRequest::SyncEnvironment { .. } => 300,
+        // Completions use 7s — the daemon's kernel-level timeout is 5s,
+        // so the daemon always responds within ~5s under normal operation.
+        NotebookRequest::Complete { .. } => 7,
         _ => 30,
     };
-
-    let result = tokio::time::timeout(
-        Duration::from_secs(timeout_secs),
-        wait_for_response(
-            reader,
-            frame_tx,
-            req_broadcast_tx,
-            notebook_id,
-            &expected_id,
-        ),
-    )
-    .await;
-
-    match result {
-        Ok(inner) => inner,
-        Err(_) => {
-            warn!(
-                "[relay] Request timed out after {}s: {:?}",
-                timeout_secs, request
-            );
-            // NOTE: We intentionally do NOT drain stale response frames here.
-            // `recv_typed_frame` uses `read_exact` internally, which is not
-            // cancellation-safe — wrapping it in `tokio::time::timeout` could
-            // cancel mid-frame and corrupt the stream. The relay timeout (7s)
-            // exceeds the daemon's kernel-level timeout (5s), so the daemon
-            // always responds before the relay gives up. Any stale Response
-            // frames that reach the select loop are harmlessly discarded by
-            // `pipe_frame`.
-            Err(SyncError::Timeout)
-        }
-    }
-}
-
-/// Wait for a Response frame, piping all other frames to the frontend.
-async fn wait_for_response<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
-    req_broadcast_tx: Option<&tokio::sync::broadcast::Sender<NotebookBroadcast>>,
-    _notebook_id: &str,
-    expected_id: &str,
-) -> Result<NotebookResponse, SyncError> {
-    loop {
-        let frame = connection::recv_typed_frame(reader)
-            .await
-            .map_err(SyncError::Io)?
-            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
-
-        match frame.frame_type {
-            NotebookFrameType::Response => {
-                let envelope: notebook_protocol::protocol::NotebookResponseEnvelope =
-                    serde_json::from_slice(&frame.payload)
-                        .map_err(|e| SyncError::Serialization(e.to_string()))?;
-                // Relay serializes requests per room, so the id we're waiting
-                // for should always match. A mismatch means a stale response
-                // leaked past a timeout or a protocol bug — warn and keep
-                // reading so we eventually land on ours.
-                if let Some(id) = envelope.id.as_deref() {
-                    if id != expected_id {
-                        warn!(
-                            "[relay] Ignoring response with id {:?}, waiting for {:?}",
-                            id, expected_id
-                        );
-                        continue;
-                    }
-                }
-                return Ok(envelope.response);
-            }
-
-            NotebookFrameType::Broadcast => {
-                // Deliver to request-specific broadcast channel if provided
-                // (for real-time progress during long requests like LaunchKernel)
-                if let Some(tx) = req_broadcast_tx {
-                    if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
-                        let _ = tx.send(bc);
-                    }
-                }
-                // Also pipe to frontend
-                pipe_frame(frame_tx, &frame);
-            }
-
-            _ => {
-                // Sync, presence, etc. — pipe to frontend
-                pipe_frame(frame_tx, &frame);
-            }
-        }
-    }
+    Duration::from_secs(secs)
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3137,6 +3137,7 @@ async fn send_frame_bytes(
 
     match frame_type {
         frame_types::AUTOMERGE_SYNC
+        | frame_types::REQUEST
         | frame_types::PRESENCE
         | frame_types::RUNTIME_STATE_SYNC
         | frame_types::POOL_STATE_SYNC => handle

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4518,6 +4518,21 @@ async fn handle_notebook_request(
             env_source,
             notebook_path,
         } => {
+            // Fall back to the room's on-disk path when the caller doesn't
+            // supply one. The frontend typically launches with
+            // `notebook_path: None` and relies on the room knowing its own
+            // path; without this fallback, notebook-relative working dirs
+            // and auto-detection of `pyproject.toml` / `environment.yml` /
+            // `pixi.toml` silently stop working for saved notebooks.
+            let notebook_path = match notebook_path {
+                Some(p) => Some(p),
+                None => room
+                    .path
+                    .read()
+                    .await
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
+            };
             // Check RuntimeStateDoc for launch serialization.
             // Uses write lock so we can atomically check + set "starting"
             // to prevent two concurrent LaunchKernel requests from both

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -4,18 +4,50 @@
  * Bridges the `runtimed` `SyncEngine` to the daemon via Tauri IPC:
  *   - `sendFrame` → `invoke("send_frame", bytes)`
  *   - `onFrame` → `getCurrentWebview().listen("notebook:frame")`
+ *   - `sendRequest` → encode `NotebookRequestEnvelope`, send as `0x01` frame,
+ *                     wait for matching `0x02` response via an internal
+ *                     frame tap keyed by correlation id.
  *
- * Lives in this package (not in `apps/notebook`) so other hosts can depend
- * on a single canonical Tauri transport rather than re-implementing it.
+ * The pending map is tapped directly off `notebook:frame` events so Rust
+ * and JS callers can share the same socket concurrently — responses are
+ * dispatched by id, not by serialization order.
  */
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import type { FrameListener, NotebookRequest, NotebookTransport } from "runtimed";
+import type { FrameListener, NotebookRequest, NotebookResponse, NotebookTransport } from "runtimed";
+
+const FRAME_TYPE_REQUEST = 0x01;
+const FRAME_TYPE_RESPONSE = 0x02;
+
+/** Per-request-type timeouts. Mirror `relay_task::request_timeout` in Rust. */
+function requestTimeoutMs(request: NotebookRequest): number {
+  switch (request.type) {
+    case "launch_kernel":
+    case "sync_environment":
+      return 300_000;
+    case "complete":
+      return 7_000;
+    default:
+      return 30_000;
+  }
+}
+
+interface PendingEntry {
+  resolve: (response: NotebookResponse) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 export class TauriTransport implements NotebookTransport {
   private _connected = true;
   private unlisteners: Array<() => void> = [];
+  /** In-flight requests keyed by correlation id. */
+  private pending = new Map<string, PendingEntry>();
+
+  constructor() {
+    this.attachResponseTap();
+  }
 
   get connected(): boolean {
     return this._connected;
@@ -74,30 +106,38 @@ export class TauriTransport implements NotebookTransport {
 
   async sendRequest(request: unknown): Promise<unknown> {
     const req = request as NotebookRequest;
-    switch (req.type) {
-      case "launch_kernel":
-        return invoke("launch_kernel_via_daemon", {
-          kernelType: req.kernel_type,
-          envSource: req.env_source,
-          notebookPath: req.notebook_path,
-        });
-      case "execute_cell":
-        return invoke("execute_cell_via_daemon", { cellId: req.cell_id });
-      case "clear_outputs":
-        return invoke("clear_outputs_via_daemon", { cellId: req.cell_id });
-      case "interrupt":
-        return invoke("interrupt_via_daemon");
-      case "shutdown_kernel":
-        return invoke("shutdown_kernel_via_daemon");
-      case "sync_environment":
-        return invoke("sync_environment_via_daemon");
-      case "run_all_cells":
-        return invoke("run_all_cells_via_daemon");
-      case "send_comm":
-        return invoke("send_comm_via_daemon", { message: req.message });
-      default:
-        throw new Error(`TauriTransport: unknown request type: ${(req as { type: string }).type}`);
-    }
+    const id = crypto.randomUUID();
+
+    // Wire shape matches Rust's `NotebookRequestEnvelope` with
+    // `#[serde(tag = "action")]` on the flattened `NotebookRequest`:
+    //   { id: "...", action: "execute_cell", cell_id: "..." }
+    // TS uses `type:` as the discriminator internally, so translate on
+    // the way out.
+    const { type, ...rest } = req as { type: string } & Record<string, unknown>;
+    const envelope = { id, action: type, ...rest };
+    const payload = new TextEncoder().encode(JSON.stringify(envelope));
+
+    const timeoutMs = requestTimeoutMs(req);
+
+    return new Promise<NotebookResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`Request timeout after ${timeoutMs}ms: ${type}`));
+        }
+      }, timeoutMs);
+
+      this.pending.set(id, { resolve, reject, timer });
+
+      // Fire the 0x01 frame. If `sendFrame` itself fails (rare — only if
+      // the Tauri relay rejects the frame type), fail fast instead of
+      // waiting out the timeout.
+      void this.sendFrame(FRAME_TYPE_REQUEST, payload).catch((err) => {
+        if (this.pending.delete(id)) {
+          clearTimeout(timer);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    });
   }
 
   disconnect(): void {
@@ -106,5 +146,85 @@ export class TauriTransport implements NotebookTransport {
       unlisten();
     }
     this.unlisteners = [];
+    // Reject any still-pending requests so callers don't hang.
+    for (const [id, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error(`Transport disconnected (request ${id})`));
+    }
+    this.pending.clear();
+  }
+
+  /**
+   * Attach a permanent tap on `notebook:frame` that intercepts `0x02`
+   * response frames and dispatches them to the pending map.
+   *
+   * Non-response frames are ignored here — user-registered `onFrame`
+   * callbacks (e.g., the SyncEngine) see every frame independently.
+   * Tauri webview events fan out to all listeners, so the tap doesn't
+   * steal frames from other subscribers.
+   */
+  private attachResponseTap(): void {
+    const webview = getCurrentWebview();
+    let unlistenFn: (() => void) | null = null;
+    let cancelled = false;
+
+    const unlistenPromise = webview.listen<number[]>("notebook:frame", (event) => {
+      try {
+        this.dispatchResponseFrame(event.payload);
+      } catch (err) {
+        console.error("[tauri-transport] response tap failed:", err);
+      }
+    });
+
+    unlistenPromise
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlistenFn = fn;
+        }
+      })
+      .catch((err) => {
+        console.error("[tauri-transport] failed to attach response tap:", err);
+      });
+
+    this.unlisteners.push(() => {
+      cancelled = true;
+      if (unlistenFn) {
+        unlistenFn();
+        unlistenFn = null;
+      }
+    });
+  }
+
+  private dispatchResponseFrame(bytes: number[] | Uint8Array): void {
+    const first = (bytes as { [i: number]: number })[0];
+    if (first !== FRAME_TYPE_RESPONSE) return;
+
+    const view =
+      bytes instanceof Uint8Array ? bytes.subarray(1) : new Uint8Array(Array.from(bytes).slice(1));
+    const json = new TextDecoder().decode(view);
+
+    let envelope: { id?: string } & Record<string, unknown>;
+    try {
+      envelope = JSON.parse(json);
+    } catch (err) {
+      console.error("[tauri-transport] malformed response envelope:", err);
+      return;
+    }
+
+    const id = envelope.id;
+    if (typeof id !== "string") return;
+
+    const entry = this.pending.get(id);
+    if (!entry) return;
+
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+
+    // Strip the envelope id from the returned response so callers see a
+    // clean `NotebookResponse`.
+    const { id: _id, ...response } = envelope;
+    entry.resolve(response as NotebookResponse);
   }
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -92,7 +92,13 @@ export {
 
 // Notebook client
 export { NotebookClient, type NotebookClientOptions } from "./notebook-client";
-export type { CommRequestMessage, NotebookRequest, NotebookResponse } from "./request-types";
+export type {
+  CommRequestMessage,
+  CompletionItem,
+  HistoryEntry,
+  NotebookRequest,
+  NotebookResponse,
+} from "./request-types";
 
 // MIME priority
 export { DEFAULT_MIME_PRIORITY } from "./mime-priority";

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -10,7 +10,13 @@
 
 import type { SyncEngineLogger } from "./sync-engine";
 import type { NotebookTransport } from "./transport";
-import type { CommRequestMessage, NotebookRequest, NotebookResponse } from "./request-types";
+import type {
+  CommRequestMessage,
+  CompletionItem,
+  HistoryEntry,
+  NotebookRequest,
+  NotebookResponse,
+} from "./request-types";
 
 const nullLogger: SyncEngineLogger = {
   debug() {},
@@ -88,7 +94,7 @@ export class NotebookClient {
   /** Interrupt kernel execution. */
   async interruptKernel(): Promise<NotebookResponse> {
     try {
-      return await this.sendRequest({ type: "interrupt" });
+      return await this.sendRequest({ type: "interrupt_execution" });
     } catch (e) {
       this.log.error("[notebook-client] Interrupt failed:", e);
       throw e;
@@ -126,6 +132,66 @@ export class NotebookClient {
       return await this.sendRequest({ type: "run_all_cells" });
     } catch (e) {
       this.log.error("[notebook-client] Run all cells failed:", e);
+      throw e;
+    }
+  }
+
+  /**
+   * Search the kernel's input history.
+   *
+   * Throws on `no_kernel` (caller can prompt the user to start one) or on
+   * daemon-side errors — callers rely on these rejections to distinguish
+   * "no results" from "can't search right now" (e.g., the
+   * `HistorySearchDialog`'s "Start a kernel to search history" state).
+   */
+  async getHistory(pattern: string | null, n: number, unique: boolean): Promise<HistoryEntry[]> {
+    try {
+      const response = await this.sendRequest({
+        type: "get_history",
+        pattern,
+        n,
+        unique,
+      });
+      const result = (response as { result: string }).result;
+      if (result === "history_result") {
+        return (response as { result: "history_result"; entries: HistoryEntry[] }).entries;
+      }
+      if (result === "no_kernel") {
+        throw new Error("No kernel running");
+      }
+      if (result === "error") {
+        throw new Error((response as { error: string }).error);
+      }
+      throw new Error(`Unexpected response for get_history: ${result}`);
+    } catch (e) {
+      this.log.error("[notebook-client] Get history failed:", e);
+      throw e;
+    }
+  }
+
+  /** Request code completions from the kernel. */
+  async complete(
+    code: string,
+    cursorPos: number,
+  ): Promise<{ items: CompletionItem[]; cursorStart: number; cursorEnd: number }> {
+    try {
+      const response = await this.sendRequest({
+        type: "complete",
+        code,
+        cursor_pos: cursorPos,
+      });
+      if ((response as { result: string }).result === "completion_result") {
+        const r = response as {
+          result: "completion_result";
+          items: CompletionItem[];
+          cursor_start: number;
+          cursor_end: number;
+        };
+        return { items: r.items, cursorStart: r.cursor_start, cursorEnd: r.cursor_end };
+      }
+      return { items: [], cursorStart: cursorPos, cursorEnd: cursorPos };
+    } catch (e) {
+      this.log.error("[notebook-client] Complete failed:", e);
       throw e;
     }
   }

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -17,11 +17,34 @@ export type NotebookRequest =
     }
   | { type: "execute_cell"; cell_id: string }
   | { type: "clear_outputs"; cell_id: string }
-  | { type: "interrupt" }
+  | { type: "interrupt_execution" }
   | { type: "shutdown_kernel" }
   | { type: "sync_environment" }
   | { type: "run_all_cells" }
-  | { type: "send_comm"; message: CommRequestMessage };
+  | { type: "send_comm"; message: CommRequestMessage }
+  | {
+      type: "get_history";
+      /** Glob-style pattern to match. null for no filter. */
+      pattern: string | null;
+      /** Maximum number of entries to return. */
+      n: number;
+      /** Deduplicate identical entries when true. */
+      unique: boolean;
+    }
+  | { type: "complete"; code: string; cursor_pos: number };
+
+/** One entry returned by `get_history`. */
+export interface HistoryEntry {
+  session: number;
+  line: number;
+  source: string;
+}
+
+/** One item returned in a `completion_result`. */
+export interface CompletionItem {
+  label: string;
+  kind?: string | null;
+}
 
 /** Message shape for send_comm requests. */
 export interface CommRequestMessage {
@@ -70,4 +93,11 @@ export type NotebookResponse =
       result: "sync_environment_failed";
       error: string;
       needs_restart: boolean;
+    }
+  | { result: "history_result"; entries: HistoryEntry[] }
+  | {
+      result: "completion_result";
+      items: CompletionItem[];
+      cursor_start: number;
+      cursor_end: number;
     };


### PR DESCRIPTION
## Summary

Routes request/response through the existing `0x01` / `0x02` frame path instead of per-type Tauri commands. Builds on the correlation-id envelope landed in #1895.

After this PR the Tauri command surface for kernel ops is ~zero: the frontend encodes a request envelope, sends `0x01`, waits for the matching `0x02` via correlation id. Same code path Electron will use when it ships — no per-request wrappers to port.

## Rust-side changes

**`crates/notebook-sync/src/relay_task.rs`** — relay now maintains a `HashMap<String, PendingEntry>` keyed by correlation id:

- `RelayCommand::SendRequest`: generate uuid, register pending, write `0x01` envelope with id. Caller awaits the oneshot.
- Incoming frames: on `0x02`, parse envelope, look up id, deliver to the Rust caller's oneshot if registered. Otherwise pipe to frontend — that's a JS request's response. Broadcasts still fan out to all subscribed `broadcast_tx` (for `LaunchKernel` progress).
- On shutdown, drain pending and deliver `Err(Disconnected)` so callers don't hang.
- Per-request-type timeout moved from inline to `request_timeout()` helper; `RelayHandle::send_request` wraps the oneshot in it.

**`crates/notebook/src/lib.rs`** — `0x01` is now valid in the outgoing `send_frame` Tauri allowlist so JS can forward its own requests through the relay without a per-type wrapper.

## JS-side changes

**`packages/notebook-host/src/tauri/transport.ts`** — `TauriTransport` maintains its own `Map<id, {resolve, reject, timer}>`:

- Constructor attaches a `notebook:frame` tap that matches `0x02` frames to the pending map. User `onFrame` callbacks see every frame independently — Tauri webview events fan out.
- `sendRequest`: assign uuid, wrap request as `{id, action: <type>, ...rest}`, JSON-encode, send as `0x01` frame. Returns a promise resolved by the response tap or rejected by the per-type timeout (300s for launch/sync_env, 7s for complete, 30s otherwise — mirrors Rust).
- **Per-type dispatch table is gone.** All requests ride the frame path.
- `disconnect()` rejects any still-pending requests so callers don't hang.

## Frontend migrations

- `apps/notebook/src/hooks/useHistorySearch.ts` — uses `NotebookClient.getHistory()` (which goes through the frame path) instead of `invoke("get_history_via_daemon")`.
- `apps/notebook/src/lib/kernel-completion.ts` — uses `NotebookClient.complete()` via a `setKernelCompletionHost(host)` setter (same pattern as logger / blob-port / open-url). `main.tsx` wires it up.
- `packages/runtimed/src/request-types.ts` — adds `get_history` / `complete` variants to the `NotebookRequest` TS union plus `HistoryEntry` / `CompletionItem` types.
- `packages/runtimed/src/notebook-client.ts` — new `getHistory()` and `complete()` methods.

## What's NOT in this PR

The `*_via_daemon` Tauri commands in `crates/notebook/src/lib.rs` are now dead code — no JS caller, the transport doesn't invoke them. They're still registered via `generate_handler!`, so Tauri keeps them live for compilation. A follow-up cleanup PR deletes the 15+ commands and their registrations once this one proves stable in CI and manual testing.

## Test plan

- [x] `cargo test -p notebook-sync --lib` — 37 pass.
- [x] `cargo check --workspace` — clean.
- [x] `pnpm test` — 1054 pass.
- [x] `cargo xtask lint` — clean.
- [ ] **Manual**: `cargo xtask notebook` —
  - Run a cell (`execute_cell`) → output appears.
  - Clear outputs → output clears.
  - Interrupt → running cell stops.
  - Restart kernel → relaunches cleanly.
  - Tab completion in a code cell → completions appear.
  - Kernel history / up-arrow search in terminal → entries load.
  - Save / Save As / Clone → daemon writes file.
  - Run all → all code cells execute in order.
  - Widget interaction (slider drag) → state flows.
- [ ] CI including E2E on Linux.

## Follow-ups

1. Delete dead `*_via_daemon` Tauri commands (separate cleanup PR).
2. `createElectronHost()` — with the frame path in place, the Electron implementation is: open the socket, speak the protocol. No per-request wrappers.