### PR TITLE
fix(runtimed): IOPub outputs silently dropped by shared-actor fork merges

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2771,6 +2771,70 @@ mod tests {
     }
 
     #[test]
+    fn merging_two_forks_with_shared_actor_returns_duplicate_seq_error() {
+        // Documents the Automerge invariant that motivates
+        // jupyter_kernel's `unique_kernel_actor` helper: two
+        // independent forks that set the same actor ID each produce
+        // ops under that actor's seq series. The first merge lands;
+        // the second merge comes in with an op at a seq number that
+        // actor already used on main, and Automerge rejects it with
+        // `DuplicateSeqNumber`.
+        //
+        // Before the fix, the daemon's IOPub handler ignored the Err
+        // via `let _ = sd.merge(...)` and the second insert vanished.
+        // The production call sites now assign a unique actor per
+        // fork so this error is impossible to hit in practice.
+        let mut main = RuntimeStateDoc::new();
+        main.create_execution("exec-1", "cell-1");
+
+        let shared_actor = "rt:kernel:shared";
+
+        let mut fa = main.fork();
+        fa.set_actor(shared_actor);
+        fa.append_output("exec-1", &test_stream("stream-a"))
+            .unwrap();
+
+        let mut fb = main.fork();
+        fb.set_actor(shared_actor);
+        fb.append_output("exec-1", &test_stream("display-b"))
+            .unwrap();
+
+        main.merge(&mut fa).unwrap();
+        let second = main.merge(&mut fb);
+        match second {
+            Err(AutomergeError::DuplicateSeqNumber(_, _)) => {}
+            other => panic!("expected DuplicateSeqNumber, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn append_output_from_forks_with_unique_actors_keeps_all_inserts() {
+        // Same setup as the previous test but each fork gets its own
+        // actor suffix. Both inserts must survive the merge.
+        let mut main = RuntimeStateDoc::new();
+        main.create_execution("exec-1", "cell-1");
+
+        let mut fa = main.fork();
+        fa.set_actor("rt:kernel:shared:fork-a");
+        fa.append_output("exec-1", &test_stream("stream-a"))
+            .unwrap();
+
+        let mut fb = main.fork();
+        fb.set_actor("rt:kernel:shared:fork-b");
+        fb.append_output("exec-1", &test_stream("display-b"))
+            .unwrap();
+
+        main.merge(&mut fa).unwrap();
+        main.merge(&mut fb).unwrap();
+
+        assert_eq!(
+            main.get_outputs("exec-1").len(),
+            2,
+            "both inserts should survive merge when each fork has a unique actor"
+        );
+    }
+
+    #[test]
     fn test_set_outputs() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution("exec-1", "cell-1");

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -39,6 +39,25 @@ use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
 use notebook_protocol::protocol::LaunchedEnvConfig;
 
+/// Generate a unique Automerge actor ID for an IOPub / shell fork while
+/// preserving the kernel attribution prefix.
+///
+/// Every fork+merge cycle MUST use a distinct Automerge actor ID. Reusing
+/// the same actor across concurrent forks (e.g. shell task and iopub task
+/// each holding a fork derived from the same main heads) produces ops that
+/// share an `(actor, seq)` namespace. When the second fork merges back,
+/// Automerge deduplicates by `(actor, seq)` and silently drops the newer
+/// ops — which manifests as output entries disappearing from the CRDT
+/// list even though the insert ran to completion on the fork.
+///
+/// The widget-echo filter in the runtime agent matches on the
+/// `rt:kernel:` prefix, so we keep that prefix and append a UUID suffix
+/// per fork. Attribution still works; each fork has its own (actor, seq)
+/// series and merges are guaranteed disjoint.
+fn unique_kernel_actor(base: &str) -> String {
+    format!("{}:{}", base, Uuid::new_v4())
+}
+
 /// Type alias for pending completion response channels.
 type PendingCompletions =
     Arc<StdMutex<HashMap<String, oneshot::Sender<(Vec<CompletionItem>, usize, usize)>>>>;
@@ -815,7 +834,7 @@ impl KernelConnection for JupyterKernel {
                                     let mut fork = {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         let mut f = sd.fork();
-                                        f.set_actor(&iopub_actor_id);
+                                        f.set_actor(&unique_kernel_actor(&iopub_actor_id));
                                         f
                                     };
 
@@ -1019,7 +1038,7 @@ impl KernelConnection for JupyterKernel {
                                         let mut fork = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             let mut f = sd.fork();
-                                            f.set_actor(&iopub_actor_id);
+                                            f.set_actor(&unique_kernel_actor(&iopub_actor_id));
                                             f
                                         };
 
@@ -1065,7 +1084,7 @@ impl KernelConnection for JupyterKernel {
                                     let mut fork = {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         let mut f = sd.fork();
-                                        f.set_actor(&iopub_actor_id);
+                                        f.set_actor(&unique_kernel_actor(&iopub_actor_id));
                                         f
                                     };
 
@@ -1237,7 +1256,7 @@ impl KernelConnection for JupyterKernel {
                                         let mut fork = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             let mut f = sd.fork();
-                                            f.set_actor(&iopub_actor_id);
+                                            f.set_actor(&unique_kernel_actor(&iopub_actor_id));
                                             f
                                         };
 
@@ -1674,7 +1693,7 @@ impl KernelConnection for JupyterKernel {
                                             let mut fork = {
                                                 let mut sd = shell_state_doc.write().await;
                                                 let mut f = sd.fork();
-                                                f.set_actor(&shell_actor_id);
+                                                f.set_actor(&unique_kernel_actor(&shell_actor_id));
                                                 f
                                             };
 


### PR DESCRIPTION
## Summary

Stream and display_data outputs were vanishing from cell outputs on roughly every third execution of a cell with `@interact`. The daemon wrote them to the fork, but the merge into the main state doc silently dropped the insert. Easy repro: run a cell with `print(random.random())` followed by `@interact(...)` three times in a row and watch one of the outputs disappear.

## Root cause

The IOPub handler's `stream`, `display_data`, `execute_result`, and `comm_open` arms each do this pattern:

```rust
let mut fork = {
    let mut sd = state_doc_for_iopub.write().await;
    let mut f = sd.fork();
    f.set_actor(&iopub_actor_id);  // <-- same actor every time
    f
};
// async work...
let _ = sd.merge(&mut fork);  // <-- Err silently swallowed
```

All four fork sites set the same actor ID (`iopub_actor_id = kernel_actor_id`). The shell handler's page-display fork also reused `shell_actor_id = kernel_actor_id`.

Automerge rejects a merge whose ops collide with another fork's `(actor, seq)` pairs. Confirmed by instrumenting the merge to return the error directly instead of swallowing:

```
DuplicateSeqNumber(1, ActorID("rt:kernel:abcd1234"))
```

The daemon's `catch_automerge_panic` wrapper was catching panics but not surfacing errors. The insert was dropped with no log, just a missing output in the cell.

## Fix

Each fork now gets a unique actor ID via a small helper:

```rust
fn unique_kernel_actor(base: &str) -> String {
    format!("{}:{}", base, Uuid::new_v4())
}
```

Keeps the `rt:kernel:{session}` prefix so the widget-echo filter in `receive_sync_and_foreign_comms` still matches. Appends a UUID suffix so each fork has its own `(actor, seq)` series.

## Verified

Ran the repro cell 8 consecutive times via `mcp__nteract-dev__execute_cell`. Before the fix: missing outputs on runs 1, 3, and occasionally others. After: all 8 runs have both the stream and widget-view outputs.

## Tests

- `append_output_from_forks_with_unique_actors_keeps_all_inserts`: both inserts land when each fork has a unique actor.
- `merging_two_forks_with_shared_actor_returns_duplicate_seq_error`: documents the Automerge invariant the fix relies on. Any future regression that reuses actors will surface here rather than disappearing silently into dropped outputs.

## Follow-up thought

Kyle raised the idea of making outputs a map keyed by execution_id + fractional index (or per-output UUID), similar to how cells are structured. That'd avoid the whole class of list-insert merge issues. Good candidate for a design doc in a later PR. This fix is the minimum surgery to stop bleeding.