### PR TITLE
fix(notebook-doc): eliminate TOCTOU gap in RuntimeStateDoc initial sync

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2108,20 +2108,35 @@ impl RuntimeStateDoc {
     /// Eliminates the TOCTOU race where the doc grows between a pre-send size
     /// check and the actual frame send. If the message is oversized, this
     /// compacts via save→load, resets `peer_state`, and regenerates.
-    pub fn generate_sync_message_bounded(
+    ///
+    /// Returns the encoded bytes directly, avoiding a redundant clone of the
+    /// sync message. Only safe before the first sync exchange with the peer
+    /// (i.e., `peer_state` must be fresh or about to be reset).
+    pub fn generate_sync_message_bounded_encoded(
         &mut self,
         peer_state: &mut sync::State,
         max_encoded_bytes: usize,
-    ) -> Option<sync::Message> {
-        let msg = self.doc.sync().generate_sync_message(peer_state)?;
-        if msg.clone().encode().len() <= max_encoded_bytes {
-            return Some(msg);
+    ) -> Option<Vec<u8>> {
+        let encoded = self.doc.sync().generate_sync_message(peer_state)?.encode();
+        if encoded.len() <= max_encoded_bytes {
+            return Some(encoded);
         }
+        #[cfg(feature = "persistence")]
+        log::warn!(
+            "[runtime-state] Sync message ({} bytes) exceeds threshold ({} bytes), compacting",
+            encoded.len(),
+            max_encoded_bytes,
+        );
         if !self.rebuild_from_save() {
-            return None;
+            #[cfg(feature = "persistence")]
+            log::warn!("[runtime-state] Compaction failed during bounded sync generation");
+            return Some(encoded);
         }
         *peer_state = sync::State::new();
-        self.doc.sync().generate_sync_message(peer_state)
+        self.doc
+            .sync()
+            .generate_sync_message(peer_state)
+            .map(|m| m.encode())
     }
 
     /// Receive a sync message with change stripping (read-only enforcement).
@@ -2633,7 +2648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_sync_message_bounded_compacts_on_oversized() {
+    fn test_generate_sync_message_bounded_encoded_compacts_on_oversized() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution("exec-1", "cell-1");
         for i in 0..50 {
@@ -2647,13 +2662,17 @@ mod tests {
 
         let mut peer_state = sync::State::new();
         // Threshold of 1 byte forces compaction
-        let msg = doc.generate_sync_message_bounded(&mut peer_state, 1);
-        assert!(msg.is_some(), "should produce a message after compaction");
+        let encoded = doc.generate_sync_message_bounded_encoded(&mut peer_state, 1);
+        assert!(
+            encoded.is_some(),
+            "should produce a message after compaction"
+        );
 
         // Verify the compacted message syncs correctly to a fresh client
         let mut client = RuntimeStateDoc::new_empty();
         let mut client_state = sync::State::new();
-        if let Some(msg) = msg {
+        if let Some(bytes) = encoded {
+            let msg = sync::Message::decode(&bytes).expect("decode compacted message");
             client
                 .doc_mut()
                 .sync()
@@ -2681,13 +2700,13 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_sync_message_bounded_no_compact_under_limit() {
+    fn test_generate_sync_message_bounded_encoded_no_compact_under_limit() {
         let mut doc = RuntimeStateDoc::new();
         doc.set_kernel_status("idle");
 
         let mut peer_state = sync::State::new();
-        let msg = doc.generate_sync_message_bounded(&mut peer_state, 100 * 1024 * 1024);
-        assert!(msg.is_some());
+        let encoded = doc.generate_sync_message_bounded_encoded(&mut peer_state, 100 * 1024 * 1024);
+        assert!(encoded.is_some());
     }
 
     // ── Execution lifecycle tests ───────────────────────────────────

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2102,6 +2102,26 @@ impl RuntimeStateDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
+    /// Generate a sync message, compacting the doc if the encoded message
+    /// would exceed `max_encoded_bytes`.
+    ///
+    /// Eliminates the TOCTOU race where the doc grows between a pre-send size
+    /// check and the actual frame send. If the message is oversized, this
+    /// compacts via save→load, resets `peer_state`, and regenerates.
+    pub fn generate_sync_message_bounded(
+        &mut self,
+        peer_state: &mut sync::State,
+        max_encoded_bytes: usize,
+    ) -> Option<sync::Message> {
+        let msg = self.doc.sync().generate_sync_message(peer_state)?;
+        if msg.clone().encode().len() <= max_encoded_bytes {
+            return Some(msg);
+        }
+        self.rebuild_from_save();
+        *peer_state = sync::State::new();
+        self.doc.sync().generate_sync_message(peer_state)
+    }
+
     /// Receive a sync message with change stripping (read-only enforcement).
     ///
     /// The daemon is the sole authority for runtime state. Any changes a
@@ -2601,6 +2621,64 @@ mod tests {
             client_state.last_saved,
             Some("2025-01-15T12:00:00Z".to_string()),
         );
+    }
+
+    #[test]
+    fn test_generate_sync_message_bounded_compacts_on_oversized() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1", "cell-1");
+        for i in 0..50 {
+            let manifest = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": {"blob": format!("hash-{}", i), "size": 1000 + i}
+            });
+            doc.append_output("exec-1", &manifest).unwrap();
+        }
+
+        let mut peer_state = sync::State::new();
+        // Threshold of 1 byte forces compaction
+        let msg = doc.generate_sync_message_bounded(&mut peer_state, 1);
+        assert!(msg.is_some(), "should produce a message after compaction");
+
+        // Verify the compacted message syncs correctly to a fresh client
+        let mut client = RuntimeStateDoc::new_empty();
+        let mut client_state = sync::State::new();
+        if let Some(msg) = msg {
+            client
+                .doc_mut()
+                .sync()
+                .receive_sync_message(&mut client_state, msg)
+                .expect("client receive after compaction");
+        }
+        for _ in 0..5 {
+            if let Some(reply) = client
+                .doc_mut()
+                .sync()
+                .generate_sync_message(&mut client_state)
+            {
+                doc.receive_sync_message_with_changes(&mut peer_state, reply)
+                    .ok();
+            }
+            if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
+                client
+                    .doc_mut()
+                    .sync()
+                    .receive_sync_message(&mut client_state, msg)
+                    .ok();
+            }
+        }
+        assert_eq!(client.get_outputs("exec-1").len(), 50);
+    }
+
+    #[test]
+    fn test_generate_sync_message_bounded_no_compact_under_limit() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("idle");
+
+        let mut peer_state = sync::State::new();
+        let msg = doc.generate_sync_message_bounded(&mut peer_state, 100 * 1024 * 1024);
+        assert!(msg.is_some());
     }
 
     // ── Execution lifecycle tests ───────────────────────────────────

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2117,7 +2117,9 @@ impl RuntimeStateDoc {
         if msg.clone().encode().len() <= max_encoded_bytes {
             return Some(msg);
         }
-        self.rebuild_from_save();
+        if !self.rebuild_from_save() {
+            return None;
+        }
         *peer_state = sync::State::new();
         self.doc.sync().generate_sync_message(peer_state)
     }
@@ -3361,7 +3363,7 @@ mod tests {
         let growth_factor = size_after_100 as f64 / size_after_first as f64;
         assert!(
             growth_factor < 3.0,
-            "Doc grew {:.1}x after 100 stream updates (expected < 6x). \
+            "Doc grew {:.1}x after 100 stream updates (expected < 3x). \
              size_after_first={}, size_after_100={}",
             growth_factor,
             size_after_first,

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2132,6 +2132,13 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
+        #[cfg(feature = "persistence")]
+        if !message.changes.is_empty() {
+            log::debug!(
+                "[notebook-sync] Stripped {} change(s) from client RuntimeStateDoc sync message",
+                message.changes.len(),
+            );
+        }
         // Strip client changes — keep only the sync protocol handshake.
         let filtered = sync::Message {
             heads: message.heads,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1730,10 +1730,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
 
     // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
     // Scope the state_doc write guard so it drops before the async send.
+    // Uses bounded generation to compact if oversized (same 80 MiB threshold).
     let mut state_sync_state = automerge::sync::State::new();
     let state_sync_msg = {
         let mut sd = room.state_doc.write().await;
-        sd.generate_sync_message(&mut state_sync_state)
+        sd.generate_sync_message_bounded(&mut state_sync_state, 80 * 1024 * 1024)
             .map(|msg| msg.encode())
     };
     if let Some(encoded) = state_sync_msg {
@@ -2614,7 +2615,10 @@ where
         connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded).await?;
     }
 
-    // Phase 1.1: Initial RuntimeStateDoc sync — encode inside lock, send outside
+    // Phase 1.1: Initial RuntimeStateDoc sync — encode inside lock, send outside.
+    // Uses bounded generation to compact atomically if the message would exceed
+    // the 100 MiB frame limit (80 MiB threshold leaves headroom).
+    const STATE_SYNC_COMPACT_THRESHOLD: usize = 80 * 1024 * 1024;
     let initial_state_encoded = {
         let mut state_doc = room.state_doc.write().await;
         // Safety net: compact before initial sync if the doc grew too large.
@@ -2625,7 +2629,10 @@ where
         }
         match catch_automerge_panic("initial-state-sync", || {
             state_doc
-                .generate_sync_message(&mut state_peer_state)
+                .generate_sync_message_bounded(
+                    &mut state_peer_state,
+                    STATE_SYNC_COMPACT_THRESHOLD,
+                )
                 .map(|msg| msg.encode())
         }) {
             Ok(encoded) => encoded,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2629,10 +2629,7 @@ where
         }
         match catch_automerge_panic("initial-state-sync", || {
             state_doc
-                .generate_sync_message_bounded(
-                    &mut state_peer_state,
-                    STATE_SYNC_COMPACT_THRESHOLD,
-                )
+                .generate_sync_message_bounded(&mut state_peer_state, STATE_SYNC_COMPACT_THRESHOLD)
                 .map(|msg| msg.encode())
         }) {
             Ok(encoded) => encoded,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -77,6 +77,11 @@ fn trigger_global_shutdown() {
 /// full doc sync ("peer lagged") rather than losing messages.
 const KERNEL_BROADCAST_CAPACITY: usize = 256;
 
+/// Compaction threshold for RuntimeStateDoc initial sync messages.
+/// If the encoded message exceeds this, compact before sending. Leaves
+/// 20 MiB headroom under the 100 MiB frame limit.
+const STATE_SYNC_COMPACT_THRESHOLD: usize = 80 * 1024 * 1024;
+
 /// Catch panics from automerge internal operations.
 ///
 /// Automerge 0.7.4 (and 0.8.0) has a known bug where the change collector
@@ -1734,7 +1739,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let mut state_sync_state = automerge::sync::State::new();
     let state_sync_msg = {
         let mut sd = room.state_doc.write().await;
-        sd.generate_sync_message_bounded(&mut state_sync_state, 80 * 1024 * 1024)
+        sd.generate_sync_message_bounded(&mut state_sync_state, STATE_SYNC_COMPACT_THRESHOLD)
             .map(|msg| msg.encode())
     };
     if let Some(encoded) = state_sync_msg {
@@ -2617,8 +2622,7 @@ where
 
     // Phase 1.1: Initial RuntimeStateDoc sync — encode inside lock, send outside.
     // Uses bounded generation to compact atomically if the message would exceed
-    // the 100 MiB frame limit (80 MiB threshold leaves headroom).
-    const STATE_SYNC_COMPACT_THRESHOLD: usize = 80 * 1024 * 1024;
+    // the 100 MiB frame limit.
     let initial_state_encoded = {
         let mut state_doc = room.state_doc.write().await;
         // Safety net: compact before initial sync if the doc grew too large.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1739,8 +1739,10 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let mut state_sync_state = automerge::sync::State::new();
     let state_sync_msg = {
         let mut sd = room.state_doc.write().await;
-        sd.generate_sync_message_bounded(&mut state_sync_state, STATE_SYNC_COMPACT_THRESHOLD)
-            .map(|msg| msg.encode())
+        sd.generate_sync_message_bounded_encoded(
+            &mut state_sync_state,
+            STATE_SYNC_COMPACT_THRESHOLD,
+        )
     };
     if let Some(encoded) = state_sync_msg {
         if let Err(e) =
@@ -2632,9 +2634,10 @@ where
             info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
         }
         match catch_automerge_panic("initial-state-sync", || {
-            state_doc
-                .generate_sync_message_bounded(&mut state_peer_state, STATE_SYNC_COMPACT_THRESHOLD)
-                .map(|msg| msg.encode())
+            state_doc.generate_sync_message_bounded_encoded(
+                &mut state_peer_state,
+                STATE_SYNC_COMPACT_THRESHOLD,
+            )
         }) {
             Ok(encoded) => encoded,
             Err(e) => {


### PR DESCRIPTION
## Summary

- Adds `RuntimeStateDoc::generate_sync_message_bounded()` which compacts the doc atomically (save→load) if the encoded sync message exceeds a threshold
- Updates both initial sync paths (peer connections and runtime agent) to use the bounded variant with an 80 MiB threshold
- Eliminates the TOCTOU race where the doc could grow between a pre-send size check and the actual `send_frame` (which enforces a 100 MiB frame limit)

## Test plan

- [x] Unit test: `test_generate_sync_message_bounded_compacts_on_oversized` — forces compaction with 1-byte threshold, verifies full sync still works
- [x] Unit test: `test_generate_sync_message_bounded_no_compact_under_limit` — verifies no-op path when message is small
- [x] `cargo clippy -p notebook-doc -p runtimed -- -D warnings` passes
- [x] Full `notebook-doc` test suite passes (350 tests)