### PR TITLE
fix(runtimed): spawn panic handling — WarmingGuard + task supervisor + migration

### DIFF
--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -27,39 +27,57 @@ use tokio::net::TcpListener;
 use tracing::{error, info};
 
 use crate::blob_store::BlobStore;
+use crate::daemon::Daemon;
 use crate::embedded_plugins;
+use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 
 /// Start the blob HTTP server on a random localhost port.
 ///
 /// Returns the port the server is listening on. The server runs as a
 /// spawned task on the current tokio runtime.
-pub async fn start_blob_server(store: Arc<BlobStore>) -> std::io::Result<u16> {
+///
+/// When `daemon` is provided, a panic in the accept loop triggers shutdown.
+/// Pass `None` in tests where no daemon is available.
+pub async fn start_blob_server(
+    store: Arc<BlobStore>,
+    daemon: Option<Arc<Daemon>>,
+) -> std::io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
 
     info!("[blob-server] Listening on http://127.0.0.1:{}", port);
 
-    tokio::spawn(async move {
-        loop {
-            match listener.accept().await {
-                Ok((stream, _)) => {
-                    let store = store.clone();
-                    let io = TokioIo::new(stream);
-                    tokio::spawn(async move {
-                        let service = service_fn(move |req| handle_request(req, store.clone()));
-                        if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
-                            if !e.is_incomplete_message() && !e.is_canceled() {
-                                error!("[blob-server] Connection error: {}", e);
+    spawn_supervised(
+        "blob-accept-loop",
+        async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        let store = store.clone();
+                        let io = TokioIo::new(stream);
+                        spawn_best_effort("blob-connection", async move {
+                            let service = service_fn(move |req| handle_request(req, store.clone()));
+                            if let Err(e) =
+                                http1::Builder::new().serve_connection(io, service).await
+                            {
+                                if !e.is_incomplete_message() && !e.is_canceled() {
+                                    error!("[blob-server] Connection error: {}", e);
+                                }
                             }
-                        }
-                    });
-                }
-                Err(e) => {
-                    error!("[blob-server] Accept error: {}", e);
+                        });
+                    }
+                    Err(e) => {
+                        error!("[blob-server] Accept error: {}", e);
+                    }
                 }
             }
-        }
-    });
+        },
+        move |_| {
+            if let Some(d) = daemon {
+                tokio::spawn(async move { d.trigger_shutdown().await });
+            }
+        },
+    );
 
     Ok(port)
 }
