### PR TITLE
chore(sift-wasm): opt into workspace clippy lints with structural fixes

### DIFF
--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -28,3 +28,6 @@ parquet = { version = "54", default-features = false, features = ["arrow", "snap
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[lints]
+workspace = true

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -75,7 +75,9 @@ fn with_stores<F, R>(f: F) -> R
 where
     F: FnOnce(&mut HashMap<u32, DataStore>) -> R,
 {
-    let mut guard = STORES.lock().unwrap();
+    // wasm32 is single-threaded, so poisoning only occurs if a prior call
+    // panicked while holding the lock. Recover the inner value and carry on.
+    let mut guard = STORES.lock().unwrap_or_else(|e| e.into_inner());
     let stores = guard.get_or_insert_with(HashMap::new);
     f(stores)
 }
@@ -110,7 +112,7 @@ fn store_batches(batches: Vec<RecordBatch>, schema: &arrow::datatypes::Schema) -
     }
 
     let handle = {
-        let mut h = NEXT_HANDLE.lock().unwrap();
+        let mut h = NEXT_HANDLE.lock().unwrap_or_else(|e| e.into_inner());
         let id = *h;
         *h += 1;
         id
@@ -457,12 +459,12 @@ pub fn store_temporal_histogram(handle: u32, col: usize) -> Result<JsValue, JsVa
             let column = batch.column(col);
             extract_timestamp_ms(column, &mut ms_values);
         }
-        if ms_values.is_empty() {
-            return JsValue::from(js_sys::Array::new());
-        }
-
-        let min_ms = *ms_values.iter().min().unwrap();
-        let max_ms = *ms_values.iter().max().unwrap();
+        let (min_ms, max_ms) = match (ms_values.iter().min(), ms_values.iter().max()) {
+            (Some(&lo), Some(&hi)) => (lo, hi),
+            // Empty series: nothing to bin. Return an empty array so callers
+            // can treat "no data" uniformly.
+            _ => return JsValue::from(js_sys::Array::new()),
+        };
         let range_ms = max_ms - min_ms;
 
         // Auto-detect granularity
@@ -1377,10 +1379,10 @@ pub fn cast_column(handle: u32, col: usize, target_type: &str) -> Result<(), JsV
                         None => builder.append_null(),
                         Some(s) => {
                             if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-                                // and_hms_opt(0,0,0) only fails for invalid h/m/s, which are hardcoded valid
+                                // NaiveTime::default() is midnight; and_time
+                                // returns NaiveDateTime directly — no Option.
                                 let ts = dt
-                                    .and_hms_opt(0, 0, 0)
-                                    .unwrap()
+                                    .and_time(chrono::NaiveTime::default())
                                     .and_utc()
                                     .timestamp_millis();
                                 builder.append_value(ts);


### PR DESCRIPTION
Replaces #1921. That PR opted into the workspace clippy lints but dodged five `unwrap_used` warnings with `#[allow(clippy::expect_used)]` + safety comments. The intent of the lint is "don't panic in non-test code," and scoped-allow respects the lint, not the intent. This PR fixes each site at the root.

## Fixes by shape

**`STORES` / `NEXT_HANDLE` mutex locks.** wasm32 is single-threaded, so `PoisonError` only occurs after a prior panic inside a guarded section. Real recovery is to take the inner value and continue, not to re-panic. Swapped `.unwrap()` for `.unwrap_or_else(|e| e.into_inner())`.

Why this beats a scoped allow: the allow was claiming "this can't happen in practice" while still panicking on the off chance it did. `into_inner()` removes the panic path entirely.

**`ms_values.iter().min() / .max()` in `store_temporal_histogram`.** The unwrap was guarded by an `is_empty()` check one line up — the compiler can't see that. Restructured as `match (min, max)` so the Option variants are exhaustive: `(Some, Some)` destructures both, any other pattern returns the empty-array result the `is_empty()` branch already did. The failure path is gone, not suppressed.

**`NaiveDate::and_hms_opt(0, 0, 0).unwrap()`.** The args are hardcoded valid, but the API returns Option regardless. Switched to `date.and_time(NaiveTime::default())`. `NaiveTime::default()` is midnight and returns `NaiveTime` directly; `and_time` produces `NaiveDateTime` with no Option step. Failure case disappears at the type level.

(Note: `NaiveTime::MIDNIGHT` const would be cleaner but isn't exposed in the chrono version in use here — `Default` is equivalent and non-deprecated.)

## Verification

- `cargo clippy -p sift-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings` — clean
- `cargo build -p sift-wasm --target wasm32-unknown-unknown` — builds
- `cargo xtask lint` — all checks pass
- Grep for `#[allow(clippy::unwrap_used)]` / `#[allow(clippy::expect_used)]` in the diff — none

## Test plan

- [x] Clippy passes with `-D warnings` on wasm32 target
- [x] sift-wasm builds for wasm32
- [x] Workspace lint passes