### PR TITLE
fix(runtimed): periodic RuntimeStateDoc compaction prevents frame overflow

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -527,6 +527,25 @@ impl RuntimeStateDoc {
         }
     }
 
+    /// Compact the document if its serialized size exceeds `threshold` bytes.
+    ///
+    /// Returns `true` if compaction was performed.
+    pub fn compact_if_oversized(&mut self, threshold: usize) -> bool {
+        let actor = self.doc.get_actor().clone();
+        let bytes = self.doc.save();
+        if bytes.len() <= threshold {
+            return false;
+        }
+        match AutoCommit::load(&bytes) {
+            Ok(mut doc) => {
+                doc.set_actor(actor);
+                self.doc = doc;
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
     /// Set the actor identity for this document.
     ///
     /// Forks should call this with a distinct label so their changes are
@@ -4054,5 +4073,23 @@ mod tests {
         assert_eq!(outputs[2]["output_id"], "oid-stdout-2");
         // Two stdout chunks must have distinct IDs
         assert_ne!(outputs[0]["output_id"], outputs[2]["output_id"]);
+    }
+
+    #[test]
+    fn test_compact_if_oversized_below_threshold() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("idle");
+        // Doc is tiny — should not compact
+        assert!(!doc.compact_if_oversized(1024 * 1024));
+    }
+
+    #[test]
+    fn test_compact_if_oversized_above_threshold() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("idle");
+        // Threshold of 0 forces compaction
+        assert!(doc.compact_if_oversized(0));
+        // State is preserved after compaction
+        assert_eq!(doc.read_state().kernel.status, "idle");
     }
 }

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -208,7 +208,15 @@ impl KernelState {
                 let mut sd = self.state_doc.write().await;
                 let mut changed = sd.set_execution_done(execution_id, success);
                 changed |= sd.set_queue(None, &doc_queued);
-                changed |= sd.trim_executions(MAX_EXECUTION_ENTRIES) > 0;
+                let trimmed = sd.trim_executions(MAX_EXECUTION_ENTRIES);
+                changed |= trimmed > 0;
+                if trimmed > 0 {
+                    sd.rebuild_from_save();
+                    debug!(
+                        "[kernel-state] Compacted RuntimeStateDoc after trimming {} executions",
+                        trimmed
+                    );
+                }
                 if changed {
                     let _ = self.state_changed_tx.send(());
                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2613,6 +2613,12 @@ where
     // Phase 1.1: Initial RuntimeStateDoc sync — encode inside lock, send outside
     let initial_state_encoded = {
         let mut state_doc = room.state_doc.write().await;
+        // Safety net: compact before initial sync if the doc grew too large.
+        // 80 MiB leaves headroom under the 100 MiB frame limit.
+        const COMPACTION_THRESHOLD: usize = 80 * 1024 * 1024;
+        if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
+            info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
+        }
         match catch_automerge_panic("initial-state-sync", || {
             state_doc
                 .generate_sync_message(&mut state_peer_state)


### PR DESCRIPTION
## Summary

- After `trim_executions` removes old execution entries, immediately `rebuild_from_save()` to strip accumulated Automerge history/tombstones
- Before initial RuntimeStateDoc sync to a new peer, compact if the serialized doc exceeds 80 MiB (safety net under the 100 MiB frame limit)
- Adds `compact_if_oversized(threshold)` method to `RuntimeStateDoc`

Fixes the "frame too large" error that occurs when RuntimeStateDoc accumulates unbounded CRDT history from repeated execution trimming and stream coalescence.

## Test plan

- [x] Unit tests for `compact_if_oversized` (below threshold: no-op, above threshold: compacts and preserves state)
- [x] `cargo clippy -p runtimed -p notebook-doc` clean
- [x] Release build succeeds
- [x] Nightly daemon starts and runs healthy
- [ ] Gremlin suite validates no regression on output_id persistence