### PR TITLE
feat(kernel-env): unified env hash + base-package constants (PR 1/3)

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -47,6 +47,29 @@ pub fn default_cache_dir_conda() -> PathBuf {
         .join("conda-envs")
 }
 
+/// Base package set every Conda kernel env is warmed with.
+///
+/// Used by the daemon's Conda pool warmer (`conda_prewarmed_packages` in
+/// runtimed) and by the unified env design's capture step (`strip_base`) so
+/// the notebook's metadata records only user-level deps. Keep this in sync
+/// with the warmer.
+pub const CONDA_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat"];
+
+/// Compute the unified env hash for a notebook. Used by the captured-deps
+/// reopen path from the unified env resolution design (see
+/// `docs/superpowers/specs/2026-04-20-unified-env-resolution.md`).
+///
+/// Requires `deps.env_id` to be `Some`. Distinct from [`compute_env_hash`]
+/// only in that contract: the existing function tolerates `env_id = None`
+/// for cross-notebook sharing, and this one doesn't. Hash output is
+/// identical when `env_id` is `Some` — no on-disk migration needed when
+/// PR 2 switches callers.
+pub fn compute_unified_env_hash(deps: &CondaDependencies, env_id: &str) -> String {
+    let mut with_id = deps.clone();
+    with_id.env_id = Some(env_id.to_string());
+    compute_env_hash(&with_id)
+}
+
 /// Compute a stable cache key for the given dependencies.
 ///
 /// The hash includes sorted deps, sorted channels, python constraint,
@@ -966,5 +989,55 @@ mod tests {
         };
 
         assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+
+    // ── unified env hash (PR 1, spec 2026-04-20) ─────────────────────────
+
+    #[test]
+    fn unified_hash_matches_legacy_with_env_id() {
+        // Conda's legacy hash already always includes env_id, so the unified
+        // hash produces identical output for the same inputs. Sanity-check
+        // the bridge so switching callers in PR 2 doesn't invalidate any
+        // on-disk env.
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into(), "scipy".into()],
+            channels: vec!["conda-forge".into()],
+            python: None,
+            env_id: Some("abc".into()),
+        };
+        assert_eq!(
+            compute_env_hash(&deps),
+            compute_unified_env_hash(&deps, "abc"),
+        );
+    }
+
+    #[test]
+    fn unified_hash_overrides_env_id_in_deps() {
+        // If the caller already populated deps.env_id, the unified function
+        // uses the explicit env_id argument. This lets us pass in-flight
+        // values without reshaping the struct.
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: None,
+            env_id: Some("stale".into()),
+        };
+        let with_explicit = compute_unified_env_hash(&deps, "fresh");
+        let mut expected_deps = deps.clone();
+        expected_deps.env_id = Some("fresh".into());
+        assert_eq!(with_explicit, compute_env_hash(&expected_deps));
+    }
+
+    #[test]
+    fn unified_hash_isolates_by_env_id() {
+        let deps = CondaDependencies {
+            dependencies: vec!["numpy".into()],
+            channels: vec!["conda-forge".into()],
+            python: None,
+            env_id: None,
+        };
+        let h1 = compute_unified_env_hash(&deps, "notebook-1");
+        let h2 = compute_unified_env_hash(&deps, "notebook-2");
+        assert_ne!(h1, h2);
     }
 }

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -119,6 +119,31 @@ mod strip_base_tests {
     }
 
     #[test]
