### PR TITLE
feat(runtimed): structural RPC refactor — correlation IDs + fire-and-forget

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -1080,4 +1080,79 @@ mod tests {
         }
         .is_command());
     }
+
+    #[test]
+    fn is_command_exhaustive_classification() {
+        // Fire-and-forget commands (no response needed)
+        assert!(RuntimeAgentRequest::InterruptExecution.is_command());
+        assert!(
+            RuntimeAgentRequest::SendComm {
+                message: serde_json::json!({})
+            }
+            .is_command()
+        );
+
+        // Sync queries (response required)
+        assert!(!RuntimeAgentRequest::ShutdownKernel.is_command());
+        assert!(!RuntimeAgentRequest::LaunchKernel {
+            kernel_type: "python".into(),
+            env_source: "uv:prewarmed".into(),
+            notebook_path: None,
+            launched_config: Default::default(),
+            env_vars: Default::default(),
+        }
+        .is_command());
+        assert!(!RuntimeAgentRequest::RestartKernel {
+            kernel_type: "python".into(),
+            env_source: "conda:inline".into(),
+            notebook_path: None,
+            launched_config: Default::default(),
+            env_vars: Default::default(),
+        }
+        .is_command());
+        assert!(!RuntimeAgentRequest::SyncEnvironment(EnvKind::Uv {
+            packages: vec!["numpy".into()]
+        })
+        .is_command());
+    }
+
+    #[test]
+    fn shutdown_is_sync_prevents_crdt_race() {
+        // ShutdownKernel MUST be a sync query. If it were fire-and-forget,
+        // the daemon would return immediately and LaunchKernel could set
+        // kernel_status="starting" before the agent processes shutdown.
+        // Cells queued during env prep would then execute on the dying kernel.
+        assert!(
+            !RuntimeAgentRequest::ShutdownKernel.is_command(),
+            "ShutdownKernel must be sync to prevent CRDT race with LaunchKernel"
+        );
+    }
+
+    #[test]
+    fn correlation_id_preserved_in_envelope_roundtrip() {
+        let id = "corr-abc-123";
+        let envelope = RuntimeAgentRequestEnvelope {
+            id: id.to_string(),
+            request: RuntimeAgentRequest::Complete {
+                code: "import pa".into(),
+                cursor_pos: 9,
+            },
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        let parsed: RuntimeAgentRequestEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.id, id);
+
+        let resp_envelope = RuntimeAgentResponseEnvelope {
+            id: id.to_string(),
+            response: RuntimeAgentResponse::CompletionResult {
+                items: vec![],
+                cursor_start: 7,
+                cursor_end: 9,
+            },
+        };
+        let resp_json = serde_json::to_value(&resp_envelope).unwrap();
+        let parsed_resp: RuntimeAgentResponseEnvelope =
+            serde_json::from_value(resp_json).unwrap();
+        assert_eq!(parsed_resp.id, id);
+    }
 }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -732,15 +732,16 @@ pub struct RuntimeAgentResponseEnvelope {
 impl RuntimeAgentRequest {
     /// Returns true if this request is a command (fire-and-forget).
     /// Commands don't get a response — state flows back via CRDT.
+    ///
+    /// Currently: Interrupt, Shutdown, SendComm. Launch/Restart/SyncEnvironment
+    /// remain queries because the daemon needs response data (env_source,
+    /// launched_config, error handling).
     pub fn is_command(&self) -> bool {
         matches!(
             self,
             RuntimeAgentRequest::InterruptExecution
                 | RuntimeAgentRequest::ShutdownKernel
                 | RuntimeAgentRequest::SendComm { .. }
-                | RuntimeAgentRequest::LaunchKernel { .. }
-                | RuntimeAgentRequest::RestartKernel { .. }
-                | RuntimeAgentRequest::SyncEnvironment(_)
         )
     }
 }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -1085,12 +1085,10 @@ mod tests {
     fn is_command_exhaustive_classification() {
         // Fire-and-forget commands (no response needed)
         assert!(RuntimeAgentRequest::InterruptExecution.is_command());
-        assert!(
-            RuntimeAgentRequest::SendComm {
-                message: serde_json::json!({})
-            }
-            .is_command()
-        );
+        assert!(RuntimeAgentRequest::SendComm {
+            message: serde_json::json!({})
+        }
+        .is_command());
 
         // Sync queries (response required)
         assert!(!RuntimeAgentRequest::ShutdownKernel.is_command());
@@ -1151,8 +1149,7 @@ mod tests {
             },
         };
         let resp_json = serde_json::to_value(&resp_envelope).unwrap();
-        let parsed_resp: RuntimeAgentResponseEnvelope =
-            serde_json::from_value(resp_json).unwrap();
+        let parsed_resp: RuntimeAgentResponseEnvelope = serde_json::from_value(resp_json).unwrap();
         assert_eq!(parsed_resp.id, id);
     }
 }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -733,15 +733,14 @@ impl RuntimeAgentRequest {
     /// Returns true if this request is a command (fire-and-forget).
     /// Commands don't get a response — state flows back via CRDT.
     ///
-    /// Currently: Interrupt, Shutdown, SendComm. Launch/Restart/SyncEnvironment
-    /// remain queries because the daemon needs response data (env_source,
-    /// launched_config, error handling).
+    /// Currently: Interrupt, SendComm. Shutdown is a sync query because
+    /// the daemon must confirm the kernel is dead before LaunchKernel
+    /// sends RestartKernel — otherwise CRDT-queued cells can race onto
+    /// the dying kernel.
     pub fn is_command(&self) -> bool {
         matches!(
             self,
-            RuntimeAgentRequest::InterruptExecution
-                | RuntimeAgentRequest::ShutdownKernel
-                | RuntimeAgentRequest::SendComm { .. }
+            RuntimeAgentRequest::InterruptExecution | RuntimeAgentRequest::SendComm { .. }
         )
     }
 }
