### PR TITLE
fix(runtimed): add per-request timeouts to runtime agent RPCs

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -96,10 +96,19 @@ type RuntimeAgentRequestSender = tokio::sync::mpsc::Sender<(
 /// The runtime agent's sync handler receives the request as a frame 0x01 and
 /// sends the response as frame 0x02. Returns error if no runtime agent is
 /// connected.
+///
+/// Bounded by a per-request timeout so that a stuck or overloaded runtime
+/// agent cannot block the daemon's request-handling path indefinitely.
+/// The timeout is chosen per request type: fast for interrupt/shutdown
+/// (which must respond quickly), generous for launch/sync (which do real
+/// work). The daemon-side sync loop serialises RPCs (`pending_reply`
+/// guard), so a slow RPC also delays subsequent ones — the timeout
+/// prevents that cascade from exceeding the client-side 30 s window.
 pub(crate) async fn send_runtime_agent_request(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,
 ) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
+    let timeout = runtime_agent_request_timeout(&request);
     let tx = {
         let guard = room.runtime_agent_request_tx.lock().await;
         guard
@@ -110,9 +119,32 @@ pub(crate) async fn send_runtime_agent_request(
     tx.send((request, reply_tx))
         .await
         .map_err(|_| anyhow::anyhow!("Runtime agent disconnected"))?;
-    reply_rx
-        .await
-        .map_err(|_| anyhow::anyhow!("Runtime agent dropped reply"))
+    match tokio::time::timeout(timeout, reply_rx).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(_)) => Err(anyhow::anyhow!("Runtime agent dropped reply")),
+        Err(_) => Err(anyhow::anyhow!("Runtime agent request timed out")),
+    }
+}
+
+/// Per-request timeout for runtime agent RPCs.
+///
+/// Must be shorter than the client-side relay timeout (30 s for most
+/// requests, 300 s for LaunchKernel/SyncEnvironment) so that the daemon
+/// always responds before the client gives up.
+fn runtime_agent_request_timeout(
+    request: &notebook_protocol::protocol::RuntimeAgentRequest,
+) -> std::time::Duration {
+    use notebook_protocol::protocol::RuntimeAgentRequest;
+    match request {
+        RuntimeAgentRequest::InterruptExecution => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::ShutdownKernel => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::LaunchKernel { .. } => std::time::Duration::from_secs(240),
+        RuntimeAgentRequest::RestartKernel { .. } => std::time::Duration::from_secs(240),
+        RuntimeAgentRequest::SyncEnvironment(_) => std::time::Duration::from_secs(240),
+        RuntimeAgentRequest::SendComm { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::Complete { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::GetHistory { .. } => std::time::Duration::from_secs(10),
+    }
 }
 
 /// Trust state for a notebook room.


### PR DESCRIPTION
## Summary

- `send_runtime_agent_request` had no timeout — a stuck or slow runtime agent blocked the daemon's request-handling path indefinitely. The daemon-side sync loop serialises RPCs via a `pending_reply` guard (one in-flight at a time), so a slow RPC also delayed subsequent ones — including time-critical `InterruptExecution` — past the client-side 30 s window, surfacing as "Connection timed out".
- Added per-request timeouts to `send_runtime_agent_request` so the daemon always responds before the client gives up: 10 s for interrupt/shutdown/completions, 240 s for launch/restart/sync-environment.
- When the timeout fires the daemon returns a clear error ("Runtime agent request timed out") instead of hanging, letting the MCP caller retry.

## Root cause

The learner gremlin (batch-size 6) hit kernel interrupt/restart timeouts during build `96ceef30`. Both `interrupt_kernel` and `restart_kernel` MCP tools returned "Connection timed out" after 30 s.

The daemon's runtime agent sync loop processes RPCs serially — a `pending_reply.is_none()` guard on the `select!` arm ensures only one RPC is forwarded to the runtime agent subprocess at a time. `send_runtime_agent_request` awaited the oneshot reply with **no timeout**, so if any RPC was slow (kernel busy on ZeroMQ control channel, `SyncEnvironment` doing pip install, `LaunchKernel` during env prep), subsequent RPCs queued behind it in the mpsc(16) buffer. The client-side 30 s relay timeout would fire first, returning `SyncError::Timeout` ("Connection timed out") to the MCP tool, while the daemon-side handler leaked a stuck task.

## Fix

New `runtime_agent_request_timeout()` function returns a per-request `Duration`:

| Request | Timeout | Rationale |
|---------|---------|-----------|
| `InterruptExecution` | 10 s | Must be fast; kernel interrupt itself has a 5 s ZeroMQ timeout |
| `ShutdownKernel` | 10 s | Same — quick lifecycle op |
| `Complete`, `GetHistory`, `SendComm` | 10 s | Interactive, should never be slow |
| `LaunchKernel`, `RestartKernel` | 240 s | Real work (env prep), but < client's 300 s |
| `SyncEnvironment` | 240 s | pip/conda install, but < client's 300 s |

`send_runtime_agent_request` wraps the oneshot `reply_rx.await` in `tokio::time::timeout(timeout, ...)`. On timeout it returns `Err("Runtime agent request timed out")` — the daemon responds to the client instead of hanging.

The existing eviction-path 5 s outer timeout (line 2313) still fires first for that call site, so eviction behaviour is unchanged.

## Test plan

- [x] 109 `notebook_sync_server` unit tests pass
- [x] `tokio_mutex_lint` test passes (no guards held across `.await`)
- [x] `cargo xtask lint --fix` clean
- [x] Release build succeeds
- [x] Nightly install + daemon status verified
- [ ] Gremlin replay: learner and breaker gremlins at batch-size 6 (pending experiments-manager)