### PR TITLE
chore(runt-trust): opt into workspace clippy lints

### DIFF
--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -18,3 +18,6 @@ sha2 = "0.11"
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -177,7 +177,10 @@ pub fn get_pixi_metadata(
 pub fn compute_signature(key: &[u8; 32], metadata: &HashMap<String, serde_json::Value>) -> String {
     let content = extract_signable_content(metadata);
 
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can accept any key size");
+    // Safety: HMAC-SHA256 accepts keys of any length via `new_from_slice`; the
+    // underlying `KeyInit::new_from_slice` is infallible for `SimpleHmac`/`Hmac`.
+    #[allow(clippy::expect_used)]
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(content.as_bytes());
     let result = mac.finalize();
 
@@ -206,7 +209,9 @@ pub fn verify_signature(
     // Compute current signature
     let content = extract_signable_content(metadata);
 
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can accept any key size");
+    // Safety: see `compute_signature` - HMAC-SHA256 accepts any key length.
+    #[allow(clippy::expect_used)]
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(content.as_bytes());
 
     // Constant-time comparison


### PR DESCRIPTION
## Summary

#1906 added workspace-wide `clippy::unwrap_used` / `clippy::expect_used` warnings, but eight crates never opted in via `[lints] workspace = true`. `runt-trust` is one with two pre-existing violations in non-test code.

Both sites call `HmacSha256::new_from_slice(key).expect(...)`. That API is infallible for HMAC - the crate accepts keys of any length. The fix is scoped `#[allow(clippy::expect_used)]` with a safety argument, so the intent is documented where it lives rather than blanket-silenced at the crate root.

- Append `[lints] workspace = true` to `crates/runt-trust/Cargo.toml`
- Add scoped allows with safety comments at the two HMAC init sites

## Test plan

- [x] `cargo clippy -p runt-trust --all-targets -- -D warnings`
- [x] `cargo test -p runt-trust`
- [x] `cargo xtask lint`