### PR TITLE
refactor(hooks): pixi/deno hook renames + conda helper extraction

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -164,7 +164,7 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 |-----------|------|---------|
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
 | `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml detection |
-| `PixiDependencyHeader.tsx` | `usePixiDependencies.ts` | Pixi project detection, read-only dep display |
+| `PixiDependencyHeader.tsx` | `usePixiDetection.ts` | Pixi project detection, read-only dep display |
 | `DenoDependencyHeader.tsx` | `useDenoDependencies.ts` | Deno configuration and deno.json detection |
 
 ## Key Files

--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -165,7 +165,7 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
 | `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml detection |
 | `PixiDependencyHeader.tsx` | `usePixiDetection.ts` | Pixi project detection, read-only dep display |
-| `DenoDependencyHeader.tsx` | `useDenoDependencies.ts` | Deno configuration and deno.json detection |
+| `DenoDependencyHeader.tsx` | `useDenoConfig.ts` | Deno configuration and deno.json detection |
 
 ## Key Files
 

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -123,7 +123,7 @@ daemon-owned detection in subsequent PRs. See
 | `usePresence` | Remote cursor/selection tracking via presence frames |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
-| `usePixiDependencies` | Pixi/conda dependency management |
+| `usePixiDetection` | Pixi project detection (pixi.toml is the source of truth) |
 | `usePoolState` | Daemon pool state via PoolDoc sync |
 | `useCrdtBridge` | CodeMirror ↔ CRDT character-level sync |
 | `useManifestResolver` | Resolves blob hashes to output data |

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -28,7 +28,7 @@ import { useAutomergeNotebook } from "./hooks/useAutomergeNotebook";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { CrdtBridgeProvider } from "./hooks/useCrdtBridge";
 import { useDaemonKernel } from "./hooks/useDaemonKernel";
-import { useDenoDependencies } from "./hooks/useDenoDependencies";
+import { useDenoConfig } from "./hooks/useDenoConfig";
 import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
@@ -283,7 +283,7 @@ function AppContent() {
   const { pixiInfo } = usePixiDetection();
 
   // Deno config detection and settings
-  const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } = useDenoDependencies();
+  const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } = useDenoConfig();
 
   // Get widget store for CRDT → WidgetStore projection.
   // Set the module-level ref so the updateManager can access it.

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -34,7 +34,7 @@ import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useGlobalFind } from "./hooks/useGlobalFind";
 import { resolveOutputValue } from "./hooks/useManifestResolver";
-import { usePixiDependencies } from "./hooks/usePixiDependencies";
+import { usePixiDetection } from "./hooks/usePixiDetection";
 import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
@@ -280,7 +280,7 @@ function AppContent() {
   } = useCondaDependencies();
 
   // Pixi project detection
-  const { pixiInfo } = usePixiDependencies();
+  const { pixiInfo } = usePixiDetection();
 
   // Deno config detection and settings
   const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } = useDenoDependencies();

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -1,7 +1,7 @@
 import { Check, ExternalLink, FileText, Info, Package, RefreshCw } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import type { DenoConfigInfo } from "../hooks/useDenoDependencies";
+import type { DenoConfigInfo } from "../hooks/useDenoConfig";
 
 interface DenoDependencyHeaderProps {
   denoConfigInfo: DenoConfigInfo | null;

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -97,78 +97,55 @@ export function useCondaDependencies() {
     }
   }, []);
 
