### PR TITLE
chore: sweep legacy protocol parser, deprecated alias, stale docstring

### DIFF
--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -201,8 +201,6 @@ cargo xtask run-mcp
 | Editing | `replace_match`, `replace_regex` |
 | Execution | `execute_cell`, `run_all_cells` |
 
-`join_notebook` is accepted as a backward-compat alias for `open_notebook`.
-
 Three packages are workspace members:
 
 | Package | Path | Purpose |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,8 +342,6 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | Editing | `replace_match`, `replace_regex` |
 | Execution | `execute_cell`, `run_all_cells` |
 
-`join_notebook` is accepted as a backward-compat alias that routes to `open_notebook`.
-
 **Audit workflow example:** After modifying daemon or kernel code, use `open_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
 
 ### Hot reload

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -903,40 +903,6 @@ mod tests {
         ));
     }
 
-    /// Legacy v2 payload (no `id` field) must deserialize as an envelope
-    /// with `id = None`. This lets a new daemon accept requests from an
-    /// old client that hasn't learned about the correlation id yet.
-    #[test]
-    fn request_envelope_accepts_legacy_v2_payload() {
-        let legacy = serde_json::json!({
-            "action": "execute_cell",
-            "cell_id": "cell-legacy",
-        });
-        let parsed: NotebookRequestEnvelope =
-            serde_json::from_value(legacy).expect("legacy payload deserializes");
-        assert!(parsed.id.is_none());
-        assert!(matches!(
-            parsed.request,
-            NotebookRequest::ExecuteCell { cell_id } if cell_id == "cell-legacy"
-        ));
-    }
-
-    /// A `NotebookRequestEnvelope` sent to a legacy v2 parser (which
-    /// deserializes into the bare `NotebookRequest` enum) must still work
-    /// — serde ignores unknown fields by default, so the `id` field is
-    /// harmlessly dropped. This lets a new client talk to an old daemon.
-    #[test]
-    fn legacy_v2_parser_accepts_envelope_payload() {
-        let envelope = NotebookRequestEnvelope {
-            id: Some("req-1".into()),
-            request: NotebookRequest::InterruptExecution {},
-        };
-        let json = serde_json::to_string(&envelope).expect("serialize");
-        let parsed: NotebookRequest =
-            serde_json::from_str(&json).expect("v2 parser accepts envelope");
-        assert!(matches!(parsed, NotebookRequest::InterruptExecution {}));
-    }
-
     #[test]
     fn response_envelope_flattens_and_round_trips() {
         let env = NotebookResponseEnvelope {
@@ -952,20 +918,6 @@ mod tests {
         assert_eq!(json["cell_id"], "cell-42");
         let parsed: NotebookResponseEnvelope = serde_json::from_value(json).expect("deserialize");
         assert_eq!(parsed.id.as_deref(), Some("req-1"));
-    }
-
-    /// A legacy v2 response parser must accept the new response envelope
-    /// (id field is unknown-and-ignored by default serde behavior).
-    #[test]
-    fn legacy_v2_response_parser_accepts_envelope() {
-        let envelope = NotebookResponseEnvelope {
-            id: Some("req-1".into()),
-            response: NotebookResponse::Ok {},
-        };
-        let json = serde_json::to_string(&envelope).expect("serialize");
-        let parsed: NotebookResponse =
-            serde_json::from_str(&json).expect("v2 parser accepts response envelope");
-        assert!(matches!(parsed, NotebookResponse::Ok {}));
     }
 
     /// Locks in the exact JSON wire shape that the TypeScript frontend

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -389,19 +389,4 @@ mod tests {
         );
         assert_eq!(extract_session_id(&params, &success_result()), None);
     }
-
-    // ── Deprecated join_notebook is NOT tracked ───────────────────────
-
-    #[test]
-    fn does_not_track_join_notebook() {
-        let params = make_params(
-            "join_notebook",
-            serde_json::json!({"notebook_id": "abc-123"}),
-        );
-        assert_eq!(
-            extract_session_id(&params, &success_result()),
-            None,
-            "join_notebook is deprecated and should not be tracked"
-        );
-    }
 }

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -330,8 +330,6 @@ pub async fn dispatch(
         // Session
         "list_active_notebooks" => session::list_active_notebooks(server).await,
         "open_notebook" => session::open_notebook(server, request).await,
-        // Backward compat: join_notebook routes to open_notebook
-        "join_notebook" => session::open_notebook(server, request).await,
         "create_notebook" => session::create_notebook(server, request).await,
         "save_notebook" => session::save_notebook(server, request).await,
         "launch_app" => session::show_notebook(server, request).await,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -250,7 +250,6 @@ pub async fn list_active_notebooks(server: &NteractMcp) -> Result<CallToolResult
 /// Open a notebook — either from a file path on disk or by connecting to an
 /// existing daemon session by UUID.
 ///
-/// Unified handler for `open_notebook` and the deprecated `join_notebook`.
 /// Requires exactly one of `path` or `notebook_id` — not both, not neither.
 pub async fn open_notebook(
     server: &NteractMcp,

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -28,12 +28,14 @@
 //!
 //! ## The `is_binary_mime` Contract
 //!
-//! Three implementations must stay in sync:
-//! - Rust: `is_binary_mime()` in this file
-//! - Rust: `is_binary_mime()` in `crates/runtimed-py/src/output_resolver.rs`
-//! - TypeScript: `isBinaryMime()` in `apps/notebook/src/lib/manifest-resolution.ts`
+//! MIME classification has one canonical home: [`notebook_doc::mime`]. All
+//! Rust crates in the workspace (`runtimed`, `runtimed-client`,
+//! `runtimed-wasm`) import `is_binary_mime()`, `mime_kind()`, and `MimeKind`
+//! from that module — there are no per-crate copies to keep in sync. The
+//! frontend no longer classifies MIMEs at all; WASM resolves `ContentRef`s
+//! to `Inline`/`Url`/`Blob` variants directly.
 //!
-//! If you change the classification, update all three.
+//! If you change the classification, change it in `notebook-doc/src/mime.rs`.
 //!
 //! ## Key Types
 //!


### PR DESCRIPTION
## Summary

Three independent bits of drift sitting in the tree long past their usefulness. Sweeping them before they rot further.

1. **`legacy_v2_payload` parser tests.** The request/response envelope wire format added the `id` correlation field a while back, and the v2 bare-enum form is no longer emitted by any current client or accepted by any callsite. Three round-trip tests in `crates/notebook-protocol/src/protocol.rs` were the only references. Deleted.

2. **`join_notebook` MCP tool alias.** The `runt mcp` dispatcher in `crates/runt-mcp/src/tools/mod.rs` had a one-line routing entry that aliased the tool name `join_notebook` to the `open_notebook` handler. Paired with a stale docstring comment and a proxy-side test asserting the alias isn't session-tracked. Gone, along with the "accepted as a backward-compat alias" line in `AGENTS.md` / `CLAUDE.md` and the Python bindings skill doc.

   Note: the Python and WASM client APIs still expose `client.join_notebook(id)` as a first-class method for joining an existing session by UUID. That's a separate interface, not an MCP tool alias, and stays.

3. **Stale `is_binary_mime` docstring.** The module comment on `crates/runtimed/src/output_store.rs` still listed three per-crate copies of `is_binary_mime` that had to stay in sync. The consolidation into `notebook-doc::mime` is done per CLAUDE.md. Updated the comment to point at the canonical module so the next reader doesn't go hunting for copies that don't exist.

Three separate commits so each item is trivially revertable.

## Commits

- `chore(notebook-protocol): drop legacy_v2_payload parser`
- `chore(runt-mcp-proxy): remove deprecated join_notebook alias`
- `docs(runtimed): point is_binary_mime docstring at notebook-doc::mime`

## Codex review

Ran `codex review --base main`. One P1 flagged: removing the `join_notebook` MCP alias breaks any MCP client that still sends that tool name. Accepted and shipping as-is. The rename window has been long enough, the Python/WASM `client.join_notebook()` API (which actual downstream users call) is unchanged, and the task explicitly asks to sweep the alias now. If a stale config surfaces in the wild we can ship a targeted doc note.

## Out of scope

There's a pre-existing clippy error in `crates/runtimed-node/src/parquet.rs:109` (`implicit_saturating_sub`) that `cargo xtask lint` surfaces. It's already failing on `main` (commit `34a45e83`, Build run failed). Not this PR.

## Test plan

- [x] `cargo check --workspace --exclude runtimed-node` (workspace builds modulo the pre-existing clippy failure)
- [x] `cargo test -p notebook-protocol --lib` (40/40 pass)
- [x] `cargo test -p runt-mcp --lib` (67/67 pass)
- [x] `cargo test -p runt-mcp-proxy --lib` (93/93 pass)
- [x] `cargo test -p runtimed --lib` (377/377 pass, 1 ignored)
- [x] `cargo xtask lint --fix` (auto-formatted trailing blank line in proxy/session.rs; remaining failure is the pre-existing runtimed-node clippy)
- [x] `rg legacy_v2_payload` returns nothing
- [x] `rg join_notebook` in `crates/runt-mcp*` returns nothing; remaining hits are the unrelated Python/WASM `client.join_notebook()` public APIs
