### PR TITLE
chore(runtimed-wasm): opt into workspace clippy lints

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4ec97572f2e115c1ab499a66bb96d65e49ca37b40328431282fe063c34ee726
+oid sha256:fcbf4fedc4c78dcb0cb5cf1d9456015853dd44171d1b20069924647789bf3935
 size 1668760

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -27,3 +27,6 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[lints]
+workspace = true

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1609,9 +1609,10 @@ impl NotebookHandle {
                 };
 
                 // Diff outputs inline in executions — detect mid-execution
-                // changes (stream append, display update, error).
-                let output_changed_cells = if changed {
-                    let current_state = state.as_ref().unwrap();
+                // changes (stream append, display update, error). `state` is
+                // Some iff `changed` is true, so this also covers the
+                // `changed` branch without a separate check.
+                let output_changed_cells = if let Some(current_state) = state.as_ref() {
                     let (changed_cells, new_snapshot) = diff_execution_outputs(
                         &self.prev_execution_outputs,
                         &current_state.executions,


### PR DESCRIPTION
## Summary

Workspace lints (#1906) added `clippy::unwrap_used` and `clippy::expect_used` as warnings, but eight crates didn't inherit them. `runtimed-wasm` had one pre-existing `unwrap()` in the RUNTIME_STATE_SYNC frame handler, on a value that was Some by construction whenever `changed` was true.

Added `[lints] workspace = true` to `crates/runtimed-wasm/Cargo.toml` and rewrote the offending block:

```rust
// before
let output_changed_cells = if changed {
    let current_state = state.as_ref().unwrap();
    ...
};

// after
let output_changed_cells = if let Some(current_state) = state.as_ref() {
    ...
};
```

Same control flow, no panic path. Rebuilt the checked-in WASM bundle.

## Test plan

- [x] `cargo clippy -p runtimed-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo test -p runtimed-wasm` (11 tests pass)
- [x] `cargo xtask lint`
- [x] `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm`