### PR TITLE
fix(runt-mcp): use connect_open for file-backed notebook rejoin

### DIFF
--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -274,13 +274,9 @@ async fn auto_rejoin_session(
             .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), r.info.notebook_id))
         } else {
             // Ephemeral: reconnect by UUID
-            notebook_sync::connect::connect(
-                socket_path.to_path_buf(),
-                notebook_id.clone(),
-                &label,
-            )
-            .await
-            .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), notebook_id.clone()))
+            notebook_sync::connect::connect(socket_path.to_path_buf(), notebook_id.clone(), &label)
+                .await
+                .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), notebook_id.clone()))
         };
 
         match result {
@@ -306,9 +302,7 @@ async fn auto_rejoin_session(
                     notebook_path: notebook_path.clone(),
                 };
                 *session.write().await = Some(new_session);
-                info!(
-                    "Auto-rejoined notebook session: {notebook_id} ({new_cell_count} cells)",
-                );
+                info!("Auto-rejoined notebook session: {notebook_id} ({new_cell_count} cells)",);
                 return;
             }
             Err(e) => {

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -259,7 +259,11 @@ async fn auto_rejoin_session(
     let label = peer_label.read().await.clone();
 
     for attempt in 0..=REJOIN_MAX_RETRIES {
-        let result = if let Some(ref path) = notebook_path {
+        let use_path = notebook_path
+            .as_ref()
+            .filter(|p| std::path::Path::new(p.as_str()).exists());
+
+        let result = if let Some(path) = use_path {
             // File-backed: use connect_open so daemon reloads from .ipynb
             notebook_sync::connect::connect_open(
                 socket_path.to_path_buf(),

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -220,6 +220,13 @@ const REJOIN_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Attempt to re-join the active notebook session after daemon reconnection.
 ///
+/// For file-backed notebooks, uses `connect_open(path)` so the daemon reloads
+/// from disk — the UUID-only reconnect would yield an empty document because
+/// the .automerge persist file is deleted for file-backed rooms.
+///
+/// For ephemeral notebooks, uses `connect(uuid)` and detects data loss (empty
+/// document after reconnect means the daemon lost the ephemeral data).
+///
 /// Retries up to [`REJOIN_MAX_RETRIES`] times with [`REJOIN_RETRY_DELAY`] between
 /// attempts, since the daemon may respond to pings before it is ready to accept
 /// notebook sync connections.
@@ -228,10 +235,16 @@ async fn auto_rejoin_session(
     session: &Arc<RwLock<Option<NotebookSession>>>,
     peer_label: &Arc<RwLock<String>>,
 ) {
-    // Read the current session's notebook_id
-    let notebook_id = {
+    let (notebook_id, notebook_path, prev_cell_count) = {
         let s = session.read().await;
-        s.as_ref().map(|s| s.notebook_id.clone())
+        match s.as_ref() {
+            Some(s) => (
+                Some(s.notebook_id.clone()),
+                s.notebook_path.clone(),
+                s.handle.get_cell_ids().len(),
+            ),
+            None => (None, None, 0),
+        }
     };
 
     let Some(notebook_id) = notebook_id else {
@@ -246,23 +259,52 @@ async fn auto_rejoin_session(
     let label = peer_label.read().await.clone();
 
     for attempt in 0..=REJOIN_MAX_RETRIES {
-        match notebook_sync::connect::connect(
-            socket_path.to_path_buf(),
-            notebook_id.clone(),
-            &label,
-        )
-        .await
-        {
-            Ok(result) => {
-                crate::presence::announce(&result.handle, &label).await;
+        let result = if let Some(ref path) = notebook_path {
+            // File-backed: use connect_open so daemon reloads from .ipynb
+            notebook_sync::connect::connect_open(
+                socket_path.to_path_buf(),
+                PathBuf::from(path),
+                &label,
+            )
+            .await
+            .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), r.info.notebook_id))
+        } else {
+            // Ephemeral: reconnect by UUID
+            notebook_sync::connect::connect(
+                socket_path.to_path_buf(),
+                notebook_id.clone(),
+                &label,
+            )
+            .await
+            .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), notebook_id.clone()))
+        };
+
+        match result {
+            Ok((handle, broadcast_rx, new_cell_count, new_notebook_id)) => {
+                // Detect ephemeral session loss: previously had cells but
+                // rejoin yields an empty doc. For ephemeral notebooks this
+                // means the data is gone (no persistence).
+                if prev_cell_count > 0 && new_cell_count == 0 && notebook_path.is_none() {
+                    warn!(
+                        "Ephemeral notebook lost: rejoined {notebook_id} but document is empty \
+                         (had {prev_cell_count} cells). Daemon restarted and ephemeral \
+                         notebook was not saved to disk.",
+                    );
+                    return;
+                }
+
+                crate::presence::announce(&handle, &label).await;
 
                 let new_session = NotebookSession {
-                    handle: result.handle,
-                    broadcast_rx: result.broadcast_rx,
-                    notebook_id: notebook_id.clone(),
+                    handle,
+                    broadcast_rx,
+                    notebook_id: new_notebook_id,
+                    notebook_path: notebook_path.clone(),
                 };
                 *session.write().await = Some(new_session);
-                info!("Auto-rejoined notebook session: {notebook_id}");
+                info!(
+                    "Auto-rejoined notebook session: {notebook_id} ({new_cell_count} cells)",
+                );
                 return;
             }
             Err(e) => {
@@ -278,7 +320,6 @@ async fn auto_rejoin_session(
                         "Failed to auto-rejoin notebook {notebook_id} after {} attempts: {e}",
                         attempt + 1
                     );
-                    // Session stays None — tools will prompt user to re-join
                 }
             }
         }

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -8,8 +8,11 @@ use notebook_sync::BroadcastReceiver;
 pub struct NotebookSession {
     /// The Automerge document handle for this notebook.
     pub handle: DocHandle,
-    /// The notebook ID (file path or UUID).
+    /// The notebook ID (always a UUID).
     pub notebook_id: String,
+    /// The file path for file-backed notebooks (opened via `open_notebook`).
+    /// `None` for ephemeral notebooks created via `create_notebook`.
+    pub notebook_path: Option<String>,
     /// Broadcast receiver for daemon events (execution done, outputs, etc.)
     pub broadcast_rx: BroadcastReceiver,
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -321,6 +321,7 @@ pub async fn open_notebook(
                     handle: result.handle,
                     broadcast_rx: result.broadcast_rx,
                     notebook_id,
+                    notebook_path: Some(abs_path.to_string_lossy().into_owned()),
                 };
                 *server.session.write().await = Some(session);
 
@@ -386,6 +387,7 @@ pub async fn open_notebook(
                     handle: result.handle,
                     broadcast_rx: result.broadcast_rx,
                     notebook_id,
+                    notebook_path: None,
                 };
                 *server.session.write().await = Some(session);
 
@@ -480,6 +482,7 @@ pub async fn create_notebook(
                 handle: result.handle,
                 broadcast_rx: result.broadcast_rx,
                 notebook_id: notebook_id.clone(),
+                notebook_path: None,
             };
             *server.session.write().await = Some(session);
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -627,6 +627,14 @@ pub async fn save_notebook(
         .await
     {
         Ok(NotebookResponse::NotebookSaved { path: saved_path }) => {
+            // Update session's notebook_path so auto-rejoin uses connect_open
+            {
+                let mut guard = server.session.write().await;
+                if let Some(ref mut s) = *guard {
+                    s.notebook_path = Some(saved_path.clone());
+                }
+            }
+
             let result = serde_json::json!({
                 "path": saved_path,
                 "notebook_id": notebook_id,


### PR DESCRIPTION
## Summary

- Fixes file-backed notebook session loss after daemon restart: `auto_rejoin_session` now uses `connect_open(path)` instead of UUID-only `connect()`, so the daemon reloads from `.ipynb` via the `OpenNotebook` handshake.
- Adds `notebook_path: Option<String>` to `NotebookSession` to distinguish file-backed from ephemeral notebooks.
- For ephemeral notebooks, detects data loss (empty doc on rejoin) and surfaces a clear warning instead of silently operating on a dead session.

## Root cause

On daemon restart, UUID-based reconnect calls `get_or_create_room(uuid, path=None)` which creates a fresh empty room. File-backed rooms delete their `.automerge` persist file at creation (since `.ipynb` is authoritative), so the content is lost. Using `connect_open(path)` triggers the `OpenNotebook` handshake which loads from disk.

## Test plan

- [ ] Open a file-backed notebook, restart daemon, verify session auto-rejoins with all cells intact
- [ ] Create an ephemeral notebook, restart daemon, verify MCP tools report "no session" (not empty silent session)
- [ ] Run conda-prebuilt gremlin suite to confirm no regressions