### PR TITLE
refactor(notebook-doc): fork_with_actor bakes unique-actor invariant into the API

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9af72c2ced0b75f213b722ca268bdf3e81458c0a361f92b62ca6476e7b7e1719
+oid sha256:c7a64287c5865f7b0d985fa5a7299d64ad08d966dc804e73b29d6799fa830d9c
 size 1669510

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -201,6 +201,37 @@ impl NotebookDoc {
         }
     }
 
+    /// Fork the document and set a distinct actor ID on the fork in one step.
+    ///
+    /// Forks inherit the parent's actor ID, and Automerge tracks ops by
+    /// `(actor, seq)`. Two concurrent forks that share an actor will each
+    /// produce ops at seq `N`, `N+1`, …; the first merge lands and the
+    /// second returns `DuplicateSeqNumber` — silently dropping writes if
+    /// the error is ignored. See the regression test
+    /// `merging_two_forks_with_shared_actor_returns_duplicate_seq_error`
+    /// in `runtime_state.rs`.
+    ///
+    /// Use this for any fork whose merge crosses an `.await` point. The
+    /// `actor` argument is set verbatim — the caller controls whether
+    /// the actor is stable per task (e.g. `"rt:kernel:abc:iopub"`) or
+    /// unique per fork (e.g. `format!("runtimed:assets:{}", Uuid::new_v4())`).
+    ///
+    /// Prefer a stable per-task actor for long-running loops that fork
+    /// many times in sequence — each unique actor consumes space in
+    /// Automerge's internal actor list. Use a UUID suffix for one-shot
+    /// sites where concurrent forks from the same logical task can
+    /// overlap across the async gap.
+    ///
+    /// For synchronous fork+merge blocks, use
+    /// [`fork_and_merge`](Self::fork_and_merge) — actor collisions are
+    /// harmless there because the merge completes before any other fork
+    /// of the same parent can exist.
+    pub fn fork_with_actor(&mut self, actor: impl AsRef<str>) -> Self {
+        let mut fork = self.fork();
+        fork.set_actor(actor.as_ref());
+        fork
+    }
+
     /// Get the current document heads (change hashes at the tip).
     pub fn get_heads(&mut self) -> Vec<automerge::ChangeHash> {
         self.doc.get_heads()

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -444,6 +444,38 @@ impl RuntimeStateDoc {
         }
     }
 
