### PR TITLE
refactor(sift): use pretext measureNaturalWidth for column sizing

### DIFF
--- a/packages/sift/src/auto-width.ts
+++ b/packages/sift/src/auto-width.ts
@@ -4,7 +4,7 @@
  * autoWidth() — initial width from header label measurement + type minimums.
  * fitColumnWidths() — refine widths by sampling actual cell data via pretext.
  */
-import { prepareWithSegments } from "@chenglou/pretext";
+import { measureNaturalWidth, prepareWithSegments } from "@chenglou/pretext";
 import type { ColumnType, TableData } from "./table";
 
 const LABEL_FONT = '600 11px Inter, "Helvetica Neue", Helvetica, Arial, sans-serif';
@@ -12,33 +12,14 @@ const CELL_FONT = '14px Inter, "Helvetica Neue", Helvetica, Arial, sans-serif';
 const HEADER_CHROME = 60; // cell padding + type icon + sort arrow
 const CELL_PAD = 24; // 12px each side — matches CELL_PAD_H in table.ts
 
-/**
- * Measure the single-line width of header label text using pretext.
- * Uses the same measurement engine as cell text for consistency.
- */
-function measureHeaderText(text: string): number {
-  const prepared = prepareWithSegments(text, LABEL_FONT);
-  let w = 0;
-  for (let i = 0; i < prepared.widths.length; i++) w += prepared.widths[i];
-  return w;
-}
-
-/**
- * Measure the single-line width of cell text using pretext.
- * Sums segment widths from prepareWithSegments — this uses the same
- * measurement engine that the table uses for layout, so column widths
- * will match what's actually rendered.
- */
-function measureCellText(text: string): number {
-  const prepared = prepareWithSegments(text, CELL_FONT);
-  let w = 0;
-  for (let i = 0; i < prepared.widths.length; i++) w += prepared.widths[i];
-  return w;
+/** Widest forced line for `text` at `font`. Same engine as the table's layout. */
+function measureText(text: string, font: string): number {
+  return measureNaturalWidth(prepareWithSegments(text, font));
 }
 
 /** Compute initial column width from header label + type constraints */
 export function autoWidth(name: string, colType: ColumnType): number {
-  const labelW = measureHeaderText(name.toUpperCase()) + HEADER_CHROME;
+  const labelW = measureText(name.toUpperCase(), LABEL_FONT) + HEADER_CHROME;
 
   switch (colType) {
     case "boolean":
@@ -71,7 +52,7 @@ export function fitColumnWidths(data: TableData, colWidths: number[], maxWidth =
     if (summary && (summary as any).isIndex === true) {
       const maxVal = (summary as any).max as number;
       const formatted = maxVal != null ? Math.round(maxVal).toLocaleString() : "";
-      const indexW = Math.ceil(measureCellText(formatted)) + CELL_PAD;
+      const indexW = Math.ceil(measureText(formatted, CELL_FONT)) + CELL_PAD;
       // Only widen — main.ts may have set a larger width from totalRows
       if (indexW > colWidths[c]) colWidths[c] = indexW;
       continue;
@@ -81,7 +62,7 @@ export function fitColumnWidths(data: TableData, colWidths: number[], maxWidth =
     for (let r = 0; r < sampleSize; r++) {
       const text = data.getCell(r, c);
       if (!text) continue;
-      const w = measureCellText(text) + CELL_PAD;
+      const w = measureText(text, CELL_FONT) + CELL_PAD;
       widths.push(w);
     }
     if (widths.length === 0) continue;

--- a/packages/sift/src/setupTests.ts
+++ b/packages/sift/src/setupTests.ts
@@ -82,4 +82,9 @@ vi.mock("@chenglou/pretext", () => ({
     segments: [text],
   })),
   layout: vi.fn(() => ({ lineCount: 1, height: 20 })),
+  measureNaturalWidth: vi.fn((prepared: { widths: number[] }) => {
+    let w = 0;
+    for (let i = 0; i < prepared.widths.length; i++) w += prepared.widths[i];
+    return w;
+  }),
 }));


### PR DESCRIPTION
## Summary

- Collapse `measureHeaderText` and `measureCellText` into one `measureText(text, font)` backed by `measureNaturalWidth()` from `@chenglou/pretext@0.0.5`.
- Behavior-equivalent for sift's single-line tabular data, and the right API if cell text ever contains forced breaks (returns widest forced line instead of sum of all segment widths).
- +12/-26. Mock in `setupTests.ts` updated to match.

## Test plan

- [x] `pnpm test` in `packages/sift` — 137 tests pass
- [x] `cargo xtask lint --fix` — TS/JS/Python clean (pre-existing Rust clippy in `runtimed-node` unrelated)