### PR TITLE
fix(runtimed): flush persist debouncer before room eviction removes it

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 
 use automerge::sync;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot, watch, Mutex, RwLock};
 use tracing::{debug, error, info, warn};
 
 use notify_debouncer_mini::DebounceEventResult;
@@ -1034,6 +1034,14 @@ pub struct NotebookRoom {
     /// Channel to send doc bytes to the debounced persistence task.
     /// Uses watch for "latest value" semantics - always keeps most recent state.
     pub persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
+    /// Channel to request a synchronous flush from the persist debouncer.
+    /// Receiver handles the request and replies on the oneshot after the write
+    /// completes. Used by room eviction to guarantee disk consistency *before*
+    /// the room is removed from the map, closing the race where a fast reconnect
+    /// would load stale bytes from the still-pending .automerge file.
+    ///
+    /// `None` for ephemeral rooms (persistence skipped) and matches `persist_tx`.
+    pub flush_request_tx: Option<mpsc::UnboundedSender<FlushRequest>>,
     /// Persistence path for this room's document.
     pub persist_path: PathBuf,
     /// Number of active peer connections in this room.
@@ -1264,12 +1272,13 @@ impl NotebookRoom {
             let _ = doc.set_metadata("ephemeral", "true");
         }
 
-        let persist_tx = if ephemeral {
-            None
+        let (persist_tx, flush_request_tx) = if ephemeral {
+            (None, None)
         } else {
             let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
-            spawn_persist_debouncer(persist_rx, persist_path.clone());
-            Some(persist_tx)
+            let (flush_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
+            spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
+            (Some(persist_tx), Some(flush_tx))
         };
 
         let trust_state = match &path {
@@ -1337,6 +1346,7 @@ impl NotebookRoom {
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
             persist_tx,
+            flush_request_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
@@ -1397,7 +1407,8 @@ impl NotebookRoom {
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
-        spawn_persist_debouncer(persist_rx, persist_path.clone());
+        let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
+        spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
         let (presence_tx, _) = broadcast::channel(64);
         let path = if is_untitled_notebook(notebook_id) {
             None
@@ -1430,6 +1441,7 @@ impl NotebookRoom {
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
             persist_tx: Some(persist_tx),
+            flush_request_tx: Some(flush_request_tx),
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
@@ -2137,6 +2149,45 @@ where
                     notebook_id_for_eviction
                 );
                 return;
+            }
+
+            // Force a synchronous flush of the persist debouncer BEFORE removing
+            // the room from the map. Without this, a fast reconnect lands in
+            // the window between HashMap removal and the debouncer's shutdown
+            // flush (which only fires when the last Arc to the room drops, and
+            // the eviction task still holds one while running kernel/env
+            // teardown). In that window get_or_create_room creates a fresh
+            // room that loads stale bytes from the .automerge file — or no
+            // file at all for brand-new untitled notebooks — silently losing
+            // cells and edits.
+            //
+            // Request/ack over a dedicated channel. The debouncer has a
+            // select! arm that writes the latest doc bytes and replies on the
+            // oneshot. Bounded with a timeout so a wedged debouncer can't
+            // deadlock the eviction task; teardown must proceed either way.
+            if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
+                let (ack_tx, ack_rx) = oneshot::channel::<()>();
+                if flush_tx.send(ack_tx).is_ok() {
+                    match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(_)) => {
+                            // Debouncer dropped the ack sender without replying —
+                            // task already exited (e.g. previous eviction flushed
+                            // and closed). Any pending bytes went through the
+                            // shutdown path.
+                            debug!(
+                                "[notebook-sync] Eviction flush ack dropped for {} (debouncer exited)",
+                                notebook_id_for_eviction
+                            );
+                        }
+                        Err(_) => {
+                            warn!(
+                                "[notebook-sync] Eviction flush timed out for {} after 5s; proceeding with teardown",
+                                notebook_id_for_eviction
+                            );
+                        }
+                    }
+                }
             }
 
             // Remove room from the map under the lock, then drop the lock
@@ -7878,6 +7929,12 @@ impl Default for PersistDebouncerConfig {
     }
 }
 
+/// Request to force the persist debouncer to flush pending data immediately.
+/// The debouncer replies on the oneshot after the write completes (or immediately
+/// if there's nothing to write). Used by room eviction to guarantee the persisted
+/// file reflects the latest doc state *before* the room is removed from the map.
+type FlushRequest = oneshot::Sender<()>;
+
 /// Spawn a debounced persistence task that coalesces writes.
 ///
 /// Uses a `watch` channel for "latest value" semantics - new values replace old ones,
@@ -7886,12 +7943,18 @@ impl Default for PersistDebouncerConfig {
 /// Persistence strategy:
 /// - **Debounce (500ms)**: Wait 500ms after last update before writing
 /// - **Max interval (5s)**: During continuous output, flush at least every 5s
+/// - **Flush request**: Force an immediate write and ack (used by eviction)
 /// - **Shutdown flush**: Persist any pending data when channel closes
 ///
 /// This reduces disk I/O during rapid output while ensuring durability.
-fn spawn_persist_debouncer(persist_rx: watch::Receiver<Option<Vec<u8>>>, persist_path: PathBuf) {
+fn spawn_persist_debouncer(
+    persist_rx: watch::Receiver<Option<Vec<u8>>>,
+    flush_rx: mpsc::UnboundedReceiver<FlushRequest>,
+    persist_path: PathBuf,
+) {
     spawn_persist_debouncer_with_config(
         persist_rx,
+        flush_rx,
         persist_path,
         PersistDebouncerConfig::default(),
     );
@@ -7900,6 +7963,7 @@ fn spawn_persist_debouncer(persist_rx: watch::Receiver<Option<Vec<u8>>>, persist
 /// Spawn debouncer with custom timing configuration (for testing).
 fn spawn_persist_debouncer_with_config(
     mut persist_rx: watch::Receiver<Option<Vec<u8>>>,
+    mut flush_rx: mpsc::UnboundedReceiver<FlushRequest>,
     persist_path: PathBuf,
     config: PersistDebouncerConfig,
 ) {
@@ -7930,6 +7994,37 @@ fn spawn_persist_debouncer_with_config(
                         break;
                     }
                     last_receive = Some(Instant::now());
+                }
+                maybe_req = flush_rx.recv() => {
+                    match maybe_req {
+                        Some(ack) => {
+                            // Eviction (or another caller) wants a synchronous flush.
+                            // Write the latest doc bytes, then ack. Holding the watch
+                            // borrow across do_persist is safe: do_persist is sync I/O
+                            // and the borrow is released before we reply.
+                            let bytes = persist_rx.borrow().clone();
+                            if let Some(data) = bytes {
+                                do_persist(&data, &persist_path);
+                                last_flush = Some(Instant::now());
+                                last_receive = None;
+                            }
+                            // Receiver may have dropped (eviction timed out); ignore.
+                            let _ = ack.send(());
+                        }
+                        None => {
+                            // All flush senders dropped. The room is being torn
+                            // down; the watch receiver will close next and we'll
+                            // hit the shutdown flush on the persist_rx.changed()
+                            // Err arm. Break defensively to avoid hot-looping if
+                            // that somehow doesn't fire (we still want to flush
+                            // any pending bytes first).
+                            let bytes = persist_rx.borrow().clone();
+                            if let Some(data) = bytes {
+                                do_persist(&data, &persist_path);
+                            }
+                            break;
+                        }
+                    }
                 }
                 _ = check_interval.tick() => {
                     // Check if we should flush based on debounce or max interval
@@ -10218,7 +10313,8 @@ mod tests {
         let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let persist_path = tmp.path().join("doc.automerge");
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
-        spawn_persist_debouncer(persist_rx, persist_path.clone());
+        let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
+        spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
 
         let (presence_tx, _) = broadcast::channel(64);
 
@@ -10232,6 +10328,7 @@ mod tests {
             presence_tx,
             presence: Arc::new(RwLock::new(PresenceState::new())),
             persist_tx: Some(persist_tx),
+            flush_request_tx: Some(flush_request_tx),
             persist_path,
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
@@ -10476,12 +10573,13 @@ mod tests {
 
         // Create watch channel and spawn debouncer with short intervals for testing
         let (tx, rx) = watch::channel::<Option<Vec<u8>>>(None);
+        let (_flush_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
         let config = PersistDebouncerConfig {
             debounce_ms: 50,       // 50ms debounce window
             max_interval_ms: 200,  // 200ms max between flushes
             check_interval_ms: 10, // Check every 10ms
         };
-        spawn_persist_debouncer_with_config(rx, persist_path.clone(), config);
+        spawn_persist_debouncer_with_config(rx, flush_rx, persist_path.clone(), config);
 
         // Send updates every 20ms (faster than 50ms debounce, so debounce never triggers)
         // The 200ms max interval should force a flush even without a quiet period.
@@ -10506,6 +10604,53 @@ mod tests {
         assert!(
             content_str.starts_with("update-"),
             "Content should be from an update"
+        );
+    }
+
+    /// Regression test for the eviction/debouncer race.
+    ///
+    /// The bug: room eviction used to remove the room from the HashMap before
+    /// the persist debouncer's debounce window elapsed, so a fast reconnect
+    /// would load stale/empty bytes. The fix: eviction sends a flush request
+    /// on `flush_request_tx` and awaits an ack on the oneshot *before* the
+    /// HashMap mutation. This test pins the contract: the ack must arrive
+    /// after the latest watch value has been written to disk, well inside
+    /// the debounce window.
+    #[tokio::test]
+    async fn test_persist_debouncer_flush_request_is_synchronous() {
+        use std::time::Duration;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let persist_path = tmp.path().join("race.automerge");
+
+        // Use production defaults for debounce (500ms) so the timed flush
+        // can't mask the flush-request ack timing.
+        let (tx, rx) = watch::channel::<Option<Vec<u8>>>(None);
+        let (flush_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
+        spawn_persist_debouncer(rx, flush_rx, persist_path.clone());
+
+        // Push latest bytes and request a flush immediately. No sleeps — the
+        // debounce timer must not be the thing that persists this write.
+        let payload = b"eviction-latest-bytes".to_vec();
+        tx.send(Some(payload.clone())).unwrap();
+
+        let (ack_tx, ack_rx) = oneshot::channel::<()>();
+        flush_tx.send(ack_tx).unwrap();
+
+        // The ack must come back fast. 500ms is 10x margin over local disk I/O.
+        let ack_result = tokio::time::timeout(Duration::from_millis(500), ack_rx).await;
+        assert!(
+            matches!(ack_result, Ok(Ok(()))),
+            "flush ack did not arrive synchronously: {:?}",
+            ack_result
+        );
+
+        // And the file on disk must hold the latest payload, not stale bytes.
+        assert!(persist_path.exists(), "file must exist after flush ack");
+        let on_disk = std::fs::read(&persist_path).unwrap();
+        assert_eq!(
+            on_disk, payload,
+            "file contents must match latest payload after flush ack"
         );
     }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2184,10 +2184,21 @@ where
                 const MAX_FLUSH_RETRIES: u32 = 4;
                 let mut flush_ok = true;
                 if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
-                    let (ack_tx, ack_rx) = oneshot::channel::<()>();
+                    let (ack_tx, ack_rx) = oneshot::channel::<bool>();
                     if flush_tx.send(ack_tx).is_ok() {
                         match tokio::time::timeout(FLUSH_TIMEOUT, ack_rx).await {
-                            Ok(Ok(())) => {}
+                            Ok(Ok(true)) => {}
+                            Ok(Ok(false)) => {
+                                // Write returned an I/O error (ENOSPC, EIO, perm).
+                                // Retry — the filesystem may recover, and forcing
+                                // teardown now would leave the user's latest
+                                // bytes only in the soon-to-be-dropped room.
+                                warn!(
+                                    "[notebook-sync] Eviction flush reported write failure for {}",
+                                    notebook_id_for_eviction
+                                );
+                                flush_ok = false;
+                            }
                             Ok(Err(_)) => {
                                 // Debouncer dropped the ack sender without replying —
                                 // task already exited (e.g. previous eviction
@@ -7967,10 +7978,12 @@ impl Default for PersistDebouncerConfig {
 }
 
 /// Request to force the persist debouncer to flush pending data immediately.
-/// The debouncer replies on the oneshot after the write completes (or immediately
-/// if there's nothing to write). Used by room eviction to guarantee the persisted
-/// file reflects the latest doc state *before* the room is removed from the map.
-type FlushRequest = oneshot::Sender<()>;
+/// The debouncer replies on the oneshot with `true` if the write succeeded
+/// (or if there were no pending bytes to write), `false` on I/O error. Used
+/// by room eviction to guarantee the persisted file reflects the latest doc
+/// state *before* the room is removed from the map; a `false` reply tells
+/// the caller the file on disk is still stale.
+type FlushRequest = oneshot::Sender<bool>;
 
 /// Spawn a debounced persistence task that coalesces writes.
 ///
@@ -8036,17 +8049,24 @@ fn spawn_persist_debouncer_with_config(
                     match maybe_req {
                         Some(ack) => {
                             // Eviction (or another caller) wants a synchronous flush.
-                            // Write the latest doc bytes, then ack. Holding the watch
-                            // borrow across do_persist is safe: do_persist is sync I/O
-                            // and the borrow is released before we reply.
+                            // Write the latest doc bytes, then ack with the write
+                            // result so the caller knows whether the file is
+                            // current. No pending bytes = nothing to write = ack true
+                            // (the file either doesn't exist or already reflects
+                            // the latest state).
                             let bytes = persist_rx.borrow().clone();
-                            if let Some(data) = bytes {
-                                do_persist(&data, &persist_path);
-                                last_flush = Some(Instant::now());
-                                last_receive = None;
-                            }
+                            let ok = if let Some(data) = bytes {
+                                let write_ok = do_persist(&data, &persist_path);
+                                if write_ok {
+                                    last_flush = Some(Instant::now());
+                                    last_receive = None;
+                                }
+                                write_ok
+                            } else {
+                                true
+                            };
                             // Receiver may have dropped (eviction timed out); ignore.
-                            let _ = ack.send(());
+                            let _ = ack.send(ok);
                         }
                         None => {
                             // All flush senders dropped. The room is being torn
@@ -8228,9 +8248,10 @@ fn spawn_autosave_debouncer_with_config(
 }
 
 /// Actually persist bytes to disk, logging if it takes too long.
-fn do_persist(data: &[u8], path: &Path) {
+/// Returns `true` on success, `false` on I/O error.
+fn do_persist(data: &[u8], path: &Path) -> bool {
     let start = std::time::Instant::now();
-    persist_notebook_bytes(data, path);
+    let ok = persist_notebook_bytes(data, path);
     let elapsed = start.elapsed();
     if elapsed > std::time::Duration::from_millis(500) {
         warn!(
@@ -8238,22 +8259,30 @@ fn do_persist(data: &[u8], path: &Path) {
             path, elapsed
         );
     }
+    ok
 }
 
 /// Persist pre-serialized notebook bytes to disk.
-pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) {
+///
+/// Returns `true` on success, `false` on I/O error. Callers that need to
+/// know whether the bytes actually hit disk (e.g. eviction's flush-and-ack
+/// path) must check the return value; earlier call sites that only care
+/// about best-effort debounced writes can ignore it.
+pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) -> bool {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
             warn!(
                 "[notebook-sync] Failed to create parent dir for {:?}: {}",
                 path, e
             );
-            return;
+            return false;
         }
     }
     if let Err(e) = std::fs::write(path, data) {
         warn!("[notebook-sync] Failed to save notebook doc: {}", e);
+        return false;
     }
+    true
 }
 
 // =============================================================================
@@ -10671,14 +10700,15 @@ mod tests {
         let payload = b"eviction-latest-bytes".to_vec();
         tx.send(Some(payload.clone())).unwrap();
 
-        let (ack_tx, ack_rx) = oneshot::channel::<()>();
+        let (ack_tx, ack_rx) = oneshot::channel::<bool>();
         flush_tx.send(ack_tx).unwrap();
 
-        // The ack must come back fast. 500ms is 10x margin over local disk I/O.
+        // The ack must come back fast (success=true). 500ms is 10x margin over
+        // local disk I/O.
         let ack_result = tokio::time::timeout(Duration::from_millis(500), ack_rx).await;
         assert!(
-            matches!(ack_result, Ok(Ok(()))),
-            "flush ack did not arrive synchronously: {:?}",
+            matches!(ack_result, Ok(Ok(true))),
+            "flush ack did not arrive synchronously with success=true: {:?}",
             ack_result
         );
 
@@ -10688,6 +10718,47 @@ mod tests {
         assert_eq!(
             on_disk, payload,
             "file contents must match latest payload after flush ack"
+        );
+    }
+
+    /// The flush-and-ack must report I/O failures so the eviction task can
+    /// retry (rather than remove the room and leave stale bytes on disk).
+    /// Force a write failure by pointing persist_path at a non-writable
+    /// location, then confirm the ack carries `false`.
+    #[tokio::test]
+    async fn test_persist_debouncer_flush_request_reports_write_failure() {
+        use std::time::Duration;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Write target is a file *inside* a path that includes a non-directory
+        // component — `std::fs::create_dir_all` on parent will succeed, but
+        // `std::fs::write` on the final path will fail because it conflicts
+        // with a regular file we planted there. This simulates ENOSPC-class
+        // failures without needing OS-specific tricks.
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"regular file").unwrap();
+        let persist_path = blocker.join("race.automerge");
+
+        let (tx, rx) = watch::channel::<Option<Vec<u8>>>(None);
+        let (flush_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
+        spawn_persist_debouncer(rx, flush_rx, persist_path.clone());
+
+        let payload = b"write-will-fail".to_vec();
+        tx.send(Some(payload)).unwrap();
+
+        let (ack_tx, ack_rx) = oneshot::channel::<bool>();
+        flush_tx.send(ack_tx).unwrap();
+
+        let ack_result = tokio::time::timeout(Duration::from_millis(500), ack_rx).await;
+        assert!(
+            matches!(ack_result, Ok(Ok(false))),
+            "flush ack must report write failure: {:?}",
+            ack_result
+        );
+        // The file should not exist, since the write errored before any bytes hit disk.
+        assert!(
+            !persist_path.exists(),
+            "persist_path must not exist after failed write"
         );
     }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2169,41 +2169,35 @@ where
                 // cells and edits.
                 //
                 // Request/ack over a dedicated channel. The debouncer has a
-                // select! arm that writes the latest doc bytes and replies on the
-                // oneshot.
+                // select! arm that writes the latest doc bytes and replies on
+                // the oneshot with the I/O result.
                 //
-                // On timeout we back off and retry. Proceeding with HashMap
-                // removal would reopen the race (the write may still be in
-                // flight; reconnect would create a fresh room from a partial
-                // file). Retrying keeps the room live so reconnects see the
-                // in-memory doc, and gives the write another shot — bounded
-                // retries prevent a permanently-wedged filesystem from leaking
-                // rooms forever.
+                // On timeout or write failure we back off and retry indefinitely.
+                // Proceeding with HashMap removal on a failed flush reopens the
+                // race: either the write is still in flight, or the latest bytes
+                // are only in the soon-to-be-dropped room. We'd rather leak a
+                // room than silently lose user edits. A reconnect still finds
+                // the live in-memory room and recovers; a genuinely wedged
+                // filesystem will surface through other signals, and daemon
+                // shutdown still tries a last flush on persist_tx drop.
                 const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
                 const FLUSH_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
-                const MAX_FLUSH_RETRIES: u32 = 4;
                 let mut flush_ok = true;
+                let mut flush_failure_kind: Option<&'static str> = None;
                 if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
                     let (ack_tx, ack_rx) = oneshot::channel::<bool>();
                     if flush_tx.send(ack_tx).is_ok() {
                         match tokio::time::timeout(FLUSH_TIMEOUT, ack_rx).await {
                             Ok(Ok(true)) => {}
                             Ok(Ok(false)) => {
-                                // Write returned an I/O error (ENOSPC, EIO, perm).
-                                // Retry — the filesystem may recover, and forcing
-                                // teardown now would leave the user's latest
-                                // bytes only in the soon-to-be-dropped room.
-                                warn!(
-                                    "[notebook-sync] Eviction flush reported write failure for {}",
-                                    notebook_id_for_eviction
-                                );
                                 flush_ok = false;
+                                flush_failure_kind = Some("write error");
                             }
                             Ok(Err(_)) => {
-                                // Debouncer dropped the ack sender without replying —
-                                // task already exited (e.g. previous eviction
-                                // flushed and closed). Any pending bytes went
-                                // through the shutdown path.
+                                // Debouncer dropped the ack sender without
+                                // replying — task already exited (e.g. a
+                                // previous eviction flushed and closed). Any
+                                // pending bytes went through the shutdown path.
                                 debug!(
                                     "[notebook-sync] Eviction flush ack dropped for {} (debouncer exited)",
                                     notebook_id_for_eviction
@@ -2211,29 +2205,22 @@ where
                             }
                             Err(_) => {
                                 flush_ok = false;
+                                flush_failure_kind = Some("timeout");
                             }
                         }
                     }
                 }
                 if !flush_ok {
-                    if flush_retries >= MAX_FLUSH_RETRIES {
-                        // Give up and force teardown. After ~2 minutes of
-                        // wedged flushes we prefer a leaked .automerge over
-                        // a leaked room+kernel; the daemon's shutdown flush
-                        // (on process exit) is the last line of defense.
-                        warn!(
-                            "[notebook-sync] Eviction flush wedged for {} after {} retries; forcing teardown",
-                            notebook_id_for_eviction, flush_retries
-                        );
-                    } else {
-                        flush_retries += 1;
-                        warn!(
-                            "[notebook-sync] Eviction flush timed out for {} (retry {}/{}); keeping room resident",
-                            notebook_id_for_eviction, flush_retries, MAX_FLUSH_RETRIES
-                        );
-                        delay = FLUSH_RETRY_DELAY;
-                        continue;
-                    }
+                    flush_retries += 1;
+                    warn!(
+                        "[notebook-sync] Eviction flush failed for {} ({}; attempt {}); keeping room resident, retrying in {:?}",
+                        notebook_id_for_eviction,
+                        flush_failure_kind.unwrap_or("unknown"),
+                        flush_retries,
+                        FLUSH_RETRY_DELAY
+                    );
+                    delay = FLUSH_RETRY_DELAY;
+                    continue;
                 }
                 break;
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2163,8 +2163,13 @@ where
             //
             // Request/ack over a dedicated channel. The debouncer has a
             // select! arm that writes the latest doc bytes and replies on the
-            // oneshot. Bounded with a timeout so a wedged debouncer can't
-            // deadlock the eviction task; teardown must proceed either way.
+            // oneshot.
+            //
+            // On timeout we abort this eviction rather than forcing removal.
+            // Proceeding would reopen the exact race we're closing (the write
+            // may still be in flight; reconnect would create a fresh room
+            // from a partial file). The room stays resident; the next peer
+            // disconnect (or the periodic eviction hook) will reschedule.
             if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
                 let (ack_tx, ack_rx) = oneshot::channel::<()>();
                 if flush_tx.send(ack_tx).is_ok() {
@@ -2181,10 +2186,15 @@ where
                             );
                         }
                         Err(_) => {
+                            // Persist write is slow or wedged. Keep the room in
+                            // the HashMap so a reconnect sees the live in-memory
+                            // doc rather than a potentially partial file. Abort
+                            // this eviction; the next disconnect reschedules.
                             warn!(
-                                "[notebook-sync] Eviction flush timed out for {} after 5s; proceeding with teardown",
+                                "[notebook-sync] Eviction flush timed out for {} after 5s; aborting eviction to avoid stale-reconnect race",
                                 notebook_id_for_eviction
                             );
+                            return;
                         }
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2140,64 +2140,91 @@ where
         );
 
         tokio::spawn(async move {
-            tokio::time::sleep(eviction_delay).await;
+            // Outer loop wraps the eviction attempt so a flush timeout can
+            // back off and retry rather than leak the room (and any attached
+            // kernel / watcher) indefinitely. The loop exits either by
+            // cancelling (peers reconnected) or by completing teardown.
+            let mut delay = eviction_delay;
+            let mut flush_retries: u32 = 0;
+            loop {
+                tokio::time::sleep(delay).await;
 
-            // Check if peers reconnected during the delay
-            if room_for_eviction.active_peers.load(Ordering::Relaxed) > 0 {
-                info!(
-                    "[notebook-sync] Eviction cancelled for {} (peers reconnected)",
-                    notebook_id_for_eviction
-                );
-                return;
-            }
+                // Check if peers reconnected during the delay
+                if room_for_eviction.active_peers.load(Ordering::Relaxed) > 0 {
+                    info!(
+                        "[notebook-sync] Eviction cancelled for {} (peers reconnected)",
+                        notebook_id_for_eviction
+                    );
+                    return;
+                }
 
-            // Force a synchronous flush of the persist debouncer BEFORE removing
-            // the room from the map. Without this, a fast reconnect lands in
-            // the window between HashMap removal and the debouncer's shutdown
-            // flush (which only fires when the last Arc to the room drops, and
-            // the eviction task still holds one while running kernel/env
-            // teardown). In that window get_or_create_room creates a fresh
-            // room that loads stale bytes from the .automerge file — or no
-            // file at all for brand-new untitled notebooks — silently losing
-            // cells and edits.
-            //
-            // Request/ack over a dedicated channel. The debouncer has a
-            // select! arm that writes the latest doc bytes and replies on the
-            // oneshot.
-            //
-            // On timeout we abort this eviction rather than forcing removal.
-            // Proceeding would reopen the exact race we're closing (the write
-            // may still be in flight; reconnect would create a fresh room
-            // from a partial file). The room stays resident; the next peer
-            // disconnect (or the periodic eviction hook) will reschedule.
-            if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
-                let (ack_tx, ack_rx) = oneshot::channel::<()>();
-                if flush_tx.send(ack_tx).is_ok() {
-                    match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
-                        Ok(Ok(())) => {}
-                        Ok(Err(_)) => {
-                            // Debouncer dropped the ack sender without replying —
-                            // task already exited (e.g. previous eviction flushed
-                            // and closed). Any pending bytes went through the
-                            // shutdown path.
-                            debug!(
-                                "[notebook-sync] Eviction flush ack dropped for {} (debouncer exited)",
-                                notebook_id_for_eviction
-                            );
-                        }
-                        Err(_) => {
-                            // Persist write is slow or wedged. Keep the room in
-                            // the HashMap so a reconnect sees the live in-memory
-                            // doc rather than a potentially partial file. Abort
-                            // this eviction; the next disconnect reschedules.
-                            warn!(
-                                "[notebook-sync] Eviction flush timed out for {} after 5s; aborting eviction to avoid stale-reconnect race",
-                                notebook_id_for_eviction
-                            );
-                            return;
+                // Force a synchronous flush of the persist debouncer BEFORE removing
+                // the room from the map. Without this, a fast reconnect lands in
+                // the window between HashMap removal and the debouncer's shutdown
+                // flush (which only fires when the last Arc to the room drops, and
+                // the eviction task still holds one while running kernel/env
+                // teardown). In that window get_or_create_room creates a fresh
+                // room that loads stale bytes from the .automerge file — or no
+                // file at all for brand-new untitled notebooks — silently losing
+                // cells and edits.
+                //
+                // Request/ack over a dedicated channel. The debouncer has a
+                // select! arm that writes the latest doc bytes and replies on the
+                // oneshot.
+                //
+                // On timeout we back off and retry. Proceeding with HashMap
+                // removal would reopen the race (the write may still be in
+                // flight; reconnect would create a fresh room from a partial
+                // file). Retrying keeps the room live so reconnects see the
+                // in-memory doc, and gives the write another shot — bounded
+                // retries prevent a permanently-wedged filesystem from leaking
+                // rooms forever.
+                const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+                const FLUSH_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
+                const MAX_FLUSH_RETRIES: u32 = 4;
+                let mut flush_ok = true;
+                if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
+                    let (ack_tx, ack_rx) = oneshot::channel::<()>();
+                    if flush_tx.send(ack_tx).is_ok() {
+                        match tokio::time::timeout(FLUSH_TIMEOUT, ack_rx).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(_)) => {
+                                // Debouncer dropped the ack sender without replying —
+                                // task already exited (e.g. previous eviction
+                                // flushed and closed). Any pending bytes went
+                                // through the shutdown path.
+                                debug!(
+                                    "[notebook-sync] Eviction flush ack dropped for {} (debouncer exited)",
+                                    notebook_id_for_eviction
+                                );
+                            }
+                            Err(_) => {
+                                flush_ok = false;
+                            }
                         }
                     }
                 }
+                if !flush_ok {
+                    if flush_retries >= MAX_FLUSH_RETRIES {
+                        // Give up and force teardown. After ~2 minutes of
+                        // wedged flushes we prefer a leaked .automerge over
+                        // a leaked room+kernel; the daemon's shutdown flush
+                        // (on process exit) is the last line of defense.
+                        warn!(
+                            "[notebook-sync] Eviction flush wedged for {} after {} retries; forcing teardown",
+                            notebook_id_for_eviction, flush_retries
+                        );
+                    } else {
+                        flush_retries += 1;
+                        warn!(
+                            "[notebook-sync] Eviction flush timed out for {} (retry {}/{}); keeping room resident",
+                            notebook_id_for_eviction, flush_retries, MAX_FLUSH_RETRIES
+                        );
+                        delay = FLUSH_RETRY_DELAY;
+                        continue;
+                    }
+                }
+                break;
             }
 
             // Remove room from the map under the lock, then drop the lock

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -628,6 +628,96 @@ async fn test_untitled_notebook_persists_through_eviction() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
+/// Regression test for the eviction/debouncer race (PR follow-up).
+///
+/// The race: the daemon's eviction task used to remove a room from the
+/// `notebook_rooms` HashMap, then run async teardown (kernel shutdown,
+/// env cleanup, etc.), and only finally drop the room's `Arc` — which
+/// in turn closed the `watch` channel feeding the persist debouncer,
+/// triggering its shutdown flush. A fast reconnect in the window
+/// between HashMap removal and Arc drop would hit `get_or_create_room`
+/// with the room gone, instantiate a fresh one, and load the still-stale
+/// `.automerge` from disk — silently dropping the user's edits.
+///
+/// The fix makes the eviction task send a flush request to the debouncer
+/// and await its ack *before* touching the HashMap. This test drives a
+/// rapid disconnect/reconnect cycle to cover the happy path end-to-end.
+/// The existing `test_untitled_notebook_persists_through_eviction` covers
+/// the slower-reconnect case with an explicit file-size wait.
+#[tokio::test]
+async fn test_eviction_flushes_before_reconnect() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    // Instant eviction — the fix must guarantee the flush runs before the
+    // HashMap removal regardless of the eviction timer.
+    config.room_eviction_delay_ms = Some(0);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+
+    // Create an untitled notebook with a few cells, then drop the client to
+    // trigger eviction. No autosave path exists for untitled notebooks, so
+    // the `.automerge` debouncer is the only thing keeping content durable.
+    let notebook_id;
+    {
+        let result = connect::connect_create(socket_path.clone(), "python", None, "test", false)
+            .await
+            .unwrap();
+        notebook_id = result.info.notebook_id.clone();
+        let client = result.handle;
+
+        client.add_cell_after("c1", "code", None).unwrap();
+        client.update_source("c1", "race_test = 1").unwrap();
+        client.add_cell_after("c2", "code", Some("c1")).unwrap();
+        client.update_source("c2", "race_test = 2").unwrap();
+        client.add_cell_after("c3", "markdown", Some("c2")).unwrap();
+        client
+            .update_source("c3", "# Race regression guard")
+            .unwrap();
+    }
+
+    // Reconnect fast — no sleep. The fix's flush-and-ack ensures the room's
+    // latest doc bytes are on disk before the HashMap drop, so regardless of
+    // whether the reconnect hits the still-evicting room or spawns a fresh
+    // one from disk, all three cells must be visible.
+    let client2 = connect::connect(socket_path.clone(), notebook_id.clone(), "test")
+        .await
+        .expect("reconnect should succeed")
+        .handle;
+
+    let mut watcher = client2.subscribe();
+    let mut cells = client2.get_cells();
+    for _ in 0..30 {
+        if cells.len() == 3 {
+            break;
+        }
+        match tokio::time::timeout(Duration::from_millis(250), watcher.changed()).await {
+            Ok(Ok(())) => cells = client2.get_cells(),
+            _ => break,
+        }
+    }
+
+    assert_eq!(
+        cells.len(),
+        3,
+        "reconnected client must see all 3 cells, got {}: {:?}",
+        cells.len(),
+        cells
+    );
+    assert_eq!(cells[0].source, "race_test = 1");
+    assert_eq!(cells[1].source, "race_test = 2");
+    assert_eq!(cells[2].source, "# Race regression guard");
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
 #[tokio::test]
 async fn test_notebook_cell_delete_propagation() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixes a real data-loss race in untitled (and fast-close/reopen) notebooks.

**The race:** the daemon's eviction task used to remove the room from the `notebook_rooms` HashMap, then run async teardown. The persist debouncer only flushes on `watch` sender drop, which happens when the last `Arc<NotebookRoom>` drops - after the eviction task exits. A reconnect that lands in the window between HashMap removal and Arc drop hits `get_or_create_room` with the room gone, spawns a fresh one, and loads the stale/empty `.automerge` from disk. Edits vanish.

**The fix:** add a `flush_request_tx: mpsc::UnboundedSender<oneshot::Sender<bool>>` on each room. The debouncer's `select!` loop handles a flush request by writing the latest watch value to disk and replying on the oneshot with the I/O result. The eviction task sends a flush request and awaits the ack **before** touching the HashMap. On failure (timeout or write error) it retries indefinitely with 30s backoff - keeping the room resident until persistence succeeds or the user reconnects. `active_peers` checks at the top of the retry loop make reconnects cancel eviction cleanly.

Diff shape:
- new field on `NotebookRoom` + paired channel in `new_fresh` / `load_or_create` / test fixture
- new `select!` arm in `spawn_persist_debouncer_with_config` that performs the flush-and-ack
- `do_persist` / `persist_notebook_bytes` now return `bool` so write failure surfaces through the ack
- eviction task wraps the flush in a retry loop that never gives up as long as a client could reconnect

**This supersedes #1907's test-side hardening.** That PR added a 500ms sleep + "file size > 0" poll to `test_untitled_notebook_persists_through_eviction`. Polling "file is non-empty" can't distinguish "debouncer flushed the latest version" from "debouncer flushed an earlier version and is still mid-debounce for newer bytes." The real fix is daemon-side.

## Production impact

- Close the app window, reopen quickly (<200ms): edits gone. Especially bad for untitled notebooks with no `.ipynb` fallback.
- Any notebook where the user's last keystroke lands inside the 500ms debounce window, followed by a fast reconnect.
- On slow or failing filesystems, previous behaviour would proceed with teardown on timeout, silently dropping the latest bytes.

## Tests

- New `test_persist_debouncer_flush_request_is_synchronous` (unit): pins the success path. Sends a payload, requests a flush, asserts the ack arrives with `true` inside the debounce window and the on-disk bytes match. Verified to **fail without the fix** (ack sender dropped without replying) and **pass with** it.
- New `test_persist_debouncer_flush_request_reports_write_failure` (unit): plants a regular file at a path where the debouncer will try to create a directory, forcing `std::fs::write` to fail. Confirms the ack carries `false` and the debouncer keeps running.
- New `test_eviction_flushes_before_reconnect` (integration): end-to-end happy path. 0ms eviction delay, disconnect immediately followed by reconnect, asserts all 3 cells visible.
- Existing `test_untitled_notebook_persists_through_eviction` stays green: 5/5 in a loop.

## Review iteration

Codex flagged three issues across review passes; all addressed:

1. `timeout` branch originally fell through to `rooms.remove()`, reopening the race. Fixed: `return` / retry.
2. `return` left a zero-peer room leaked if flush never succeeded. Fixed: retry loop with `active_peers` check.
3. `do_persist` logged write errors but acked success. Fixed: bool return, propagated through the ack.
4. Initial retry cap (`MAX_FLUSH_RETRIES=4`) still force-evicted after ~2 min. Fixed: retry indefinitely; wedged filesystems are a real failure that surfaces via `warn!` rather than silent data loss.

## Follow-up (out of scope)

Codex also flagged: during a 30s retry backoff, a reconnect+disconnect cycle isn't observed by the retry loop until the next sleep ends, so grace-period semantics are slightly off. Not a data-loss bug - will address separately with a proper disconnect-generation/cancellation signal.

## Test plan

- [x] `cargo test -p runtimed --lib notebook_sync_server::tests` (327 passed)
- [x] `cargo test -p runtimed --test integration -- --test-threads=1` (25 passed)
- [x] `cargo test -p runtimed --test integration test_untitled_notebook_persists_through_eviction` x5 in a loop (5/5)
- [x] `cargo xtask lint`