### PR TITLE
perf(outputs): eliminate prop-alloc hot paths at output+widget boundary

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1377,18 +1377,20 @@ const updateManager = new WidgetUpdateManager({
   getCrdtWriter: getCrdtCommWriter,
 });
 
+function WidgetViewRenderer({ data }: { data: unknown }) {
+  const { model_id } = data as { model_id: string };
+  return <WidgetView modelId={model_id} />;
+}
+
+const MEDIA_RENDERERS = {
+  "application/vnd.jupyter.widget-view+json": WidgetViewRenderer,
+};
+
 export default function App() {
   return (
     <ErrorBoundary fallback={AppErrorFallback}>
       <WidgetStoreProvider sendMessage={sendMessage} updateManager={updateManager}>
-        <MediaProvider
-          renderers={{
-            "application/vnd.jupyter.widget-view+json": ({ data }) => {
-              const { model_id } = data as { model_id: string };
-              return <WidgetView modelId={model_id} />;
-            },
-          }}
-        >
+        <MediaProvider renderers={MEDIA_RENDERERS}>
           <AppContent />
         </MediaProvider>
       </WidgetStoreProvider>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useId, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef } from "react";
 import {
   CommBridgeManager,
   type IframeToParentMessage,
@@ -259,6 +259,10 @@ export function OutputArea({
 
   const darkMode = useDarkMode();
   const colorTheme = useColorTheme();
+  const maxHeightStyle = useMemo(
+    () => (maxHeight ? { maxHeight: `${maxHeight}px` } : undefined),
+    [maxHeight],
+  );
   // Ref for reading current darkMode in callbacks without adding to deps
   const darkModeRef = useRef(darkMode);
   darkModeRef.current = darkMode;
@@ -507,7 +511,7 @@ export function OutputArea({
         <div
           id={id}
           className={cn("space-y-2", maxHeight && "overflow-y-auto")}
-          style={maxHeight ? { maxHeight: `${maxHeight}px` } : undefined}
+          style={maxHeightStyle}
         >
           {/* Preloaded or active isolated frame */}
           {(shouldIsolate || showPreloadedIframe) && (
@@ -534,7 +538,7 @@ export function OutputArea({
               {outputs.map((output, index) => (
                 <div key={`output-${index}`} data-slot="output-item" data-output-index={index}>
                   <ErrorBoundary
-                    resetKeys={[JSON.stringify(output)]}
+                    resetKeys={[output]}
                     fallback={(error, reset) => (
                       <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
                     )}


### PR DESCRIPTION
## Diagnosis

Three allocations per render were happening on hot paths at the output + widget boundary, flagged by the output-render audit in #1912.

1. `OutputArea` serialized every in-DOM output with `JSON.stringify` on every render to feed `ErrorBoundary.resetKeys`. Outputs are replaced by reference on updates, so a shallow identity compare is equivalent and skips an O(size) walk per visible output.
2. `OutputArea` built a fresh `style={{ maxHeight }}` object inline every render. Trivial, but it forced React to diff a new object identity each pass.
3. `App` handed `MediaProvider` a fresh `renderers={{ ... }}` object plus an inline arrow each render. `App()` happens to be stateless today, but the shape is a footgun the next time state lands there.

## Fixes

- `src/components/cell/OutputArea.tsx:537` - `resetKeys={[output]}`. Drop the `JSON.stringify`.
- `src/components/cell/OutputArea.tsx:510` - `style` wrapped in `useMemo` keyed on `maxHeight`.
- `apps/notebook/src/App.tsx:1384` - hoist `renderers` to a module-level `MEDIA_RENDERERS` const and extract the widget arrow into a named `WidgetViewRenderer` component.

Narrow and mechanical. No behavior change.

## Test plan

- [ ] `cargo xtask lint` passes
- [ ] Open a notebook with many in-DOM outputs, confirm they render and error boundaries still reset on output updates
- [ ] Open a notebook with ipywidgets, confirm widget views still render via `MediaProvider`
- [ ] `maxHeight` prop still constrains output area scroll