### PR TITLE
chore(sift-wasm): opt into workspace clippy lints

### DIFF
--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -28,3 +28,6 @@ parquet = { version = "54", default-features = false, features = ["arrow", "snap
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[lints]
+workspace = true

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -75,7 +75,9 @@ fn with_stores<F, R>(f: F) -> R
 where
     F: FnOnce(&mut HashMap<u32, DataStore>) -> R,
 {
-    let mut guard = STORES.lock().unwrap();
+    #[allow(clippy::expect_used)]
+    // wasm32 is single-threaded; mutex can only be poisoned by a prior panic while holding the lock
+    let mut guard = STORES.lock().expect("STORES mutex poisoned");
     let stores = guard.get_or_insert_with(HashMap::new);
     f(stores)
 }
@@ -110,7 +112,9 @@ fn store_batches(batches: Vec<RecordBatch>, schema: &arrow::datatypes::Schema) -
     }
 
     let handle = {
-        let mut h = NEXT_HANDLE.lock().unwrap();
+        #[allow(clippy::expect_used)]
+        // wasm32 is single-threaded; mutex can only be poisoned by a prior panic while holding the lock
+        let mut h = NEXT_HANDLE.lock().expect("NEXT_HANDLE mutex poisoned");
         let id = *h;
         *h += 1;
         id
@@ -461,8 +465,17 @@ pub fn store_temporal_histogram(handle: u32, col: usize) -> Result<JsValue, JsVa
             return JsValue::from(js_sys::Array::new());
         }
 
-        let min_ms = *ms_values.iter().min().unwrap();
-        let max_ms = *ms_values.iter().max().unwrap();
+        // Safe: ms_values is non-empty (guarded by the is_empty() early return above).
+        #[allow(clippy::expect_used)] // non-emptiness verified above
+        let min_ms = *ms_values
+            .iter()
+            .min()
+            .expect("ms_values is non-empty (checked above)");
+        #[allow(clippy::expect_used)] // non-emptiness verified above
+        let max_ms = *ms_values
+            .iter()
+            .max()
+            .expect("ms_values is non-empty (checked above)");
         let range_ms = max_ms - min_ms;
 
         // Auto-detect granularity
@@ -1378,9 +1391,11 @@ pub fn cast_column(handle: u32, col: usize, target_type: &str) -> Result<(), JsV
                         Some(s) => {
                             if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                                 // and_hms_opt(0,0,0) only fails for invalid h/m/s, which are hardcoded valid
+                                #[allow(clippy::expect_used)]
+                                // and_hms_opt only fails for invalid h/m/s; 0,0,0 is always valid
                                 let ts = dt
                                     .and_hms_opt(0, 0, 0)
-                                    .unwrap()
+                                    .expect("and_hms_opt(0, 0, 0) is always valid (midnight)")
                                     .and_utc()
                                     .timestamp_millis();
                                 builder.append_value(ts);


### PR DESCRIPTION
## Summary

Opts `sift-wasm` into `[workspace.lints]` (one of eight crates missed by #1906) and fixes the five resulting `unwrap_used` violations. All five are safe by construction:

- `STORES` / `NEXT_HANDLE` mutex locks — wasm32 is single-threaded, so `PoisonError` would require a prior panic holding the same lock.
- `ms_values.iter().min()` / `.max()` — guarded by `is_empty()` one line above.
- `NaiveDate::and_hms_opt(0, 0, 0)` — hardcoded valid arguments.

Each uses `expect(...)` with `#[allow(clippy::expect_used)]` plus a one-line justification, matching the pattern already used in `blob_server`, `kernel_client`, `output_store`, etc.

## Test plan

- [x] `cargo clippy -p sift-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` passes
- [x] `cargo build -p sift-wasm --target wasm32-unknown-unknown` passes
- [x] `cargo xtask lint` passes
- [ ] No `sift-wasm` tests exist; WASM build artifact unchanged semantically