-  const addDependency = useCallback(
-    async (pkg: string) => {
-      if (!pkg.trim()) return;
+  // Wrap a mutating WASM op with the shared loading + trust-resign + error log
+  // shape. `label` appears in the error message so grep still works.
+  const withTrustResign = useCallback(
+    async (op: () => Promise<void>, label: string) => {
       setLoading(true);
       try {
-        await addCondaDepWasm(pkg.trim());
+        await op();
         await resignTrust();
       } catch (e) {
-        logger.error("Failed to add conda dependency:", e);
+        logger.error(`Failed to ${label}:`, e);
       } finally {
         setLoading(false);
       }
     },
     [resignTrust],
+  );
+
+  const addDependency = useCallback(
+    async (pkg: string) => {
+      if (!pkg.trim()) return;
+      await withTrustResign(() => addCondaDepWasm(pkg.trim()), "add conda dependency");
+    },
+    [withTrustResign],
   );
 
   const removeDependency = useCallback(
     async (pkg: string) => {
-      setLoading(true);
-      try {
-        await removeCondaDepWasm(pkg);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to remove conda dependency:", e);
-      } finally {
-        setLoading(false);
-      }
+      await withTrustResign(() => removeCondaDepWasm(pkg), "remove conda dependency");
     },
-    [resignTrust],
+    [withTrustResign],
   );
 
   // Remove the entire conda dependency section from notebook metadata
   const clearAllDependencies = useCallback(async () => {
-    setLoading(true);
-    try {
-      await clearCondaSection();
-      await resignTrust();
-    } catch (e) {
-      logger.error("Failed to clear conda dependencies:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, [resignTrust]);
+    await withTrustResign(() => clearCondaSection(), "clear conda dependencies");
+  }, [withTrustResign]);
 
   const setChannels = useCallback(
     async (channels: string[]) => {
-      setLoading(true);
-      try {
-        await setCondaChannelsWasm(channels);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to set channels:", e);
-      } finally {
-        setLoading(false);
-      }
+      await withTrustResign(() => setCondaChannelsWasm(channels), "set channels");
     },
-    [resignTrust],
+    [withTrustResign],
   );
 
   const setPython = useCallback(
     async (version: string | null) => {
-      setLoading(true);
-      try {
-        await setCondaPythonWasm(version);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to set python version:", e);
-      } finally {
-        setLoading(false);
-      }
+      await withTrustResign(() => setCondaPythonWasm(version), "set python version");
     },
-    [resignTrust],
+    [withTrustResign],
   );
 
   const hasDependencies = dependencies !== null && dependencies.dependencies.length > 0;

--- a/apps/notebook/src/hooks/useDenoConfig.ts
+++ b/apps/notebook/src/hooks/useDenoConfig.ts
@@ -15,7 +15,7 @@ export interface DenoConfigInfo {
   has_tasks: boolean;
 }
 
-export function useDenoDependencies() {
+export function useDenoConfig() {
   const [denoConfigInfo, setDenoConfigInfo] = useState<DenoConfigInfo | null>(null);
   // Reactive read from the WASM Automerge doc via useSyncExternalStore.
   // Re-renders automatically when the doc changes (bootstrap, sync, writes).

--- a/apps/notebook/src/hooks/usePixiDetection.ts
+++ b/apps/notebook/src/hooks/usePixiDetection.ts
@@ -10,7 +10,7 @@ import type { PixiInfo } from "../types";
  * Pixi dependencies are managed via `pixi add`/`pixi remove` in the terminal,
  * not through the notebook metadata — pixi.toml is the source of truth.
  */
-export function usePixiDependencies() {
+export function usePixiDetection() {
   const [pixiInfo, setPixiInfo] = useState<PixiInfo | null>(null);
 
   useEffect(() => {

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -527,7 +527,7 @@ Three UI components manage dependencies for different runtimes:
 |-----------|------|---------|
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
 | `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml and pixi.toml detection |
-| `DenoDependencyHeader.tsx` | `useDenoDependencies.ts` | Deno configuration and deno.json detection |
+| `DenoDependencyHeader.tsx` | `useDenoConfig.ts` | Deno configuration and deno.json detection |
 
 The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 - Listens for `notebook:broadcast` events (re-emitted by `useAutomergeNotebook` after WASM frame demux)

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -179,7 +179,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 | `useHistorySearch` | Kernel input history search |
 | `useTrust` | Notebook trust verification state |
 | `useUpdater` | App update checking and installation |
-| `usePixiDependencies` | Pixi/conda dependency management |
+| `usePixiDetection` | Pixi project detection (pixi.toml is the source of truth) |
 | `usePoolState` | Daemon pool state |
 | `useCrdtBridge` | CodeMirror ↔ CRDT character-level sync |
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -170,7 +170,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 | `useEnvProgress` | Environment setup progress tracking |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
-| `useDenoDependencies` | Deno dependency management |
+| `useDenoConfig` | Deno config detection plus flexible-npm-imports toggle |
 | `useManifestResolver` | Resolves blob hashes to output data |
 | `useCellKeyboardNavigation` | Arrow keys, enter/escape modes |
 | `useEditorRegistry` | CodeMirror editor instance registry |

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -119,7 +119,7 @@ export interface HostTrust {
  * Dependency-validation surface.
  *
  * This namespace will grow as we migrate dep-edit flows
- * (useDependencies, useCondaDependencies, usePixiDependencies,
+ * (useDependencies, useCondaDependencies, usePixiDetection,
  * useDenoDependencies) off direct `invoke(...)`. `checkTyposquats`
  * lives here and not in `HostTrust` because it validates package
  * names, not notebook attestation.

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -120,7 +120,7 @@ export interface HostTrust {
  *
  * This namespace will grow as we migrate dep-edit flows
  * (useDependencies, useCondaDependencies, usePixiDetection,
- * useDenoDependencies) off direct `invoke(...)`. `checkTyposquats`
+ * useDenoConfig) off direct `invoke(...)`. `checkTyposquats`
  * lives here and not in `HostTrust` because it validates package
  * names, not notebook attestation.
  */


### PR DESCRIPTION
## Summary

Three frontend-hook names lied about what the hooks did. Fix that, plus a small internal duplication in `useCondaDependencies`. Three commits, one PR, no behavior change.

- `usePixiDependencies` -> `usePixiDetection`. The hook detects `pixi.toml` and returns its info. Pixi deps are managed via `pixi add`/`pixi remove`; the `pixi.toml` is the source of truth. The old name advertised behavior the file deliberately does not do.
- `useDenoDependencies` -> `useDenoConfig`. The hook does `deno.json` detection plus one `flexibleNpmImports` toggle. Not dep management. `DenoDependencyHeader` keeps its name since it's the visible UI shell around the config banner and import examples; renaming ripples into user-facing things that are out of scope here.
- `useCondaDependencies`: five mutating methods (`addDependency`, `removeDependency`, `clearAllDependencies`, `setChannels`, `setPython`) shared the exact same `setLoading` + try/catch + `resignTrust` + finally shape. Extract one local `withTrustResign(op, label)` helper. Method signatures and return types are unchanged.

## Callers touched

- `apps/notebook/src/App.tsx`: two hook imports plus two call sites.
- `apps/notebook/src/components/DenoDependencyHeader.tsx`: one type-only import.
- Docs: `contributing/frontend-architecture.md`, `contributing/environments.md`, `.claude/rules/frontend-architecture.md`, `.claude/rules/environments.md`, and a comment in `packages/notebook-host/src/types.ts`.

## Verification

- `cargo xtask lint --fix` - clean.
- `npx tsc -b` in `apps/notebook` - no errors.
- `pnpm test:run` - 54 files, 1057 passed, 3 skipped.
- `codex review --base main` - "did not find any code changes here that introduce a validated behavioral regression".

## Test plan

- [x] Typecheck passes (`apps/notebook` tsc -b)
- [x] Lint passes (`cargo xtask lint --fix`)
- [x] Frontend unit tests pass (`pnpm test:run`)
- [x] Codex review clean
- [ ] Smoke-check in the app: open a notebook with conda deps, add/remove one package, confirm no behavior change. (Not run here; GUI launch from agent session.)
