### PR TITLE
fix(runt-cli): enable panic=unwind for MCP server to fix silent connection drops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,4 +91,13 @@ opt-level = 'z'
 strip = true
 lto = true
 codegen-units = 1
+# Prevent panics in user-facing code - crashes are terrible UX.
 panic = "abort"
+
+# runt-cli hosts the MCP server which uses catch_unwind to recover from
+# automerge panics during sync (automerge/automerge#1187). panic=abort
+# makes those guards no-ops, causing silent process death on shared notebooks.
+# This profile inherits from release but enables unwinding.
+[profile.release-mcp]
+inherits = "release"
+panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,13 +91,8 @@ opt-level = 'z'
 strip = true
 lto = true
 codegen-units = 1
-# Prevent panics in user-facing code - crashes are terrible UX.
-panic = "abort"
-
-# runt-cli hosts the MCP server which uses catch_unwind to recover from
-# automerge panics during sync (automerge/automerge#1187). panic=abort
-# makes those guards no-ops, causing silent process death on shared notebooks.
-# This profile inherits from release but enables unwinding.
-[profile.release-mcp]
-inherits = "release"
+# Keep unwinding so catch_unwind guards work in release — both runtimed
+# (spawn_supervised task recovery) and runt-cli (automerge sync panic
+# recovery, automerge/automerge#1187). The binary size cost is ~2-5%
+# but prevents silent process death on shared notebooks.
 panic = "unwind"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -771,6 +771,41 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         );
     }
 
