### PR TITLE
fix(widgets): attribute widget writes to break the echo loop

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -363,13 +363,13 @@ function AppContent() {
     };
   }, [getHandle, triggerSync]);
 
-  // Dev-only bridge for E2E tests to drive widget updates through the
-  // real pipeline (WidgetUpdateManager → debounced CRDT write → daemon
-  // → kernel) without reaching into the security-isolated iframe. Gated
-  // on `import.meta.env.DEV` so production bundles don't expose these
-  // on `window`.
+  // E2E-only bridge for driving widget updates through the real pipeline
+  // (WidgetUpdateManager → debounced CRDT write → daemon → kernel) from
+  // a WebDriver spec, without reaching into the security-isolated iframe.
+  // Gated on `VITE_E2E` — `cargo xtask e2e build` sets it, production
+  // builds don't, so these globals aren't exposed to end users.
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!import.meta.env.VITE_E2E) return;
     const w = window as unknown as Record<string, unknown>;
     w.__nteractWidgetUpdate = (commId: string, patch: Record<string, unknown>) => {
       updateManager.updateAndPersist(commId, patch);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -363,6 +363,24 @@ function AppContent() {
     };
   }, [getHandle, triggerSync]);
 
+  // Dev-only bridge for E2E tests to drive widget updates through the
+  // real pipeline (WidgetUpdateManager → debounced CRDT write → daemon
+  // → kernel) without reaching into the security-isolated iframe. Gated
+  // on `import.meta.env.DEV` so production bundles don't expose these
+  // on `window`.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const w = window as unknown as Record<string, unknown>;
+    w.__nteractWidgetUpdate = (commId: string, patch: Record<string, unknown>) => {
+      updateManager.updateAndPersist(commId, patch);
+    };
+    w.__nteractWidgetStore = widgetStore;
+    return () => {
+      delete w.__nteractWidgetUpdate;
+      delete w.__nteractWidgetStore;
+    };
+  }, [widgetStore]);
+
   // ── CRDT → WidgetStore projection via SyncEngine.commChanges$ ──────
   // Replaces the old Jupyter message synthesis path. The SyncEngine diffs
   // RuntimeStateDoc.comms, resolves ContentRefs via WASM, and emits

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -1965,6 +1965,33 @@ impl RuntimeStateDoc {
         let heads_after = self.doc.get_heads();
         Ok(heads_before != heads_after)
     }
+
+    /// Like `receive_sync_message_with_changes`, but also returns the
+    /// actor IDs that authored the newly-applied changes.
+    ///
+    /// Callers use this to distinguish foreign-authored changes (what a
+    /// remote peer just sent us) from any changes that were already in
+    /// the document. Specifically, the runtime agent uses it to skip
+    /// forwarding kernel echoes back to the kernel — an echo written by
+    /// the runtime agent's own iopub actor must not re-enter the
+    /// "frontend said something" forwarding path.
+    pub fn receive_sync_message_capture_actors(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<Vec<ActorId>, AutomergeError> {
+        let heads_before = self.doc.get_heads();
+        self.doc.sync().receive_sync_message(peer_state, message)?;
+        // Collect authors of changes that advanced the doc past
+        // `heads_before`. If no heads moved, returns an empty Vec.
+        let applied_actors: Vec<ActorId> = self
+            .doc
+            .get_changes(&heads_before)
+            .into_iter()
+            .map(|c| c.actor_id().clone())
+            .collect();
+        Ok(applied_actors)
+    }
 }
 
 // ── Output diff utility ─────────────────────────────────────────────