+    /// Fork the document and set a distinct actor ID on the fork in one step.
+    ///
+    /// Forks inherit the parent's actor ID, and Automerge tracks ops by
+    /// `(actor, seq)`. Two concurrent forks that share an actor will
+    /// each produce ops at seq `N`, `N+1`, …; the first merge lands and
+    /// the second returns `DuplicateSeqNumber` — silently dropping
+    /// writes if the error is ignored. The regression test
+    /// [`merging_two_forks_with_shared_actor_returns_duplicate_seq_error`]
+    /// pins this invariant.
+    ///
+    /// Use this for any fork whose merge crosses an `.await` point.
+    /// The `actor` argument is set verbatim — the caller controls
+    /// whether the actor is stable per task (e.g.
+    /// `"rt:kernel:abc:iopub"`) or unique per fork (e.g.
+    /// `format!("runtimed:state:interrupt:{}", Uuid::new_v4())`).
+    ///
+    /// Prefer a stable per-task actor for long-running loops that fork
+    /// many times in sequence — each unique actor consumes space in
+    /// Automerge's internal actor list. Use a UUID suffix for one-shot
+    /// sites where concurrent forks from the same logical task can
+    /// overlap across the async gap.
+    ///
+    /// For synchronous fork+merge blocks, use
+    /// [`fork_and_merge`](Self::fork_and_merge) — actor collisions are
+    /// harmless there because the merge completes before any other
+    /// fork of the same parent can exist.
+    pub fn fork_with_actor(&mut self, actor: impl AsRef<str>) -> Self {
+        let mut fork = self.fork();
+        fork.set_actor(actor.as_ref());
+        fork
+    }
+
     /// Merge another `RuntimeStateDoc`'s changes into this one.
     ///
     /// Returns the change hashes that were applied. CRDT merge semantics

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -820,9 +820,7 @@ impl KernelConnection for JupyterKernel {
 
                                     let mut fork = {
                                         let mut sd = state_doc_for_iopub.write().await;
-                                        let mut f = sd.fork();
-                                        f.set_actor(&iopub_actor_id);
-                                        f
+                                        sd.fork_with_actor(&iopub_actor_id)
                                     };
 
                                     let upsert_result = fork.upsert_stream_output(
@@ -1024,9 +1022,7 @@ impl KernelConnection for JupyterKernel {
 
                                         let mut fork = {
                                             let mut sd = state_doc_for_iopub.write().await;
-                                            let mut f = sd.fork();
-                                            f.set_actor(&iopub_actor_id);
-                                            f
+                                            sd.fork_with_actor(&iopub_actor_id)
                                         };
 
                                         if let Err(e) = fork.append_output(&eid, &manifest_json) {
@@ -1070,9 +1066,7 @@ impl KernelConnection for JupyterKernel {
                                 if let Some(ref display_id) = update.transient.display_id {
                                     let mut fork = {
                                         let mut sd = state_doc_for_iopub.write().await;
-                                        let mut f = sd.fork();
-                                        f.set_actor(&iopub_actor_id);
-                                        f
+                                        sd.fork_with_actor(&iopub_actor_id)
                                     };
 
                                     let updated = update_output_by_display_id_with_manifests(
@@ -1242,9 +1236,7 @@ impl KernelConnection for JupyterKernel {
 
                                         let mut fork = {
                                             let mut sd = state_doc_for_iopub.write().await;
-                                            let mut f = sd.fork();
-                                            f.set_actor(&iopub_actor_id);
-                                            f
+                                            sd.fork_with_actor(&iopub_actor_id)
                                         };
 
                                         if let Err(e) = fork.append_output(&eid, &manifest_json) {
@@ -1679,9 +1671,7 @@ impl KernelConnection for JupyterKernel {
                                             let eid = execution_id.clone().unwrap_or_default();
                                             let mut fork = {
                                                 let mut sd = shell_state_doc.write().await;
-                                                let mut f = sd.fork();
-                                                f.set_actor(&shell_actor_id);
-                                                f
+                                                sd.fork_with_actor(&shell_actor_id)
                                             };
 
                                             if let Err(e) = fork.append_output(&eid, &manifest_json)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -639,8 +639,7 @@ async fn process_markdown_assets(room: &NotebookRoom) {
             .filter(|cell| cell.cell_type == "markdown")
             .map(|cell| (cell.id, cell.source, cell.resolved_assets))
             .collect();
-        let mut fork = doc.fork();
-        fork.set_actor(&unique_fork_actor("runtimed:assets"));
+        let fork = doc.fork_with_actor(format!("runtimed:assets:{}", uuid::Uuid::new_v4()));
         (cells, fork)
     };
 
@@ -814,9 +813,7 @@ pub(crate) async fn apply_interrupt_to_state_doc(
     // Fork state_doc so mutations compose with any concurrent writes.
     let mut fork = {
         let mut sd = room_state_doc.write().await;
-        let mut f = sd.fork();
-        f.set_actor(&unique_fork_actor("runtimed:state:interrupt"));
-        f
+        sd.fork_with_actor(format!("runtimed:state:interrupt:{}", uuid::Uuid::new_v4()))
     };
 
     // Read the currently-executing entry from the CRDT (it stays — the
@@ -5937,9 +5934,17 @@ async fn handle_notebook_request(
                     tokio::spawn(async move {
                         if let Some(runtime) = detect_room_runtime(&room_clone).await {
                             if let Some(formatted) = format_source(&source_clone, &runtime).await {
+                                // Actor is assigned here (not via fork_with_actor)
+                                // because the formatter identity depends on the
+                                // runtime, which is detected after the fork was
+                                // created. The UUID suffix keeps concurrent
+                                // formatter forks from colliding on `(actor, seq)`.
                                 let mut fork = fork;
-                                let actor = unique_fork_actor(&formatter_actor(&runtime));
-                                fork.set_actor(&actor);
+                                fork.set_actor(&format!(
+                                    "{}:{}",
+                                    formatter_actor(&runtime),
+                                    uuid::Uuid::new_v4()
+                                ));
                                 if fork.update_source(&cell_id_clone, &formatted).is_ok() {
                                     let mut doc = room_clone.doc.write().await;
                                     if let Err(e) = catch_automerge_panic("format-merge", || {
@@ -7184,22 +7189,6 @@ fn formatter_actor(runtime: &str) -> String {
     format!("runtimed:{tool}")
 }
 
-/// Append a UUID suffix to an Automerge actor base string.
-///
-/// Every concurrent fork+merge cycle MUST have a distinct actor ID.
-/// Automerge rejects merges whose `(actor, seq)` pairs collide with a
-/// previously-merged fork's, which manifests as a silent
-/// `DuplicateSeqNumber` under `catch_automerge_panic` — see #1905 for
-/// the IOPub variant of this bug. This helper is the fix for the other
-/// fork sites in this file (assets, interrupt, formatter) where two
-/// triggers can overlap in the async gap between fork and merge.
-///
-/// The base prefix is preserved so any downstream attribution filter
-/// that matches on e.g. `"runtimed:"` still works.
-fn unique_fork_actor(base: &str) -> String {
-    format!("{}:{}", base, uuid::Uuid::new_v4())
-}
-
 /// Detect the runtime from room metadata, returning "python", "deno", or None.
 async fn detect_room_runtime(room: &NotebookRoom) -> Option<String> {
     let doc = room.doc.read().await;
@@ -7240,9 +7229,11 @@ async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, String> {
     // live doc, and Automerge's text CRDT merges them cleanly.
     let mut fork = {
         let mut doc = room.doc.write().await;
-        let mut f = doc.fork();
-        f.set_actor(&unique_fork_actor(&formatter_actor(&runtime)));
-        f
+        doc.fork_with_actor(format!(
+            "{}:{}",
+            formatter_actor(&runtime),
+            uuid::Uuid::new_v4()
+        ))
     };
 
     let mut formatted_count = 0;
@@ -9069,8 +9060,10 @@ async fn apply_ipynb_changes(
         // saved_sources `.await`s (deadlock prevention).
         let deferred_executions = {
             let mut doc = room.doc.write().await;
-            let mut fork = doc.fork();
-            fork.set_actor("runtimed:filesystem");
+            // Synchronous fork+merge inside the write guard — no `.await`
+            // between fork and merge. A stable actor is safe here because
+            // no other fork of this doc can exist concurrently.
+            let mut fork = doc.fork_with_actor("runtimed:filesystem");
 
             // Delete all current cells and re-add in external order on the fork
             for cell in &current_cells {
@@ -9268,11 +9261,10 @@ async fn apply_ipynb_changes(
         // the user's recent edits. Only genuine external changes (git pull,
         // external editor) — where the disk content differs from what we
         // last saved — trigger a source update.
-        let mut source_fork = {
-            let mut f = doc.fork();
-            f.set_actor("runtimed:filesystem");
-            Some(f)
-        };
+        // Synchronous fork+merge inside the write guard — a stable actor
+        // is safe here because no other fork of this doc can exist
+        // concurrently.
+        let mut source_fork = Some(doc.fork_with_actor("runtimed:filesystem"));
 
         let mut deferred_execs: Vec<DeferredExecution> = Vec::new();
         // Track cells whose execution_id should be cleared (no new outputs)


### PR DESCRIPTION
## Why

Automerge tracks ops by `(actor, seq)`. Two concurrent forks that share an actor each produce ops at seq N, N+1, …; the first merge lands and the second returns `DuplicateSeqNumber`. If that error is caught and ignored (as under `catch_automerge_panic`), writes are silently dropped. #1905 fixed the IOPub variant; #1911 covered the rest of `notebook_sync_server`.

The invariant was still manual at the callsite. Every fork that merges across an `.await` had to follow the pattern `doc.fork()` then `f.set_actor(&unique_*_actor(...))`, with two near-identical local helpers — one in `jupyter_kernel.rs`, one in `notebook_sync_server.rs` — that just formatted `"{base}:{uuid}"`. Easy to forget on the next fork, and the failure mode is silent.

## What

Add `fork_with_actor(actor: impl AsRef<str>)` to `NotebookDoc` and `RuntimeStateDoc`. It forks and sets the actor in one step. The actor is set verbatim, so the caller chooses:

- **Stable per-task** (`"rt:kernel:abc:iopub"`) for long-running loops that fork many times per task — each unique actor takes space in Automerge's internal actor list.
- **Unique per-fork** (`format!("runtimed:assets:{}", Uuid::new_v4())`) for one-shot sites where concurrent forks from the same logical path can overlap across an async gap.

Pre-empted a `fork_with_unique_actor(base)` variant that would append a UUID internally: it would pull `uuid` into `notebook-doc` (which also compiles to wasm), and the one-shot callsites compose the UUID cleanly with the single-helper design.

### Before / After — one migrated site

Before (jupyter_kernel.rs, iopub stream handler):

```rust
let mut fork = {
    let mut sd = state_doc_for_iopub.write().await;
    let mut f = sd.fork();
    f.set_actor(&iopub_actor_id);
    f
};
```

After:

```rust
let mut fork = {
    let mut sd = state_doc_for_iopub.write().await;
    sd.fork_with_actor(&iopub_actor_id)
};
```

### Migrated sites

- `crates/runtimed/src/jupyter_kernel.rs` — 5 iopub/shell sites with the existing stable actor IDs. `coalesce` stays on `fork_and_merge` (synchronous).
- `crates/runtimed/src/notebook_sync_server.rs` — `apply_assets_to_doc`, `apply_interrupt_to_state_doc`, and the format-all-cells site use `fork_with_actor(format!("{base}:{uuid}"))`. Two file-watcher sites (synchronous fork+merge inside the write guard) use a stable `"runtimed:filesystem"` actor.
- The formatter fork for `ExecuteCell` still sets its actor inside the spawned task, because the formatter identity depends on the runtime detected after the fork is created. A comment documents why.
- `unique_fork_actor` local helper deleted. No equivalent ever existed in `jupyter_kernel.rs`; actor IDs there are computed once at kernel start.

### Safety net

The regression test `merging_two_forks_with_shared_actor_returns_duplicate_seq_error` in `runtime_state.rs` still pins the underlying Automerge invariant, independent of whether callers use `fork_with_actor` or the raw pair.

### WASM

`runtimed_wasm_bg.wasm` rebuilt because `notebook-doc` exports changed.

## Test plan

- [x] `cargo build -p notebook-doc -p runtimed`
- [x] `cargo test -p notebook-doc` (341 pass + regression test)
- [x] `cargo test -p runtimed --lib` (325 pass)
- [x] `cargo xtask lint`
- [x] `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm`