### PR TITLE
chore(runtimed-py): opt into workspace clippy lints

### DIFF
--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -24,3 +24,6 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 log = "0.4"
 runt-workspace = { path = "../runt-workspace" }
+
+[lints]
+workspace = true

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -125,7 +125,11 @@ impl AsyncSession {
         // Return overridden ID if set; otherwise return the connect-time UUID.
         // This lock is a std::sync::Mutex (not tokio), so it never contends
         // with async SessionState operations.
-        if let Some(ref id) = *self.notebook_id_override.lock().unwrap() {
+        let guard = self
+            .notebook_id_override
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(ref id) = *guard {
             return id.clone();
         }
         self.notebook_id.clone()
@@ -209,7 +213,7 @@ impl AsyncSession {
         let effective_id = self
             .notebook_id_override
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
         future_into_py(py, async move {
@@ -615,7 +619,7 @@ impl AsyncSession {
         let effective_id = self
             .notebook_id_override
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
         let path = path.map(crate::daemon_paths::resolve_notebook_path);


### PR DESCRIPTION
## Summary

- Appends `[lints] workspace = true` to `crates/runtimed-py/Cargo.toml` so it inherits the workspace's `clippy::unwrap_used = "warn"` and `clippy::expect_used = "warn"`.
- Resolves the three resulting violations in `crates/runtimed-py/src/async_session.rs` — all `std::sync::Mutex::lock().unwrap()` calls on `notebook_id_override`.

## Diagnosis

The lock guards a plain `Option<String>` and is never held across `.await`. A `PyResult` path isn't available for the `notebook_id` getter (`-> String`), so propagating via `?` wasn't an option. `expect_used` is also warned. Recovery via `PoisonError::into_inner()` is the right fit: it keeps the getters and the PyO3 entrypoints infallible and treats a poisoned mutex (which would mean another thread already panicked holding this trivial `Option<String>`) as recoverable rather than a second panic.

## Test plan

- [x] `cargo clippy -p runtimed-py --all-targets -- -D warnings`
- [x] `cargo xtask lint`
- [x] `cargo test -p runtimed-py`