@@ -3331,5 +3358,63 @@ mod tests {
         // Object values are always written (no deep comparison)
         let delta = serde_json::json!({"nested": {"a": 1}});
         assert!(doc.merge_comm_state_delta("w1", &delta));
+    }
+
+    #[test]
+    fn receive_sync_capture_actors_reports_change_authors() {
+        // Receiver (e.g. the runtime agent) starts fresh.
+        let mut receiver = RuntimeStateDoc::new();
+        receiver.set_actor("rt:kernel:deadbeef");
+        let mut receiver_sync = sync::State::new();
+
+        // Peer A (e.g. frontend) writes a comm change on a fork with a
+        // distinct actor, syncs to the receiver.
+        let mut peer_a = receiver.fork();
+        peer_a.set_actor("human:peer-a");
+        peer_a.put_comm("w1", "jupyter.widget", "", "", &serde_json::json!({}), 0);
+        let mut peer_a_sync = sync::State::new();
+        // Drive the sync handshake to convergence (bloom-filter based,
+        // needs a couple of round-trips).
+        for _ in 0..3 {
+            if let Some(msg) = peer_a.doc.sync().generate_sync_message(&mut peer_a_sync) {
+                let actors = receiver
+                    .receive_sync_message_capture_actors(&mut receiver_sync, msg)
+                    .expect("receive");
+                if !actors.is_empty() {
+                    assert!(
+                        actors.iter().any(|a| a.to_bytes().starts_with(b"human:")),
+                        "expected a human:* authored change, got {:?}",
+                        actors
+                    );
+                    return;
+                }
+            }
+            if let Some(reply) = receiver.generate_sync_message(&mut receiver_sync) {
+                let _ = peer_a
+                    .doc
+                    .sync()
+                    .receive_sync_message(&mut peer_a_sync, reply);
+            }
+        }
+        panic!("sync never converged to report an applied change");
+    }
+
+    #[test]
+    fn receive_sync_capture_actors_empty_on_handshake() {
+        let mut receiver = RuntimeStateDoc::new();
+        let mut receiver_sync = sync::State::new();
+        let mut peer = RuntimeStateDoc::new();
+        let mut peer_sync = sync::State::new();
+
+        // First message is just a handshake (no new changes).
+        if let Some(msg) = peer.generate_sync_message(&mut peer_sync) {
+            let actors = receiver
+                .receive_sync_message_capture_actors(&mut receiver_sync, msg)
+                .expect("handshake");
+            assert!(
+                actors.is_empty(),
+                "handshake should not report applied actors"
+            );
+        }
     }
 }

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -58,8 +58,8 @@
 //! ```
 
 use automerge::{
-    sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjType,
-    ReadDoc, ScalarValue, Value, ROOT,
+    sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjId,
+    ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -1966,32 +1966,127 @@ impl RuntimeStateDoc {
         Ok(heads_before != heads_after)
     }
 
-    /// Like `receive_sync_message_with_changes`, but also returns the
-    /// actor IDs that authored the newly-applied changes.
+    /// Apply a sync message and return both the list of applied-change
+    /// authors AND a view of `comms` as it would look if only changes
+    /// authored by "foreign" actors had been applied.
     ///
-    /// Callers use this to distinguish foreign-authored changes (what a
-    /// remote peer just sent us) from any changes that were already in
-    /// the document. Specifically, the runtime agent uses it to skip
-    /// forwarding kernel echoes back to the kernel — an echo written by
-    /// the runtime agent's own iopub actor must not re-enter the
-    /// "frontend said something" forwarding path.
-    pub fn receive_sync_message_capture_actors(
+    /// This is the key primitive for the runtime agent's echo-suppression:
+    /// if a single `RuntimeStateSync` frame coalesces a kernel-authored
+    /// echo together with a frontend widget update, diffing the full
+    /// post-sync doc against `comms_before` would re-forward the echo to
+    /// the kernel. Diffing against `foreign_comms` sees only the
+    /// frontend's changes, breaking the amplification loop at
+    /// per-change granularity instead of per-frame.
+    ///
+    /// Implementation: fork at `heads_before`, apply only non-self
+    /// changes on the fork, read `comms` from it. The main doc still
+    /// absorbs every applied change (including kernel echoes) so local
+    /// state stays consistent — only the `foreign_comms` view is filtered.
+    ///
+    /// `is_foreign(&ActorId) -> bool` decides which applied changes to
+    /// include in the fork. Runtime agent passes a closure that returns
+    /// `false` for actors starting with `rt:kernel:`.
+    pub fn receive_sync_and_foreign_comms<F>(
         &mut self,
         peer_state: &mut sync::State,
         message: sync::Message,
-    ) -> Result<Vec<ActorId>, AutomergeError> {
+        is_foreign: F,
+    ) -> Result<ForeignSyncView, AutomergeError>
+    where
+        F: Fn(&ActorId) -> bool,
+    {
         let heads_before = self.doc.get_heads();
         self.doc.sync().receive_sync_message(peer_state, message)?;
-        // Collect authors of changes that advanced the doc past
-        // `heads_before`. If no heads moved, returns an empty Vec.
-        let applied_actors: Vec<ActorId> = self
-            .doc
-            .get_changes(&heads_before)
-            .into_iter()
-            .map(|c| c.actor_id().clone())
-            .collect();
-        Ok(applied_actors)
+
+        let applied = self.doc.get_changes(&heads_before);
+        if applied.is_empty() {
+            // Handshake / ack — nothing moved.
+            return Ok(ForeignSyncView {
+                applied_actors: Vec::new(),
+                foreign_comms: None,
+            });
+        }
+
+        let applied_actors: Vec<ActorId> = applied.iter().map(|c| c.actor_id().clone()).collect();
+
+        if !applied_actors.iter().any(&is_foreign) {
+            // Every applied change was self-authored (e.g., our own
+            // kernel echoes reflected back). No foreign view to build.
+            return Ok(ForeignSyncView {
+                applied_actors,
+                foreign_comms: None,
+            });
+        }
+
+        // Per-field authorship view: walk each comm's `state` and
+        // retain only fields whose current LWW winner was written by a
+        // foreign actor. Fields last-written by the kernel (either
+        // directly or via the coalesced-echo writer, which carries the
+        // kernel's actor ID) are stripped — the runtime agent must not
+        // forward them back to the kernel and trigger amplification.
+        //
+        // `fork_at(heads_before) + apply_changes(foreign_only)` is *not*
+        // safe here: when frontend writes are causally after kernel
+        // writes (the common case during continuous slider drag), the
+        // frontend change's dependencies include kernel-authored
+        // parents, and applying the foreign subset alone orphans them.
+        // Per-field authorship sidesteps causality entirely.
+        let comms_obj = match self.doc.get(ROOT, "comms")? {
+            Some((Value::Object(ObjType::Map), obj)) => obj,
+            _ => {
+                return Ok(ForeignSyncView {
+                    applied_actors,
+                    foreign_comms: Some(HashMap::new()),
+                });
+            }
+        };
+
+        let mut foreign_comms: HashMap<String, CommDocEntry> = HashMap::new();
+        let all = self.read_state().comms;
+        for (comm_id, mut entry) in all {
+            let Some((_, entry_obj)) = self.doc.get(&comms_obj, comm_id.as_str())? else {
+                continue;
+            };
+            let Some((Value::Object(ObjType::Map), state_obj)) =
+                self.doc.get(&entry_obj, "state")?
+            else {
+                continue;
+            };
+            let Some(state_map) = entry.state.as_object_mut() else {
+                continue;
+            };
+            let keys: Vec<String> = state_map.keys().cloned().collect();
+            for key in keys {
+                let authored_by_foreign = match self.doc.get(&state_obj, key.as_str())? {
+                    Some((_, ObjId::Id(_, actor, _))) => is_foreign(&actor),
+                    _ => false,
+                };
+                if !authored_by_foreign {
+                    state_map.remove(&key);
+                }
+            }
+            if !state_map.is_empty() {
+                foreign_comms.insert(comm_id, entry);
+            }
+        }
+
+        Ok(ForeignSyncView {
+            applied_actors,
+            foreign_comms: Some(foreign_comms),
+        })
     }
+}
+
+/// Result of [`RuntimeStateDoc::receive_sync_and_foreign_comms`].
+#[derive(Debug)]
+pub struct ForeignSyncView {
+    /// All actors that authored changes applied by the sync message.
+    /// Empty when the message was a handshake / ack.
+    pub applied_actors: Vec<ActorId>,
+    /// `comms` as it would appear if only foreign-authored applied
+    /// changes were in the doc. `None` when the message applied no
+    /// foreign changes (handshake, or every change was self-authored).
+    pub foreign_comms: Option<HashMap<String, CommDocEntry>>,
 }
 
 // ── Output diff utility ─────────────────────────────────────────────
@@ -3361,60 +3456,210 @@ mod tests {
     }
 
     #[test]
-    fn receive_sync_capture_actors_reports_change_authors() {
-        // Receiver (e.g. the runtime agent) starts fresh.
+    fn foreign_sync_view_filters_self_authored_fields() {
+        // Two comms in one sync frame: kernel-widget's "value" was
+        // last-written by the kernel actor (a self-echo); human-widget's
+        // "value" was last-written by a frontend actor. The per-field
+        // filter should strip the kernel echo and retain the frontend
+        // write, even though both changes ride the same sync message.
+        //
+        // Production writes go through `fork_and_merge`, so each write
+        // creates an independent change tagged with the fork's actor.
+        // We model that here by forking the donor separately for each
+        // actor identity.
         let mut receiver = RuntimeStateDoc::new();
         receiver.set_actor("rt:kernel:deadbeef");
         let mut receiver_sync = sync::State::new();
 
-        // Peer A (e.g. frontend) writes a comm change on a fork with a
-        // distinct actor, syncs to the receiver.
-        let mut peer_a = receiver.fork();
-        peer_a.set_actor("human:peer-a");
-        peer_a.put_comm("w1", "jupyter.widget", "", "", &serde_json::json!({}), 0);
-        let mut peer_a_sync = sync::State::new();
-        // Drive the sync handshake to convergence (bloom-filter based,
-        // needs a couple of round-trips).
-        for _ in 0..3 {
-            if let Some(msg) = peer_a.doc.sync().generate_sync_message(&mut peer_a_sync) {
-                let actors = receiver
-                    .receive_sync_message_capture_actors(&mut receiver_sync, msg)
+        let mut donor = receiver.fork();
+        // Kernel-authored comm: self-echo.
+        donor.fork_and_merge(|f| {
+            f.set_actor("rt:kernel:deadbeef");
+            f.put_comm(
+                "kernel-widget",
+                "j.w",
+                "",
+                "",
+                &serde_json::json!({"value": 1}),
+                0,
+            );
+        });
+        // Frontend-authored comm: legitimate write.
+        donor.fork_and_merge(|f| {
+            f.set_actor("human:peer");
+            f.put_comm(
+                "human-widget",
+                "j.w",
+                "",
+                "",
+                &serde_json::json!({"value": 2}),
+                0,
+            );
+        });
+
+        let mut donor_sync = sync::State::new();
+        for _ in 0..4 {
+            if let Some(msg) = donor.doc.sync().generate_sync_message(&mut donor_sync) {
+                let view = receiver
+                    .receive_sync_and_foreign_comms(&mut receiver_sync, msg, |actor| {
+                        !actor.to_bytes().starts_with(b"rt:kernel:")
+                    })
                     .expect("receive");
-                if !actors.is_empty() {
-                    assert!(
-                        actors.iter().any(|a| a.to_bytes().starts_with(b"human:")),
-                        "expected a human:* authored change, got {:?}",
-                        actors
-                    );
-                    return;
+                if let Some(foreign_comms) = view.foreign_comms {
+                    if foreign_comms.contains_key("human-widget") {
+                        assert!(
+                            !foreign_comms.contains_key("kernel-widget"),
+                            "foreign view must not contain kernel-authored echo: {:?}",
+                            foreign_comms.keys().collect::<Vec<_>>()
+                        );
+                        assert!(
+                            view.applied_actors
+                                .iter()
+                                .any(|a| a.to_bytes().starts_with(b"human:")),
+                            "applied_actors should include human: entry"
+                        );
+                        return;
+                    }
                 }
             }
             if let Some(reply) = receiver.generate_sync_message(&mut receiver_sync) {
-                let _ = peer_a
+                let _ = donor
                     .doc
                     .sync()
-                    .receive_sync_message(&mut peer_a_sync, reply);
+                    .receive_sync_message(&mut donor_sync, reply);
             }
         }
-        panic!("sync never converged to report an applied change");
+        panic!("sync never converged to produce a foreign view");
     }
 
     #[test]
-    fn receive_sync_capture_actors_empty_on_handshake() {
+    fn foreign_sync_view_strips_kernel_overwrites_on_shared_field() {
+        // Frontend wrote `value=15`, kernel subsequently echoed
+        // `value=10` on the same comm.state key. The per-field filter
+        // must recognize the current LWW winner was authored by the
+        // kernel actor and OMIT that key from the foreign view so the
+        // runtime agent does not forward the kernel echo back.
+        let mut receiver = RuntimeStateDoc::new();
+        receiver.set_actor("rt:kernel:deadbeef");
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = receiver.fork();
+        donor.fork_and_merge(|f| {
+            f.set_actor("human:peer");
+            f.put_comm(
+                "slider",
+                "j.w",
+                "",
+                "",
+                &serde_json::json!({"value": 15}),
+                0,
+            );
+        });
+        // Kernel echoes a different value on the same key AFTER the
+        // frontend's write — causally later, so LWW winner is the
+        // kernel's 10.
+        donor.fork_and_merge(|f| {
+            f.set_actor("rt:kernel:deadbeef");
+            f.merge_comm_state_delta("slider", &serde_json::json!({"value": 10}));
+        });
+
+        let mut donor_sync = sync::State::new();
+        for _ in 0..4 {
+            if let Some(msg) = donor.doc.sync().generate_sync_message(&mut donor_sync) {
+                let view = receiver
+                    .receive_sync_and_foreign_comms(&mut receiver_sync, msg, |actor| {
+                        !actor.to_bytes().starts_with(b"rt:kernel:")
+                    })
+                    .expect("receive");
+                if let Some(foreign_comms) = view.foreign_comms {
+                    // Applied both the frontend open and the kernel
+                    // echo? The current LWW winner on `value` is the
+                    // kernel's 10, so the slider comm is either absent
+                    // from the foreign view entirely (no foreign fields
+                    // remain) or present with `value` stripped.
+                    if view
+                        .applied_actors
+                        .iter()
+                        .any(|a| a.to_bytes().starts_with(b"rt:kernel:"))
+                        && view
+                            .applied_actors
+                            .iter()
+                            .any(|a| a.to_bytes().starts_with(b"human:"))
+                    {
+                        match foreign_comms.get("slider") {
+                            None => return,
+                            Some(entry) => {
+                                let state = entry.state.as_object().expect("state");
+                                assert!(
+                                    !state.contains_key("value"),
+                                    "kernel-authored value must be stripped, got {:?}",
+                                    state
+                                );
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(reply) = receiver.generate_sync_message(&mut receiver_sync) {
+                let _ = donor
+                    .doc
+                    .sync()
+                    .receive_sync_message(&mut donor_sync, reply);
+            }
+        }
+        panic!("sync never converged");
+    }
+
+    #[test]
+    fn foreign_sync_view_none_for_handshake() {
         let mut receiver = RuntimeStateDoc::new();
         let mut receiver_sync = sync::State::new();
         let mut peer = RuntimeStateDoc::new();
         let mut peer_sync = sync::State::new();
 
-        // First message is just a handshake (no new changes).
         if let Some(msg) = peer.generate_sync_message(&mut peer_sync) {
-            let actors = receiver
-                .receive_sync_message_capture_actors(&mut receiver_sync, msg)
+            let view = receiver
+                .receive_sync_and_foreign_comms(&mut receiver_sync, msg, |_| true)
                 .expect("handshake");
-            assert!(
-                actors.is_empty(),
-                "handshake should not report applied actors"
-            );
+            assert!(view.applied_actors.is_empty());
+            assert!(view.foreign_comms.is_none());
         }
+    }
+
+    #[test]
+    fn foreign_sync_view_none_when_all_self_authored() {
+        let mut receiver = RuntimeStateDoc::new();
+        receiver.set_actor("rt:kernel:deadbeef");
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = receiver.fork();
+        donor.set_actor("rt:kernel:deadbeef");
+        donor.put_comm("w", "j.w", "", "", &serde_json::json!({}), 0);
+
+        let mut donor_sync = sync::State::new();
+        for _ in 0..4 {
+            if let Some(msg) = donor.doc.sync().generate_sync_message(&mut donor_sync) {
+                let view = receiver
+                    .receive_sync_and_foreign_comms(&mut receiver_sync, msg, |actor| {
+                        !actor.to_bytes().starts_with(b"rt:kernel:")
+                    })
+                    .expect("receive");
+                if !view.applied_actors.is_empty() {
+                    assert!(
+                        view.foreign_comms.is_none(),
+                        "all-self-authored message should produce no foreign view"
+                    );
+                    return;
+                }
+            }
+            if let Some(reply) = receiver.generate_sync_message(&mut receiver_sync) {
+                let _ = donor
+                    .doc
+                    .sync()
+                    .receive_sync_message(&mut donor_sync, reply);
+            }
+        }
+        panic!("sync never converged");
     }
 }

--- a/crates/notebook/fixtures/audit-test/16-widget-slider.ipynb
+++ b/crates/notebook/fixtures/audit-test/16-widget-slider.ipynb
@@ -1,0 +1,58 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.13.0"
+    },
+    "runt": {
+      "schema_version": "1"
+    }
+  },
+  "cells": [
+    {
+      "id": "slider-setup",
+      "cell_type": "code",
+      "source": [
+        "from ipywidgets import interact, FloatSlider\n",
+        "\n",
+        "\n",
+        "@interact(freq=FloatSlider(min=0.5, max=5, step=0.1, value=1, description=\"Frequency\"))\n",
+        "def show(freq):\n",
+        "    print(f\"freq={freq:.1f}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "67b483abaf4444ae9f130ed2d34a4cc6"
+            },
+            "text/plain": "interactive(children=(FloatSlider(value=1.0, description='Frequency', max=5.0, min=0.5), Output()), _dom_class…"
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 1
+    },
+    {
+      "id": "verify-cell",
+      "cell_type": "code",
+      "source": [
+        "import random; print(f'alive-{random.random():.6f}')"
+      ],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1856,6 +1856,13 @@ impl KernelConnection for JupyterKernel {
         let coalesce_state_doc = shared.state_doc.clone();
         let coalesce_state_changed = shared.state_changed_tx.clone();
         let coalesce_blob_store = shared.blob_store.clone();
+        // Coalesced comm writes must carry the kernel actor ID so the
+        // runtime agent's actor filter in `receive_sync_and_foreign_comms`
+        // recognizes them as self-authored echoes and doesn't forward
+        // them back to the kernel. Without this, writes inherit the
+        // doc's default actor (`runtimed:state`) and the filter lets
+        // them through, re-triggering the amplification loop.
+        let coalesce_actor_id = kernel_actor_id.clone();
         let comm_coalesce_task = tokio::spawn(async move {
             let mut pending: HashMap<String, serde_json::Value> = HashMap::new();
             let mut timer = tokio::time::interval(std::time::Duration::from_millis(16));
@@ -1889,11 +1896,14 @@ impl KernelConnection for JupyterKernel {
                         }
                         let mut sd = coalesce_state_doc.write().await;
                         let mut any_changed = false;
-                        for (comm_id, delta) in &batch {
-                            if sd.merge_comm_state_delta(comm_id, delta) {
-                                any_changed = true;
+                        sd.fork_and_merge(|f| {
+                            f.set_actor(&coalesce_actor_id);
+                            for (comm_id, delta) in &batch {
+                                if f.merge_comm_state_delta(comm_id, delta) {
+                                    any_changed = true;
+                                }
                             }
-                        }
+                        });
                         if any_changed {
                             let _ = coalesce_state_changed.send(());
                         }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -157,42 +157,38 @@ pub async fn run_runtime_agent(
                                     // detect frontend-originated widget state changes.
                                     let comms_before = sd.read_state().comms;
 
-                                    match sd.receive_sync_message_capture_actors(
+                                    // Per-change actor filter: diff comm state against a
+                                    // foreign-only view of the post-sync doc. If the
+                                    // coordinator coalesces a kernel-authored echo with a
+                                    // frontend widget write into one RuntimeStateSync frame,
+                                    // the foreign view omits the echo so we don't re-forward
+                                    // it back to the kernel and trigger amplification.
+                                    // Actors are opaque byte strings; the kernel-side writer
+                                    // uses a UTF-8 `rt:kernel:<session>` prefix (see
+                                    // `jupyter_kernel.rs`), so `starts_with` on the raw
+                                    // bytes is sufficient.
+                                    match sd.receive_sync_and_foreign_comms(
                                         &mut coordinator_sync_state,
                                         msg,
+                                        |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
                                     ) {
-                                        Ok(applied_actors) if !applied_actors.is_empty() => {
+                                        Ok(view) if !view.applied_actors.is_empty() => {
                                             let _ = state_changed_tx.send(());
 
-                                            // Actor-based filter for the echo-amplification loop:
-                                            // if every applied change was authored by the runtime
-                                            // agent's own kernel-writer actor (`rt:kernel:*`),
-                                            // the sync only reflected our own echoes bouncing
-                                            // back through the coordinator. Forwarding those to
-                                            // the kernel re-sends the value the kernel already
-                                            // set and triggers exponential message growth on
-                                            // the ZMQ shell channel during rapid slider input.
-                                            // Actors are opaque byte strings; the kernel-side
-                                            // writer uses a UTF-8 `rt:kernel:<session>` prefix
-                                            // (see `jupyter_kernel.rs`), so a straight
-                                            // `starts_with` on the raw bytes is sufficient.
-                                            let any_foreign = applied_actors.iter().any(|a| {
-                                                !a.to_bytes().starts_with(b"rt:kernel:")
-                                            });
-
-                                            // Diff comm state -- forward changes to kernel
-                                            let comms_after = sd.read_state().comms;
                                             let queued = sd.get_queued_executions();
                                             drop(sd); // release write lock before kernel interaction
 
-                                            let comm_updates = if any_foreign {
-                                                diff_comm_state(&comms_before, &comms_after)
-                                            } else {
-                                                debug!(
-                                                    "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
-                                                    applied_actors.len()
-                                                );
-                                                Vec::new()
+                                            let comm_updates = match view.foreign_comms {
+                                                Some(foreign_comms) => {
+                                                    diff_comm_state(&comms_before, &foreign_comms)
+                                                }
+                                                None => {
+                                                    debug!(
+                                                        "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
+                                                        view.applied_actors.len()
+                                                    );
+                                                    Vec::new()
+                                                }
                                             };
                                             if !comm_updates.is_empty() {
                                                 if let Some(ref mut k) = kernel {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -157,19 +157,43 @@ pub async fn run_runtime_agent(
                                     // detect frontend-originated widget state changes.
                                     let comms_before = sd.read_state().comms;
 
-                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                    match sd.receive_sync_message_capture_actors(
                                         &mut coordinator_sync_state,
                                         msg,
                                     ) {
-                                        if changed {
+                                        Ok(applied_actors) if !applied_actors.is_empty() => {
                                             let _ = state_changed_tx.send(());
+
+                                            // Actor-based filter for the echo-amplification loop:
+                                            // if every applied change was authored by the runtime
+                                            // agent's own kernel-writer actor (`rt:kernel:*`),
+                                            // the sync only reflected our own echoes bouncing
+                                            // back through the coordinator. Forwarding those to
+                                            // the kernel re-sends the value the kernel already
+                                            // set and triggers exponential message growth on
+                                            // the ZMQ shell channel during rapid slider input.
+                                            // Actors are opaque byte strings; the kernel-side
+                                            // writer uses a UTF-8 `rt:kernel:<session>` prefix
+                                            // (see `jupyter_kernel.rs`), so a straight
+                                            // `starts_with` on the raw bytes is sufficient.
+                                            let any_foreign = applied_actors.iter().any(|a| {
+                                                !a.to_bytes().starts_with(b"rt:kernel:")
+                                            });
 
                                             // Diff comm state -- forward changes to kernel
                                             let comms_after = sd.read_state().comms;
                                             let queued = sd.get_queued_executions();
                                             drop(sd); // release write lock before kernel interaction
 
-                                            let comm_updates = diff_comm_state(&comms_before, &comms_after);
+                                            let comm_updates = if any_foreign {
+                                                diff_comm_state(&comms_before, &comms_after)
+                                            } else {
+                                                debug!(
+                                                    "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
+                                                    applied_actors.len()
+                                                );
+                                                Vec::new()
+                                            };
                                             if !comm_updates.is_empty() {
                                                 if let Some(ref mut k) = kernel {
                                                     for (comm_id, delta) in &comm_updates {
@@ -208,7 +232,16 @@ pub async fn run_runtime_agent(
                                                     }
                                                 }
                                             }
-                                        } else {
+                                        }
+                                        Ok(_) => {
+                                            // No changes applied (handshake/ack).
+                                            drop(sd);
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                "[runtime-agent] Failed to apply RuntimeStateSync: {}",
+                                                e
+                                            );
                                             drop(sd);
                                         }
                                     }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1122,6 +1122,11 @@ fn cmd_e2e_test_all() {
             "e2e/specs/deno.spec.js",
             "Deno Kernel Test",
         ),
+        (
+            "crates/notebook/fixtures/audit-test/16-widget-slider.ipynb",
+            "e2e/specs/widget-slider-stall.spec.js",
+            "Widget Slider Stall Reproducer",
+        ),
     ];
 
     for (notebook, spec, name) in fixtures {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -920,9 +920,15 @@ fn cmd_e2e_build() {
     // Build runtimed daemon binary for bundling (debug mode for faster builds)
     build_runtimed_daemon(false);
 
-    // pnpm build runs: notebook UI
+    // pnpm build runs: notebook UI. Set `VITE_E2E=1` so the bundler
+    // keeps the E2E-only test bridge (`window.__nteractWidgetUpdate`,
+    // `window.__nteractWidgetStore`) in the output — it's gated on
+    // `import.meta.env.VITE_E2E` in `App.tsx` so production bundles
+    // without this env var don't expose it.
     println!("Building frontend (notebook)...");
+    std::env::set_var("VITE_E2E", "1");
     run_frontend_build(true);
+    std::env::remove_var("VITE_E2E");
 
     println!("Building debug binary with WebDriver server...");
     run_cmd(

--- a/e2e/specs/widget-slider-stall.spec.js
+++ b/e2e/specs/widget-slider-stall.spec.js
@@ -1,0 +1,236 @@
+/**
+ * E2E Test: Widget Slider Stall Reproducer
+ *
+ * Reproduces the echo amplification bug where rapid alternating slider
+ * input freezes widget-state sync. The runtime agent re-forwards stale
+ * kernel echoes, creating exponential comm_msg growth that buries
+ * execute_request messages in the ZMQ shell FIFO.
+ *
+ * Strategy:
+ * 1. Execute a cell that creates a FloatSlider via @interact
+ * 2. Wait for the widget to render (iframe in output area)
+ * 3. Drive rapid alternating value changes via the parent-window
+ *    widget update pipeline (__nteractWidgetUpdate), bypassing the
+ *    security-isolated iframe. This exercises the exact same code path
+ *    as real slider interaction: WidgetUpdateManager → debounced CRDT
+ *    write → daemon → runtime agent → kernel.
+ * 4. After rapid input, execute a second cell to verify the kernel
+ *    is responsive (stall detector).
+ *
+ * Fixture: 16-widget-slider.ipynb
+ *   Cell 0: @interact FloatSlider (print-based, no matplotlib)
+ *   Cell 1: random.random() — lightweight kernel-responsiveness check
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  getKernelStatus,
+  setCellSource,
+  waitForCellOutput,
+  waitForKernelReady,
+  waitForNotebookSynced,
+} from "../helpers.js";
+
+/**
+ * Find the isolated iframe inside a cell's output area.
+ * Returns the iframe element or null if not found.
+ */
+async function findWidgetIframe(cell) {
+  try {
+    const iframe = await cell.$('[data-slot="isolated-frame"]');
+    if (await iframe.isExisting()) {
+      return iframe;
+    }
+  } catch {
+    // Element not found
+  }
+  return null;
+}
+
+/**
+ * Get the comm ID of the first FloatSlider model from the widget store.
+ * Returns null if no slider model found.
+ */
+async function getSliderCommId() {
+  return await browser.execute(() => {
+    const store = window.__nteractWidgetStore;
+    if (!store) return null;
+    const snapshot = store.getSnapshot();
+    for (const [commId, model] of snapshot) {
+      if (
+        model.state._model_name === "FloatSliderModel" ||
+        model.state._model_name === "IntSliderModel"
+      ) {
+        return commId;
+      }
+    }
+    return null;
+  });
+}
+
+/**
+ * Drive rapid alternating slider value changes through the real widget
+ * update pipeline. Uses __nteractWidgetUpdate (exposed by App.tsx for
+ * E2E tests) which calls WidgetUpdateManager.updateAndPersist().
+ *
+ * This exercises the full chain: instant store update → debounced CRDT
+ * write → sync to daemon → runtime agent diff_comm_state → comm_msg
+ * to kernel → kernel @interact callback → IOPub echo → coalescing
+ * writer → CRDT back to frontend.
+ */
+async function driveSliderValues(commId, changes) {
+  await browser.execute(
+    (cid, vals) => {
+      const update = window.__nteractWidgetUpdate;
+      if (!update) throw new Error("__nteractWidgetUpdate not available");
+      for (const val of vals) {
+        update(cid, { value: val });
+      }
+    },
+    commId,
+    changes,
+  );
+}
+
+/**
+ * Generate alternating slider values for stress testing.
+ * Produces [low, high, low, high, ...] pattern that triggers echo
+ * amplification when the runtime agent doesn't suppress echoes.
+ */
+function alternatingValues(count, low = 4.9, high = 5.1) {
+  const values = [];
+  for (let i = 0; i < count; i++) {
+    values.push(i % 2 === 0 ? low : high);
+  }
+  return values;
+}
+
+describe("Widget Slider Stall Reproducer", () => {
+  let sliderCell;
+
+  it("should launch kernel and render widget", async () => {
+    await waitForNotebookSynced();
+    await waitForKernelReady(300000);
+
+    const status = await getKernelStatus();
+    expect(status).toBe("idle");
+
+    const cells = await $$('[data-cell-type="code"]');
+    expect(cells.length).toBeGreaterThanOrEqual(2);
+
+    sliderCell = cells[0];
+    const executeButton = await sliderCell.$('[data-testid="execute-button"]');
+    await executeButton.waitForClickable({ timeout: 5000 });
+    await executeButton.click();
+
+    // Wait for kernel to finish executing (ipywidgets init can be slow)
+    await browser.waitUntil(
+      async () => (await getKernelStatus()) === "idle",
+      { timeout: 120000, interval: 500, timeoutMsg: "Kernel not idle after slider cell execution" },
+    );
+
+    // Widget renders inside an isolated iframe — wait for it to appear
+    await browser.waitUntil(
+      async () => {
+        const iframe = await findWidgetIframe(sliderCell);
+        return iframe !== null;
+      },
+      {
+        timeout: 30000,
+        interval: 500,
+        timeoutMsg: "Widget iframe did not appear within 30s after kernel idle",
+      },
+    );
+
+    console.log("[slider-stall] Widget iframe detected in output area");
+
+    // Wait for the widget store to have the slider model
+    await browser.waitUntil(
+      async () => (await getSliderCommId()) !== null,
+      {
+        timeout: 15000,
+        interval: 500,
+        timeoutMsg: "Slider model not found in widget store within 15s",
+      },
+    );
+
+    const commId = await getSliderCommId();
+    console.log(`[slider-stall] Slider model found: ${commId}`);
+  });
+
+  it("should survive rapid alternating value changes (echo amplification test)", async () => {
+    const commId = await getSliderCommId();
+    if (!commId) {
+      console.log("[slider-stall] No slider model found, skipping value change test");
+      return;
+    }
+
+    // Verify the E2E bridge is available
+    const bridgeReady = await browser.execute(() => typeof window.__nteractWidgetUpdate === "function");
+    expect(bridgeReady).toBe(true);
+
+    // Phase 1: Rapid alternating values (100 changes, no pause)
+    // This is the exact pattern that triggers echo amplification.
+    console.log("[slider-stall] Phase 1: 100 rapid alternating values");
+    await driveSliderValues(commId, alternatingValues(100));
+    await browser.pause(500);
+
+    // Phase 2: Another burst of 200 alternating changes
+    console.log("[slider-stall] Phase 2: 200 rapid alternating values");
+    await driveSliderValues(commId, alternatingValues(200));
+    await browser.pause(500);
+
+    // Phase 3: Sweep up then sweep down (unidirectional stress)
+    console.log("[slider-stall] Phase 3: unidirectional sweep (50 steps each way)");
+    const sweepUp = Array.from({ length: 50 }, (_, i) => 0.0 + i * 0.2);
+    const sweepDown = Array.from({ length: 50 }, (_, i) => 10.0 - i * 0.2);
+    await driveSliderValues(commId, [...sweepUp, ...sweepDown]);
+    await browser.pause(500);
+
+    // Phase 4: Final rapid alternating burst
+    console.log("[slider-stall] Phase 4: 200 more rapid alternating values");
+    await driveSliderValues(commId, alternatingValues(200));
+
+    // Let the system settle — queued comm_msg updates drain
+    console.log("[slider-stall] Settling for 3s after value changes...");
+    await browser.pause(3000);
+  });
+
+  it("should respond to new execution after rapid input (stall detector)", async () => {
+    const cells = await $$('[data-cell-type="code"]');
+    expect(cells.length).toBeGreaterThanOrEqual(2);
+    const verifyCell = cells[1];
+
+    await setCellSource(verifyCell, "import random; print(f'alive-{random.random():.6f}')");
+
+    const executeButton = await verifyCell.$('[data-testid="execute-button"]');
+    await executeButton.waitForClickable({ timeout: 5000 });
+
+    console.log("[slider-stall] Executing verification cell...");
+    const execStart = Date.now();
+    await executeButton.click();
+
+    let output;
+    try {
+      output = await waitForCellOutput(verifyCell, 30000);
+    } catch {
+      const elapsed = Math.round((Date.now() - execStart) / 1000);
+      const status = await getKernelStatus();
+      console.error(
+        `[slider-stall] STALL DETECTED: no output after ${elapsed}s (kernel: ${status})`,
+      );
+      throw new Error(
+        `Widget sync stall detected: verification cell got no output after ${elapsed}s (kernel: ${status})`,
+      );
+    }
+
+    const elapsed = Math.round((Date.now() - execStart) / 1000);
+    console.log(`[slider-stall] Verification output in ${elapsed}s: ${output}`);
+    expect(output).toContain("alive-");
+
+    await browser.waitUntil(
+      async () => (await getKernelStatus()) === "idle",
+      { timeout: 30000, interval: 300, timeoutMsg: "Kernel not idle after verification" },
+    );
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -37,6 +37,7 @@ const FIXTURE_SPECS = [
   "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory
   "uv-inline.spec.js",
   "uv-pyproject.spec.js",
+  "widget-slider-stall.spec.js", // Requires fixture notebook with ipywidgets slider
 ];
 
 /**

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -174,20 +174,26 @@ describe("WidgetUpdateManager", () => {
       expect(result).toEqual({ value: 10, description: "from kernel" });
     });
 
-    it("clears optimistic keys after flush", () => {
+    it("keeps optimistic keys for a grace period after flush, then clears", () => {
       const { manager } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
-      // During debounce window — suppressed
+      // During debounce window — suppressed.
       expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
 
-      // Flush
+      // Flush — CRDT write happens, but optimistic keys stay alive for
+      // a grace period so in-flight echoes of the value we just wrote
+      // (and earlier stale ones) don't clobber the user's state while
+      // the round trip to the kernel + back completes.
       vi.advanceTimersByTime(50);
+      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
 
-      // After flush — passes through
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
-      expect(result).toEqual({ value: 10 });
+      // After the grace period — echoes pass through.
+      vi.advanceTimersByTime(500);
+      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toEqual({
+        value: 10,
+      });
     });
 
     it("suppresses during continuous drag", () => {

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -143,13 +143,35 @@ describe("WidgetUpdateManager", () => {
   // ── Echo suppression ────────────────────────────────────────────
 
   describe("echo suppression", () => {
-    it("suppresses echoes for optimistic keys", () => {
+    it("suppresses echoes that match the last-written value", () => {
       const { manager } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
-      const result = manager.shouldSuppressEcho("comm-1", { value: 10 });
+      // Kernel bounces back the same value — pure echo.
+      const result = manager.shouldSuppressEcho("comm-1", { value: 42 });
       expect(result).toBeNull();
+    });
+
+    it("lets kernel corrections pass through even for optimistic keys", () => {
+      const { manager } = setup();
+
+      // Frontend sends 5.1 (out of bounds for a max-5.0 slider).
+      manager.updateAndPersist("comm-1", { value: 5.1 });
+
+      // Kernel clamps to 5.0 and echoes the corrected value.
+      const result = manager.shouldSuppressEcho("comm-1", { value: 5.0 });
+      expect(result).toEqual({ value: 5.0 });
+    });
+
+    it("uses structural equality for array/object values", () => {
+      const { manager } = setup();
+
+      manager.updateAndPersist("comm-1", { value: [1, 2, 3] });
+      expect(manager.shouldSuppressEcho("comm-1", { value: [1, 2, 3] })).toBeNull();
+      expect(manager.shouldSuppressEcho("comm-1", { value: [1, 2] })).toEqual({
+        value: [1, 2],
+      });
     });
 
     it("passes through non-optimistic keys", () => {
@@ -157,8 +179,10 @@ describe("WidgetUpdateManager", () => {
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
+      // value matches last-written and is suppressed; description is
+      // not an optimistic key so passes through.
       const result = manager.shouldSuppressEcho("comm-1", {
-        value: 10,
+        value: 42,
         description: "from kernel",
       });
       expect(result).toEqual({ description: "from kernel" });
@@ -174,29 +198,28 @@ describe("WidgetUpdateManager", () => {
       expect(result).toEqual({ value: 10, description: "from kernel" });
     });
 
-    it("keeps optimistic keys for a grace period after flush, then clears", () => {
+    it("keeps optimistic values for a grace period after flush, then clears", () => {
       const { manager } = setup();
 
       manager.updateAndPersist("comm-1", { value: 42 });
 
-      // During debounce window — suppressed.
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
+      // During debounce window — echo of the written value is suppressed.
+      expect(manager.shouldSuppressEcho("comm-1", { value: 42 })).toBeNull();
 
-      // Flush — CRDT write happens, but optimistic keys stay alive for
-      // a grace period so in-flight echoes of the value we just wrote
-      // (and earlier stale ones) don't clobber the user's state while
-      // the round trip to the kernel + back completes.
+      // Flush — CRDT write happens, but optimistic values stay alive
+      // for a grace period so in-flight echoes of what we just wrote
+      // don't flicker the user's state while the round trip completes.
       vi.advanceTimersByTime(50);
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
+      expect(manager.shouldSuppressEcho("comm-1", { value: 42 })).toBeNull();
 
       // After the grace period — echoes pass through.
       vi.advanceTimersByTime(500);
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toEqual({
-        value: 10,
+      expect(manager.shouldSuppressEcho("comm-1", { value: 42 })).toEqual({
+        value: 42,
       });
     });
 
-    it("suppresses during continuous drag", () => {
+    it("suppresses echoes of the latest write during continuous drag", () => {
       const { manager } = setup();
 
       // Simulate continuous slider drag
@@ -206,11 +229,18 @@ describe("WidgetUpdateManager", () => {
       vi.advanceTimersByTime(16);
       manager.updateAndPersist("comm-1", { value: 20 });
 
-      // Stale echo from earlier value — suppressed
-      expect(manager.shouldSuppressEcho("comm-1", { value: 5 })).toBeNull();
+      // Echo of the most recent value — suppressed
+      expect(manager.shouldSuppressEcho("comm-1", { value: 20 })).toBeNull();
+
+      // Stale echo from an earlier drag step — passes through. In
+      // practice the coalescing writer only forwards the latest state,
+      // but the filter must not silently drop non-matching values.
+      expect(manager.shouldSuppressEcho("comm-1", { value: 5 })).toEqual({
+        value: 5,
+      });
 
       // Non-value keys still pass through
-      expect(manager.shouldSuppressEcho("comm-1", { value: 5, _view_name: "x" })).toEqual({
+      expect(manager.shouldSuppressEcho("comm-1", { value: 20, _view_name: "x" })).toEqual({
         _view_name: "x",
       });
     });
@@ -318,8 +348,8 @@ describe("WidgetUpdateManager", () => {
       manager.updateAndPersist("comm-1", { value: 42 });
       vi.advanceTimersByTime(50);
 
-      // Still optimistic since flush failed
-      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
+      // Still optimistic since flush failed — echo of last-written suppressed
+      expect(manager.shouldSuppressEcho("comm-1", { value: 42 })).toBeNull();
     });
   });
 });

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -29,6 +29,41 @@ const DEBOUNCE_MS = 50;
  */
 const ECHO_GRACE_MS = 500;
 
+/**
+ * Structural equality for JSON-serializable widget values.
+ *
+ * Widget state travels through comm messages as JSON, so values are
+ * limited to null, booleans, numbers, strings, arrays, and plain
+ * objects. `Object.is` handles primitives (including NaN); arrays and
+ * plain objects recurse.
+ */
+function structuralEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!structuralEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  if (aKeys.length !== Object.keys(bo).length) return false;
+  for (const key of aKeys) {
+    if (!Object.hasOwn(bo, key)) return false;
+    if (!structuralEqual(ao[key], bo[key])) return false;
+  }
+  return true;
+}
+
 export interface WidgetUpdateManagerOptions {
   getStore: () => WidgetStore | null;
   getCrdtWriter: () => CrdtCommWriter | null;
@@ -40,8 +75,16 @@ export class WidgetUpdateManager {
 
   /** Accumulated patches waiting for debounced flush, per comm. */
   private pendingState = new Map<string, Record<string, unknown>>();
-  /** Keys with local-only values not yet flushed to CRDT. */
-  private optimisticKeys = new Map<string, Set<string>>();
+  /**
+   * Last-written value per key for echo deduplication.
+   *
+   * Stores the value we most recently wrote locally for each key. Only
+   * echoes whose value structurally matches the last-written value are
+   * suppressed — if the kernel normalizes/clamps/rewrites the trait
+   * (e.g., `5.1` → `5.0` on a max-`5.0` slider), the corrected value
+   * passes through and replaces local state.
+   */
+  private optimisticKeys = new Map<string, Map<string, unknown>>();
   /** Per-comm debounce timers. */
   private flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Per-comm grace timers for delayed optimistic key cleanup. */
@@ -65,14 +108,14 @@ export class WidgetUpdateManager {
     // 1. Instant store update — UI reflects change immediately
     this.getStore()?.updateModel(commId, patch, buffers);
 
-    // 2. Track optimistic keys
+    // 2. Track optimistic keys + their last-written values
     let keys = this.optimisticKeys.get(commId);
     if (!keys) {
-      keys = new Set();
+      keys = new Map();
       this.optimisticKeys.set(commId, keys);
     }
-    for (const key of Object.keys(patch)) {
-      keys.add(key);
+    for (const [key, value] of Object.entries(patch)) {
+      keys.set(key, value);
     }
 
     // 3. Accumulate patch
@@ -97,8 +140,13 @@ export class WidgetUpdateManager {
   }
 
   /**
-   * Filter an incoming CRDT echo, suppressing keys that have pending
-   * optimistic values.
+   * Filter an incoming CRDT echo, suppressing keys whose echoed value
+   * matches the frontend's most recent local write.
+   *
+   * A kernel correction (e.g., ipywidgets clamping `5.1` → `5.0`) has a
+   * value that differs from what we wrote, so it passes through and
+   * updates the store. A true echo (kernel bouncing back what we sent)
+   * has an identical value and is dropped.
    *
    * Returns the filtered patch to apply, or null if entirely suppressed.
    */
@@ -112,10 +160,13 @@ export class WidgetUpdateManager {
     const filtered: Record<string, unknown> = {};
     let hasKeys = false;
     for (const [key, value] of Object.entries(incomingPatch)) {
-      if (!keys.has(key)) {
-        filtered[key] = value;
-        hasKeys = true;
+      const optimisticValue = keys.get(key);
+      const isOptimistic = keys.has(key);
+      if (isOptimistic && structuralEqual(optimisticValue, value)) {
+        continue;
       }
+      filtered[key] = value;
+      hasKeys = true;
     }
     return hasKeys ? filtered : null;
   }

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -19,6 +19,16 @@ type CrdtCommWriter = (commId: string, patch: Record<string, unknown>) => void;
 /** Debounce interval for CRDT writes (ms). */
 const DEBOUNCE_MS = 50;
 
+/**
+ * Grace period after CRDT flush before clearing optimistic keys (ms).
+ *
+ * Covers the full round trip: CRDT write → sync flush (20ms) → daemon
+ * receives sync → diffs → sends comm_msg to kernel → kernel processes
+ * @interact callback → echoes on IOPub → 16ms coalesce → CRDT write →
+ * sync back to frontend. With a slow callback this can take 200–500ms.
+ */
+const ECHO_GRACE_MS = 500;
+
 export interface WidgetUpdateManagerOptions {
   getStore: () => WidgetStore | null;
   getCrdtWriter: () => CrdtCommWriter | null;
@@ -34,6 +44,8 @@ export class WidgetUpdateManager {
   private optimisticKeys = new Map<string, Set<string>>();
   /** Per-comm debounce timers. */
   private flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Per-comm grace timers for delayed optimistic key cleanup. */
+  private echoGraceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(opts: WidgetUpdateManagerOptions) {
     this.getStore = opts.getStore;
@@ -116,7 +128,11 @@ export class WidgetUpdateManager {
     for (const timer of this.flushTimers.values()) {
       clearTimeout(timer);
     }
+    for (const timer of this.echoGraceTimers.values()) {
+      clearTimeout(timer);
+    }
     this.flushTimers.clear();
+    this.echoGraceTimers.clear();
     this.pendingState.clear();
     this.optimisticKeys.clear();
   }
@@ -137,6 +153,11 @@ export class WidgetUpdateManager {
     if (timer !== undefined) {
       clearTimeout(timer);
       this.flushTimers.delete(commId);
+    }
+    const graceTimer = this.echoGraceTimers.get(commId);
+    if (graceTimer !== undefined) {
+      clearTimeout(graceTimer);
+      this.echoGraceTimers.delete(commId);
     }
     this.pendingState.delete(commId);
     this.optimisticKeys.delete(commId);
@@ -167,9 +188,21 @@ export class WidgetUpdateManager {
     this.pendingState.delete(commId);
     writer(commId, patch);
 
-    // Clear optimistic keys after flush. Echoes arriving after this
-    // point carry the value we just wrote (or a kernel-validated value)
-    // and should pass through.
-    this.optimisticKeys.delete(commId);
+    // Keep optimistic keys alive for a grace period after flush.
+    // The CRDT write triggers a sync chain (frontend → daemon →
+    // kernel → IOPub echo → CRDT → frontend) that can take 200-500ms.
+    // If we cleared immediately, the stale kernel echo would pass
+    // through shouldSuppressEcho and clobber the user's value.
+    const existingGrace = this.echoGraceTimers.get(commId);
+    if (existingGrace !== undefined) {
+      clearTimeout(existingGrace);
+    }
+    this.echoGraceTimers.set(
+      commId,
+      setTimeout(() => {
+        this.optimisticKeys.delete(commId);
+        this.echoGraceTimers.delete(commId);
+      }, ECHO_GRACE_MS),
+    );
   }
 }

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -58,7 +58,7 @@ function structuralEqual(a: unknown, b: unknown): boolean {
   const aKeys = Object.keys(ao);
   if (aKeys.length !== Object.keys(bo).length) return false;
   for (const key of aKeys) {
-    if (!Object.hasOwn(bo, key)) return false;
+    if (!Object.prototype.hasOwnProperty.call(bo, key)) return false;
     if (!structuralEqual(ao[key], bo[key])) return false;
   }
   return true;


### PR DESCRIPTION
## Summary

Widget writes were arriving anonymous. The IOPub echo writer on the daemon side was writing to the CRDT under the default `runtimed:state` actor, so peers receiving a sync couldn't tell a kernel-authored echo apart from a frontend write. The runtime agent forwarded the echo back to the kernel, and the loop started. During rapid slider drags, the pipeline stalled.

The fix is attribution. Every echo now carries an `rt:kernel:*` actor ID. The runtime agent reads who wrote each comm field and forwards only what a foreign actor wrote.

Supersedes #1896.

## The fix

Three changes.

**1. Writes carry the kernel's actor ID.** The IOPub-driven comm-state writer was grabbing the state_doc lock and writing under the default `runtimed:state` actor. It now does `fork_and_merge` with the kernel's own `rt:kernel:*` actor. Every echo is attributable.

**2. Per-field foreign view in `receive_sync_and_foreign_comms`.** The runtime agent's filter was per-frame. If the coordinator coalesced a kernel echo with an unrelated status or queue update, the frame had a foreign change and the echo slipped through. The new view walks each `comm.state` and keeps only fields whose current LWW winner was a foreign actor. Kernel-authored values get stripped before the diff runs.

**3. Value-aware `optimisticKeys` on the frontend.** The optimistic cache now stores the last-written value per key, not just a key set. Echoes that match what the frontend wrote get suppressed. Kernel corrections (think ipywidgets clamping `5.1` back to `5.0` on a max-`5.0` slider) pass through and replace local state.

## E2E reproducer

Cherry-picked from #1896:

- `e2e/specs/widget-slider-stall.spec.js`
- `crates/notebook/fixtures/audit-test/16-widget-slider.ipynb`
- xtask fixture registration and `e2e/wdio.conf.js` entry

Drives alternating slider values through the real widget pipeline, then runs a second cell to confirm the kernel's still responsive. Also switched the `__nteractWidgetUpdate` / `__nteractWidgetStore` bridge from `DEV`-gated to `VITE_E2E`-gated so the bundled E2E build actually exposes it.

## Test plan

- [x] `cargo test -p notebook-doc --lib`: 332 pass, 4 new foreign-sync tests
- [x] `cargo test -p runtimed --lib`: 325 pass
- [x] `pnpm vp test run widget-update-manager`: 19 pass
- [x] `cargo xtask lint`: clean
- [ ] `cargo xtask e2e test-fixture 16-widget-slider`: repro on main, pass on this branch
- [ ] Manual: open a FloatSlider, drag fast, kernel stays responsive