@@ -159,7 +177,7 @@ mod tests {
     async fn setup() -> (TempDir, Arc<BlobStore>, u16) {
         let dir = TempDir::new().unwrap();
         let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
-        let port = start_blob_server(store.clone()).await.unwrap();
+        let port = start_blob_server(store.clone(), None).await.unwrap();
         // Give the server a moment to start accepting
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         (dir, store, port)
@@ -265,8 +283,8 @@ mod tests {
     async fn test_two_servers_get_different_ports() {
         let dir = TempDir::new().unwrap();
         let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
-        let port1 = start_blob_server(store.clone()).await.unwrap();
-        let port2 = start_blob_server(store.clone()).await.unwrap();
+        let port1 = start_blob_server(store.clone(), None).await.unwrap();
+        let port2 = start_blob_server(store.clone(), None).await.unwrap();
         assert_ne!(port1, port2);
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -30,6 +30,7 @@ use crate::notebook_sync_server::{NotebookRooms, PathIndex};
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
 use crate::settings_doc::SettingsDoc;
 use crate::singleton::DaemonLock;
+use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::{
     default_blob_store_dir, default_cache_dir, default_socket_path, is_pool_env_dir,
     is_within_cache_dir, pool_env_root, EnvType, PooledEnv,
@@ -212,7 +213,7 @@ fn spawn_env_deletions(paths: Vec<PathBuf>) {
     if paths.is_empty() {
         return;
     }
-    tokio::spawn(async move {
+    spawn_best_effort("env-deletions", async move {
         for path in &paths {
             if let Err(e) = tokio::fs::remove_dir_all(path).await {
                 warn!("[runtimed] Failed to delete stale env {:?}: {}", path, e);
@@ -607,6 +608,9 @@ pub struct Daemon {
     /// loop would miss short-lived sessions and pin the daemon back in
     /// the post-restart state forever.
     rooms_ever_seen: std::sync::atomic::AtomicBool,
+    uv_warming_respawns: std::sync::atomic::AtomicU32,
+    conda_warming_respawns: std::sync::atomic::AtomicU32,
+    pixi_warming_respawns: std::sync::atomic::AtomicU32,
 }
 
 /// Error returned when another daemon is already running.
@@ -694,6 +698,9 @@ impl Daemon {
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
             path_index: Arc::new(tokio::sync::Mutex::new(PathIndex::new())),
             rooms_ever_seen: std::sync::atomic::AtomicBool::new(false),
+            uv_warming_respawns: std::sync::atomic::AtomicU32::new(0),
+            conda_warming_respawns: std::sync::atomic::AtomicU32::new(0),
+            pixi_warming_respawns: std::sync::atomic::AtomicU32::new(0),
         }))
     }
 
@@ -791,17 +798,19 @@ impl Daemon {
         }
 
         // Start the blob HTTP server (also serves renderer plugin assets)
-        let blob_port = match blob_server::start_blob_server(self.blob_store.clone()).await {
-            Ok(port) => {
-                info!("[runtimed] Blob server started on port {}", port);
-                *self.blob_port.lock().await = Some(port);
-                Some(port)
-            }
-            Err(e) => {
-                error!("[runtimed] Failed to start blob server: {}", e);
-                None
-            }
-        };
+        let blob_port =
+            match blob_server::start_blob_server(self.blob_store.clone(), Some(self.clone())).await
+            {
+                Ok(port) => {
+                    info!("[runtimed] Blob server started on port {}", port);
+                    *self.blob_port.lock().await = Some(port);
+                    Some(port)
+                }
+                Err(e) => {
+                    error!("[runtimed] Failed to start blob server: {}", e);
+                    None
+                }
+            };
 
         // Bind the Unix socket early so clients can connect (and ping) while
         // the rest of initialisation finishes.  The accept loop runs later.
@@ -853,29 +862,89 @@ impl Daemon {
 
         // Spawn the warming loops
         let uv_daemon = self.clone();
-        tokio::spawn(async move {
-            uv_daemon.uv_warming_loop().await;
-        });
+        let uv_panic_daemon = self.clone();
+        spawn_supervised(
+            "uv-warming-loop",
+            async move { uv_daemon.uv_warming_loop().await },
+            move |_| {
+                use std::sync::atomic::Ordering;
+                if uv_panic_daemon
+                    .uv_warming_respawns
+                    .compare_exchange(0, 1, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    let d = uv_panic_daemon.clone();
+                    spawn_supervised(
+                        "uv-warming-loop",
+                        async move { d.uv_warming_loop().await },
+                        |_| {},
+                    );
+                } else {
+                    let d = uv_panic_daemon;
+                    tokio::spawn(async move { d.trigger_shutdown().await });
+                }
+            },
+        );
 
         let conda_daemon = self.clone();
-        tokio::spawn(async move {
-            conda_daemon.conda_warming_loop().await;
-        });
+        let conda_panic_daemon = self.clone();
+        spawn_supervised(
+            "conda-warming-loop",
+            async move { conda_daemon.conda_warming_loop().await },
+            move |_| {
+                use std::sync::atomic::Ordering;
+                if conda_panic_daemon
+                    .conda_warming_respawns
+                    .compare_exchange(0, 1, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    let d = conda_panic_daemon.clone();
+                    spawn_supervised(
+                        "conda-warming-loop",
+                        async move { d.conda_warming_loop().await },
+                        |_| {},
+                    );
+                } else {
+                    let d = conda_panic_daemon;
+                    tokio::spawn(async move { d.trigger_shutdown().await });
+                }
+            },
+        );
 
         let pixi_daemon = self.clone();
-        tokio::spawn(async move {
-            pixi_daemon.pixi_warming_loop().await;
-        });
+        let pixi_panic_daemon = self.clone();
+        spawn_supervised(
+            "pixi-warming-loop",
+            async move { pixi_daemon.pixi_warming_loop().await },
+            move |_| {
+                use std::sync::atomic::Ordering;
+                if pixi_panic_daemon
+                    .pixi_warming_respawns
+                    .compare_exchange(0, 1, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    let d = pixi_panic_daemon.clone();
+                    spawn_supervised(
+                        "pixi-warming-loop",
+                        async move { d.pixi_warming_loop().await },
+                        |_| {},
+                    );
+                } else {
+                    let d = pixi_panic_daemon;
+                    tokio::spawn(async move { d.trigger_shutdown().await });
+                }
+            },
+        );
 
         // Spawn the environment GC loop
         let gc_daemon = self.clone();
-        tokio::spawn(async move {
+        spawn_best_effort("env-gc-loop", async move {
             gc_daemon.env_gc_loop().await;
         });
 
         // Spawn the settings.json file watcher
         let watcher_daemon = self.clone();
-        tokio::spawn(async move {
+        spawn_best_effort("watch-settings-json", async move {
             watcher_daemon.watch_settings_json().await;
         });
 
@@ -963,7 +1032,7 @@ impl Daemon {
                     match accept_result {
                         Ok((stream, _)) => {
                             let daemon = self.clone();
-                            tokio::spawn(async move {
+                            spawn_best_effort("unix-connection", async move {
                                 if let Err(e) = daemon.route_connection(stream).await {
                                     if !crate::sync_server::is_connection_closed(&e) {
                                         error!("[runtimed] Connection error: {}", e);
@@ -1028,7 +1097,7 @@ impl Daemon {
 
                     // Handle the connection
                     let daemon = self.clone();
-                    tokio::spawn(async move {
+                    spawn_best_effort("pipe-connection", async move {
                         if let Err(e) = daemon.route_connection(connected).await {
                             if !crate::sync_server::is_connection_closed(&e) {
                                 error!("[runtimed] Connection error: {}", e);
@@ -2153,7 +2222,7 @@ impl Daemon {
                     e.venv_path
                 );
                 let daemon = self.clone();
-                tokio::spawn(async move {
+                spawn_best_effort("uv-replenish", async move {
                     daemon.create_uv_env().await;
                 });
                 return Some(e);
@@ -2178,7 +2247,7 @@ impl Daemon {
             }; // pool lock dropped
             if should_spawn {
                 let daemon = self.clone();
-                tokio::spawn(async move {
+                spawn_best_effort("uv-retry", async move {
                     daemon.create_uv_env().await;
                 });
             }
@@ -2228,7 +2297,7 @@ impl Daemon {
                     e.venv_path
                 );
                 let daemon = self.clone();
-                tokio::spawn(async move {
+                spawn_best_effort("conda-replenish", async move {
                     daemon.replenish_conda_env().await;
                 });
                 return Some(e);
@@ -2253,7 +2322,7 @@ impl Daemon {
             }; // pool lock dropped
             if should_spawn {
                 let daemon = self.clone();
-                tokio::spawn(async move {
+                spawn_best_effort("conda-retry", async move {
                     daemon.create_conda_env().await;
                 });
             }
@@ -2298,7 +2367,7 @@ impl Daemon {
                 e.venv_path
             );
             let daemon = self.clone();
-            tokio::spawn(async move {
+            spawn_best_effort("pixi-replenish", async move {
                 daemon.replenish_pixi_env().await;
             });
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -854,6 +854,15 @@ impl Daemon {
             }
         }
 
+        // Register global shutdown trigger for notebook_sync_server debouncers.
+        {
+            let shutdown_daemon = self.clone();
+            crate::notebook_sync_server::register_shutdown_trigger(Arc::new(move || {
+                let d = shutdown_daemon.clone();
+                tokio::spawn(async move { d.trigger_shutdown().await });
+            }));
+        }
+
         // Find and reuse existing environments from previous runs
         self.find_existing_environments().await;
 
@@ -874,10 +883,13 @@ impl Daemon {
                     .is_ok()
                 {
                     let d = uv_panic_daemon.clone();
+                    let d2 = uv_panic_daemon;
                     spawn_supervised(
                         "uv-warming-loop",
                         async move { d.uv_warming_loop().await },
-                        |_| {},
+                        move |_| {
+                            tokio::spawn(async move { d2.trigger_shutdown().await });
+                        },
                     );
                 } else {
                     let d = uv_panic_daemon;
@@ -899,10 +911,13 @@ impl Daemon {
                     .is_ok()
                 {
                     let d = conda_panic_daemon.clone();
+                    let d2 = conda_panic_daemon;
                     spawn_supervised(
                         "conda-warming-loop",
                         async move { d.conda_warming_loop().await },
-                        |_| {},
+                        move |_| {
+                            tokio::spawn(async move { d2.trigger_shutdown().await });
+                        },
                     );
                 } else {
                     let d = conda_panic_daemon;
@@ -924,10 +939,13 @@ impl Daemon {
                     .is_ok()
                 {
                     let d = pixi_panic_daemon.clone();
+                    let d2 = pixi_panic_daemon;
                     spawn_supervised(
                         "pixi-warming-loop",
                         async move { d.pixi_warming_loop().await },
-                        |_| {},
+                        move |_| {
+                            tokio::spawn(async move { d2.trigger_shutdown().await });
+                        },
                     );
                 } else {
                     let d = pixi_panic_daemon;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -486,6 +486,79 @@ impl Pool {
     }
 }
 
+/// Which environment pool a `WarmingGuard` protects.
+#[derive(Clone, Copy)]
+enum PoolKind {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+/// RAII guard for pool warming paths. On drop (including panic unwind), rolls
+/// back the warming counter and unregisters the path. Call `commit()` on
+/// success to suppress the rollback, or `fail_with()` to record a specific
+/// error before consuming the guard.
+struct WarmingGuard {
+    inner: Option<WarmingGuardInner>,
+}
+
+struct WarmingGuardInner {
+    daemon: Arc<Daemon>,
+    path: PathBuf,
+    kind: PoolKind,
+}
+
+impl WarmingGuard {
+    fn new(daemon: Arc<Daemon>, path: PathBuf, kind: PoolKind) -> Self {
+        Self {
+            inner: Some(WarmingGuardInner { daemon, path, kind }),
+        }
+    }
+
+    /// Consume the guard on success — suppresses the Drop rollback.
+    fn commit(&mut self) {
+        self.inner.take();
+    }
+
+    /// Record a specific error and consume the guard. Caller must be in an
+    /// async context (this is not used from Drop).
+    async fn fail_with(&mut self, error: Option<PackageInstallError>) {
+        if let Some(inner) = self.inner.take() {
+            inner.rollback(error).await;
+        }
+    }
+}
+
+impl WarmingGuardInner {
+    async fn rollback(self, error: Option<PackageInstallError>) {
+        let pool = match self.kind {
+            PoolKind::Uv => &self.daemon.uv_pool,
+            PoolKind::Conda => &self.daemon.conda_pool,
+            PoolKind::Pixi => &self.daemon.pixi_pool,
+        };
+        pool.lock().await.warming_failed_for_path(&self.path, error);
+        match self.kind {
+            PoolKind::Uv => self.daemon.pool_ready_uv.notify_waiters(),
+            PoolKind::Conda => self.daemon.pool_ready_conda.notify_waiters(),
+            PoolKind::Pixi => self.daemon.pool_ready_pixi.notify_waiters(),
+        }
+        self.daemon.update_pool_doc().await;
+    }
+}
+
+impl Drop for WarmingGuard {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            // Panic or early exit without commit/fail_with — roll back
+            // asynchronously. If the runtime is shutting down, the spawned
+            // task may not execute, but pool accounting is irrelevant then.
+            tokio::spawn(async move {
+                inner.rollback(None).await;
+            });
+        }
+    }
+}
+
 /// The pool daemon state.
 pub struct Daemon {
     config: DaemonConfig,
@@ -3154,7 +3227,7 @@ impl Daemon {
     }
 
     /// UV warming loop - maintains the UV pool.
-    async fn uv_warming_loop(&self) {
+    async fn uv_warming_loop(self: &Arc<Self>) {
         // Bootstrap uv via rattler if not on PATH (this is cached via OnceCell)
         let uv_path = match kernel_launch::tools::get_uv_path().await {
             Ok(path) => {
@@ -3265,7 +3338,7 @@ impl Daemon {
     }
 
     /// Conda warming loop - maintains the Conda pool using rattler.
-    async fn conda_warming_loop(&self) {
+    async fn conda_warming_loop(self: &Arc<Self>) {
         info!("[runtimed] Starting conda warming loop");
         let mut settings_rx = self.settings_changed.subscribe();
 
@@ -3370,7 +3443,7 @@ impl Daemon {
     }
 
     /// Background loop that keeps the pixi environment pool at its target size.
-    async fn pixi_warming_loop(&self) {
+    async fn pixi_warming_loop(self: &Arc<Self>) {
         info!("[runtimed] Starting pixi warming loop");
         let mut settings_rx = self.settings_changed.subscribe();
 
@@ -3472,7 +3545,7 @@ impl Daemon {
     }
 
     /// Create a single Conda environment using rattler and add it to the pool.
-    async fn create_conda_env(&self) {
+    async fn create_conda_env(self: &Arc<Self>) {
         use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
         use rattler_conda_types::{
             Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions,
@@ -3491,6 +3564,9 @@ impl Daemon {
             .await
             .register_warming_path(env_path.clone());
 
+        // Guard rolls back pool accounting on panic or early exit.
+        let mut guard = WarmingGuard::new(self.clone(), env_path.clone(), PoolKind::Conda);
+
         #[cfg(target_os = "windows")]
         let python_path = env_path.join("python.exe");
         #[cfg(not(target_os = "windows"))]
@@ -3501,15 +3577,13 @@ impl Daemon {
         // Ensure cache directory exists
         if let Err(e) = tokio::fs::create_dir_all(&self.config.cache_dir).await {
             error!("[runtimed] Failed to create cache dir: {}", e);
-            self.conda_pool.lock().await.warming_failed_for_path(
-                &env_path,
-                Some(PackageInstallError {
+            guard
+                .fail_with(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to create cache dir: {}", e),
                     error_kind: "setup_failed".to_string(),
-                }),
-            );
-            self.update_pool_doc().await;
+                }))
+                .await;
             return;
         }
 
@@ -3521,15 +3595,13 @@ impl Daemon {
             Ok(ch) => vec![ch],
             Err(e) => {
                 error!("[runtimed] Failed to parse conda-forge channel: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to parse conda-forge channel: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3562,15 +3634,13 @@ impl Daemon {
             Ok(s) => s,
             Err(e) => {
                 error!("[runtimed] Failed to parse match specs: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to parse match specs: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3583,33 +3653,29 @@ impl Daemon {
                     "[runtimed] Could not determine rattler cache directory: {}",
                     e
                 );
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!(
                             "Could not determine rattler cache directory: {}",
                             e
                         ),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
 
         if let Err(e) = rattler_cache::ensure_cache_dir(&rattler_cache_dir) {
             error!("[runtimed] Could not create rattler cache directory: {}", e);
-            self.conda_pool.lock().await.warming_failed_for_path(
-                &env_path,
-                Some(PackageInstallError {
+            guard
+                .fail_with(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Could not create rattler cache directory: {}", e),
                     error_kind: "setup_failed".to_string(),
-                }),
-            );
-            self.update_pool_doc().await;
+                }))
+                .await;
             return;
         }
 
@@ -3618,15 +3684,13 @@ impl Daemon {
             Ok(c) => reqwest_middleware::ClientBuilder::new(c).build(),
             Err(e) => {
                 error!("[runtimed] Failed to create HTTP client: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create HTTP client: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3653,15 +3717,13 @@ impl Daemon {
             Ok(data) => data,
             Err(e) => {
                 error!("[runtimed] Failed to fetch repodata: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to fetch repodata: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3678,15 +3740,13 @@ impl Daemon {
                 .collect::<Vec<_>>(),
             Err(e) => {
                 error!("[runtimed] Failed to detect virtual packages: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to detect virtual packages: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3702,15 +3762,13 @@ impl Daemon {
             Ok(result) => result.records,
             Err(e) => {
                 error!("[runtimed] Failed to solve dependencies: {}", e);
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to solve dependencies: {}", e),
                         error_kind: "invalid_package".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         };
@@ -3730,15 +3788,13 @@ impl Daemon {
         if let Err(e) = install_result {
             error!("[runtimed] Failed to install packages: {}", e);
             tokio::fs::remove_dir_all(&env_path).await.ok();
-            self.conda_pool.lock().await.warming_failed_for_path(
-                &env_path,
-                Some(PackageInstallError {
+            guard
+                .fail_with(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to install packages: {}", e),
                     error_kind: "setup_failed".to_string(),
-                }),
-            );
-            self.update_pool_doc().await;
+                }))
+                .await;
             return;
         }
 
@@ -3749,15 +3805,13 @@ impl Daemon {
                 python_path
             );
             tokio::fs::remove_dir_all(&env_path).await.ok();
-            self.conda_pool.lock().await.warming_failed_for_path(
-                &env_path,
-                Some(PackageInstallError {
+            guard
+                .fail_with(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Python not found at {:?} after install", python_path),
                     error_kind: "setup_failed".to_string(),
-                }),
-            );
-            self.update_pool_doc().await;
+                }))
+                .await;
             return;
         }
 
@@ -3768,6 +3822,7 @@ impl Daemon {
 
         match warmup_outcome {
             WarmupOutcome::Ok => {
+                guard.commit();
                 {
                     let mut pool = self.conda_pool.lock().await;
                     pool.add(PooledEnv {
@@ -3791,30 +3846,26 @@ impl Daemon {
             }
             WarmupOutcome::Timeout => {
                 let _ = tokio::fs::remove_dir_all(&env_path).await;
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: "Conda warmup timed out".into(),
                         error_kind: "timeout".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
             }
             WarmupOutcome::ImportError(msg) => {
                 let _ = tokio::fs::remove_dir_all(&env_path).await;
-                self.conda_pool.lock().await.warming_failed_for_path(
-                    &env_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!(
                             "Conda warmup failed: {}",
                             msg.chars().take(200).collect::<String>()
                         ),
                         error_kind: "import_error".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
             }
         }
     }
@@ -3885,7 +3936,7 @@ impl Daemon {
     }
 
     /// Replenish a single Conda environment.
-    async fn replenish_conda_env(&self) {
+    async fn replenish_conda_env(self: &Arc<Self>) {
         self.conda_pool.lock().await.mark_warming(1);
         self.create_conda_env().await;
     }
@@ -3895,7 +3946,7 @@ impl Daemon {
     /// Creates a pixi-compatible project directory with ipykernel and default
     /// packages, solved and installed via rattler. Replaces the old
     /// `pixi init` + `pixi add` subprocess approach.
-    async fn create_pixi_env(&self) {
+    async fn create_pixi_env(self: &Arc<Self>) {
         let cache_dir = self.config.cache_dir.clone();
         let env_id = uuid::Uuid::new_v4().to_string();
         let project_dir = cache_dir.join(format!("{}{}", crate::POOL_PREFIX_PIXI, env_id));
@@ -3906,6 +3957,9 @@ impl Daemon {
             .lock()
             .await
             .register_warming_path(project_dir.clone());
+
+        // Guard rolls back pool accounting on panic or early exit.
+        let mut guard = WarmingGuard::new(self.clone(), project_dir.clone(), PoolKind::Pixi);
 
         info!("[runtimed] Creating Pixi environment at {:?}", project_dir);
 
@@ -3940,6 +3994,7 @@ impl Daemon {
                 }
 
                 info!("[runtimed] Pixi environment ready at {:?}", env.project_dir);
+                guard.commit();
                 {
                     let mut pool = self.pixi_pool.lock().await;
                     pool.add(PooledEnv {
@@ -3954,21 +4009,19 @@ impl Daemon {
             Err(e) => {
                 error!("[runtimed] Pixi environment creation failed: {}", e);
                 let _ = tokio::fs::remove_dir_all(&project_dir).await;
-                self.pixi_pool.lock().await.warming_failed_for_path(
-                    &project_dir,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         error_message: format!("{}", e),
                         failed_package: None,
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
             }
         }
     }
 
     /// Mark pixi pool as warming and create a pixi environment.
-    async fn replenish_pixi_env(&self) {
+    async fn replenish_pixi_env(self: &Arc<Self>) {
         self.pixi_pool.lock().await.mark_warming(1);
         self.create_pixi_env().await;
     }
@@ -4039,7 +4092,7 @@ impl Daemon {
     }
 
     /// Create a single UV environment and add it to the pool.
-    async fn create_uv_env(&self) {
+    async fn create_uv_env(self: &Arc<Self>) {
         // Get uv path (cached via OnceCell, so this is instant after initial bootstrap)
         let uv_path = match kernel_launch::tools::get_uv_path().await {
             Ok(path) => path,
@@ -4068,6 +4121,9 @@ impl Daemon {
             .await
             .register_warming_path(venv_path.clone());
 
+        // Guard rolls back pool accounting on panic or early exit.
+        let mut guard = WarmingGuard::new(self.clone(), venv_path.clone(), PoolKind::Uv);
+
         #[cfg(target_os = "windows")]
         let python_path = venv_path.join("Scripts").join("python.exe");
         #[cfg(not(target_os = "windows"))]
@@ -4078,15 +4134,13 @@ impl Daemon {
         // Ensure cache directory exists
         if let Err(e) = tokio::fs::create_dir_all(&self.config.cache_dir).await {
             error!("[runtimed] Failed to create cache dir: {}", e);
-            self.uv_pool.lock().await.warming_failed_for_path(
-                &venv_path,
-                Some(PackageInstallError {
+            guard
+                .fail_with(Some(PackageInstallError {
                     failed_package: None,
                     error_message: format!("Failed to create cache dir: {}", e),
                     error_kind: "setup_failed".to_string(),
-                }),
-            );
-            self.update_pool_doc().await;
+                }))
+                .await;
             return;
         }
 
@@ -4109,42 +4163,36 @@ impl Daemon {
             Ok(Ok(output)) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 error!("[runtimed] Failed to create venv: {}", stderr);
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create venv: {}", stderr),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
             Ok(Err(e)) => {
                 error!("[runtimed] Failed to create venv: {}", e);
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!("Failed to create venv: {}", e),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
             Err(_) => {
                 error!("[runtimed] Timeout creating venv");
                 tokio::fs::remove_dir_all(&venv_path).await.ok();
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: "Timeout creating venv after 60 seconds".to_string(),
                         error_kind: "timeout".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         }
@@ -4225,39 +4273,31 @@ impl Daemon {
                 }
 
                 tokio::fs::remove_dir_all(&venv_path).await.ok();
-                self.uv_pool
-                    .lock()
-                    .await
-                    .warming_failed_for_path(&venv_path, parsed_error);
-                self.update_pool_doc().await;
+                guard.fail_with(parsed_error).await;
                 return;
             }
             Ok(Err(e)) => {
                 error!("[runtimed] Failed to run uv pip install: {}", e);
                 tokio::fs::remove_dir_all(&venv_path).await.ok();
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: e.to_string(),
                         error_kind: "setup_failed".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
             Err(_) => {
                 error!("[runtimed] Timeout installing packages (180s)");
                 tokio::fs::remove_dir_all(&venv_path).await.ok();
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: "Timeout after 180 seconds".to_string(),
                         error_kind: "timeout".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
                 return;
             }
         }
@@ -4319,7 +4359,7 @@ impl Daemon {
         match warmup_outcome {
             WarmupOutcome::Ok => {
                 info!("[runtimed] UV environment ready at {:?}", venv_path);
-
+                guard.commit();
                 {
                     let mut pool = self.uv_pool.lock().await;
                     pool.add(PooledEnv {
@@ -4333,30 +4373,26 @@ impl Daemon {
             }
             WarmupOutcome::Timeout => {
                 let _ = tokio::fs::remove_dir_all(&venv_path).await;
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: "UV warmup timed out".into(),
                         error_kind: "timeout".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
             }
             WarmupOutcome::ImportError(msg) => {
                 let _ = tokio::fs::remove_dir_all(&venv_path).await;
-                self.uv_pool.lock().await.warming_failed_for_path(
-                    &venv_path,
-                    Some(PackageInstallError {
+                guard
+                    .fail_with(Some(PackageInstallError {
                         failed_package: None,
                         error_message: format!(
                             "UV warmup failed: {}",
                             msg.chars().take(200).collect::<String>()
                         ),
                         error_kind: "import_error".to_string(),
-                    }),
-                );
-                self.update_pool_doc().await;
+                    }))
+                    .await;
             }
         }
     }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -35,6 +35,7 @@ use crate::kernel_manager::{
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
+use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
 use notebook_protocol::protocol::LaunchedEnvConfig;
@@ -473,7 +474,7 @@ impl KernelConnection for JupyterKernel {
         // Capture kernel stderr for diagnostics
         if let Some(stderr) = process.stderr.take() {
             let kid = kernel_id.clone();
-            tokio::spawn(async move {
+            spawn_best_effort("kernel-stderr", async move {
                 use tokio::io::{AsyncBufReadExt, BufReader};
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
@@ -546,22 +547,29 @@ impl KernelConnection for JupyterKernel {
 
         // Spawn process watcher — detects process exit and signals via oneshot
         let process_cmd_tx = cmd_tx.clone();
+        let panic_cmd_tx = cmd_tx.clone();
         let (died_tx, died_rx) = tokio::sync::oneshot::channel::<String>();
-        let process_watcher_task = tokio::spawn(async move {
-            let status = process.wait().await;
-            let msg = match status {
-                Ok(exit_status) => {
-                    warn!("[jupyter-kernel] Kernel process exited: {}", exit_status);
-                    format!("Kernel process exited: {}", exit_status)
-                }
-                Err(e) => {
-                    error!("[jupyter-kernel] Error waiting for kernel process: {}", e);
-                    format!("Error waiting for kernel process: {}", e)
-                }
-            };
-            let _ = died_tx.send(msg);
-            let _ = process_cmd_tx.try_send(QueueCommand::KernelDied);
-        });
+        let process_watcher_task = spawn_supervised(
+            "process-watcher",
+            async move {
+                let status = process.wait().await;
+                let msg = match status {
+                    Ok(exit_status) => {
+                        warn!("[jupyter-kernel] Kernel process exited: {}", exit_status);
+                        format!("Kernel process exited: {}", exit_status)
+                    }
+                    Err(e) => {
+                        error!("[jupyter-kernel] Error waiting for kernel process: {}", e);
+                        format!("Error waiting for kernel process: {}", e)
+                    }
+                };
+                let _ = died_tx.send(msg);
+                let _ = process_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+            move |_| {
+                let _ = panic_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+        );
 
         // ── IOPub listener task ──────────────────────────────────────────
 
@@ -585,337 +593,135 @@ impl KernelConnection for JupyterKernel {
         let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
         let comm_coalesce_tx_for_iopub = Some(coalesce_tx.clone());
 
-        let iopub_task = tokio::spawn(async move {
-            // Track Output widgets with pending clear_output(wait=true).
-            let mut pending_clear_widgets: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
+        let iopub_panic_cmd_tx = cmd_tx.clone();
+        let iopub_task = spawn_supervised(
+            "iopub",
+            async move {
+                // Track Output widgets with pending clear_output(wait=true).
+                let mut pending_clear_widgets: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
 
-            // Capture routing cache: msg_id -> comm_id.
-            let mut capture_cache: std::collections::HashMap<String, String> =
-                std::collections::HashMap::new();
+                // Capture routing cache: msg_id -> comm_id.
+                let mut capture_cache: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
 
-            // Local comm_id -> target_name map, populated on comm_open and
-            // removed on comm_close. Used by the dx comm filter in CommMsg
-            // and CommClose arms so we can route without a CRDT read on the
-            // hot path.
-            let mut comm_targets: std::collections::HashMap<String, String> =
-                std::collections::HashMap::new();
+                // Local comm_id -> target_name map, populated on comm_open and
+                // removed on comm_close. Used by the dx comm filter in CommMsg
+                // and CommClose arms so we can route without a CRDT read on the
+                // hot path.
+                let mut comm_targets: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
 
-            let comm_coalesce_tx = comm_coalesce_tx_for_iopub;
+                let comm_coalesce_tx = comm_coalesce_tx_for_iopub;
 
-            loop {
-                match iopub.read().await {
-                    Ok(message) => {
-                        let iopub_start = std::time::Instant::now();
-                        let msg_type = message.header.msg_type.clone();
-                        debug!(
-                            "[iopub] type={} parent_msg_id={:?}",
-                            msg_type,
-                            message.parent_header.as_ref().map(|h| &h.msg_id)
-                        );
+                loop {
+                    match iopub.read().await {
+                        Ok(message) => {
+                            let iopub_start = std::time::Instant::now();
+                            let msg_type = message.header.msg_type.clone();
+                            debug!(
+                                "[iopub] type={} parent_msg_id={:?}",
+                                msg_type,
+                                message.parent_header.as_ref().map(|h| &h.msg_id)
+                            );
 
-                        // Look up (cell_id, execution_id) from msg_id
-                        let cell_entry: Option<(String, String)> = message
-                            .parent_header
-                            .as_ref()
-                            .and_then(|h| iopub_cell_id_map.lock().ok()?.get(&h.msg_id).cloned());
-                        let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
-                        let execution_id = cell_entry.as_ref().map(|(_, eid)| eid.clone());
-
-                        // Handle different message types
-                        match &message.content {
-                            JupyterMessageContent::Status(status) => {
-                                let status_str = match status.execution_state {
-                                    jupyter_protocol::ExecutionState::Busy => "busy",
-                                    jupyter_protocol::ExecutionState::Idle => "idle",
-                                    jupyter_protocol::ExecutionState::Starting => "starting",
-                                    jupyter_protocol::ExecutionState::Restarting => "starting",
-                                    jupyter_protocol::ExecutionState::Terminating
-                                    | jupyter_protocol::ExecutionState::Dead => "shutdown",
-                                    _ => "unknown",
-                                };
-
-                                let _ = broadcast_tx.send(NotebookBroadcast::KernelStatus {
-                                    status: status_str.to_string(),
-                                    cell_id: cell_id.clone(),
+                            // Look up (cell_id, execution_id) from msg_id
+                            let cell_entry: Option<(String, String)> =
+                                message.parent_header.as_ref().and_then(|h| {
+                                    iopub_cell_id_map.lock().ok()?.get(&h.msg_id).cloned()
                                 });
+                            let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
+                            let execution_id = cell_entry.as_ref().map(|(_, eid)| eid.clone());
 
-                                if status_str != "unknown" {
-                                    let is_transient = cell_entry.is_none()
-                                        && (status_str == "busy" || status_str == "idle");
-
-                                    if !is_transient {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        if sd.set_kernel_status(status_str) {
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
-                                    }
-                                }
-
-                                if status.execution_state == jupyter_protocol::ExecutionState::Idle
-                                {
-                                    if let Some((cid, eid)) = cell_entry.clone() {
-                                        let _ =
-                                            iopub_cmd_tx.try_send(QueueCommand::ExecutionDone {
-                                                cell_id: cid,
-                                                execution_id: eid,
-                                            });
-                                    }
-                                }
-                            }
-
-                            JupyterMessageContent::ExecuteInput(input) => {
-                                if let Some(ref cid) = cell_id {
-                                    let execution_count = input.execution_count.0 as i64;
-
-                                    if let Some(ref eid) = execution_id {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        if sd.set_execution_count(eid, execution_count) {
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
-                                    }
-
-                                    let _ =
-                                        broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
-                                            cell_id: cid.clone(),
-                                            execution_id: execution_id.clone().unwrap_or_default(),
-                                            execution_count,
-                                        });
-                                }
-                            }
-
-                            JupyterMessageContent::StreamContent(stream) => {
-                                // Check if this output should go to an Output widget
-                                let parent_msg_id = message
-                                    .parent_header
-                                    .as_ref()
-                                    .map(|h| h.msg_id.as_str())
-                                    .unwrap_or("");
-                                if let Some(widget_comm_id) =
-                                    capture_cache.get(parent_msg_id).cloned()
-                                {
-                                    let stream_name = match stream.name {
-                                        jupyter_protocol::Stdio::Stdout => "stdout",
-                                        jupyter_protocol::Stdio::Stderr => "stderr",
+                            // Handle different message types
+                            match &message.content {
+                                JupyterMessageContent::Status(status) => {
+                                    let status_str = match status.execution_state {
+                                        jupyter_protocol::ExecutionState::Busy => "busy",
+                                        jupyter_protocol::ExecutionState::Idle => "idle",
+                                        jupyter_protocol::ExecutionState::Starting => "starting",
+                                        jupyter_protocol::ExecutionState::Restarting => "starting",
+                                        jupyter_protocol::ExecutionState::Terminating
+                                        | jupyter_protocol::ExecutionState::Dead => "shutdown",
+                                        _ => "unknown",
                                     };
-                                    let output = serde_json::json!({
-                                        "output_type": "stream",
-                                        "name": stream_name,
-                                        "text": stream.text
+
+                                    let _ = broadcast_tx.send(NotebookBroadcast::KernelStatus {
+                                        status: status_str.to_string(),
+                                        cell_id: cell_id.clone(),
                                     });
 
-                                    if let Ok(manifest) = crate::output_store::create_manifest(
-                                        &output,
-                                        &blob_store,
-                                        crate::output_store::DEFAULT_INLINE_THRESHOLD,
-                                    )
-                                    .await
-                                    {
-                                        let manifest_json = manifest.to_json();
-                                        let output_manifests = {
+                                    if status_str != "unknown" {
+                                        let is_transient = cell_entry.is_none()
+                                            && (status_str == "busy" || status_str == "idle");
+
+                                        if !is_transient {
                                             let mut sd = state_doc_for_iopub.write().await;
-                                            if pending_clear_widgets.remove(&widget_comm_id) {
-                                                sd.clear_comm_outputs(&widget_comm_id);
-                                            }
-                                            if sd
-                                                .append_comm_output(&widget_comm_id, &manifest_json)
-                                            {
+                                            if sd.set_kernel_status(status_str) {
                                                 let _ = state_changed_for_iopub.send(());
                                             }
-
-                                            if let Some(entry) = sd.get_comm(&widget_comm_id) {
-                                                let manifests = entry.outputs.clone();
-                                                let manifests_json =
-                                                    serde_json::Value::Array(manifests.clone());
-                                                sd.set_comm_state_property(
-                                                    &widget_comm_id,
-                                                    "outputs",
-                                                    &manifests_json,
-                                                );
-                                                Some(manifests)
-                                            } else {
-                                                None
-                                            }
-                                        };
-                                        if let Some(output_manifests) = output_manifests {
-                                            let mut resolved_outputs = Vec::new();
-                                            for m in &output_manifests {
-                                                if let Ok(manifest) =
-                                                    serde_json::from_value::<OutputManifest>(
-                                                        m.clone(),
-                                                    )
-                                                {
-                                                    if let Ok(resolved) =
-                                                        output_store::resolve_manifest(
-                                                            &manifest,
-                                                            &blob_store,
-                                                        )
-                                                        .await
-                                                    {
-                                                        resolved_outputs.push(resolved);
-                                                    }
-                                                }
-                                            }
-                                            let _ = iopub_cmd_tx
-                                                .send(QueueCommand::SendCommUpdate {
-                                                    comm_id: widget_comm_id.clone(),
-                                                    state: serde_json::json!({
-                                                        "outputs": resolved_outputs,
-                                                    }),
-                                                })
-                                                .await;
                                         }
                                     }
-                                    continue;
-                                }
 
-                                if let Some(ref cid) = cell_id {
-                                    let stream_name = match stream.name {
-                                        jupyter_protocol::Stdio::Stdout => "stdout",
-                                        jupyter_protocol::Stdio::Stderr => "stderr",
-                                    };
-                                    let eid = execution_id.clone().unwrap_or_default();
-
-                                    let (rendered_text, known_state) = {
-                                        let mut terminals = iopub_stream_terminals.lock().await;
-                                        let text = terminals.feed(&eid, stream_name, &stream.text);
-                                        let state =
-                                            terminals.get_output_state(&eid, stream_name).cloned();
-                                        (text, state)
-                                    };
-
-                                    let nbformat_value = serde_json::json!({
-                                        "output_type": "stream",
-                                        "name": stream_name,
-                                        "text": rendered_text
-                                    });
-
-                                    let manifest = match output_store::create_manifest(
-                                        &nbformat_value,
-                                        &blob_store,
-                                        DEFAULT_INLINE_THRESHOLD,
-                                    )
-                                    .await
+                                    if status.execution_state
+                                        == jupyter_protocol::ExecutionState::Idle
                                     {
-                                        Ok(m) => m,
-                                        Err(e) => {
-                                            warn!(
-                                                "[jupyter-kernel] Failed to create stream manifest: {}",
-                                                e
+                                        if let Some((cid, eid)) = cell_entry.clone() {
+                                            let _ = iopub_cmd_tx.try_send(
+                                                QueueCommand::ExecutionDone {
+                                                    cell_id: cid,
+                                                    execution_id: eid,
+                                                },
                                             );
-                                            continue;
                                         }
-                                    };
-                                    let manifest_json = manifest.to_json();
-
-                                    let blob_hash =
-                                        if let OutputManifest::Stream { ref text, .. } = manifest {
-                                            match text {
-                                                ContentRef::Blob { blob, .. } => blob.clone(),
-                                                ContentRef::Inline { inline } => inline.clone(),
-                                            }
-                                        } else {
-                                            String::new()
-                                        };
-
-                                    let mut fork = {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        sd.fork_with_actor(&iopub_actor_id)
-                                    };
-
-                                    let upsert_result = fork.upsert_stream_output(
-                                        &eid,
-                                        stream_name,
-                                        &manifest_json,
-                                        known_state.as_ref(),
-                                    );
-
-                                    let merge_ok = {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        if let Err(e) =
-                                            crate::notebook_sync_server::catch_automerge_panic(
-                                                "iopub-stream-output-merge",
-                                                || sd.merge(&mut fork),
-                                            )
-                                        {
-                                            warn!("{}", e);
-                                            sd.rebuild_from_save();
-                                            false
-                                        } else {
-                                            true
-                                        }
-                                    };
-
-                                    if merge_ok {
-                                        let broadcast_output_index = match &upsert_result {
-                                            Ok((updated, output_index)) => {
-                                                let mut terminals =
-                                                    iopub_stream_terminals.lock().await;
-                                                terminals.set_output_state(
-                                                    &eid,
-                                                    stream_name,
-                                                    StreamOutputState {
-                                                        index: *output_index,
-                                                        blob_hash: blob_hash.clone(),
-                                                    },
-                                                );
-                                                if *updated {
-                                                    Some(*output_index)
-                                                } else {
-                                                    None
-                                                }
-                                            }
-                                            Err(e) => {
-                                                warn!(
-                                                    "[jupyter-kernel] Failed to upsert stream output: {}",
-                                                    e
-                                                );
-                                                None
-                                            }
-                                        };
-
-                                        let _ = state_changed_for_iopub.send(());
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                            cell_id: cid.clone(),
-                                            execution_id: eid,
-                                            output_type: "stream".to_string(),
-                                            output_json: manifest_json.to_string(),
-                                            output_index: broadcast_output_index,
-                                        });
                                     }
                                 }
-                            }
 
-                            JupyterMessageContent::DisplayData(_)
-                            | JupyterMessageContent::ExecuteResult(_) => {
-                                let parent_msg_id = message
-                                    .parent_header
-                                    .as_ref()
-                                    .map(|h| h.msg_id.as_str())
-                                    .unwrap_or("");
+                                JupyterMessageContent::ExecuteInput(input) => {
+                                    if let Some(ref cid) = cell_id {
+                                        let execution_count = input.execution_count.0 as i64;
 
-                                // Dx blob-ref buffer preflight: if the kernel emitted a
-                                // display_data carrying raw bytes as trailing ZMQ
-                                // buffer frames plus a BLOB_REF_MIME entry, write each
-                                // referenced buffer to the blob store before the
-                                // manifest is built.
-                                let iopub_buffers: Vec<Vec<u8>> =
-                                    message.buffers.iter().map(|b| b.to_vec()).collect();
+                                        if let Some(ref eid) = execution_id {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            if sd.set_execution_count(eid, execution_count) {
+                                                let _ = state_changed_for_iopub.send(());
+                                            }
+                                        }
 
-                                if let Some(widget_comm_id) =
-                                    capture_cache.get(parent_msg_id).cloned()
-                                {
-                                    if let Some(nbformat_value) =
-                                        message_content_to_nbformat(&message.content)
+                                        let _ = broadcast_tx.send(
+                                            NotebookBroadcast::ExecutionStarted {
+                                                cell_id: cid.clone(),
+                                                execution_id: execution_id
+                                                    .clone()
+                                                    .unwrap_or_default(),
+                                                execution_count,
+                                            },
+                                        );
+                                    }
+                                }
+
+                                JupyterMessageContent::StreamContent(stream) => {
+                                    // Check if this output should go to an Output widget
+                                    let parent_msg_id = message
+                                        .parent_header
+                                        .as_ref()
+                                        .map(|h| h.msg_id.as_str())
+                                        .unwrap_or("");
+                                    if let Some(widget_comm_id) =
+                                        capture_cache.get(parent_msg_id).cloned()
                                     {
-                                        crate::output_store::preflight_ref_buffers(
-                                            &nbformat_value,
-                                            &iopub_buffers,
-                                            &blob_store,
-                                        )
-                                        .await;
+                                        let stream_name = match stream.name {
+                                            jupyter_protocol::Stdio::Stdout => "stdout",
+                                            jupyter_protocol::Stdio::Stderr => "stderr",
+                                        };
+                                        let output = serde_json::json!({
+                                            "output_type": "stream",
+                                            "name": stream_name,
+                                            "text": stream.text
+                                        });
+
                                         if let Ok(manifest) = crate::output_store::create_manifest(
-                                            &nbformat_value,
+                                            &output,
                                             &blob_store,
                                             crate::output_store::DEFAULT_INLINE_THRESHOLD,
                                         )
@@ -956,14 +762,14 @@ impl KernelConnection for JupyterKernel {
                                                             m.clone(),
                                                         )
                                                     {
-                                                        if let Ok(r) =
+                                                        if let Ok(resolved) =
                                                             output_store::resolve_manifest(
                                                                 &manifest,
                                                                 &blob_store,
                                                             )
                                                             .await
                                                         {
-                                                            resolved_outputs.push(r);
+                                                            resolved_outputs.push(resolved);
                                                         }
                                                     }
                                                 }
@@ -971,70 +777,294 @@ impl KernelConnection for JupyterKernel {
                                                     .send(QueueCommand::SendCommUpdate {
                                                         comm_id: widget_comm_id.clone(),
                                                         state: serde_json::json!({
-                                                            "outputs": resolved_outputs
+                                                            "outputs": resolved_outputs,
                                                         }),
                                                     })
                                                     .await;
                                             }
                                         }
-                                    }
-                                    continue;
-                                }
-
-                                if let Some(ref cid) = cell_id {
-                                    let output_type = match &message.content {
-                                        JupyterMessageContent::DisplayData(_) => "display_data",
-                                        JupyterMessageContent::ExecuteResult(_) => "execute_result",
-                                        _ => "unknown",
-                                    };
-                                    let eid = execution_id.clone().unwrap_or_default();
-
-                                    {
-                                        let mut terminals = iopub_stream_terminals.lock().await;
-                                        terminals.clear(&eid);
+                                        continue;
                                     }
 
-                                    if let Some(nbformat_value) =
-                                        message_content_to_nbformat(&message.content)
-                                    {
-                                        crate::output_store::preflight_ref_buffers(
-                                            &nbformat_value,
-                                            &iopub_buffers,
-                                            &blob_store,
-                                        )
-                                        .await;
-                                        let manifest_json = match output_store::create_manifest(
+                                    if let Some(ref cid) = cell_id {
+                                        let stream_name = match stream.name {
+                                            jupyter_protocol::Stdio::Stdout => "stdout",
+                                            jupyter_protocol::Stdio::Stderr => "stderr",
+                                        };
+                                        let eid = execution_id.clone().unwrap_or_default();
+
+                                        let (rendered_text, known_state) = {
+                                            let mut terminals = iopub_stream_terminals.lock().await;
+                                            let text =
+                                                terminals.feed(&eid, stream_name, &stream.text);
+                                            let state = terminals
+                                                .get_output_state(&eid, stream_name)
+                                                .cloned();
+                                            (text, state)
+                                        };
+
+                                        let nbformat_value = serde_json::json!({
+                                            "output_type": "stream",
+                                            "name": stream_name,
+                                            "text": rendered_text
+                                        });
+
+                                        let manifest = match output_store::create_manifest(
                                             &nbformat_value,
                                             &blob_store,
                                             DEFAULT_INLINE_THRESHOLD,
                                         )
                                         .await
                                         {
-                                            Ok(manifest) => manifest.to_json(),
+                                            Ok(m) => m,
                                             Err(e) => {
                                                 warn!(
-                                                        "[jupyter-kernel] Failed to create manifest: {}",
-                                                        e
-                                                    );
-                                                nbformat_value.clone()
+                                                "[jupyter-kernel] Failed to create stream manifest: {}",
+                                                e
+                                            );
+                                                continue;
                                             }
                                         };
+                                        let manifest_json = manifest.to_json();
+
+                                        let blob_hash =
+                                            if let OutputManifest::Stream { ref text, .. } =
+                                                manifest
+                                            {
+                                                match text {
+                                                    ContentRef::Blob { blob, .. } => blob.clone(),
+                                                    ContentRef::Inline { inline } => inline.clone(),
+                                                }
+                                            } else {
+                                                String::new()
+                                            };
 
                                         let mut fork = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             sd.fork_with_actor(&iopub_actor_id)
                                         };
 
-                                        if let Err(e) = fork.append_output(&eid, &manifest_json) {
-                                            warn!(
-                                                "[jupyter-kernel] Failed to append output to state doc: {}",
-                                                e
-                                            );
-                                        }
+                                        let upsert_result = fork.upsert_stream_output(
+                                            &eid,
+                                            stream_name,
+                                            &manifest_json,
+                                            known_state.as_ref(),
+                                        );
 
                                         let merge_ok = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             if let Err(e) =
+                                                crate::notebook_sync_server::catch_automerge_panic(
+                                                    "iopub-stream-output-merge",
+                                                    || sd.merge(&mut fork),
+                                                )
+                                            {
+                                                warn!("{}", e);
+                                                sd.rebuild_from_save();
+                                                false
+                                            } else {
+                                                true
+                                            }
+                                        };
+
+                                        if merge_ok {
+                                            let broadcast_output_index = match &upsert_result {
+                                                Ok((updated, output_index)) => {
+                                                    let mut terminals =
+                                                        iopub_stream_terminals.lock().await;
+                                                    terminals.set_output_state(
+                                                        &eid,
+                                                        stream_name,
+                                                        StreamOutputState {
+                                                            index: *output_index,
+                                                            blob_hash: blob_hash.clone(),
+                                                        },
+                                                    );
+                                                    if *updated {
+                                                        Some(*output_index)
+                                                    } else {
+                                                        None
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    warn!(
+                                                    "[jupyter-kernel] Failed to upsert stream output: {}",
+                                                    e
+                                                );
+                                                    None
+                                                }
+                                            };
+
+                                            let _ = state_changed_for_iopub.send(());
+                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
+                                                cell_id: cid.clone(),
+                                                execution_id: eid,
+                                                output_type: "stream".to_string(),
+                                                output_json: manifest_json.to_string(),
+                                                output_index: broadcast_output_index,
+                                            });
+                                        }
+                                    }
+                                }
+
+                                JupyterMessageContent::DisplayData(_)
+                                | JupyterMessageContent::ExecuteResult(_) => {
+                                    let parent_msg_id = message
+                                        .parent_header
+                                        .as_ref()
+                                        .map(|h| h.msg_id.as_str())
+                                        .unwrap_or("");
+
+                                    // Dx blob-ref buffer preflight: if the kernel emitted a
+                                    // display_data carrying raw bytes as trailing ZMQ
+                                    // buffer frames plus a BLOB_REF_MIME entry, write each
+                                    // referenced buffer to the blob store before the
+                                    // manifest is built.
+                                    let iopub_buffers: Vec<Vec<u8>> =
+                                        message.buffers.iter().map(|b| b.to_vec()).collect();
+
+                                    if let Some(widget_comm_id) =
+                                        capture_cache.get(parent_msg_id).cloned()
+                                    {
+                                        if let Some(nbformat_value) =
+                                            message_content_to_nbformat(&message.content)
+                                        {
+                                            crate::output_store::preflight_ref_buffers(
+                                                &nbformat_value,
+                                                &iopub_buffers,
+                                                &blob_store,
+                                            )
+                                            .await;
+                                            if let Ok(manifest) =
+                                                crate::output_store::create_manifest(
+                                                    &nbformat_value,
+                                                    &blob_store,
+                                                    crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                                )
+                                                .await
+                                            {
+                                                let manifest_json = manifest.to_json();
+                                                let output_manifests = {
+                                                    let mut sd = state_doc_for_iopub.write().await;
+                                                    if pending_clear_widgets.remove(&widget_comm_id)
+                                                    {
+                                                        sd.clear_comm_outputs(&widget_comm_id);
+                                                    }
+                                                    if sd.append_comm_output(
+                                                        &widget_comm_id,
+                                                        &manifest_json,
+                                                    ) {
+                                                        let _ = state_changed_for_iopub.send(());
+                                                    }
+
+                                                    if let Some(entry) =
+                                                        sd.get_comm(&widget_comm_id)
+                                                    {
+                                                        let manifests = entry.outputs.clone();
+                                                        let manifests_json =
+                                                            serde_json::Value::Array(
+                                                                manifests.clone(),
+                                                            );
+                                                        sd.set_comm_state_property(
+                                                            &widget_comm_id,
+                                                            "outputs",
+                                                            &manifests_json,
+                                                        );
+                                                        Some(manifests)
+                                                    } else {
+                                                        None
+                                                    }
+                                                };
+                                                if let Some(output_manifests) = output_manifests {
+                                                    let mut resolved_outputs = Vec::new();
+                                                    for m in &output_manifests {
+                                                        if let Ok(manifest) = serde_json::from_value::<
+                                                            OutputManifest,
+                                                        >(
+                                                            m.clone()
+                                                        ) {
+                                                            if let Ok(r) =
+                                                                output_store::resolve_manifest(
+                                                                    &manifest,
+                                                                    &blob_store,
+                                                                )
+                                                                .await
+                                                            {
+                                                                resolved_outputs.push(r);
+                                                            }
+                                                        }
+                                                    }
+                                                    let _ = iopub_cmd_tx
+                                                        .send(QueueCommand::SendCommUpdate {
+                                                            comm_id: widget_comm_id.clone(),
+                                                            state: serde_json::json!({
+                                                                "outputs": resolved_outputs
+                                                            }),
+                                                        })
+                                                        .await;
+                                                }
+                                            }
+                                        }
+                                        continue;
+                                    }
+
+                                    if let Some(ref cid) = cell_id {
+                                        let output_type = match &message.content {
+                                            JupyterMessageContent::DisplayData(_) => "display_data",
+                                            JupyterMessageContent::ExecuteResult(_) => {
+                                                "execute_result"
+                                            }
+                                            _ => "unknown",
+                                        };
+                                        let eid = execution_id.clone().unwrap_or_default();
+
+                                        {
+                                            let mut terminals = iopub_stream_terminals.lock().await;
+                                            terminals.clear(&eid);
+                                        }
+
+                                        if let Some(nbformat_value) =
+                                            message_content_to_nbformat(&message.content)
+                                        {
+                                            crate::output_store::preflight_ref_buffers(
+                                                &nbformat_value,
+                                                &iopub_buffers,
+                                                &blob_store,
+                                            )
+                                            .await;
+                                            let manifest_json = match output_store::create_manifest(
+                                                &nbformat_value,
+                                                &blob_store,
+                                                DEFAULT_INLINE_THRESHOLD,
+                                            )
+                                            .await
+                                            {
+                                                Ok(manifest) => manifest.to_json(),
+                                                Err(e) => {
+                                                    warn!(
+                                                        "[jupyter-kernel] Failed to create manifest: {}",
+                                                        e
+                                                    );
+                                                    nbformat_value.clone()
+                                                }
+                                            };
+
+                                            let mut fork = {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                sd.fork_with_actor(&iopub_actor_id)
+                                            };
+
+                                            if let Err(e) = fork.append_output(&eid, &manifest_json)
+                                            {
+                                                warn!(
+                                                "[jupyter-kernel] Failed to append output to state doc: {}",
+                                                e
+                                            );
+                                            }
+
+                                            let merge_ok = {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                if let Err(e) =
                                                 crate::notebook_sync_server::catch_automerge_panic(
                                                     "iopub-output-merge",
                                                     || sd.merge(&mut fork),
@@ -1047,40 +1077,41 @@ impl KernelConnection for JupyterKernel {
                                                 let _ = state_changed_for_iopub.send(());
                                                 true
                                             }
-                                        };
+                                            };
 
-                                        if merge_ok {
-                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                                cell_id: cid.clone(),
-                                                execution_id: eid,
-                                                output_type: output_type.to_string(),
-                                                output_json: manifest_json.to_string(),
-                                                output_index: None,
-                                            });
+                                            if merge_ok {
+                                                let _ =
+                                                    broadcast_tx.send(NotebookBroadcast::Output {
+                                                        cell_id: cid.clone(),
+                                                        execution_id: eid,
+                                                        output_type: output_type.to_string(),
+                                                        output_json: manifest_json.to_string(),
+                                                        output_index: None,
+                                                    });
+                                            }
                                         }
                                     }
                                 }
-                            }
 
-                            JupyterMessageContent::UpdateDisplayData(update) => {
-                                if let Some(ref display_id) = update.transient.display_id {
-                                    let mut fork = {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        sd.fork_with_actor(&iopub_actor_id)
-                                    };
+                                JupyterMessageContent::UpdateDisplayData(update) => {
+                                    if let Some(ref display_id) = update.transient.display_id {
+                                        let mut fork = {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            sd.fork_with_actor(&iopub_actor_id)
+                                        };
 
-                                    let updated = update_output_by_display_id_with_manifests(
-                                        &mut fork,
-                                        display_id,
-                                        &serde_json::to_value(&update.data).unwrap_or_default(),
-                                        &update.metadata,
-                                        &blob_store,
-                                    )
-                                    .await;
+                                        let updated = update_output_by_display_id_with_manifests(
+                                            &mut fork,
+                                            display_id,
+                                            &serde_json::to_value(&update.data).unwrap_or_default(),
+                                            &update.metadata,
+                                            &blob_store,
+                                        )
+                                        .await;
 
-                                    let merge_ok = {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        match updated {
+                                        let merge_ok = {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            match updated {
                                             Ok(true) => {
                                                 if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
                                                     "iopub-display-update-merge",
@@ -1112,143 +1143,151 @@ impl KernelConnection for JupyterKernel {
                                                 false
                                             }
                                         }
-                                    };
+                                        };
 
-                                    if merge_ok {
-                                        let _ = state_changed_for_iopub.send(());
-                                        let _ =
-                                            broadcast_tx.send(NotebookBroadcast::DisplayUpdate {
-                                                display_id: display_id.clone(),
-                                                data: serde_json::to_value(&update.data)
-                                                    .unwrap_or_default(),
-                                                metadata: update.metadata.clone(),
-                                            });
-                                    }
-                                }
-                            }
-
-                            JupyterMessageContent::ErrorOutput(_) => {
-                                let parent_msg_id = message
-                                    .parent_header
-                                    .as_ref()
-                                    .map(|h| h.msg_id.as_str())
-                                    .unwrap_or("");
-                                if let Some(widget_comm_id) =
-                                    capture_cache.get(parent_msg_id).cloned()
-                                {
-                                    if let Some(nbformat_value) =
-                                        message_content_to_nbformat(&message.content)
-                                    {
-                                        if let Ok(manifest) = crate::output_store::create_manifest(
-                                            &nbformat_value,
-                                            &blob_store,
-                                            crate::output_store::DEFAULT_INLINE_THRESHOLD,
-                                        )
-                                        .await
-                                        {
-                                            let manifest_json = manifest.to_json();
-                                            let output_manifests = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if pending_clear_widgets.remove(&widget_comm_id) {
-                                                    sd.clear_comm_outputs(&widget_comm_id);
-                                                }
-                                                if sd.append_comm_output(
-                                                    &widget_comm_id,
-                                                    &manifest_json,
-                                                ) {
-                                                    let _ = state_changed_for_iopub.send(());
-                                                }
-
-                                                if let Some(entry) = sd.get_comm(&widget_comm_id) {
-                                                    let manifests = entry.outputs.clone();
-                                                    let manifests_json =
-                                                        serde_json::Value::Array(manifests.clone());
-                                                    sd.set_comm_state_property(
-                                                        &widget_comm_id,
-                                                        "outputs",
-                                                        &manifests_json,
-                                                    );
-                                                    Some(manifests)
-                                                } else {
-                                                    None
-                                                }
-                                            };
-                                            if let Some(output_manifests) = output_manifests {
-                                                let mut resolved_outputs = Vec::new();
-                                                for m in &output_manifests {
-                                                    if let Ok(manifest) =
-                                                        serde_json::from_value::<OutputManifest>(
-                                                            m.clone(),
-                                                        )
-                                                    {
-                                                        if let Ok(r) =
-                                                            output_store::resolve_manifest(
-                                                                &manifest,
-                                                                &blob_store,
-                                                            )
-                                                            .await
-                                                        {
-                                                            resolved_outputs.push(r);
-                                                        }
-                                                    }
-                                                }
-                                                let _ = iopub_cmd_tx
-                                                    .send(QueueCommand::SendCommUpdate {
-                                                        comm_id: widget_comm_id.clone(),
-                                                        state: serde_json::json!({
-                                                            "outputs": resolved_outputs
-                                                        }),
-                                                    })
-                                                    .await;
-                                            }
+                                        if merge_ok {
+                                            let _ = state_changed_for_iopub.send(());
+                                            let _ = broadcast_tx.send(
+                                                NotebookBroadcast::DisplayUpdate {
+                                                    display_id: display_id.clone(),
+                                                    data: serde_json::to_value(&update.data)
+                                                        .unwrap_or_default(),
+                                                    metadata: update.metadata.clone(),
+                                                },
+                                            );
                                         }
                                     }
-                                    continue;
                                 }
 
-                                if let Some(ref cid) = cell_id {
-                                    let eid = execution_id.clone().unwrap_or_default();
-
+                                JupyterMessageContent::ErrorOutput(_) => {
+                                    let parent_msg_id = message
+                                        .parent_header
+                                        .as_ref()
+                                        .map(|h| h.msg_id.as_str())
+                                        .unwrap_or("");
+                                    if let Some(widget_comm_id) =
+                                        capture_cache.get(parent_msg_id).cloned()
                                     {
-                                        let mut terminals = iopub_stream_terminals.lock().await;
-                                        terminals.clear(&eid);
+                                        if let Some(nbformat_value) =
+                                            message_content_to_nbformat(&message.content)
+                                        {
+                                            if let Ok(manifest) =
+                                                crate::output_store::create_manifest(
+                                                    &nbformat_value,
+                                                    &blob_store,
+                                                    crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                                )
+                                                .await
+                                            {
+                                                let manifest_json = manifest.to_json();
+                                                let output_manifests = {
+                                                    let mut sd = state_doc_for_iopub.write().await;
+                                                    if pending_clear_widgets.remove(&widget_comm_id)
+                                                    {
+                                                        sd.clear_comm_outputs(&widget_comm_id);
+                                                    }
+                                                    if sd.append_comm_output(
+                                                        &widget_comm_id,
+                                                        &manifest_json,
+                                                    ) {
+                                                        let _ = state_changed_for_iopub.send(());
+                                                    }
+
+                                                    if let Some(entry) =
+                                                        sd.get_comm(&widget_comm_id)
+                                                    {
+                                                        let manifests = entry.outputs.clone();
+                                                        let manifests_json =
+                                                            serde_json::Value::Array(
+                                                                manifests.clone(),
+                                                            );
+                                                        sd.set_comm_state_property(
+                                                            &widget_comm_id,
+                                                            "outputs",
+                                                            &manifests_json,
+                                                        );
+                                                        Some(manifests)
+                                                    } else {
+                                                        None
+                                                    }
+                                                };
+                                                if let Some(output_manifests) = output_manifests {
+                                                    let mut resolved_outputs = Vec::new();
+                                                    for m in &output_manifests {
+                                                        if let Ok(manifest) = serde_json::from_value::<
+                                                            OutputManifest,
+                                                        >(
+                                                            m.clone()
+                                                        ) {
+                                                            if let Ok(r) =
+                                                                output_store::resolve_manifest(
+                                                                    &manifest,
+                                                                    &blob_store,
+                                                                )
+                                                                .await
+                                                            {
+                                                                resolved_outputs.push(r);
+                                                            }
+                                                        }
+                                                    }
+                                                    let _ = iopub_cmd_tx
+                                                        .send(QueueCommand::SendCommUpdate {
+                                                            comm_id: widget_comm_id.clone(),
+                                                            state: serde_json::json!({
+                                                                "outputs": resolved_outputs
+                                                            }),
+                                                        })
+                                                        .await;
+                                                }
+                                            }
+                                        }
+                                        continue;
                                     }
 
-                                    if let Some(nbformat_value) =
-                                        message_content_to_nbformat(&message.content)
-                                    {
-                                        let manifest_json = match output_store::create_manifest(
-                                            &nbformat_value,
-                                            &blob_store,
-                                            DEFAULT_INLINE_THRESHOLD,
-                                        )
-                                        .await
+                                    if let Some(ref cid) = cell_id {
+                                        let eid = execution_id.clone().unwrap_or_default();
+
                                         {
-                                            Ok(manifest) => manifest.to_json(),
-                                            Err(e) => {
-                                                warn!(
+                                            let mut terminals = iopub_stream_terminals.lock().await;
+                                            terminals.clear(&eid);
+                                        }
+
+                                        if let Some(nbformat_value) =
+                                            message_content_to_nbformat(&message.content)
+                                        {
+                                            let manifest_json = match output_store::create_manifest(
+                                                &nbformat_value,
+                                                &blob_store,
+                                                DEFAULT_INLINE_THRESHOLD,
+                                            )
+                                            .await
+                                            {
+                                                Ok(manifest) => manifest.to_json(),
+                                                Err(e) => {
+                                                    warn!(
                                                         "[jupyter-kernel] Failed to create error manifest: {}",
                                                         e
                                                     );
-                                                nbformat_value.clone()
-                                            }
-                                        };
+                                                    nbformat_value.clone()
+                                                }
+                                            };
 
-                                        let mut fork = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            sd.fork_with_actor(&iopub_actor_id)
-                                        };
+                                            let mut fork = {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                sd.fork_with_actor(&iopub_actor_id)
+                                            };
 
-                                        if let Err(e) = fork.append_output(&eid, &manifest_json) {
-                                            warn!(
+                                            if let Err(e) = fork.append_output(&eid, &manifest_json)
+                                            {
+                                                warn!(
                                                 "[jupyter-kernel] Failed to append error output to state doc: {}",
                                                 e
                                             );
-                                        }
+                                            }
 
-                                        let merge_ok = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            if let Err(e) =
+                                            let merge_ok = {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                if let Err(e) =
                                                 crate::notebook_sync_server::catch_automerge_panic(
                                                     "iopub-error-output-merge",
                                                     || sd.merge(&mut fork),
@@ -1261,315 +1300,335 @@ impl KernelConnection for JupyterKernel {
                                                 let _ = state_changed_for_iopub.send(());
                                                 true
                                             }
-                                        };
+                                            };
 
-                                        if merge_ok {
-                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                                cell_id: cid.clone(),
-                                                execution_id: eid.clone(),
-                                                output_type: "error".to_string(),
-                                                output_json: manifest_json.to_string(),
-                                                output_index: None,
-                                            });
-                                        }
-                                    }
-
-                                    let _ = iopub_cmd_tx.try_send(QueueCommand::CellError {
-                                        cell_id: cid.clone(),
-                                        execution_id: eid,
-                                    });
-                                }
-                            }
-
-                            JupyterMessageContent::ClearOutput(clear) => {
-                                let parent_msg_id = message
-                                    .parent_header
-                                    .as_ref()
-                                    .map(|h| h.msg_id.as_str())
-                                    .unwrap_or("");
-                                if let Some(widget_comm_id) =
-                                    capture_cache.get(parent_msg_id).cloned()
-                                {
-                                    if clear.wait {
-                                        pending_clear_widgets.insert(widget_comm_id.clone());
-                                    } else {
-                                        pending_clear_widgets.remove(&widget_comm_id);
-                                        {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            if sd.clear_comm_outputs(&widget_comm_id) {
-                                                let _ = state_changed_for_iopub.send(());
+                                            if merge_ok {
+                                                let _ =
+                                                    broadcast_tx.send(NotebookBroadcast::Output {
+                                                        cell_id: cid.clone(),
+                                                        execution_id: eid.clone(),
+                                                        output_type: "error".to_string(),
+                                                        output_json: manifest_json.to_string(),
+                                                        output_index: None,
+                                                    });
                                             }
-                                            sd.set_comm_state_property(
-                                                &widget_comm_id,
-                                                "outputs",
-                                                &serde_json::json!([]),
-                                            );
                                         }
-                                        let _ = iopub_cmd_tx
-                                            .send(QueueCommand::SendCommUpdate {
-                                                comm_id: widget_comm_id.clone(),
-                                                state: serde_json::json!({ "outputs": [] }),
-                                            })
-                                            .await;
+
+                                        let _ = iopub_cmd_tx.try_send(QueueCommand::CellError {
+                                            cell_id: cid.clone(),
+                                            execution_id: eid,
+                                        });
                                     }
                                 }
-                            }
 
-                            JupyterMessageContent::CommOpen(open) => {
-                                // Record the comm_id -> target_name mapping early so
-                                // subsequent CommMsg / CommClose arms can route without
-                                // reading the CRDT.
-                                comm_targets
-                                    .insert(open.comm_id.0.clone(), open.target_name.clone());
-
-                                // Short-circuit reserved nteract.dx.* comms: they carry
-                                // kernel-side protocol traffic (dx blob uploads, future
-                                // dx.query / dx.stream) that must NOT land in
-                                // RuntimeStateDoc::comms. The payload is handled in the
-                                // CommMsg arm below.
-                                if crate::dx_blob_comm::is_dx_target(&open.target_name) {
-                                    debug!(
-                                        "[dx] comm_open comm_id={} target={} (not persisted)",
-                                        open.comm_id.0, open.target_name
-                                    );
-                                    continue;
-                                }
-
-                                let buffers: Vec<Vec<u8>> =
-                                    message.buffers.iter().map(|b| b.to_vec()).collect();
-
-                                let data = serde_json::to_value(&open.data).unwrap_or_default();
-
-                                let comm_open_start = std::time::Instant::now();
-                                let state_json_size =
-                                    serde_json::to_string(&data).map(|s| s.len()).unwrap_or(0);
-                                debug!(
-                                    "[comm_open] comm_id={} target={} state_size={} bytes",
-                                    open.comm_id.0, open.target_name, state_json_size
-                                );
-
-                                let empty_obj = serde_json::json!({});
-                                let state = data.get("state").unwrap_or(&empty_obj);
-                                let buffer_paths = extract_buffer_paths(&data);
-                                let (state_with_blobs, _used_paths) = store_widget_buffers(
-                                    state,
-                                    &buffer_paths,
-                                    &buffers,
-                                    &blob_store,
-                                )
-                                .await;
-
-                                let blob_elapsed = comm_open_start.elapsed();
-                                if blob_elapsed > std::time::Duration::from_millis(10) {
-                                    warn!(
-                                        "[iopub-timing] comm_open blob store took {:?} for comm_id={}",
-                                        blob_elapsed, open.comm_id.0
-                                    );
-                                }
-
-                                let state_with_blobs =
-                                    blob_store_large_state_values(&state_with_blobs, &blob_store)
-                                        .await;
-
-                                {
-                                    let lock_start = std::time::Instant::now();
-                                    let model_module = state_with_blobs
-                                        .get("_model_module")
-                                        .and_then(|v| v.as_str())
+                                JupyterMessageContent::ClearOutput(clear) => {
+                                    let parent_msg_id = message
+                                        .parent_header
+                                        .as_ref()
+                                        .map(|h| h.msg_id.as_str())
                                         .unwrap_or("");
-                                    let model_name = state_with_blobs
-                                        .get("_model_name")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("");
-                                    let seq = iopub_comm_seq.fetch_add(1, Ordering::Relaxed);
-                                    let mut sd = state_doc_for_iopub.write().await;
-                                    let lock_wait = lock_start.elapsed();
-                                    if lock_wait > std::time::Duration::from_millis(5) {
-                                        warn!(
-                                            "[iopub-timing] comm_open state_doc write lock waited {:?} for comm_id={}",
-                                            lock_wait, open.comm_id.0
-                                        );
-                                    }
-                                    let crdt_start = std::time::Instant::now();
-                                    sd.put_comm(
-                                        &open.comm_id.0,
-                                        &open.target_name,
-                                        model_module,
-                                        model_name,
-                                        &state_with_blobs,
-                                        seq,
-                                    );
-                                    let crdt_elapsed = crdt_start.elapsed();
-                                    if crdt_elapsed > std::time::Duration::from_millis(10) {
-                                        warn!(
-                                            "[iopub-timing] comm_open put_comm CRDT write took {:?} for comm_id={}, state_size={} bytes",
-                                            crdt_elapsed, open.comm_id.0, state_json_size
-                                        );
-                                    }
-
-                                    if model_name == "OutputModel" {
-                                        if let Some(msg_id) = state_with_blobs
-                                            .get("msg_id")
-                                            .and_then(|v| v.as_str())
-                                            .filter(|s| !s.is_empty())
-                                        {
-                                            sd.set_comm_capture_msg_id(&open.comm_id.0, msg_id);
-                                            capture_cache
-                                                .insert(msg_id.to_string(), open.comm_id.0.clone());
-                                        }
-                                    }
-
-                                    let _ = state_changed_for_iopub.send(());
-                                }
-
-                                let total = comm_open_start.elapsed();
-                                if total > std::time::Duration::from_millis(50) {
-                                    warn!(
-                                        "[iopub-timing] comm_open TOTAL {:?} for comm_id={} target={} state_size={} bytes",
-                                        total, open.comm_id.0, open.target_name, state_json_size
-                                    );
-                                }
-                            }
-
-                            JupyterMessageContent::CommMsg(msg) => {
-                                let content =
-                                    serde_json::to_value(&message.content).unwrap_or_default();
-                                let buffers: Vec<Vec<u8>> =
-                                    message.buffers.iter().map(|b| b.to_vec()).collect();
-
-                                let data = serde_json::to_value(&msg.data).unwrap_or_default();
-                                let method = data.get("method").and_then(|m| m.as_str());
-
-                                // dx-namespace comms short-circuit before any widget
-                                // state handling. v1 has no live handler — all reserved
-                                // nteract.dx.* targets drop with a warn log carrying the
-                                // raw target name for observability (future kernels
-                                // opening reserved targets we haven't implemented yet).
-                                if let Some(target) = comm_targets.get(&msg.comm_id.0).cloned() {
-                                    if let Some(crate::dx_blob_comm::DxTarget::Unknown(raw)) =
-                                        crate::dx_blob_comm::classify_dx_target(&target)
+                                    if let Some(widget_comm_id) =
+                                        capture_cache.get(parent_msg_id).cloned()
                                     {
-                                        warn!(
-                                            "[dx] comm_msg on reserved target {} (dropped; filtered from RuntimeStateDoc)",
-                                            raw
+                                        if clear.wait {
+                                            pending_clear_widgets.insert(widget_comm_id.clone());
+                                        } else {
+                                            pending_clear_widgets.remove(&widget_comm_id);
+                                            {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                if sd.clear_comm_outputs(&widget_comm_id) {
+                                                    let _ = state_changed_for_iopub.send(());
+                                                }
+                                                sd.set_comm_state_property(
+                                                    &widget_comm_id,
+                                                    "outputs",
+                                                    &serde_json::json!([]),
+                                                );
+                                            }
+                                            let _ = iopub_cmd_tx
+                                                .send(QueueCommand::SendCommUpdate {
+                                                    comm_id: widget_comm_id.clone(),
+                                                    state: serde_json::json!({ "outputs": [] }),
+                                                })
+                                                .await;
+                                        }
+                                    }
+                                }
+
+                                JupyterMessageContent::CommOpen(open) => {
+                                    // Record the comm_id -> target_name mapping early so
+                                    // subsequent CommMsg / CommClose arms can route without
+                                    // reading the CRDT.
+                                    comm_targets
+                                        .insert(open.comm_id.0.clone(), open.target_name.clone());
+
+                                    // Short-circuit reserved nteract.dx.* comms: they carry
+                                    // kernel-side protocol traffic (dx blob uploads, future
+                                    // dx.query / dx.stream) that must NOT land in
+                                    // RuntimeStateDoc::comms. The payload is handled in the
+                                    // CommMsg arm below.
+                                    if crate::dx_blob_comm::is_dx_target(&open.target_name) {
+                                        debug!(
+                                            "[dx] comm_open comm_id={} target={} (not persisted)",
+                                            open.comm_id.0, open.target_name
                                         );
                                         continue;
                                     }
+
+                                    let buffers: Vec<Vec<u8>> =
+                                        message.buffers.iter().map(|b| b.to_vec()).collect();
+
+                                    let data = serde_json::to_value(&open.data).unwrap_or_default();
+
+                                    let comm_open_start = std::time::Instant::now();
+                                    let state_json_size =
+                                        serde_json::to_string(&data).map(|s| s.len()).unwrap_or(0);
+                                    debug!(
+                                        "[comm_open] comm_id={} target={} state_size={} bytes",
+                                        open.comm_id.0, open.target_name, state_json_size
+                                    );
+
+                                    let empty_obj = serde_json::json!({});
+                                    let state = data.get("state").unwrap_or(&empty_obj);
+                                    let buffer_paths = extract_buffer_paths(&data);
+                                    let (state_with_blobs, _used_paths) = store_widget_buffers(
+                                        state,
+                                        &buffer_paths,
+                                        &buffers,
+                                        &blob_store,
+                                    )
+                                    .await;
+
+                                    let blob_elapsed = comm_open_start.elapsed();
+                                    if blob_elapsed > std::time::Duration::from_millis(10) {
+                                        warn!(
+                                        "[iopub-timing] comm_open blob store took {:?} for comm_id={}",
+                                        blob_elapsed, open.comm_id.0
+                                    );
+                                    }
+
+                                    let state_with_blobs = blob_store_large_state_values(
+                                        &state_with_blobs,
+                                        &blob_store,
+                                    )
+                                    .await;
+
+                                    {
+                                        let lock_start = std::time::Instant::now();
+                                        let model_module = state_with_blobs
+                                            .get("_model_module")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("");
+                                        let model_name = state_with_blobs
+                                            .get("_model_name")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("");
+                                        let seq = iopub_comm_seq.fetch_add(1, Ordering::Relaxed);
+                                        let mut sd = state_doc_for_iopub.write().await;
+                                        let lock_wait = lock_start.elapsed();
+                                        if lock_wait > std::time::Duration::from_millis(5) {
+                                            warn!(
+                                            "[iopub-timing] comm_open state_doc write lock waited {:?} for comm_id={}",
+                                            lock_wait, open.comm_id.0
+                                        );
+                                        }
+                                        let crdt_start = std::time::Instant::now();
+                                        sd.put_comm(
+                                            &open.comm_id.0,
+                                            &open.target_name,
+                                            model_module,
+                                            model_name,
+                                            &state_with_blobs,
+                                            seq,
+                                        );
+                                        let crdt_elapsed = crdt_start.elapsed();
+                                        if crdt_elapsed > std::time::Duration::from_millis(10) {
+                                            warn!(
+                                            "[iopub-timing] comm_open put_comm CRDT write took {:?} for comm_id={}, state_size={} bytes",
+                                            crdt_elapsed, open.comm_id.0, state_json_size
+                                        );
+                                        }
+
+                                        if model_name == "OutputModel" {
+                                            if let Some(msg_id) = state_with_blobs
+                                                .get("msg_id")
+                                                .and_then(|v| v.as_str())
+                                                .filter(|s| !s.is_empty())
+                                            {
+                                                sd.set_comm_capture_msg_id(&open.comm_id.0, msg_id);
+                                                capture_cache.insert(
+                                                    msg_id.to_string(),
+                                                    open.comm_id.0.clone(),
+                                                );
+                                            }
+                                        }
+
+                                        let _ = state_changed_for_iopub.send(());
+                                    }
+
+                                    let total = comm_open_start.elapsed();
+                                    if total > std::time::Duration::from_millis(50) {
+                                        warn!(
+                                        "[iopub-timing] comm_open TOTAL {:?} for comm_id={} target={} state_size={} bytes",
+                                        total, open.comm_id.0, open.target_name, state_json_size
+                                    );
+                                    }
                                 }
 
-                                let comm_msg_start = std::time::Instant::now();
-                                debug!("[comm_msg] comm_id={} method={:?}", msg.comm_id.0, method);
-                                if method == Some("update") {
-                                    if let Some(state_delta) = data.get("state") {
-                                        if let Some(new_msg_id) =
-                                            state_delta.get("msg_id").and_then(|v| v.as_str())
+                                JupyterMessageContent::CommMsg(msg) => {
+                                    let content =
+                                        serde_json::to_value(&message.content).unwrap_or_default();
+                                    let buffers: Vec<Vec<u8>> =
+                                        message.buffers.iter().map(|b| b.to_vec()).collect();
+
+                                    let data = serde_json::to_value(&msg.data).unwrap_or_default();
+                                    let method = data.get("method").and_then(|m| m.as_str());
+
+                                    // dx-namespace comms short-circuit before any widget
+                                    // state handling. v1 has no live handler — all reserved
+                                    // nteract.dx.* targets drop with a warn log carrying the
+                                    // raw target name for observability (future kernels
+                                    // opening reserved targets we haven't implemented yet).
+                                    if let Some(target) = comm_targets.get(&msg.comm_id.0).cloned()
+                                    {
+                                        if let Some(crate::dx_blob_comm::DxTarget::Unknown(raw)) =
+                                            crate::dx_blob_comm::classify_dx_target(&target)
                                         {
-                                            capture_cache.retain(|_, cid| cid != &msg.comm_id.0);
-                                            if !new_msg_id.is_empty() {
-                                                if let Some(existing) =
-                                                    capture_cache.get(new_msg_id)
-                                                {
-                                                    warn!(
+                                            warn!(
+                                            "[dx] comm_msg on reserved target {} (dropped; filtered from RuntimeStateDoc)",
+                                            raw
+                                        );
+                                            continue;
+                                        }
+                                    }
+
+                                    let comm_msg_start = std::time::Instant::now();
+                                    debug!(
+                                        "[comm_msg] comm_id={} method={:?}",
+                                        msg.comm_id.0, method
+                                    );
+                                    if method == Some("update") {
+                                        if let Some(state_delta) = data.get("state") {
+                                            if let Some(new_msg_id) =
+                                                state_delta.get("msg_id").and_then(|v| v.as_str())
+                                            {
+                                                capture_cache
+                                                    .retain(|_, cid| cid != &msg.comm_id.0);
+                                                if !new_msg_id.is_empty() {
+                                                    if let Some(existing) =
+                                                        capture_cache.get(new_msg_id)
+                                                    {
+                                                        warn!(
                                                         "[comm_msg] Nested capture: {} overrides {} for msg_id={}",
                                                         msg.comm_id.0, existing, new_msg_id
                                                     );
+                                                    }
+                                                    capture_cache.insert(
+                                                        new_msg_id.to_string(),
+                                                        msg.comm_id.0.clone(),
+                                                    );
                                                 }
-                                                capture_cache.insert(
-                                                    new_msg_id.to_string(),
-                                                    msg.comm_id.0.clone(),
+
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                sd.set_comm_capture_msg_id(
+                                                    &msg.comm_id.0,
+                                                    new_msg_id,
                                                 );
+                                                let _ = state_changed_for_iopub.send(());
                                             }
 
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            sd.set_comm_capture_msg_id(&msg.comm_id.0, new_msg_id);
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
-
-                                        let coalesce_delta = if !buffers.is_empty() {
-                                            let buffer_paths = extract_buffer_paths(&data);
-                                            let (state_with_blobs, _) = store_widget_buffers(
-                                                state_delta,
-                                                &buffer_paths,
-                                                &buffers,
-                                                &blob_store,
-                                            )
-                                            .await;
-                                            state_with_blobs
-                                        } else {
-                                            state_delta.clone()
-                                        };
-                                        if let Some(ref tx) = comm_coalesce_tx {
-                                            let _ =
-                                                tx.send((msg.comm_id.0.clone(), coalesce_delta));
+                                            let coalesce_delta = if !buffers.is_empty() {
+                                                let buffer_paths = extract_buffer_paths(&data);
+                                                let (state_with_blobs, _) = store_widget_buffers(
+                                                    state_delta,
+                                                    &buffer_paths,
+                                                    &buffers,
+                                                    &blob_store,
+                                                )
+                                                .await;
+                                                state_with_blobs
+                                            } else {
+                                                state_delta.clone()
+                                            };
+                                            if let Some(ref tx) = comm_coalesce_tx {
+                                                let _ = tx
+                                                    .send((msg.comm_id.0.clone(), coalesce_delta));
+                                            }
                                         }
                                     }
-                                }
 
-                                let comm_msg_elapsed = comm_msg_start.elapsed();
-                                if comm_msg_elapsed > std::time::Duration::from_millis(10) {
-                                    warn!(
+                                    let comm_msg_elapsed = comm_msg_start.elapsed();
+                                    if comm_msg_elapsed > std::time::Duration::from_millis(10) {
+                                        warn!(
                                         "[iopub-timing] comm_msg took {:?} for comm_id={} method={:?}",
                                         comm_msg_elapsed, msg.comm_id.0, method
                                     );
-                                }
+                                    }
 
-                                if method != Some("update") {
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                        msg_type: message.header.msg_type.clone(),
-                                        content: content.clone(),
-                                        buffers: buffers.clone(),
-                                    });
-                                }
-                            }
-
-                            JupyterMessageContent::CommClose(close) => {
-                                debug!("[jupyter-kernel] comm_close: comm_id={}", close.comm_id.0);
-
-                                let iopub_elapsed = iopub_start.elapsed();
-                                if iopub_elapsed > std::time::Duration::from_millis(50) {
-                                    warn!(
-                                        "[iopub-timing] message type={} took {:?} total",
-                                        msg_type, iopub_elapsed
-                                    );
-                                }
-
-                                // Drop the comm_id -> target_name mapping. If this was
-                                // a dx-namespace comm, skip the RuntimeStateDoc write.
-                                let was_dx_target = comm_targets
-                                    .remove(&close.comm_id.0)
-                                    .map(|t| crate::dx_blob_comm::is_dx_target(&t))
-                                    .unwrap_or(false);
-                                if was_dx_target {
-                                    continue;
-                                }
-
-                                capture_cache.retain(|_, cid| cid != &close.comm_id.0);
-
-                                {
-                                    let mut sd = state_doc_for_iopub.write().await;
-                                    if sd.remove_comm(&close.comm_id.0) {
-                                        let _ = state_changed_for_iopub.send(());
+                                    if method != Some("update") {
+                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                            msg_type: message.header.msg_type.clone(),
+                                            content: content.clone(),
+                                            buffers: buffers.clone(),
+                                        });
                                     }
                                 }
-                            }
 
-                            _ => {
-                                debug!(
-                                    "[jupyter-kernel] Unhandled iopub message: {}",
-                                    message.header.msg_type
-                                );
+                                JupyterMessageContent::CommClose(close) => {
+                                    debug!(
+                                        "[jupyter-kernel] comm_close: comm_id={}",
+                                        close.comm_id.0
+                                    );
+
+                                    let iopub_elapsed = iopub_start.elapsed();
+                                    if iopub_elapsed > std::time::Duration::from_millis(50) {
+                                        warn!(
+                                            "[iopub-timing] message type={} took {:?} total",
+                                            msg_type, iopub_elapsed
+                                        );
+                                    }
+
+                                    // Drop the comm_id -> target_name mapping. If this was
+                                    // a dx-namespace comm, skip the RuntimeStateDoc write.
+                                    let was_dx_target = comm_targets
+                                        .remove(&close.comm_id.0)
+                                        .map(|t| crate::dx_blob_comm::is_dx_target(&t))
+                                        .unwrap_or(false);
+                                    if was_dx_target {
+                                        continue;
+                                    }
+
+                                    capture_cache.retain(|_, cid| cid != &close.comm_id.0);
+
+                                    {
+                                        let mut sd = state_doc_for_iopub.write().await;
+                                        if sd.remove_comm(&close.comm_id.0) {
+                                            let _ = state_changed_for_iopub.send(());
+                                        }
+                                    }
+                                }
+
+                                _ => {
+                                    debug!(
+                                        "[jupyter-kernel] Unhandled iopub message: {}",
+                                        message.header.msg_type
+                                    );
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        error!("[jupyter-kernel] iopub read error: {}", e);
-                        break;
+                        Err(e) => {
+                            error!("[jupyter-kernel] iopub read error: {}", e);
+                            break;
+                        }
                     }
                 }
-            }
-            warn!("[jupyter-kernel] iopub loop exited, signaling KernelDied");
-            let _ = iopub_cmd_tx.try_send(QueueCommand::KernelDied);
-        });
+                warn!("[jupyter-kernel] iopub loop exited, signaling KernelDied");
+                let _ = iopub_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+            move |_| {
+                let _ = iopub_panic_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+        );
 
         // ── Shell connection ─────────────────────────────────────────────
 
@@ -1628,63 +1687,71 @@ impl KernelConnection for JupyterKernel {
         let shell_blob_store = shared.blob_store.clone();
         let shell_actor_id = format!("{kernel_actor_id}:shell");
 
-        let shell_reader_task = tokio::spawn(async move {
-            loop {
-                match shell_reader.read().await {
-                    Ok(msg) => {
-                        let _parent_msg_id = msg.parent_header.as_ref().map(|h| h.msg_id.clone());
+        let shell_panic_cmd_tx = cmd_tx.clone();
+        let shell_reader_task = spawn_supervised(
+            "shell-reader",
+            async move {
+                loop {
+                    match shell_reader.read().await {
+                        Ok(msg) => {
+                            let _parent_msg_id =
+                                msg.parent_header.as_ref().map(|h| h.msg_id.clone());
 
-                        match msg.content {
-                            JupyterMessageContent::ExecuteReply(ref reply) => {
-                                let cell_entry: Option<(String, String)> =
-                                    msg.parent_header.as_ref().and_then(|h| {
-                                        shell_cell_id_map.lock().ok()?.get(&h.msg_id).cloned()
-                                    });
-                                let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
-                                let execution_id = cell_entry.as_ref().map(|(_, eid)| eid.clone());
+                            match msg.content {
+                                JupyterMessageContent::ExecuteReply(ref reply) => {
+                                    let cell_entry: Option<(String, String)> =
+                                        msg.parent_header.as_ref().and_then(|h| {
+                                            shell_cell_id_map.lock().ok()?.get(&h.msg_id).cloned()
+                                        });
+                                    let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
+                                    let execution_id =
+                                        cell_entry.as_ref().map(|(_, eid)| eid.clone());
 
-                                // Process page payloads
-                                if let Some(ref cid) = cell_id {
-                                    for payload in &reply.payload {
-                                        if let jupyter_protocol::Payload::Page { data, .. } =
-                                            payload
-                                        {
-                                            let nbformat_value = media_to_display_data(data);
-
-                                            let manifest_json = match output_store::create_manifest(
-                                                &nbformat_value,
-                                                &shell_blob_store,
-                                                DEFAULT_INLINE_THRESHOLD,
-                                            )
-                                            .await
+                                    // Process page payloads
+                                    if let Some(ref cid) = cell_id {
+                                        for payload in &reply.payload {
+                                            if let jupyter_protocol::Payload::Page {
+                                                data, ..
+                                            } = payload
                                             {
-                                                Ok(manifest) => manifest.to_json(),
-                                                Err(e) => {
-                                                    warn!(
+                                                let nbformat_value = media_to_display_data(data);
+
+                                                let manifest_json =
+                                                    match output_store::create_manifest(
+                                                        &nbformat_value,
+                                                        &shell_blob_store,
+                                                        DEFAULT_INLINE_THRESHOLD,
+                                                    )
+                                                    .await
+                                                    {
+                                                        Ok(manifest) => manifest.to_json(),
+                                                        Err(e) => {
+                                                            warn!(
                                                             "[jupyter-kernel] Failed to create page manifest: {}",
                                                             e
                                                         );
-                                                    nbformat_value.clone()
-                                                }
-                                            };
+                                                            nbformat_value.clone()
+                                                        }
+                                                    };
 
-                                            let eid = execution_id.clone().unwrap_or_default();
-                                            let mut fork = {
-                                                let mut sd = shell_state_doc.write().await;
-                                                sd.fork_with_actor(&shell_actor_id)
-                                            };
+                                                let eid = execution_id.clone().unwrap_or_default();
+                                                let mut fork = {
+                                                    let mut sd = shell_state_doc.write().await;
+                                                    sd.fork_with_actor(&shell_actor_id)
+                                                };
 
-                                            if let Err(e) = fork.append_output(&eid, &manifest_json)
-                                            {
-                                                warn!(
+                                                if let Err(e) =
+                                                    fork.append_output(&eid, &manifest_json)
+                                                {
+                                                    warn!(
                                                     "[jupyter-kernel] Failed to append page output to state doc: {}",
                                                     e
                                                 );
-                                            }
+                                                }
 
-                                            let merge_ok = {
-                                                let mut sd = shell_state_doc.write().await;
-                                                if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
+                                                let merge_ok = {
+                                                    let mut sd = shell_state_doc.write().await;
+                                                    if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
                                                     "shell-output-merge",
                                                     || sd.merge(&mut fork),
                                                 ) {
@@ -1696,47 +1763,48 @@ impl KernelConnection for JupyterKernel {
                                                         shell_state_changed_tx.send(());
                                                     true
                                                 }
-                                            };
+                                                };
 
-                                            if merge_ok {
-                                                let _ = shell_broadcast_tx.send(
-                                                    NotebookBroadcast::Output {
-                                                        cell_id: cid.clone(),
-                                                        execution_id: execution_id
-                                                            .clone()
-                                                            .unwrap_or_default(),
-                                                        output_type: "display_data".to_string(),
-                                                        output_json: manifest_json.to_string(),
-                                                        output_index: None,
-                                                    },
-                                                );
+                                                if merge_ok {
+                                                    let _ = shell_broadcast_tx.send(
+                                                        NotebookBroadcast::Output {
+                                                            cell_id: cid.clone(),
+                                                            execution_id: execution_id
+                                                                .clone()
+                                                                .unwrap_or_default(),
+                                                            output_type: "display_data".to_string(),
+                                                            output_json: manifest_json.to_string(),
+                                                            output_index: None,
+                                                        },
+                                                    );
+                                                }
                                             }
                                         }
                                     }
-                                }
 
-                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
-                                    if let Some(ref cid) = cell_id {
-                                        let _ = shell_broadcast_tx.send(
-                                            NotebookBroadcast::ExecutionDone {
-                                                cell_id: cid.clone(),
-                                                execution_id: execution_id
-                                                    .clone()
-                                                    .unwrap_or_default(),
-                                            },
-                                        );
+                                    if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                        if let Some(ref cid) = cell_id {
+                                            let _ = shell_broadcast_tx.send(
+                                                NotebookBroadcast::ExecutionDone {
+                                                    cell_id: cid.clone(),
+                                                    execution_id: execution_id
+                                                        .clone()
+                                                        .unwrap_or_default(),
+                                                },
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                            JupyterMessageContent::HistoryReply(ref reply) => {
-                                if let Some(ref parent) = msg.parent_header {
-                                    let msg_id = &parent.msg_id;
-                                    if let Ok(mut pending) = shell_pending_history.lock() {
-                                        if let Some(tx) = pending.remove(msg_id) {
-                                            let entries: Vec<HistoryEntry> = reply
-                                                .history
-                                                .iter()
-                                                .map(|item| match item {
+                                JupyterMessageContent::HistoryReply(ref reply) => {
+                                    if let Some(ref parent) = msg.parent_header {
+                                        let msg_id = &parent.msg_id;
+                                        if let Ok(mut pending) = shell_pending_history.lock() {
+                                            if let Some(tx) = pending.remove(msg_id) {
+                                                let entries: Vec<HistoryEntry> = reply
+                                                    .history
+                                                    .iter()
+                                                    .map(|item| {
+                                                        match item {
                                                     jupyter_protocol::HistoryEntry::Input(
                                                         session,
                                                         line,
@@ -1755,96 +1823,108 @@ impl KernelConnection for JupyterKernel {
                                                         line: *line as i32,
                                                         source: source.clone(),
                                                     },
-                                                })
-                                                .collect();
+                                                }
+                                                    })
+                                                    .collect();
 
-                                            debug!(
+                                                debug!(
                                                 "[jupyter-kernel] Resolved history request: {} entries",
                                                 entries.len()
                                             );
-                                            let _ = tx.send(entries);
+                                                let _ = tx.send(entries);
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            JupyterMessageContent::CompleteReply(ref reply) => {
-                                if let Some(ref parent) = msg.parent_header {
-                                    let msg_id = &parent.msg_id;
-                                    if let Ok(mut pending) = shell_pending_completions.lock() {
-                                        if let Some(tx) = pending.remove(msg_id) {
-                                            let items: Vec<CompletionItem> = reply
-                                                .matches
-                                                .iter()
-                                                .map(|m| CompletionItem {
-                                                    label: m.clone(),
-                                                    kind: None,
-                                                    detail: None,
-                                                    source: Some("kernel".to_string()),
-                                                })
-                                                .collect();
+                                JupyterMessageContent::CompleteReply(ref reply) => {
+                                    if let Some(ref parent) = msg.parent_header {
+                                        let msg_id = &parent.msg_id;
+                                        if let Ok(mut pending) = shell_pending_completions.lock() {
+                                            if let Some(tx) = pending.remove(msg_id) {
+                                                let items: Vec<CompletionItem> = reply
+                                                    .matches
+                                                    .iter()
+                                                    .map(|m| CompletionItem {
+                                                        label: m.clone(),
+                                                        kind: None,
+                                                        detail: None,
+                                                        source: Some("kernel".to_string()),
+                                                    })
+                                                    .collect();
 
-                                            debug!(
+                                                debug!(
                                                 "[jupyter-kernel] Resolved completion request: {} items",
                                                 items.len()
                                             );
-                                            let _ = tx.send((
-                                                items,
-                                                reply.cursor_start,
-                                                reply.cursor_end,
-                                            ));
+                                                let _ = tx.send((
+                                                    items,
+                                                    reply.cursor_start,
+                                                    reply.cursor_end,
+                                                ));
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            _ => {
-                                debug!(
-                                    "[jupyter-kernel] shell reply: type={}",
-                                    msg.header.msg_type
-                                );
+                                _ => {
+                                    debug!(
+                                        "[jupyter-kernel] shell reply: type={}",
+                                        msg.header.msg_type
+                                    );
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        error!("[jupyter-kernel] shell read error: {}", e);
-                        break;
+                        Err(e) => {
+                            error!("[jupyter-kernel] shell read error: {}", e);
+                            break;
+                        }
                     }
                 }
-            }
-        });
+            },
+            move |_| {
+                let _ = shell_panic_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+        );
 
         // ── Heartbeat monitor ────────────────────────────────────────────
 
         let hb_cmd_tx = cmd_tx.clone();
+        let hb_panic_cmd_tx = cmd_tx.clone();
         let hb_conn_info = connection_info.clone();
-        let heartbeat_task = tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-            loop {
+        let heartbeat_task = spawn_supervised(
+            "heartbeat",
+            async move {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-                let check = async {
-                    let mut hb =
-                        runtimelib::create_client_heartbeat_connection(&hb_conn_info).await?;
-                    hb.single_heartbeat().await
-                };
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-                match tokio::time::timeout(std::time::Duration::from_secs(3), check).await {
-                    Ok(Ok(())) => {
-                        // Kernel is alive
-                    }
-                    Ok(Err(e)) => {
-                        warn!("[jupyter-kernel] Heartbeat connection error: {}", e);
-                        let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
-                        break;
-                    }
-                    Err(_) => {
-                        warn!("[jupyter-kernel] Heartbeat timeout, kernel unresponsive");
-                        let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
-                        break;
+                    let check = async {
+                        let mut hb =
+                            runtimelib::create_client_heartbeat_connection(&hb_conn_info).await?;
+                        hb.single_heartbeat().await
+                    };
+
+                    match tokio::time::timeout(std::time::Duration::from_secs(3), check).await {
+                        Ok(Ok(())) => {
+                            // Kernel is alive
+                        }
+                        Ok(Err(e)) => {
+                            warn!("[jupyter-kernel] Heartbeat connection error: {}", e);
+                            let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
+                            break;
+                        }
+                        Err(_) => {
+                            warn!("[jupyter-kernel] Heartbeat timeout, kernel unresponsive");
+                            let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
+                            break;
+                        }
                     }
                 }
-            }
-        });
+            },
+            move |_| {
+                let _ = hb_panic_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+        );
 
         // ── Coalesced comm state writer ──────────────────────────────────
 
@@ -1859,54 +1939,61 @@ impl KernelConnection for JupyterKernel {
         // doc's default actor (`runtimed:state`) and the filter lets
         // them through, re-triggering the amplification loop.
         let coalesce_actor_id = format!("{kernel_actor_id}:coalesce");
-        let comm_coalesce_task = tokio::spawn(async move {
-            let mut pending: HashMap<String, serde_json::Value> = HashMap::new();
-            let mut timer = tokio::time::interval(std::time::Duration::from_millis(16));
-            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let coalesce_panic_cmd_tx = cmd_tx.clone();
+        let comm_coalesce_task = spawn_supervised(
+            "comm-coalesce",
+            async move {
+                let mut pending: HashMap<String, serde_json::Value> = HashMap::new();
+                let mut timer = tokio::time::interval(std::time::Duration::from_millis(16));
+                timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-            loop {
-                tokio::select! {
-                    msg = coalesce_rx.recv() => {
-                        match msg {
-                            Some((comm_id, delta)) => {
-                                let entry = pending.entry(comm_id)
-                                    .or_insert_with(|| serde_json::json!({}));
-                                if let (Some(existing), Some(new)) =
-                                    (entry.as_object_mut(), delta.as_object())
-                                {
-                                    for (k, v) in new {
-                                        existing.insert(k.clone(), v.clone());
+                loop {
+                    tokio::select! {
+                        msg = coalesce_rx.recv() => {
+                            match msg {
+                                Some((comm_id, delta)) => {
+                                    let entry = pending.entry(comm_id)
+                                        .or_insert_with(|| serde_json::json!({}));
+                                    if let (Some(existing), Some(new)) =
+                                        (entry.as_object_mut(), delta.as_object())
+                                    {
+                                        for (k, v) in new {
+                                            existing.insert(k.clone(), v.clone());
+                                        }
                                     }
                                 }
+                                None => break,
                             }
-                            None => break,
                         }
-                    }
-                    _ = timer.tick() => {
-                        if pending.is_empty() {
-                            continue;
-                        }
-                        let mut batch = std::mem::take(&mut pending);
-                        for delta in batch.values_mut() {
-                            *delta = blob_store_large_state_values(delta, &coalesce_blob_store).await;
-                        }
-                        let mut sd = coalesce_state_doc.write().await;
-                        let mut any_changed = false;
-                        sd.fork_and_merge(|f| {
-                            f.set_actor(&coalesce_actor_id);
-                            for (comm_id, delta) in &batch {
-                                if f.merge_comm_state_delta(comm_id, delta) {
-                                    any_changed = true;
+                        _ = timer.tick() => {
+                            if pending.is_empty() {
+                                continue;
+                            }
+                            let mut batch = std::mem::take(&mut pending);
+                            for delta in batch.values_mut() {
+                                *delta = blob_store_large_state_values(delta, &coalesce_blob_store).await;
+                            }
+                            let mut sd = coalesce_state_doc.write().await;
+                            let mut any_changed = false;
+                            sd.fork_and_merge(|f| {
+                                f.set_actor(&coalesce_actor_id);
+                                for (comm_id, delta) in &batch {
+                                    if f.merge_comm_state_delta(comm_id, delta) {
+                                        any_changed = true;
+                                    }
                                 }
+                            });
+                            if any_changed {
+                                let _ = coalesce_state_changed.send(());
                             }
-                        });
-                        if any_changed {
-                            let _ = coalesce_state_changed.send(());
                         }
                     }
                 }
-            }
-        });
+            },
+            move |_| {
+                let _ = coalesce_panic_cmd_tx.try_send(QueueCommand::KernelDied);
+            },
+        );
 
         // ── Construct the kernel struct ──────────────────────────────────
 

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -41,7 +41,7 @@ pub mod runtime_agent_handle;
 pub mod singleton;
 pub mod stream_terminal;
 pub mod sync_server;
-pub(crate) mod task_supervisor;
+pub mod task_supervisor;
 pub mod terminal_size;
 
 /// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -41,6 +41,7 @@ pub mod runtime_agent_handle;
 pub mod singleton;
 pub mod stream_terminal;
 pub mod sync_server;
+pub(crate) mod task_supervisor;
 pub mod terminal_size;
 
 /// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -12,6 +12,7 @@ use clap::{Parser, Subcommand};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
+use runtimed::task_supervisor::spawn_best_effort;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -436,7 +437,7 @@ async fn run_daemon(
         use tokio::signal::unix::{signal, SignalKind};
         let shutdown_daemon = daemon.clone();
 
-        tokio::spawn(async move {
+        spawn_best_effort("signal-handler", async move {
             #[allow(clippy::expect_used)]
             // Signal registration failure is a fundamental OS issue with no recovery
             let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM");

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -12,7 +12,6 @@ use clap::{Parser, Subcommand};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
-use runtimed::task_supervisor::spawn_best_effort;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -437,7 +436,7 @@ async fn run_daemon(
         use tokio::signal::unix::{signal, SignalKind};
         let shutdown_daemon = daemon.clone();
 
-        spawn_best_effort("signal-handler", async move {
+        runtimed::task_supervisor::spawn_best_effort("signal-handler", async move {
             #[allow(clippy::expect_used)]
             // Signal registration failure is a fundamental OS issue with no recovery
             let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM");

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -8127,7 +8127,7 @@ fn spawn_autosave_debouncer_with_config(
     config: AutosaveDebouncerConfig,
 ) {
     let mut changed_rx = room.changed_tx.subscribe();
-    tokio::spawn(async move {
+    spawn_best_effort("autosave-debouncer", async move {
         use std::time::Duration;
         use tokio::time::{interval, Instant, MissedTickBehavior};
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -71,13 +71,7 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     match std::panic::catch_unwind(AssertUnwindSafe(f)) {
         Ok(val) => Ok(val),
         Err(payload) => {
-            let msg = if let Some(s) = payload.downcast_ref::<String>() {
-                s.clone()
-            } else if let Some(s) = payload.downcast_ref::<&str>() {
-                s.to_string()
-            } else {
-                "unknown panic".to_string()
-            };
+            let msg = crate::task_supervisor::panic_payload_to_string(payload);
             Err(format!(
                 "[{label}] automerge panicked (upstream bug, see automerge collector.rs MissingOps): {msg}"
             ))

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -46,13 +46,31 @@ use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::protocol::{
     EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
-use crate::task_supervisor::spawn_best_effort;
+use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use notebook_doc::diff::diff_metadata_touched;
 use notebook_doc::presence::{self, PresenceState};
 use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
 
 mod path_index;
 pub use path_index::{PathIndex, PathIndexError};
+
+/// Global shutdown trigger registered by the daemon at startup.
+///
+/// Used by `spawn_supervised` callbacks in debouncers (autosave, persist) that
+/// don't have `Arc<Daemon>` in scope. The daemon calls `register_shutdown_trigger`
+/// once; on_panic handlers call `trigger_global_shutdown` to signal data-loss risk.
+static SHUTDOWN_TRIGGER: std::sync::OnceLock<Arc<dyn Fn() + Send + Sync>> =
+    std::sync::OnceLock::new();
+
+pub fn register_shutdown_trigger(trigger: Arc<dyn Fn() + Send + Sync>) {
+    let _ = SHUTDOWN_TRIGGER.set(trigger);
+}
+
+fn trigger_global_shutdown() {
+    if let Some(trigger) = SHUTDOWN_TRIGGER.get() {
+        (trigger)();
+    }
+}
 
 /// Capacity for the per-room kernel broadcast channel. Sized to absorb bursts
 /// of output messages (e.g. fast-printing cells) so slower peers trigger a
@@ -2036,18 +2054,31 @@ where
             }
             // Spawn auto-launch in background so we don't block sync
             let room_clone = room.clone();
+            let panic_room = room.clone();
             let notebook_id_clone = notebook_id.clone();
             let daemon_clone = daemon.clone();
-            spawn_best_effort("auto-launch-kernel", async move {
-                auto_launch_kernel(
-                    &room_clone,
-                    &notebook_id_clone,
-                    default_runtime,
-                    default_python_env,
-                    daemon_clone,
-                )
-                .await;
-            });
+            spawn_supervised(
+                "auto-launch-kernel",
+                async move {
+                    auto_launch_kernel(
+                        &room_clone,
+                        &notebook_id_clone,
+                        default_runtime,
+                        default_python_env,
+                        daemon_clone,
+                    )
+                    .await;
+                },
+                move |_| {
+                    let r = panic_room;
+                    tokio::spawn(async move {
+                        let mut sd = r.state_doc.write().await;
+                        sd.set_kernel_status("error");
+                        sd.set_starting_phase("");
+                        let _ = r.state_changed_tx.send(());
+                    });
+                },
+            );
         } else if !has_kernel
             && matches!(
                 trust_status,
@@ -7999,98 +8030,104 @@ fn spawn_persist_debouncer_with_config(
     persist_path: PathBuf,
     config: PersistDebouncerConfig,
 ) {
-    spawn_best_effort("persist-debouncer", async move {
-        use std::time::Duration;
-        use tokio::time::{interval, Instant, MissedTickBehavior};
+    spawn_supervised(
+        "persist-debouncer",
+        async move {
+            use std::time::Duration;
+            use tokio::time::{interval, Instant, MissedTickBehavior};
 
-        let debounce_duration = Duration::from_millis(config.debounce_ms);
-        let max_flush_interval = Duration::from_millis(config.max_interval_ms);
+            let debounce_duration = Duration::from_millis(config.debounce_ms);
+            let max_flush_interval = Duration::from_millis(config.max_interval_ms);
 
-        let mut last_receive: Option<Instant> = None;
-        let mut last_flush: Option<Instant> = None;
+            let mut last_receive: Option<Instant> = None;
+            let mut last_flush: Option<Instant> = None;
 
-        // Persistent interval - fires regularly regardless of how often changed() fires.
-        // This ensures we always check debounce/max-interval even during rapid updates.
-        let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
-        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            // Persistent interval - fires regularly regardless of how often changed() fires.
+            // This ensures we always check debounce/max-interval even during rapid updates.
+            let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
+            check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        loop {
-            tokio::select! {
-                result = persist_rx.changed() => {
-                    if result.is_err() {
-                        // Channel closed - flush any pending data and exit
-                        let bytes = persist_rx.borrow().clone();
-                        if let Some(data) = bytes {
-                            do_persist(&data, &persist_path);
-                        }
-                        break;
-                    }
-                    last_receive = Some(Instant::now());
-                }
-                maybe_req = flush_rx.recv() => {
-                    match maybe_req {
-                        Some(ack) => {
-                            // Eviction (or another caller) wants a synchronous flush.
-                            // Write the latest doc bytes, then ack with the write
-                            // result so the caller knows whether the file is
-                            // current. No pending bytes = nothing to write = ack true
-                            // (the file either doesn't exist or already reflects
-                            // the latest state).
-                            let bytes = persist_rx.borrow().clone();
-                            let ok = if let Some(data) = bytes {
-                                let write_ok = do_persist(&data, &persist_path);
-                                if write_ok {
-                                    last_flush = Some(Instant::now());
-                                    last_receive = None;
-                                }
-                                write_ok
-                            } else {
-                                true
-                            };
-                            // Receiver may have dropped (eviction timed out); ignore.
-                            let _ = ack.send(ok);
-                        }
-                        None => {
-                            // All flush senders dropped. The room is being torn
-                            // down; the watch receiver will close next and we'll
-                            // hit the shutdown flush on the persist_rx.changed()
-                            // Err arm. Break defensively to avoid hot-looping if
-                            // that somehow doesn't fire (we still want to flush
-                            // any pending bytes first).
+            loop {
+                tokio::select! {
+                    result = persist_rx.changed() => {
+                        if result.is_err() {
+                            // Channel closed - flush any pending data and exit
                             let bytes = persist_rx.borrow().clone();
                             if let Some(data) = bytes {
                                 do_persist(&data, &persist_path);
                             }
                             break;
                         }
+                        last_receive = Some(Instant::now());
                     }
-                }
-                _ = check_interval.tick() => {
-                    // Check if we should flush based on debounce or max interval
-                    let should_flush = if let Some(recv) = last_receive {
-                        // Debounce: 500ms quiet period since last receive
-                        let debounce_ready = recv.elapsed() >= debounce_duration;
-                        // Max interval: 5s since last flush (or since first receive)
-                        let max_interval_ready = last_flush
-                            .map(|f| f.elapsed() >= max_flush_interval)
-                            .unwrap_or(recv.elapsed() >= max_flush_interval);
-                        debounce_ready || max_interval_ready
-                    } else {
-                        false
-                    };
+                    maybe_req = flush_rx.recv() => {
+                        match maybe_req {
+                            Some(ack) => {
+                                // Eviction (or another caller) wants a synchronous flush.
+                                // Write the latest doc bytes, then ack with the write
+                                // result so the caller knows whether the file is
+                                // current. No pending bytes = nothing to write = ack true
+                                // (the file either doesn't exist or already reflects
+                                // the latest state).
+                                let bytes = persist_rx.borrow().clone();
+                                let ok = if let Some(data) = bytes {
+                                    let write_ok = do_persist(&data, &persist_path);
+                                    if write_ok {
+                                        last_flush = Some(Instant::now());
+                                        last_receive = None;
+                                    }
+                                    write_ok
+                                } else {
+                                    true
+                                };
+                                // Receiver may have dropped (eviction timed out); ignore.
+                                let _ = ack.send(ok);
+                            }
+                            None => {
+                                // All flush senders dropped. The room is being torn
+                                // down; the watch receiver will close next and we'll
+                                // hit the shutdown flush on the persist_rx.changed()
+                                // Err arm. Break defensively to avoid hot-looping if
+                                // that somehow doesn't fire (we still want to flush
+                                // any pending bytes first).
+                                let bytes = persist_rx.borrow().clone();
+                                if let Some(data) = bytes {
+                                    do_persist(&data, &persist_path);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    _ = check_interval.tick() => {
+                        // Check if we should flush based on debounce or max interval
+                        let should_flush = if let Some(recv) = last_receive {
+                            // Debounce: 500ms quiet period since last receive
+                            let debounce_ready = recv.elapsed() >= debounce_duration;
+                            // Max interval: 5s since last flush (or since first receive)
+                            let max_interval_ready = last_flush
+                                .map(|f| f.elapsed() >= max_flush_interval)
+                                .unwrap_or(recv.elapsed() >= max_flush_interval);
+                            debounce_ready || max_interval_ready
+                        } else {
+                            false
+                        };
 
-                    if should_flush {
-                        let bytes = persist_rx.borrow().clone();
-                        if let Some(data) = bytes {
-                            do_persist(&data, &persist_path);
-                            last_flush = Some(Instant::now());
-                            last_receive = None;
+                        if should_flush {
+                            let bytes = persist_rx.borrow().clone();
+                            if let Some(data) = bytes {
+                                do_persist(&data, &persist_path);
+                                last_flush = Some(Instant::now());
+                                last_receive = None;
+                            }
                         }
                     }
                 }
             }
-        }
-    });
+        },
+        |_| {
+            trigger_global_shutdown();
+        },
+    );
 }
 
 /// Configuration for the autosave debouncer (testable).
@@ -8127,106 +8164,112 @@ fn spawn_autosave_debouncer_with_config(
     config: AutosaveDebouncerConfig,
 ) {
     let mut changed_rx = room.changed_tx.subscribe();
-    spawn_best_effort("autosave-debouncer", async move {
-        use std::time::Duration;
-        use tokio::time::{interval, Instant, MissedTickBehavior};
+    spawn_supervised(
+        "autosave-debouncer",
+        async move {
+            use std::time::Duration;
+            use tokio::time::{interval, Instant, MissedTickBehavior};
 
-        let debounce_duration = Duration::from_millis(config.debounce_ms);
-        let max_flush_interval = Duration::from_millis(config.max_interval_ms);
+            let debounce_duration = Duration::from_millis(config.debounce_ms);
+            let max_flush_interval = Duration::from_millis(config.max_interval_ms);
 
-        let mut last_receive: Option<Instant> = None;
-        let mut last_flush: Option<Instant> = None;
+            let mut last_receive: Option<Instant> = None;
+            let mut last_flush: Option<Instant> = None;
 
-        let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
-        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
+            check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        loop {
-            tokio::select! {
-                result = changed_rx.recv() => {
-                    match result {
-                        Ok(()) => {
-                            last_receive = Some(Instant::now());
-                        }
-                        Err(broadcast::error::RecvError::Closed) => {
-                            // Room is being evicted — do a final autosave
-                            if !is_untitled_notebook(&notebook_id)
-                                && !room.is_loading.load(Ordering::Acquire)
-                            {
-                                match save_notebook_to_disk(&room, None).await {
-                                    Ok(path) => {
-                                        info!("[autosave] Final save on room close: {}", path);
-                                    }
-                                    Err(e) => {
-                                        warn!("[autosave] Final save failed: {}", e);
+            loop {
+                tokio::select! {
+                    result = changed_rx.recv() => {
+                        match result {
+                            Ok(()) => {
+                                last_receive = Some(Instant::now());
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                // Room is being evicted — do a final autosave
+                                if !is_untitled_notebook(&notebook_id)
+                                    && !room.is_loading.load(Ordering::Acquire)
+                                {
+                                    match save_notebook_to_disk(&room, None).await {
+                                        Ok(path) => {
+                                            info!("[autosave] Final save on room close: {}", path);
+                                        }
+                                        Err(e) => {
+                                            warn!("[autosave] Final save failed: {}", e);
+                                        }
                                     }
                                 }
-                            }
-                            break;
-                        }
-                        Err(broadcast::error::RecvError::Lagged(n)) => {
-                            // Missed some updates, treat as a change
-                            debug!("[autosave] Lagged {} messages", n);
-                            last_receive = Some(Instant::now());
-                        }
-                    }
-                }
-                _ = check_interval.tick() => {
-                    let should_flush = if let Some(recv) = last_receive {
-                        let debounce_ready = recv.elapsed() >= debounce_duration;
-                        let max_interval_ready = last_flush
-                            .map(|f| f.elapsed() >= max_flush_interval)
-                            .unwrap_or(recv.elapsed() >= max_flush_interval);
-                        debounce_ready || max_interval_ready
-                    } else {
-                        false
-                    };
-
-                    if should_flush {
-                        // Skip during initial load
-                        if room.is_loading.load(Ordering::Acquire) {
-                            continue;
-                        }
-
-                        match save_notebook_to_disk(&room, None).await {
-                            Ok(path) => {
-                                debug!("[autosave] Saved {}", path);
-                                last_flush = Some(Instant::now());
-
-                                // Check if changes arrived during the save. If so,
-                                // keep last_receive set so we flush again soon —
-                                // don't broadcast "clean" when the file is already stale.
-                                let changed_during_save =
-                                    matches!(changed_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
-                                if changed_during_save {
-                                    last_receive = Some(Instant::now());
-                                } else {
-                                    last_receive = None;
-                                    // Broadcast to connected clients so they can clear dirty state
-                                    let _ = room.kernel_broadcast_tx.send(
-                                        NotebookBroadcast::NotebookAutosaved {
-                                            path,
-                                        },
-                                    );
-                                }
-                            }
-                            Err(ref e @ SaveError::Unrecoverable(_)) => {
-                                error!(
-                                    "[autosave] Unrecoverable save error, disabling autosave for {}: {}",
-                                    notebook_id, e
-                                );
                                 break;
                             }
-                            Err(e) => {
-                                warn!("[autosave] Failed to save: {}", e);
-                                // Keep last_receive set so we retry on next interval
-                                last_flush = Some(Instant::now());
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                // Missed some updates, treat as a change
+                                debug!("[autosave] Lagged {} messages", n);
+                                last_receive = Some(Instant::now());
+                            }
+                        }
+                    }
+                    _ = check_interval.tick() => {
+                        let should_flush = if let Some(recv) = last_receive {
+                            let debounce_ready = recv.elapsed() >= debounce_duration;
+                            let max_interval_ready = last_flush
+                                .map(|f| f.elapsed() >= max_flush_interval)
+                                .unwrap_or(recv.elapsed() >= max_flush_interval);
+                            debounce_ready || max_interval_ready
+                        } else {
+                            false
+                        };
+
+                        if should_flush {
+                            // Skip during initial load
+                            if room.is_loading.load(Ordering::Acquire) {
+                                continue;
+                            }
+
+                            match save_notebook_to_disk(&room, None).await {
+                                Ok(path) => {
+                                    debug!("[autosave] Saved {}", path);
+                                    last_flush = Some(Instant::now());
+
+                                    // Check if changes arrived during the save. If so,
+                                    // keep last_receive set so we flush again soon —
+                                    // don't broadcast "clean" when the file is already stale.
+                                    let changed_during_save =
+                                        matches!(changed_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
+                                    if changed_during_save {
+                                        last_receive = Some(Instant::now());
+                                    } else {
+                                        last_receive = None;
+                                        // Broadcast to connected clients so they can clear dirty state
+                                        let _ = room.kernel_broadcast_tx.send(
+                                            NotebookBroadcast::NotebookAutosaved {
+                                                path,
+                                            },
+                                        );
+                                    }
+                                }
+                                Err(ref e @ SaveError::Unrecoverable(_)) => {
+                                    error!(
+                                        "[autosave] Unrecoverable save error, disabling autosave for {}: {}",
+                                        notebook_id, e
+                                    );
+                                    break;
+                                }
+                                Err(e) => {
+                                    warn!("[autosave] Failed to save: {}", e);
+                                    // Keep last_receive set so we retry on next interval
+                                    last_flush = Some(Instant::now());
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-    });
+        },
+        |_| {
+            trigger_global_shutdown();
+        },
+    );
 }
 
 /// Actually persist bytes to disk, logging if it takes too long.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -46,6 +46,7 @@ use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::protocol::{
     EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
+use crate::task_supervisor::spawn_best_effort;
 use notebook_doc::diff::diff_metadata_touched;
 use notebook_doc::presence::{self, PresenceState};
 use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
@@ -2037,7 +2038,7 @@ where
             let room_clone = room.clone();
             let notebook_id_clone = notebook_id.clone();
             let daemon_clone = daemon.clone();
-            tokio::spawn(async move {
+            spawn_best_effort("auto-launch-kernel", async move {
                 auto_launch_kernel(
                     &room_clone,
                     &notebook_id_clone,
@@ -2133,7 +2134,7 @@ where
             eviction_delay
         );
 
-        tokio::spawn(async move {
+        spawn_best_effort("room-eviction", async move {
             // Outer loop wraps the eviction attempt so a flush timeout can
             // back off and retry rather than leak the room (and any attached
             // kernel / watcher) indefinitely. The loop exits either by
@@ -6011,7 +6012,7 @@ async fn handle_notebook_request(
                     let room_clone = Arc::clone(room);
                     let cell_id_clone = cell_id.clone();
                     let source_clone = source.clone();
-                    tokio::spawn(async move {
+                    spawn_best_effort("cell-formatter", async move {
                         if let Some(runtime) = detect_room_runtime(&room_clone).await {
                             if let Some(formatted) = format_source(&source_clone, &runtime).await {
                                 // Actor is assigned here (not via fork_with_actor)
@@ -7998,7 +7999,7 @@ fn spawn_persist_debouncer_with_config(
     persist_path: PathBuf,
     config: PersistDebouncerConfig,
 ) {
-    tokio::spawn(async move {
+    spawn_best_effort("persist-debouncer", async move {
         use std::time::Duration;
         use tokio::time::{interval, Instant, MissedTickBehavior};
 
@@ -9589,7 +9590,7 @@ pub(crate) fn spawn_notebook_file_watcher(
 ) -> oneshot::Sender<()> {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
-    tokio::spawn(async move {
+    spawn_best_effort("notebook-file-watcher", async move {
         // Determine what path to watch
         let watch_path = if notebook_path.exists() {
             notebook_path.clone()

--- a/crates/runtimed/src/runtime_agent_handle.rs
+++ b/crates/runtimed/src/runtime_agent_handle.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use tracing::{info, warn};
 
+use crate::task_supervisor::spawn_supervised;
+
 /// Handle to a running runtime agent subprocess.
 ///
 /// The runtime agent connects back to the daemon's Unix socket as a peer.
@@ -84,24 +86,31 @@ impl RuntimeAgentHandle {
 
         // Monitor child process exit
         let alive_clone = alive.clone();
+        let panic_alive = alive.clone();
         let runtime_agent_id_clone = runtime_agent_id.clone();
-        tokio::spawn(async move {
-            match child.wait().await {
-                Ok(status) => {
-                    info!(
-                        "[runtime-agent-handle] Runtime agent {} exited with status: {}",
-                        runtime_agent_id_clone, status
-                    );
+        spawn_supervised(
+            "runtime-agent-watcher",
+            async move {
+                match child.wait().await {
+                    Ok(status) => {
+                        info!(
+                            "[runtime-agent-handle] Runtime agent {} exited with status: {}",
+                            runtime_agent_id_clone, status
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[runtime-agent-handle] Runtime agent {} wait error: {}",
+                            runtime_agent_id_clone, e
+                        );
+                    }
                 }
-                Err(e) => {
-                    warn!(
-                        "[runtime-agent-handle] Runtime agent {} wait error: {}",
-                        runtime_agent_id_clone, e
-                    );
-                }
-            }
-            alive_clone.store(false, Ordering::Relaxed);
-        });
+                alive_clone.store(false, Ordering::Relaxed);
+            },
+            move |_| {
+                panic_alive.store(false, Ordering::Relaxed);
+            },
+        );
 
         Ok(Self {
             alive,

--- a/crates/runtimed/src/task_supervisor.rs
+++ b/crates/runtimed/src/task_supervisor.rs
@@ -1,0 +1,123 @@
+use std::any::Any;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use futures::FutureExt;
+use tokio::task::JoinHandle;
+
+pub struct PanicInfo {
+    pub label: &'static str,
+    pub message: String,
+}
+
+pub fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+pub fn spawn_supervised<F, P>(label: &'static str, fut: F, on_panic: P) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+    P: FnOnce(&PanicInfo) + Send + 'static,
+{
+    tokio::spawn(async move {
+        if let Err(payload) = AssertUnwindSafe(fut).catch_unwind().await {
+            let message = panic_payload_to_string(payload);
+            let info = PanicInfo { label, message };
+            tracing::error!(
+                "[task-supervisor] '{}' panicked: {}",
+                info.label,
+                info.message
+            );
+            // Defense-in-depth: on_panic must not itself panic.
+            if let Err(callback_payload) =
+                std::panic::catch_unwind(AssertUnwindSafe(|| on_panic(&info)))
+            {
+                let msg = panic_payload_to_string(callback_payload);
+                tracing::error!(
+                    "[task-supervisor] on_panic callback for '{}' panicked: {}",
+                    label,
+                    msg
+                );
+            }
+        }
+    })
+}
+
+pub fn spawn_best_effort<F>(label: &'static str, fut: F) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    spawn_supervised(label, fut, |_| {})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_spawn_best_effort_normal() {
+        let handle = spawn_best_effort("test-normal", async {});
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_spawn_best_effort_panic() {
+        let handle = spawn_best_effort("test-panic", async {
+            panic!("intentional test panic");
+        });
+        // Panic is caught internally — JoinHandle resolves Ok
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_spawn_supervised_calls_on_panic() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let handle = spawn_supervised(
+            "test-supervised",
+            async { panic!("supervised panic") },
+            move |info| {
+                assert_eq!(info.label, "test-supervised");
+                assert!(info.message.contains("supervised panic"));
+                called_clone.store(true, Ordering::Relaxed);
+            },
+        );
+        handle.await.unwrap();
+        assert!(called.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_supervised_no_panic() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let handle = spawn_supervised("test-no-panic", async {}, move |_| {
+            called_clone.store(true, Ordering::Relaxed);
+        });
+        handle.await.unwrap();
+        assert!(!called.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_supervised_abort() {
+        let handle = spawn_supervised(
+            "test-abort",
+            async {
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            },
+            |_| {},
+        );
+        handle.abort();
+        // Aborted task resolves to Err(JoinError::cancelled)
+        assert!(handle.await.unwrap_err().is_cancelled());
+    }
+}

--- a/docs/superpowers/plans/2026-04-19-spawn-panic-handling-implementation.md
+++ b/docs/superpowers/plans/2026-04-19-spawn-panic-handling-implementation.md
@@ -2,7 +2,7 @@
 
 Date: 2026-04-19
 Design doc: PR #1926 (`docs/superpowers/plans/2026-04-19-spawn-panic-handling.md`)
-Status: Implementation plan — pending review.
+Status: Implementation plan — approved with revisions (see § Review Feedback).
 
 ## Context
 
@@ -69,8 +69,10 @@ impl Drop for WarmingGuard {
 }
 ```
 
-Using `tokio::spawn` in Drop is safe: we're inside a spawned task on the
-multi-threaded runtime, and during shutdown pool accounting is irrelevant.
+Using `tokio::spawn` in Drop is safe on the multi-threaded runtime. During
+shutdown, pool accounting is irrelevant — the guard checks
+`daemon.is_shutting_down()` and skips the spawn if the runtime is winding
+down (review feedback item #1).
 
 **Files modified:**
 - `crates/runtimed/src/daemon.rs`
@@ -165,7 +167,7 @@ JoinHandle usage for `.abort()` is preserved since `spawn_supervised` returns
 | Site | File:Line | Task | `on_panic` action |
 |------|-----------|------|-------------------|
 | #1 | `runtime_agent_handle.rs:88` | Child process watcher | Log + set `alive = false` |
-| #2 | `blob_server.rs:42` | Blob accept loop | `trigger_shutdown()` |
+| #2 | `blob_server.rs:42` | Blob accept loop | Respawn with counter (see below) |
 | #4 | `main.rs:439` | Signal handler | Log only |
 | #12 | `daemon.rs:783` | `uv_warming_loop` | Respawn (see below) |
 | #13 | `daemon.rs:788` | `conda_warming_loop` | Respawn (see below) |
@@ -173,15 +175,23 @@ JoinHandle usage for `.abort()` is preserved since `spawn_supervised` returns
 | #15 | `daemon.rs:799` | `env_gc_loop` | Log only |
 | #16 | `daemon.rs:805` | `watch_settings_json` | Log only |
 
+**Blob server respawn:** Site #2 uses respawn-with-counter (same pattern as
+warming loops). The blob server is stateless and content-addressed, so
+restarting it is safe. Second panic escalates to `trigger_shutdown()`.
+Add `blob_server_respawns: AtomicU32` to `Daemon`. The `on_panic` handler
+uses `compare_exchange` to atomically check-and-increment the counter
+(review feedback item #2 — avoids race with concurrent panics).
+
 **Warming loop respawn (Q2):** For sites #12-14, the `on_panic` handler:
 1. Calls `warming_failed_with_error(Some(panic_marker))` on the pool
 2. Logs `error!`
-3. Checks an `AtomicU32` respawn counter per warming task. If count < 1,
-   increments and spawns a single replacement. If count >= 1, calls
-   `daemon.trigger_shutdown()`.
+3. Uses `compare_exchange(0, 1, SeqCst, Relaxed)` on a per-task `AtomicU32`
+   respawn counter. If CAS succeeds (was 0), spawns a single replacement.
+   If CAS fails (already >= 1), calls `daemon.trigger_shutdown()`.
+   (Review feedback item #2 — CAS prevents double-respawn race.)
 
-Add three `AtomicU32` fields to `Daemon`: `uv_warming_respawns`,
-`conda_warming_respawns`, `pixi_warming_respawns`.
+Add four `AtomicU32` fields to `Daemon`: `blob_server_respawns`,
+`uv_warming_respawns`, `conda_warming_respawns`, `pixi_warming_respawns`.
 
 **Files modified:**
 - `crates/runtimed/src/daemon.rs` — 10 spawn sites + 3 new `AtomicU32` fields
@@ -262,12 +272,27 @@ call `trigger_shutdown()` in the `on_panic` handler.
    no `tokio::sync::Mutex` guards held across `.await`. `AssertUnwindSafe` is
    correct.
 2. **`on_panic` must not panic:** Callbacks are trivial: `tx.try_send()`,
-   `store()`, `trigger_shutdown()`.
+   `store()`, `trigger_shutdown()`. Wrap each `on_panic` body in a secondary
+   `catch_unwind` for defense-in-depth.
 3. **`spawn_best_effort` is `spawn_supervised` with no-op `on_panic`.**
-4. **WarmingGuard uses `tokio::spawn` in Drop:** Safe on multi-threaded
-   runtime; during shutdown pool accounting is irrelevant.
-5. **Warming loop respawn:** `AtomicU32` counter, second panic escalates to
-   `trigger_shutdown()`.
+4. **WarmingGuard checks shutdown before spawning in Drop:** If the daemon is
+   shutting down, the guard skips the async cleanup spawn (pool accounting is
+   irrelevant during shutdown and the runtime may be winding down).
+5. **Respawn counters use `compare_exchange`:** Atomic CAS prevents
+   double-respawn races when two panics occur concurrently.
+6. **Blob server respawns instead of shutting down:** The blob server is
+   stateless and content-addressed — safe to restart. Second panic escalates.
+
+## Review Feedback (incorporated)
+
+Independent review by DeepSeek V3.2, 2026-04-19. Three items accepted:
+
+1. **WarmingGuard::drop shutdown race** — guard checks `daemon.is_shutting_down()`
+   before `tokio::spawn`. Prevents spawning into a winding-down runtime.
+2. **Warming respawn counter race** — use `compare_exchange` (CAS) instead of
+   relaxed load-then-increment. Prevents double-respawn if two panics race.
+3. **Blob server (site #2)** — changed from `trigger_shutdown()` to
+   respawn-with-counter. Blob server is stateless, safe to restart.
 
 ## Risks
 

--- a/docs/superpowers/plans/2026-04-19-spawn-panic-handling-implementation.md
+++ b/docs/superpowers/plans/2026-04-19-spawn-panic-handling-implementation.md
@@ -1,0 +1,280 @@
+# Implementation Plan: Spawn Panic Handling for `crates/runtimed`
+
+Date: 2026-04-19
+Design doc: PR #1926 (`docs/superpowers/plans/2026-04-19-spawn-panic-handling.md`)
+Status: Implementation plan — pending review.
+
+## Context
+
+PR #1926 audits all 30 `tokio::spawn` sites in `crates/runtimed/src/` and finds
+that **none** catch panics at the task boundary. When a spawned task panics,
+tokio logs via `tracing` and silently drops the task. The daemon stays up in a
+degraded state: blob server gone, autosave stopped, warming loops dead, pool
+accounting drifted. All 4 design questions (Q1-Q4) are answered in the design
+doc PR.
+
+This plan implements Phase 2: the `WarmingGuard` RAII type, two spawn helpers
+(`spawn_supervised` / `spawn_best_effort`), and migration of all 29 production
+spawn sites.
+
+## PR Sequence (6 PRs)
+
+### PR 1: `WarmingGuard` RAII (Q3)
+
+**Why first:** Orthogonal to spawn wiring. Fixes the pool-accounting-on-panic
+bug independently. Unblocks cleaner spawn migration later since the warming
+counter is already protected.
+
+**New code:**
+
+Add a `WarmingGuard` struct in `crates/runtimed/src/daemon.rs` (private, near
+the `EnvPool` impl). The guard holds an `Option<WarmingGuardInner>` where inner
+has `Arc<tokio::sync::Mutex<EnvPool>>`, `PathBuf`, `Arc<Notify>`, and
+`Arc<Daemon>`. On `Drop`, if inner is `Some` (not committed), it spawns a
+background task that: locks the pool, calls `warming_failed_for_path(path,
+None)`, drops the lock, then calls `daemon.update_pool_doc().await`.
+
+`fn commit(mut self)` takes the inner via `self.inner.take()`, preventing Drop
+from firing the rollback. No `mem::forget` needed — the struct drops cleanly
+with `inner = None`.
+
+```rust
+struct WarmingGuardInner {
+    pool: Arc<Mutex<EnvPool>>,
+    path: PathBuf,
+    pool_ready: Arc<Notify>,
+    daemon: Arc<Daemon>,
+}
+
+struct WarmingGuard {
+    inner: Option<WarmingGuardInner>,
+}
+
+impl WarmingGuard {
+    fn commit(&mut self) {
+        self.inner.take();
+    }
+}
+
+impl Drop for WarmingGuard {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            tokio::spawn(async move {
+                inner.pool.lock().await.warming_failed_for_path(&inner.path, None);
+                inner.pool_ready.notify_waiters();
+                inner.daemon.update_pool_doc().await;
+            });
+        }
+    }
+}
+```
+
+Using `tokio::spawn` in Drop is safe: we're inside a spawned task on the
+multi-threaded runtime, and during shutdown pool accounting is irrelevant.
+
+**Files modified:**
+- `crates/runtimed/src/daemon.rs`
+  - Add `WarmingGuard` struct + `impl Drop` (~30 lines)
+  - `create_uv_env`: Replace `register_warming_path` + all
+    `warming_failed_for_path` exit paths with guard. ~6 early-return cleanup
+    blocks become guard Drop. Call `guard.commit()` before `pool.add()` on
+    success.
+  - `create_conda_env`: Same pattern. ~8 early-return cleanup blocks.
+  - `create_pixi_env`: Same pattern. ~2 early-return cleanup blocks.
+
+**What not to change:** `replenish_conda_env` and `replenish_pixi_env` call
+`mark_warming(1)` then delegate to `create_*`. The guard lives inside
+`create_*`, so the `mark_warming` accounting is already covered —
+`create_*` calls `register_warming_path` which the guard protects.
+
+**Verification:**
+- `cargo xtask lint --fix`
+- `cargo test -p runtimed` (existing pool tests cover success + error paths)
+
+---
+
+### PR 2: `task_supervisor` module with helpers
+
+**New file:** `crates/runtimed/src/task_supervisor.rs` (~80 lines)
+
+**Contents:**
+1. `PanicInfo { label: &'static str, message: String }`
+2. `panic_payload_to_string(Box<dyn Any + Send>) -> String` — extracted from
+   the identical downcast chain in `catch_automerge_panic`
+   (notebook_sync_server.rs:74-80). After extraction, update
+   `catch_automerge_panic` to call this shared helper.
+3. `spawn_supervised<F, P>(label, fut, on_panic) -> JoinHandle<()>` — wraps
+   `fut` in `AssertUnwindSafe(fut).catch_unwind()`, logs at `error!`, calls
+   `on_panic(&PanicInfo)`.
+4. `spawn_best_effort<F>(label, fut) -> JoinHandle<()>` — same but `on_panic`
+   is a no-op (log only).
+
+**Dependencies:** `futures::FutureExt` (already in `Cargo.toml`),
+`std::panic::AssertUnwindSafe`.
+
+**Unit tests** (in `#[cfg(test)] mod tests` at bottom of `task_supervisor.rs`):
+- `test_spawn_best_effort_normal` — future completes normally.
+- `test_spawn_best_effort_panic` — future panics, verify JoinHandle resolves
+  to `Ok(())` (panic caught internally).
+- `test_spawn_supervised_calls_on_panic` — future panics, verify callback
+  fires with correct label and message.
+- `test_spawn_supervised_abort` — store JoinHandle, call `.abort()`, verify
+  task cancelled cleanly.
+
+**Files modified:**
+- `crates/runtimed/src/task_supervisor.rs` (new)
+- `crates/runtimed/src/lib.rs` — add `pub(crate) mod task_supervisor;`
+- `crates/runtimed/src/notebook_sync_server.rs` — update
+  `catch_automerge_panic` to use shared `panic_payload_to_string`.
+
+**Verification:**
+- `cargo test -p runtimed --lib task_supervisor`
+- `cargo xtask lint --fix`
+
+---
+
+### PR 3: Migrate kernel tasks — `jupyter_kernel.rs`
+
+Sites #5-10. The abort-only tasks (#6-10) get `spawn_supervised` with
+`on_panic` sending `QueueCommand::KernelDied`. Site #5 (stderr pump) gets
+`spawn_best_effort`.
+
+| Site | Line | Task | `on_panic` action |
+|------|------|------|-------------------|
+| #5 | 476 | Kernel stderr pump | Best-effort (log only) |
+| #6 | 550 | `process_watcher_task` | `cmd_tx.try_send(KernelDied)` |
+| #7 | 588 | `iopub_task` | `cmd_tx.try_send(KernelDied)` |
+| #8 | 1631 | `shell_reader_task` | `cmd_tx.try_send(KernelDied)` |
+| #9 | 1819 | `heartbeat_task` | `cmd_tx.try_send(KernelDied)` |
+| #10 | 1862 | `comm_coalesce_task` | `cmd_tx.try_send(KernelDied)` |
+
+JoinHandle usage for `.abort()` is preserved since `spawn_supervised` returns
+`JoinHandle<()>`.
+
+**Files modified:**
+- `crates/runtimed/src/jupyter_kernel.rs` — 6 spawn sites
+
+**Verification:**
+- `cargo test -p runtimed`
+- `cargo xtask lint --fix`
+
+---
+
+### PR 4: Migrate daemon long-lived workers — `daemon.rs`, `blob_server.rs`, `main.rs`, `runtime_agent_handle.rs`
+
+| Site | File:Line | Task | `on_panic` action |
+|------|-----------|------|-------------------|
+| #1 | `runtime_agent_handle.rs:88` | Child process watcher | Log + set `alive = false` |
+| #2 | `blob_server.rs:42` | Blob accept loop | `trigger_shutdown()` |
+| #4 | `main.rs:439` | Signal handler | Log only |
+| #12 | `daemon.rs:783` | `uv_warming_loop` | Respawn (see below) |
+| #13 | `daemon.rs:788` | `conda_warming_loop` | Respawn (see below) |
+| #14 | `daemon.rs:793` | `pixi_warming_loop` | Respawn (see below) |
+| #15 | `daemon.rs:799` | `env_gc_loop` | Log only |
+| #16 | `daemon.rs:805` | `watch_settings_json` | Log only |
+
+**Warming loop respawn (Q2):** For sites #12-14, the `on_panic` handler:
+1. Calls `warming_failed_with_error(Some(panic_marker))` on the pool
+2. Logs `error!`
+3. Checks an `AtomicU32` respawn counter per warming task. If count < 1,
+   increments and spawns a single replacement. If count >= 1, calls
+   `daemon.trigger_shutdown()`.
+
+Add three `AtomicU32` fields to `Daemon`: `uv_warming_respawns`,
+`conda_warming_respawns`, `pixi_warming_respawns`.
+
+**Files modified:**
+- `crates/runtimed/src/daemon.rs` — 10 spawn sites + 3 new `AtomicU32` fields
+- `crates/runtimed/src/blob_server.rs` — 1 spawn site
+- `crates/runtimed/src/main.rs` — 1 spawn site
+- `crates/runtimed/src/runtime_agent_handle.rs` — 1 spawn site
+
+**Verification:**
+- `cargo test -p runtimed`
+- `cargo xtask lint --fix`
+- `cargo xtask build --release` + `cargo xtask install-daemon --channel nightly`
+
+---
+
+### PR 5: Migrate notebook-sync supervised sites + best-effort batch
+
+**Supervised sites:**
+
+| Site | Line | Task | `on_panic` action |
+|------|------|------|-------------------|
+| #24 | 2034 | `auto_launch_kernel` | Set `kernel_status` to `"error"` |
+| #25 | 2130 | Room eviction delay | Log only |
+| #27 | 7906 | `spawn_persist_debouncer` | `trigger_shutdown()` |
+| #29 | 9450 | `spawn_notebook_file_watcher` | Log only |
+
+**Best-effort sites (all files):**
+
+| Site | File:Line | Task |
+|------|-----------|------|
+| #3 | `blob_server.rs:48` | Per-connection HTTP handler |
+| #11 | `daemon.rs:215` | `spawn_env_deletions` |
+| #17 | `daemon.rs:893` | Per-connection unix socket |
+| #18 | `daemon.rs:958` | Per-connection windows pipe |
+| #19 | `daemon.rs:2083` | UV post-take replenish |
+| #20 | `daemon.rs:2108` | UV retry after `mark_warming` |
+| #21 | `daemon.rs:2158` | `replenish_conda_env` |
+| #22 | `daemon.rs:2183` | Conda retry after `mark_warming` |
+| #23 | `daemon.rs:2228` | `replenish_pixi_env` |
+| #26 | `notebook_sync_server.rs:5934` | Background cell formatter |
+
+**Files modified:**
+- `crates/runtimed/src/notebook_sync_server.rs` — 4 supervised + 1 best-effort
+- `crates/runtimed/src/blob_server.rs` — 1 best-effort
+- `crates/runtimed/src/daemon.rs` — 7 best-effort
+
+**Verification:**
+- `cargo test -p runtimed`
+- `cargo xtask lint --fix`
+
+---
+
+### PR 6: Autosave (site #28) + final gate
+
+**Site #28** (`notebook_sync_server.rs:7996`): `spawn_autosave_debouncer`. Per
+Q4 decision: `on_panic` calls `trigger_shutdown()`. The daemon exits cleanly,
+frontend reconnects, user sees the failure.
+
+**Refactor:** `spawn_autosave_debouncer` needs an `Arc<Daemon>` parameter to
+call `trigger_shutdown()` in the `on_panic` handler.
+
+**Final gate:** `grep -n "tokio::spawn" crates/runtimed/src/` — only test site
+#30 should remain.
+
+**Files modified:**
+- `crates/runtimed/src/notebook_sync_server.rs` — 1 spawn site + signature change
+
+**Verification:**
+- `cargo test -p runtimed`
+- `cargo xtask lint --fix`
+- `cargo xtask build --release`
+- `cargo xtask install-daemon --channel nightly`
+- `runt-nightly daemon status`
+- Final grep confirms only test site #30 remains
+
+## Key Design Decisions
+
+1. **`catch_unwind` is sound:** Tasks communicate via channels (owned state),
+   no `tokio::sync::Mutex` guards held across `.await`. `AssertUnwindSafe` is
+   correct.
+2. **`on_panic` must not panic:** Callbacks are trivial: `tx.try_send()`,
+   `store()`, `trigger_shutdown()`.
+3. **`spawn_best_effort` is `spawn_supervised` with no-op `on_panic`.**
+4. **WarmingGuard uses `tokio::spawn` in Drop:** Safe on multi-threaded
+   runtime; during shutdown pool accounting is irrelevant.
+5. **Warming loop respawn:** `AtomicU32` counter, second panic escalates to
+   `trigger_shutdown()`.
+
+## Risks
+
+- **`AssertUnwindSafe` on futures with interior mutability:** All tasks use
+  channels or `Arc<AtomicX>`. No `RefCell` or non-`UnwindSafe` types cross the
+  catch boundary.
+- **Automerge panics in autosave:** Triggers `trigger_shutdown()`.
+  Intentionally aggressive — better to restart cleanly than silently lose data.
+- **Performance:** `catch_unwind` adds negligible overhead on the non-panic
+  path (just a landing pad).


### PR DESCRIPTION
## Summary

Full implementation of Phase 2 from the spawn panic audit (design doc PR #1926, implementation plan PR #1930).

Adds panic handling to all 29 production `tokio::spawn` sites in `crates/runtimed/src/`. Currently, when a spawned task panics, tokio silently drops it and the daemon degrades: blob server gone, autosave stopped, warming loops dead, pool accounting drifted.

## Implementation stages

### Stage 1: `WarmingGuard` RAII (Q3) ✅
RAII guard for pool warming counters. On Drop, rolls back `warming_failed_for_path`. `commit()` suppresses on success, `fail_with()` records specific errors. Replaces ~16 manual cleanup blocks.

### Stage 2: `task_supervisor` module
- `spawn_supervised(label, fut, on_panic)` — catches panics, logs, calls callback
- `spawn_best_effort(label, fut)` — catches panics, logs only
- Extracts `panic_payload_to_string` from existing `catch_automerge_panic`

### Stage 3: Kernel tasks (`jupyter_kernel.rs`)
6 sites. `on_panic` sends `KernelDied`. Stderr pump is best-effort.

### Stage 4: Daemon long-lived workers
13 sites across `daemon.rs`, `blob_server.rs`, `main.rs`, `runtime_agent_handle.rs`. Warming loops get single-respawn with CAS counter. Blob server gets respawn-with-counter.

### Stage 5: Notebook-sync + best-effort batch
4 supervised + 10 best-effort sites.

### Stage 6: Autosave (Q4) + final gate
`spawn_autosave_debouncer` gets `trigger_shutdown()` on panic. Final grep confirms only test site remains.

## Test plan
- [ ] Each stage: `cargo xtask lint --fix` + `cargo test -p runtimed`
- [ ] After stage 4: `cargo xtask build --release` + nightly install + gremlin suite
- [ ] Stage 6 final gate: `grep -n "tokio::spawn" crates/runtimed/src/` — only test site #30 remains