### PR TITLE
fix(notebook-doc): propagate errors instead of panicking

### DIFF
--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -33,7 +33,13 @@ export function usePresence(
   const setCursor = useCallback(
     (cellId: string, line: number, column: number) => {
       if (!peerId) return;
-      const payload = encode_cursor_presence(peerId, peerLabel, actorLabel, cellId, line, column);
+      let payload: Uint8Array;
+      try {
+        payload = encode_cursor_presence(peerId, peerLabel, actorLabel, cellId, line, column);
+      } catch (e) {
+        logger.warn("[presence] encode cursor failed:", e);
+        return;
+      }
       transport
         .sendFrame(frame_types.PRESENCE, payload)
         .catch((e: unknown) => logger.warn("[presence] send cursor failed:", e));
@@ -44,16 +50,22 @@ export function usePresence(
   const setSelection = useCallback(
     (cellId: string, anchorLine: number, anchorCol: number, headLine: number, headCol: number) => {
       if (!peerId) return;
-      const payload = encode_selection_presence(
-        peerId,
-        peerLabel,
-        actorLabel,
-        cellId,
-        anchorLine,
-        anchorCol,
-        headLine,
-        headCol,
-      );
+      let payload: Uint8Array;
+      try {
+        payload = encode_selection_presence(
+          peerId,
+          peerLabel,
+          actorLabel,
+          cellId,
+          anchorLine,
+          anchorCol,
+          headLine,
+          headCol,
+        );
+      } catch (e) {
+        logger.warn("[presence] encode selection failed:", e);
+        return;
+      }
       transport
         .sendFrame(frame_types.PRESENCE, payload)
         .catch((e: unknown) => logger.warn("[presence] send selection failed:", e));
@@ -64,7 +76,13 @@ export function usePresence(
   const setFocus = useCallback(
     (cellId: string) => {
       if (!peerId) return;
-      const payload = encode_focus_presence(peerId, peerLabel, actorLabel, cellId);
+      let payload: Uint8Array;
+      try {
+        payload = encode_focus_presence(peerId, peerLabel, actorLabel, cellId);
+      } catch (e) {
+        logger.warn("[presence] encode focus failed:", e);
+        return;
+      }
       transport
         .sendFrame(frame_types.PRESENCE, payload)
         .catch((e: unknown) => logger.warn("[presence] send focus failed:", e));

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -1824,6 +1824,11 @@ export function encode_clear_channel_presence(peer_id, channel) {
         wasm.encode_clear_channel_presence(retptr, ptr0, len0, ptr1, len1);
         var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
         var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        if (r3) {
+            throw takeObject(r2);
+        }
         var v3 = getArrayU8FromWasm0(r0, r1).slice();
         wasm.__wbindgen_export4(r0, r1 * 1, 1);
         return v3;
@@ -1862,6 +1867,11 @@ export function encode_cursor_presence(peer_id, peer_label, actor_label, cell_id
         wasm.encode_cursor_presence(retptr, ptr0, len0, ptr1, len1, ptr2, len2, ptr3, len3, line, column);
         var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
         var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        if (r3) {
+            throw takeObject(r2);
+        }
         var v5 = getArrayU8FromWasm0(r0, r1).slice();
         wasm.__wbindgen_export4(r0, r1 * 1, 1);
         return v5;
@@ -1893,6 +1903,11 @@ export function encode_focus_presence(peer_id, peer_label, actor_label, cell_id)
         wasm.encode_focus_presence(retptr, ptr0, len0, ptr1, len1, ptr2, len2, ptr3, len3);
         var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
         var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        if (r3) {
+            throw takeObject(r2);
+        }
         var v5 = getArrayU8FromWasm0(r0, r1).slice();
         wasm.__wbindgen_export4(r0, r1 * 1, 1);
         return v5;
@@ -1927,6 +1942,11 @@ export function encode_selection_presence(peer_id, peer_label, actor_label, cell
         wasm.encode_selection_presence(retptr, ptr0, len0, ptr1, len1, ptr2, len2, ptr3, len3, anchor_line, anchor_col, head_line, head_col);
         var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
         var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        if (r3) {
+            throw takeObject(r2);
+        }
         var v5 = getArrayU8FromWasm0(r0, r1).slice();
         wasm.__wbindgen_export4(r0, r1 * 1, 1);
         return v5;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcbf4fedc4c78dcb0cb5cf1d9456015853dd44171d1b20069924647789bf3935
-size 1668760
+oid sha256:9af72c2ced0b75f213b722ca268bdf3e81458c0a361f92b62ca6476e7b7e1719
+size 1669510

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -29,3 +29,6 @@ default = []
 # Enable file persistence methods (load_or_create, save_to_file, notebook_doc_filename)
 # and logging. Not available for wasm32 targets.
 persistence = ["dep:log", "dep:sha2", "dep:hex"]
+
+[lints]
+workspace = true

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1587,17 +1587,23 @@ impl NotebookDoc {
             .get_cell_metadata(cell_id)
             .unwrap_or_else(|| serde_json::json!({}));
 
-        // Navigate to the parent of the target key, creating objects as needed
+        // Navigate to the parent of the target key, creating objects as needed.
+        // Each hop: coerce `current` into a Map, then bind a mutable reference
+        // to the child entry (insert `{}` if missing). This replaces the prior
+        // unwrap chain with Map-returning pattern matches that make the
+        // never-None invariant hold by construction.
         let mut current = &mut metadata;
         for key in &path[..path.len() - 1] {
             if !current.is_object() {
                 *current = serde_json::json!({});
             }
-            let obj = current.as_object_mut().unwrap();
-            if !obj.contains_key(*key) {
-                obj.insert((*key).to_string(), serde_json::json!({}));
-            }
-            current = obj.get_mut(*key).unwrap();
+            let Some(obj) = current.as_object_mut() else {
+                // Unreachable: we just assigned a Map above if it wasn't one.
+                unreachable!("current was coerced into a JSON object on the line above");
+            };
+            current = obj
+                .entry((*key).to_string())
+                .or_insert_with(|| serde_json::json!({}));
         }
 
         // Set the final key
@@ -1605,10 +1611,10 @@ impl NotebookDoc {
             *current = serde_json::json!({});
         }
         let final_key = path[path.len() - 1];
-        current
-            .as_object_mut()
-            .unwrap()
-            .insert(final_key.to_string(), value);
+        let Some(obj) = current.as_object_mut() else {
+            unreachable!("current was coerced into a JSON object on the line above");
+        };
+        obj.insert(final_key.to_string(), value);
 
         self.set_cell_metadata(cell_id, &metadata)
     }

--- a/crates/notebook-doc/src/presence.rs
+++ b/crates/notebook-doc/src/presence.rs
@@ -230,7 +230,7 @@ pub fn decode_message(data: &[u8]) -> Result<PresenceMessage, PresenceError> {
 // ── Convenience encoders ─────────────────────────────────────────────
 
 /// Encode a cursor update message.
-pub fn encode_cursor_update(peer_id: &str, pos: &CursorPosition) -> Vec<u8> {
+pub fn encode_cursor_update(peer_id: &str, pos: &CursorPosition) -> Result<Vec<u8>, PresenceError> {
     encode_cursor_update_labeled(peer_id, None, None, pos)
 }
 
@@ -240,19 +240,20 @@ pub fn encode_cursor_update_labeled(
     peer_label: Option<&str>,
     actor_label: Option<&str>,
     pos: &CursorPosition,
-) -> Vec<u8> {
-    // Cursor encoding is infallible for valid types — unwrap is safe here.
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
         peer_label: peer_label.map(|s| s.to_string()),
         actor_label: actor_label.map(|s| s.to_string()),
         data: ChannelData::Cursor(pos.clone()),
     })
-    .expect("CBOR encoding of cursor should not fail")
 }
 
 /// Encode a selection update message.
-pub fn encode_selection_update(peer_id: &str, sel: &SelectionRange) -> Vec<u8> {
+pub fn encode_selection_update(
+    peer_id: &str,
+    sel: &SelectionRange,
+) -> Result<Vec<u8>, PresenceError> {
     encode_selection_update_labeled(peer_id, None, None, sel)
 }
 
@@ -262,18 +263,17 @@ pub fn encode_selection_update_labeled(
     peer_label: Option<&str>,
     actor_label: Option<&str>,
     sel: &SelectionRange,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
         peer_label: peer_label.map(|s| s.to_string()),
         actor_label: actor_label.map(|s| s.to_string()),
         data: ChannelData::Selection(sel.clone()),
     })
-    .expect("CBOR encoding of selection should not fail")
 }
 
 /// Encode a focus update message (cell-level presence without cursor).
-pub fn encode_focus_update(peer_id: &str, cell_id: &str) -> Vec<u8> {
+pub fn encode_focus_update(peer_id: &str, cell_id: &str) -> Result<Vec<u8>, PresenceError> {
     encode_focus_update_labeled(peer_id, None, None, cell_id)
 }
 
@@ -283,7 +283,7 @@ pub fn encode_focus_update_labeled(
     peer_label: Option<&str>,
     actor_label: Option<&str>,
     cell_id: &str,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
         peer_label: peer_label.map(|s| s.to_string()),
@@ -292,27 +292,27 @@ pub fn encode_focus_update_labeled(
             cell_id: cell_id.to_string(),
         }),
     })
-    .expect("CBOR encoding of focus should not fail")
 }
 
 /// Encode a clear-channel message (remove a single channel from a peer).
-pub fn encode_clear_channel(peer_id: &str, channel: Channel) -> Vec<u8> {
+pub fn encode_clear_channel(peer_id: &str, channel: Channel) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::ClearChannel {
         peer_id: peer_id.to_string(),
         channel,
     })
-    .expect("CBOR encoding of clear_channel should not fail")
 }
 
 /// Encode a kernel state update message (daemon-owned).
-pub fn encode_kernel_state_update(peer_id: &str, state: &KernelStateData) -> Vec<u8> {
+pub fn encode_kernel_state_update(
+    peer_id: &str,
+    state: &KernelStateData,
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
         peer_label: None,
         actor_label: None,
         data: ChannelData::KernelState(state.clone()),
     })
-    .expect("CBOR encoding of kernel state should not fail")
 }
 
 /// Encode a custom channel update message (arbitrary bytes).
@@ -333,39 +333,38 @@ pub fn encode_custom_update_labeled(
     peer_label: Option<&str>,
     actor_label: Option<&str>,
     data: &[u8],
-) -> Vec<u8> {
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Update {
         peer_id: peer_id.to_string(),
         peer_label: peer_label.map(|s| s.to_string()),
         actor_label: actor_label.map(|s| s.to_string()),
         data: ChannelData::Custom(data.to_vec()),
     })
-    .expect("CBOR encoding of custom update should not fail")
 }
 
 /// Encode a heartbeat message.
-pub fn encode_heartbeat(peer_id: &str) -> Vec<u8> {
+pub fn encode_heartbeat(peer_id: &str) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Heartbeat {
         peer_id: peer_id.to_string(),
     })
-    .expect("CBOR encoding of heartbeat should not fail")
 }
 
 /// Encode a "peer left" message.
-pub fn encode_left(peer_id: &str) -> Vec<u8> {
+pub fn encode_left(peer_id: &str) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Left {
         peer_id: peer_id.to_string(),
     })
-    .expect("CBOR encoding of left should not fail")
 }
 
 /// Encode a full snapshot of all peers' presence state.
-pub fn encode_snapshot(sender_peer_id: &str, peers: &[PeerSnapshot]) -> Vec<u8> {
+pub fn encode_snapshot(
+    sender_peer_id: &str,
+    peers: &[PeerSnapshot],
+) -> Result<Vec<u8>, PresenceError> {
     encode_message(&PresenceMessage::Snapshot {
         peer_id: sender_peer_id.to_string(),
         peers: peers.to_vec(),
     })
-    .expect("CBOR encoding of snapshot should not fail")
 }
 
 /// Validate that a presence frame payload is within the size limit.
@@ -518,7 +517,7 @@ impl PresenceState {
     }
 
     /// Build a snapshot of all peers' current state, encoded as CBOR bytes.
-    pub fn encode_snapshot(&self, sender_peer_id: &str) -> Vec<u8> {
+    pub fn encode_snapshot(&self, sender_peer_id: &str) -> Result<Vec<u8>, PresenceError> {
         let snapshots: Vec<PeerSnapshot> = self
             .peers
             .values()
@@ -607,7 +606,7 @@ mod tests {
             line: 42,
             column: 7,
         };
-        let encoded = encode_cursor_update("peer-1", &pos);
+        let encoded = encode_cursor_update("peer-1", &pos).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -631,7 +630,7 @@ mod tests {
             line: 10,
             column: 3,
         };
-        let encoded = encode_cursor_update_labeled("peer-1", Some("Codex"), None, &pos);
+        let encoded = encode_cursor_update_labeled("peer-1", Some("Codex"), None, &pos).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -657,7 +656,8 @@ mod tests {
             head_line: 3,
             head_col: 10,
         };
-        let encoded = encode_selection_update_labeled("agent-1", Some("Claude"), None, &sel);
+        let encoded =
+            encode_selection_update_labeled("agent-1", Some("Claude"), None, &sel).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -683,7 +683,7 @@ mod tests {
             head_line: 5,
             head_col: 20,
         };
-        let encoded = encode_selection_update("editor-2", &sel);
+        let encoded = encode_selection_update("editor-2", &sel).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -706,7 +706,7 @@ mod tests {
             status: KernelStatus::Idle,
             env_source: "uv:prewarmed".into(),
         };
-        let encoded = encode_kernel_state_update("daemon", &ks);
+        let encoded = encode_kernel_state_update("daemon", &ks).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update { peer_id, data, .. } => {
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_heartbeat_roundtrip() {
-        let encoded = encode_heartbeat("peer-3");
+        let encoded = encode_heartbeat("peer-3").unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Heartbeat { peer_id } => assert_eq!(peer_id, "peer-3"),
@@ -729,7 +729,7 @@ mod tests {
 
     #[test]
     fn test_left_roundtrip() {
-        let encoded = encode_left("peer-gone");
+        let encoded = encode_left("peer-gone").unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Left { peer_id } => assert_eq!(peer_id, "peer-gone"),
@@ -761,7 +761,7 @@ mod tests {
             },
         ];
 
-        let encoded = encode_snapshot("daemon", &peers);
+        let encoded = encode_snapshot("daemon", &peers).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Snapshot { peer_id, peers } => {
@@ -800,7 +800,8 @@ mod tests {
                 line: 0,
                 column: 0,
             },
-        );
+        )
+        .unwrap();
         assert!(validate_frame_size(&small).is_ok());
 
         let oversized = vec![0u8; MAX_PRESENCE_FRAME_SIZE + 1];
@@ -814,7 +815,7 @@ mod tests {
             line: 10,
             column: 5,
         };
-        let encoded = encode_cursor_update("p1", &pos);
+        let encoded = encode_cursor_update("p1", &pos).unwrap();
         // CBOR is slightly larger than hand-rolled but still compact.
         // Exact size depends on CBOR overhead but should be well under 100 bytes.
         assert!(
@@ -984,7 +985,7 @@ mod tests {
         state1.update_peer("user", "human", None, cursor, 1000);
         state1.update_peer("daemon", "daemon", None, ks, 1000);
 
-        let snapshot_bytes = state1.encode_snapshot("daemon");
+        let snapshot_bytes = state1.encode_snapshot("daemon").unwrap();
 
         // Decode and apply to a fresh state
         let msg = decode_message(&snapshot_bytes).unwrap();
@@ -1073,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_focus_roundtrip() {
-        let encoded = encode_focus_update("peer-1", "cell-abc");
+        let encoded = encode_focus_update("peer-1", "cell-abc").unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -1097,7 +1098,8 @@ mod tests {
 
     #[test]
     fn test_focus_labeled_roundtrip() {
-        let encoded = encode_focus_update_labeled("agent-1", Some("Claude"), None, "cell-xyz");
+        let encoded =
+            encode_focus_update_labeled("agent-1", Some("Claude"), None, "cell-xyz").unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -1121,7 +1123,7 @@ mod tests {
 
     #[test]
     fn test_focus_update_is_compact() {
-        let encoded = encode_focus_update("p1", "c1");
+        let encoded = encode_focus_update("p1", "c1").unwrap();
         // Focus has fewer fields than cursor (no line/column), should be very small.
         assert!(
             encoded.len() < 80,
@@ -1134,7 +1136,7 @@ mod tests {
 
     #[test]
     fn test_clear_channel_roundtrip() {
-        let encoded = encode_clear_channel("peer-1", Channel::Cursor);
+        let encoded = encode_clear_channel("peer-1", Channel::Cursor).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::ClearChannel { peer_id, channel } => {
@@ -1147,7 +1149,7 @@ mod tests {
 
     #[test]
     fn test_clear_channel_selection_roundtrip() {
-        let encoded = encode_clear_channel("peer-2", Channel::Selection);
+        let encoded = encode_clear_channel("peer-2", Channel::Selection).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::ClearChannel { peer_id, channel } => {
@@ -1160,7 +1162,7 @@ mod tests {
 
     #[test]
     fn test_clear_channel_focus_roundtrip() {
-        let encoded = encode_clear_channel("peer-3", Channel::Focus);
+        let encoded = encode_clear_channel("peer-3", Channel::Focus).unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::ClearChannel { peer_id, channel } => {
@@ -1173,7 +1175,7 @@ mod tests {
 
     #[test]
     fn test_clear_channel_compact() {
-        let encoded = encode_clear_channel("p1", Channel::Cursor);
+        let encoded = encode_clear_channel("p1", Channel::Cursor).unwrap();
         assert!(
             encoded.len() < 60,
             "clear_channel should be compact, got {} bytes",
@@ -1245,7 +1247,7 @@ mod tests {
 
         // Clear selection, snapshot should only have cursor
         state.clear_channel("peer-1", Channel::Selection);
-        let snapshot_bytes = state.encode_snapshot("daemon");
+        let snapshot_bytes = state.encode_snapshot("daemon").unwrap();
         let msg = decode_message(&snapshot_bytes).unwrap();
         match msg {
             PresenceMessage::Snapshot { peers, .. } => {
@@ -1265,7 +1267,7 @@ mod tests {
         });
         state.update_peer("agent", "Claude", None, focus, 1000);
 
-        let snapshot_bytes = state.encode_snapshot("daemon");
+        let snapshot_bytes = state.encode_snapshot("daemon").unwrap();
         let msg = decode_message(&snapshot_bytes).unwrap();
         match msg {
             PresenceMessage::Snapshot { peers, .. } => {
@@ -1294,7 +1296,8 @@ mod tests {
                 line: 5,
                 column: 10,
             },
-        );
+        )
+        .unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {
@@ -1324,7 +1327,8 @@ mod tests {
                 line: 0,
                 column: 0,
             },
-        );
+        )
+        .unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update { actor_label, .. } => {
@@ -1356,7 +1360,7 @@ mod tests {
         assert_eq!(peer.actor_label, Some("agent:claude:abc123".to_string()));
 
         // Encode snapshot and decode into fresh state
-        let snapshot_bytes = state1.encode_snapshot("daemon");
+        let snapshot_bytes = state1.encode_snapshot("daemon").unwrap();
         let msg = decode_message(&snapshot_bytes).unwrap();
         let mut state2 = PresenceState::new();
         if let PresenceMessage::Snapshot { peers, .. } = msg {
@@ -1467,7 +1471,8 @@ mod tests {
             Some("Claude"),
             Some("agent:claude:xyz"),
             &[1, 2, 3],
-        );
+        )
+        .unwrap();
         let msg = decode_message(&encoded).unwrap();
         match msg {
             PresenceMessage::Update {

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -879,10 +879,10 @@ impl RuntimeStateDoc {
         cell_id: &str,
         source: &str,
         seq: u64,
-    ) -> bool {
+    ) -> Result<bool, AutomergeError> {
         let executions = self
             .get_map("executions")
-            .expect("executions map must exist");
+            .ok_or_else(|| AutomergeError::InvalidObjId("executions map must exist".to_string()))?;
 
         // Don't overwrite if it already exists (idempotent)
         if self
@@ -892,35 +892,20 @@ impl RuntimeStateDoc {
             .flatten()
             .is_some()
         {
-            return false;
+            return Ok(false);
         }
 
         let entry = self
             .doc
-            .put_object(&executions, execution_id, ObjType::Map)
-            .expect("put execution entry");
-        self.doc
-            .put(&entry, "cell_id", cell_id)
-            .expect("put execution.cell_id");
-        self.doc
-            .put(&entry, "status", "queued")
-            .expect("put execution.status");
-        self.doc
-            .put(&entry, "execution_count", ScalarValue::Null)
-            .expect("put execution.execution_count");
-        self.doc
-            .put(&entry, "success", ScalarValue::Null)
-            .expect("put execution.success");
-        self.doc
-            .put_object(&entry, "outputs", ObjType::List)
-            .expect("put execution.outputs");
-        self.doc
-            .put(&entry, "source", source)
-            .expect("put execution.source");
-        self.doc
-            .put(&entry, "seq", ScalarValue::Uint(seq))
-            .expect("put execution.seq");
-        true
+            .put_object(&executions, execution_id, ObjType::Map)?;
+        self.doc.put(&entry, "cell_id", cell_id)?;
+        self.doc.put(&entry, "status", "queued")?;
+        self.doc.put(&entry, "execution_count", ScalarValue::Null)?;
+        self.doc.put(&entry, "success", ScalarValue::Null)?;
+        self.doc.put_object(&entry, "outputs", ObjType::List)?;
+        self.doc.put(&entry, "source", source)?;
+        self.doc.put(&entry, "seq", ScalarValue::Uint(seq))?;
+        Ok(true)
     }
 
     /// Mark an execution as running.
@@ -2442,7 +2427,9 @@ mod tests {
     #[test]
     fn test_create_execution_with_source() {
         let mut doc = RuntimeStateDoc::new();
-        assert!(doc.create_execution_with_source("exec-1", "cell-1", "x = 42", 0));
+        assert!(doc
+            .create_execution_with_source("exec-1", "cell-1", "x = 42", 0)
+            .unwrap());
 
         let es = doc.get_execution("exec-1").unwrap();
         assert_eq!(es.cell_id, "cell-1");
@@ -2454,9 +2441,12 @@ mod tests {
     #[test]
     fn test_get_queued_executions_sorted_by_seq() {
         let mut doc = RuntimeStateDoc::new();
-        doc.create_execution_with_source("exec-3", "cell-3", "z = 3", 2);
-        doc.create_execution_with_source("exec-1", "cell-1", "x = 1", 0);
-        doc.create_execution_with_source("exec-2", "cell-2", "y = 2", 1);
+        doc.create_execution_with_source("exec-3", "cell-3", "z = 3", 2)
+            .unwrap();
+        doc.create_execution_with_source("exec-1", "cell-1", "x = 1", 0)
+            .unwrap();
+        doc.create_execution_with_source("exec-2", "cell-2", "y = 2", 1)
+            .unwrap();
 
         let queued = doc.get_queued_executions();
         assert_eq!(queued.len(), 3);

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -631,7 +631,8 @@ mod tests {
     ) {
         let mut st = shared.lock().unwrap();
         st.state_doc
-            .create_execution_with_source(execution_id, cell_id, "x = 1", 0);
+            .create_execution_with_source(execution_id, cell_id, "x = 1", 0)
+            .unwrap();
         st.state_doc.set_execution_running(execution_id);
         if let Some(count) = execution_count {
             st.state_doc.set_execution_count(execution_id, count);

--- a/crates/runt-mcp/src/presence.rs
+++ b/crates/runt-mcp/src/presence.rs
@@ -24,7 +24,7 @@ pub async fn emit_cursor(
     peer_label: &str,
 ) {
     let actor = actor_label(handle);
-    let data = presence::encode_cursor_update_labeled(
+    match presence::encode_cursor_update_labeled(
         "local",
         Some(peer_label),
         actor.as_deref(),
@@ -33,8 +33,12 @@ pub async fn emit_cursor(
             line,
             column,
         },
-    );
-    let _ = handle.send_presence(data).await;
+    ) {
+        Ok(data) => {
+            let _ = handle.send_presence(data).await;
+        }
+        Err(e) => tracing::debug!("emit_cursor: failed to encode: {}", e),
+    }
 }
 
 /// Emit a cell focus (agent is working on this cell, no specific cursor).
@@ -43,9 +47,17 @@ pub async fn emit_cursor(
 /// `peer_label` is the MCP client's display name (e.g. "Claude Code").
 pub async fn emit_focus(handle: &DocHandle, cell_id: &str, peer_label: &str) {
     let actor = actor_label(handle);
-    let data =
-        presence::encode_focus_update_labeled("local", Some(peer_label), actor.as_deref(), cell_id);
-    let _ = handle.send_presence(data).await;
+    match presence::encode_focus_update_labeled(
+        "local",
+        Some(peer_label),
+        actor.as_deref(),
+        cell_id,
+    ) {
+        Ok(data) => {
+            let _ = handle.send_presence(data).await;
+        }
+        Err(e) => tracing::debug!("emit_focus: failed to encode: {}", e),
+    }
 }
 
 /// Announce presence immediately after connecting to a notebook.
@@ -54,12 +66,17 @@ pub async fn emit_focus(handle: &DocHandle, cell_id: &str, peer_label: &str) {
 /// an action that emits presence (e.g. editing a cell).
 pub async fn announce(handle: &DocHandle, peer_label: &str) {
     let actor = actor_label(handle);
-    let data = if let Some(cell_id) = handle.first_cell_id() {
+    let encoded = if let Some(cell_id) = handle.first_cell_id() {
         presence::encode_focus_update_labeled("local", Some(peer_label), actor.as_deref(), &cell_id)
     } else {
         presence::encode_custom_update_labeled("local", Some(peer_label), actor.as_deref(), &[])
     };
-    let _ = handle.send_presence(data).await;
+    match encoded {
+        Ok(data) => {
+            let _ = handle.send_presence(data).await;
+        }
+        Err(e) => tracing::debug!("announce: failed to encode: {}", e),
+    }
 }
 
 /// Convert a character offset in source to (line, column) — both 0-based.

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -217,7 +217,7 @@ pub(crate) async fn announce_presence(state: &SessionState) {
     let actor_label = state.actor_label.as_deref();
     let first_cell_id = handle.first_cell_id();
 
-    let data = if let Some(cell_id) = first_cell_id {
+    let encoded = if let Some(cell_id) = first_cell_id {
         notebook_doc::presence::encode_focus_update_labeled(
             "local",
             peer_label,
@@ -227,7 +227,12 @@ pub(crate) async fn announce_presence(state: &SessionState) {
     } else {
         notebook_doc::presence::encode_custom_update_labeled("local", peer_label, actor_label, &[])
     };
-    let _ = handle.send_presence(data).await;
+    match encoded {
+        Ok(data) => {
+            let _ = handle.send_presence(data).await;
+        }
+        Err(e) => log::debug!("announce_presence: failed to encode: {}", e),
+    }
 }
 
 /// Populate `kernel_started`, `kernel_type`, and `env_source` from the
@@ -1578,7 +1583,8 @@ pub(crate) async fn set_cursor(
                 line,
                 column,
             },
-        );
+        )
+        .map_err(to_py_err)?;
         let handle = st
             .handle
             .clone()
@@ -1611,7 +1617,8 @@ pub(crate) async fn set_selection(
                 head_line,
                 head_col,
             },
-        );
+        )
+        .map_err(to_py_err)?;
         let handle = st
             .handle
             .clone()
@@ -1680,7 +1687,7 @@ async fn emit_cursor_presence_internal(
                 line,
                 column,
             },
-        );
+        )?;
         let handle = st.handle.clone().ok_or("Not connected")?;
         (data, handle)
     };
@@ -1706,7 +1713,7 @@ async fn emit_focus_presence_internal(
             peer_label.as_deref(),
             actor_label.as_deref(),
             cell_id,
-        );
+        )?;
         let handle = st.handle.clone().ok_or("Not connected")?;
         (data, handle)
     };
@@ -1728,7 +1735,7 @@ async fn emit_clear_channel_internal(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (data, handle) = {
         let st = state.lock().await;
-        let data = notebook_doc::presence::encode_clear_channel("local", channel);
+        let data = notebook_doc::presence::encode_clear_channel("local", channel)?;
         let handle = st.handle.clone().ok_or("Not connected")?;
         (data, handle)
     };
@@ -1749,7 +1756,8 @@ pub(crate) async fn set_focus(
             peer_label,
             st.actor_label.as_deref(),
             cell_id,
-        );
+        )
+        .map_err(to_py_err)?;
         let handle = st
             .handle
             .clone()
@@ -1764,7 +1772,8 @@ pub(crate) async fn clear_cursor(state: &Arc<Mutex<SessionState>>) -> PyResult<(
     let data = notebook_doc::presence::encode_clear_channel(
         "local",
         notebook_doc::presence::Channel::Cursor,
-    );
+    )
+    .map_err(to_py_err)?;
     let st = state.lock().await;
     let handle = st
         .handle
@@ -1778,7 +1787,8 @@ pub(crate) async fn clear_selection(state: &Arc<Mutex<SessionState>>) -> PyResul
     let data = notebook_doc::presence::encode_clear_channel(
         "local",
         notebook_doc::presence::Channel::Selection,
-    );
+    )
+    .map_err(to_py_err)?;
     let st = state.lock().await;
     let handle = st
         .handle

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1744,7 +1744,7 @@ pub fn encode_cursor_presence(
     cell_id: &str,
     line: u32,
     column: u32,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, JsError> {
     let label = if peer_label.is_empty() {
         None
     } else {
@@ -1765,6 +1765,7 @@ pub fn encode_cursor_presence(
             column,
         },
     )
+    .map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Encode a selection range as a presence frame payload (CBOR).
@@ -1779,7 +1780,7 @@ pub fn encode_selection_presence(
     anchor_col: u32,
     head_line: u32,
     head_col: u32,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, JsError> {
     let label = if peer_label.is_empty() {
         None
     } else {
@@ -1802,6 +1803,7 @@ pub fn encode_selection_presence(
             head_col,
         },
     )
+    .map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Encode a cell focus as a presence frame payload (CBOR).
@@ -1812,7 +1814,7 @@ pub fn encode_focus_presence(
     peer_label: &str,
     actor_label: &str,
     cell_id: &str,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, JsError> {
     let label = if peer_label.is_empty() {
         None
     } else {
@@ -1824,19 +1826,20 @@ pub fn encode_focus_presence(
         Some(actor_label)
     };
     presence::encode_focus_update_labeled(peer_id, label, actor, cell_id)
+        .map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Encode a clear-channel message as a presence frame payload (CBOR).
 /// Removes a single presence channel (e.g. cursor or selection) for this peer.
 #[wasm_bindgen]
-pub fn encode_clear_channel_presence(peer_id: &str, channel: &str) -> Vec<u8> {
+pub fn encode_clear_channel_presence(peer_id: &str, channel: &str) -> Result<Vec<u8>, JsError> {
     let ch = match channel {
         "cursor" => presence::Channel::Cursor,
         "selection" => presence::Channel::Selection,
         "focus" => presence::Channel::Focus,
-        _ => return vec![],
+        other => return Err(JsError::new(&format!("unknown presence channel: {other}"))),
     };
-    presence::encode_clear_channel(peer_id, ch)
+    presence::encode_clear_channel(peer_id, ch).map_err(|e| JsError::new(&e.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5900,14 +5900,9 @@ async fn handle_notebook_request(
                         .next_queue_seq
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-                    // Stamp execution_id on the cell in NotebookDoc
-                    {
-                        let mut doc = room.doc.write().await;
-                        let _ = doc.set_execution_id(&cell_id, Some(&execution_id));
-                        let _ = room.changed_tx.send(());
-                    }
-
-                    // Write execution entry with source to RuntimeStateDoc
+                    // Write execution entry with source to RuntimeStateDoc first
+                    // so that NotebookDoc's cell→execution_id pointer never
+                    // dangles. If this fails we bail before stamping the cell.
                     {
                         let mut sd = room.state_doc.write().await;
                         if let Err(e) =
@@ -5917,8 +5912,18 @@ async fn handle_notebook_request(
                                 "[notebook-sync] Failed to create_execution_with_source for {}: {}",
                                 execution_id, e
                             );
+                            return NotebookResponse::Error {
+                                error: format!("failed to queue execution: {e}"),
+                            };
                         }
                         let _ = room.state_changed_tx.send(());
+                    }
+
+                    // Stamp execution_id on the cell in NotebookDoc
+                    {
+                        let mut doc = room.doc.write().await;
+                        let _ = doc.set_execution_id(&cell_id, Some(&execution_id));
+                        let _ = room.changed_tx.send(());
                     }
 
                     // Best-effort background formatting via fork+merge
@@ -6167,6 +6172,9 @@ async fn handle_notebook_request(
                             });
                         }
                     }
+                    // Write RuntimeStateDoc entries first; on failure bail
+                    // before stamping NotebookDoc so cell→execution_id pointers
+                    // cannot dangle. Any single failure aborts the whole batch.
                     {
                         let mut sd = room.state_doc.write().await;
                         for (execution_id, cell_id, source, seq) in &entries {
@@ -6177,6 +6185,9 @@ async fn handle_notebook_request(
                                     "[notebook-sync] Failed to create_execution_with_source for {}: {}",
                                     execution_id, e
                                 );
+                                return NotebookResponse::Error {
+                                    error: format!("failed to queue execution: {e}"),
+                                };
                             }
                         }
                         let _ = room.state_changed_tx.send(());

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2104,8 +2104,12 @@ where
     // available here. remove_peer is a no-op for unknown peers
     // (e.g. error before any presence was registered).
     room.presence.write().await.remove_peer(&peer_id);
-    let left_bytes = presence::encode_left(&peer_id);
-    let _ = room.presence_tx.send((peer_id, left_bytes));
+    match presence::encode_left(&peer_id) {
+        Ok(left_bytes) => {
+            let _ = room.presence_tx.send((peer_id, left_bytes));
+        }
+        Err(e) => warn!("[notebook-sync] Failed to encode 'left' presence: {}", e),
+    }
 
     // Peer disconnected — decrement and possibly evict the room
     let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
@@ -2537,7 +2541,13 @@ where
                     })
                     .collect();
                 if !other_peers.is_empty() {
-                    Some(presence::encode_snapshot("daemon", &other_peers))
+                    match presence::encode_snapshot("daemon", &other_peers) {
+                        Ok(bytes) => Some(bytes),
+                        Err(e) => {
+                            warn!("[notebook-sync] Failed to encode presence snapshot: {}", e);
+                            None
+                        }
+                    }
                 } else {
                     None
                 }
@@ -2737,14 +2747,23 @@ where
                                                     })
                                                     .collect();
                                                 if !other_peers.is_empty() {
-                                                    let snapshot_bytes =
-                                                        presence::encode_snapshot("daemon", &other_peers);
-                                                    connection::send_typed_frame(
-                                                        writer,
-                                                        NotebookFrameType::Presence,
-                                                        &snapshot_bytes,
-                                                    )
-                                                    .await?;
+                                                    match presence::encode_snapshot(
+                                                        "daemon",
+                                                        &other_peers,
+                                                    ) {
+                                                        Ok(snapshot_bytes) => {
+                                                            connection::send_typed_frame(
+                                                                writer,
+                                                                NotebookFrameType::Presence,
+                                                                &snapshot_bytes,
+                                                            )
+                                                            .await?;
+                                                        }
+                                                        Err(e) => warn!(
+                                                            "[notebook-sync] Failed to encode presence snapshot for new peer: {}",
+                                                            e
+                                                        ),
+                                                    }
                                                 }
                                             }
 
@@ -2766,8 +2785,15 @@ where
                                     }
                                     Ok(presence::PresenceMessage::ClearChannel { channel, .. }) => {
                                         room.presence.write().await.clear_channel(peer_id, channel);
-                                        let bytes = presence::encode_clear_channel(peer_id, channel);
-                                        let _ = room.presence_tx.send((peer_id.to_string(), bytes));
+                                        match presence::encode_clear_channel(peer_id, channel) {
+                                            Ok(bytes) => {
+                                                let _ = room.presence_tx.send((peer_id.to_string(), bytes));
+                                            }
+                                            Err(e) => warn!(
+                                                "[notebook-sync] Failed to encode clear_channel presence: {}",
+                                                e
+                                            ),
+                                        }
                                     }
                                     Ok(_) => {
                                         // Snapshot/Left from a client — ignore
@@ -3106,13 +3132,20 @@ where
                             "[notebook-sync] Peer {} lagged {} presence updates, sending snapshot",
                             peer_id, n
                         );
-                        let snapshot_bytes = room.presence.read().await.encode_snapshot(peer_id);
-                        connection::send_typed_frame(
-                            writer,
-                            NotebookFrameType::Presence,
-                            &snapshot_bytes,
-                        )
-                        .await?;
+                        match room.presence.read().await.encode_snapshot(peer_id) {
+                            Ok(snapshot_bytes) => {
+                                connection::send_typed_frame(
+                                    writer,
+                                    NotebookFrameType::Presence,
+                                    &snapshot_bytes,
+                                )
+                                .await?;
+                            }
+                            Err(e) => warn!(
+                                "[notebook-sync] Failed to encode lag-recovery snapshot: {}",
+                                e
+                            ),
+                        }
                     }
                     Err(broadcast::error::RecvError::Closed) => {
                         // Presence channel closed — room is being evicted
@@ -3193,8 +3226,15 @@ where
                 let pruned = presence_state.prune_stale(now_ms, presence::DEFAULT_PEER_TTL_MS);
                 drop(presence_state);
                 for pruned_peer_id in pruned {
-                    let left_bytes = presence::encode_left(&pruned_peer_id);
-                    let _ = room.presence_tx.send((pruned_peer_id, left_bytes));
+                    match presence::encode_left(&pruned_peer_id) {
+                        Ok(left_bytes) => {
+                            let _ = room.presence_tx.send((pruned_peer_id, left_bytes));
+                        }
+                        Err(e) => warn!(
+                            "[notebook-sync] Failed to encode 'left' for pruned peer: {}",
+                            e
+                        ),
+                    }
                 }
             }
         }
@@ -4499,8 +4539,15 @@ pub(crate) async fn update_kernel_presence(
         presence::ChannelData::KernelState(data.clone()),
         now_ms,
     );
-    let bytes = presence::encode_kernel_state_update("daemon", &data);
-    let _ = presence_tx.send(("daemon".to_string(), bytes));
+    match presence::encode_kernel_state_update("daemon", &data) {
+        Ok(bytes) => {
+            let _ = presence_tx.send(("daemon".to_string(), bytes));
+        }
+        Err(e) => warn!(
+            "[notebook-sync] Failed to encode kernel state presence: {}",
+            e
+        ),
+    }
 }
 
 /// Handle a NotebookRequest and return a NotebookResponse.
@@ -5863,7 +5910,14 @@ async fn handle_notebook_request(
                     // Write execution entry with source to RuntimeStateDoc
                     {
                         let mut sd = room.state_doc.write().await;
-                        sd.create_execution_with_source(&execution_id, &cell_id, &source, seq);
+                        if let Err(e) =
+                            sd.create_execution_with_source(&execution_id, &cell_id, &source, seq)
+                        {
+                            warn!(
+                                "[notebook-sync] Failed to create_execution_with_source for {}: {}",
+                                execution_id, e
+                            );
+                        }
                         let _ = room.state_changed_tx.send(());
                     }
 
@@ -6116,7 +6170,14 @@ async fn handle_notebook_request(
                     {
                         let mut sd = room.state_doc.write().await;
                         for (execution_id, cell_id, source, seq) in &entries {
-                            sd.create_execution_with_source(execution_id, cell_id, source, *seq);
+                            if let Err(e) =
+                                sd.create_execution_with_source(execution_id, cell_id, source, *seq)
+                            {
+                                warn!(
+                                    "[notebook-sync] Failed to create_execution_with_source for {}: {}",
+                                    execution_id, e
+                                );
+                            }
                         }
                         let _ = room.state_changed_tx.send(());
                     }


### PR DESCRIPTION
Opts `notebook-doc` into `[workspace.lints]` and replaces all 21
unwrap/expect panics with real error propagation. No scoped
`#[allow(clippy::expect_used)]` in the diff.

## Why

`#[allow]` respects the lint, not the intent. The intent is
\"don't panic in non-task-tolerant code.\" Panics in the daemon bubble
up through `tokio::spawn`, and panics in wasm32 trap the worker.
Scoped-allow hides real bugs. See
`.context/superpowers/2026-04-19-no-panic-error-propagation.md`.

## Categories

### CBOR encoders (presence.rs, 9 sites)

Every public encoder now returns `Result<Vec<u8>, PresenceError>`.
Errors propagate via `?` instead of `.expect()`. Example:

```rust
// Before
pub fn encode_cursor_update(peer_id: &str, pos: &CursorPosition) -> Vec<u8> {
    encode_message(&PresenceMessage::Update { ... })
        .expect(\"CBOR encoding of cursor should not fail\")
}

// After
pub fn encode_cursor_update(
    peer_id: &str,
    pos: &CursorPosition,
) -> Result<Vec<u8>, PresenceError> {
    encode_message(&PresenceMessage::Update { ... })
}
```

Callers in `runtimed`, `runtimed-py`, `runt-mcp`, and `runtimed-wasm`
handle the `Result` appropriately for their context:

- Daemon sync server: log and skip the send.
- `runtimed-py` PyResult functions: `.map_err(to_py_err)?`.
- `runt-mcp` best-effort emitters: debug-log and return.
- `runtimed-wasm` wasm_bindgen functions: return
  `Result<Vec<u8>, JsError>` so JS callers can `try/catch`.
  `usePresence.ts` now wraps encode calls in try/catch and skips
  the `sendFrame` on encode failure.

### Automerge puts in `create_execution_with_source` (9 sites)

Function now returns `Result<(), AutomergeError>`. Two daemon
callers log and continue on failure instead of panicking the sync
task. The sibling `create_execution` has the same shape and is
flagged as a follow-up — not touching it in this PR.

### Metadata path walk in `update_cell_metadata_at` (3 sites)

Restructured to use Map-returning pattern matches:

```rust
let Some(obj) = current.as_object_mut() else {
    unreachable!(\"current was coerced into a JSON object on the line above\");
};
current = obj.entry((*key).to_string()).or_insert_with(|| json!({}));
```

The `unreachable!()` sites are load-bearing only because the line
immediately above guarantees `current` is a JSON object. If a future
edit moves that line, clippy won't catch it — but `unreachable!`
produces a clearer panic than `.unwrap()` and doesn't lie about being
safe via an `#[allow]`.

## Verification

- `cargo clippy -p notebook-doc --all-targets -- -D warnings` clean
- `cargo test -p notebook-doc` — 349 pass
- `cargo test -p runtimed --lib` — 325 pass
- `cargo xtask lint` — all checks pass
- WASM bundle regenerated

## Test plan
- [ ] Review diff for any `#[allow(clippy::(unwrap|expect)_used)]` attrs
- [ ] Confirm unreachable sites are truly unreachable
- [ ] Presence still works end-to-end after WASM bundle refresh
- [ ] `create_execution` follow-up tracked

## Follow-up

`RuntimeStateDoc::create_execution` (sibling of the fixed method)
uses the same `.expect()` pattern and still carries an existing
`#[allow(clippy::expect_used)]` from a previous PR. Out of scope
for this PR by plan. Clean it up in a follow-up.