### PR TITLE
Fix Codex nteract-dev setup

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,8 @@
 [mcp_servers.nteract-dev]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
+cwd = "."
+startup_timeout_sec = 120
 
 [mcp_servers.nteract-dev.env]
 RUNTIMED_DEV = "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,7 +306,7 @@ cargo xtask run-mcp --print-config
 
 Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
 
-For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same server using the `nteract-dev` entry name.
+For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same server using the `nteract-dev` entry name. The Codex config sets `cwd = "."` so GUI-launched sessions still start the supervisor from the repo root, and bumps the startup timeout because the first `cargo run -p mcp-supervisor` can take longer than the default while it builds.
 
 ### MCP Server
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -344,10 +344,14 @@ Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes
 [mcp_servers.nteract-dev]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
+cwd = "."
+startup_timeout_sec = 120
 
 [mcp_servers.nteract-dev.env]
 RUNTIMED_DEV = "1"
 ```
+
+`cwd = "."` matters for Codex app/CLI: it forces `mcp-supervisor` to start from the repo root, which is enough to keep the server pinned to the worktree even when Codex was launched outside a direnv-managed shell. The longer startup timeout avoids dropping `nteract-dev` during the initial cargo build.
 
 Or configure `.zed/settings.json` directly (gitignored):
 


### PR DESCRIPTION
## Summary
- Pin Codex's `nteract-dev` MCP server to the repo root with `cwd = "."`
- Increase the startup timeout so the first `cargo run -p mcp-supervisor` build can complete
- Document the Codex-specific launch behavior in the repo guides

## Testing
- Not run (not requested)