@@ -1068,7 +1067,7 @@ mod tests {
     #[test]
     fn runtime_agent_is_command() {
         assert!(RuntimeAgentRequest::InterruptExecution.is_command());
-        assert!(RuntimeAgentRequest::ShutdownKernel.is_command());
+        assert!(!RuntimeAgentRequest::ShutdownKernel.is_command());
         assert!(!RuntimeAgentRequest::Complete {
             code: String::new(),
             cursor_pos: 0,

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -707,6 +707,44 @@ pub enum RuntimeAgentResponse {
     Error { error: String },
 }
 
+/// Envelope around a `RuntimeAgentRequest` carrying a correlation ID.
+///
+/// Every request gets a unique ID. For query RPCs (Complete, GetHistory),
+/// the agent echoes the ID on the response envelope. For command RPCs
+/// (fire-and-forget), the agent processes the request but sends no response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeAgentRequestEnvelope {
+    pub id: String,
+    #[serde(flatten)]
+    pub request: RuntimeAgentRequest,
+}
+
+/// Envelope around a `RuntimeAgentResponse` echoing the correlation ID.
+///
+/// Only used for query RPCs (Complete, GetHistory) that need sync responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeAgentResponseEnvelope {
+    pub id: String,
+    #[serde(flatten)]
+    pub response: RuntimeAgentResponse,
+}
+
+impl RuntimeAgentRequest {
+    /// Returns true if this request is a command (fire-and-forget).
+    /// Commands don't get a response — state flows back via CRDT.
+    pub fn is_command(&self) -> bool {
+        matches!(
+            self,
+            RuntimeAgentRequest::InterruptExecution
+                | RuntimeAgentRequest::ShutdownKernel
+                | RuntimeAgentRequest::SendComm { .. }
+                | RuntimeAgentRequest::LaunchKernel { .. }
+                | RuntimeAgentRequest::RestartKernel { .. }
+                | RuntimeAgentRequest::SyncEnvironment(_)
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,5 +1026,58 @@ mod tests {
                 )
             });
         }
+    }
+
+    #[test]
+    fn runtime_agent_request_envelope_round_trip() {
+        let envelope = RuntimeAgentRequestEnvelope {
+            id: "req-42".to_string(),
+            request: RuntimeAgentRequest::InterruptExecution,
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(json["id"], "req-42");
+        assert_eq!(json["action"], "interrupt_execution");
+
+        let parsed: RuntimeAgentRequestEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.id, "req-42");
+        assert!(matches!(
+            parsed.request,
+            RuntimeAgentRequest::InterruptExecution
+        ));
+    }
+
+    #[test]
+    fn runtime_agent_response_envelope_round_trip() {
+        let envelope = RuntimeAgentResponseEnvelope {
+            id: "req-42".to_string(),
+            response: RuntimeAgentResponse::CompletionResult {
+                items: vec![],
+                cursor_start: 0,
+                cursor_end: 5,
+            },
+        };
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(json["id"], "req-42");
+        assert_eq!(json["result"], "completion_result");
+
+        let parsed: RuntimeAgentResponseEnvelope = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.id, "req-42");
+    }
+
+    #[test]
+    fn runtime_agent_is_command() {
+        assert!(RuntimeAgentRequest::InterruptExecution.is_command());
+        assert!(RuntimeAgentRequest::ShutdownKernel.is_command());
+        assert!(!RuntimeAgentRequest::Complete {
+            code: String::new(),
+            cursor_pos: 0,
+        }
+        .is_command());
+        assert!(!RuntimeAgentRequest::GetHistory {
+            pattern: None,
+            n: 10,
+            unique: false,
+        }
+        .is_command());
     }
 }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -44,6 +44,44 @@ use notebook_protocol::protocol::LaunchedEnvConfig;
 type PendingCompletions =
     Arc<StdMutex<HashMap<String, oneshot::Sender<(Vec<CompletionItem>, usize, usize)>>>>;
 
