### PR TITLE
perf(build): optimize third-party deps in dev + disable incremental for sccache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,12 @@ expect_used = "warn"
 
 [profile.dev]
 split-debuginfo = "packed"
+# sccache and cargo's incremental compilation fight each other: sccache
+# caches whole-crate outputs, incremental caches per-function deltas
+# inside a crate. With incremental on, sccache's Rust hit rate hovers
+# near zero. Turn it off so sccache actually shares builds across
+# worktrees, branches, and fresh clones.
+incremental = false
 
 # Build third-party deps optimized even in dev. Our own crates stay at
 # opt-level=0 for fast incremental rebuilds. Automerge in particular is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,19 @@ expect_used = "warn"
 [profile.dev]
 split-debuginfo = "packed"
 
+# Build third-party deps optimized even in dev. Our own crates stay at
+# opt-level=0 for fast incremental rebuilds. Automerge in particular is
+# unusable at opt-level=0: widget comm_opens were taking 300-450ms of
+# CRDT write time each. Cost is a slower first compile; sccache caches
+# the optimized deps so every later build and fresh worktree benefits.
+[profile.dev.package."*"]
+opt-level = 3
+
+# Build scripts and proc macros run at build time; optimizing them cuts
+# the total dev build wall-clock even accounting for the slower compile.
+[profile.dev.build-override]
+opt-level = 3
+
 [profile.release]
 opt-level = 'z'
 strip = true


### PR DESCRIPTION
## Summary

Dev builds are slower than they should be, for two different reasons. Fix both in the `[profile.dev]` block.

**Automerge at opt-level=0 is unusable.** Daemon logs from a single `@interact` cell showed widget `comm_open` CRDT writes taking 300-450ms each, serialized under the state_doc write lock. Six `comm_opens` per `@interact` is 2-3s of pure write latency before the slider renders. Build third-party deps at opt-level=3 even in dev (our own crates stay at 0 for fast rebuilds).

**sccache wasn't actually caching.** Ran `sccache --show-stats` and found a 0.15% Rust cache hit rate (2 out of 1351 attempts). Cargo's dev profile defaults to `incremental = true`, which caches per-function deltas inside a crate; sccache caches whole-crate outputs. They fight. With incremental off, sccache gets real hits across worktrees, branches, and fresh clones.

## The changes

```toml
[profile.dev]
split-debuginfo = "packed"
incremental = false

[profile.dev.package."*"]
opt-level = 3

[profile.dev.build-override]
opt-level = 3
```

## Tradeoffs

- First clean build on this box went from ~30s to 6m 13s for `cargo check -p runtimed`. That's a one-shot cost.
- Tight inner-loop edits on our own crates lose per-function incremental. Rebuild of a single edited crate is slightly slower, but whole-crate sccache hits on deps dominate.
- Every subsequent build and every fresh worktree / fresh clone on this machine benefits from the cached optimized deps.

## Test plan

- [x] `cargo check -p runtimed` compiles clean
- [x] `cargo build -p runtimed` (via `up rebuild=true`) produces a working daemon
- [ ] Daemon timing: rerun an `@interact` cell, confirm `comm_open put_comm CRDT write` drops well below 300ms
- [ ] sccache hit rate rises from 0.15% into double digits after a couple of builds

## Related

Surfaced while investigating a widget output regression off #1900. The slow comm_open writes are a symptom of dev-mode Automerge; fixing the profile makes that go away without needing to run release mode locally.