### PR TITLE
test(runtimed-py): re-enable stable xfail tests and bump syntax-error warmup timeout

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1240,10 +1240,6 @@ class TestKernelLaunchMetadata:
         assert ks["display_name"] == "Minimal Kernel"
         assert "language" not in ks  # Should not be present when not set
 
-    @pytest.mark.xfail(
-        reason="Flaky on CI: inline dep kernel output capture is unreliable on slow runners",
-        strict=False,
-    )
     @pytest.mark.timeout(120)
     async def test_uv_inline_deps_trusted(self, session):
         """Python kernel with UV inline deps from metadata launches correctly.
@@ -1266,10 +1262,6 @@ class TestKernelLaunchMetadata:
         assert result.success, f"Failed to import requests: {result.stderr}"
         assert result.stdout.strip(), "requests version should not be empty"
 
-    @pytest.mark.xfail(
-        reason="Flaky on CI: inline dep kernel output capture is unreliable on slow runners",
-        strict=False,
-    )
     @pytest.mark.timeout(120)
     async def test_uv_inline_deps_env_has_python(self, session):
         """UV inline env actually has a working Python with the declared deps."""
@@ -1369,10 +1361,6 @@ class TestDenoKernel:
 
 
 @pytest.mark.timeout(180)
-@pytest.mark.xfail(
-    reason="Flaky on CI: conda inline env output capture is unreliable on slow runners",
-    strict=False,
-)
 class TestCondaInlineDeps:
     """Test conda inline dependency environments.
 
@@ -1949,7 +1937,7 @@ class TestErrorHandling:
         await async_start_kernel_with_retry(session)
 
         warmup_cell = await async_create_cell_and_wait_for_sync(session, "warmup = 1")
-        warmup_result = await session.execute_cell(warmup_cell)
+        warmup_result = await session.execute_cell(warmup_cell, timeout_secs=120)
         assert warmup_result.success
 
         cell_id = await async_create_cell_and_wait_for_sync(session, "if True print('broken')")


### PR DESCRIPTION
## Summary

Four runtimed-py integration tests carry `@pytest.mark.xfail(strict=False, reason="Flaky on CI: ...")` but XPASS on every recent run. Because `strict=False` suppresses XPASS-as-failure, regressions in these tests wouldn't fail CI. The RPC correlation refactor (#1937, 2d98daea) and the 240s LaunchKernel timeout bump (#1941, 6ad923aa) appear to have stabilized them. Time to turn them back into real tests.

XPASS evidence across five recent Build runs on `main`:

| Test | Observations |
|---|---|
| `test_uv_inline_deps_trusted` | XPASS x 4, XFAIL x 0 |
| `test_uv_inline_deps_env_has_python` | XPASS x 4, XFAIL x 1 |
| `TestCondaInlineDeps::test_conda_inline_deps` | XPASS x 5 |
| `TestCondaInlineDeps::test_conda_inline_env_has_python` | XPASS x 5 |

Also fixes a real flake. `TestErrorHandling::test_async_syntax_error` timed out at 60s on run [24663002794](https://github.com/nteract/desktop/actions/runs/24663002794) with `runtimed.RuntimedError: Execution timed out after 60 seconds`. The default `session.execute_cell(timeout_secs=60.0)` is bounded by `crates/runtimed-py/src/async_session.rs:1008`. The warmup `execute_cell` that runs right after `async_start_kernel_with_retry` is the most vulnerable point to transient CI IO contention (first post-launch exec binds IOPub, imports, etc.). Bump just that one call to `timeout_secs=120`; the syntax-error cell keeps the default since syntax errors return near-instantly.

Out of scope:
- `test_interrupt_clears_queue_and_unblocks` still XFAILs consistently (tracked separately, references #1583).
- `test_open_notebook_second_client_joins_room` skipif in CI (separate multi-peer sync issue).

## Test plan

- [ ] `runtimed-py Integration Tests` CI job summary becomes `114 passed, 1 skipped, 1 xfailed, 0 xpassed` (was `110 passed, 1 skipped, 1 xfailed, 4 xpassed`).
- [ ] The one remaining xfail is `test_interrupt_clears_queue_and_unblocks` only.
- [ ] No new flakes on the four re-enabled tests across the next handful of runs.