### PR TITLE
fix(notebook-doc): correct coalescence test assertions and add stale-key coverage

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -3090,6 +3090,32 @@ mod tests {
     }
 
     #[test]
+    fn test_replace_output_removes_stale_keys() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1", "cell-1");
+
+        // Original manifest has an extra key (display_id)
+        let original = serde_json::json!({
+            "output_type": "display_data",
+            "display_id": "plot-1",
+            "data": {"text/plain": {"blob": "h1", "size": 2}}
+        });
+        doc.append_output("exec-1", &original).unwrap();
+
+        // Replacement manifest omits display_id
+        let replacement = serde_json::json!({
+            "output_type": "display_data",
+            "data": {"text/plain": {"blob": "h2", "size": 2}}
+        });
+        doc.replace_output("exec-1", 0, &replacement).unwrap();
+
+        let outputs = doc.get_outputs("exec-1");
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0], replacement);
+        assert!(outputs[0].get("display_id").is_none());
+    }
+
+    #[test]
     fn test_upsert_stream_output_append() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution("exec-1", "cell-1");
@@ -3271,12 +3297,12 @@ mod tests {
         }
 
         let size_after_100 = doc.doc.save().len();
-        // With in-place updates, only text.blob and text.size scalars change
-        // (2 ops per update). The doc should stay well under 3x initial size.
+        // In-place scalar puts generate zero Map tombstones (unlike delete+insert),
+        // so history grows only by the op log for ~5 scalar puts per update.
         let growth_factor = size_after_100 as f64 / size_after_first as f64;
         assert!(
             growth_factor < 3.0,
-            "Doc grew {:.1}x after 100 stream updates (expected < 6x). \
+            "Doc grew {:.1}x after 100 stream updates (expected < 3x). \
              size_after_first={}, size_after_100={}",
             growth_factor,
             size_after_first,


### PR DESCRIPTION
## Summary
- Fix test assertion message: check is `< 3.0` but error said "expected < 6x" — now says "< 3x"
- Rewrite "2 ops per update" comment to explain the actual win (zero Map tombstones from in-place scalar puts)
- Add `test_replace_output_removes_stale_keys` verifying that `replace_output` deletes keys present in the original manifest but absent in the replacement

Follow-up to #1947.

## Test plan
- [x] `cargo test -p notebook-doc -- test_replace_output` passes (existing + new test)
- [x] `cargo test -p notebook-doc -- test_stream_coalescence_doc_size_bounded` passes
- [x] `cargo xtask lint --fix` clean