### PR TITLE
fix(sift): let the last column resize and absorb viewport slack

### DIFF
--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -384,4 +384,35 @@ describe("createTable", () => {
       expect(stats?.dataset.value).toContain("50");
     });
   });
+
+  describe("column resize", () => {
+    it("last column has a resize handle", async () => {
+      await flushRAF();
+      const headerCells = container.querySelectorAll(".sift-th");
+      expect(headerCells).toHaveLength(4);
+      const lastHandle = headerCells[headerCells.length - 1].querySelector(".sift-resize-handle");
+      expect(lastHandle).not.toBeNull();
+    });
+
+    it("grows last column to fill when viewport reports width wider than columns", async () => {
+      const wide = document.createElement("div");
+      document.body.appendChild(wide);
+      const e = createTable(wide, makeTableData(makeRows(10)));
+      await flushRAF();
+      const viewport = wide.querySelector<HTMLElement>(".sift-viewport")!;
+      // jsdom reports clientWidth as 0; stub it to simulate a wide container
+      // and fire a resize event to trigger fitLastColumnToViewport().
+      Object.defineProperty(viewport, "clientWidth", { value: 1600, configurable: true });
+      window.dispatchEvent(new Event("resize"));
+      await flushRAF();
+      const headers = wide.querySelectorAll<HTMLElement>(".sift-th");
+      const total = Array.from(headers).reduce(
+        (s, h) => s + Number.parseFloat(h.style.width || "0"),
+        0,
+      );
+      expect(total).toBeGreaterThanOrEqual(1600 - 2);
+      e.destroy();
+      wide.remove();
+    });
+  });
 });

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -555,12 +555,10 @@ export function createTable(
       }
     });
 
-    if (c < columns.length - 1) {
-      const handle = document.createElement("div");
-      handle.className = "sift-resize-handle";
-      handle.addEventListener("pointerdown", (e) => onResizeStart(e, c));
-      th.appendChild(handle);
-    }
+    const handle = document.createElement("div");
+    handle.className = "sift-resize-handle";
+    handle.addEventListener("pointerdown", (e) => onResizeStart(e, c));
+    th.appendChild(handle);
 
     headerCells.push(th);
     headerRowEl.appendChild(th);
@@ -891,6 +889,29 @@ export function createTable(
       updateScrollContentWidth();
       heightsDirty = true;
     }
+  }
+
+  // Grow the last column to fill leftover viewport space. Active until the
+  // user resizes the last column explicitly. Re-runs on viewport resize and
+  // after non-last column resizes, so maximize/restore just works.
+  let lastColumnAutoFill = true;
+
+  function fitLastColumnToViewport() {
+    if (!lastColumnAutoFill) return;
+    const last = columns.length - 1;
+    if (last < 0) return;
+    const viewportW = viewport.clientWidth;
+    if (viewportW <= 0) return;
+    let fixedW = 0;
+    for (let c = 0; c < last; c++) fixedW += colWidths[c];
+    const target = Math.max(MIN_COL_WIDTH, viewportW - fixedW);
+    if (target === colWidths[last]) return;
+    colWidths[last] = target;
+    headerCells[last].style.width = target + "px";
+    renderSummary(last);
+    updateScrollContentWidth();
+    heightsDirty = true;
+    scheduleRender();
   }
 
   function rebuildFilterPills() {
@@ -1280,7 +1301,11 @@ export function createTable(
 
   viewport.addEventListener("scroll", onScroll, { passive: true });
 
-  window.addEventListener("resize", scheduleRender);
+  const onWindowResize = () => {
+    fitLastColumnToViewport();
+    scheduleRender();
+  };
+  window.addEventListener("resize", onWindowResize);
 
   // --- Mobile tap-row detail sheet ---
 
@@ -1454,6 +1479,8 @@ export function createTable(
     handle.setPointerCapture(e.pointerId);
     const startX = e.clientX;
     const startWidth = colWidths[colIndex];
+    const isLast = colIndex === columns.length - 1;
+    if (isLast) lastColumnAutoFill = false;
 
     const onMove = (ev: PointerEvent) => {
       const delta = ev.clientX - startX;
@@ -1463,6 +1490,7 @@ export function createTable(
       updateScrollContentWidth();
       heightsDirty = true;
       scheduleRender();
+      if (!isLast) fitLastColumnToViewport();
     };
 
     const onUp = () => {
@@ -1596,13 +1624,24 @@ export function createTable(
   // Watch for header height changes (e.g. when React summary charts mount async)
   // so rowPool.style.top stays in sync
   let headerResizeObserver: ResizeObserver | null = null;
+  let viewportResizeObserver: ResizeObserver | null = null;
   if (typeof ResizeObserver !== "undefined") {
     headerResizeObserver = new ResizeObserver(() => {
       heightsDirty = true;
       scheduleRender();
     });
     headerResizeObserver.observe(headerEl);
+
+    // Keep the last column sized to fill the viewport as the container resizes
+    // (e.g. the user maximizes the notebook window or resizes a split pane).
+    viewportResizeObserver = new ResizeObserver(() => {
+      fitLastColumnToViewport();
+    });
+    viewportResizeObserver.observe(viewport);
   }
+
+  // Initial fit in case the proportional scale above left sub-pixel slack.
+  fitLastColumnToViewport();
 
   // --- Keyboard navigation ---
 
@@ -1665,7 +1704,8 @@ export function createTable(
     viewport.removeEventListener("scroll", onScroll);
 
     container.removeEventListener("keydown", onKeyDown);
-    window.removeEventListener("resize", scheduleRender);
+    window.removeEventListener("resize", onWindowResize);
+    viewportResizeObserver?.disconnect();
     document.removeEventListener("fullscreenchange", onFullscreenChange);
     document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
 


### PR DESCRIPTION
## Summary
- The rightmost column in a sift table had no resize handle, so it was locked at whatever width the initial auto-sizing landed on. Maximize the notebook and the empty space to the right of the last column stayed empty.
- Give every column a resize handle (drop the `c < columns.length - 1` guard in `table.ts:558`).
- Add `fitLastColumnToViewport()`: when `viewport.clientWidth` exceeds the sum of column widths, pad the last column. Runs on window resize, viewport `ResizeObserver`, and after non-last column drags. Switches off the moment the user drags the last column explicitly, so manual widths stick.

## Test plan
- [x] `npm test` in `packages/sift` (137 passed, 2 new under `column resize`)
- [x] `cargo xtask lint` — TS/JS + Python clean (pre-existing `runtimed-node` clippy is unrelated)
- [ ] Manual: open a sift table, maximize window, confirm the last column grows
- [ ] Manual: drag a non-last column wider/narrower, confirm last column absorbs slack
- [ ] Manual: drag the last column explicitly, confirm it sticks across a window resize