### PR TITLE
ci(labeler): skip for fork PRs to avoid permissions failure

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   label:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/labeler@v6
         with:


### PR DESCRIPTION
## Summary
- Fork PRs get a restricted `GITHUB_TOKEN` that cannot write labels, causing the labeler job to fail with a permissions error
- Add `if: github.event.pull_request.head.repo.full_name == github.repository` so the job is skipped (not failed) for fork PRs
- Maintainer PRs (same-repo branches) still run the labeler normally

## Test plan
- [ ] Verify existing fork PR (#1949) no longer shows labeler failure after merge
- [ ] Verify maintainer PRs still get labels applied