### PR TITLE
fix(widgets): store a trail of optimistic values, not just the latest

### DIFF
--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -219,22 +219,25 @@ describe("WidgetUpdateManager", () => {
       });
     });
 
-    it("suppresses echoes of the latest write during continuous drag", () => {
+    it("suppresses echoes of any recent write during continuous drag", () => {
       const { manager } = setup();
 
-      // Simulate continuous slider drag
+      // Continuous slider drag: every intermediate value is remembered.
       manager.updateAndPersist("comm-1", { value: 10 });
       vi.advanceTimersByTime(16);
       manager.updateAndPersist("comm-1", { value: 15 });
       vi.advanceTimersByTime(16);
       manager.updateAndPersist("comm-1", { value: 20 });
 
-      // Echo of the most recent value — suppressed
+      // Kernel echoes arrive in the order we sent, potentially behind
+      // our current drag position. All of them must be suppressed so
+      // the UI doesn't snap backward to a stale value.
+      expect(manager.shouldSuppressEcho("comm-1", { value: 10 })).toBeNull();
+      expect(manager.shouldSuppressEcho("comm-1", { value: 15 })).toBeNull();
       expect(manager.shouldSuppressEcho("comm-1", { value: 20 })).toBeNull();
 
-      // Stale echo from an earlier drag step — passes through. In
-      // practice the coalescing writer only forwards the latest state,
-      // but the filter must not silently drop non-matching values.
+      // A value we never wrote (e.g., kernel clamp or external change)
+      // still passes through.
       expect(manager.shouldSuppressEcho("comm-1", { value: 5 })).toEqual({
         value: 5,
       });

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -76,15 +76,21 @@ export class WidgetUpdateManager {
   /** Accumulated patches waiting for debounced flush, per comm. */
   private pendingState = new Map<string, Record<string, unknown>>();
   /**
-   * Last-written value per key for echo deduplication.
+   * Trail of recently-written values per key, for echo deduplication.
    *
-   * Stores the value we most recently wrote locally for each key. Only
-   * echoes whose value structurally matches the last-written value are
-   * suppressed — if the kernel normalizes/clamps/rewrites the trait
-   * (e.g., `5.1` → `5.0` on a max-`5.0` slider), the corrected value
-   * passes through and replaces local state.
+   * During rapid drag (slider moving at 60/sec), the kernel processes
+   * our writes in order and echoes each back. A stale echo of `1.2`
+   * while the user is already at `1.4` would otherwise clobber the
+   * optimistic state. Storing only the latest value catches the final
+   * echo but misses in-flight intermediates.
+   *
+   * We keep every value we wrote during the grace window and suppress
+   * any echo whose value matches any entry in the trail. Legitimate
+   * kernel corrections (clamping `5.1` back to `5.0` when we never
+   * wrote `5.0`) fall through because the corrected value isn't in
+   * the trail.
    */
-  private optimisticKeys = new Map<string, Map<string, unknown>>();
+  private optimisticKeys = new Map<string, Map<string, unknown[]>>();
   /** Per-comm debounce timers. */
   private flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Per-comm grace timers for delayed optimistic key cleanup. */
@@ -108,14 +114,19 @@ export class WidgetUpdateManager {
     // 1. Instant store update — UI reflects change immediately
     this.getStore()?.updateModel(commId, patch, buffers);
 
-    // 2. Track optimistic keys + their last-written values
+    // 2. Append each written value to the per-key trail.
     let keys = this.optimisticKeys.get(commId);
     if (!keys) {
       keys = new Map();
       this.optimisticKeys.set(commId, keys);
     }
     for (const [key, value] of Object.entries(patch)) {
-      keys.set(key, value);
+      let trail = keys.get(key);
+      if (!trail) {
+        trail = [];
+        keys.set(key, trail);
+      }
+      trail.push(value);
     }
 
     // 3. Accumulate patch
@@ -141,12 +152,11 @@ export class WidgetUpdateManager {
 
   /**
    * Filter an incoming CRDT echo, suppressing keys whose echoed value
-   * matches the frontend's most recent local write.
+   * matches any recent local write for that key.
    *
-   * A kernel correction (e.g., ipywidgets clamping `5.1` → `5.0`) has a
-   * value that differs from what we wrote, so it passes through and
-   * updates the store. A true echo (kernel bouncing back what we sent)
-   * has an identical value and is dropped.
+   * Echoes of any value in the trail are dropped. Kernel corrections
+   * (values we never wrote, e.g. ipywidgets clamping `5.1` back to
+   * `5.0`) pass through and update the store.
    *
    * Returns the filtered patch to apply, or null if entirely suppressed.
    */
@@ -160,9 +170,8 @@ export class WidgetUpdateManager {
     const filtered: Record<string, unknown> = {};
     let hasKeys = false;
     for (const [key, value] of Object.entries(incomingPatch)) {
-      const optimisticValue = keys.get(key);
-      const isOptimistic = keys.has(key);
-      if (isOptimistic && structuralEqual(optimisticValue, value)) {
+      const trail = keys.get(key);
+      if (trail && trail.some((written) => structuralEqual(written, value))) {
         continue;
       }
       filtered[key] = value;


### PR DESCRIPTION
## Summary

Continuous slider drags were bouncing backward mid-drag. The fix merged in #1900 stored only the last-written value, so stale kernel echoes of intermediate drag steps weren't recognized as echoes.

During rapid drag the frontend writes `value=1.0, 1.1, 1.2, ..., 1.4` in sequence. The kernel processes them in order and echoes each back. When the echo of `1.2` arrives while the user is at `1.4`, the daemon sees `1.2 != 1.4` and writes the stale value into the CRDT. The frontend's `shouldSuppressEcho` used to check only the last-written value: `optimisticValue=1.4`, `echo=1.2`, different, so it passed through and snapped the UI backward.

Store every value we wrote during the grace window. Suppress any echo whose value matches any entry in the trail. Legitimate kernel corrections (values we never wrote, e.g. clamping `5.1` to `5.0` on a max-`5.0` slider) still pass through because the corrected value isn't in the trail.

## Bound

Trail lives at most until the 500ms grace window expires. At 60 writes/sec that's roughly 30 entries per key per comm. Cleared on flush-grace expiry, `clearComm`, and `reset`.

## Not in this PR

There's a separate, pre-existing intermittent bug where `@interact` cells occasionally render no output at all. It reproduces on clean main, not on this branch, so it's orthogonal. Tracking separately.

## Test plan

- [x] `pnpm vp test run src/components/widgets/__tests__/widget-update-manager.test.ts`: 19 pass, including a new test for drag-trail suppression
- [x] `cargo xtask lint`: clean
- [ ] Manual: drag a FloatSlider continuously, confirm the UI does not snap backward to earlier drag values