### PR TITLE
docs(outputs): explain the two-path output materialization

### DIFF
--- a/crates/notebook-doc/src/diff.rs
+++ b/crates/notebook-doc/src/diff.rs
@@ -207,6 +207,22 @@ impl DocChangeset {
 /// and each re-ran `doc.diff` on the same heads. Cost goes from O(N*3)
 /// to O(N) where N is the number of patches.
 ///
+/// # Why this does not emit output-change flags
+///
+/// Cell outputs live in `RuntimeStateDoc`, not in `NotebookDoc`. The
+/// runtime agent writes them via IOPub; the daemon syncs them via frame
+/// `0x05`. The WASM layer handles that path separately via
+/// `runtime_state::diff_execution_outputs`, which emits
+/// `RuntimeStateSyncApplied.output_changed_cells`. The sync engine then
+/// synthesizes a `CellChangeset` with `fields.outputs = true` for those
+/// cells so materialization goes through the same path as structural
+/// changes.
+///
+/// Do not add an output scan here. If you're tempted to, read
+/// `crates/runtimed-wasm/src/lib.rs` (`RuntimeStateSyncApplied` emit
+/// site) and `packages/runtimed/src/sync-engine.ts` (synthetic
+/// CellChangeset) first.
+///
 /// # Arguments
 ///
 /// Same semantics as [`diff_cells`] — `before == &[]` or `before == after`

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -695,6 +695,16 @@ export class SyncEngine {
               // Output changes detected by WASM-side diff of RuntimeStateDoc.
               // The WASM compares output hash lists before/after sync and
               // reports cell IDs that need re-materialization.
+              //
+              // This is the ONLY source of `fields.outputs = true` in the
+              // materialization pipeline. The `diff_doc` in notebook-doc
+              // walks NotebookDoc only, and NotebookDoc never carries cell
+              // outputs — they live exclusively in RuntimeStateDoc. If this
+              // synthesis goes away, outputs stop re-rendering on kernel
+              // IOPub.
+              //
+              // See `crates/notebook-doc/src/diff.rs` (diff_doc docstring)
+              // for the other half of the contract.
               const outputChangedCells: string[] = e.output_changed_cells ?? [];
               if (outputChangedCells.length > 0) {
                 // Deduplicate against cells already handled by transitions


### PR DESCRIPTION
## Why

Cell outputs live in `RuntimeStateDoc`, not `NotebookDoc`. `diff_doc` in notebook-doc walks `NotebookDoc` only; output re-rendering relies on the sync engine synthesizing `fields.outputs = true` from `RuntimeStateSyncApplied.output_changed_cells`.

This is robust but invisible. A future refactor could easily:

- Add an output scan to `diff_doc` thinking it's missing, producing double-materialization.
- Remove the synthetic `CellChangeset` synthesis in sync-engine.ts thinking it's dead code (outputs stop rendering).
- Collapse the two materialization triggers into one.

Add defensive comments at both ends of the contract so the next person sees the rationale.

## What

- `crates/notebook-doc/src/diff.rs` — `diff_doc` docstring explains why outputs aren't checked here, points to the other half.
- `packages/runtimed/src/sync-engine.ts` — synthesis block explains it's the only source of `fields.outputs`, points back.

## Test plan

- [x] `cargo xtask lint` clean
- No behavior change, docs only
