### PR TITLE
fix(runt-mcp): survive daemon disconnect during kernel restart

### DIFF
--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -4,6 +4,7 @@ use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::ErrorData as McpError;
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
+use notebook_sync::SyncError;
 
 use crate::NteractMcp;
 
@@ -45,6 +46,22 @@ pub async fn restart_kernel(
         }
     };
 
+    // Capture kernel_type from the *current* RuntimeState before shutdown.
+    // After a daemon restart the fresh RuntimeStateDoc has kernel.name = "",
+    // so reading it post-reconnect would silently regress to "python".
+    let pre_shutdown_kernel_type = handle
+        .get_runtime_state()
+        .ok()
+        .and_then(|s| {
+            let name = &s.kernel.name;
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.clone())
+            }
+        })
+        .unwrap_or_else(|| "python".to_string());
+
     // Step 1: Shutdown existing kernel
     match handle
         .send_request(NotebookRequest::ShutdownKernel {})
@@ -66,9 +83,10 @@ pub async fn restart_kernel(
         match guard.as_ref() {
             Some(s) => s.handle.clone(),
             None => {
-                // Session dropped — wait briefly for health monitor to reconnect
+                // Session dropped — wait for health monitor to reconnect.
+                // PING_INTERVAL is 5s; give it two cycles plus margin.
                 drop(guard);
-                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(8)).await;
                 let guard = server.session.read().await;
                 match guard.as_ref() {
                     Some(s) => s.handle.clone(),
@@ -88,32 +106,16 @@ pub async fn restart_kernel(
         tracing::warn!("confirm_sync failed before restart_kernel launch: {e}");
     }
 
-    // Step 3: Determine kernel type and env_source.
-    // Use metadata-based detection (not RuntimeState env_source) to scope the
-    // auto-detect. This ensures the correct package manager pool is used even
-    // if the previous kernel was launched with a different env (e.g., UV default
-    // when the notebook metadata says pixi). See #1605.
-    let (kernel_type, env_source) = {
-        let state = handle.get_runtime_state().ok();
-        let kernel_type = state
-            .as_ref()
-            .and_then(|s| {
-                let name = &s.kernel.name;
-                if name.is_empty() {
-                    None
-                } else {
-                    Some(name.clone())
-                }
-            })
-            .unwrap_or_else(|| "python".to_string());
-        // Scope auto-detect based on notebook metadata, not stale env_source
+    // Step 3: Determine env_source from metadata. kernel_type was captured
+    // pre-shutdown so it survives daemon restarts that clear RuntimeStateDoc.
+    let kernel_type = pre_shutdown_kernel_type;
+    let env_source = {
         let detected_manager = super::deps::detect_package_manager(&handle);
-        let env_source = match detected_manager.as_str() {
+        match detected_manager.as_str() {
             "pixi" => "auto:pixi".to_string(),
             "conda" => "auto:conda".to_string(),
             _ => "auto:uv".to_string(),
-        };
-        (kernel_type, env_source)
+        }
     };
 
     // Step 4: Launch kernel
@@ -134,9 +136,9 @@ pub async fn restart_kernel(
     // If LaunchKernel failed with a disconnection, the daemon may have
     // restarted. Wait for the health monitor to reconnect and retry once.
     let launch_result = match launch_result {
-        Err(ref e) if e.to_string().contains("Disconnected") => {
+        Err(SyncError::Disconnected) => {
             tracing::warn!("LaunchKernel disconnected during restart, waiting for reconnection");
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(8)).await;
             let guard = server.session.read().await;
             match guard.as_ref() {
                 Some(s) => {
@@ -150,7 +152,7 @@ pub async fn restart_kernel(
                         })
                         .await
                 }
-                None => launch_result,
+                None => Err(SyncError::Disconnected),
             }
         }
         other => other,

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -58,12 +58,37 @@ pub async fn restart_kernel(
     // Brief pause for shutdown to complete
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
+    // Step 2: Get a fresh handle (the original may have been invalidated by
+    // a daemon restart during the shutdown sequence). If the session was
+    // replaced by the health monitor's auto_rejoin, we pick up the new one.
+    let handle = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => s.handle.clone(),
+            None => {
+                // Session dropped — wait briefly for health monitor to reconnect
+                drop(guard);
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                let guard = server.session.read().await;
+                match guard.as_ref() {
+                    Some(s) => s.handle.clone(),
+                    None => {
+                        return tool_error(
+                            "Lost connection to daemon during kernel restart. \
+                             The session will auto-reconnect — retry in a few seconds.",
+                        )
+                    }
+                }
+            }
+        }
+    };
+
     // Ensure daemon has latest metadata (deps may have changed since last sync)
     if let Err(e) = handle.confirm_sync().await {
         tracing::warn!("confirm_sync failed before restart_kernel launch: {e}");
     }
 
-    // Step 2: Determine kernel type and env_source.
+    // Step 3: Determine kernel type and env_source.
     // Use metadata-based detection (not RuntimeState env_source) to scope the
     // auto-detect. This ensures the correct package manager pool is used even
     // if the previous kernel was launched with a different env (e.g., UV default
@@ -91,25 +116,52 @@ pub async fn restart_kernel(
         (kernel_type, env_source)
     };
 
-    // Step 3: Launch kernel
-
+    // Step 4: Launch kernel
     let notebook_path = if notebook_id.contains('/') || notebook_id.contains('\\') {
         Some(notebook_id)
     } else {
         None
     };
 
-    match handle
+    let launch_result = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: kernel_type.clone(),
             env_source: env_source.clone(),
-            notebook_path,
+            notebook_path: notebook_path.clone(),
         })
-        .await
-    {
+        .await;
+
+    // If LaunchKernel failed with a disconnection, the daemon may have
+    // restarted. Wait for the health monitor to reconnect and retry once.
+    let launch_result = match launch_result {
+        Err(ref e) if e.to_string().contains("Disconnected") => {
+            tracing::warn!("LaunchKernel disconnected during restart, waiting for reconnection");
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let guard = server.session.read().await;
+            match guard.as_ref() {
+                Some(s) => {
+                    let fresh_handle = s.handle.clone();
+                    drop(guard);
+                    fresh_handle
+                        .send_request(NotebookRequest::LaunchKernel {
+                            kernel_type: kernel_type.clone(),
+                            env_source: env_source.clone(),
+                            notebook_path,
+                        })
+                        .await
+                }
+                None => launch_result,
+            }
+        }
+        other => other,
+    };
+
+    match launch_result {
         Ok(NotebookResponse::KernelLaunched { .. })
         | Ok(NotebookResponse::KernelAlreadyRunning { .. }) => {
-            // Poll RuntimeState for kernel to become ready
+            // Poll RuntimeState for kernel to become ready.
+            // Re-read the session handle each iteration in case it was
+            // replaced by the health monitor during reconnection.
             let start = std::time::Instant::now();
             let timeout = std::time::Duration::from_secs(120);
             loop {
@@ -117,7 +169,14 @@ pub async fn restart_kernel(
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                if let Ok(state) = handle.get_runtime_state() {
+                let current_handle = {
+                    let guard = server.session.read().await;
+                    guard.as_ref().map(|s| s.handle.clone())
+                };
+                let Some(h) = current_handle else {
+                    continue;
+                };
+                if let Ok(state) = h.get_runtime_state() {
                     if state.kernel.status == "idle" || state.kernel.status == "busy" {
                         break;
                     }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -561,6 +561,12 @@ async fn test_untitled_notebook_persists_through_eviction() {
             .unwrap()
             .handle;
 
+        // Wait for the daemon's document structure (cells map) to arrive via
+        // background sync — connect_create returns after handshake but the Map
+        // may not be delivered yet on slow CI runners.
+        let mut watcher = client1.subscribe();
+        let _ = tokio::time::timeout(Duration::from_secs(2), watcher.changed()).await;
+
         client1.add_cell_after("c1", "code", None).unwrap();
         client1.update_source("c1", "persisted = True").unwrap();
         client1
@@ -671,6 +677,9 @@ async fn test_eviction_flushes_before_reconnect() {
             .unwrap();
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
+
+        let mut watcher = client.subscribe();
+        let _ = tokio::time::timeout(Duration::from_secs(2), watcher.changed()).await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "race_test = 1").unwrap();


### PR DESCRIPTION
## Summary
- Re-read session handle after shutdown sleep to pick up health monitor's `auto_rejoin` if it fired during the gap
- Retry `LaunchKernel` once with a 5s reconnection window if first attempt returns `Disconnected`
- Poll `RuntimeState` with a fresh handle each iteration (stale handle from pre-reconnect is dead)

Root cause: conda-prebuilt gremlin hit "Failed to restart kernel: Disconnected from sync task" when the daemon restarted during the 500ms inter-request sleep in `restart_kernel`. The tool captured the handle at entry and never refreshed it.

Fixes the conda-prebuilt gremlin's 2 kernel restart errors (task #33).

## Test plan
- [x] `cargo check -p runt-mcp` clean
- [x] `cargo clippy -p runt-mcp` no warnings
- [x] `cargo xtask lint --fix` clean
- [ ] Gremlin suite run against new nightly to confirm no more restart disconnects