### PR TITLE
fix(sync-engine): re-surface comm updates dropped while resolver wasn't ready

### DIFF
--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -908,7 +908,22 @@ export class SyncEngine {
     const updated: Array<{ comm: ResolvedComm; textPaths: string[][] }> = [];
     for (const { commId, entry } of result.updated) {
       const resolved = resolve(commId);
-      if (!resolved) continue;
+      if (!resolved) {
+        // resolver not ready (e.g. blob_port transiently missing after
+        // reconnect). Revert `next` to the previous state for this comm
+        // so the next diff re-surfaces this update instead of swallowing
+        // it. Without this revert, `next.json[commId]` would record the
+        // new state, and the next projection would see "no change" and
+        // never re-emit — the update would be lost permanently until an
+        // unrelated future change to the same comm.
+        const prevEntry = this.commDiffState.comms[commId];
+        const prevJson = this.commDiffState.json[commId];
+        if (prevEntry !== undefined && prevJson !== undefined) {
+          next.comms[commId] = prevEntry;
+          next.json[commId] = prevJson;
+        }
+        continue;
+      }
       updated.push({
         comm: {
           commId,

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1650,9 +1650,7 @@ describe("SyncEngine", () => {
       let portReady = false;
       handle = createMockHandle({
         resolve_comm_state: vi.fn((_id: unknown) =>
-          portReady
-            ? { state: { value: 42 }, buffer_paths: [], text_paths: [] }
-            : undefined,
+          portReady ? { state: { value: 42 }, buffer_paths: [], text_paths: [] } : undefined,
         ),
       });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1640,6 +1640,68 @@ describe("SyncEngine", () => {
       }
     });
 
+    it("re-surfaces an update dropped while resolver was not ready", async () => {
+      // Simulates the race where an update to an already-opened comm
+      // arrives before blob_port is set (resolve_comm_state returns
+      // undefined). Before the fix, projectComms advanced the diff's
+      // recorded json for that comm, so the next projection saw "no
+      // change" and never re-emitted — the update was lost.
+      const commId = "race1";
+      let portReady = false;
+      handle = createMockHandle({
+        resolve_comm_state: vi.fn((_id: unknown) =>
+          portReady
+            ? { state: { value: 42 }, buffer_paths: [], text_paths: [] }
+            : undefined,
+        ),
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      const emissions: Array<{
+        opened: Array<{ commId: string; state: unknown }>;
+        updated: Array<{ commId: string; state: unknown }>;
+      }> = [];
+      engine.commChanges$.subscribe((c) => emissions.push(c));
+
+      // Open: resolver ready, comm opens fine.
+      portReady = true;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 1 })),
+      ]);
+      transport.deliver([0x05, 0x01]);
+      await vi.waitFor(() => expect(emissions.length).toBe(1));
+      expect(emissions[0].opened.map((o) => o.commId)).toEqual([commId]);
+
+      // Update arrives while resolver is briefly unavailable (e.g. port
+      // reconnect). Before the fix, this update was swallowed and never
+      // re-surfaced on later projections.
+      portReady = false;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 2 })),
+      ]);
+      transport.deliver([0x05, 0x02]);
+
+      // Give the pipeline a turn — there should be no new emission yet.
+      await Promise.resolve();
+      expect(emissions.length).toBe(1);
+
+      // Resolver comes back. Next projection should re-surface the
+      // deferred update instead of comparing against the stale recorded
+      // state and concluding "no change."
+      portReady = true;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 2 })),
+      ]);
+      transport.deliver([0x05, 0x03]);
+
+      await vi.waitFor(() => expect(emissions.length).toBe(2));
+      expect(emissions[1].updated.map((u) => u.commId)).toEqual([commId]);
+
+      engine.stop();
+    });
+
     it("does not retry 4xx — leaves URL in state and emits anyway", async () => {
       const commId = "missing1";
       handle = createMockHandle({


### PR DESCRIPTION
## Summary

`projectComms` silently dropped updated comms when `resolve_comm_state` returned `undefined` (e.g. blob_port transiently missing after reconnect), and still advanced `commDiffState.json` to the new state. The next projection compared against the newly-recorded state, saw no change, and never re-emitted. The update was lost permanently until an unrelated future change to the same comm arrived.

The `opened` path already handles this by deleting the deferred entry from `next` so the next diff re-surfaces it. The `updated` path needs the equivalent: revert `next.comms[commId]` and `next.json[commId]` to the prev state so the next diff re-detects the delta once the resolver recovers.

## Suspected symptom

Widget outputs (`@interact`, Output widget contents) intermittently missing on notebook open. Surfaced during investigation of a reproducible "cell runs but widget area never renders" bug where the daemon logs showed all comm_opens landing in the CRDT. The dropped-update path is a plausible cause, though not the only one. Shipping this as a standalone fix while we keep investigating.

## Test plan

- [x] `pnpm vp test run packages/runtimed/tests/sync-engine.test.ts`: 71 pass, including a new regression test that flips resolve availability across three projections and confirms the deferred update is re-surfaced
- [x] `cargo xtask lint`: clean