### PR TITLE
fix(notebook-doc): use in-place CRDT updates for stream coalescence

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -1411,9 +1411,11 @@ impl RuntimeStateDoc {
                                 );
                             }
                         }
-                        // Validated! Delete old and insert new at same index
-                        self.doc.delete(&list_id, state.index)?;
-                        crate::insert_json_at_index(
+                        // In-place update: reuse the existing Map object,
+                        // only updating changed fields (text, llm_preview).
+                        // This avoids delete+insert which generates tombstones
+                        // for the entire Map on every stream coalescence.
+                        crate::update_json_at_index(
                             &mut self.doc,
                             &list_id,
                             state.index,
@@ -1434,7 +1436,8 @@ impl RuntimeStateDoc {
     /// Replace an output at a specific index for an execution.
     ///
     /// Used by UpdateDisplayData handling for in-place manifest updates.
-    /// Deletes the old entry and inserts the new manifest at the same position.
+    /// Reuses the existing Map object and only updates changed fields to
+    /// minimize CRDT ops (avoids delete+insert tombstone accumulation).
     pub fn replace_output(
         &mut self,
         execution_id: &str,
@@ -1447,9 +1450,7 @@ impl RuntimeStateDoc {
         if output_idx >= self.doc.length(&list_id) {
             return Ok(false);
         }
-        // Delete old entry and insert new manifest at same position
-        self.doc.delete(&list_id, output_idx)?;
-        crate::insert_json_at_index(&mut self.doc, &list_id, output_idx, manifest)?;
+        crate::update_json_at_index(&mut self.doc, &list_id, output_idx, manifest)?;
         Ok(true)
     }
 
@@ -3204,6 +3205,63 @@ mod tests {
         assert_eq!(
             outputs[0]["text"]["blob"], "hash-b",
             "Content should be updated to the new manifest"
+        );
+    }
+
+    #[test]
+    fn test_stream_coalescence_doc_size_bounded() {
+        // Simulate 100 stream updates (typical ML training loop).
+        // With in-place updates, doc size should grow sub-linearly
+        // because only the text ContentRef scalars change — no tombstones
+        // from deleted Maps accumulate.
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1", "cell-1");
+
+        let initial = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "stream-uuid",
+            "name": "stdout",
+            "text": {"blob": "hash-0", "size": 100}
+        });
+        doc.append_output("exec-1", &initial).unwrap();
+
+        let size_after_first = doc.doc.save().len();
+
+        let mut state = StreamOutputState {
+            index: 0,
+            blob_hash: "hash-0".to_string(),
+        };
+
+        for i in 1..100 {
+            let new_hash = format!("hash-{}", i);
+            let manifest = serde_json::json!({
+                "output_type": "stream",
+                "output_id": "new-uuid",
+                "name": "stdout",
+                "text": {"blob": &new_hash, "size": 100 + i}
+            });
+            let (updated, idx) = doc
+                .upsert_stream_output("exec-1", "stdout", &manifest, Some(&state))
+                .unwrap();
+            assert!(updated);
+            assert_eq!(idx, 0);
+            state = StreamOutputState {
+                index: 0,
+                blob_hash: new_hash,
+            };
+        }
+
+        let size_after_100 = doc.doc.save().len();
+        // With in-place updates, only text.blob and text.size scalars change
+        // (2 ops per update). The doc should stay well under 3x initial size.
+        let growth_factor = size_after_100 as f64 / size_after_first as f64;
+        assert!(
+            growth_factor < 3.0,
+            "Doc grew {:.1}x after 100 stream updates (expected < 6x). \
+             size_after_first={}, size_after_100={}",
+            growth_factor,
+            size_after_first,
+            size_after_100,
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace delete+insert with `update_json_at_index` for stream output coalescence (`upsert_stream_output`) and UpdateDisplayData replacement (`replace_output`)
- Reuses existing Automerge Map objects, only updating changed scalar fields (`text.blob`, `text.size`), avoiding tombstone accumulation from repeated Map deletion
- Companion to #1942 (compaction addresses accumulated history; this addresses the generation rate)

## Measured improvement (100 stream coalescence cycles)

| Metric | Before (delete+insert) | After (in-place update) |
|--------|----------------------|------------------------|
| Doc growth | 2.43x | 1.77x |
| Doc size | 1353 bytes | 986 bytes |
| Ops per stream update | ~12 | 2 |
| Tombstone accumulation | Yes (permanent) | No (scalar supersession via `pred`) |

**27% smaller docs** after 100 stream coalescence cycles. The gap widens with more updates since tombstones are append-only.

## How it works

Stream coalescence updates the same output manifest Map on every kernel `stream` IOPub message (potentially hundreds per cell execution in ML training). Previously, each update:
1. Deleted the entire Map at the list index (generating tombstones for all ~6 child fields)
2. Inserted a fresh Map with all fields recreated (~6 new ops)

Now it uses `update_json_at_index` which:
1. Gets the ObjId of the existing Map
2. Removes stale keys not in the new value (handles inline→blob transition)
3. Recursively updates only changed children via `put()` (1 op per changed scalar)

Static fields (`output_type`, `name`, `output_id`) are never touched.

## Test plan

- [x] All 82 `runtime_state` unit tests pass (including existing coalescence tests)
- [x] All 349 `notebook-doc` tests pass
- [x] All 337 `runtimed` unit tests + 25 integration tests pass
- [x] New `test_stream_coalescence_doc_size_bounded` validates doc growth stays < 3x after 100 updates
- [x] `test_upsert_stream_output_inline_to_blob_transition` confirms inline→blob handled correctly
- [x] `test_upsert_stream_preserves_output_id` confirms output_id stability
- [ ] Gremlin suite validation on nightly build (in progress)