### PR TITLE
fix(runt-mcp): clarify save_notebook path requirement for ephemeral notebooks

### DIFF
--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -111,7 +111,7 @@ pub fn all_tools() -> Vec<Tool> {
         .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
         Tool::new(
             "save_notebook",
-            "Save notebook to disk.",
+            "Save notebook to disk. For notebooks created with create_notebook(), you must provide a path.",
             schema_for::<session::SaveNotebookParams>(),
         )
         .annotate(

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -225,7 +225,9 @@ pub struct ShowNotebookParams {
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SaveNotebookParams {
-    /// Path to save the notebook to. If None, saves to original location.
+    /// Path to save the notebook to (e.g., "~/analysis.ipynb").
+    /// Required for ephemeral notebooks created with create_notebook().
+    /// Omit to save to the notebook's existing file path.
     #[serde(default)]
     pub path: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Update `save_notebook` tool description to state that `path` is required for notebooks created with `create_notebook()`
- Update `path` param documentation to clarify when it's required vs optional

Fixes wasted tool calls where LLMs omit the path for ephemeral notebooks because the schema implied it was always optional.

## Test plan

- [x] `cargo clippy -p runt-mcp` clean
- [ ] Gremlin suite confirms no more "No path specified" errors on first save attempt