### PR TITLE
docs: lead with positive voice for daemon lifecycle

### DIFF
--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -269,12 +269,12 @@ ls -la ~/.cache/runt/envs/
 
 Check that uv/conda are installed and working.
 
-## NEVER Use pkill or killall
-
-**Never** use `pkill runtimed`, `killall runtimed`, or similar. These kill ALL runtimed processes system-wide, disrupting other agents and worktrees. Use:
+## Stopping the Daemon
 
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
 - `cargo xtask install-nightly` — gracefully installs/reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
+
+Avoid system-wide process killers (`pkill`, `killall`) — they affect every worktree and every other agent on the machine.
 
 ## Shipped App Behavior
 

--- a/.codex/skills/nteract-daemon-dev/SKILL.md
+++ b/.codex/skills/nteract-daemon-dev/SKILL.md
@@ -18,9 +18,9 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 
 ## Guardrails
 
-- Never use `pkill`, `killall`, or other system-wide process killers for `runtimed`.
-- Never assume the system daemon is correct for a repo worktree.
-- Never run the notebook GUI from an agent terminal; let the human launch it.
+- Stop the daemon with `./target/debug/runt daemon stop`. System-wide killers (`pkill`, `killall`) affect every worktree on the machine.
+- Assume the worktree daemon is the target for dev work; the system daemon is for diagnostics only.
+- Let the human launch the notebook GUI from their own terminal.
 - If a test or script depends on notebook execution, blob resolution, or MCP server behavior, confirm it is pointed at the worktree daemon first.
 - Use `default_socket_path()` for the current process. Reach for `socket_path_for_channel(...)` only when you intentionally need stable/nightly discovery that ignores `RUNTIMED_SOCKET_PATH`.
 - **Any daemon code that reads CRDT state, does async work, then writes back must use `fork()` + `merge()`.** For synchronous blocks use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` and `.codex/skills/nteract-notebook-sync/references/crdt-ownership.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,13 +427,12 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 
 The daemon is a separate process from the notebook app. When you change code in `crates/runtimed/`, the running daemon still uses the old binary until you reinstall it.
 
-### Do NOT Use pkill or killall
+### Stopping the Daemon
 
-**Never** use `pkill runtimed`, `killall runtimed`, or similar commands. These kill **all** runtimed processes system-wide, disrupting other agents and worktrees.
-
-Use instead:
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
 - `cargo xtask install-nightly` — gracefully installs or reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
+
+Avoid system-wide process killers (`pkill`, `killall`) — they affect every worktree and every other agent on the machine.
 
 ### Per-Worktree Daemon Isolation
 


### PR DESCRIPTION
## Summary

Three files repeated the same `pkill` warning, twice with it promoted to the section heading (`### Do NOT Use pkill or killall`, `## NEVER Use pkill or killall`). The positive action is simple — `./target/debug/runt daemon stop` — and deserves the headline. The system-wide-killer caveat stays as a short parenthetical so the guidance is preserved without dominating.

Changed files:
- `AGENTS.md` — `### Do NOT Use pkill or killall` → `### Stopping the Daemon`
- `.claude/skills/daemon-dev/SKILL.md` — `## NEVER Use pkill or killall` → `## Stopping the Daemon`
- `.codex/skills/nteract-daemon-dev/SKILL.md` — three `Never ...` guardrails rewritten as positive-voice directives

## Test plan

- [ ] Skim the three edited sections and confirm the positive guidance reads clearly
- [ ] Confirm `pkill` / `killall` are still mentioned as discouraged (just no longer in headings)
