### PR TITLE
fix(runtimed): increase RestartKernel/LaunchKernel/SyncEnvironment timeout to 240s

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -117,8 +117,12 @@ fn runtime_agent_query_timeout(
 ) -> std::time::Duration {
     use notebook_protocol::protocol::RuntimeAgentRequest;
     match request {
-        RuntimeAgentRequest::Complete { .. } => std::time::Duration::from_secs(10),
-        RuntimeAgentRequest::GetHistory { .. } => std::time::Duration::from_secs(10),
+        RuntimeAgentRequest::Complete { .. } | RuntimeAgentRequest::GetHistory { .. } => {
+            std::time::Duration::from_secs(10)
+        }
+        RuntimeAgentRequest::LaunchKernel { .. }
+        | RuntimeAgentRequest::RestartKernel { .. }
+        | RuntimeAgentRequest::SyncEnvironment(_) => std::time::Duration::from_secs(240),
         _ => std::time::Duration::from_secs(30),
     }
 }


### PR DESCRIPTION
## Summary

- RestartKernel, LaunchKernel, and SyncEnvironment now get a 240s timeout instead of the 30s catch-all
- Fixes UV-data-scientist gremlin regression where `uv sync` during RestartKernel exceeded 30s, causing the daemon to SIGKILL the agent and trigger a retry loop (950s / 51 turns instead of ~120s / 26 turns)
- Conda was unaffected because prewarmed pool environments resolve instantly

## Test plan

- [ ] uv-data-scientist gremlin passes (was failing with 6-8x slowdown)
- [ ] Full 19-gremlin suite green
- [ ] CI passes (lint, clippy, tests)