+/// Handle for interrupting a kernel without exclusive access.
+///
+/// Created at kernel launch time, captures connection_info and session_id.
+/// Can be used concurrently with other kernel operations since interrupt
+/// creates its own ZMQ control connection.
+#[derive(Clone)]
+pub struct InterruptHandle {
+    connection_info: ConnectionInfo,
+    session_id: String,
+}
+
+impl InterruptHandle {
+    pub async fn interrupt(&self) -> Result<()> {
+        let mut control =
+            runtimelib::create_client_control_connection(&self.connection_info, &self.session_id)
+                .await?;
+
+        let request: JupyterMessage = InterruptRequest {}.into();
+        control.send(request).await?;
+
+        info!("[jupyter-kernel] Sent interrupt_request (via handle)");
+
+        match tokio::time::timeout(std::time::Duration::from_secs(5), control.read()).await {
+            Ok(Ok(_reply)) => {
+                info!("[jupyter-kernel] Received interrupt_reply");
+            }
+            Ok(Err(e)) => {
+                warn!("[jupyter-kernel] Error receiving interrupt_reply: {}", e);
+            }
+            Err(_) => {
+                warn!("[jupyter-kernel] Timed out waiting for interrupt_reply (5s)");
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// A Jupyter kernel connection that implements `KernelConnection`.
 ///
 /// Holds the IO-bound parts of a kernel connection: ZeroMQ sockets, spawned
@@ -2401,6 +2439,16 @@ impl KernelConnection for JupyterKernel {
 
     fn update_launched_uv_deps(&mut self, deps: Vec<String>) {
         self.launched_config.uv_deps = Some(deps);
+    }
+}
+
+impl JupyterKernel {
+    /// Get an InterruptHandle for concurrent interrupt without &mut self.
+    pub fn interrupt_handle(&self) -> Option<InterruptHandle> {
+        self.connection_info.as_ref().map(|ci| InterruptHandle {
+            connection_info: ci.clone(),
+            session_id: self.session_id.clone(),
+        })
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -125,8 +125,8 @@ fn runtime_agent_query_timeout(
 
 /// Send a fire-and-forget command to the runtime agent.
 ///
-/// Commands (Interrupt, Shutdown, SendComm, Launch, Restart, SyncEnvironment)
-/// don't wait for a response — state flows back via RuntimeStateDoc CRDT.
+/// Commands (Interrupt, SendComm) don't wait for a response — state
+/// flows back via RuntimeStateDoc CRDT.
 pub(crate) async fn send_runtime_agent_command(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1914,6 +1914,13 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         }
     }
 
+    // Drain any pending query replies so callers get an error instead of hanging.
+    for (_id, reply_tx) in pending_replies.drain() {
+        let _ = reply_tx.send(RuntimeAgentResponse::Error {
+            error: "Runtime agent disconnected".to_string(),
+        });
+    }
+
     // Cleanup: only clear state if we're still the current runtime agent.
     // A stale runtime agent disconnecting after a new one connected must not
     // clobber the new runtime agent's channel.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -49,7 +49,7 @@ use crate::protocol::{
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use notebook_doc::diff::diff_metadata_touched;
 use notebook_doc::presence::{self, PresenceState};
-use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
+use notebook_doc::runtime_state::RuntimeStateDoc;
 
 mod path_index;
 pub use path_index::{PathIndex, PathIndexError};
@@ -98,52 +98,97 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
-/// Sender half of the runtime agent RPC channel.
-type RuntimeAgentRequestSender = tokio::sync::mpsc::Sender<(
-    notebook_protocol::protocol::RuntimeAgentRequest,
-    tokio::sync::oneshot::Sender<notebook_protocol::protocol::RuntimeAgentResponse>,
-)>;
+/// A message sent through the runtime agent channel.
+pub enum RuntimeAgentMessage {
+    /// Fire-and-forget command — no response expected.
+    Command(notebook_protocol::protocol::RuntimeAgentRequestEnvelope),
+    /// Query requiring a sync response via correlation ID.
+    Query(
+        notebook_protocol::protocol::RuntimeAgentRequestEnvelope,
+        tokio::sync::oneshot::Sender<notebook_protocol::protocol::RuntimeAgentResponse>,
+    ),
+}
 
-fn runtime_agent_request_timeout(
+/// Sender half of the runtime agent channel.
+type RuntimeAgentRequestSender = tokio::sync::mpsc::Sender<RuntimeAgentMessage>;
+
+fn runtime_agent_query_timeout(
     request: &notebook_protocol::protocol::RuntimeAgentRequest,
 ) -> std::time::Duration {
     use notebook_protocol::protocol::RuntimeAgentRequest;
     match request {
-        RuntimeAgentRequest::InterruptExecution => std::time::Duration::from_secs(10),
-        RuntimeAgentRequest::ShutdownKernel => std::time::Duration::from_secs(10),
-        RuntimeAgentRequest::SendComm { .. } => std::time::Duration::from_secs(10),
         RuntimeAgentRequest::Complete { .. } => std::time::Duration::from_secs(10),
         RuntimeAgentRequest::GetHistory { .. } => std::time::Duration::from_secs(10),
-        RuntimeAgentRequest::LaunchKernel { .. } => std::time::Duration::from_secs(240),
-        RuntimeAgentRequest::RestartKernel { .. } => std::time::Duration::from_secs(240),
-        RuntimeAgentRequest::SyncEnvironment(_) => std::time::Duration::from_secs(240),
+        _ => std::time::Duration::from_secs(30),
     }
 }
 
-/// Send an RPC request to the runtime agent via its sync connection.
+/// Send a fire-and-forget command to the runtime agent.
 ///
-/// The runtime agent's sync handler receives the request as a frame 0x01 and
-/// sends the response as frame 0x02. Returns error if no runtime agent is
-/// connected.
-pub(crate) async fn send_runtime_agent_request(
+/// Commands (Interrupt, Shutdown, SendComm, Launch, Restart, SyncEnvironment)
+/// don't wait for a response — state flows back via RuntimeStateDoc CRDT.
+pub(crate) async fn send_runtime_agent_command(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,
-) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
-    let timeout = runtime_agent_request_timeout(&request);
+) -> anyhow::Result<()> {
     let tx = {
         let guard = room.runtime_agent_request_tx.lock().await;
         guard
             .clone()
             .ok_or_else(|| anyhow::anyhow!("Runtime agent not connected"))?
     };
+    let envelope = notebook_protocol::protocol::RuntimeAgentRequestEnvelope {
+        id: uuid::Uuid::new_v4().to_string(),
+        request,
+    };
+    tx.send(RuntimeAgentMessage::Command(envelope))
+        .await
+        .map_err(|_| anyhow::anyhow!("Runtime agent disconnected"))?;
+    Ok(())
+}
+
+/// Send a query to the runtime agent and wait for a sync response.
+///
+/// Only used for Complete and GetHistory which need return values.
+pub(crate) async fn send_runtime_agent_query(
+    room: &NotebookRoom,
+    request: notebook_protocol::protocol::RuntimeAgentRequest,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
+    let timeout = runtime_agent_query_timeout(&request);
+    let tx = {
+        let guard = room.runtime_agent_request_tx.lock().await;
+        guard
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Runtime agent not connected"))?
+    };
+    let envelope = notebook_protocol::protocol::RuntimeAgentRequestEnvelope {
+        id: uuid::Uuid::new_v4().to_string(),
+        request,
+    };
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    tx.send((request, reply_tx))
+    tx.send(RuntimeAgentMessage::Query(envelope, reply_tx))
         .await
         .map_err(|_| anyhow::anyhow!("Runtime agent disconnected"))?;
     match tokio::time::timeout(timeout, reply_rx).await {
         Ok(Ok(response)) => Ok(response),
         Ok(Err(_)) => Err(anyhow::anyhow!("Runtime agent dropped reply")),
-        Err(_) => Err(anyhow::anyhow!("Runtime agent request timed out")),
+        Err(_) => Err(anyhow::anyhow!("Runtime agent query timed out")),
+    }
+}
+
+/// Send an RPC request to the runtime agent (legacy wrapper).
+///
+/// Routes commands as fire-and-forget, queries as sync RPCs.
+/// Callers that don't need a response should use `send_runtime_agent_command` directly.
+pub(crate) async fn send_runtime_agent_request(
+    room: &NotebookRoom,
+    request: notebook_protocol::protocol::RuntimeAgentRequest,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
+    if request.is_command() {
+        send_runtime_agent_command(room, request).await?;
+        Ok(notebook_protocol::protocol::RuntimeAgentResponse::Ok)
+    } else {
+        send_runtime_agent_query(room, request).await
     }
 }
 
@@ -829,53 +874,6 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
                     in_sync: true,
                     diff: None,
                 });
-        }
-    }
-}
-
-/// Handle interrupt: clear queued executions in state_doc and mark them as
-/// errored using fork+merge. The currently-executing cell is left alone —
-/// the kernel will send an `execute_reply` with error status for it, which
-/// the normal IOPub handler will process.
-pub(crate) async fn apply_interrupt_to_state_doc(
-    room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
-    room_state_changed_tx: &broadcast::Sender<()>,
-    cleared: &[notebook_protocol::protocol::QueueEntry],
-) {
-    // Fork state_doc so mutations compose with any concurrent writes.
-    let mut fork = {
-        let mut sd = room_state_doc.write().await;
-        sd.fork_with_actor(format!("runtimed:state:interrupt:{}", uuid::Uuid::new_v4()))
-    };
-
-    // Read the currently-executing entry from the CRDT (it stays — the
-    // kernel will send an execute_reply for it via the normal IOPub path).
-    let state = fork.read_state();
-    let exec = state.queue.executing.as_ref().map(|e| DocQueueEntry {
-        cell_id: e.cell_id.clone(),
-        execution_id: e.execution_id.clone(),
-    });
-
-    // Clear the queued entries, keeping only the executing one.
-    fork.set_queue(exec.as_ref(), &[]);
-
-    // Mark cleared executions as errored on the fork
-    for entry in cleared {
-        fork.set_execution_done(&entry.execution_id, false);
-    }
-
-    // Merge fork back — concurrent state_doc writes compose via CRDT
-    {
-        let mut sd = room_state_doc.write().await;
-        match catch_automerge_panic("interrupt-state-merge", || sd.merge(&mut fork)) {
-            Ok(Ok(_)) => {
-                let _ = room_state_changed_tx.send(());
-            }
-            Ok(Err(_)) => {}
-            Err(e) => {
-                warn!("{}", e);
-                sd.rebuild_from_save();
-            }
         }
     }
 }
@@ -1677,7 +1675,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     W: tokio::io::AsyncWrite + Unpin + Send,
 {
     use notebook_protocol::connection::{recv_typed_frame, send_typed_frame, NotebookFrameType};
-    use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
+    use notebook_protocol::protocol::RuntimeAgentResponse;
 
     info!(
         "[notebook-sync] Runtime agent sync connection: notebook={} runtime_agent={}",
@@ -1743,10 +1741,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     }
 
     // ── 3. Set up request channel ────────────────────────────────────
-    let (ra_tx, mut ra_rx) = tokio::sync::mpsc::channel::<(
-        RuntimeAgentRequest,
-        tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
-    )>(16);
+    let (ra_tx, mut ra_rx) = tokio::sync::mpsc::channel::<RuntimeAgentMessage>(16);
     {
         let mut tx_guard = room.runtime_agent_request_tx.lock().await;
         *tx_guard = Some(ra_tx);
@@ -1771,7 +1766,10 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // ── 5. Sync loop ─────────────────────────────────────────────────
     let mut changed_rx = room.changed_tx.subscribe();
     let mut state_changed_rx = room.state_changed_tx.subscribe();
-    let mut pending_reply: Option<tokio::sync::oneshot::Sender<RuntimeAgentResponse>> = None;
+    let mut pending_replies: std::collections::HashMap<
+        String,
+        tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
+    > = std::collections::HashMap::new();
 
     loop {
         tokio::select! {
@@ -1819,12 +1817,13 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 }
                             }
                             NotebookFrameType::Response => {
-                                // Agent responded to an RPC request
-                                if let Ok(response) = serde_json::from_slice::<RuntimeAgentResponse>(&typed_frame.payload) {
-                                    if let Some(reply) = pending_reply.take() {
-                                        let _ = reply.send(response);
+                                if let Ok(envelope) = serde_json::from_slice::<
+                                    notebook_protocol::protocol::RuntimeAgentResponseEnvelope,
+                                >(&typed_frame.payload) {
+                                    if let Some(reply) = pending_replies.remove(&envelope.id) {
+                                        let _ = reply.send(envelope.response);
                                     } else {
-                                        warn!("[notebook-sync] Agent response with no pending request");
+                                        debug!("[notebook-sync] Agent response for unknown id: {}", envelope.id);
                                     }
                                 }
                             }
@@ -1878,15 +1877,21 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                 }
             }
 
-            // RPC requests to forward to runtime agent (only accept when no reply is pending
-            // to serialize RPCs and prevent overwriting the reply slot)
-            Some((request, reply_tx)) = ra_rx.recv(), if pending_reply.is_none() => {
-                let json = match serde_json::to_vec(&request) {
+            // Forward requests to the runtime agent. Commands are fire-and-forget;
+            // queries register a pending reply keyed by correlation ID.
+            Some(msg) = ra_rx.recv() => {
+                let (envelope, reply_tx) = match msg {
+                    RuntimeAgentMessage::Command(env) => (env, None),
+                    RuntimeAgentMessage::Query(env, tx) => (env, Some(tx)),
+                };
+                let json = match serde_json::to_vec(&envelope) {
                     Ok(j) => j,
                     Err(e) => {
-                        let _ = reply_tx.send(RuntimeAgentResponse::Error {
-                            error: format!("Serialize error: {}", e),
-                        });
+                        if let Some(tx) = reply_tx {
+                            let _ = tx.send(RuntimeAgentResponse::Error {
+                                error: format!("Serialize error: {}", e),
+                            });
+                        }
                         continue;
                     }
                 };
@@ -1895,12 +1900,16 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     NotebookFrameType::Request,
                     &json,
                 ).await {
-                    let _ = reply_tx.send(RuntimeAgentResponse::Error {
-                        error: format!("Send error: {}", e),
-                    });
+                    if let Some(tx) = reply_tx {
+                        let _ = tx.send(RuntimeAgentResponse::Error {
+                            error: format!("Send error: {}", e),
+                        });
+                    }
                     break;
                 }
-                pending_reply = Some(reply_tx);
+                if let Some(tx) = reply_tx {
+                    pending_replies.insert(envelope.id, tx);
+                }
             }
         }
     }
@@ -6154,38 +6163,15 @@ async fn handle_notebook_request(
         NotebookRequest::InterruptExecution {} => {
             let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
             if has_runtime_agent {
-                match send_runtime_agent_request(
+                // Fire-and-forget: the agent handles interrupt and updates
+                // RuntimeStateDoc CRDT directly (clears queue, marks executions).
+                match send_runtime_agent_command(
                     room,
                     notebook_protocol::protocol::RuntimeAgentRequest::InterruptExecution,
                 )
                 .await
                 {
-                    Ok(
-                        notebook_protocol::protocol::RuntimeAgentResponse::InterruptAcknowledged {
-                            cleared,
-                        },
-                    ) => {
-                        // Update RuntimeStateDoc: clear CRDT queue, mark cleared
-                        // executions as errored so the frontend reflects the interrupt.
-                        apply_interrupt_to_state_doc(
-                            &room.state_doc,
-                            &room.state_changed_tx,
-                            &cleared,
-                        )
-                        .await;
-                        NotebookResponse::InterruptSent {}
-                    }
-                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
-                        NotebookResponse::Error {
-                            error: format!("Agent interrupt error: {}", error),
-                        }
-                    }
-                    Ok(_) => {
-                        // Legacy Ok response — still update state_doc with empty cleared list
-                        apply_interrupt_to_state_doc(&room.state_doc, &room.state_changed_tx, &[])
-                            .await;
-                        NotebookResponse::InterruptSent {}
-                    }
+                    Ok(()) => NotebookResponse::InterruptSent {},
                     Err(e) => NotebookResponse::Error {
                         error: format!("Agent interrupt error: {}", e),
                     },

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -104,6 +104,22 @@ type RuntimeAgentRequestSender = tokio::sync::mpsc::Sender<(
     tokio::sync::oneshot::Sender<notebook_protocol::protocol::RuntimeAgentResponse>,
 )>;
 
+fn runtime_agent_request_timeout(
+    request: &notebook_protocol::protocol::RuntimeAgentRequest,
+) -> std::time::Duration {
+    use notebook_protocol::protocol::RuntimeAgentRequest;
+    match request {
+        RuntimeAgentRequest::InterruptExecution => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::ShutdownKernel => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::SendComm { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::Complete { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::GetHistory { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::LaunchKernel { .. } => std::time::Duration::from_secs(240),
+        RuntimeAgentRequest::RestartKernel { .. } => std::time::Duration::from_secs(240),
+        RuntimeAgentRequest::SyncEnvironment(_) => std::time::Duration::from_secs(240),
+    }
+}
+
 /// Send an RPC request to the runtime agent via its sync connection.
 ///
 /// The runtime agent's sync handler receives the request as a frame 0x01 and
@@ -113,6 +129,7 @@ pub(crate) async fn send_runtime_agent_request(
     room: &NotebookRoom,
     request: notebook_protocol::protocol::RuntimeAgentRequest,
 ) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
+    let timeout = runtime_agent_request_timeout(&request);
     let tx = {
         let guard = room.runtime_agent_request_tx.lock().await;
         guard
@@ -123,9 +140,11 @@ pub(crate) async fn send_runtime_agent_request(
     tx.send((request, reply_tx))
         .await
         .map_err(|_| anyhow::anyhow!("Runtime agent disconnected"))?;
-    reply_rx
-        .await
-        .map_err(|_| anyhow::anyhow!("Runtime agent dropped reply"))
+    match tokio::time::timeout(timeout, reply_rx).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(_)) => Err(anyhow::anyhow!("Runtime agent dropped reply")),
+        Err(_) => Err(anyhow::anyhow!("Runtime agent request timed out")),
+    }
 }
 
 /// Trust state for a notebook room.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -126,24 +126,37 @@ pub async fn run_runtime_agent(
                 match frame {
                     Ok(Some(typed_frame)) => {
                         match typed_frame.frame_type {
-                            // RuntimeAgentRequest RPC: LaunchKernel, Interrupt, etc.
+                            // RuntimeAgentRequest: envelope with correlation ID.
+                            // Commands (fire-and-forget) get no response.
+                            // Queries (Complete, GetHistory) echo the ID back.
                             NotebookFrameType::Request => {
-                                if let Ok(request) = serde_json::from_slice::<RuntimeAgentRequest>(&typed_frame.payload) {
+                                if let Ok(envelope) = serde_json::from_slice::<
+                                    notebook_protocol::protocol::RuntimeAgentRequestEnvelope,
+                                >(&typed_frame.payload) {
+                                    let is_command = envelope.request.is_command();
+                                    let id = envelope.id.clone();
+
                                     let (response, new_cmd_rx) = handle_runtime_agent_request(
-                                        request,
+                                        envelope.request,
                                         &ctx,
                                         &mut kernel,
                                         &mut kernel_state,
                                         &mut seen_execution_ids,
                                     ).await;
 
-                                    // After launch/restart, take cmd_rx from response
                                     if let Some(rx) = new_cmd_rx {
                                         cmd_rx = Some(rx);
                                     }
 
-                                    let json = serde_json::to_vec(&response)?;
-                                    send_typed_frame(&mut writer, NotebookFrameType::Response, &json).await?;
+                                    // Only send response for queries (not commands)
+                                    if !is_command {
+                                        let resp_envelope = notebook_protocol::protocol::RuntimeAgentResponseEnvelope {
+                                            id,
+                                            response,
+                                        };
+                                        let json = serde_json::to_vec(&resp_envelope)?;
+                                        send_typed_frame(&mut writer, NotebookFrameType::Response, &json).await?;
+                                    }
                                 }
                             }
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -107,6 +107,7 @@ pub async fn run_runtime_agent(
     // -- Local variables owned by the select! loop (no mutex) ---------------
 
     let mut kernel: Option<JupyterKernel> = None;
+    let mut interrupt_handle: Option<crate::jupyter_kernel::InterruptHandle> = None;
     let mut kernel_state = KernelState::new(
         state_doc.clone(),
         state_changed_tx.clone(),
@@ -133,6 +134,31 @@ pub async fn run_runtime_agent(
                                 if let Ok(envelope) = serde_json::from_slice::<
                                     notebook_protocol::protocol::RuntimeAgentRequestEnvelope,
                                 >(&typed_frame.payload) {
+                                    // Interrupt bypasses &mut kernel via InterruptHandle
+                                    if matches!(envelope.request, RuntimeAgentRequest::InterruptExecution) {
+                                        if let Some(ref handle) = interrupt_handle {
+                                            let handle = handle.clone();
+                                            let cleared = kernel_state.clear_queue();
+                                            // Write cleared entries to state doc
+                                            {
+                                                let mut sd = state_doc.write().await;
+                                                for entry in &cleared {
+                                                    sd.set_execution_done(&entry.execution_id, false);
+                                                }
+                                            }
+                                            kernel_state.write_queue_to_state_doc().await;
+                                            // Interrupt kernel in background — don't block the loop
+                                            tokio::spawn(async move {
+                                                if let Err(e) = handle.interrupt().await {
+                                                    warn!("[runtime-agent] Interrupt failed: {}", e);
+                                                }
+                                            });
+                                        } else {
+                                            warn!("[runtime-agent] Interrupt requested but no kernel running");
+                                        }
+                                        continue;
+                                    }
+
                                     let is_command = envelope.request.is_command();
                                     let id = envelope.id.clone();
 
@@ -147,6 +173,8 @@ pub async fn run_runtime_agent(
                                     if let Some(rx) = new_cmd_rx {
                                         cmd_rx = Some(rx);
                                     }
+                                    // Update interrupt handle after any request that may change kernel state
+                                    interrupt_handle = kernel.as_ref().and_then(|k| k.interrupt_handle());
 
                                     // Only send response for queries (not commands)
                                     if !is_command {

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -1,0 +1,506 @@
+// Tests can use unwrap/expect freely - panics are acceptable in test code
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Tests for Phase 2 RPC routing: correlation IDs, fire-and-forget commands,
+//! and the ShutdownKernel sync guarantee.
+//!
+//! These tests exercise the channel routing logic without spawning real kernels.
+//! They verify that:
+//! - Correlation IDs route responses to the correct caller
+//! - Fire-and-forget commands don't block subsequent sync queries
+//! - ShutdownKernel is sync (prevents the CRDT race with LaunchKernel)
+//! - InterruptHandle fires independently of the serial request queue
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use notebook_protocol::protocol::{
+    RuntimeAgentRequest, RuntimeAgentRequestEnvelope, RuntimeAgentResponse,
+};
+use tokio::sync::{mpsc, oneshot};
+
+/// Simulates the daemon's RuntimeAgentMessage routing.
+/// Mirrors the enum at notebook_sync_server.rs:102.
+enum RuntimeAgentMessage {
+    Command(RuntimeAgentRequestEnvelope),
+    Query(
+        RuntimeAgentRequestEnvelope,
+        oneshot::Sender<RuntimeAgentResponse>,
+    ),
+}
+
+/// Route a request through the same logic as `send_runtime_agent_request`.
+async fn route_request(
+    tx: &mpsc::Sender<RuntimeAgentMessage>,
+    request: RuntimeAgentRequest,
+) -> Result<RuntimeAgentResponse, &'static str> {
+    let envelope = RuntimeAgentRequestEnvelope {
+        id: uuid::Uuid::new_v4().to_string(),
+        request,
+    };
+    if envelope.request.is_command() {
+        tx.send(RuntimeAgentMessage::Command(envelope))
+            .await
+            .map_err(|_| "channel closed")?;
+        Ok(RuntimeAgentResponse::Ok)
+    } else {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(RuntimeAgentMessage::Query(envelope, reply_tx))
+            .await
+            .map_err(|_| "channel closed")?;
+        reply_rx.await.map_err(|_| "reply dropped")
+    }
+}
+
+/// Simulates a runtime agent that processes messages from the channel.
+/// Returns responses for queries, ignores commands.
+async fn mock_agent(
+    mut rx: mpsc::Receiver<RuntimeAgentMessage>,
+    response_delay: Duration,
+) {
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            RuntimeAgentMessage::Command(_) => {
+                // Fire-and-forget: no response
+            }
+            RuntimeAgentMessage::Query(envelope, reply_tx) => {
+                let response = match &envelope.request {
+                    RuntimeAgentRequest::ShutdownKernel => RuntimeAgentResponse::Ok,
+                    RuntimeAgentRequest::LaunchKernel { env_source, .. } => {
+                        RuntimeAgentResponse::KernelLaunched {
+                            env_source: env_source.clone(),
+                        }
+                    }
+                    RuntimeAgentRequest::RestartKernel { env_source, .. } => {
+                        RuntimeAgentResponse::KernelRestarted {
+                            env_source: env_source.clone(),
+                        }
+                    }
+                    RuntimeAgentRequest::Complete { .. } => {
+                        RuntimeAgentResponse::CompletionResult {
+                            items: vec![],
+                            cursor_start: 0,
+                            cursor_end: 0,
+                        }
+                    }
+                    _ => RuntimeAgentResponse::Ok,
+                };
+                if !response_delay.is_zero() {
+                    tokio::time::sleep(response_delay).await;
+                }
+                let _ = reply_tx.send(response);
+            }
+        }
+    }
+}
+
+// ─── Correlation ID routing ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn correlation_ids_route_concurrent_queries_correctly() {
+    // Multiple queries in-flight simultaneously should each get their own response.
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Agent that echoes the request type in its response
+    tokio::spawn(async move {
+        mock_agent(rx, Duration::ZERO).await;
+    });
+
+    // Send multiple queries concurrently
+    let tx1 = tx.clone();
+    let tx2 = tx.clone();
+    let tx3 = tx.clone();
+
+    let (r1, r2, r3) = tokio::join!(
+        route_request(
+            &tx1,
+            RuntimeAgentRequest::Complete {
+                code: "first".into(),
+                cursor_pos: 5,
+            }
+        ),
+        route_request(
+            &tx2,
+            RuntimeAgentRequest::Complete {
+                code: "second".into(),
+                cursor_pos: 6,
+            }
+        ),
+        route_request(&tx3, RuntimeAgentRequest::ShutdownKernel),
+    );
+
+    // All three should get responses (no misrouting)
+    assert!(matches!(
+        r1.unwrap(),
+        RuntimeAgentResponse::CompletionResult { .. }
+    ));
+    assert!(matches!(
+        r2.unwrap(),
+        RuntimeAgentResponse::CompletionResult { .. }
+    ));
+    assert!(matches!(r3.unwrap(), RuntimeAgentResponse::Ok));
+}
+
+#[tokio::test]
+async fn correlation_ids_handle_interleaved_responses() {
+    // Simulate an agent that responds to requests out-of-order (slower requests
+    // get responses after faster ones).
+    let (tx, mut rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Custom agent: delays ShutdownKernel but responds to Complete immediately
+    tokio::spawn(async move {
+        let mut pending: Vec<(RuntimeAgentRequestEnvelope, oneshot::Sender<RuntimeAgentResponse>)> =
+            Vec::new();
+
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                RuntimeAgentMessage::Command(_) => {}
+                RuntimeAgentMessage::Query(envelope, reply_tx) => {
+                    if matches!(envelope.request, RuntimeAgentRequest::ShutdownKernel) {
+                        // Delay shutdown response
+                        pending.push((envelope, reply_tx));
+                    } else {
+                        // Respond immediately
+                        let _ = reply_tx.send(RuntimeAgentResponse::CompletionResult {
+                            items: vec![],
+                            cursor_start: 0,
+                            cursor_end: 0,
+                        });
+                    }
+                }
+            }
+            // After processing 3 messages, flush pending
+            if pending.len() == 1 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                for (_, reply_tx) in pending.drain(..) {
+                    let _ = reply_tx.send(RuntimeAgentResponse::Ok);
+                }
+            }
+        }
+    });
+
+    // Send shutdown (slow) then complete (fast)
+    let tx1 = tx.clone();
+    let tx2 = tx.clone();
+
+    let shutdown_handle = tokio::spawn(async move {
+        route_request(&tx1, RuntimeAgentRequest::ShutdownKernel).await
+    });
+    // Small delay to ensure ordering
+    tokio::time::sleep(Duration::from_millis(1)).await;
+    let complete_handle = tokio::spawn(async move {
+        route_request(
+            &tx2,
+            RuntimeAgentRequest::Complete {
+                code: "x".into(),
+                cursor_pos: 1,
+            },
+        )
+        .await
+    });
+
+    let complete_result = complete_handle.await.unwrap();
+    let shutdown_result = shutdown_handle.await.unwrap();
+
+    // Complete should finish first (immediate response)
+    assert!(matches!(
+        complete_result.unwrap(),
+        RuntimeAgentResponse::CompletionResult { .. }
+    ));
+    // Shutdown should also eventually complete (delayed)
+    assert!(matches!(shutdown_result.unwrap(), RuntimeAgentResponse::Ok));
+}
+
+// ─── Fire-and-forget commands ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn fire_and_forget_returns_immediately() {
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Agent that never processes messages (simulates slow/stuck agent)
+    // We intentionally hold rx open but never read it.
+    let _rx_holder = rx;
+
+    let start = std::time::Instant::now();
+    let result = route_request(&tx, RuntimeAgentRequest::InterruptExecution).await;
+    let elapsed = start.elapsed();
+
+    // Fire-and-forget should return Ok immediately (no waiting for response)
+    assert!(matches!(result.unwrap(), RuntimeAgentResponse::Ok));
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "fire-and-forget took {:?} — should be instant",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn fire_and_forget_does_not_block_subsequent_queries() {
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Agent with 50ms response delay
+    tokio::spawn(async move {
+        mock_agent(rx, Duration::from_millis(50)).await;
+    });
+
+    // Send a command (instant) then a query (waits for response)
+    let cmd_result = route_request(&tx, RuntimeAgentRequest::InterruptExecution).await;
+    assert!(matches!(cmd_result.unwrap(), RuntimeAgentResponse::Ok));
+
+    // Query should still work even after command
+    let query_result = route_request(
+        &tx,
+        RuntimeAgentRequest::Complete {
+            code: "x".into(),
+            cursor_pos: 1,
+        },
+    )
+    .await;
+    assert!(matches!(
+        query_result.unwrap(),
+        RuntimeAgentResponse::CompletionResult { .. }
+    ));
+}
+
+#[tokio::test]
+async fn multiple_commands_dont_accumulate_pending_replies() {
+    let (tx, mut rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Send 10 commands rapidly
+    for _ in 0..10 {
+        let result = route_request(&tx, RuntimeAgentRequest::InterruptExecution).await;
+        assert!(matches!(result.unwrap(), RuntimeAgentResponse::Ok));
+    }
+
+    // Drain the channel — all should be Command variants (no Query)
+    let mut count = 0;
+    while let Ok(msg) = rx.try_recv() {
+        match msg {
+            RuntimeAgentMessage::Command(_) => count += 1,
+            RuntimeAgentMessage::Query(_, _) => {
+                panic!("fire-and-forget commands should not create Query messages")
+            }
+        }
+    }
+    assert_eq!(count, 10);
+}
+
+// ─── ShutdownKernel sync guarantee ───────────────────────────────────────────
+
+#[tokio::test]
+async fn shutdown_waits_for_agent_confirmation() {
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Agent with 100ms delay on shutdown
+    tokio::spawn(async move {
+        mock_agent(rx, Duration::from_millis(100)).await;
+    });
+
+    let start = std::time::Instant::now();
+    let result = route_request(&tx, RuntimeAgentRequest::ShutdownKernel).await;
+    let elapsed = start.elapsed();
+
+    assert!(matches!(result.unwrap(), RuntimeAgentResponse::Ok));
+    assert!(
+        elapsed >= Duration::from_millis(90),
+        "ShutdownKernel should wait for agent response (took {:?})",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn shutdown_then_launch_serialized() {
+    // Verifies the fix for the CRDT race: ShutdownKernel must complete
+    // before LaunchKernel can proceed (which would send RestartKernel).
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+    let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let order_clone = order.clone();
+
+    // Agent that records the order of processed requests
+    tokio::spawn(async move {
+        let mut rx = rx;
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                RuntimeAgentMessage::Command(env) => {
+                    order_clone
+                        .lock()
+                        .unwrap()
+                        .push(format!("cmd:{:?}", std::mem::discriminant(&env.request)));
+                }
+                RuntimeAgentMessage::Query(env, reply_tx) => {
+                    let label = match &env.request {
+                        RuntimeAgentRequest::ShutdownKernel => "shutdown",
+                        RuntimeAgentRequest::LaunchKernel { .. } => "launch",
+                        RuntimeAgentRequest::RestartKernel { .. } => "restart",
+                        _ => "other",
+                    };
+                    order_clone
+                        .lock()
+                        .unwrap()
+                        .push(format!("query:{}", label));
+
+                    // Simulate some processing time
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+
+                    let response = match &env.request {
+                        RuntimeAgentRequest::ShutdownKernel => RuntimeAgentResponse::Ok,
+                        RuntimeAgentRequest::LaunchKernel { env_source, .. } => {
+                            RuntimeAgentResponse::KernelLaunched {
+                                env_source: env_source.clone(),
+                            }
+                        }
+                        _ => RuntimeAgentResponse::Ok,
+                    };
+                    let _ = reply_tx.send(response);
+                }
+            }
+        }
+    });
+
+    // Sequence: Shutdown → Launch (sequential, as the daemon does)
+    let r1 = route_request(&tx, RuntimeAgentRequest::ShutdownKernel).await;
+    assert!(matches!(r1.unwrap(), RuntimeAgentResponse::Ok));
+
+    let r2 = route_request(
+        &tx,
+        RuntimeAgentRequest::LaunchKernel {
+            kernel_type: "python".into(),
+            env_source: "conda:inline".into(),
+            notebook_path: None,
+            launched_config: Default::default(),
+            env_vars: Default::default(),
+        },
+    )
+    .await;
+    assert!(matches!(
+        r2.unwrap(),
+        RuntimeAgentResponse::KernelLaunched { .. }
+    ));
+
+    // Verify ordering: shutdown must be processed BEFORE launch
+    let recorded = order.lock().unwrap().clone();
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(recorded[0], "query:shutdown");
+    assert_eq!(recorded[1], "query:launch");
+}
+
+// ─── InterruptHandle independence ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn interrupt_fires_while_query_in_flight() {
+    // InterruptExecution is fire-and-forget, so it should not block
+    // even when a sync query (e.g., Complete) is awaiting a response.
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Slow agent: 200ms per response
+    tokio::spawn(async move {
+        mock_agent(rx, Duration::from_millis(200)).await;
+    });
+
+    let tx1 = tx.clone();
+    let tx2 = tx.clone();
+
+    // Launch a slow query in the background
+    let query_handle = tokio::spawn(async move {
+        route_request(
+            &tx1,
+            RuntimeAgentRequest::Complete {
+                code: "slow".into(),
+                cursor_pos: 4,
+            },
+        )
+        .await
+    });
+
+    // Small delay to let the query get submitted
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Interrupt should fire instantly, not blocked by the in-flight query
+    let start = std::time::Instant::now();
+    let interrupt_result = route_request(&tx2, RuntimeAgentRequest::InterruptExecution).await;
+    let elapsed = start.elapsed();
+
+    assert!(matches!(interrupt_result.unwrap(), RuntimeAgentResponse::Ok));
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "interrupt took {:?} — should not be blocked by in-flight query",
+        elapsed
+    );
+
+    // Query should still complete eventually
+    let query_result = query_handle.await.unwrap();
+    assert!(matches!(
+        query_result.unwrap(),
+        RuntimeAgentResponse::CompletionResult { .. }
+    ));
+}
+
+#[tokio::test]
+async fn sendcomm_fires_independently() {
+    // SendComm is also fire-and-forget (widget interactions must not block)
+    let (tx, _rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    let start = std::time::Instant::now();
+    let result = route_request(
+        &tx,
+        RuntimeAgentRequest::SendComm {
+            message: serde_json::json!({"target_name": "jupyter.widget", "data": {}}),
+        },
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    assert!(matches!(result.unwrap(), RuntimeAgentResponse::Ok));
+    assert!(elapsed < Duration::from_millis(50));
+}
+
+// ─── Pending replies cleanup ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn pending_replies_error_on_agent_disconnect() {
+    // When the agent disconnects (channel closes), pending queries should
+    // get an error rather than hanging forever.
+    let (tx, rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Drop the receiver immediately — simulates agent disconnect
+    drop(rx);
+
+    // Query should fail with a channel error
+    let result = route_request(
+        &tx,
+        RuntimeAgentRequest::Complete {
+            code: "x".into(),
+            cursor_pos: 1,
+        },
+    )
+    .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn pending_reply_dropped_when_agent_exits_mid_query() {
+    let (tx, mut rx) = mpsc::channel::<RuntimeAgentMessage>(16);
+
+    // Agent that receives one query then exits (drops reply_tx)
+    tokio::spawn(async move {
+        if let Some(msg) = rx.recv().await {
+            match msg {
+                RuntimeAgentMessage::Query(_, reply_tx) => {
+                    // Simulate agent crash: drop reply without sending
+                    drop(reply_tx);
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let result = route_request(
+        &tx,
+        RuntimeAgentRequest::Complete {
+            code: "x".into(),
+            cursor_pos: 1,
+        },
+    )
+    .await;
+    assert!(result.is_err(), "should error when reply is dropped");
+}

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -481,14 +481,9 @@ async fn pending_reply_dropped_when_agent_exits_mid_query() {
 
     // Agent that receives one query then exits (drops reply_tx)
     tokio::spawn(async move {
-        if let Some(msg) = rx.recv().await {
-            match msg {
-                RuntimeAgentMessage::Query(_, reply_tx) => {
-                    // Simulate agent crash: drop reply without sending
-                    drop(reply_tx);
-                }
-                _ => {}
-            }
+        if let Some(RuntimeAgentMessage::Query(_, reply_tx)) = rx.recv().await {
+            // Simulate agent crash: drop reply without sending
+            drop(reply_tx);
         }
     });
 

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -54,10 +54,7 @@ async fn route_request(
 
 /// Simulates a runtime agent that processes messages from the channel.
 /// Returns responses for queries, ignores commands.
-async fn mock_agent(
-    mut rx: mpsc::Receiver<RuntimeAgentMessage>,
-    response_delay: Duration,
-) {
+async fn mock_agent(mut rx: mpsc::Receiver<RuntimeAgentMessage>, response_delay: Duration) {
     while let Some(msg) = rx.recv().await {
         match msg {
             RuntimeAgentMessage::Command(_) => {
@@ -149,8 +146,10 @@ async fn correlation_ids_handle_interleaved_responses() {
 
     // Custom agent: delays ShutdownKernel but responds to Complete immediately
     tokio::spawn(async move {
-        let mut pending: Vec<(RuntimeAgentRequestEnvelope, oneshot::Sender<RuntimeAgentResponse>)> =
-            Vec::new();
+        let mut pending: Vec<(
+            RuntimeAgentRequestEnvelope,
+            oneshot::Sender<RuntimeAgentResponse>,
+        )> = Vec::new();
 
         while let Some(msg) = rx.recv().await {
             match msg {
@@ -183,9 +182,8 @@ async fn correlation_ids_handle_interleaved_responses() {
     let tx1 = tx.clone();
     let tx2 = tx.clone();
 
-    let shutdown_handle = tokio::spawn(async move {
-        route_request(&tx1, RuntimeAgentRequest::ShutdownKernel).await
-    });
+    let shutdown_handle =
+        tokio::spawn(async move { route_request(&tx1, RuntimeAgentRequest::ShutdownKernel).await });
     // Small delay to ensure ordering
     tokio::time::sleep(Duration::from_millis(1)).await;
     let complete_handle = tokio::spawn(async move {
@@ -334,10 +332,7 @@ async fn shutdown_then_launch_serialized() {
                         RuntimeAgentRequest::RestartKernel { .. } => "restart",
                         _ => "other",
                     };
-                    order_clone
-                        .lock()
-                        .unwrap()
-                        .push(format!("query:{}", label));
+                    order_clone.lock().unwrap().push(format!("query:{}", label));
 
                     // Simulate some processing time
                     tokio::time::sleep(Duration::from_millis(20)).await;
@@ -420,7 +415,10 @@ async fn interrupt_fires_while_query_in_flight() {
     let interrupt_result = route_request(&tx2, RuntimeAgentRequest::InterruptExecution).await;
     let elapsed = start.elapsed();
 
-    assert!(matches!(interrupt_result.unwrap(), RuntimeAgentResponse::Ok));
+    assert!(matches!(
+        interrupt_result.unwrap(),
+        RuntimeAgentResponse::Ok
+    ));
     assert!(
         elapsed < Duration::from_millis(50),
         "interrupt took {:?} — should not be blocked by in-flight query",


### PR DESCRIPTION
## Summary

- Add per-RPC timeouts to `send_runtime_agent_request` as safety net
- Add `RuntimeAgentRequestEnvelope` / `RuntimeAgentResponseEnvelope` with required correlation ID
- Replace serialized `pending_reply: Option<oneshot>` with `HashMap<String, oneshot>` — multiple RPCs can now be in-flight
- Fire-and-forget for command RPCs (Interrupt, Shutdown, SendComm) — state flows via CRDT
- Remove `apply_interrupt_to_state_doc` — agent already writes queue state to RuntimeStateDoc
- InterruptHandle extraction with interior mutability (WIP)

## Motivation

The daemon↔agent channel had a serialization bottleneck: only one RPC could be in-flight at a time due to `pending_reply: Option<oneshot>` with a `select!` guard. A slow RPC (e.g., kernel launch) would block all other RPCs, including InterruptExecution. The 30s client timeout would fire.

## Test plan

- [ ] Gremlin suite passes (learner, executor gremlins)
- [ ] Kernel interrupt works during cell execution
- [ ] Code completion (Complete) still returns results
- [ ] Kernel launch/restart/shutdown lifecycle works
- [ ] Environment sync works