### PR TITLE
chore(lints): allow unwrap/expect in test code workspace-wide

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -855,7 +855,6 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -24,9 +24,7 @@
 //! kernel_env::conda::prepare_environment(&deps, &handler).await?;
 //! ```
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 #[cfg(feature = "runtime")]

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -24,6 +24,11 @@
 //! kernel_env::conda::prepare_environment(&deps, &handler).await?;
 //! ```
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 #[cfg(feature = "runtime")]
 pub mod conda;
 #[cfg(feature = "runtime")]

--- a/crates/kernel-env/src/lock.rs
+++ b/crates/kernel-env/src/lock.rs
@@ -131,7 +131,6 @@ pub async fn install_from_lock(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -400,7 +400,6 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -820,7 +820,6 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-env/src/warmup.rs
+++ b/crates/kernel-env/src/warmup.rs
@@ -59,7 +59,6 @@ exec(_script)"#,
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-launch/src/lib.rs
+++ b/crates/kernel-launch/src/lib.rs
@@ -19,6 +19,11 @@
 //! let ruff = tools::get_ruff_path().await?;
 //! ```
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod tools;
 
 // Re-export commonly used items

--- a/crates/kernel-launch/src/lib.rs
+++ b/crates/kernel-launch/src/lib.rs
@@ -19,9 +19,7 @@
 //! let ruff = tools::get_ruff_path().await?;
 //! ```
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod tools;

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -991,7 +991,6 @@ pub async fn pixi_shell_hook(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -16,6 +16,11 @@
 //!   # or via xtask:
 //!   cargo xtask mcp
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
@@ -2552,7 +2557,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -16,9 +16,7 @@
 //!   # or via xtask:
 //!   cargo xtask mcp
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::collections::HashMap;

--- a/crates/notebook-doc/src/diff.rs
+++ b/crates/notebook-doc/src/diff.rs
@@ -633,7 +633,6 @@ pub fn diff_metadata_touched(
 // ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -34,9 +34,7 @@
 //!     notebook_metadata: Str      ← Legacy JSON string (backward compat, dual-written)
 //! ```
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod diff;

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -34,6 +34,11 @@
 //!     notebook_metadata: Str      ← Legacy JSON string (backward compat, dual-written)
 //! ```
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod diff;
 pub mod frame_types;
 pub mod metadata;
@@ -2545,7 +2550,6 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -712,7 +712,6 @@ pub fn validate_package_specifier(spec: &str) -> Result<(), String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-doc/tests/generate_fixtures.rs
+++ b/crates/notebook-doc/tests/generate_fixtures.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Generate Automerge document fixtures for frontend (vitest) integration tests.
 //!
 //! Each scenario creates a NotebookDoc with daemon-authored mutations (outputs,

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -522,7 +522,6 @@ pub async fn recv_json_frame<R: AsyncRead + Unpin, T: DeserializeOwned>(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-protocol/src/lib.rs
+++ b/crates/notebook-protocol/src/lib.rs
@@ -1,6 +1,4 @@
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod connection;

--- a/crates/notebook-protocol/src/lib.rs
+++ b/crates/notebook-protocol/src/lib.rs
@@ -1,2 +1,7 @@
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod connection;
 pub mod protocol;

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -708,7 +708,6 @@ pub enum RuntimeAgentResponse {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -47,9 +47,7 @@
 //!
 //! Document mutations (`with_doc`) are synchronous and microsecond-fast.
 //! Only daemon protocol operations (`send_request`, `confirm_sync`) are async.
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod broadcast;

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -47,6 +47,11 @@
 //!
 //! Document mutations (`with_doc`) are synchronous and microsecond-fast.
 //! Only daemon protocol operations (`send_request`, `confirm_sync`) are async.
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod broadcast;
 pub mod connect;
 pub mod error;

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -4,7 +4,7 @@
 //! Integration tests (behind `#[ignore]`) connect to a running daemon.
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::module_inception)]
+#[allow(clippy::module_inception)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
@@ -831,7 +831,6 @@ mod tests {
 // =========================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod integration_tests {
     use std::path::PathBuf;
     use std::time::Duration;

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -932,7 +932,6 @@ fn ensure_shell_path(bin_dir: &std::path::Path) -> Result<(), String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -274,7 +274,6 @@ fn strip_jsonc_comments(content: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/environment_yml.rs
+++ b/crates/notebook/src/environment_yml.rs
@@ -258,7 +258,6 @@ pub fn get_all_dependencies(config: &EnvironmentYmlConfig) -> (Vec<String>, Vec<
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1,6 +1,4 @@
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cli_install;

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1,3 +1,8 @@
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod cli_install;
 pub mod conda_env;
 pub mod deno_env;
@@ -925,7 +930,6 @@ async fn setup_sync_receivers(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{next_available_sample_path, reopen_action, ReopenAction};
     use tempfile::TempDir;

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -1,6 +1,4 @@
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use clap::Parser;

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -1,3 +1,8 @@
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use clap::Parser;
 use notebook::Runtime;
 use std::path::PathBuf;

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -344,7 +344,6 @@ pub fn create_menu(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
         about_menu_label, app_name, build_about_metadata, window_label_for_menu_item_id,

--- a/crates/notebook/src/pixi.rs
+++ b/crates/notebook/src/pixi.rs
@@ -334,7 +334,6 @@ impl PixiConfig {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/pyproject.rs
+++ b/crates/notebook/src/pyproject.rs
@@ -195,7 +195,6 @@ pub fn get_all_dependencies(config: &PyProjectConfig) -> Vec<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -251,7 +251,6 @@ pub fn window_label_for_session(session: &WindowSession) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::Runtime;

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -106,7 +106,6 @@ pub fn load_settings() -> SyncedSettings {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/shell_env.rs
+++ b/crates/notebook/src/shell_env.rs
@@ -177,7 +177,6 @@ fn apply_well_known_paths() {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -368,7 +368,6 @@ pub fn check_packages(packages: &[String]) -> Vec<TyposquatWarning> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -23,3 +23,6 @@ arrow-string = { version = "54", default-features = false }
 
 # Parquet reader
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "flate2", "zstd"] }
+
+[lints]
+workspace = true

--- a/crates/nteract-predicate/src/lib.rs
+++ b/crates/nteract-predicate/src/lib.rs
@@ -7,6 +7,11 @@
 //! This crate is intentionally free of `wasm-bindgen` so it compiles as
 //! a plain `rlib` in native builds without pulling in JS interop code.
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod arrow_utils;
 pub mod filter;
 pub mod parquet_summary;

--- a/crates/nteract-predicate/src/lib.rs
+++ b/crates/nteract-predicate/src/lib.rs
@@ -7,9 +7,7 @@
 //! This crate is intentionally free of `wasm-bindgen` so it compiles as
 //! a plain `rlib` in native builds without pulling in JS interop code.
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod arrow_utils;

--- a/crates/repr-llm/src/lib.rs
+++ b/crates/repr-llm/src/lib.rs
@@ -20,6 +20,11 @@
 //! assert!(summary.is_some());
 //! ```
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod geojson;
 pub mod json;
 pub mod parquet;

--- a/crates/repr-llm/src/lib.rs
+++ b/crates/repr-llm/src/lib.rs
@@ -20,9 +20,7 @@
 //! assert!(summary.is_some());
 //! ```
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod geojson;

--- a/crates/repr-llm/src/plotly.rs
+++ b/crates/repr-llm/src/plotly.rs
@@ -666,7 +666,6 @@ fn summarize_generic(trace: &Value, trace_type: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/repr-llm/src/stats.rs
+++ b/crates/repr-llm/src/stats.rs
@@ -138,7 +138,7 @@ pub fn extract_title(v: &Value) -> Option<&str> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::approx_constant)]
+#[allow(clippy::approx_constant)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp-proxy/src/circuit_breaker.rs
+++ b/crates/runt-mcp-proxy/src/circuit_breaker.rs
@@ -71,7 +71,6 @@ impl Default for CircuitBreaker {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -7,9 +7,7 @@
 //! - `runt-proxy` — shipped as a sidecar in the nteract app and inside the `.mcpb` Claude Desktop extension
 //! - `mcp-supervisor` — dev environment MCP proxy with file watching and build management
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod child;

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -7,6 +7,11 @@
 //! - `runt-proxy` — shipped as a sidecar in the nteract app and inside the `.mcpb` Claude Desktop extension
 //! - `mcp-supervisor` — dev environment MCP proxy with file watching and build management
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub mod child;
 pub mod circuit_breaker;
 pub mod proxy;

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -942,7 +942,6 @@ impl McpProxy {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use rmcp::model::Content;

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -116,7 +116,6 @@ pub async fn auto_rejoin(client: &RunningChild, notebook_id: &str) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use rmcp::model::Content;

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -119,7 +119,6 @@ pub fn detect_divergence(old_tools: &[Tool], new_tools: &[Tool]) -> ToolDivergen
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp-proxy/src/version.rs
+++ b/crates/runt-mcp-proxy/src/version.rs
@@ -46,7 +46,6 @@ impl ReconnectionEvent {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp/src/editing.rs
+++ b/crates/runt-mcp/src/editing.rs
@@ -193,7 +193,6 @@ pub fn apply_replacement(source: &str, span: &EditSpan, replacement: &str) -> St
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -3,6 +3,11 @@
 //! Implements the MCP protocol using `rmcp`, backed by `runtimed-client`
 //! for daemon IPC and `notebook-sync` for Automerge document operations.
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -3,9 +3,7 @@
 //! Implements the MCP protocol using `rmcp`, backed by `runtimed-client`
 //! for daemon IPC and `notebook-sync` for Automerge document operations.
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::path::PathBuf;

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -492,7 +492,6 @@ pub async fn build_execution_result(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -736,7 +736,6 @@ pub async fn show_notebook(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     /// When package_manager is explicitly provided, it takes precedence
     /// over whatever the daemon detected.

--- a/crates/runt-proxy/src/main.rs
+++ b/crates/runt-proxy/src/main.rs
@@ -5,6 +5,11 @@
 //! `runt mcp` as a child, and proxies MCP over stdio with transparent
 //! restart on child death (daemon upgrade, crash, etc.).
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/runt-proxy/src/main.rs
+++ b/crates/runt-proxy/src/main.rs
@@ -5,9 +5,7 @@
 //! `runt mcp` as a child, and proxies MCP over stdio with transparent
 //! restart on child death (daemon upgrade, crash, etc.).
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::collections::HashMap;

--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -13,6 +13,11 @@
 //! - Editing code in cells: notebook stays trusted
 //! - External modification of dependencies: requires re-approval
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -337,7 +342,6 @@ pub fn sign_notebook_dependencies(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -13,9 +13,7 @@
 //! - Editing code in cells: notebook stays trusted
 //! - External modification of dependencies: requires re-approval
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use hmac::{Hmac, KeyInit, Mac};

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -13,3 +13,6 @@ sha2 = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
+
+[lints]
+workspace = true

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -3,9 +3,7 @@
 //! This crate provides utilities for detecting development mode and managing
 //! workspace-specific paths, enabling per-worktree isolation during development.
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use sha2::{Digest, Sha256};

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -3,6 +3,11 @@
 //! This crate provides utilities for detecting development mode and managing
 //! workspace-specific paths, enabling per-worktree isolation during development.
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use sha2::{Digest, Sha256};
 #[cfg(any(target_os = "macos", test))]
 use std::ffi::OsString;
@@ -1078,7 +1083,6 @@ pub fn session_state_path() -> PathBuf {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1,6 +1,4 @@
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 extern crate runtimed_client as runtimed;

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1,3 +1,8 @@
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 extern crate runtimed_client as runtimed;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -5383,7 +5388,6 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     /// Test that the shutdown command correctly identifies UUIDs vs file paths.
     /// This is critical for handling both saved notebooks (paths) and untitled

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -741,7 +741,6 @@ pub enum EnsureDaemonError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed-client/src/daemon_connection.rs
+++ b/crates/runtimed-client/src/daemon_connection.rs
@@ -475,7 +475,6 @@ async fn stop(state: &Arc<RwLock<ConnectionState>>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed-client/src/daemon_paths.rs
+++ b/crates/runtimed-client/src/daemon_paths.rs
@@ -90,7 +90,6 @@ pub async fn get_blob_paths_async(socket_path: &Path) -> (Option<String>, Option
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -12,9 +12,7 @@
 //! - `runtimed-py` (Python bindings) — PoolClient, SyncClient, settings
 //! - `runtimed` (daemon) — re-exports everything, adds server-only code
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::ffi::OsStr;

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -12,6 +12,11 @@
 //! - `runtimed-py` (Python bindings) — PoolClient, SyncClient, settings
 //! - `runtimed` (daemon) — re-exports everything, adds server-only code
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -219,7 +219,6 @@ pub enum BlobResponse {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/runtimed-client/src/runtime.rs
+++ b/crates/runtimed-client/src/runtime.rs
@@ -76,7 +76,6 @@ impl std::str::FromStr for Runtime {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -1001,7 +1001,6 @@ pub fn service_config_path() -> PathBuf {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1003,7 +1003,6 @@ pub fn read_nested_list(doc: &AutoCommit, map_key: &str, sub_key: &str) -> Vec<S
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -113,7 +113,6 @@ pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<Daemon
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -478,7 +478,6 @@ pub async fn try_get_synced_settings() -> Result<SyncedSettings, SyncClientError
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::runtime::Runtime;

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -4,9 +4,7 @@
 //! - `NativeAsyncClient`: Async daemon operations (status, ping, list active notebooks)
 //! - `AsyncSession`: Async notebook interaction with kernel management
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 extern crate runtimed_client as runtimed;

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -4,6 +4,11 @@
 //! - `NativeAsyncClient`: Async daemon operations (status, ping, list active notebooks)
 //! - `AsyncSession`: Async notebook interaction with kernel management
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 extern crate runtimed_client as runtimed;
 use pyo3::prelude::*;
 use std::path::PathBuf;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -5,6 +5,10 @@
 //! this WASM module instead of `@automerge/automerge` to avoid
 //! version mismatch issues that produce phantom cells.
 
+// Allow `expect()` and `unwrap()` in tests
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+use automerge::patches::PatchAction;
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use notebook_doc::diff::{diff_doc, CellChangeset, TextPatch};

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -8,7 +8,6 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-use automerge::patches::PatchAction;
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use notebook_doc::diff::{diff_doc, CellChangeset, TextPatch};

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -152,7 +152,6 @@ fn text_response(status: StatusCode, body: &str) -> Response<Full<Bytes>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -267,7 +267,6 @@ impl BlobStore {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4370,7 +4370,6 @@ fn looks_like_untitled_notebook_path(path: &str) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/runtimed/src/dx_blob_comm.rs
+++ b/crates/runtimed/src/dx_blob_comm.rs
@@ -48,7 +48,6 @@ pub fn classify_dx_target(target_name: &str) -> Option<DxTarget> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -405,7 +405,6 @@ impl KernelState {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -12,9 +12,7 @@
 //! using length-prefixed binary framing with a channel-based handshake.
 
 // Re-export everything from runtimed-client for backward compatibility
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub use runtimed_client::*;

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -12,6 +12,11 @@
 //! using length-prefixed binary framing with a channel-based handshake.
 
 // Re-export everything from runtimed-client for backward compatibility
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 pub use runtimed_client::*;
 
 // ============================================================================

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -3,6 +3,11 @@
 //! This runs the runtime daemon as a standalone process that manages
 //! prewarmed Python environments for notebook windows.
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -3,9 +3,7 @@
 //! This runs the runtime daemon as a standalone process that manages
 //! prewarmed Python environments for notebook windows.
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::path::PathBuf;

--- a/crates/runtimed/src/markdown_assets.rs
+++ b/crates/runtimed/src/markdown_assets.rs
@@ -260,7 +260,6 @@ fn estimated_base64_decoded_len(payload: &str) -> usize {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1390,7 +1390,6 @@ impl NotebookRoom {
     /// For normal operation, `new_fresh` is used to ensure the .ipynb file
     /// is the source of truth.
     #[cfg(test)]
-    #[allow(clippy::unwrap_used, clippy::expect_used)]
     pub fn load_or_create(notebook_id: &str, docs_dir: &Path, blob_store: Arc<BlobStore>) -> Self {
         // Derive UUID from notebook_id if it parses as a UUID, else mint a fresh one.
         let id = uuid::Uuid::parse_str(notebook_id).unwrap_or_else(|_| uuid::Uuid::new_v4());
@@ -9551,7 +9550,6 @@ pub(crate) fn spawn_notebook_file_watcher(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/crates/runtimed/src/notebook_sync_server/path_index.rs
+++ b/crates/runtimed/src/notebook_sync_server/path_index.rs
@@ -68,7 +68,6 @@ impl PathIndex {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1015,7 +1015,6 @@ fn value_to_string(value: &Value) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -370,7 +370,6 @@ fn parse_environment_yml_content(content: &str) -> Result<EnvironmentYmlConfig, 
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -994,7 +994,6 @@ fn diff_comm_state(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -420,7 +420,6 @@ fn color_to_ansi(color: &Color, is_foreground: bool) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/tests/tokio_mutex_lint.rs
+++ b/crates/runtimed/tests/tokio_mutex_lint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! CI lint: ensure no tokio::sync::Mutex guards are held across .await points.
 //!
 //! Uses the async-rust-lsp rule engine (tree-sitter based) to scan all runtimed

--- a/crates/sift-wasm/src/lib.rs
+++ b/crates/sift-wasm/src/lib.rs
@@ -5,6 +5,11 @@
 //! The stateful dataset store (`DataStore`) lives here because it only
 //! makes sense in a WASM context (JS holds handles via keep-alive).
 
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 

--- a/crates/sift-wasm/src/lib.rs
+++ b/crates/sift-wasm/src/lib.rs
@@ -5,9 +5,7 @@
 //! The stateful dataset store (`DataStore`) lives here because it only
 //! makes sense in a WASM context (JS holds handles via keep-alive).
 
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use wasm_bindgen::prelude::wasm_bindgen;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,8 @@
+// Tests are allowed to use unwrap()/expect()—they're how you assert
+// preconditions and keep test failures informative. Workspace-wide
+// `clippy::unwrap_used = "warn"` applies to non-test code.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -3285,7 +3290,6 @@ fn update_manifest_tools(manifest_json: &str, tools: &[serde_json::Value]) -> St
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::path::Path;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,4 @@
-// Tests are allowed to use unwrap()/expect()—they're how you assert
-// preconditions and keep test failures informative. Workspace-wide
-// `clippy::unwrap_used = "warn"` applies to non-test code.
+// Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 use std::env;


### PR DESCRIPTION
## Summary

- Add `#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]` at each crate root so tests no longer need boilerplate `#[allow(clippy::unwrap_used, clippy::expect_used)]` on every `#[cfg(test)] mod tests`.
- Remove 59 now-redundant per-module allow attributes in `#[cfg(test)]` modules.
- Preserve any allow attributes that carry extra lint names (`module_inception`, `approx_constant`, `new_without_default`) — either stripping just the unwrap/expect tokens or leaving the line untouched.

Workspace-level `clippy::unwrap_used = "warn"` / `expect_used = "warn"` still applies to non-test code, so production code is unchanged.

## Why not Cargo.toml alone?

`[workspace.lints.clippy]` in Cargo.toml has no per-profile / per-`cfg` mechanism — lints apply uniformly across all builds of a crate. `#![cfg_attr(test, allow(...))]` at each crate root is the standard Rust way to gate lint allowance on the test cfg.

Follow-up in a separate PR: audit the non-test `#[allow(clippy::unwrap_used)]` / `#[allow(clippy::expect_used)]` sites still scattered through production code.

## Test plan
- [x] `cargo xtask lint` passes (`cargo clippy --workspace --all-targets -- -D warnings`, fmt, biome, ruff, ty)