### PR TITLE
fix(runt-mcp): preserve session during auto-rejoin failure

### DIFF
--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -253,9 +253,6 @@ async fn auto_rejoin_session(
 
     info!("Auto-rejoining notebook session: {notebook_id}");
 
-    // Drop the old session first (its DocHandle/sync task are dead)
-    *session.write().await = None;
-
     let label = peer_label.read().await.clone();
 
     for attempt in 0..=REJOIN_MAX_RETRIES {
@@ -283,12 +280,16 @@ async fn auto_rejoin_session(
             Ok((handle, broadcast_rx, new_cell_count, new_notebook_id)) => {
                 // Detect ephemeral session loss: previously had cells but
                 // rejoin yields an empty doc. For ephemeral notebooks this
-                // means the data is gone (no persistence).
+                // means the data is gone (no persistence). Keep the old
+                // session rather than leaving it None — the stale session
+                // produces clearer errors ("Cell not found") than no session
+                // ("No active notebook session"), and the user can still
+                // call open_notebook to start fresh.
                 if prev_cell_count > 0 && new_cell_count == 0 && notebook_path.is_none() {
                     warn!(
                         "Ephemeral notebook lost: rejoined {notebook_id} but document is empty \
                          (had {prev_cell_count} cells). Daemon restarted and ephemeral \
-                         notebook was not saved to disk.",
+                         notebook was not saved to disk. Keeping stale session.",
                     );
                     return;
                 }
@@ -301,6 +302,7 @@ async fn auto_rejoin_session(
                     notebook_id: new_notebook_id,
                     notebook_path: notebook_path.clone(),
                 };
+                // Replace old session only on successful rejoin
                 *session.write().await = Some(new_session);
                 info!("Auto-rejoined notebook session: {notebook_id} ({new_cell_count} cells)",);
                 return;
@@ -314,8 +316,12 @@ async fn auto_rejoin_session(
                     );
                     tokio::time::sleep(REJOIN_RETRY_DELAY).await;
                 } else {
+                    // Keep old session intact — it's stale but better than None.
+                    // Tools will get sync errors that prompt re-connection rather
+                    // than "No active notebook session" which is confusing mid-run.
                     warn!(
-                        "Failed to auto-rejoin notebook {notebook_id} after {} attempts: {e}",
+                        "Failed to auto-rejoin notebook {notebook_id} after {} attempts, \
+                         keeping stale session: {e}",
                         attempt + 1
                     );
                 }


### PR DESCRIPTION
## Summary

- Fix regression from #1953 where `auto_rejoin_session` eagerly set `session = None` before attempting reconnection
- If reconnection failed (ephemeral notebook lost on daemon restart, connection error), session stayed `None` permanently
- Now the old session is preserved until a valid replacement exists — tools get degraded-but-informative errors instead of "No active notebook session"

## What changed

Removed the unconditional `*session.write().await = None` at the start of `auto_rejoin_session`. The session is now only replaced on successful rejoin:

- **Successful rejoin**: atomically swap old → new session
- **Ephemeral loss** (empty doc after restart): keep stale session, log warning
- **Connection failure** (all retries exhausted): keep stale session, log warning

## Impact

Before: daemon restart mid-session → "No active notebook session" on next tool call (confusing, looks like the user never opened a notebook)

After: daemon restart mid-session → stale session produces sync-level errors that clearly indicate disconnection, user can call `open_notebook` to recover

## Test plan

- [x] `cargo test -p runt-mcp` passes
- [x] `cargo clippy -p runt-mcp` clean
- [ ] Gremlin suite replay without daemon restart mid-run (validates no session loss)