### PR TITLE
chore(notebook-doc): opt into workspace clippy lints

### DIFF
--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -29,3 +29,6 @@ default = []
 # Enable file persistence methods (load_or_create, save_to_file, notebook_doc_filename)
 # and logging. Not available for wasm32 targets.
 persistence = ["dep:log", "dep:sha2", "dep:hex"]
+
+[lints]
+workspace = true

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1573,6 +1573,10 @@ impl NotebookDoc {
     /// Note: This performs a read-modify-write on the JSON string. Concurrent updates
     /// to different paths may conflict (last-write-wins), but this is rare in practice
     /// since metadata updates are typically user-initiated actions.
+    // Allow reason: the `expect` calls below are safe by construction —
+    // each is guarded by an `is_object()` check or a `contains_key` insertion
+    // on the immediately preceding line, so the `Option` is provably `Some`.
+    #[allow(clippy::expect_used)]
     pub fn update_cell_metadata_at(
         &mut self,
         cell_id: &str,
@@ -1593,11 +1597,15 @@ impl NotebookDoc {
             if !current.is_object() {
                 *current = serde_json::json!({});
             }
-            let obj = current.as_object_mut().unwrap();
+            let obj = current
+                .as_object_mut()
+                .expect("current was just set to an object above");
             if !obj.contains_key(*key) {
                 obj.insert((*key).to_string(), serde_json::json!({}));
             }
-            current = obj.get_mut(*key).unwrap();
+            current = obj
+                .get_mut(*key)
+                .expect("key was just inserted above if missing");
         }
 
         // Set the final key
@@ -1607,7 +1615,7 @@ impl NotebookDoc {
         let final_key = path[path.len() - 1];
         current
             .as_object_mut()
-            .unwrap()
+            .expect("current was just set to an object above")
             .insert(final_key.to_string(), value);
 
         self.set_cell_metadata(cell_id, &metadata)

--- a/crates/notebook-doc/src/presence.rs
+++ b/crates/notebook-doc/src/presence.rs
@@ -228,6 +228,14 @@ pub fn decode_message(data: &[u8]) -> Result<PresenceMessage, PresenceError> {
 }
 
 // ── Convenience encoders ─────────────────────────────────────────────
+//
+// The encoders below serialize fixed-shape structs into a `Vec<u8>` via
+// `ciborium::ser::into_writer`. Serialization failure requires either a
+// writer I/O error (impossible for `Vec<u8>`) or an unserializable type
+// (ruled out at compile time by the struct definitions). A panic here
+// would indicate a bug in ciborium or a breaking schema change, not a
+// runtime condition callers can handle, so these paths use `expect` with
+// a `#[allow(clippy::expect_used)]` opt-out.
 
 /// Encode a cursor update message.
 pub fn encode_cursor_update(peer_id: &str, pos: &CursorPosition) -> Vec<u8> {
@@ -235,6 +243,7 @@ pub fn encode_cursor_update(peer_id: &str, pos: &CursorPosition) -> Vec<u8> {
 }
 
 /// Encode a cursor update with optional peer and actor labels.
+#[allow(clippy::expect_used)]
 pub fn encode_cursor_update_labeled(
     peer_id: &str,
     peer_label: Option<&str>,
@@ -257,6 +266,7 @@ pub fn encode_selection_update(peer_id: &str, sel: &SelectionRange) -> Vec<u8> {
 }
 
 /// Encode a selection update with optional peer and actor labels.
+#[allow(clippy::expect_used)]
 pub fn encode_selection_update_labeled(
     peer_id: &str,
     peer_label: Option<&str>,
@@ -278,6 +288,7 @@ pub fn encode_focus_update(peer_id: &str, cell_id: &str) -> Vec<u8> {
 }
 
 /// Encode a focus update with optional peer and actor labels.
+#[allow(clippy::expect_used)]
 pub fn encode_focus_update_labeled(
     peer_id: &str,
     peer_label: Option<&str>,
@@ -296,6 +307,7 @@ pub fn encode_focus_update_labeled(
 }
 
 /// Encode a clear-channel message (remove a single channel from a peer).
+#[allow(clippy::expect_used)]
 pub fn encode_clear_channel(peer_id: &str, channel: Channel) -> Vec<u8> {
     encode_message(&PresenceMessage::ClearChannel {
         peer_id: peer_id.to_string(),
@@ -305,6 +317,7 @@ pub fn encode_clear_channel(peer_id: &str, channel: Channel) -> Vec<u8> {
 }
 
 /// Encode a kernel state update message (daemon-owned).
+#[allow(clippy::expect_used)]
 pub fn encode_kernel_state_update(peer_id: &str, state: &KernelStateData) -> Vec<u8> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
@@ -328,6 +341,7 @@ pub fn encode_custom_update(peer_id: &str, data: &[u8]) -> Result<Vec<u8>, Prese
 }
 
 /// Encode a custom channel update message with optional peer and actor labels.
+#[allow(clippy::expect_used)]
 pub fn encode_custom_update_labeled(
     peer_id: &str,
     peer_label: Option<&str>,
@@ -344,6 +358,7 @@ pub fn encode_custom_update_labeled(
 }
 
 /// Encode a heartbeat message.
+#[allow(clippy::expect_used)]
 pub fn encode_heartbeat(peer_id: &str) -> Vec<u8> {
     encode_message(&PresenceMessage::Heartbeat {
         peer_id: peer_id.to_string(),
@@ -352,6 +367,7 @@ pub fn encode_heartbeat(peer_id: &str) -> Vec<u8> {
 }
 
 /// Encode a "peer left" message.
+#[allow(clippy::expect_used)]
 pub fn encode_left(peer_id: &str) -> Vec<u8> {
     encode_message(&PresenceMessage::Left {
         peer_id: peer_id.to_string(),
@@ -360,6 +376,7 @@ pub fn encode_left(peer_id: &str) -> Vec<u8> {
 }
 
 /// Encode a full snapshot of all peers' presence state.
+#[allow(clippy::expect_used)]
 pub fn encode_snapshot(sender_peer_id: &str, peers: &[PeerSnapshot]) -> Vec<u8> {
     encode_message(&PresenceMessage::Snapshot {
         peer_id: sender_peer_id.to_string(),

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -873,6 +873,10 @@ impl RuntimeStateDoc {
     /// source is stored as an audit log, and `seq` determines execution order.
     /// The runtime agent discovers new entries via CRDT sync and processes them
     /// in `seq` order.
+    // Allow reason: identical rationale to `create_execution` above — the
+    // `executions` map and the object handle we just created are guaranteed to
+    // exist, so the Automerge put operations cannot fail in practice.
+    #[allow(clippy::expect_used)]
     pub fn create_execution_with_source(
         &mut self,
         execution_id: &str,


### PR DESCRIPTION
## Summary

Opts `notebook-doc` into `[workspace.lints]` (introduced in #1906), covering the 21 pre-existing `clippy::unwrap_used` / `clippy::expect_used` violations in non-test code. Each site sits in a path where failure is ruled out by construction, so the fixes are documentation rather than behavior change: function-scoped `#[allow(clippy::expect_used)]` with a rationale comment, plus `.unwrap()` -> `.expect("<reason>")` where a call-site message clarifies the invariant.

## Fixes by category

- **CBOR encoders (9 in `presence.rs`)** — fixed-shape structs serialized into a `Vec<u8>` writer. I/O failure is impossible, and the struct definitions rule out unserializable values at compile time. Tagged each public encoder with `#[allow(clippy::expect_used)]` and added a section-level comment explaining the rationale.
- **Automerge puts (9 in `runtime_state.rs::create_execution_with_source`)** — operates on a map and object the function either just created via `put_object` or read unconditionally via `get_map`. The sibling `create_execution` already uses this pattern with a function-level allow; this PR applies it to the `_with_source` variant.
- **Metadata path walk (3 in `lib.rs::update_cell_metadata_at`)** — each unwrap is guarded by an `is_object()` check or a `contains_key` insertion on the immediately preceding line. Converted to `.expect()` with messages describing the invariant, with a single function-level allow.

Eight crates still need to opt in after this merges.

## Test plan

- [x] `cargo clippy -p notebook-doc --all-targets -- -D warnings` clean
- [x] `cargo xtask lint` passes (Rust, JS/TS, Python)
- [x] `cargo test -p notebook-doc` passes (5/5 + doctests)
- [ ] CI green