### PR TITLE
feat(live-viewer): tailnet notebook viewer with WASM CRDT sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -653,8 +654,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -3117,6 +3120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cdb727cec723cee65912a74a7f9f0c3ad0c6f9df4f03d05a5c7a15398bbad1"
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "http-serde"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4000,6 +4009,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "live-viewer-server"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "futures",
+ "notebook-protocol",
+ "notebook-sync",
+ "runtimed-client",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,6 +4196,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicov"
@@ -7755,6 +7791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9133,6 +9180,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9310,13 +9369,19 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9518,6 +9583,23 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archspec"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +690,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -4013,9 +4044,11 @@ name = "live-viewer-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-server",
  "futures",
  "notebook-protocol",
  "notebook-sync",
+ "reqwest 0.12.28",
  "runtimed-client",
  "serde",
  "serde_json",
@@ -7268,11 +7301,21 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7290,6 +7333,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/repr-llm",
     "crates/nteract-predicate",
     "crates/sift-wasm",
+    "apps/live-viewer/server",
 ]
 default-members = ["crates/notebook"]
 resolver = "2"

--- a/apps/live-viewer/COMPONENT_TREE_INTEGRATION.md
+++ b/apps/live-viewer/COMPONENT_TREE_INTEGRATION.md
@@ -1,0 +1,179 @@
+# Component Tree Integration Report
+
+Full component tree swap attempted for the live-viewer.
+Documents every coupling boundary between the live-viewer and the notebook app.
+
+## What Works (shared components successfully imported)
+
+| Component | Path | Notes |
+|-----------|------|-------|
+| `CellContainer` | `src/components/cell/CellContainer.tsx` | Zero coupling. Fully portable. |
+| `CompactExecutionButton` | `src/components/cell/CompactExecutionButton.tsx` | Zero coupling. Fully portable. |
+| `OutputArea` | `src/components/cell/OutputArea.tsx` | Works with WidgetStoreProvider context + IsolatedRendererProvider. |
+| `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | Works with renderer plugin stubs/artifacts. |
+| `MediaRouter` | `src/components/outputs/media-router.tsx` | Fully portable for in-DOM outputs. |
+| `AnsiStreamOutput` / `AnsiErrorOutput` | `src/components/outputs/ansi-output.tsx` | Zero coupling. |
+| `CodeMirrorEditor` | `src/components/editor/codemirror-editor.tsx` | Works in read-only mode. |
+| `WidgetStoreProvider` | `src/components/widgets/widget-store-context.tsx` | Requires crypto.randomUUID (HTTPS or polyfill). |
+| `IsolatedRendererProvider` | `src/components/isolated/isolated-renderer-context.tsx` | Needs virtual module or pre-built artifacts. |
+| `NotebookHostProvider` | `packages/notebook-host/` | Works with browser host implementation. |
+
+## Coupling Boundaries (what cannot be imported cleanly)
+
+### 1. Virtual Renderer Plugin Modules
+
+**Edge:** `src/components/isolated/iframe-libraries.ts` imports `virtual:renderer-plugin/*`
+
+**Problem:** These are Vite virtual modules provided by `apps/notebook/vite-plugin-isolated-renderer.ts`.
+The plugin reads pre-built CJS artifacts from `apps/notebook/src/renderer-plugins/`.
+
+**Solution:** Live-viewer has its own Vite plugin that reads the same pre-built artifacts.
+Empty stubs work if you only need in-DOM rendering (isolated={false}).
+
+**Affected MIME types:** text/markdown, text/latex, application/vnd.plotly.v1+json,
+application/geo+json, application/vnd.vega.v5+json, application/vnd.apache.parquet
+
+### 2. crypto.randomUUID (Secure Context)
+
+**Edge:** `src/components/widgets/use-comm-router.ts` line 124
+
+**Problem:** `const SESSION_ID = crypto.randomUUID()` executes at module load time.
+`crypto.randomUUID` requires SecureContext (HTTPS or localhost).
+
+**Solution:** Serve over HTTPS (Tailscale TLS certs) + polyfill for dev.
+
+### 3. Cell UI State Store (notebook-cells.ts, cell-ui-state.ts)
+
+**Edge:** `apps/notebook/src/lib/notebook-cells.ts` and `cell-ui-state.ts`
+
+**Problem:** NotebookView, CodeCell, MarkdownCell all depend on these stores for:
+- `useCell(id)` — per-cell reactive subscriptions
+- `useIsCellFocused(id)` — focus state
+- `useIsCellExecuting(id)` — execution state
+- `useIsCellQueued(id)` — queue state
+- `useCellIds()` — ordered cell list
+
+**Impact:** Cannot use the app's `NotebookView` or `CodeCell` directly.
+
+**Live-viewer approach:** Props-based rendering. The viewer owns its own cell array
+via `useState<CellData[]>` and passes execution state as props to `CellView`.
+
+### 4. CRDT Bridge (useCrdtBridge)
+
+**Edge:** `apps/notebook/src/hooks/useCrdtBridge.ts`
+
+**Problem:** CodeCell requires useCrdtBridge for character-level sync between
+CodeMirror and the Automerge CRDT. This hook depends on the notebook's WASM
+NotebookHandle and the global notebook-frame-bus.
+
+**Impact:** Cannot use the app's CodeCell for editing.
+
+**Live-viewer approach:** Read-only `CodeMirrorEditor` with no bridge.
+
+### 5. Keyboard Navigation (useCellKeyboardNavigation)
+
+**Edge:** `apps/notebook/src/hooks/useCellKeyboardNavigation.ts`
+
+**Problem:** Provides Shift-Enter, Alt-Up/Down, etc. keybindings.
+Depends on cell-ui-state and editor-registry.
+
+**Impact:** Not needed for read-only viewer.
+
+### 6. Presence System (PresenceContext, cursor-registry)
+
+**Edge:** `apps/notebook/src/contexts/PresenceContext.tsx`
+
+**Problem:** Renders remote peer cursors and selections. Requires:
+- notebook-frame-bus presence subscription
+- cursor-registry for per-editor cursor state
+- EditorView instances (from useCrdtBridge)
+
+**Impact:** Could be added later if we want to show who's viewing.
+
+### 7. Editor Registry (useEditorRegistry)
+
+**Edge:** `apps/notebook/src/hooks/useEditorRegistry.ts`
+
+**Problem:** Global registry of CodeMirror EditorView instances.
+Used by cell navigation and global find.
+
+**Impact:** Not needed for read-only.
+
+### 8. Drag-and-Drop (dnd-kit)
+
+**Edge:** `NotebookView` uses `@dnd-kit/core` and `@dnd-kit/sortable`
+
+**Problem:** Cell reordering via drag handles. Requires sortable context,
+stable DOM order hack, and CRDT move_cell mutations.
+
+**Impact:** Not needed for read-only viewer.
+
+### 9. MarkdownCell with Edit/Preview Toggle
+
+**Edge:** `apps/notebook/src/components/MarkdownCell.tsx`
+
+**Problem:** Full markdown cell has:
+- Click-to-edit with CRDT bridge
+- Preview rendering via IsolatedFrame
+- Presence sender extension
+- Blob port for embedded images (useBlobPort)
+
+**Live-viewer approach:** Render markdown source as `text/markdown` output
+through OutputArea's iframe isolation (same visual result, no editing).
+
+### 10. Blob Port Resolution
+
+**Edge:** `apps/notebook/src/lib/blob-port.ts`
+
+**Problem:** Resolves `attachment:` refs and blob hashes to URLs.
+Needed for embedded images in markdown cells and widget ESM.
+
+**Impact:** Limited — most outputs work without blob resolution.
+Could be added by proxying daemon blob store through the relay server.
+
+## Architecture Summary
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Live Viewer                      │
+├─────────────────────────────────────────────────┤
+│  NotebookHostProvider (browser host)             │
+│    └── IsolatedRendererProvider                  │
+│          └── WidgetStoreProvider                 │
+│                └── NotebookViewer                │
+│                      ├── CellView (code)        │
+│                      │   ├── CompactExecButton  │
+│                      │   ├── CodeMirrorEditor   │  ← read-only
+│                      │   └── OutputArea         │
+│                      │       ├── IsolatedFrame  │  ← rich outputs
+│                      │       ├── MediaRouter    │  ← in-DOM outputs
+│                      │       └── AnsiOutput     │
+│                      └── CellView (markdown)    │
+│                          └── OutputArea         │  ← renders as text/markdown
+└─────────────────────────────────────────────────┘
+         │
+         │ WebSocket (Automerge sync + RuntimeState)
+         │
+┌────────▼────────────────────────────────────────┐
+│            Relay Server (Rust/axum)               │
+│  TLS (Tailscale certs) + SPA fallback            │
+├─────────────────────────────────────────────────┤
+│         Unix socket                              │
+│            └── runtimed daemon                   │
+└─────────────────────────────────────────────────┘
+```
+
+## What's Possible Next
+
+1. **Widget rendering** — WidgetStoreProvider is already wired. Need to feed
+   comm state from RuntimeStateDoc into the store (same as useDaemonKernel does).
+
+2. **Blob port proxy** — Add `/blob/{hash}` route to relay server that proxies
+   the daemon's blob store. Enables embedded images and widget ESM.
+
+3. **Presence display** — Show colored dots for active viewers. Would need
+   presence frame forwarding in the relay.
+
+4. **Read-only NotebookView** — Factor out a `ReadOnlyNotebookView` from the
+   app's `NotebookView` that uses the same stable-DOM-order trick but skips
+   dnd-kit, cell-ui-state, and keyboard navigation.

--- a/apps/live-viewer/PORTABILITY_AUDIT.md
+++ b/apps/live-viewer/PORTABILITY_AUDIT.md
@@ -1,0 +1,146 @@
+# Component Portability Audit
+
+Assessment of what blocks reuse of nteract notebook app UI components in non-Tauri contexts (e.g., this browser-served live viewer).
+
+## Summary
+
+**Only 10 files out of 100+ have `@tauri-apps` imports.** The architecture is already designed for portability via the `NotebookHost` abstraction.
+
+---
+
+## Shared Components (`src/components/`) — ALL REUSABLE AS-IS
+
+Zero Tauri or app-specific imports. The live viewer imports these via the `@/` path alias:
+
+| Component | Path | Status |
+|-----------|------|--------|
+| `CellContainer` | `src/components/cell/CellContainer.tsx` | Used by live-viewer |
+| `ExecutionCount` | `src/components/cell/ExecutionCount.tsx` | Used by live-viewer |
+| `ExecutionStatus` | `src/components/cell/ExecutionStatus.tsx` | Used by live-viewer |
+| `OutputArea` | `src/components/cell/OutputArea.tsx` | Available (needs WidgetStoreProvider) |
+| `gutter-colors` | `src/components/cell/gutter-colors.ts` | Used by live-viewer |
+| `MediaRouter` | `src/components/outputs/media-router.tsx` | Used by live-viewer |
+| `AnsiStreamOutput` | `src/components/outputs/ansi-output.tsx` | Used by live-viewer |
+| `AnsiErrorOutput` | `src/components/outputs/ansi-output.tsx` | Used by live-viewer |
+| `CodeMirrorEditor` | `src/components/editor/codemirror-editor.tsx` | Used by live-viewer |
+| All output renderers | `src/components/outputs/*.tsx` | Available |
+| All UI primitives | `src/components/ui/*.tsx` | Available (shadcn) |
+
+---
+
+## Files with `@tauri-apps` Imports (Exhaustive)
+
+| # | File | Import | Purpose | Viewer needs it? |
+|---|------|--------|---------|-----------------|
+| 1 | `apps/notebook/src/lib/tauri-rx.ts` | `getCurrentWebview` | Frame events as RxJS Observable | No — SyncEngine handles frames |
+| 2 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | `fromTauriEvent` + Host | Wires WASM handle to Tauri transport | No — viewer uses WebSocketTransport |
+| 3 | `apps/notebook/src/hooks/useDaemonKernel.ts` | `invoke` + `getCurrentWebview` | Kernel execution commands | No — read-only viewer |
+| 4 | `apps/notebook/src/lib/notebook-file-ops.ts` | `invoke` (9x) | Save/open/clone notebooks | No — read-only |
+| 5 | `apps/notebook/src/hooks/useDependencies.ts` | `invoke` | UV dependency detection | No |
+| 6 | `apps/notebook/src/hooks/useCondaDependencies.ts` | `invoke` (3x) | Conda environment detection | No |
+| 7 | `apps/notebook/src/hooks/usePixiDependencies.ts` | `invoke` | Pixi project detection | No |
+| 8 | `apps/notebook/src/hooks/useDenoDependencies.ts` | `invoke` | Deno config detection | No |
+| 9 | `apps/notebook/src/hooks/useUpdater.ts` | `invoke` | App auto-update | No |
+| 10 | `apps/notebook/src/components/PoolErrorBanner.tsx` | `invoke` | Settings window button | No |
+
+---
+
+## App Components (`apps/notebook/src/components/`)
+
+| Component | Tauri-free? | Blocker |
+|-----------|-------------|---------|
+| `NotebookView.tsx` | Yes | Uses app stores (`notebook-cells`, `cell-ui-state`, `PresenceContext`) — all pure React |
+| `CodeCell.tsx` | Yes | Uses `useCrdtBridge` (clean), `kernel-completion` (takes Host type), `open-url` (takes Host) |
+| `MarkdownCell.tsx` | Yes | Same pattern as CodeCell |
+| `RawCell.tsx` | Yes | Same |
+| `PoolErrorBanner.tsx` | **No** | Direct `invoke("open_settings_window")` |
+
+---
+
+## App Libraries
+
+| Module | Tauri-free? | Notes |
+|--------|-------------|-------|
+| `notebook-cells.ts` | Yes | Pure `useSyncExternalStore` |
+| `runtime-state.ts` | Yes | Re-exports from `runtimed` package |
+| `notebook-frame-bus.ts` | Yes | Pure in-memory pub/sub |
+| `materialize-cells.ts` | Yes | WASM → React conversion |
+| `cell-ui-state.ts` | Yes | Pure store |
+| `tauri-rx.ts` | **No** | `getCurrentWebview()` — 42 lines, not needed |
+| `notebook-file-ops.ts` | **No** | 9x invoke — not needed for viewer |
+| `kernel-completion.ts` | Partially | Takes `NotebookHost` type param |
+
+---
+
+## Decoupling Difficulty
+
+| Level | What | Fix |
+|-------|------|-----|
+| **Done** | Frame transport | Live viewer uses `WebSocketTransport` → `SyncEngine` |
+| **Done** | Shared components | `CellContainer`, `ExecutionCount`, `MediaRouter`, `CodeMirrorEditor` all imported |
+| **~200 LOC** | `createBrowserHost()` | Implement `NotebookHost` with WebSocket transport + no-ops |
+| **Medium (6 files)** | Direct `invoke()` calls | Migrate to `host.transport.sendRequest()` |
+| **Not needed** | File ops, deps, updater | Read-only viewer doesn't use these |
+
+---
+
+## Migration Roadmap
+
+### Phase 1 (Complete)
+- SyncEngine + WebSocketTransport wired directly
+- RuntimeStateDoc subscription (kernel status, execution state, queue)
+- Basic cell rendering with `gutter-colors` and `AnsiOutput`
+
+### Phase 2 (Complete)
+- `CellContainer` for full layout (ribbon, gutter, segmented code/output)
+- `ExecutionCount` and `ExecutionStatus` for execution indicators
+- `CodeMirrorEditor` (read-only) for syntax-highlighted source
+- `MediaRouter` for rich output dispatch (images, JSON, markdown, LaTeX, etc.)
+- `AnsiStreamOutput` / `AnsiErrorOutput` for stream/error outputs
+
+### Phase 3 (Next — `createBrowserHost()`)
+- Create `packages/notebook-host/src/browser/index.ts`
+- Implement `NotebookHost` interface: transport = WebSocketTransport, blobs = relay endpoint, log = console, everything else = no-op
+- Wrap app in `NotebookHostProvider` — unlocks the full `NotebookView` → `CodeCell` component tree
+- Enables: presence, CRDT bridge (collaborative editing), kernel completion
+
+### Phase 4 (Future — full editor parity)
+- Migrate the 10 invoke-coupled files onto `host.transport.sendRequest()`
+- Already planned in the frontend-architecture roadmap
+- Enables: save, execute, dependency management through browser
+
+---
+
+## Architecture Layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  FULLY PORTABLE (no Tauri deps)                              │
+│                                                               │
+│  src/components/cell/*      ← CellContainer, OutputArea      │
+│  src/components/outputs/*   ← MediaRouter, all renderers     │
+│  src/components/editor/*    ← CodeMirrorEditor               │
+│  src/components/ui/*        ← shadcn primitives              │
+│  packages/runtimed/         ← SyncEngine, RuntimeState       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  HOST-ABSTRACTED (swappable via NotebookHost interface)       │
+│                                                               │
+│  apps/notebook/src/App.tsx             ← top-level wiring    │
+│  apps/notebook/src/hooks/usePresence   ← host.transport      │
+│  apps/notebook/src/hooks/useTrust      ← host.trust          │
+│  apps/notebook/src/lib/blob-port.ts    ← host.blobs          │
+│  apps/notebook/src/lib/logger.ts       ← host.log            │
+│  apps/notebook/src/lib/open-url.ts     ← host.externalLinks  │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  TAURI-COUPLED (10 files, direct invoke/webview)             │
+│                                                               │
+│  tauri-rx.ts, useDaemonKernel.ts, notebook-file-ops.ts       │
+│  useDependencies.ts, useCondaDependencies.ts                 │
+│  usePixiDependencies.ts, useDenoDependencies.ts              │
+│  useUpdater.ts, kernel-completion.ts, PoolErrorBanner.tsx    │
+└─────────────────────────────────────────────────────────────┘
+```

--- a/apps/live-viewer/client/index.html
+++ b/apps/live-viewer/client/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>nteract live viewer</title>
+<style>
+body { font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; padding: 24px; }
+h1 { font-size: 1.2em; margin-bottom: 16px; }
+.status { font-size: 0.8em; padding: 2px 8px; border-radius: 8px; }
+.status.ok { background: #23863533; color: #3fb950; }
+.status.err { background: #da363333; color: #f85149; }
+pre { font-size: 0.8em; background: #161b22; padding: 12px; border-radius: 8px; overflow: auto; max-height: 400px; }
+#log { white-space: pre-wrap; }
+button { background: #21262d; color: #e6edf3; border: 1px solid #30363d; padding: 6px 12px; border-radius: 6px; cursor: pointer; margin: 4px; }
+button:hover { background: #30363d; }
+</style>
+</head>
+<body>
+<h1>nteract live viewer <span class="status" id="status">loading...</span></h1>
+<p style="font-size:0.85em;color:#8b949e;margin-bottom:16px">
+  Frame relay prototype — raw daemon frames over WebSocket.
+  The full WASM+React app will replace this page.
+</p>
+<div id="notebooks" style="margin-bottom:16px"></div>
+<div id="controls"></div>
+<pre id="log"></pre>
+
+<script>
+const statusEl = document.getElementById('status');
+const logEl = document.getElementById('log');
+const notebooksEl = document.getElementById('notebooks');
+const controlsEl = document.getElementById('controls');
+
+function log(msg) {
+  const line = `[${new Date().toLocaleTimeString()}] ${msg}\n`;
+  logEl.textContent += line;
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+// Fetch notebook list
+async function loadNotebooks() {
+  try {
+    const resp = await fetch('/api/notebooks');
+    const rooms = await resp.json();
+    statusEl.textContent = `${rooms.length} rooms`;
+    statusEl.className = 'status ok';
+
+    let html = '<strong>Active notebooks:</strong><br>';
+    for (const room of rooms) {
+      const id = room.notebook_id;
+      const short = id.slice(0, 8);
+      const status = room.kernel_status || 'no-kernel';
+      html += `<button onclick="joinNotebook('${id}')">${short} (${status})</button> `;
+    }
+    notebooksEl.innerHTML = html;
+    log(`Found ${rooms.length} active notebook rooms`);
+  } catch (e) {
+    statusEl.textContent = 'error';
+    statusEl.className = 'status err';
+    log(`Error listing notebooks: ${e}`);
+  }
+}
+
+let ws = null;
+let frameCount = 0;
+
+function joinNotebook(id) {
+  if (ws) { ws.close(); ws = null; }
+
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = `${proto}//${location.host}/ws/join?id=${encodeURIComponent(id)}`;
+  log(`Connecting to ${id.slice(0, 8)}...`);
+
+  ws = new WebSocket(url);
+  ws.binaryType = 'arraybuffer';
+  frameCount = 0;
+
+  ws.onopen = () => {
+    log(`Connected! Receiving daemon frames...`);
+    controlsEl.innerHTML = `<button onclick="ws && ws.close()">Disconnect</button>`;
+  };
+
+  ws.onmessage = (event) => {
+    frameCount++;
+    const data = new Uint8Array(event.data);
+    const frameType = data[0];
+    const typeNames = {0:'AutomergeSync', 1:'Request', 2:'Response', 3:'Broadcast', 4:'Presence', 5:'RuntimeStateSync', 6:'PoolStateSync'};
+    const name = typeNames[frameType] || `Unknown(${frameType})`;
+    log(`Frame #${frameCount}: ${name} (${data.length} bytes)`);
+
+    // If it's a broadcast, try to decode the JSON
+    if (frameType === 3) {
+      try {
+        const json = new TextDecoder().decode(data.slice(1));
+        const broadcast = JSON.parse(json);
+        log(`  Broadcast: ${broadcast.type || JSON.stringify(broadcast).slice(0, 100)}`);
+      } catch {}
+    }
+  };
+
+  ws.onclose = () => {
+    log(`Disconnected (received ${frameCount} frames total)`);
+    controlsEl.innerHTML = '';
+  };
+
+  ws.onerror = () => log('WebSocket error');
+}
+
+loadNotebooks();
+</script>
+</body>
+</html>

--- a/apps/live-viewer/client/index.html
+++ b/apps/live-viewer/client/index.html
@@ -1,112 +1,160 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-<meta charset="utf-8">
-<title>nteract live viewer</title>
-<style>
-body { font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; padding: 24px; }
-h1 { font-size: 1.2em; margin-bottom: 16px; }
-.status { font-size: 0.8em; padding: 2px 8px; border-radius: 8px; }
-.status.ok { background: #23863533; color: #3fb950; }
-.status.err { background: #da363333; color: #f85149; }
-pre { font-size: 0.8em; background: #161b22; padding: 12px; border-radius: 8px; overflow: auto; max-height: 400px; }
-#log { white-space: pre-wrap; }
-button { background: #21262d; color: #e6edf3; border: 1px solid #30363d; padding: 6px 12px; border-radius: 6px; cursor: pointer; margin: 4px; }
-button:hover { background: #30363d; }
-</style>
-</head>
-<body>
-<h1>nteract live viewer <span class="status" id="status">loading...</span></h1>
-<p style="font-size:0.85em;color:#8b949e;margin-bottom:16px">
-  Frame relay prototype — raw daemon frames over WebSocket.
-  The full WASM+React app will replace this page.
-</p>
-<div id="notebooks" style="margin-bottom:16px"></div>
-<div id="controls"></div>
-<pre id="log"></pre>
+  <head>
+    <meta charset="utf-8" />
+    <title>nteract live viewer</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        background: #0d1117;
+        color: #e6edf3;
+        padding: 24px;
+      }
+      h1 {
+        font-size: 1.2em;
+        margin-bottom: 16px;
+      }
+      .status {
+        font-size: 0.8em;
+        padding: 2px 8px;
+        border-radius: 8px;
+      }
+      .status.ok {
+        background: #23863533;
+        color: #3fb950;
+      }
+      .status.err {
+        background: #da363333;
+        color: #f85149;
+      }
+      pre {
+        font-size: 0.8em;
+        background: #161b22;
+        padding: 12px;
+        border-radius: 8px;
+        overflow: auto;
+        max-height: 400px;
+      }
+      #log {
+        white-space: pre-wrap;
+      }
+      button {
+        background: #21262d;
+        color: #e6edf3;
+        border: 1px solid #30363d;
+        padding: 6px 12px;
+        border-radius: 6px;
+        cursor: pointer;
+        margin: 4px;
+      }
+      button:hover {
+        background: #30363d;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>nteract live viewer <span class="status" id="status">loading...</span></h1>
+    <p style="font-size: 0.85em; color: #8b949e; margin-bottom: 16px">
+      Frame relay prototype — raw daemon frames over WebSocket. The full WASM+React app will replace
+      this page.
+    </p>
+    <div id="notebooks" style="margin-bottom: 16px"></div>
+    <div id="controls"></div>
+    <pre id="log"></pre>
 
-<script>
-const statusEl = document.getElementById('status');
-const logEl = document.getElementById('log');
-const notebooksEl = document.getElementById('notebooks');
-const controlsEl = document.getElementById('controls');
+    <script>
+      const statusEl = document.getElementById("status");
+      const logEl = document.getElementById("log");
+      const notebooksEl = document.getElementById("notebooks");
+      const controlsEl = document.getElementById("controls");
 
-function log(msg) {
-  const line = `[${new Date().toLocaleTimeString()}] ${msg}\n`;
-  logEl.textContent += line;
-  logEl.scrollTop = logEl.scrollHeight;
-}
+      function log(msg) {
+        const line = `[${new Date().toLocaleTimeString()}] ${msg}\n`;
+        logEl.textContent += line;
+        logEl.scrollTop = logEl.scrollHeight;
+      }
 
-// Fetch notebook list
-async function loadNotebooks() {
-  try {
-    const resp = await fetch('/api/notebooks');
-    const rooms = await resp.json();
-    statusEl.textContent = `${rooms.length} rooms`;
-    statusEl.className = 'status ok';
+      // Fetch notebook list
+      async function loadNotebooks() {
+        try {
+          const resp = await fetch("/api/notebooks");
+          const rooms = await resp.json();
+          statusEl.textContent = `${rooms.length} rooms`;
+          statusEl.className = "status ok";
 
-    let html = '<strong>Active notebooks:</strong><br>';
-    for (const room of rooms) {
-      const id = room.notebook_id;
-      const short = id.slice(0, 8);
-      const status = room.kernel_status || 'no-kernel';
-      html += `<button onclick="joinNotebook('${id}')">${short} (${status})</button> `;
-    }
-    notebooksEl.innerHTML = html;
-    log(`Found ${rooms.length} active notebook rooms`);
-  } catch (e) {
-    statusEl.textContent = 'error';
-    statusEl.className = 'status err';
-    log(`Error listing notebooks: ${e}`);
-  }
-}
+          let html = "<strong>Active notebooks:</strong><br>";
+          for (const room of rooms) {
+            const id = room.notebook_id;
+            const short = id.slice(0, 8);
+            const status = room.kernel_status || "no-kernel";
+            html += `<button onclick="joinNotebook('${id}')">${short} (${status})</button> `;
+          }
+          notebooksEl.innerHTML = html;
+          log(`Found ${rooms.length} active notebook rooms`);
+        } catch (e) {
+          statusEl.textContent = "error";
+          statusEl.className = "status err";
+          log(`Error listing notebooks: ${e}`);
+        }
+      }
 
-let ws = null;
-let frameCount = 0;
+      let ws = null;
+      let frameCount = 0;
 
-function joinNotebook(id) {
-  if (ws) { ws.close(); ws = null; }
+      function joinNotebook(id) {
+        if (ws) {
+          ws.close();
+          ws = null;
+        }
 
-  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const url = `${proto}//${location.host}/ws/join?id=${encodeURIComponent(id)}`;
-  log(`Connecting to ${id.slice(0, 8)}...`);
+        const proto = location.protocol === "https:" ? "wss:" : "ws:";
+        const url = `${proto}//${location.host}/ws/join?id=${encodeURIComponent(id)}`;
+        log(`Connecting to ${id.slice(0, 8)}...`);
 
-  ws = new WebSocket(url);
-  ws.binaryType = 'arraybuffer';
-  frameCount = 0;
+        ws = new WebSocket(url);
+        ws.binaryType = "arraybuffer";
+        frameCount = 0;
 
-  ws.onopen = () => {
-    log(`Connected! Receiving daemon frames...`);
-    controlsEl.innerHTML = `<button onclick="ws && ws.close()">Disconnect</button>`;
-  };
+        ws.onopen = () => {
+          log(`Connected! Receiving daemon frames...`);
+          controlsEl.innerHTML = `<button onclick="ws && ws.close()">Disconnect</button>`;
+        };
 
-  ws.onmessage = (event) => {
-    frameCount++;
-    const data = new Uint8Array(event.data);
-    const frameType = data[0];
-    const typeNames = {0:'AutomergeSync', 1:'Request', 2:'Response', 3:'Broadcast', 4:'Presence', 5:'RuntimeStateSync', 6:'PoolStateSync'};
-    const name = typeNames[frameType] || `Unknown(${frameType})`;
-    log(`Frame #${frameCount}: ${name} (${data.length} bytes)`);
+        ws.onmessage = (event) => {
+          frameCount++;
+          const data = new Uint8Array(event.data);
+          const frameType = data[0];
+          const typeNames = {
+            0: "AutomergeSync",
+            1: "Request",
+            2: "Response",
+            3: "Broadcast",
+            4: "Presence",
+            5: "RuntimeStateSync",
+            6: "PoolStateSync",
+          };
+          const name = typeNames[frameType] || `Unknown(${frameType})`;
+          log(`Frame #${frameCount}: ${name} (${data.length} bytes)`);
 
-    // If it's a broadcast, try to decode the JSON
-    if (frameType === 3) {
-      try {
-        const json = new TextDecoder().decode(data.slice(1));
-        const broadcast = JSON.parse(json);
-        log(`  Broadcast: ${broadcast.type || JSON.stringify(broadcast).slice(0, 100)}`);
-      } catch {}
-    }
-  };
+          // If it's a broadcast, try to decode the JSON
+          if (frameType === 3) {
+            try {
+              const json = new TextDecoder().decode(data.slice(1));
+              const broadcast = JSON.parse(json);
+              log(`  Broadcast: ${broadcast.type || JSON.stringify(broadcast).slice(0, 100)}`);
+            } catch {}
+          }
+        };
 
-  ws.onclose = () => {
-    log(`Disconnected (received ${frameCount} frames total)`);
-    controlsEl.innerHTML = '';
-  };
+        ws.onclose = () => {
+          log(`Disconnected (received ${frameCount} frames total)`);
+          controlsEl.innerHTML = "";
+        };
 
-  ws.onerror = () => log('WebSocket error');
-}
+        ws.onerror = () => log("WebSocket error");
+      }
 
-loadNotebooks();
-</script>
-</body>
+      loadNotebooks();
+    </script>
+  </body>
 </html>

--- a/apps/live-viewer/index.html
+++ b/apps/live-viewer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>nteract live viewer</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/apps/live-viewer/index.html
+++ b/apps/live-viewer/index.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="dark">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>nteract live viewer</title>
-</head>
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>nteract live viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/apps/live-viewer/package.json
+++ b/apps/live-viewer/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
-    "build": "tsc -b && vp build",
+    "build": "vp build",
     "preview": "vp preview"
   },
   "dependencies": {

--- a/apps/live-viewer/package.json
+++ b/apps/live-viewer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "live-viewer",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "tsc -b && vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "runtimed": "workspace:*",
+    "rxjs": "^7.8.2"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.8",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^6.0.1",
+    "tailwindcss": "^4.1.8",
+    "typescript": "~5.8.3",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/apps/live-viewer/package.json
+++ b/apps/live-viewer/package.json
@@ -12,6 +12,7 @@
     "@nteract/notebook-host": "workspace:*",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router": "^7.14.1",
     "runtimed": "workspace:*",
     "rxjs": "^7.8.2"
   },

--- a/apps/live-viewer/package.json
+++ b/apps/live-viewer/package.json
@@ -9,6 +9,7 @@
     "preview": "vp preview"
   },
   "dependencies": {
+    "@nteract/notebook-host": "workspace:*",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "runtimed": "workspace:*",

--- a/apps/live-viewer/server/Cargo.toml
+++ b/apps/live-viewer/server/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures = "0.3"
+reqwest = { version = "0.12", default-features = false }

--- a/apps/live-viewer/server/Cargo.toml
+++ b/apps/live-viewer/server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "live-viewer-server"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+notebook-sync = { path = "../../../crates/notebook-sync" }
+notebook-protocol = { path = "../../../crates/notebook-protocol" }
+runtimed-client = { path = "../../../crates/runtimed-client" }
+
+tokio = { version = "1", features = ["full"] }
+axum = { version = "0.8", features = ["ws"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+futures = "0.3"

--- a/apps/live-viewer/server/Cargo.toml
+++ b/apps/live-viewer/server/Cargo.toml
@@ -11,6 +11,7 @@ runtimed-client = { path = "../../../crates/runtimed-client" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -63,7 +63,9 @@ async fn ws_join(
     Query(params): Query<JoinParams>,
 ) -> impl IntoResponse {
     info!("[relay] join request: {}", &params.id);
-    ws.on_upgrade(move |socket| handle_relay_connection(socket, state, RelayTarget::Join(params.id)))
+    ws.on_upgrade(move |socket| {
+        handle_relay_connection(socket, state, RelayTarget::Join(params.id))
+    })
 }
 
 enum RelayTarget {
@@ -143,8 +145,9 @@ async fn handle_relay_connection(socket: WebSocket, state: AppState, target: Rel
                     let frame_type = data[0];
                     // Read-only: only allow sync frames from browser
                     if frame_type == 0x00 || frame_type == 0x05 || frame_type == 0x06 {
-                        if let Err(e) =
-                            relay_clone.forward_frame(frame_type, data[1..].to_vec()).await
+                        if let Err(e) = relay_clone
+                            .forward_frame(frame_type, data[1..].to_vec())
+                            .await
                         {
                             warn!("[relay] forward_frame error: {e}");
                             break;
@@ -163,7 +166,10 @@ async fn handle_relay_connection(socket: WebSocket, state: AppState, target: Rel
         _ = inbound => {},
     }
 
-    info!("[relay] disconnected from notebook {}", &notebook_id[..8.min(notebook_id.len())]);
+    info!(
+        "[relay] disconnected from notebook {}",
+        &notebook_id[..8.min(notebook_id.len())]
+    );
 }
 
 // ─── REST endpoints ─────────────────────────────────────────────────────
@@ -237,7 +243,8 @@ async fn main() {
         .with_state(state);
 
     if has_dist {
-        app = app.fallback_service(ServeDir::new(&dist_path).append_index_html_on_directories(true));
+        app =
+            app.fallback_service(ServeDir::new(&dist_path).append_index_html_on_directories(true));
     } else {
         app = app.route("/", get(handle_index));
     }

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -25,7 +25,7 @@ use notebook_sync::relay::RelayHandle;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 use tower_http::cors::CorsLayer;
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 use tracing::{info, warn};
 
 const PORT: u16 = 8743;
@@ -243,8 +243,13 @@ async fn main() {
         .with_state(state);
 
     if has_dist {
-        app =
-            app.fallback_service(ServeDir::new(&dist_path).append_index_html_on_directories(true));
+        let index_html = dist_path.join("index.html");
+        let spa_fallback = ServeFile::new(&index_html);
+        app = app.fallback_service(
+            ServeDir::new(&dist_path)
+                .append_index_html_on_directories(true)
+                .fallback(spa_fallback),
+        );
     } else {
         app = app.route("/", get(handle_index));
     }

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -1,0 +1,234 @@
+//! Live notebook viewer — WebSocket frame relay for the runtimed daemon.
+//!
+//! Bridges the daemon's Unix socket to browser WebSocket clients on the tailnet.
+//! Each browser connection gets its own RelayHandle to the daemon — the browser
+//! owns the Automerge sync state via WASM, and this server just pipes bytes.
+//!
+//! Architecture:
+//! - Browser opens WebSocket to `/ws/open?path=...` or `/ws/join?id=...`
+//! - Server creates a relay connection to the daemon for that notebook
+//! - Daemon frames → binary WebSocket messages → browser
+//! - Browser frames → relay.forward_frame() → daemon
+//! - Read-only mode: only outbound frame types 0x00 (sync) and 0x05 (RuntimeStateSync) allowed
+
+use std::path::PathBuf;
+
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{Query, State, WebSocketUpgrade};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse};
+use axum::routing::get;
+use axum::Router;
+use futures::stream::StreamExt;
+use futures::SinkExt;
+use notebook_sync::relay::RelayHandle;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tower_http::cors::CorsLayer;
+use tracing::{info, warn};
+
+const PORT: u16 = 8743;
+
+#[derive(Clone)]
+struct AppState {
+    socket_path: PathBuf,
+}
+
+#[derive(Deserialize)]
+struct OpenParams {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct JoinParams {
+    id: String,
+}
+
+// ─── WebSocket handlers ─────────────────────────────────────────────────
+
+async fn ws_open(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Query(params): Query<OpenParams>,
+) -> impl IntoResponse {
+    let path = PathBuf::from(&params.path);
+    info!("[relay] open request: {:?}", path);
+    ws.on_upgrade(move |socket| handle_relay_connection(socket, state, RelayTarget::Open(path)))
+}
+
+async fn ws_join(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    Query(params): Query<JoinParams>,
+) -> impl IntoResponse {
+    info!("[relay] join request: {}", &params.id);
+    ws.on_upgrade(move |socket| handle_relay_connection(socket, state, RelayTarget::Join(params.id)))
+}
+
+enum RelayTarget {
+    Open(PathBuf),
+    Join(String),
+}
+
+/// Handle a single WebSocket connection — create a relay to the daemon and pipe frames.
+async fn handle_relay_connection(socket: WebSocket, state: AppState, target: RelayTarget) {
+    let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+
+    // Connect to daemon as a relay
+    let relay: RelayHandle = match &target {
+        RelayTarget::Open(path) => {
+            match notebook_sync::connect::connect_open_relay(
+                state.socket_path.clone(),
+                path.clone(),
+                frame_tx,
+            )
+            .await
+            {
+                Ok(result) => {
+                    info!(
+                        "[relay] connected to notebook {} (path={:?})",
+                        result.info.notebook_id,
+                        path.file_name()
+                    );
+                    result.handle
+                }
+                Err(e) => {
+                    warn!("[relay] open failed: {e}");
+                    return;
+                }
+            }
+        }
+        RelayTarget::Join(id) => {
+            match notebook_sync::connect::connect_relay(
+                state.socket_path.clone(),
+                id.clone(),
+                frame_tx,
+            )
+            .await
+            {
+                Ok(result) => {
+                    info!("[relay] joined notebook {}", id);
+                    result.handle
+                }
+                Err(e) => {
+                    warn!("[relay] join failed: {e}");
+                    return;
+                }
+            }
+        }
+    };
+
+    let notebook_id = relay.notebook_id();
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    // Task: daemon frames → WebSocket (binary)
+    let outbound = tokio::spawn(async move {
+        while let Some(frame) = frame_rx.recv().await {
+            if ws_tx.send(Message::Binary(frame.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Task: WebSocket → daemon (forward_frame)
+    let relay_clone = relay.clone();
+    let inbound = tokio::spawn(async move {
+        while let Some(Ok(msg)) = ws_rx.next().await {
+            match msg {
+                Message::Binary(data) => {
+                    if data.is_empty() {
+                        continue;
+                    }
+                    let frame_type = data[0];
+                    // Read-only: only allow sync frames from browser
+                    if frame_type == 0x00 || frame_type == 0x05 || frame_type == 0x06 {
+                        if let Err(e) =
+                            relay_clone.forward_frame(frame_type, data[1..].to_vec()).await
+                        {
+                            warn!("[relay] forward_frame error: {e}");
+                            break;
+                        }
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+    });
+
+    // Wait for either direction to finish
+    tokio::select! {
+        _ = outbound => {},
+        _ = inbound => {},
+    }
+
+    info!("[relay] disconnected from notebook {}", &notebook_id[..8.min(notebook_id.len())]);
+}
+
+// ─── REST endpoints ─────────────────────────────────────────────────────
+
+async fn handle_index() -> Html<&'static str> {
+    Html(include_str!("../../client/index.html"))
+}
+
+/// List active notebook rooms on the daemon.
+async fn handle_list(State(state): State<AppState>) -> impl IntoResponse {
+    let client = runtimed_client::client::PoolClient::new(state.socket_path.clone());
+    match client.list_rooms().await {
+        Ok(rooms) => {
+            let json = serde_json::to_string(&rooms).unwrap_or_default();
+            (StatusCode::OK, [("content-type", "application/json")], json)
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [("content-type", "application/json")],
+            format!("{{\"error\":\"{e}\"}}"),
+        ),
+    }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "live_viewer_server=info".into()),
+        )
+        .init();
+
+    let socket_path =
+        runtimed_client::socket_path_for_channel(runtimed_client::BuildChannel::Nightly);
+    info!("daemon socket: {:?}", socket_path);
+
+    let state = AppState { socket_path };
+
+    let app = Router::new()
+        .route("/", get(handle_index))
+        .route("/api/notebooks", get(handle_list))
+        .route("/ws/open", get(ws_open))
+        .route("/ws/join", get(ws_join))
+        .layer(CorsLayer::permissive())
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{PORT}"))
+        .await
+        .expect("failed to bind");
+
+    let hostname = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(r#"tailscale status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('Self',{}).get('DNSName','').rstrip('.'))" 2>/dev/null"#)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "0.0.0.0".into());
+
+    info!("nteract live viewer (frame relay)");
+    info!("  Tailnet: http://{}:{}", hostname, PORT);
+    info!("  Local:   http://localhost:{}", PORT);
+
+    axum::serve(listener, app).await.unwrap();
+}

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -25,6 +25,7 @@ use notebook_sync::relay::RelayHandle;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 use tower_http::cors::CorsLayer;
+use tower_http::services::ServeDir;
 use tracing::{info, warn};
 
 const PORT: u16 = 8743;
@@ -204,13 +205,42 @@ async fn main() {
 
     let state = AppState { socket_path };
 
-    let app = Router::new()
-        .route("/", get(handle_index))
+    // Serve the Vite build output if available, otherwise fall back to test HTML.
+    // Check env var first, then look relative to the cargo manifest dir (dev),
+    // then relative to the binary.
+    let dist_path = std::env::var("LIVE_VIEWER_DIST")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let manifest_relative = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../dist");
+            if manifest_relative.join("index.html").exists() {
+                return manifest_relative;
+            }
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+                .unwrap_or_default()
+                .join("dist")
+        });
+
+    let has_dist = dist_path.join("index.html").exists();
+    if has_dist {
+        info!("serving built app from {:?}", dist_path);
+    } else {
+        info!("no dist/ found, serving embedded test page");
+    }
+
+    let mut app = Router::new()
         .route("/api/notebooks", get(handle_list))
         .route("/ws/open", get(ws_open))
         .route("/ws/join", get(ws_join))
         .layer(CorsLayer::permissive())
         .with_state(state);
+
+    if has_dist {
+        app = app.fallback_service(ServeDir::new(&dist_path).append_index_html_on_directories(true));
+    } else {
+        app = app.route("/", get(handle_index));
+    }
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{PORT}"))
         .await

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -254,10 +254,6 @@ async fn main() {
         app = app.route("/", get(handle_index));
     }
 
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{PORT}"))
-        .await
-        .expect("failed to bind");
-
     let hostname = std::process::Command::new("sh")
         .arg("-c")
         .arg(r#"tailscale status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('Self',{}).get('DNSName','').rstrip('.'))" 2>/dev/null"#)
@@ -268,9 +264,33 @@ async fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "0.0.0.0".into());
 
-    info!("nteract live viewer (frame relay)");
-    info!("  Tailnet: http://{}:{}", hostname, PORT);
-    info!("  Local:   http://localhost:{}", PORT);
+    // Try to find Tailscale TLS certs for HTTPS
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+    let cert_dir = PathBuf::from(&home).join(".local/share/tailscale/certs");
+    let cert_file = cert_dir.join(format!("{hostname}.crt"));
+    let key_file = cert_dir.join(format!("{hostname}.key"));
 
-    axum::serve(listener, app).await.unwrap();
+    if cert_file.exists() && key_file.exists() {
+        info!("nteract live viewer (TLS)");
+        info!("  Tailnet: https://{}:{}", hostname, PORT);
+        info!("  Local:   https://localhost:{}", PORT);
+
+        let config = axum_server::tls_rustls::RustlsConfig::from_pem_file(&cert_file, &key_file)
+            .await
+            .expect("failed to load TLS certs");
+
+        axum_server::bind_rustls(format!("0.0.0.0:{PORT}").parse().unwrap(), config)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    } else {
+        info!("nteract live viewer (plain HTTP — no TLS certs found)");
+        info!("  Tailnet: http://{}:{}", hostname, PORT);
+        info!("  Local:   http://localhost:{}", PORT);
+
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{PORT}"))
+            .await
+            .expect("failed to bind");
+        axum::serve(listener, app).await.unwrap();
+    }
 }

--- a/apps/live-viewer/server/src/main.rs
+++ b/apps/live-viewer/server/src/main.rs
@@ -33,6 +33,7 @@ const PORT: u16 = 8743;
 #[derive(Clone)]
 struct AppState {
     socket_path: PathBuf,
+    blob_port: u16,
 }
 
 #[derive(Deserialize)]
@@ -172,6 +173,36 @@ async fn handle_relay_connection(socket: WebSocket, state: AppState, target: Rel
     );
 }
 
+// ─── Blob proxy ────────────────────────────────────────────────────────
+
+async fn handle_blob(
+    State(state): State<AppState>,
+    axum::extract::Path(hash): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    let url = format!("http://127.0.0.1:{}/blob/{}", state.blob_port, hash);
+    match reqwest::get(&url).await {
+        Ok(resp) if resp.status().is_success() => {
+            let content_type = resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("application/octet-stream")
+                .to_string();
+            let bytes = resp.bytes().await.unwrap_or_default();
+            (
+                StatusCode::OK,
+                [
+                    ("content-type", content_type),
+                    ("cache-control", "public, max-age=31536000, immutable".to_string()),
+                ],
+                bytes,
+            )
+                .into_response()
+        }
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
 // ─── REST endpoints ─────────────────────────────────────────────────────
 
 async fn handle_index() -> Html<&'static str> {
@@ -209,7 +240,17 @@ async fn main() {
         runtimed_client::socket_path_for_channel(runtimed_client::BuildChannel::Nightly);
     info!("daemon socket: {:?}", socket_path);
 
-    let state = AppState { socket_path };
+    // Read blob port from daemon.json
+    let blob_port = socket_path
+        .parent()
+        .map(|p| p.join("daemon.json"))
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.get("blob_port").and_then(|p| p.as_u64()))
+        .unwrap_or(0) as u16;
+    info!("daemon blob port: {}", blob_port);
+
+    let state = AppState { socket_path, blob_port };
 
     // Serve the Vite build output if available, otherwise fall back to test HTML.
     // Check env var first, then look relative to the cargo manifest dir (dev),
@@ -237,6 +278,7 @@ async fn main() {
 
     let mut app = Router::new()
         .route("/api/notebooks", get(handle_list))
+        .route("/blob/{hash}", get(handle_blob))
         .route("/ws/open", get(ws_open))
         .route("/ws/join", get(ws_join))
         .layer(CorsLayer::permissive())

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { NotebookViewer } from "./components/NotebookViewer";
+
+interface RoomInfo {
+  notebook_id: string;
+  active_peers: number;
+  has_kernel: boolean;
+  kernel_type?: string;
+  kernel_status?: string;
+  env_source?: string;
+}
+
+export function App() {
+  const [rooms, setRooms] = useState<RoomInfo[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchRooms() {
+      try {
+        const resp = await fetch("/api/notebooks");
+        const data: RoomInfo[] = await resp.json();
+        setRooms(data);
+        setError(null);
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+    fetchRooms();
+    const interval = setInterval(fetchRooms, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (selectedId) {
+    return (
+      <div className="dark min-h-screen bg-background text-foreground">
+        <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
+          <button
+            onClick={() => setSelectedId(null)}
+            className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-secondary"
+          >
+            &larr; Back
+          </button>
+          <h1 className="text-sm font-semibold">nteract live viewer</h1>
+          <span className="ml-auto font-mono text-xs text-muted-foreground">
+            {selectedId.slice(0, 8)}
+          </span>
+        </header>
+        <NotebookViewer notebookId={selectedId} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="dark min-h-screen bg-background text-foreground">
+      <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
+        <h1 className="text-sm font-semibold">nteract live viewer</h1>
+        <span className="rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground">
+          {rooms.length} notebooks
+        </span>
+      </header>
+
+      <main className="mx-auto max-w-3xl p-6">
+        {error && (
+          <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive-foreground">
+            {error}
+          </div>
+        )}
+
+        {rooms.length === 0 && !error && (
+          <div className="py-20 text-center text-muted-foreground">
+            <p className="text-lg">No active notebooks</p>
+            <p className="mt-1 text-sm opacity-70">
+              Open a notebook in nteract to see it here.
+            </p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          {rooms.map((room) => (
+            <button
+              key={room.notebook_id}
+              onClick={() => setSelectedId(room.notebook_id)}
+              className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-secondary"
+            >
+              <div className="flex-1">
+                <div className="font-mono text-sm text-card-foreground">
+                  {room.notebook_id.slice(0, 8)}
+                </div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  {room.active_peers} peer{room.active_peers !== 1 ? "s" : ""}
+                  {room.kernel_type && ` · ${room.kernel_type}`}
+                  {room.env_source && ` · ${room.env_source}`}
+                </div>
+              </div>
+              {room.kernel_status && (
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    room.kernel_status === "idle"
+                      ? "bg-green-900/30 text-green-400"
+                      : room.kernel_status === "busy"
+                        ? "bg-yellow-900/30 text-yellow-400"
+                        : "bg-blue-900/30 text-blue-400"
+                  }`}
+                >
+                  {room.kernel_status}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -1,3 +1,4 @@
+import { BrowserRouter, Routes, Route, useNavigate, useParams } from "react-router";
 import { useEffect, useState } from "react";
 import { NotebookViewer } from "./components/NotebookViewer";
 
@@ -11,9 +12,20 @@ interface RoomInfo {
 }
 
 export function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<NotebookList />} />
+        <Route path="/:notebookId" element={<ViewerPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+function NotebookList() {
   const [rooms, setRooms] = useState<RoomInfo[]>([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function fetchRooms() {
@@ -30,26 +42,6 @@ export function App() {
     const interval = setInterval(fetchRooms, 5000);
     return () => clearInterval(interval);
   }, []);
-
-  if (selectedId) {
-    return (
-      <div className="dark min-h-screen bg-background text-foreground">
-        <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-          <button
-            onClick={() => setSelectedId(null)}
-            className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-secondary"
-          >
-            &larr; Back
-          </button>
-          <h1 className="text-sm font-semibold">nteract live viewer</h1>
-          <span className="ml-auto font-mono text-xs text-muted-foreground">
-            {selectedId.slice(0, 8)}
-          </span>
-        </header>
-        <NotebookViewer notebookId={selectedId} />
-      </div>
-    );
-  }
 
   return (
     <div className="dark min-h-screen bg-background text-foreground">
@@ -78,7 +70,7 @@ export function App() {
           {rooms.map((room) => (
             <button
               key={room.notebook_id}
-              onClick={() => setSelectedId(room.notebook_id)}
+              onClick={() => navigate(`/${room.notebook_id}`)}
               className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-secondary"
             >
               <div className="flex-1">
@@ -108,6 +100,31 @@ export function App() {
           ))}
         </div>
       </main>
+    </div>
+  );
+}
+
+function ViewerPage() {
+  const { notebookId } = useParams<{ notebookId: string }>();
+  const navigate = useNavigate();
+
+  if (!notebookId) return null;
+
+  return (
+    <div className="dark min-h-screen bg-background text-foreground">
+      <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
+        <button
+          onClick={() => navigate("/")}
+          className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-secondary"
+        >
+          &larr; Back
+        </button>
+        <h1 className="text-sm font-semibold">nteract live viewer</h1>
+        <span className="ml-auto font-mono text-xs text-muted-foreground">
+          {notebookId.slice(0, 8)}
+        </span>
+      </header>
+      <NotebookViewer notebookId={notebookId} />
     </div>
   );
 }

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -18,8 +18,7 @@ export function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<NotebookList />} />
-        <Route path="/full/:notebookId" element={<FullTreePage />} />
-        <Route path="/:notebookId" element={<ViewerPage />} />
+        <Route path="/:notebookId" element={<FullTreePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Link, useNavigate, useParams } from "react-router";
+import { FullTreeViewer } from "./components/FullTreeViewer";
 import { useEffect, useState } from "react";
 import { NotebookViewer } from "./components/NotebookViewer";
 
@@ -17,6 +18,7 @@ export function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<NotebookList />} />
+        <Route path="/full/:notebookId" element={<FullTreePage />} />
         <Route path="/:notebookId" element={<ViewerPage />} />
       </Routes>
     </BrowserRouter>
@@ -163,6 +165,30 @@ function ViewerPage() {
         </span>
       </header>
       <NotebookViewer notebookId={notebookId} />
+    </div>
+  );
+}
+
+function FullTreePage() {
+  const { notebookId } = useParams<{ notebookId: string }>();
+
+  if (!notebookId) return null;
+
+  return (
+    <div className="dark min-h-screen bg-background text-foreground">
+      <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
+        <Link
+          to="/"
+          className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-secondary"
+        >
+          &larr; Back
+        </Link>
+        <h1 className="text-sm font-semibold">FULL TREE TEST</h1>
+        <span className="ml-auto font-mono text-xs text-muted-foreground">
+          {notebookId.slice(0, 8)}
+        </span>
+      </header>
+      <FullTreeViewer notebookId={notebookId} />
     </div>
   );
 }

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -70,9 +70,7 @@ export function App() {
         {rooms.length === 0 && !error && (
           <div className="py-20 text-center text-muted-foreground">
             <p className="text-lg">No active notebooks</p>
-            <p className="mt-1 text-sm opacity-70">
-              Open a notebook in nteract to see it here.
-            </p>
+            <p className="mt-1 text-sm opacity-70">Open a notebook in nteract to see it here.</p>
           </div>
         )}
 

--- a/apps/live-viewer/src/App.tsx
+++ b/apps/live-viewer/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, useNavigate, useParams } from "react-router";
+import { BrowserRouter, Routes, Route, Link, useNavigate, useParams } from "react-router";
 import { useEffect, useState } from "react";
 import { NotebookViewer } from "./components/NotebookViewer";
 
@@ -9,6 +9,7 @@ interface RoomInfo {
   kernel_type?: string;
   kernel_status?: string;
   env_source?: string;
+  ephemeral?: boolean;
 }
 
 export function App() {
@@ -25,6 +26,7 @@ export function App() {
 function NotebookList() {
   const [rooms, setRooms] = useState<RoomInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [lastFetch, setLastFetch] = useState<Date | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -34,12 +36,13 @@ function NotebookList() {
         const data: RoomInfo[] = await resp.json();
         setRooms(data);
         setError(null);
+        setLastFetch(new Date());
       } catch (e) {
         setError(String(e));
       }
     }
     fetchRooms();
-    const interval = setInterval(fetchRooms, 5000);
+    const interval = setInterval(fetchRooms, 3000);
     return () => clearInterval(interval);
   }, []);
 
@@ -48,21 +51,24 @@ function NotebookList() {
       <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
         <h1 className="text-sm font-semibold">nteract live viewer</h1>
         <span className="rounded-full bg-secondary px-2 py-0.5 text-xs text-muted-foreground">
-          {rooms.length} notebooks
+          {rooms.length} notebook{rooms.length !== 1 ? "s" : ""}
         </span>
+        {lastFetch && (
+          <span className="ml-auto text-[10px] text-muted-foreground/60">polling every 3s</span>
+        )}
       </header>
 
       <main className="mx-auto max-w-3xl p-6">
         {error && (
-          <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive-foreground">
-            {error}
+          <div className="mb-4 rounded-md border border-red-500/30 bg-red-950/20 p-3 text-sm text-red-400">
+            Failed to reach daemon: {error}
           </div>
         )}
 
         {rooms.length === 0 && !error && (
           <div className="py-20 text-center text-muted-foreground">
             <p className="text-lg">No active notebooks</p>
-            <p className="mt-1 text-sm opacity-70">Open a notebook in nteract to see it here.</p>
+            <p className="mt-2 text-sm opacity-70">Open a notebook in nteract to see it here.</p>
           </div>
         )}
 
@@ -71,31 +77,48 @@ function NotebookList() {
             <button
               key={room.notebook_id}
               onClick={() => navigate(`/${room.notebook_id}`)}
-              className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-secondary"
+              className="group flex items-center gap-4 rounded-lg border border-border bg-card p-4 text-left transition-all hover:border-muted-foreground/30 hover:bg-secondary"
             >
-              <div className="flex-1">
-                <div className="font-mono text-sm text-card-foreground">
-                  {room.notebook_id.slice(0, 8)}
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-secondary text-muted-foreground">
+                {room.ephemeral ? (
+                  <span className="text-base">*</span>
+                ) : (
+                  <span className="text-xs font-mono">.nb</span>
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm text-card-foreground">
+                    {room.notebook_id.slice(0, 8)}
+                  </span>
+                  {room.ephemeral && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                      ephemeral
+                    </span>
+                  )}
                 </div>
-                <div className="mt-0.5 text-xs text-muted-foreground">
-                  {room.active_peers} peer{room.active_peers !== 1 ? "s" : ""}
-                  {room.kernel_type && ` · ${room.kernel_type}`}
-                  {room.env_source && ` · ${room.env_source}`}
+                <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {room.active_peers} peer{room.active_peers !== 1 ? "s" : ""}
+                  </span>
+                  {room.kernel_type && (
+                    <>
+                      <span className="text-border">·</span>
+                      <span>{room.kernel_type}</span>
+                    </>
+                  )}
+                  {room.env_source && (
+                    <>
+                      <span className="text-border">·</span>
+                      <span>{room.env_source}</span>
+                    </>
+                  )}
                 </div>
               </div>
-              {room.kernel_status && (
-                <span
-                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                    room.kernel_status === "idle"
-                      ? "bg-green-900/30 text-green-400"
-                      : room.kernel_status === "busy"
-                        ? "bg-yellow-900/30 text-yellow-400"
-                        : "bg-blue-900/30 text-blue-400"
-                  }`}
-                >
-                  {room.kernel_status}
-                </span>
-              )}
+              {room.kernel_status && <KernelPill status={room.kernel_status} />}
+              <span className="text-muted-foreground/40 transition-transform group-hover:translate-x-0.5">
+                &rsaquo;
+              </span>
             </button>
           ))}
         </div>
@@ -104,21 +127,36 @@ function NotebookList() {
   );
 }
 
+function KernelPill({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    idle: "bg-green-900/30 text-green-400",
+    busy: "bg-amber-900/30 text-amber-400",
+    starting: "bg-blue-900/30 text-blue-400",
+    error: "bg-red-900/30 text-red-400",
+  };
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs font-medium ${styles[status] ?? "bg-secondary text-muted-foreground"}`}
+    >
+      {status}
+    </span>
+  );
+}
+
 function ViewerPage() {
   const { notebookId } = useParams<{ notebookId: string }>();
-  const navigate = useNavigate();
 
   if (!notebookId) return null;
 
   return (
     <div className="dark min-h-screen bg-background text-foreground">
       <header className="sticky top-0 z-50 flex items-center gap-3 border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-        <button
-          onClick={() => navigate("/")}
+        <Link
+          to="/"
           className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-secondary"
         >
           &larr; Back
-        </button>
+        </Link>
         <h1 className="text-sm font-semibold">nteract live viewer</h1>
         <span className="ml-auto font-mono text-xs text-muted-foreground">
           {notebookId.slice(0, 8)}

--- a/apps/live-viewer/src/components/CellView.tsx
+++ b/apps/live-viewer/src/components/CellView.tsx
@@ -1,0 +1,105 @@
+import { getGutterColors } from "@/components/cell/gutter-colors";
+import { AnsiOutput } from "@/components/outputs/ansi-output";
+
+interface OutputData {
+  output_type: string;
+  text?: string;
+  data?: Record<string, unknown>;
+  name?: string;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+interface CellData {
+  id: string;
+  cell_type: string;
+  source: string;
+  execution_count: number | null;
+  outputs: OutputData[];
+}
+
+interface Props {
+  cell: CellData;
+}
+
+export function CellView({ cell }: Props) {
+  const colors = getGutterColors(cell.cell_type);
+
+  return (
+    <div className="group flex items-stretch py-0.5">
+      {/* Ribbon */}
+      <div className={`w-[3px] shrink-0 rounded-sm ${colors.ribbon.default} my-0.5 ml-2`} />
+
+      {/* Gutter */}
+      <div className="flex w-10 shrink-0 items-start justify-end px-1.5 pt-1.5 font-mono text-[10px] text-muted-foreground select-none">
+        {cell.cell_type === "code" && cell.execution_count != null && (
+          <span>[{cell.execution_count}]</span>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="min-w-0 flex-1 py-0.5">
+        {/* Source */}
+        <div
+          className={`rounded-md border border-border px-3 py-2 font-mono text-[13px] leading-relaxed ${
+            cell.cell_type === "markdown"
+              ? "border-transparent bg-transparent text-muted-foreground"
+              : "bg-background"
+          }`}
+        >
+          <pre className="whitespace-pre-wrap break-words">{cell.source}</pre>
+        </div>
+
+        {/* Outputs */}
+        {cell.outputs.length > 0 && (
+          <div className="mt-1 space-y-1 pl-0.5">
+            {cell.outputs.map((output, i) => (
+              <CellOutput key={i} output={output} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CellOutput({ output }: { output: OutputData }) {
+  if (output.output_type === "stream") {
+    const text = output.text ?? "";
+    const isStderr = output.name === "stderr";
+    return (
+      <div className={`font-mono text-xs leading-relaxed ${isStderr ? "text-red-400" : "text-muted-foreground"}`}>
+        <AnsiOutput isError={isStderr}>{text}</AnsiOutput>
+      </div>
+    );
+  }
+
+  if (output.output_type === "error") {
+    const tb = output.traceback?.join("\n") ?? `${output.ename}: ${output.evalue}`;
+    return (
+      <div className="rounded-md bg-red-950/30 p-2 font-mono text-xs leading-relaxed text-red-400">
+        <AnsiOutput isError>{tb}</AnsiOutput>
+      </div>
+    );
+  }
+
+  if (output.output_type === "execute_result" || output.output_type === "display_data") {
+    const data = output.data ?? {};
+    const textPlain = data["text/plain"] as string | undefined;
+    if (textPlain) {
+      return (
+        <div className="font-mono text-xs leading-relaxed text-blue-300">
+          <AnsiOutput>{textPlain}</AnsiOutput>
+        </div>
+      );
+    }
+    return (
+      <div className="font-mono text-xs text-muted-foreground italic">
+        [display_data: {Object.keys(data).join(", ")}]
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/live-viewer/src/components/CellView.tsx
+++ b/apps/live-viewer/src/components/CellView.tsx
@@ -1,8 +1,27 @@
+/**
+ * Full component tree integration for the live-viewer.
+ *
+ * Uses the same shared components as the notebook app:
+ * - CellContainer (segmented ribbon, gutter, right-gutter layout)
+ * - CompactExecutionButton (execution count + play/stop)
+ * - OutputArea (iframe isolation, MediaRouter, ANSI, error rendering)
+ * - CodeMirrorEditor (syntax highlighting, read-only)
+ *
+ * Coupling boundaries documented inline where the viewer diverges
+ * from the notebook app's CodeCell:
+ * - No useCrdtBridge (read-only, no editing)
+ * - No useCellKeyboardNavigation (no cell focus navigation)
+ * - No usePresenceContext (no remote cursors)
+ * - No useEditorRegistry (no editor instance tracking)
+ * - No cell-ui-state hooks (focus/executing/queued driven by props)
+ * - No HistorySearchDialog (no Ctrl+R)
+ * - No drag handles (no reordering)
+ */
+
+import { memo } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
-import { ExecutionCount } from "@/components/cell/ExecutionCount";
-import { ExecutionStatus } from "@/components/cell/ExecutionStatus";
-import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
-import { MediaRouter } from "@/components/outputs/media-router";
+import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
+import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { ExecutionState } from "runtimed/src/runtime-state";
@@ -13,6 +32,7 @@ interface CellData {
   source: string;
   execution_count: number | null;
   outputs: JupyterOutput[];
+  metadata?: Record<string, unknown>;
 }
 
 interface Props {
@@ -20,68 +40,64 @@ interface Props {
   executionState: ExecutionState | null;
 }
 
-export function CellView({ cell, executionState }: Props) {
+export const CellView = memo(function CellView({ cell, executionState }: Props) {
   const isRunning = executionState?.status === "running";
   const isQueued = executionState?.status === "queued";
+
+  // Shared components from the real app's CodeCell — read-only mode
+  // COUPLING EDGE: CodeCell uses useCrdtBridge for live editing.
+  // We skip it entirely since this is read-only.
+  const isCode = cell.cell_type === "code";
+  const isMarkdown = cell.cell_type === "markdown";
+
+  // Check source_hidden / outputs_hidden (JupyterLab convention)
+  const jupyter = cell.metadata?.jupyter as
+    | { source_hidden?: boolean; outputs_hidden?: boolean }
+    | undefined;
+  const isSourceHidden = jupyter?.source_hidden === true;
+  const isOutputsHidden = jupyter?.outputs_hidden === true;
 
   return (
     <CellContainer
       id={cell.id}
       cellType={cell.cell_type}
       gutterContent={
-        cell.cell_type === "code" ? (
-          <div className="flex flex-col items-end gap-0.5">
-            <ExecutionCount count={cell.execution_count} isExecuting={isRunning} />
-            {(isRunning || isQueued) && <ExecutionStatus executionState={executionState.status} />}
-          </div>
+        isCode ? (
+          <CompactExecutionButton
+            count={cell.execution_count}
+            isExecuting={isRunning}
+            isQueued={isQueued}
+          />
         ) : undefined
       }
       codeContent={
-        cell.cell_type === "markdown" ? (
-          <pre className="whitespace-pre-wrap break-words text-[13px] text-muted-foreground">
+        isSourceHidden ? (
+          <div className="flex items-center text-xs text-muted-foreground italic py-0.5">
+            source hidden
+          </div>
+        ) : isMarkdown ? (
+          <div className="whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground/90">
             {cell.source}
-          </pre>
+          </div>
         ) : (
           <CodeMirrorEditor
             initialValue={cell.source}
-            language={cell.cell_type === "code" ? "python" : undefined}
+            language={isCode ? "python" : undefined}
             readOnly
           />
         )
       }
       outputContent={
-        cell.outputs.length > 0 ? (
-          <div className="space-y-2 pl-6 pr-3">
-            {cell.outputs.map((output, i) => (
-              <CellOutput key={i} output={output} />
-            ))}
-          </div>
+        isOutputsHidden ? undefined : isCode && cell.outputs.length > 0 ? (
+          <OutputArea
+            outputs={cell.outputs}
+            cellId={cell.id}
+            preloadIframe={false}
+            isolated="auto"
+          />
         ) : undefined
       }
+      hideOutput={isCode && cell.outputs.length === 0}
     />
   );
-}
-
-function CellOutput({ output }: { output: JupyterOutput }) {
-  if (output.output_type === "stream") {
-    const text = Array.isArray(output.text) ? output.text.join("") : output.text;
-    return <AnsiStreamOutput text={text} streamName={output.name} />;
-  }
-
-  if (output.output_type === "error") {
-    return (
-      <AnsiErrorOutput ename={output.ename} evalue={output.evalue} traceback={output.traceback} />
-    );
-  }
-
-  if (output.output_type === "execute_result" || output.output_type === "display_data") {
-    return (
-      <MediaRouter
-        data={output.data}
-        metadata={output.metadata as Record<string, Record<string, unknown> | undefined>}
-      />
-    );
-  }
-
-  return null;
-}
+});

--- a/apps/live-viewer/src/components/CellView.tsx
+++ b/apps/live-viewer/src/components/CellView.tsx
@@ -1,103 +1,85 @@
-import { getGutterColors } from "@/components/cell/gutter-colors";
-import { AnsiOutput } from "@/components/outputs/ansi-output";
-
-interface OutputData {
-  output_type: string;
-  text?: string;
-  data?: Record<string, unknown>;
-  name?: string;
-  ename?: string;
-  evalue?: string;
-  traceback?: string[];
-}
+import { CellContainer } from "@/components/cell/CellContainer";
+import { ExecutionCount } from "@/components/cell/ExecutionCount";
+import { ExecutionStatus } from "@/components/cell/ExecutionStatus";
+import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
+import { MediaRouter } from "@/components/outputs/media-router";
+import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import type { ExecutionState } from "runtimed/src/runtime-state";
 
 interface CellData {
   id: string;
   cell_type: string;
   source: string;
   execution_count: number | null;
-  outputs: OutputData[];
+  outputs: JupyterOutput[];
 }
 
 interface Props {
   cell: CellData;
+  executionState: ExecutionState | null;
 }
 
-export function CellView({ cell }: Props) {
-  const colors = getGutterColors(cell.cell_type);
+export function CellView({ cell, executionState }: Props) {
+  const isRunning = executionState?.status === "running";
+  const isQueued = executionState?.status === "queued";
 
   return (
-    <div className="group flex items-stretch py-0.5">
-      {/* Ribbon */}
-      <div className={`w-[3px] shrink-0 rounded-sm ${colors.ribbon.default} my-0.5 ml-2`} />
-
-      {/* Gutter */}
-      <div className="flex w-10 shrink-0 items-start justify-end px-1.5 pt-1.5 font-mono text-[10px] text-muted-foreground select-none">
-        {cell.cell_type === "code" && cell.execution_count != null && (
-          <span>[{cell.execution_count}]</span>
-        )}
-      </div>
-
-      {/* Body */}
-      <div className="min-w-0 flex-1 py-0.5">
-        {/* Source */}
-        <div
-          className={`rounded-md border border-border px-3 py-2 font-mono text-[13px] leading-relaxed ${
-            cell.cell_type === "markdown"
-              ? "border-transparent bg-transparent text-muted-foreground"
-              : "bg-background"
-          }`}
-        >
-          <pre className="whitespace-pre-wrap break-words">{cell.source}</pre>
-        </div>
-
-        {/* Outputs */}
-        {cell.outputs.length > 0 && (
-          <div className="mt-1 space-y-1 pl-0.5">
+    <CellContainer
+      id={cell.id}
+      cellType={cell.cell_type}
+      gutterContent={
+        cell.cell_type === "code" ? (
+          <div className="flex flex-col items-end gap-0.5">
+            <ExecutionCount count={cell.execution_count} isExecuting={isRunning} />
+            {(isRunning || isQueued) && <ExecutionStatus executionState={executionState.status} />}
+          </div>
+        ) : undefined
+      }
+      codeContent={
+        cell.cell_type === "markdown" ? (
+          <pre className="whitespace-pre-wrap break-words text-[13px] text-muted-foreground">
+            {cell.source}
+          </pre>
+        ) : (
+          <CodeMirrorEditor
+            initialValue={cell.source}
+            language={cell.cell_type === "code" ? "python" : undefined}
+            readOnly
+          />
+        )
+      }
+      outputContent={
+        cell.outputs.length > 0 ? (
+          <div className="space-y-2 pl-6 pr-3">
             {cell.outputs.map((output, i) => (
               <CellOutput key={i} output={output} />
             ))}
           </div>
-        )}
-      </div>
-    </div>
+        ) : undefined
+      }
+    />
   );
 }
 
-function CellOutput({ output }: { output: OutputData }) {
+function CellOutput({ output }: { output: JupyterOutput }) {
   if (output.output_type === "stream") {
-    const text = output.text ?? "";
-    const isStderr = output.name === "stderr";
-    return (
-      <div className={`font-mono text-xs leading-relaxed ${isStderr ? "text-red-400" : "text-muted-foreground"}`}>
-        <AnsiOutput isError={isStderr}>{text}</AnsiOutput>
-      </div>
-    );
+    const text = Array.isArray(output.text) ? output.text.join("") : output.text;
+    return <AnsiStreamOutput text={text} streamName={output.name} />;
   }
 
   if (output.output_type === "error") {
-    const tb = output.traceback?.join("\n") ?? `${output.ename}: ${output.evalue}`;
     return (
-      <div className="rounded-md bg-red-950/30 p-2 font-mono text-xs leading-relaxed text-red-400">
-        <AnsiOutput isError>{tb}</AnsiOutput>
-      </div>
+      <AnsiErrorOutput ename={output.ename} evalue={output.evalue} traceback={output.traceback} />
     );
   }
 
   if (output.output_type === "execute_result" || output.output_type === "display_data") {
-    const data = output.data ?? {};
-    const textPlain = data["text/plain"] as string | undefined;
-    if (textPlain) {
-      return (
-        <div className="font-mono text-xs leading-relaxed text-blue-300">
-          <AnsiOutput>{textPlain}</AnsiOutput>
-        </div>
-      );
-    }
     return (
-      <div className="font-mono text-xs text-muted-foreground italic">
-        [display_data: {Object.keys(data).join(", ")}]
-      </div>
+      <MediaRouter
+        data={output.data}
+        metadata={output.metadata as Record<string, Record<string, unknown> | undefined>}
+      />
     );
   }
 

--- a/apps/live-viewer/src/components/CellView.tsx
+++ b/apps/live-viewer/src/components/CellView.tsx
@@ -92,8 +92,7 @@ export const CellView = memo(function CellView({ cell, executionState }: Props) 
           <OutputArea
             outputs={cell.outputs}
             cellId={cell.id}
-            preloadIframe={false}
-            isolated="auto"
+            preloadIframe
           />
         ) : undefined
       }

--- a/apps/live-viewer/src/components/CellView.tsx
+++ b/apps/live-viewer/src/components/CellView.tsx
@@ -18,7 +18,7 @@
  * - No drag handles (no reordering)
  */
 
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea } from "@/components/cell/OutputArea";
@@ -57,6 +57,19 @@ export const CellView = memo(function CellView({ cell, executionState }: Props) 
   const isSourceHidden = jupyter?.source_hidden === true;
   const isOutputsHidden = jupyter?.outputs_hidden === true;
 
+  // Render markdown cells as rendered output via OutputArea's iframe
+  // isolation (same path as text/markdown MIME in execute_result).
+  // COUPLING EDGE: The real MarkdownCell uses IsolatedFrame directly
+  // with edit/preview toggle and CRDT bridge. We fake it as an output.
+  const markdownAsOutput: JupyterOutput[] = useMemo(() => {
+    if (!isMarkdown || !cell.source) return [];
+    return [{
+      output_type: "display_data" as const,
+      data: { "text/markdown": cell.source },
+      metadata: {},
+    }];
+  }, [isMarkdown, cell.source]);
+
   return (
     <CellContainer
       id={cell.id}
@@ -76,9 +89,11 @@ export const CellView = memo(function CellView({ cell, executionState }: Props) 
             source hidden
           </div>
         ) : isMarkdown ? (
-          <div className="whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground/90">
-            {cell.source}
-          </div>
+          <OutputArea
+            outputs={markdownAsOutput}
+            cellId={cell.id}
+            preloadIframe
+          />
         ) : (
           <CodeMirrorEditor
             initialValue={cell.source}

--- a/apps/live-viewer/src/components/FullTreeViewer.tsx
+++ b/apps/live-viewer/src/components/FullTreeViewer.tsx
@@ -238,10 +238,17 @@ export function FullTreeViewer({ notebookId }: Props) {
         } else {
           const tb = resolveRef(obj.traceback);
           if (tb === null) return null;
-          try { traceback = JSON.parse(tb); } catch { traceback = [tb]; }
+          try {
+            const parsed = JSON.parse(tb);
+            traceback = Array.isArray(parsed) ? parsed : [String(parsed)];
+          } catch {
+            traceback = [tb];
+          }
         }
         return {
-          output_type: "error", ename: obj.ename, evalue: obj.evalue,
+          output_type: "error",
+          ename: String(obj.ename ?? ""),
+          evalue: String(obj.evalue ?? ""),
           traceback,
         };
       }

--- a/apps/live-viewer/src/components/FullTreeViewer.tsx
+++ b/apps/live-viewer/src/components/FullTreeViewer.tsx
@@ -232,11 +232,17 @@ export function FullTreeViewer({ notebookId }: Props) {
         return { output_type: "stream", name: obj.name, text };
       }
       if (obj.output_type === "error") {
-        const tb = resolveRef(obj.traceback);
-        if (tb === null) return null;
+        let traceback: string[];
+        if (Array.isArray(obj.traceback)) {
+          traceback = obj.traceback as string[];
+        } else {
+          const tb = resolveRef(obj.traceback);
+          if (tb === null) return null;
+          try { traceback = JSON.parse(tb); } catch { traceback = [tb]; }
+        }
         return {
           output_type: "error", ename: obj.ename, evalue: obj.evalue,
-          traceback: JSON.parse(tb),
+          traceback,
         };
       }
       if (obj.output_type === "display_data" || obj.output_type === "execute_result") {

--- a/apps/live-viewer/src/components/FullTreeViewer.tsx
+++ b/apps/live-viewer/src/components/FullTreeViewer.tsx
@@ -66,6 +66,7 @@ import {
   replaceNotebookCells,
 } from "notebook-app/lib/notebook-cells";
 
+
 // Cell UI state (focus, executing, queued)
 import {
   setFocusedCellId,
@@ -73,6 +74,7 @@ import {
   setQueuedCellIds,
   flushCellUIState,
 } from "notebook-app/lib/cell-ui-state";
+
 
 // The actual NotebookView component with dnd-kit, stable DOM order, etc.
 import { NotebookView } from "notebook-app/components/NotebookView";
@@ -174,6 +176,9 @@ export function FullTreeViewer({ notebookId }: Props) {
         }
         setExecutingCellIds(executing);
         setQueuedCellIds(queued);
+
+        // Re-materialize when runtime state changes (execution counts updated)
+        materializeCells();
       });
 
       engine.start();
@@ -184,15 +189,88 @@ export function FullTreeViewer({ notebookId }: Props) {
       if (!handle) return;
 
       try {
-        const h = handle as unknown as { get_cells_json(): string };
-        const json = h.get_cells_json();
-        const parsed = JSON.parse(json) as NotebookCell[];
-        // Write to the module-level cell store — this is what drives
-        // useCell(id) and useCellIds() subscriptions in NotebookView/CodeCell
-        replaceNotebookCells(parsed);
+        const h = handle as unknown as NotebookHandle;
+        const cellIds: string[] = h.get_cell_ids();
+        const cells: NotebookCell[] = [];
+        for (const id of cellIds) {
+          const cellType = h.get_cell_type(id);
+          if (!cellType) continue;
+          const source = h.get_cell_source(id) ?? "";
+          const metadata = h.get_cell_metadata(id) ?? {};
+
+          if (cellType === "code") {
+            const rawOutputs: unknown[] = h.get_cell_outputs(id) ?? [];
+            const outputs = rawOutputs
+              .map(resolveOutput)
+              .filter((o): o is NonNullable<typeof o> => o !== null);
+            cells.push({
+              id, cell_type: "code", source,
+              execution_count: null, outputs, metadata,
+            });
+          } else if (cellType === "markdown") {
+            cells.push({ id, cell_type: "markdown", source, metadata });
+          } else {
+            cells.push({ id, cell_type: "raw", source, metadata });
+          }
+        }
+        replaceNotebookCells(cells);
       } catch {
         // Handle may not have synced yet
       }
+    }
+
+    // Resolve a raw output from WASM into a JupyterOutput.
+    // ContentRefs with blob hashes → same-origin /blob/{hash} URLs.
+    function resolveOutput(output: unknown): any | null {
+      if (typeof output !== "object" || output === null) return null;
+      const obj = output as Record<string, unknown>;
+      if (!("output_type" in obj)) return null;
+
+      if (obj.output_type === "stream") {
+        const text = resolveRef(obj.text);
+        if (text === null) return null;
+        return { output_type: "stream", name: obj.name, text };
+      }
+      if (obj.output_type === "error") {
+        const tb = resolveRef(obj.traceback);
+        if (tb === null) return null;
+        return {
+          output_type: "error", ename: obj.ename, evalue: obj.evalue,
+          traceback: JSON.parse(tb),
+        };
+      }
+      if (obj.output_type === "display_data" || obj.output_type === "execute_result") {
+        const data = obj.data as Record<string, unknown> | undefined;
+        if (!data) return null;
+        const resolved: Record<string, unknown> = {};
+        for (const [mime, ref_] of Object.entries(data)) {
+          const val = resolveRef(ref_);
+          if (val === null) continue;
+          if (mime.includes("json")) {
+            try { resolved[mime] = JSON.parse(val); } catch { resolved[mime] = val; }
+          } else {
+            resolved[mime] = val;
+          }
+        }
+        if (Object.keys(resolved).length === 0) return null;
+        return {
+          output_type: obj.output_type, data: resolved,
+          metadata: obj.metadata ?? {},
+          execution_count: obj.execution_count ?? null,
+        };
+      }
+      return obj;
+    }
+
+    function resolveRef(ref_: unknown): string | null {
+      if (typeof ref_ === "string") return ref_;
+      if (typeof ref_ !== "object" || ref_ === null) return null;
+      const r = ref_ as Record<string, unknown>;
+      if ("inline" in r && typeof r.inline === "string") return r.inline;
+      if ("url" in r && typeof r.url === "string") return r.url;
+      if ("blob" in r && typeof r.blob === "string")
+        return `${window.location.origin}/blob/${r.blob}`;
+      return null;
     }
 
     initViewer();
@@ -223,7 +301,7 @@ export function FullTreeViewer({ notebookId }: Props) {
   const noopString = (_id: string) => {};
 
   const content = (
-    <div className="mx-auto max-w-5xl">
+    <div className="w-full">
       <div className="mb-3 flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground">
         <span
           className={`h-2 w-2 rounded-full ${

--- a/apps/live-viewer/src/components/FullTreeViewer.tsx
+++ b/apps/live-viewer/src/components/FullTreeViewer.tsx
@@ -1,0 +1,301 @@
+/**
+ * FULL TREE INTEGRATION — uses the REAL NotebookView + CodeCell from
+ * apps/notebook/src/ in a browser context (no Tauri).
+ *
+ * RUNTIME COUPLING ANALYSIS (all discovered edges):
+ *
+ * 1. CrdtBridgeProvider (REQUIRED) — CodeCell calls useCrdtBridge(cellId)
+ *    which throws "must be used within CrdtBridgeProvider" without context.
+ *    We provide the real WASM handle; outbound path no-ops when read-only.
+ *
+ * 2. PresenceProvider (REQUIRED) — wraps usePresence which calls
+ *    useNotebookHost().transport.sendFrame(). Must be inside NotebookHostProvider.
+ *    Safe at mount — WASM encode functions only fire on user interaction.
+ *
+ * 3. NotebookHostProvider (REQUIRED) — PresenceProvider, kernel-completion,
+ *    history-search all call useNotebookHost(). We provide createBrowserHost()
+ *    with the WebSocket transport.
+ *
+ * 4. Module-level cell store (REQUIRED) — NotebookView reads from
+ *    useCellIds()/useCell(id). We populate via replaceNotebookCells() when
+ *    WASM handle syncs.
+ *
+ * 5. cell-ui-state (REQUIRED) — CodeCell reads useIsCellFocused/Executing/
+ *    Queued. We drive via setExecutingCellIds/setQueuedCellIds from
+ *    RuntimeState subscription. flushCellUIState() called each render.
+ *
+ * 6. EditorRegistryProvider — NotebookView wraps its content in this
+ *    internally (line 811 of NotebookView.tsx). No external provision needed.
+ *
+ * 7. cursor-registry.ts — module-level, subscribes via startCursorDispatch()
+ *    which is NOT called at import time. Safe without explicit activation.
+ *
+ * 8. kernel-completion — module-level _host is null, completion source
+ *    early-returns. No crash.
+ *
+ * 9. HistorySearchDialog — lazy-loaded, only triggers on Ctrl+R. Uses
+ *    useNotebookHost() which we provide.
+ *
+ * 10. IsolatedRendererProvider + WidgetStoreProvider — needed for OutputArea
+ *     iframe isolation and widget models.
+ *
+ * REMAINING WALLS (not solvable without code changes):
+ * - Read-only: no local edits (CrdtBridge outbound path never fires)
+ * - No kernel execution (onExecuteCell is no-op)
+ * - No drag-and-drop reordering persisted (onMoveCell is no-op)
+ * - WASM encode functions (presence) work but send to no peer
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { NotebookHostProvider } from "@nteract/notebook-host";
+import { createBrowserHost } from "@nteract/notebook-host/browser";
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context";
+import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
+import { SyncEngine } from "runtimed/src/sync-engine";
+import type { SyncableHandle } from "runtimed/src/handle";
+import type { RuntimeState } from "runtimed/src/runtime-state";
+import init, { NotebookHandle } from "runtimed-wasm/runtimed_wasm.js";
+import { WebSocketTransport } from "~/lib/ws-transport";
+
+// ─── THE REAL IMPORTS ───────────────────────────────────────────────────
+// These come from apps/notebook/src/ — the actual notebook app code.
+
+// Cell store (module-level singletons — shared across components)
+import {
+  useCellIds,
+  replaceNotebookCells,
+} from "notebook-app/lib/notebook-cells";
+
+// Cell UI state (focus, executing, queued)
+import {
+  setFocusedCellId,
+  setExecutingCellIds,
+  setQueuedCellIds,
+  flushCellUIState,
+} from "notebook-app/lib/cell-ui-state";
+
+// The actual NotebookView component with dnd-kit, stable DOM order, etc.
+import { NotebookView } from "notebook-app/components/NotebookView";
+
+// CrdtBridgeProvider — CodeCell throws without this context
+import { CrdtBridgeProvider } from "notebook-app/hooks/useCrdtBridge";
+
+// PresenceProvider — CodeCell uses usePresenceContext (returns null safely)
+import { PresenceProvider } from "notebook-app/contexts/PresenceContext";
+
+// Types
+import type { NotebookCell } from "notebook-app/types";
+
+interface Props {
+  notebookId: string;
+}
+
+/**
+ * FullTreeViewer — attempts to use the real NotebookView component.
+ *
+ * COUPLING EDGES DISCOVERED (runtime):
+ * - NotebookView requires cellIds to be populated in the module-level store
+ * - NotebookView requires runtime prop (kernel language for syntax highlighting)
+ * - CodeCell requires useCrdtBridge which needs a WASM handle in module scope
+ * - CodeCell calls useIsCellFocused/useIsCellExecuting from cell-ui-state
+ * - NotebookView auto-seeds first cell on empty notebooks (onAddCell)
+ * - NotebookView expects all callbacks (onExecuteCell, onDeleteCell, etc.)
+ */
+export function FullTreeViewer({ notebookId }: Props) {
+  const [status, setStatus] = useState<"connecting" | "syncing" | "live" | "error">("connecting");
+  const [kernelStatus, setKernelStatus] = useState<string>("");
+  const [transport, setTransport] = useState<WebSocketTransport | null>(null);
+  const engineRef = useRef<SyncEngine | null>(null);
+  const transportRef = useRef<WebSocketTransport | null>(null);
+  const handleRef = useRef<SyncableHandle | null>(null);
+
+  // Track cell IDs from the store
+  const cellIds = useCellIds();
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function initViewer() {
+      await init();
+      if (disposed) return;
+
+      const handle = NotebookHandle.create_bootstrap("live-viewer");
+      handleRef.current = handle as unknown as SyncableHandle;
+
+      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const url = `${proto}//${window.location.host}/ws/join?id=${encodeURIComponent(notebookId)}`;
+
+      const ws = new WebSocketTransport({
+        url,
+        onOpen: () => setStatus("syncing"),
+        onClose: () => {
+          if (!disposed) setStatus("error");
+        },
+      });
+      transportRef.current = ws;
+      setTransport(ws);
+
+      const engine = new SyncEngine({
+        getHandle: () => handleRef.current,
+        transport: ws,
+        logger: {
+          debug: () => {},
+          info: console.info.bind(console),
+          warn: console.warn.bind(console),
+          error: console.error.bind(console),
+        },
+      });
+      engineRef.current = engine;
+
+      // When cells change, materialize into the module-level store
+      // This is what useAutomergeNotebook does internally
+      engine.cellChanges$.subscribe(() => {
+        if (disposed) return;
+        materializeCells();
+        setStatus("live");
+      });
+
+      engine.initialSyncComplete$.subscribe(() => {
+        if (disposed) return;
+        setStatus("live");
+        materializeCells();
+      });
+
+      engine.runtimeState$.subscribe((state: RuntimeState) => {
+        if (disposed) return;
+        setKernelStatus(state.kernel.status);
+
+        // Drive the cell-ui-state store with execution info
+        const executing = new Set<string>();
+        const queued = new Set<string>();
+        for (const exec of Object.values(state.executions)) {
+          if (exec.status === "running") executing.add(exec.cell_id);
+          if (exec.status === "queued") queued.add(exec.cell_id);
+        }
+        setExecutingCellIds(executing);
+        setQueuedCellIds(queued);
+      });
+
+      engine.start();
+    }
+
+    function materializeCells() {
+      const handle = handleRef.current;
+      if (!handle) return;
+
+      try {
+        const h = handle as unknown as { get_cells_json(): string };
+        const json = h.get_cells_json();
+        const parsed = JSON.parse(json) as NotebookCell[];
+        // Write to the module-level cell store — this is what drives
+        // useCell(id) and useCellIds() subscriptions in NotebookView/CodeCell
+        replaceNotebookCells(parsed);
+      } catch {
+        // Handle may not have synced yet
+      }
+    }
+
+    initViewer();
+
+    return () => {
+      disposed = true;
+      engineRef.current?.stop();
+      transportRef.current?.disconnect();
+      const h = handleRef.current as unknown as { free?(): void } | null;
+      h?.free?.();
+    };
+  }, [notebookId]);
+
+  // Flush cell-ui-state on every render (normally done by AppContent's useLayoutEffect)
+  useEffect(() => {
+    flushCellUIState();
+  });
+
+  const host = useMemo(() => {
+    if (!transport) return null;
+    return createBrowserHost({ transport });
+  }, [transport]);
+
+  // ─── COUPLING EDGE: NotebookView expects all these callbacks ────────
+  // In the real app, these come from useAutomergeNotebook + useDaemonKernel.
+  // For read-only mode, they're no-ops.
+  const noop = () => {};
+  const noopString = (_id: string) => {};
+
+  const content = (
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-3 flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground">
+        <span
+          className={`h-2 w-2 rounded-full ${
+            status === "live" ? "bg-green-500" : status === "error" ? "bg-red-500" : "bg-blue-500 animate-pulse"
+          }`}
+        />
+        <span>{status}</span>
+        {kernelStatus && (
+          <>
+            <span className="text-border">·</span>
+            <span>kernel: {kernelStatus}</span>
+          </>
+        )}
+        <span className="text-border">·</span>
+        <span>{cellIds.length} cells</span>
+      </div>
+
+      {cellIds.length === 0 && status === "live" && (
+        <div className="py-12 text-center text-muted-foreground">Empty notebook</div>
+      )}
+
+      {cellIds.length > 0 && (
+        <NotebookView
+          cellIds={cellIds}
+          isLoading={status !== "live"}
+          runtime="python"
+          onFocusCell={(id) => setFocusedCellId(id)}
+          onExecuteCell={noopString}
+          onInterruptKernel={noop}
+          onDeleteCell={noopString}
+          onAddCell={noop as any}
+          onMoveCell={noopString as any}
+        />
+      )}
+    </div>
+  );
+
+  // CrdtBridgeProvider: CodeCell → useCrdtBridge throws without this.
+  // We provide the real WASM handle (read-only, no sync needed).
+  const getHandle = useCallback(() => handleRef.current as any, []);
+  const noopSync = useCallback(() => {}, []);
+  const noopDirty = useCallback((_dirty: boolean) => {}, []);
+
+  // Inner providers that need NotebookHost (PresenceProvider uses useNotebookHost)
+  const innerProviders = (children: React.ReactNode) => (
+    <PresenceProvider peerId="live-viewer" peerLabel="viewer" actorLabel="viewer:readonly">
+      <CrdtBridgeProvider
+        getHandle={getHandle}
+        onSyncNeeded={noopSync}
+        setDirty={noopDirty}
+        localActor="viewer:readonly"
+      >
+        {children}
+      </CrdtBridgeProvider>
+    </PresenceProvider>
+  );
+
+  // Outer providers that don't need host
+  const outerProviders = (children: React.ReactNode) => (
+    <IsolatedRendererProvider loader={() => import("virtual:isolated-renderer")}>
+      <WidgetStoreProvider>{children}</WidgetStoreProvider>
+    </IsolatedRendererProvider>
+  );
+
+  if (host) {
+    return (
+      <NotebookHostProvider host={host}>
+        {outerProviders(innerProviders(content))}
+      </NotebookHostProvider>
+    );
+  }
+  // Without host, PresenceProvider will crash (useNotebookHost).
+  // Fall back without presence/crdt — NotebookView won't render CodeCell correctly.
+  return outerProviders(content);
+}

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from "react";
+import { SyncEngine } from "runtimed/src/sync-engine";
+import type { SyncableHandle } from "runtimed/src/handle";
+import { WebSocketTransport } from "~/lib/ws-transport";
+import { CellView } from "./CellView";
+
+interface CellData {
+  id: string;
+  cell_type: string;
+  source: string;
+  execution_count: number | null;
+  outputs: OutputData[];
+}
+
+interface OutputData {
+  output_type: string;
+  text?: string;
+  data?: Record<string, unknown>;
+  name?: string;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+interface Props {
+  notebookId: string;
+}
+
+export function NotebookViewer({ notebookId }: Props) {
+  const [cells, setCells] = useState<CellData[]>([]);
+  const [status, setStatus] = useState<"connecting" | "syncing" | "live" | "error">("connecting");
+  const [kernelStatus, setKernelStatus] = useState<string>("");
+  const engineRef = useRef<SyncEngine | null>(null);
+  const transportRef = useRef<WebSocketTransport | null>(null);
+  const handleRef = useRef<SyncableHandle | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function init() {
+      const { default: wasmInit, NotebookHandle } = await import("runtimed-wasm");
+      await wasmInit();
+
+      if (disposed) return;
+
+      const handle = NotebookHandle.create_bootstrap("live-viewer");
+      handleRef.current = handle as unknown as SyncableHandle;
+
+      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const url = `${proto}//${window.location.host}/ws/join?id=${encodeURIComponent(notebookId)}`;
+
+      const transport = new WebSocketTransport({
+        url,
+        onOpen: () => setStatus("syncing"),
+        onClose: () => {
+          if (!disposed) setStatus("error");
+        },
+      });
+      transportRef.current = transport;
+
+      const engine = new SyncEngine({
+        getHandle: () => handleRef.current,
+        transport,
+        logger: {
+          debug: () => {},
+          info: console.info.bind(console),
+          warn: console.warn.bind(console),
+          error: console.error.bind(console),
+        },
+      });
+      engineRef.current = engine;
+
+      engine.cellChanges$.subscribe((changeset) => {
+        if (disposed) return;
+        materializeCells();
+        if (status !== "live") setStatus("live");
+      });
+
+      engine.initialSyncComplete$.subscribe(() => {
+        if (disposed) return;
+        setStatus("live");
+        materializeCells();
+      });
+
+      engine.runtimeState$.subscribe((state: unknown) => {
+        if (disposed) return;
+        const rs = state as { kernel?: { status?: string } } | null;
+        if (rs?.kernel?.status) {
+          setKernelStatus(rs.kernel.status);
+        }
+      });
+
+      engine.start();
+    }
+
+    function materializeCells() {
+      const handle = handleRef.current;
+      if (!handle) return;
+
+      try {
+        const h = handle as unknown as { get_cells_json(): string };
+        const json = h.get_cells_json();
+        const parsed = JSON.parse(json) as CellData[];
+        setCells(parsed);
+      } catch {
+        // Handle may not have synced yet
+      }
+    }
+
+    init();
+
+    return () => {
+      disposed = true;
+      engineRef.current?.stop();
+      transportRef.current?.disconnect();
+      const h = handleRef.current as unknown as { free?(): void } | null;
+      h?.free?.();
+    };
+  }, [notebookId]);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-4">
+      <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+        <span
+          className={`h-2 w-2 rounded-full ${
+            status === "live"
+              ? "bg-green-500"
+              : status === "syncing"
+                ? "bg-blue-500 animate-pulse"
+                : status === "error"
+                  ? "bg-red-500"
+                  : "bg-gray-500"
+          }`}
+        />
+        <span>{status}</span>
+        {kernelStatus && (
+          <>
+            <span className="text-border">·</span>
+            <span>kernel: {kernelStatus}</span>
+          </>
+        )}
+        <span className="text-border">·</span>
+        <span>{cells.length} cells</span>
+      </div>
+
+      {cells.length === 0 && status === "live" && (
+        <div className="py-12 text-center text-muted-foreground">
+          Empty notebook
+        </div>
+      )}
+
+      {cells.length === 0 && status !== "live" && (
+        <div className="py-12 text-center text-muted-foreground">
+          {status === "connecting" && "Connecting to relay..."}
+          {status === "syncing" && "Syncing notebook..."}
+          {status === "error" && "Connection lost"}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-0">
+        {cells.map((cell) => (
+          <CellView key={cell.id} cell={cell} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
 import { createBrowserHost } from "@nteract/notebook-host/browser";
 import { WidgetStoreProvider } from "@/components/widgets/widget-store-context";
+import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import { SyncEngine } from "runtimed/src/sync-engine";
 import type { SyncableHandle } from "runtimed/src/handle";
 import type { RuntimeState, ExecutionState, QueueEntry } from "runtimed/src/runtime-state";
@@ -184,14 +185,18 @@ export function NotebookViewer({ notebookId }: Props) {
     </div>
   );
 
+  const providers = (children: React.ReactNode) => (
+    <IsolatedRendererProvider loader={() => import("virtual:isolated-renderer")}>
+      <WidgetStoreProvider>{children}</WidgetStoreProvider>
+    </IsolatedRendererProvider>
+  );
+
   if (host) {
     return (
-      <NotebookHostProvider host={host}>
-        <WidgetStoreProvider>{content}</WidgetStoreProvider>
-      </NotebookHostProvider>
+      <NotebookHostProvider host={host}>{providers(content)}</NotebookHostProvider>
     );
   }
-  return <WidgetStoreProvider>{content}</WidgetStoreProvider>;
+  return providers(content);
 }
 
 function KernelStatusBadge({ status }: { status: string }) {

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { SyncEngine } from "runtimed/src/sync-engine";
 import type { SyncableHandle } from "runtimed/src/handle";
+import init, { NotebookHandle } from "runtimed-wasm/runtimed_wasm.js";
 import { WebSocketTransport } from "~/lib/ws-transport";
 import { CellView } from "./CellView";
 
@@ -37,9 +38,8 @@ export function NotebookViewer({ notebookId }: Props) {
   useEffect(() => {
     let disposed = false;
 
-    async function init() {
-      const { default: wasmInit, NotebookHandle } = await import("runtimed-wasm");
-      await wasmInit();
+    async function initViewer() {
+      await init();
 
       if (disposed) return;
 
@@ -70,10 +70,10 @@ export function NotebookViewer({ notebookId }: Props) {
       });
       engineRef.current = engine;
 
-      engine.cellChanges$.subscribe((changeset) => {
+      engine.cellChanges$.subscribe(() => {
         if (disposed) return;
         materializeCells();
-        if (status !== "live") setStatus("live");
+        setStatus("live");
       });
 
       engine.initialSyncComplete$.subscribe(() => {
@@ -107,7 +107,7 @@ export function NotebookViewer({ notebookId }: Props) {
       }
     }
 
-    init();
+    initViewer();
 
     return () => {
       disposed = true;

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
 import { createBrowserHost } from "@nteract/notebook-host/browser";
+import { WidgetStoreProvider } from "@/components/widgets/widget-store-context";
 import { SyncEngine } from "runtimed/src/sync-engine";
 import type { SyncableHandle } from "runtimed/src/handle";
 import type { RuntimeState, ExecutionState, QueueEntry } from "runtimed/src/runtime-state";
@@ -184,9 +185,13 @@ export function NotebookViewer({ notebookId }: Props) {
   );
 
   if (host) {
-    return <NotebookHostProvider host={host}>{content}</NotebookHostProvider>;
+    return (
+      <NotebookHostProvider host={host}>
+        <WidgetStoreProvider>{content}</WidgetStoreProvider>
+      </NotebookHostProvider>
+    );
   }
-  return content;
+  return <WidgetStoreProvider>{content}</WidgetStoreProvider>;
 }
 
 function KernelStatusBadge({ status }: { status: string }) {

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { NotebookHostProvider } from "@nteract/notebook-host";
+import { createBrowserHost } from "@nteract/notebook-host/browser";
 import { SyncEngine } from "runtimed/src/sync-engine";
 import type { SyncableHandle } from "runtimed/src/handle";
 import type { RuntimeState, ExecutionState, QueueEntry } from "runtimed/src/runtime-state";
@@ -28,6 +30,7 @@ export function NotebookViewer({ notebookId }: Props) {
     executing: null,
     queued: [],
   });
+  const [transport, setTransport] = useState<WebSocketTransport | null>(null);
   const engineRef = useRef<SyncEngine | null>(null);
   const transportRef = useRef<WebSocketTransport | null>(null);
   const handleRef = useRef<SyncableHandle | null>(null);
@@ -46,18 +49,19 @@ export function NotebookViewer({ notebookId }: Props) {
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const url = `${proto}//${window.location.host}/ws/join?id=${encodeURIComponent(notebookId)}`;
 
-      const transport = new WebSocketTransport({
+      const ws = new WebSocketTransport({
         url,
         onOpen: () => setStatus("syncing"),
         onClose: () => {
           if (!disposed) setStatus("error");
         },
       });
-      transportRef.current = transport;
+      transportRef.current = ws;
+      setTransport(ws);
 
       const engine = new SyncEngine({
         getHandle: () => handleRef.current,
-        transport,
+        transport: ws,
         logger: {
           debug: () => {},
           info: console.info.bind(console),
@@ -114,6 +118,11 @@ export function NotebookViewer({ notebookId }: Props) {
     };
   }, [notebookId]);
 
+  const host = useMemo(() => {
+    if (!transport) return null;
+    return createBrowserHost({ transport });
+  }, [transport]);
+
   const cellExecutionStatus = (cellId: string): ExecutionState | null => {
     for (const exec of Object.values(executions)) {
       if (exec.cell_id === cellId && (exec.status === "queued" || exec.status === "running")) {
@@ -123,7 +132,7 @@ export function NotebookViewer({ notebookId }: Props) {
     return null;
   };
 
-  return (
+  const content = (
     <div className="mx-auto max-w-4xl px-4 py-4">
       <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
         <span
@@ -173,6 +182,11 @@ export function NotebookViewer({ notebookId }: Props) {
       </div>
     </div>
   );
+
+  if (host) {
+    return <NotebookHostProvider host={host}>{content}</NotebookHostProvider>;
+  }
+  return content;
 }
 
 function KernelStatusBadge({ status }: { status: string }) {

--- a/apps/live-viewer/src/components/NotebookViewer.tsx
+++ b/apps/live-viewer/src/components/NotebookViewer.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { SyncEngine } from "runtimed/src/sync-engine";
 import type { SyncableHandle } from "runtimed/src/handle";
+import type { RuntimeState, ExecutionState, QueueEntry } from "runtimed/src/runtime-state";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import init, { NotebookHandle } from "runtimed-wasm/runtimed_wasm.js";
 import { WebSocketTransport } from "~/lib/ws-transport";
 import { CellView } from "./CellView";
@@ -10,17 +12,7 @@ interface CellData {
   cell_type: string;
   source: string;
   execution_count: number | null;
-  outputs: OutputData[];
-}
-
-interface OutputData {
-  output_type: string;
-  text?: string;
-  data?: Record<string, unknown>;
-  name?: string;
-  ename?: string;
-  evalue?: string;
-  traceback?: string[];
+  outputs: JupyterOutput[];
 }
 
 interface Props {
@@ -31,6 +23,11 @@ export function NotebookViewer({ notebookId }: Props) {
   const [cells, setCells] = useState<CellData[]>([]);
   const [status, setStatus] = useState<"connecting" | "syncing" | "live" | "error">("connecting");
   const [kernelStatus, setKernelStatus] = useState<string>("");
+  const [executions, setExecutions] = useState<Record<string, ExecutionState>>({});
+  const [queue, setQueue] = useState<{ executing: QueueEntry | null; queued: QueueEntry[] }>({
+    executing: null,
+    queued: [],
+  });
   const engineRef = useRef<SyncEngine | null>(null);
   const transportRef = useRef<WebSocketTransport | null>(null);
   const handleRef = useRef<SyncableHandle | null>(null);
@@ -82,12 +79,11 @@ export function NotebookViewer({ notebookId }: Props) {
         materializeCells();
       });
 
-      engine.runtimeState$.subscribe((state: unknown) => {
+      engine.runtimeState$.subscribe((state: RuntimeState) => {
         if (disposed) return;
-        const rs = state as { kernel?: { status?: string } } | null;
-        if (rs?.kernel?.status) {
-          setKernelStatus(rs.kernel.status);
-        }
+        setKernelStatus(state.kernel.status);
+        setExecutions(state.executions);
+        setQueue(state.queue);
       });
 
       engine.start();
@@ -118,6 +114,15 @@ export function NotebookViewer({ notebookId }: Props) {
     };
   }, [notebookId]);
 
+  const cellExecutionStatus = (cellId: string): ExecutionState | null => {
+    for (const exec of Object.values(executions)) {
+      if (exec.cell_id === cellId && (exec.status === "queued" || exec.status === "running")) {
+        return exec;
+      }
+    }
+    return null;
+  };
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-4">
       <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
@@ -136,17 +141,21 @@ export function NotebookViewer({ notebookId }: Props) {
         {kernelStatus && (
           <>
             <span className="text-border">·</span>
-            <span>kernel: {kernelStatus}</span>
+            <KernelStatusBadge status={kernelStatus} />
           </>
         )}
         <span className="text-border">·</span>
         <span>{cells.length} cells</span>
+        {(queue.executing || queue.queued.length > 0) && (
+          <>
+            <span className="text-border">·</span>
+            <QueueIndicator executing={queue.executing} queued={queue.queued} />
+          </>
+        )}
       </div>
 
       {cells.length === 0 && status === "live" && (
-        <div className="py-12 text-center text-muted-foreground">
-          Empty notebook
-        </div>
+        <div className="py-12 text-center text-muted-foreground">Empty notebook</div>
       )}
 
       {cells.length === 0 && status !== "live" && (
@@ -159,9 +168,43 @@ export function NotebookViewer({ notebookId }: Props) {
 
       <div className="flex flex-col gap-0">
         {cells.map((cell) => (
-          <CellView key={cell.id} cell={cell} />
+          <CellView key={cell.id} cell={cell} executionState={cellExecutionStatus(cell.id)} />
         ))}
       </div>
     </div>
   );
+}
+
+function KernelStatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    idle: "text-green-400",
+    busy: "text-amber-400",
+    starting: "text-blue-400",
+    error: "text-red-400",
+    not_started: "text-muted-foreground",
+    shutdown: "text-muted-foreground",
+  };
+  const icons: Record<string, string> = {
+    idle: "\u25CF",
+    busy: "\u25CF",
+    starting: "\u25CB",
+    error: "\u2716",
+  };
+  return (
+    <span className={colors[status] ?? "text-muted-foreground"}>
+      {icons[status] && <span className="mr-0.5">{icons[status]}</span>}
+      kernel: {status}
+    </span>
+  );
+}
+
+function QueueIndicator({
+  executing,
+  queued,
+}: {
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
+}) {
+  const total = (executing ? 1 : 0) + queued.length;
+  return <span className="text-amber-400 animate-pulse">{total} in queue</span>;
 }

--- a/apps/live-viewer/src/full-tree-test.tsx
+++ b/apps/live-viewer/src/full-tree-test.tsx
@@ -1,0 +1,69 @@
+/**
+ * FULL TREE IMPORT TEST
+ *
+ * This file attempts to import every significant component and hook from
+ * apps/notebook/src/ to discover coupling boundaries. Each import is tested
+ * independently — when the build fails, the error message tells us exactly
+ * what's coupled and why.
+ *
+ * NOT MEANT TO RUN — just to compile and find edges.
+ */
+
+// ─── App-specific hooks ─────────────────────────────────────────────────
+
+// The big one: useAutomergeNotebook owns the WASM handle and sync pipeline
+export { useAutomergeNotebook } from "notebook-app/hooks/useAutomergeNotebook";
+
+// Cell UI state store (module-level singletons)
+export {
+  useCellIds,
+  useCell,
+  replaceNotebookCells,
+  updateCellById,
+} from "notebook-app/lib/notebook-cells";
+
+// Transient UI state
+export {
+  useFocusedCellId,
+  useIsCellFocused,
+  useIsCellExecuting,
+  setFocusedCellId,
+  setExecutingCellIds,
+} from "notebook-app/lib/cell-ui-state";
+
+// Frame bus (module-level pub/sub)
+export {
+  subscribeBroadcast,
+  emitBroadcast,
+  subscribePresence,
+} from "notebook-app/lib/notebook-frame-bus";
+
+// ─── App-specific components ────────────────────────────────────────────
+
+// The full NotebookView with dnd-kit, stable DOM order, cell adders
+export { NotebookView } from "notebook-app/components/NotebookView";
+
+// CodeCell with CRDT bridge, presence, keyboard nav
+export { CodeCell } from "notebook-app/components/CodeCell";
+
+// MarkdownCell with edit/preview toggle
+export { MarkdownCell } from "notebook-app/components/MarkdownCell";
+
+// ─── Supporting hooks ───────────────────────────────────────────────────
+
+// CRDT bridge (CodeMirror ↔ Automerge)
+export { useCrdtBridge } from "notebook-app/hooks/useCrdtBridge";
+
+// Keyboard navigation
+export { useCellKeyboardNavigation } from "notebook-app/hooks/useCellKeyboardNavigation";
+
+// Editor registry
+export { useEditorRegistry, EditorRegistryProvider } from "notebook-app/hooks/useEditorRegistry";
+
+// Daemon kernel hook (execution, broadcasts, widget comm)
+export { useDaemonKernel } from "notebook-app/hooks/useDaemonKernel";
+
+// ─── Contexts ───────────────────────────────────────────────────────────
+
+// Presence context
+export { usePresenceContext, PresenceProvider } from "notebook-app/contexts/PresenceContext";

--- a/apps/live-viewer/src/index.css
+++ b/apps/live-viewer/src/index.css
@@ -1,0 +1,64 @@
+@config "../../../tailwind.config.js";
+@source "./**/*.{ts,tsx}";
+@source "../../../src/**/*.{ts,tsx}";
+
+@import "tailwindcss";
+@import "../../../src/styles/ansi.css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --radius: 0.625rem;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}

--- a/apps/live-viewer/src/index.css
+++ b/apps/live-viewer/src/index.css
@@ -58,7 +58,10 @@
   --radius: 0.625rem;
 }
 
+html,
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
+  background: oklch(0.12 0.02 320);
+  color: var(--foreground);
 }

--- a/apps/live-viewer/src/lib/ws-transport.ts
+++ b/apps/live-viewer/src/lib/ws-transport.ts
@@ -1,0 +1,142 @@
+/**
+ * WebSocketTransport — connects a SyncEngine to the daemon via the
+ * live-viewer frame relay server.
+ *
+ * The relay server gives us a WebSocket that pipes raw typed frames
+ * (frame_type byte + payload) bidirectionally to the daemon's RelayHandle.
+ * This transport just wraps that WebSocket in the NotebookTransport interface.
+ */
+
+import type { NotebookTransport, FrameListener } from "runtimed/src/transport";
+import { FrameType } from "runtimed/src/transport";
+
+export interface WebSocketTransportOptions {
+  /** WebSocket URL to the relay server (e.g. ws://host:8743/ws/join?id=...) */
+  url: string;
+  /** Called when the connection is established. */
+  onOpen?: () => void;
+  /** Called when the connection drops (includes close code). */
+  onClose?: (code: number) => void;
+  /** Called on WebSocket error. */
+  onError?: (event: Event) => void;
+}
+
+export class WebSocketTransport implements NotebookTransport {
+  private ws: WebSocket | null = null;
+  private subscribers = new Set<FrameListener>();
+  private _connected = false;
+  private pendingRequests = new Map<
+    string,
+    { resolve: (value: unknown) => void; reject: (reason: unknown) => void }
+  >();
+  private requestIdCounter = 0;
+
+  constructor(private readonly opts: WebSocketTransportOptions) {
+    this.connect();
+  }
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    if (!this._connected || !this.ws) {
+      throw new Error("WebSocketTransport: not connected");
+    }
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = frameType;
+    frame.set(payload, 1);
+    this.ws.send(frame);
+  }
+
+  onFrame(callback: FrameListener): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  async sendRequest(request: unknown): Promise<unknown> {
+    if (!this._connected || !this.ws) {
+      throw new Error("WebSocketTransport: not connected");
+    }
+    const id = String(++this.requestIdCounter);
+    const envelope = { id, request };
+    const json = JSON.stringify(envelope);
+    const bytes = new TextEncoder().encode(json);
+    const frame = new Uint8Array(1 + bytes.length);
+    frame[0] = FrameType.REQUEST;
+    frame.set(bytes, 1);
+    this.ws.send(frame);
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+    });
+  }
+
+  disconnect(): void {
+    this._connected = false;
+    this.subscribers.clear();
+    for (const [, { reject }] of this.pendingRequests) {
+      reject(new Error("WebSocketTransport: disconnected"));
+    }
+    this.pendingRequests.clear();
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private connect(): void {
+    const ws = new WebSocket(this.opts.url);
+    ws.binaryType = "arraybuffer";
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this._connected = true;
+      this.opts.onOpen?.();
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const data = new Uint8Array(event.data as ArrayBuffer);
+      if (data.length === 0) return;
+
+      const frameType = data[0];
+
+      // Handle response frames (correlation ID resolution)
+      if (frameType === FrameType.RESPONSE) {
+        try {
+          const json = new TextDecoder().decode(data.slice(1));
+          const envelope = JSON.parse(json) as { id?: string; response?: unknown };
+          if (envelope.id && this.pendingRequests.has(envelope.id)) {
+            const { resolve } = this.pendingRequests.get(envelope.id)!;
+            this.pendingRequests.delete(envelope.id);
+            resolve(envelope.response);
+            return;
+          }
+        } catch {
+          // Fall through to deliver as raw frame
+        }
+      }
+
+      // Deliver as raw typed frame (number[]) to match the FrameListener contract
+      const frame = Array.from(data);
+      for (const cb of this.subscribers) {
+        try {
+          cb(frame);
+        } catch (err) {
+          console.error("[WebSocketTransport] subscriber error:", err);
+        }
+      }
+    };
+
+    ws.onclose = (event: CloseEvent) => {
+      this._connected = false;
+      this.opts.onClose?.(event.code);
+    };
+
+    ws.onerror = (event: Event) => {
+      this.opts.onError?.(event);
+    };
+  }
+}

--- a/apps/live-viewer/src/main.tsx
+++ b/apps/live-viewer/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/live-viewer/src/main.tsx
+++ b/apps/live-viewer/src/main.tsx
@@ -1,3 +1,12 @@
+// Polyfill crypto.randomUUID for non-secure contexts (HTTP on tailnet).
+// crypto.randomUUID requires SecureContext (HTTPS or localhost).
+if (typeof crypto !== "undefined" && !crypto.randomUUID) {
+  crypto.randomUUID = () =>
+    "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+      (+c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))).toString(16),
+    ) as `${string}-${string}-${string}-${string}-${string}`;
+}
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";

--- a/apps/live-viewer/src/vite-env.d.ts
+++ b/apps/live-viewer/src/vite-env.d.ts
@@ -1,0 +1,31 @@
+/// <reference types="vite/client" />
+
+declare module "virtual:isolated-renderer" {
+  export const rendererCode: string;
+  export const rendererCss: string;
+}
+
+declare module "virtual:renderer-plugin/markdown" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/vega" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/plotly" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/leaflet" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/sift" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/live-viewer/tsconfig.json
+++ b/apps/live-viewer/tsconfig.json
@@ -13,7 +13,9 @@
     "isolatedModules": true,
     "paths": {
       "@/*": ["../../src/*"],
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "runtimed/*": ["../../packages/runtimed/*"],
+      "runtimed-wasm/*": ["../notebook/src/wasm/runtimed-wasm/*"]
     }
   },
   "include": ["src"]

--- a/apps/live-viewer/tsconfig.json
+++ b/apps/live-viewer/tsconfig.json
@@ -14,6 +14,7 @@
     "paths": {
       "@/*": ["../../src/*"],
       "~/*": ["./src/*"],
+      "notebook-app/*": ["../notebook/src/*"],
       "runtimed/*": ["../../packages/runtimed/*"],
       "runtimed-wasm/*": ["../notebook/src/wasm/runtimed-wasm/*"]
     }

--- a/apps/live-viewer/tsconfig.json
+++ b/apps/live-viewer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "@/*": ["../../src/*"],
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/live-viewer/vite.config.ts
+++ b/apps/live-viewer/vite.config.ts
@@ -1,28 +1,39 @@
+import fs from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { defineConfig, type Plugin } from "vite-plus";
 
 /**
- * Stub plugin for virtual:renderer-plugin/* modules.
+ * Loads pre-built renderer plugin artifacts from the notebook app's
+ * checked-in renderer-plugins/ directory and exposes them as virtual modules.
  *
- * The notebook app uses a Vite plugin that builds renderer plugins (markdown,
- * plotly, vega, leaflet, sift) as CJS bundles for the isolated iframe.
- * The live-viewer doesn't use iframe isolation, so these virtual modules
- * are stubbed to export empty strings. OutputArea with isolated={false}
- * never calls the loader, but Rolldown still needs the modules resolvable.
+ * This enables the live-viewer to use the full OutputArea with iframe
+ * isolation for rich outputs (plotly, vega, markdown/LaTeX, leaflet, sift).
  *
- * COUPLING EDGE: This is the first hard boundary between the live-viewer
- * and the notebook app's build system. The iframe-libraries.ts module has
- * dynamic imports to virtual modules that only the notebook app provides.
+ * COUPLING EDGE: The live-viewer depends on pre-built artifacts from the
+ * notebook app's build pipeline (cargo xtask renderer-plugins). If those
+ * artifacts are missing, we fall back to empty stubs (in-DOM rendering only).
  */
-function rendererPluginStubs(): Plugin {
+function rendererPlugins(): Plugin {
   const PREFIX = "virtual:renderer-plugin/";
   const RESOLVED_PREFIX = "\0virtual:renderer-plugin/";
   const ISOLATED_ID = "virtual:isolated-renderer";
   const RESOLVED_ISOLATED_ID = "\0virtual:isolated-renderer";
+
+  const PREBUILT_DIR = path.resolve(__dirname, "../notebook/src/renderer-plugins");
+
+  function readArtifact(name: string, ext: string): string {
+    const file = path.join(PREBUILT_DIR, `${name}.${ext}`);
+    try {
+      return fs.readFileSync(file, "utf-8");
+    } catch {
+      return "";
+    }
+  }
+
   return {
-    name: "live-viewer:renderer-plugin-stubs",
+    name: "live-viewer:renderer-plugins",
     resolveId(id) {
       if (id.startsWith(PREFIX)) {
         return RESOLVED_PREFIX + id.slice(PREFIX.length);
@@ -33,17 +44,22 @@ function rendererPluginStubs(): Plugin {
     },
     load(id) {
       if (id.startsWith(RESOLVED_PREFIX)) {
-        return 'export const code = ""; export const css = "";';
+        const name = id.slice(RESOLVED_PREFIX.length);
+        const code = readArtifact(name, "js");
+        const css = readArtifact(name, "css");
+        return `export const code = ${JSON.stringify(code)};\nexport const css = ${JSON.stringify(css)};`;
       }
       if (id === RESOLVED_ISOLATED_ID) {
-        return 'export const rendererCode = ""; export const rendererCss = "";';
+        const rendererCode = readArtifact("isolated-renderer", "js");
+        const rendererCss = readArtifact("isolated-renderer", "css");
+        return `export const rendererCode = ${JSON.stringify(rendererCode)};\nexport const rendererCss = ${JSON.stringify(rendererCss)};`;
       }
     },
   };
 }
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), rendererPluginStubs()],
+  plugins: [react(), tailwindcss(), rendererPlugins()],
   resolve: {
     alias: {
       "@/": path.resolve(__dirname, "../../src") + "/",

--- a/apps/live-viewer/vite.config.ts
+++ b/apps/live-viewer/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
     alias: {
       "@/": path.resolve(__dirname, "../../src") + "/",
       "~/": path.resolve(__dirname, "./src") + "/",
+      "notebook-app/": path.resolve(__dirname, "../notebook/src") + "/",
       "runtimed-wasm": path.resolve(__dirname, "../notebook/src/wasm/runtimed-wasm"),
     },
   },

--- a/apps/live-viewer/vite.config.ts
+++ b/apps/live-viewer/vite.config.ts
@@ -1,10 +1,49 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig, type Plugin } from "vite-plus";
+
+/**
+ * Stub plugin for virtual:renderer-plugin/* modules.
+ *
+ * The notebook app uses a Vite plugin that builds renderer plugins (markdown,
+ * plotly, vega, leaflet, sift) as CJS bundles for the isolated iframe.
+ * The live-viewer doesn't use iframe isolation, so these virtual modules
+ * are stubbed to export empty strings. OutputArea with isolated={false}
+ * never calls the loader, but Rolldown still needs the modules resolvable.
+ *
+ * COUPLING EDGE: This is the first hard boundary between the live-viewer
+ * and the notebook app's build system. The iframe-libraries.ts module has
+ * dynamic imports to virtual modules that only the notebook app provides.
+ */
+function rendererPluginStubs(): Plugin {
+  const PREFIX = "virtual:renderer-plugin/";
+  const RESOLVED_PREFIX = "\0virtual:renderer-plugin/";
+  const ISOLATED_ID = "virtual:isolated-renderer";
+  const RESOLVED_ISOLATED_ID = "\0virtual:isolated-renderer";
+  return {
+    name: "live-viewer:renderer-plugin-stubs",
+    resolveId(id) {
+      if (id.startsWith(PREFIX)) {
+        return RESOLVED_PREFIX + id.slice(PREFIX.length);
+      }
+      if (id === ISOLATED_ID) {
+        return RESOLVED_ISOLATED_ID;
+      }
+    },
+    load(id) {
+      if (id.startsWith(RESOLVED_PREFIX)) {
+        return 'export const code = ""; export const css = "";';
+      }
+      if (id === RESOLVED_ISOLATED_ID) {
+        return 'export const rendererCode = ""; export const rendererCss = "";';
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), rendererPluginStubs()],
   resolve: {
     alias: {
       "@/": path.resolve(__dirname, "../../src") + "/",

--- a/apps/live-viewer/vite.config.ts
+++ b/apps/live-viewer/vite.config.ts
@@ -1,0 +1,29 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@/": path.resolve(__dirname, "../../src") + "/",
+      "~/": path.resolve(__dirname, "./src") + "/",
+      "runtimed-wasm": path.resolve(__dirname, "../notebook/src/wasm/runtimed-wasm"),
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5175,
+    proxy: {
+      "/api": "http://localhost:8743",
+      "/ws": {
+        target: "ws://localhost:8743",
+        ws: true,
+      },
+    },
+  },
+});

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -7,7 +7,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./tauri": "./src/tauri/index.ts"
+    "./tauri": "./src/tauri/index.ts",
+    "./browser": "./src/browser/index.ts"
   },
   "dependencies": {
     "runtimed": "workspace:*"

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -1,0 +1,182 @@
+/**
+ * `createBrowserHost()` — Browser implementation of `NotebookHost`.
+ *
+ * Designed for the live-viewer and any future browser-served nteract app.
+ * The transport is passed in (typically a WebSocketTransport). Host
+ * namespaces that don't apply to browser contexts (updater, dialog, etc.)
+ * are implemented as no-ops.
+ */
+
+import type { NotebookTransport } from "runtimed";
+import { createCommandRegistry } from "../commands";
+import type {
+  DaemonInfo,
+  DaemonProgressPayload,
+  DaemonReadyPayload,
+  DaemonUnavailablePayload,
+  GitInfo,
+  HostBlobs,
+  HostDaemon,
+  HostDaemonEvents,
+  HostDeps,
+  HostDialog,
+  HostExternalLinks,
+  HostLog,
+  HostNotebook,
+  HostRelay,
+  HostSystem,
+  HostTrust,
+  HostUpdater,
+  HostWindow,
+  NotebookHost,
+  TrustInfo,
+  TyposquatWarning,
+  Unlisten,
+} from "../types";
+
+export interface CreateBrowserHostOptions {
+  transport: NotebookTransport;
+  blobPort?: number;
+}
+
+const noop: Unlisten = () => {};
+
+export function createBrowserHost({ transport, blobPort }: CreateBrowserHostOptions): NotebookHost {
+  const daemon: HostDaemon = {
+    async isConnected() {
+      return transport.connected;
+    },
+    async reconnect() {},
+    async getInfo(): Promise<DaemonInfo | null> {
+      return null;
+    },
+    async getReadyInfo(): Promise<DaemonReadyPayload | null> {
+      return null;
+    },
+  };
+
+  const daemonEvents: HostDaemonEvents = {
+    onReady(_cb: (payload: DaemonReadyPayload) => void): Unlisten {
+      return noop;
+    },
+    onProgress(_cb: (payload: DaemonProgressPayload) => void): Unlisten {
+      return noop;
+    },
+    onDisconnected(_cb: () => void): Unlisten {
+      return noop;
+    },
+    onUnavailable(_cb: (payload: DaemonUnavailablePayload) => void): Unlisten {
+      return noop;
+    },
+  };
+
+  const relay: HostRelay = {
+    async notifySyncReady() {},
+  };
+
+  const blobs: HostBlobs = {
+    async port() {
+      return blobPort ?? 0;
+    },
+  };
+
+  const trust: HostTrust = {
+    async verify(): Promise<TrustInfo> {
+      return {
+        status: "no_dependencies",
+        uv_dependencies: [],
+        conda_dependencies: [],
+        conda_channels: [],
+      };
+    },
+    async approve() {},
+  };
+
+  const deps: HostDeps = {
+    async checkTyposquats(_packages: string[]): Promise<TyposquatWarning[]> {
+      return [];
+    },
+  };
+
+  const notebook: HostNotebook = {
+    async applyPathChanged(_path: string) {},
+    async markClean() {},
+  };
+
+  const window_: HostWindow = {
+    async getTitle() {
+      return document.title;
+    },
+    async setTitle(title: string) {
+      document.title = title;
+    },
+    onFocusChange(cb: (focused: boolean) => void): Unlisten {
+      const onFocus = () => cb(true);
+      const onBlur = () => cb(false);
+      globalThis.addEventListener("focus", onFocus);
+      globalThis.addEventListener("blur", onBlur);
+      return () => {
+        globalThis.removeEventListener("focus", onFocus);
+        globalThis.removeEventListener("blur", onBlur);
+      };
+    },
+  };
+
+  const system: HostSystem = {
+    async getGitInfo(): Promise<GitInfo | null> {
+      return null;
+    },
+    async getUsername() {
+      return "browser";
+    },
+  };
+
+  const dialog: HostDialog = {
+    async openFile() {
+      return null;
+    },
+    async saveFile() {
+      return null;
+    },
+  };
+
+  const externalLinks: HostExternalLinks = {
+    async open(url: string) {
+      globalThis.open(url, "_blank");
+    },
+  };
+
+  const updater: HostUpdater = {
+    async check() {
+      return null;
+    },
+  };
+
+  const log: HostLog = {
+    debug: console.debug.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+  };
+
+  const commands = createCommandRegistry();
+
+  return {
+    name: "browser",
+    transport,
+    daemon,
+    daemonEvents,
+    relay,
+    blobs,
+    trust,
+    deps,
+    notebook,
+    window: window_,
+    system,
+    dialog,
+    externalLinks,
+    updater,
+    commands,
+    log,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
 
   apps/live-viewer:
     dependencies:
+      '@nteract/notebook-host':
+        specifier: workspace:*
+        version: link:../../packages/notebook-host
       react:
         specifier: 19.1.0
         version: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,46 @@ importers:
         specifier: ^8.40.0
         version: 8.46.0
 
+  apps/live-viewer:
+    dependencies:
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+      runtimed:
+        specifier: workspace:*
+        version: link:../../packages/runtimed
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.8
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))
+      tailwindcss:
+        specifier: ^4.1.8
+        version: 4.2.2
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: 'catalog:'
+        version: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.18(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))(esbuild@0.27.0)(jiti@2.6.1)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)
+
   apps/mcp-app:
     dependencies:
       '@modelcontextprotocol/ext-apps':
@@ -2491,11 +2531,24 @@ packages:
     resolution: {integrity: sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@oxc-project/runtime@0.124.0':
+    resolution: {integrity: sha512-sSg6n37J3w3mM4odFvRqzQENf6+qxKnvStr/gU0FgRRg1VE/4MqryLd9PJmE0a7K5xlDfbrctBtSagaFH6ij9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/types@0.123.0':
     resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
   '@oxfmt/binding-android-arm-eabi@0.43.0':
     resolution: {integrity: sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm-eabi@0.45.0':
+    resolution: {integrity: sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -2506,8 +2559,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxfmt/binding-android-arm64@0.45.0':
+    resolution: {integrity: sha512-L63z4uZmHjgvvqvMJD7mwff8aSBkM0+X4uFr6l6U5t6+Qc9DCLVZWIunJ7Gm4fn4zHPdSq6FFQnhu9yqqobxIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@oxfmt/binding-darwin-arm64@0.43.0':
     resolution: {integrity: sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-arm64@0.45.0':
+    resolution: {integrity: sha512-UV34dd623FzqT+outIGndsCA/RBB+qgB3XVQhgmmJ9PJwa37NzPC9qzgKeOhPKxVk2HW+JKldQrVL54zs4Noww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2518,8 +2583,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxfmt/binding-darwin-x64@0.45.0':
+    resolution: {integrity: sha512-pMNJv0CMa1pDefVPeNbuQxibh8ITpWDFEhMC/IBB9Zlu76EbgzYwrzI4Cb11mqX2+rIYN70UTrh3z06TM59ptQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@oxfmt/binding-freebsd-x64@0.43.0':
     resolution: {integrity: sha512-rgz8JpkKiI/umOf7fl9gwKyQasC8bs5SYHy6g7e4SunfLBY3+8ATcD5caIg8KLGEtKFm5ujKaH8EfjcmnhzTLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-freebsd-x64@0.45.0':
+    resolution: {integrity: sha512-xTcRoxbbo61sW2+ZRPeH+vp/o9G8gkdhiVumFU+TpneiPm14c79l6GFlxPXlCE9bNWikigbsrvJw46zCVAQFfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2530,14 +2607,33 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxfmt/binding-linux-arm-gnueabihf@0.45.0':
+    resolution: {integrity: sha512-hWL8Hdni+3U1mPFx1UtWeGp3tNb6EhBAUHRMbKUxVkOp3WwoJbpVO2bfUVbS4PfpledviXXNHSTl1veTa6FhkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxfmt/binding-linux-arm-musleabihf@0.43.0':
     resolution: {integrity: sha512-sFg+NWJbLfupYTF4WELHAPSnLPOn1jiDZ33Z1jfDnTaA+cC3iB35x0FMMZTFdFOz3icRIArncwCcemJFGXu6TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
+  '@oxfmt/binding-linux-arm-musleabihf@0.45.0':
+    resolution: {integrity: sha512-6Blt/0OBT7vvfQpqYuYbpbFLPqSiaYpEJzUUWhinPEuADypDbtV1+LdjM0vYBNGPvnj85ex7lTerEX6JGcPt9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxfmt/binding-linux-arm64-gnu@0.43.0':
     resolution: {integrity: sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.45.0':
+    resolution: {integrity: sha512-jLjoLfe+hGfjhA8hNBSdw85yCA8ePKq7ME4T+g6P9caQXvmt6IhE2X7iVjnVdkmYUWEzZrxlh4p6RkDmAMJY/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2550,8 +2646,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxfmt/binding-linux-arm64-musl@0.45.0':
+    resolution: {integrity: sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxfmt/binding-linux-ppc64-gnu@0.43.0':
     resolution: {integrity: sha512-PJRs/uNxmFipJJ8+SyKHh7Y7VZIKQicqrrBzvfyM5CtKi8D7yZKTwUOZV3ffxmiC2e7l1SDJpkBEOyue5NAFsg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.45.0':
+    resolution: {integrity: sha512-+g5RiG+xOkdrCWkKodv407nTvMq4vYM18Uox2MhZBm/YoqFxxJpWKsloskFFG5NU13HGPw1wzYjjOVcyd9moCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2564,8 +2674,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxfmt/binding-linux-riscv64-gnu@0.45.0':
+    resolution: {integrity: sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxfmt/binding-linux-riscv64-musl@0.43.0':
     resolution: {integrity: sha512-RYWxAcslKxvy7yri24Xm9cmD0RiANaiEPs007EFG6l9h1ChM69Q5SOzACaCoz4Z9dEplnhhneeBaTWMEdpgIbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.45.0':
+    resolution: {integrity: sha512-Vdelft1sAEYojVGgcODEFXSWYQYlIvoyIGWebKCuUibd1tvS1TjTx413xG2ZLuHpYj45CkN/ztMLMX6jrgqpgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -2578,8 +2702,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxfmt/binding-linux-s390x-gnu@0.45.0':
+    resolution: {integrity: sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxfmt/binding-linux-x64-gnu@0.43.0':
     resolution: {integrity: sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.45.0':
+    resolution: {integrity: sha512-U/QQ0+BQNSHxjuXR/utvXnQ50Vu5kUuqEomZvQ1/3mhgbBiMc2WU9q5kZ5WwLp3gnFIx9ibkveoRSe2EZubkqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2592,8 +2730,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxfmt/binding-linux-x64-musl@0.45.0':
+    resolution: {integrity: sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxfmt/binding-openharmony-arm64@0.43.0':
     resolution: {integrity: sha512-OE6TdietLXV3F6c7pNIhx/9YC1/2YFwjU9DPc/fbjxIX19hNIaP1rS0cFjCGJlGX+cVJwIKWe8Mos+LdQ1yAJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-openharmony-arm64@0.45.0':
+    resolution: {integrity: sha512-RnGcV3HgPuOjsGx/k9oyRNKmOp+NBLGzZTdPDYbc19r7NGeYPplnUU/BfU35bX2Y/O4ejvHxcfkvW2WoYL/gsg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2604,14 +2755,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxfmt/binding-win32-arm64-msvc@0.45.0':
+    resolution: {integrity: sha512-v3Vj7iKKsUFwt9w5hsqIIoErKVoENC6LoqfDlteOQ5QMDCXihlqLoxpmviUhXnNncg4zV6U9BPwlBbwa+qm4wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxfmt/binding-win32-ia32-msvc@0.43.0':
     resolution: {integrity: sha512-9aokTR4Ft+tRdvgN/pKzSkVy2ksc4/dCpDm9L/xFrbIw0yhLtASLbvoG/5WOTUh/BRPPnfGTsWznEqv0dlOmhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
+  '@oxfmt/binding-win32-ia32-msvc@0.45.0':
+    resolution: {integrity: sha512-N8yotPBX6ph0H3toF4AEpdCeVPrdcSetj+8eGiZGsrLsng3bs/Q5HPu4bbSxip5GBPx5hGbGHrZwH4+rcrjhHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxfmt/binding-win32-x64-msvc@0.43.0':
     resolution: {integrity: sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.45.0':
+    resolution: {integrity: sha512-w5MMTRCK1dpQeRA+HHqXQXyN33DlG/N2LOYxJmaT4fJjcmZrbNnqw7SmIk7I2/a2493PPLZ+2E/Ar6t2iKVMug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2652,8 +2821,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxlint/binding-android-arm-eabi@1.60.0':
+    resolution: {integrity: sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxlint/binding-android-arm64@1.58.0':
     resolution: {integrity: sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.60.0':
+    resolution: {integrity: sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2664,8 +2845,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxlint/binding-darwin-arm64@1.60.0':
+    resolution: {integrity: sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxlint/binding-darwin-x64@1.58.0':
     resolution: {integrity: sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.60.0':
+    resolution: {integrity: sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2676,8 +2869,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxlint/binding-freebsd-x64@1.60.0':
+    resolution: {integrity: sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxlint/binding-linux-arm-gnueabihf@1.58.0':
     resolution: {integrity: sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.60.0':
+    resolution: {integrity: sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2688,8 +2893,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxlint/binding-linux-arm-musleabihf@1.60.0':
+    resolution: {integrity: sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxlint/binding-linux-arm64-gnu@1.58.0':
     resolution: {integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-gnu@1.60.0':
+    resolution: {integrity: sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2702,8 +2920,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-arm64-musl@1.60.0':
+    resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-ppc64-gnu@1.58.0':
     resolution: {integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.60.0':
+    resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2716,8 +2948,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-riscv64-gnu@1.60.0':
+    resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-riscv64-musl@1.58.0':
     resolution: {integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-riscv64-musl@1.60.0':
+    resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -2730,8 +2976,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-s390x-gnu@1.60.0':
+    resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-x64-gnu@1.58.0':
     resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.60.0':
+    resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2744,8 +3004,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-x64-musl@1.60.0':
+    resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-openharmony-arm64@1.58.0':
     resolution: {integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-openharmony-arm64@1.60.0':
+    resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2756,14 +3029,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxlint/binding-win32-arm64-msvc@1.60.0':
+    resolution: {integrity: sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxlint/binding-win32-ia32-msvc@1.58.0':
     resolution: {integrity: sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
+  '@oxlint/binding-win32-ia32-msvc@1.60.0':
+    resolution: {integrity: sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxlint/binding-win32-x64-msvc@1.58.0':
     resolution: {integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.60.0':
+    resolution: {integrity: sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4582,8 +4873,74 @@ packages:
       yaml:
         optional: true
 
+  '@voidzero-dev/vite-plus-core@0.1.18':
+    resolution: {integrity: sha512-3PmXOL26yHzlw8ET9SwXCmglGzUYq2fOTYf2t0mxvVIs7ua3bnf6tOnmR+6YX5k1Ez26B0ooYzx+znc8k+CAMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.21.8
+      '@tsdown/exe': 0.21.8
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      publint: ^0.3.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      yaml:
+        optional: true
+
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.16':
     resolution: {integrity: sha512-InG0ZmuGh7DTrn7zWQ0UvKapElphKI6G1oYfys+jraedG70EhIIee9gtO+mTE1T0bF67SgAcLXwNyaiNda0XwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.18':
+    resolution: {integrity: sha512-bw2pWWE8RZRELWjXcdxdmRaOaYjmGmsxEm23TxvGxQXFb7k9l51W8tpjxariPGLxrEl+Cw5u601IL5LASaPJ5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -4594,8 +4951,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.18':
+    resolution: {integrity: sha512-8TFj6yJNsumoH+yFc+6zf3g2UuzvrPHq2FAAVORffaVZ29PWnDSsXjegaIBmoAtGO5Xb4lcilQx7NoF9hONrZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.16':
     resolution: {integrity: sha512-AoFKu6dIOtlkp/mwmtU8ES2uzoaxCHhIym1Tk7qMxyvke4IXnye6VDc4kPMRQwD8mwR3T3bO0HuaEEHxrIWDxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.18':
+    resolution: {integrity: sha512-xHRqncKanOZ0zNnZSufL4Yx/gWrIFkCjU6jFzCukBOOCrcemq3SrALPHrNf+Nw1RLwNptGUZn2Vx/IjRLzUQDw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -4608,6 +4978,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.18':
+    resolution: {integrity: sha512-CA6XxZbkT8lYwWzS2yAj6exr7nHl3R8Sz+ZdOhYCU4yR2qvzGatdVgFr7oPnrkHLF426cHJ172rmNNj8NKie/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.16':
     resolution: {integrity: sha512-nY9/2g+qjhwsW5U3MrFLlx+bOBsdOJiO2HzbxQy7jo/S3jPTnXhFlrRegQuAmqrHAXrSdNwgblgRpICKhx1xZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4615,8 +4992,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.18':
+    resolution: {integrity: sha512-xBO3MtLGVASPjH/GDRxexfLCT0othVpiFMdEQ83Y+woVNbrrzcdQTGFUuFG4cAiMhtmjytyFwPBtZ76BWsDO3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.16':
     resolution: {integrity: sha512-JGKEAMoXqzdr9lHT/13uRNV9uzrSYXAFhjAfIC8WEQMG2VUFksvq5/TOc26hzmzbqu+bxRmfN8h1aVTDL8KwFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.18':
+    resolution: {integrity: sha512-ADNis6SMarY7i8+b2ynUJ1PiqCHqnVwY7EQ+fSGug5zZ+W/cZq14+VWPxOvGR9LJk+iol8XuqsHy4BaV2+gjzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4647,14 +5038,57 @@ packages:
       jsdom:
         optional: true
 
+  '@voidzero-dev/vite-plus-test@0.1.18':
+    resolution: {integrity: sha512-dovC2kJgiwMI8ay0i+3NvQGCDWPj8HQB2ONP/HbdJ5/XQVPq13+BihnCq8/ztz6uGhiDD8Nu4OZ3RgB14uvTfA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.16':
     resolution: {integrity: sha512-IugPUCLY7HmiPcCeuHKUqO1+G2vxHnYzAGhS02AixD0sJLTAIKCUANDOiVUFf/HMw+jh/UkugW7MWek8lf/JrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.18':
+    resolution: {integrity: sha512-EcDETMHG8xgjIlMizIu/wf0UtRZLGz+lHFvYFZVCkz4vLLz93a06vZ+3Oi9xY2Kc8aOHsCf8Gj5/dox/03cscw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.16':
     resolution: {integrity: sha512-tq93CIeMs92HF7rdylJknRiyzMOWMKCmpw+g8nl5Q5nmUDNLUsrL3CGfbyqjgbruuPnIr761r9MfydPqZU/cYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.18':
+    resolution: {integrity: sha512-jBgL4ZjSJJu3FDcrqj4muzbr0WKlU6Ym1ilHQnq8R+2TRvE0AtvAMMuphICDslZGi6EK3fwJ+r2Lv7GU1AipQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -7378,12 +7812,27 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  oxfmt@0.45.0:
+    resolution: {integrity: sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   oxlint-tsgolint@0.20.0:
     resolution: {integrity: sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ==}
     hasBin: true
 
   oxlint@1.58.0:
     resolution: {integrity: sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.18.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
+  oxlint@1.60.0:
+    resolution: {integrity: sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -8821,6 +9270,11 @@ packages:
 
   vite-plus@0.1.16:
     resolution: {integrity: sha512-sgYHc5zWLSDInaHb/abvEA7UOwh7sUWuyNt+Slphj55jPvzodT8Dqw115xyKwDARTuRFSpm1eo/t58qZ8/NylQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  vite-plus@0.1.18:
+    resolution: {integrity: sha512-RiWUoOmQiJMtd4Dfm6WD0v0Selqh/nQzmaGVIrkfnr+2s5UxGVZy7n2TCO5ZnR7w9noMIgtUAQN8GtKhwHEiOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -11240,63 +11694,124 @@ snapshots:
 
   '@oxc-project/runtime@0.123.0': {}
 
+  '@oxc-project/runtime@0.124.0': {}
+
   '@oxc-project/types@0.123.0': {}
 
+  '@oxc-project/types@0.124.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm-eabi@0.45.0':
     optional: true
 
   '@oxfmt/binding-android-arm64@0.43.0':
     optional: true
 
+  '@oxfmt/binding-android-arm64@0.45.0':
+    optional: true
+
   '@oxfmt/binding-darwin-arm64@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.45.0':
     optional: true
 
   '@oxfmt/binding-darwin-x64@0.43.0':
     optional: true
 
+  '@oxfmt/binding-darwin-x64@0.45.0':
+    optional: true
+
   '@oxfmt/binding-freebsd-x64@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.45.0':
     optional: true
 
   '@oxfmt/binding-linux-arm-gnueabihf@0.43.0':
     optional: true
 
+  '@oxfmt/binding-linux-arm-gnueabihf@0.45.0':
+    optional: true
+
   '@oxfmt/binding-linux-arm-musleabihf@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.45.0':
     optional: true
 
   '@oxfmt/binding-linux-arm64-gnu@0.43.0':
     optional: true
 
+  '@oxfmt/binding-linux-arm64-gnu@0.45.0':
+    optional: true
+
   '@oxfmt/binding-linux-arm64-musl@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.45.0':
     optional: true
 
   '@oxfmt/binding-linux-ppc64-gnu@0.43.0':
     optional: true
 
+  '@oxfmt/binding-linux-ppc64-gnu@0.45.0':
+    optional: true
+
   '@oxfmt/binding-linux-riscv64-gnu@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.45.0':
     optional: true
 
   '@oxfmt/binding-linux-riscv64-musl@0.43.0':
     optional: true
 
+  '@oxfmt/binding-linux-riscv64-musl@0.45.0':
+    optional: true
+
   '@oxfmt/binding-linux-s390x-gnu@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.45.0':
     optional: true
 
   '@oxfmt/binding-linux-x64-gnu@0.43.0':
     optional: true
 
+  '@oxfmt/binding-linux-x64-gnu@0.45.0':
+    optional: true
+
   '@oxfmt/binding-linux-x64-musl@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.45.0':
     optional: true
 
   '@oxfmt/binding-openharmony-arm64@0.43.0':
     optional: true
 
+  '@oxfmt/binding-openharmony-arm64@0.45.0':
+    optional: true
+
   '@oxfmt/binding-win32-arm64-msvc@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.45.0':
     optional: true
 
   '@oxfmt/binding-win32-ia32-msvc@0.43.0':
     optional: true
 
+  '@oxfmt/binding-win32-ia32-msvc@0.45.0':
+    optional: true
+
   '@oxfmt/binding-win32-x64-msvc@0.43.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.45.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-arm64@0.20.0':
@@ -11320,58 +11835,115 @@ snapshots:
   '@oxlint/binding-android-arm-eabi@1.58.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.60.0':
+    optional: true
+
   '@oxlint/binding-android-arm64@1.58.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.60.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.58.0':
     optional: true
 
+  '@oxlint/binding-darwin-arm64@1.60.0':
+    optional: true
+
   '@oxlint/binding-darwin-x64@1.58.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.60.0':
     optional: true
 
   '@oxlint/binding-freebsd-x64@1.58.0':
     optional: true
 
+  '@oxlint/binding-freebsd-x64@1.60.0':
+    optional: true
+
   '@oxlint/binding-linux-arm-gnueabihf@1.58.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.60.0':
     optional: true
 
   '@oxlint/binding-linux-arm-musleabihf@1.58.0':
     optional: true
 
+  '@oxlint/binding-linux-arm-musleabihf@1.60.0':
+    optional: true
+
   '@oxlint/binding-linux-arm64-gnu@1.58.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.60.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-musl@1.58.0':
     optional: true
 
+  '@oxlint/binding-linux-arm64-musl@1.60.0':
+    optional: true
+
   '@oxlint/binding-linux-ppc64-gnu@1.58.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.60.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-gnu@1.58.0':
     optional: true
 
+  '@oxlint/binding-linux-riscv64-gnu@1.60.0':
+    optional: true
+
   '@oxlint/binding-linux-riscv64-musl@1.58.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.60.0':
     optional: true
 
   '@oxlint/binding-linux-s390x-gnu@1.58.0':
     optional: true
 
+  '@oxlint/binding-linux-s390x-gnu@1.60.0':
+    optional: true
+
   '@oxlint/binding-linux-x64-gnu@1.58.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.60.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.58.0':
     optional: true
 
+  '@oxlint/binding-linux-x64-musl@1.60.0':
+    optional: true
+
   '@oxlint/binding-openharmony-arm64@1.58.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.60.0':
     optional: true
 
   '@oxlint/binding-win32-arm64-msvc@1.58.0':
     optional: true
 
+  '@oxlint/binding-win32-arm64-msvc@1.60.0':
+    optional: true
+
   '@oxlint/binding-win32-ia32-msvc@1.58.0':
     optional: true
 
+  '@oxlint/binding-win32-ia32-msvc@1.60.0':
+    optional: true
+
   '@oxlint/binding-win32-x64-msvc@1.58.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.60.0':
     optional: true
 
   '@panva/hkdf@1.2.1': {}
@@ -12749,6 +13321,13 @@ snapshots:
       tailwindcss: 4.2.2
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)'
 
+  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)'
+
   '@tanstack/react-virtual@3.13.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/virtual-core': 3.13.23
@@ -13134,6 +13713,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)'
 
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)'
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -13225,22 +13809,54 @@ snapshots:
       tsx: 4.21.0
       typescript: 5.9.3
 
+  '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)':
+    dependencies:
+      '@oxc-project/runtime': 0.124.0
+      '@oxc-project/types': 0.124.0
+      lightningcss: 1.32.0
+      postcss: 8.5.9
+    optionalDependencies:
+      '@types/node': 24.12.2
+      esbuild: 0.27.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      typescript: 5.8.3
+
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.16':
+    optional: true
+
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.18':
     optional: true
 
   '@voidzero-dev/vite-plus-darwin-x64@0.1.16':
     optional: true
 
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.18':
+    optional: true
+
   '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.16':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.18':
     optional: true
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.16':
     optional: true
 
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.18':
+    optional: true
+
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.16':
     optional: true
 
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.18':
+    optional: true
+
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.16':
+    optional: true
+
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.18':
     optional: true
 
   '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)':
@@ -13366,10 +13982,57 @@ snapshots:
       - utf-8-validate
       - yaml
 
+  '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))(esbuild@0.27.0)(jiti@2.6.1)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)'
+      ws: 8.19.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.12.2
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - yaml
+
   '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.16':
     optional: true
 
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.18':
+    optional: true
+
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.16':
+    optional: true
+
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.18':
     optional: true
 
   '@wdio/cli@8.46.0':
@@ -16586,6 +17249,30 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.43.0
       '@oxfmt/binding-win32-x64-msvc': 0.43.0
 
+  oxfmt@0.45.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.45.0
+      '@oxfmt/binding-android-arm64': 0.45.0
+      '@oxfmt/binding-darwin-arm64': 0.45.0
+      '@oxfmt/binding-darwin-x64': 0.45.0
+      '@oxfmt/binding-freebsd-x64': 0.45.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.45.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.45.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.45.0
+      '@oxfmt/binding-linux-arm64-musl': 0.45.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.45.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.45.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.45.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.45.0
+      '@oxfmt/binding-linux-x64-gnu': 0.45.0
+      '@oxfmt/binding-linux-x64-musl': 0.45.0
+      '@oxfmt/binding-openharmony-arm64': 0.45.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.45.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.45.0
+      '@oxfmt/binding-win32-x64-msvc': 0.45.0
+
   oxlint-tsgolint@0.20.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.20.0
@@ -16616,6 +17303,29 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.58.0
       '@oxlint/binding-win32-ia32-msvc': 1.58.0
       '@oxlint/binding-win32-x64-msvc': 1.58.0
+      oxlint-tsgolint: 0.20.0
+
+  oxlint@1.60.0(oxlint-tsgolint@0.20.0):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.60.0
+      '@oxlint/binding-android-arm64': 1.60.0
+      '@oxlint/binding-darwin-arm64': 1.60.0
+      '@oxlint/binding-darwin-x64': 1.60.0
+      '@oxlint/binding-freebsd-x64': 1.60.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.60.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.60.0
+      '@oxlint/binding-linux-arm64-gnu': 1.60.0
+      '@oxlint/binding-linux-arm64-musl': 1.60.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.60.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.60.0
+      '@oxlint/binding-linux-riscv64-musl': 1.60.0
+      '@oxlint/binding-linux-s390x-gnu': 1.60.0
+      '@oxlint/binding-linux-x64-gnu': 1.60.0
+      '@oxlint/binding-linux-x64-musl': 1.60.0
+      '@oxlint/binding-openharmony-arm64': 1.60.0
+      '@oxlint/binding-win32-arm64-msvc': 1.60.0
+      '@oxlint/binding-win32-ia32-msvc': 1.60.0
+      '@oxlint/binding-win32-x64-msvc': 1.60.0
       oxlint-tsgolint: 0.20.0
 
   p-cancelable@3.0.0: {}
@@ -18595,6 +19305,53 @@ snapshots:
       - '@tsdown/exe'
       - '@types/node'
       - '@vitejs/devtools'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - vite
+      - yaml
+
+  vite-plus@0.1.18(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))(esbuild@0.27.0)(jiti@2.6.1)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3):
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.18(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.12.2)(esbuild@0.27.0)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3))(esbuild@0.27.0)(jiti@2.6.1)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)
+      oxfmt: 0.45.0
+      oxlint: 1.60.0(oxlint-tsgolint@0.20.0)
+      oxlint-tsgolint: 0.20.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.18
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.18
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.18
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.18
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.18
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.18
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.18
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.18
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
       - '@vitest/ui'
       - bufferutil
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: ^7.14.1
+        version: 7.14.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       runtimed:
         specifier: workspace:*
         version: link:../../packages/runtimed
@@ -8210,6 +8213,16 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
+  react-router@7.14.1:
+    resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -8496,6 +8509,9 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -17773,6 +17789,14 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  react-router@7.14.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.1.0
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react-smooth@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       fast-equals: 5.4.0
@@ -18186,6 +18210,8 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

Live read-only notebook viewer served on the tailnet, dogfooding nteract's own sync architecture.

- **Rust frame relay server** (`apps/live-viewer/server/`) — axum WebSocket server that creates a `RelayHandle` per browser connection, piping raw typed frames to/from the daemon
- **WebSocketTransport** — implements `NotebookTransport` interface over the relay WebSocket
- **Vite React app** — uses `SyncEngine` + WASM `NotebookHandle.create_bootstrap()` for full CRDT sync in browser
- Reuses shared monorepo components (gutter-colors, AnsiOutput, Tailwind dark theme tokens)

Architecture: browser owns the Automerge doc via WASM, server is a transparent byte pipe (no local CRDT state). Read-only: only allows sync frame types (0x00, 0x05, 0x06) inbound from browser.

## Status

- [x] Rust relay server compiles and runs (verified: frames flow over WebSocket)
- [x] Vite app scaffolded with WebSocketTransport + SyncEngine wiring
- [ ] End-to-end test in browser (WASM init + sync + cell rendering)
- [ ] Wire in more shared components (CellContainer, MediaRouter)
- [ ] Production build + serve from relay server

## Test plan

- Start relay server: `cargo run -p live-viewer-server`
- Start Vite: `cd apps/live-viewer && vp dev`
- Open http://localhost:5175, select a notebook, verify cells render with live updates