+    // Install a panic hook that writes to the MCP log file so panics are
+    // visible for diagnosis (the default hook writes to stderr which is
+    // invisible for stdio MCP servers).
+    let panic_log_path = log_path.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        let payload = if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.as_str()
+        } else if let Some(s) = info.payload().downcast_ref::<&str>() {
+            s
+        } else {
+            "unknown panic"
+        };
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown location".to_string());
+
+        let msg = format!(
+            "[PANIC] {payload}\n  at {location}\n  pid={}\n",
+            std::process::id()
+        );
+
+        // Best-effort write directly to the log file (tracing may not flush)
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&panic_log_path)
+        {
+            use std::io::Write;
+            let _ = f.write_all(msg.as_bytes());
+        }
+
+        // Also emit via tracing in case the subscriber is still alive
+        tracing::error!("{msg}");
+    }));
+
     // ── Server setup ─────────────────────────────────────────────────
     let socket_path = runtimed_client::daemon_paths::get_socket_path();
     let (blob_base_url, blob_store_path) =

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1600,18 +1600,9 @@ fn cmd_install_nightly(args: &[String]) {
     // `RUNT_BUILD_CHANNEL=stable` exported for release validation, a naive
     // `cargo build` would produce stable binaries that then get installed
     // into the nightly namespace.
-    println!("Building runtimed, runt-cli, runt-proxy (release, channel=nightly)...");
+    println!("Building runtimed, runt-proxy (release, channel=nightly)...");
     let mut build_cmd = Command::new("cargo");
-    build_cmd.args([
-        "build",
-        "--release",
-        "-p",
-        "runtimed",
-        "-p",
-        "runt-cli",
-        "-p",
-        "runt-proxy",
-    ]);
+    build_cmd.args(["build", "--release", "-p", "runtimed", "-p", "runt-proxy"]);
     build_cmd.env("RUNT_BUILD_CHANNEL", "nightly");
     apply_sccache_env(&mut build_cmd);
     let status = build_cmd.status().unwrap_or_else(|e| {
@@ -1623,10 +1614,27 @@ fn cmd_install_nightly(args: &[String]) {
         exit(status.code().unwrap_or(1));
     }
 
+    // runt-cli uses a custom profile that enables panic=unwind so catch_unwind
+    // guards in the MCP server remain effective (automerge/automerge#1187).
+    println!("Building runt-cli (release-mcp, channel=nightly)...");
+    let mut mcp_build_cmd = Command::new("cargo");
+    mcp_build_cmd.args(["build", "--profile", "release-mcp", "-p", "runt-cli"]);
+    mcp_build_cmd.env("RUNT_BUILD_CHANNEL", "nightly");
+    apply_sccache_env(&mut mcp_build_cmd);
+    let status = mcp_build_cmd.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run cargo build: {e}");
+        exit(1);
+    });
+    if !status.success() {
+        eprintln!("cargo build --profile release-mcp failed");
+        exit(status.code().unwrap_or(1));
+    }
+
     let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
     let release_dir = Path::new("target/release");
+    let release_mcp_dir = Path::new("target/release-mcp");
     let runtimed_source = release_dir.join(format!("runtimed{exe_suffix}"));
-    let runt_source = release_dir.join(format!("runt{exe_suffix}"));
+    let runt_source = release_mcp_dir.join(format!("runt{exe_suffix}"));
     let proxy_source = release_dir.join(format!("runt-proxy{exe_suffix}"));
 
     for (label, path) in [
@@ -1905,7 +1913,10 @@ fn cmd_mcp(print_config: bool, release: bool) {
     if release {
         println!("Building runtimed (release) for supervisor...");
         run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
-        run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
+        run_cmd(
+            "cargo",
+            &["build", "--profile", "release-mcp", "-p", "runt-cli"],
+        );
     }
 
     if print_config {
@@ -3115,11 +3126,14 @@ fn cmd_sync_tool_cache(check: bool) {
     let manifest_nightly = Path::new("mcpb/manifest.nightly.json");
     let manifest_stable = Path::new("mcpb/manifest.stable.json");
 
-    eprintln!("Building runt-cli (release)...");
-    run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
+    eprintln!("Building runt-cli (release-mcp)...");
+    run_cmd(
+        "cargo",
+        &["build", "--profile", "release-mcp", "-p", "runt-cli"],
+    );
 
     eprintln!("Dumping tool list from runt mcp...");
-    let runt_bin = Path::new("target/release/runt");
+    let runt_bin = Path::new("target/release-mcp/runt");
     let tools_json = dump_mcp_tools(runt_bin);
 
     // 3. Parse and compute description bytes

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1600,9 +1600,18 @@ fn cmd_install_nightly(args: &[String]) {
     // `RUNT_BUILD_CHANNEL=stable` exported for release validation, a naive
     // `cargo build` would produce stable binaries that then get installed
     // into the nightly namespace.
-    println!("Building runtimed, runt-proxy (release, channel=nightly)...");
+    println!("Building runtimed, runt-cli, runt-proxy (release, channel=nightly)...");
     let mut build_cmd = Command::new("cargo");
-    build_cmd.args(["build", "--release", "-p", "runtimed", "-p", "runt-proxy"]);
+    build_cmd.args([
+        "build",
+        "--release",
+        "-p",
+        "runtimed",
+        "-p",
+        "runt-cli",
+        "-p",
+        "runt-proxy",
+    ]);
     build_cmd.env("RUNT_BUILD_CHANNEL", "nightly");
     apply_sccache_env(&mut build_cmd);
     let status = build_cmd.status().unwrap_or_else(|e| {
@@ -1614,27 +1623,10 @@ fn cmd_install_nightly(args: &[String]) {
         exit(status.code().unwrap_or(1));
     }
 
-    // runt-cli uses a custom profile that enables panic=unwind so catch_unwind
-    // guards in the MCP server remain effective (automerge/automerge#1187).
-    println!("Building runt-cli (release-mcp, channel=nightly)...");
-    let mut mcp_build_cmd = Command::new("cargo");
-    mcp_build_cmd.args(["build", "--profile", "release-mcp", "-p", "runt-cli"]);
-    mcp_build_cmd.env("RUNT_BUILD_CHANNEL", "nightly");
-    apply_sccache_env(&mut mcp_build_cmd);
-    let status = mcp_build_cmd.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run cargo build: {e}");
-        exit(1);
-    });
-    if !status.success() {
-        eprintln!("cargo build --profile release-mcp failed");
-        exit(status.code().unwrap_or(1));
-    }
-
     let exe_suffix = if cfg!(windows) { ".exe" } else { "" };
     let release_dir = Path::new("target/release");
-    let release_mcp_dir = Path::new("target/release-mcp");
     let runtimed_source = release_dir.join(format!("runtimed{exe_suffix}"));
-    let runt_source = release_mcp_dir.join(format!("runt{exe_suffix}"));
+    let runt_source = release_dir.join(format!("runt{exe_suffix}"));
     let proxy_source = release_dir.join(format!("runt-proxy{exe_suffix}"));
 
     for (label, path) in [
@@ -1913,10 +1905,7 @@ fn cmd_mcp(print_config: bool, release: bool) {
     if release {
         println!("Building runtimed (release) for supervisor...");
         run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
-        run_cmd(
-            "cargo",
-            &["build", "--profile", "release-mcp", "-p", "runt-cli"],
-        );
+        run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
     }
 
     if print_config {
@@ -3126,14 +3115,11 @@ fn cmd_sync_tool_cache(check: bool) {
     let manifest_nightly = Path::new("mcpb/manifest.nightly.json");
     let manifest_stable = Path::new("mcpb/manifest.stable.json");
 
-    eprintln!("Building runt-cli (release-mcp)...");
-    run_cmd(
-        "cargo",
-        &["build", "--profile", "release-mcp", "-p", "runt-cli"],
-    );
+    eprintln!("Building runt-cli (release)...");
+    run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
 
     eprintln!("Dumping tool list from runt mcp...");
-    let runt_bin = Path::new("target/release-mcp/runt");
+    let runt_bin = Path::new("target/release/runt");
     let tools_json = dump_mcp_tools(runt_bin);
 
     // 3. Parse and compute description bytes


### PR DESCRIPTION
## Summary

- Switch workspace release profile from `panic = "abort"` to `panic = "unwind"` so all `catch_unwind` guards work in release builds
- **runt-cli**: recovers from automerge sync panics ([automerge/automerge#1187](https://github.com/automerge/automerge/issues/1187)) instead of silently aborting
- **runtimed**: `spawn_supervised` task recovery (PR #1930) and existing panic hooks now function in release
- Add panic hook in `run_mcp_server()` that writes `[PANIC]` entries to the MCP log file (stderr is invisible for stdio servers)

**Root cause:** Soak testing (runs 8–10) showed intermittent `MCP error -32000: Connection closed` when gremlins opened shared notebooks. The MCP server's `catch_unwind` around `receive_sync_message` was dead code in release builds because `panic = "abort"` converts unwinds into immediate `SIGABRT`. The daemon's panic hook and spawn_supervised infrastructure had the same problem.

**Trade-off:** ~2-5% binary size increase from unwind tables. Acceptable given the alternative is silent process death with no diagnostics.

## Test plan

- [x] `cargo clippy -p runt-cli -p runtimed -p xtask --release -- -D warnings` clean
- [x] `cargo xtask install-nightly` succeeds (single `--release` build, no custom profile)
- [x] `runt-nightly daemon status` shows daemon running
- [x] Verified unwind symbols present in both binaries (`nm -D | grep _Unwind` → 14 symbols each)
- [ ] Gremlin soak re-run to confirm collaborator scenarios no longer drop

Closes #1955