### PR TITLE
fix(runtimed): respect default_python_env in LaunchKernel auto fallback

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4766,7 +4766,14 @@ async fn handle_notebook_request(
                         let fallback = match auto_scope {
                             Some("conda") => "conda:prewarmed",
                             Some("pixi") => "pixi:prewarmed",
-                            _ => "uv:prewarmed",
+                            _ => {
+                                let default_env = daemon.default_python_env().await;
+                                match default_env {
+                                    crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
+                                    crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
+                                    _ => "uv:prewarmed",
+                                }
+                            }
                         };
                         info!(
                             "[notebook-sync] No project file detected, using {}",


### PR DESCRIPTION
## Summary

The `LaunchKernel` handler's unscoped `"auto"` env_source fallback hardcoded `"uv:prewarmed"` when no project files or inline deps were found. This caused conda/pixi notebooks to relaunch with a uv environment after save-as, since the Tauri save-as path restarts the kernel with `env_source: "auto"`.

Now reads `daemon.default_python_env()` in the fallback branch, matching the pattern already used by `auto_launch_kernel` and the PEP 723 fallback in the same function.

## Verification

- [ ] Set default Python environment to conda in settings
- [ ] Create a new notebook (should show conda in dep panel)
- [ ] Save the notebook via Cmd+S to a new location
- [ ] Confirm the dependency panel still shows conda after save

_PR submitted by @rgbkrk's agent, Quill_