### PR TITLE
ci(python): drop dead push-to-main trigger

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,8 +7,6 @@
 name: Python CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- `.github/workflows/python-package.yml`'s `changes` job calls `dorny/paths-filter@v3` with no prior `actions/checkout`. On `pull_request` the action uses the GitHub API (no git needed); on `push` it shells out locally and dies with `fatal: not a git repository`, exit 128. Example: https://github.com/nteract/desktop/actions/runs/24661915051/job/72109807411
- The push-to-main variant was introduced in #1773 when publishing moved out of this workflow into `release-common.yml`. It has failed every single post-merge run since: 96 failure / 4 cancelled / **0 success** on last 100 push-main runs. Nothing noticed because Python CI isn't a required check — required checks (macOS, Windows, Lint & Format, Clippy & Tests (Linux), JS Tests & Benchmarks) all live in `build.yml`.
- PR runs on this workflow stay healthy (48 success / 2 cancelled / 0 failure on last 50) since they take the API path. That's where the real gating happens.

Drop the push trigger. The workflow stays PR-only (which is what's actually been running), plus `workflow_dispatch` for manual runs.

## Test plan

- [ ] This PR's own `Python CI` run goes green via the `pull_request` trigger.
- [ ] After merge, confirm no `Python CI` run fires on the merge commit (the whole point).