+    fn strips_dx_from_bootstrap_dx_envs() {
+        // When bootstrap_dx is on, `uv_prewarmed_packages` adds `dx` to the
+        // pool env's install list. `dx` is treated as base-level tooling
+        // (the feature flag controls it, not the user), so strip_base
+        // removes it — keeping captured notebook metadata free of the
+        // feature flag's state.
+        let installed: Vec<String> = [
+            "ipykernel",
+            "ipywidgets",
+            "anywidget",
+            "nbformat",
+            "uv",
+            "dx",
+            "pandas",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            strip_base(&installed, UV_BASE_PACKAGES),
+            vec!["pandas".to_string()]
+        );
+    }
+
+    #[test]
     fn preserves_order() {
         let installed: Vec<String> = ["pandas", "ipykernel", "numpy", "uv", "matplotlib"]
             .iter()

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -45,7 +45,92 @@ pub mod warmup;
 
 // Re-export key types
 #[cfg(feature = "runtime")]
-pub use conda::{CondaDependencies, CondaEnvironment};
+pub use conda::{CondaDependencies, CondaEnvironment, CONDA_BASE_PACKAGES};
 pub use progress::{EnvProgressPhase, LogHandler, ProgressHandler};
 #[cfg(feature = "runtime")]
-pub use uv::{UvDependencies, UvEnvironment};
+pub use uv::{UvDependencies, UvEnvironment, UV_BASE_PACKAGES};
+
+/// Return the subset of `installed` that isn't in `base`, preserving input order.
+///
+/// Used by the unified env resolution design to derive the user-level dep set
+/// from a freshly-claimed pool env's full install list. Pool warmers install
+/// `[ipykernel, ipywidgets, …, <user_defaults…>]`; at capture time we strip
+/// the known base set so the notebook's metadata carries only the user deps.
+///
+/// Comparison is exact-match on package name. If a name appears multiple times
+/// in `installed`, every occurrence is dropped as long as it's in `base`.
+#[cfg(feature = "runtime")]
+pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
+    installed
+        .iter()
+        .filter(|pkg| !base.contains(&pkg.as_str()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod strip_base_tests {
+    use super::*;
+
+    #[test]
+    fn strips_uv_base_leaves_user_defaults() {
+        let installed: Vec<String> = [
+            "ipykernel",
+            "ipywidgets",
+            "anywidget",
+            "nbformat",
+            "uv",
+            "pandas",
+            "numpy",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let result = strip_base(&installed, UV_BASE_PACKAGES);
+        assert_eq!(result, vec!["pandas".to_string(), "numpy".to_string()]);
+    }
+
+    #[test]
+    fn strips_conda_base_leaves_user_defaults() {
+        let installed: Vec<String> = ["ipykernel", "ipywidgets", "anywidget", "nbformat", "scipy"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let result = strip_base(&installed, CONDA_BASE_PACKAGES);
+        assert_eq!(result, vec!["scipy".to_string()]);
+    }
+
+    #[test]
+    fn empty_installed_returns_empty() {
+        let installed: Vec<String> = vec![];
+        assert!(strip_base(&installed, UV_BASE_PACKAGES).is_empty());
+    }
+
+    #[test]
+    fn installed_all_base_returns_empty() {
+        let installed: Vec<String> = UV_BASE_PACKAGES.iter().map(|s| s.to_string()).collect();
+        assert!(strip_base(&installed, UV_BASE_PACKAGES).is_empty());
+    }
+
+    #[test]
+    fn empty_base_returns_all() {
+        let installed: Vec<String> = vec!["pandas".into(), "numpy".into()];
+        assert_eq!(strip_base(&installed, &[]), installed);
+    }
+
+    #[test]
+    fn preserves_order() {
+        let installed: Vec<String> = ["pandas", "ipykernel", "numpy", "uv", "matplotlib"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            strip_base(&installed, UV_BASE_PACKAGES),
+            vec![
+                "pandas".to_string(),
+                "numpy".to_string(),
+                "matplotlib".to_string()
+            ]
+        );
+    }
+}

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -47,6 +47,53 @@ pub async fn check_uv_available() -> bool {
     kernel_launch::tools::get_uv_path().await.is_ok()
 }
 
+/// Base package set every UV kernel env is warmed with.
+///
+/// Used by the daemon's UV pool warmer (`uv_prewarmed_packages` in runtimed) and
+/// by the unified env design's capture step (`strip_base`) so the notebook's
+/// metadata records only user-level deps. Keep this in sync with the warmer.
+pub const UV_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat", "uv"];
+
+/// Compute the unified env hash for a notebook. Used by the captured-deps
+/// reopen path from the unified env resolution design (see
+/// `docs/superpowers/specs/2026-04-20-unified-env-resolution.md`).
+///
+/// Hashes `(sorted_deps, requires_python, prerelease, env_id)`. `env_id` is
+/// always included so each notebook's env is isolated by default, regardless
+/// of whether its captured deps overlap with another notebook's. This is the
+/// hashing rule PR 2 wires into `claim_prewarmed_environment_in` and
+/// `prepare_environment_in` once the capture flow lands.
+///
+/// Prefer this over [`compute_env_hash`] for any new call site. The legacy
+/// function is kept for the existing inline-deps codepath until PR 2 flips
+/// callers over.
+pub fn compute_unified_env_hash(deps: &UvDependencies, env_id: &str) -> String {
+    let mut hasher = Sha256::new();
+
+    let mut sorted_deps = deps.dependencies.clone();
+    sorted_deps.sort();
+    for dep in &sorted_deps {
+        hasher.update(dep.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    if let Some(ref py) = deps.requires_python {
+        hasher.update(b"requires-python:");
+        hasher.update(py.as_bytes());
+    }
+
+    if let Some(ref prerelease) = deps.prerelease {
+        hasher.update(b"\nprerelease:");
+        hasher.update(prerelease.as_bytes());
+    }
+
+    hasher.update(b"\nenv_id:");
+    hasher.update(env_id.as_bytes());
+
+    let hash = hasher.finalize();
+    hex::encode(hash)[..16].to_string()
+}
+
 /// Compute a stable cache key for the given dependencies.
 ///
 /// When deps are empty and env_id is provided, includes env_id in hash
@@ -958,5 +1005,77 @@ mod tests {
         let hash1 = compute_env_hash(&deps, None);
         let hash2 = compute_env_hash(&deps, None);
         assert_eq!(hash1, hash2);
+    }
+
+    // ── unified env hash (PR 1, spec 2026-04-20) ─────────────────────────
+
+    #[test]
+    fn unified_hash_is_stable() {
+        let deps = UvDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            requires_python: None,
+            prerelease: None,
+        };
+        let h1 = compute_unified_env_hash(&deps, "abc");
+        let h2 = compute_unified_env_hash(&deps, "abc");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn unified_hash_is_order_independent() {
+        let d1 = UvDependencies {
+            dependencies: vec!["pandas".into(), "numpy".into()],
+            requires_python: None,
+            prerelease: None,
+        };
+        let d2 = UvDependencies {
+            dependencies: vec!["numpy".into(), "pandas".into()],
+            requires_python: None,
+            prerelease: None,
+        };
+        assert_eq!(
+            compute_unified_env_hash(&d1, "abc"),
+            compute_unified_env_hash(&d2, "abc"),
+        );
+    }
+
+    #[test]
+    fn unified_hash_isolates_by_env_id_even_with_nonempty_deps() {
+        // This is the critical divergence from legacy `compute_env_hash`,
+        // which collapses different env_ids to the same hash when deps
+        // are non-empty. The unified rule always isolates.
+        let deps = UvDependencies {
+            dependencies: vec!["pandas".into()],
+            requires_python: None,
+            prerelease: None,
+        };
+        let h1 = compute_unified_env_hash(&deps, "notebook-1");
+        let h2 = compute_unified_env_hash(&deps, "notebook-2");
+        assert_ne!(h1, h2, "unified hash must isolate notebooks with same deps");
+    }
+
+    #[test]
+    fn unified_hash_isolates_by_env_id_with_empty_deps() {
+        let deps = UvDependencies::default();
+        let h1 = compute_unified_env_hash(&deps, "notebook-1");
+        let h2 = compute_unified_env_hash(&deps, "notebook-2");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn unified_hash_differs_from_legacy_for_nonempty_deps_with_env_id() {
+        // Sanity check: confirm the unified hash and legacy hash produce
+        // different outputs for the same inputs when legacy was ignoring
+        // env_id. If this ever matched the legacy hash we'd have on-disk
+        // collisions between captured-deps envs (unified rule) and
+        // inline-deps envs (legacy rule, env_id absent).
+        let deps = UvDependencies {
+            dependencies: vec!["pandas".into()],
+            requires_python: None,
+            prerelease: None,
+        };
+        let legacy = compute_env_hash(&deps, Some("abc"));
+        let unified = compute_unified_env_hash(&deps, "abc");
+        assert_ne!(legacy, unified);
     }
 }

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -52,7 +52,21 @@ pub async fn check_uv_available() -> bool {
 /// Used by the daemon's UV pool warmer (`uv_prewarmed_packages` in runtimed) and
 /// by the unified env design's capture step (`strip_base`) so the notebook's
 /// metadata records only user-level deps. Keep this in sync with the warmer.
-pub const UV_BASE_PACKAGES: &[&str] = &["ipykernel", "ipywidgets", "anywidget", "nbformat", "uv"];
+///
+/// `dx` is here even though it's only installed when the `bootstrap_dx`
+/// feature flag is on. Treating it as base keeps the feature flag's state
+/// from leaking into captured notebook metadata — the flag continues to
+/// control launch-time behaviour (`RUNT_BOOTSTRAP_DX` env var + launcher
+/// module selection) without forcing every flag-on notebook to pin `dx`
+/// in its dep list.
+pub const UV_BASE_PACKAGES: &[&str] = &[
+    "ipykernel",
+    "ipywidgets",
+    "anywidget",
+    "nbformat",
+    "uv",
+    "dx",
+];
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
 /// reopen path from the unified env resolution design (see


### PR DESCRIPTION
## Summary

PR 1 of 3 for the unified env resolution design: issue #1954.

Additive-only. New primitives land; no caller switches over; no on-disk cache invalidation. PR 2 wires these into the claim path and auto-launch prewarmed branches.

## What's new

- `kernel_env::UV_BASE_PACKAGES` / `CONDA_BASE_PACKAGES` — the fixed prelude every pool env is warmed with. Pool warmer + capture step share this list.
- `kernel_env::strip_base(installed, base)` — filters a pool env's full install list down to user-level deps, for writing into notebook metadata at capture time.
- `kernel_env::uv::compute_unified_env_hash(deps, env_id)` — UV hash that always includes `env_id`, diverging from the legacy `compute_env_hash` (which ignores env_id when deps are non-empty). Enables per-notebook isolation for captured-deps envs.
- `kernel_env::conda::compute_unified_env_hash(deps, env_id)` — bridge over the existing conda hash (which already includes env_id). Kept as a named function so PR 2's call sites can use a single mental model across UV and Conda.

## Tests

11 new tests:

- 6 for `strip_base`: UV and Conda base stripping, empty cases, order preservation, all-base edge case.
- 5 for UV `compute_unified_env_hash`: stability, order-independence, env_id isolation with empty deps, env_id isolation with non-empty deps (critical divergence from legacy), difference from legacy.
- 3 for Conda `compute_unified_env_hash`: legacy equivalence for same inputs, env_id override, env_id isolation.

Full \`cargo test -p kernel-env --lib\`: 47 passed.

CI-style clippy (\`--workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --all-targets -- -D warnings\`): clean.

## Compat risk

None. No function signature changes, no caller churn, no on-disk cache key changes. The unified functions sit alongside the legacy ones and wait for PR 2.

## Next

PR 2: thread the unified hash and capture into \`claim_prewarmed_environment_in\` and the \`uv:prewarmed\` / \`conda:prewarmed\` arms of \`auto_launch_kernel\`. Write captured deps into notebook metadata so reopens go through the cache-hit path.