### PR TITLE
refactor(runtimed): centralize path helpers in paths.rs

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -27,14 +27,12 @@ use crate::blob_server;
 use crate::blob_store::BlobStore;
 use crate::connection::{self, Handshake};
 use crate::notebook_sync_server::{NotebookRooms, PathIndex};
+use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
 use crate::settings_doc::SettingsDoc;
 use crate::singleton::DaemonLock;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
-use crate::{
-    default_blob_store_dir, default_cache_dir, default_socket_path, is_pool_env_dir,
-    is_within_cache_dir, pool_env_root, EnvType, PooledEnv,
-};
+use crate::{default_blob_store_dir, is_pool_env_dir, is_within_cache_dir, EnvType, PooledEnv};
 use runtimed_client::singleton::DaemonInfo;
 
 /// Configuration for the pool daemon.
@@ -1789,7 +1787,7 @@ impl Daemon {
             Ok(())
         }
 
-        if looks_like_untitled_notebook_path(&path) {
+        if crate::paths::looks_like_untitled_notebook_path(&path) {
             let (_reader, mut writer) = tokio::io::split(stream);
             send_error_response(
                 &mut writer,
@@ -2617,7 +2615,7 @@ impl Daemon {
                     }
                 } else {
                     // No active room - try to load from persisted file
-                    let filename = crate::notebook_doc::notebook_doc_filename(&notebook_id);
+                    let filename = crate::paths::notebook_doc_filename(&notebook_id);
                     let persist_path = self.config.notebook_docs_dir.join(filename);
                     if persist_path.exists() {
                         match std::fs::read(&persist_path) {
@@ -2908,7 +2906,7 @@ impl Daemon {
                 let active_rooms = self.notebook_rooms.lock().await;
                 let active_hashes: std::collections::HashSet<String> = active_rooms
                     .keys()
-                    .map(|id| notebook_doc::notebook_doc_filename(&id.to_string()))
+                    .map(|id| crate::paths::notebook_doc_filename(&id.to_string()))
                     .collect();
                 drop(active_rooms);
 
@@ -3226,7 +3224,7 @@ impl Daemon {
         if notebook_docs_dir.exists() {
             let active_filenames: std::collections::HashSet<String> = rooms
                 .iter()
-                .map(|(id, _)| notebook_doc::notebook_doc_filename(id))
+                .map(|(id, _)| crate::paths::notebook_doc_filename(id))
                 .collect();
 
             let mut persisted_paths: Vec<PathBuf> = Vec::new();
@@ -4645,13 +4643,6 @@ impl Daemon {
     }
 }
 
-fn looks_like_untitled_notebook_path(path: &str) -> bool {
-    let candidate = Path::new(path);
-    candidate.components().count() == 1
-        && candidate.extension().is_none()
-        && uuid::Uuid::parse_str(path).is_ok()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5596,7 +5587,7 @@ mod tests {
         assets.insert("image.png".to_string(), blob_hash.to_string());
         doc.set_cell_resolved_assets(cell_id, &assets).unwrap();
 
-        let filename = notebook_doc::notebook_doc_filename(notebook_id);
+        let filename = crate::paths::notebook_doc_filename(notebook_id);
         let path = docs_dir.join(filename);
         std::fs::create_dir_all(docs_dir).unwrap();
         std::fs::write(&path, doc.save()).unwrap();
@@ -5744,18 +5735,5 @@ mod tests {
             blob_store.get(&hash).await.unwrap().is_some(),
             "unreferenced blob within grace should survive"
         );
-    }
-
-    #[test]
-    fn bare_uuid_path_is_rejected() {
-        assert!(looks_like_untitled_notebook_path(
-            "550e8400-e29b-41d4-a716-446655440000"
-        ));
-        assert!(!looks_like_untitled_notebook_path(
-            "/tmp/550e8400-e29b-41d4-a716-446655440000"
-        ));
-        assert!(!looks_like_untitled_notebook_path(
-            "550e8400-e29b-41d4-a716-446655440000.ipynb"
-        ));
     }
 }

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -35,6 +35,7 @@ pub mod markdown_assets;
 pub mod notebook_sync_server;
 pub mod output_prep;
 pub mod output_store;
+pub mod paths;
 pub mod process_groups;
 pub mod project_file;
 pub mod runtime_agent;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -40,9 +40,10 @@ use notify_debouncer_mini::DebounceEventResult;
 use crate::blob_store::BlobStore;
 use crate::connection::{self, NotebookFrameType};
 use crate::markdown_assets::resolve_markdown_assets;
-use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
+use crate::notebook_doc::{CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
+use crate::paths::notebook_doc_filename;
 use crate::protocol::{
     EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
@@ -1202,77 +1203,6 @@ pub struct NotebookRoom {
     pub current_runtime_agent_id: Arc<RwLock<Option<String>>>,
 }
 
-/// Maximum number of snapshots to keep per notebook hash.
-const MAX_SNAPSHOTS_PER_NOTEBOOK: usize = 5;
-
-/// Snapshot a persisted automerge doc before deleting it.
-///
-/// Copies the file to `{docs_dir}/snapshots/{stem}-{millis}.automerge`
-/// and prunes old snapshots beyond `MAX_SNAPSHOTS_PER_NOTEBOOK`.
-///
-/// Returns `true` if the snapshot was created successfully. The caller
-/// should only delete the original file when this returns `true`.
-fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bool {
-    let Some(stem) = persist_path.file_stem().and_then(|s| s.to_str()) else {
-        return false;
-    };
-
-    let snapshots_dir = docs_dir.join("snapshots");
-    if let Err(e) = std::fs::create_dir_all(&snapshots_dir) {
-        warn!(
-            "[notebook-sync] Failed to create snapshots dir {:?}: {}",
-            snapshots_dir, e
-        );
-        return false;
-    }
-
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let snapshot_name = format!("{}-{}.automerge", stem, timestamp);
-    let snapshot_path = snapshots_dir.join(&snapshot_name);
-
-    match std::fs::copy(persist_path, &snapshot_path) {
-        Ok(_) => {
-            info!(
-                "[notebook-sync] Snapshotted persisted doc before refresh: {:?}",
-                snapshot_path
-            );
-        }
-        Err(e) => {
-            warn!(
-                "[notebook-sync] Failed to snapshot {:?}: {}",
-                persist_path, e
-            );
-            return false;
-        }
-    }
-
-    // Prune old snapshots for this hash (keep most recent MAX_SNAPSHOTS_PER_NOTEBOOK)
-    let prefix = format!("{}-", stem);
-    let mut snapshots: Vec<_> = std::fs::read_dir(&snapshots_dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".automerge"))
-        })
-        .collect();
-
-    if snapshots.len() > MAX_SNAPSHOTS_PER_NOTEBOOK {
-        // Sort by filename (which embeds timestamp) — ascending order
-        snapshots.sort_by_key(|e| e.file_name());
-        for entry in &snapshots[..snapshots.len() - MAX_SNAPSHOTS_PER_NOTEBOOK] {
-            let _ = std::fs::remove_file(entry.path());
-        }
-    }
-
-    true
-}
-
 impl NotebookRoom {
     /// Create a fresh room, ignoring any persisted state.
     ///
@@ -1314,7 +1244,7 @@ impl NotebookRoom {
             NotebookDoc::load_or_create_with_actor(&persist_path, &notebook_id_str, runtimed_actor)
         } else {
             if !ephemeral && persist_path.exists() {
-                if snapshot_before_delete(&persist_path, docs_dir) {
+                if crate::paths::snapshot_before_delete(&persist_path, docs_dir) {
                     let _ = std::fs::remove_file(&persist_path);
                 } else {
                     warn!(
@@ -2558,8 +2488,8 @@ where
                                 path
                             );
                         } else {
-                            let root = crate::pool_env_root(path);
-                            let cache_dir = crate::default_cache_dir();
+                            let root = crate::paths::pool_env_root(path);
+                            let cache_dir = crate::paths::default_cache_dir();
                             if !crate::is_within_cache_dir(&root, &cache_dir) {
                                 warn!(
                                     "[notebook-sync] Refusing to delete env {:?} on eviction (not within cache dir)",
@@ -4532,8 +4462,8 @@ async fn try_uv_pool_for_inline_deps(
                     );
                     // Clean up the taken pool env — it's out of the pool's
                     // tracking and would otherwise leak on disk.
-                    let root = crate::pool_env_root(&env.venv_path);
-                    let cache_dir = crate::default_cache_dir();
+                    let root = crate::paths::pool_env_root(&env.venv_path);
+                    let cache_dir = crate::paths::default_cache_dir();
                     if crate::is_within_cache_dir(&root, &cache_dir) {
                         if let Err(e) = tokio::fs::remove_dir_all(&root).await {
                             warn!(
@@ -4549,8 +4479,8 @@ async fn try_uv_pool_for_inline_deps(
         crate::inline_env::PoolDepRelation::Independent => {
             // Shouldn't reach here (pre-check above), but handle gracefully
             debug!("[notebook-sync] UV pool env doesn't match inline deps, falling back");
-            let root = crate::pool_env_root(&env.venv_path);
-            let cache_dir = crate::default_cache_dir();
+            let root = crate::paths::pool_env_root(&env.venv_path);
+            let cache_dir = crate::paths::default_cache_dir();
             if crate::is_within_cache_dir(&root, &cache_dir) {
                 if let Err(e) = tokio::fs::remove_dir_all(&root).await {
                     warn!(
@@ -4652,8 +4582,8 @@ async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Failed to install delta into Conda pool env: {}, falling back",
                         e
                     );
-                    let root = crate::pool_env_root(&env.venv_path);
-                    let cache_dir = crate::default_cache_dir();
+                    let root = crate::paths::pool_env_root(&env.venv_path);
+                    let cache_dir = crate::paths::default_cache_dir();
                     if crate::is_within_cache_dir(&root, &cache_dir) {
                         if let Err(e) = tokio::fs::remove_dir_all(&root).await {
                             warn!(
@@ -4668,8 +4598,8 @@ async fn try_conda_pool_for_inline_deps(
         }
         crate::inline_env::PoolDepRelation::Independent => {
             debug!("[notebook-sync] Conda pool env doesn't match inline deps, falling back");
-            let root = crate::pool_env_root(&env.venv_path);
-            let cache_dir = crate::default_cache_dir();
+            let root = crate::paths::pool_env_root(&env.venv_path);
+            let cache_dir = crate::paths::default_cache_dir();
             if crate::is_within_cache_dir(&root, &cache_dir) {
                 if let Err(e) = tokio::fs::remove_dir_all(&root).await {
                     warn!(
@@ -6470,7 +6400,8 @@ async fn handle_notebook_request(
                                 )
                             } else {
                                 // No name or prefix — use a hash-based env in cache
-                                let cache_dir = crate::default_cache_dir().join("conda-envs");
+                                let cache_dir =
+                                    crate::paths::default_cache_dir().join("conda-envs");
                                 let conda_deps_tmp = kernel_env::CondaDependencies {
                                     dependencies: env_config.dependencies.clone(),
                                     channels: env_config.channels.clone(),
@@ -7479,7 +7410,7 @@ async fn handle_notebook_request(
             // is required; for file-backed rooms we only need a pre-write claim
             // if the caller specified a path different from room.path.
             let target_for_claim: Option<PathBuf> = match (&path, was_untitled) {
-                (Some(p), _) => match normalize_save_target(p) {
+                (Some(p), _) => match crate::paths::normalize_save_target(p) {
                     Ok(normalized) => Some(canonical_target_path(&normalized).await),
                     Err(msg) => {
                         return NotebookResponse::SaveError {
@@ -8722,23 +8653,6 @@ async fn canonical_target_path(target: &Path) -> PathBuf {
         }
     }
     target.to_path_buf()
-}
-
-/// Normalize a user-supplied save target: append `.ipynb` if missing, reject
-/// relative paths, and return the path that `save_notebook_to_disk` will use.
-fn normalize_save_target(target: &str) -> Result<PathBuf, String> {
-    let path = PathBuf::from(target);
-    if path.is_relative() {
-        return Err(format!(
-            "Relative paths are not supported for save: '{}'. Please provide an absolute path.",
-            target
-        ));
-    }
-    Ok(if target.ends_with(".ipynb") {
-        path
-    } else {
-        PathBuf::from(format!("{}.ipynb", target))
-    })
 }
 
 /// Try to claim a path in the path_index for a given room. Returns the

--- a/crates/runtimed/src/paths.rs
+++ b/crates/runtimed/src/paths.rs
@@ -1,0 +1,180 @@
+//! Centralized path helpers for the `runtimed` crate — socket, cache, env, and
+//! notebook-doc paths live here so callers have one module to look at instead
+//! of a scatter across `daemon.rs` and `notebook_sync_server.rs`.
+//!
+//! Most entries are re-exports of helpers that live in upstream crates
+//! (`runt-workspace`, `runtimed-client`, `notebook-doc`) — the point is
+//! discoverability, not duplication. Genuinely local helpers
+//! (e.g. [`snapshot_before_delete`], [`normalize_save_target`]) live here in
+//! full.
+//!
+//! Keep this module behaviour-preserving. New path logic is fine; silently
+//! drifting from the upstream helpers is not.
+
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+// ---------------------------------------------------------------------------
+// Re-exports from upstream crates — single entry point for runtimed callers.
+// ---------------------------------------------------------------------------
+
+/// Default daemon socket path (honours `RUNTIMED_SOCKET_PATH`).
+///
+/// Re-exported from `runt_workspace`.
+pub use runt_workspace::default_socket_path;
+
+/// Default cache directory for environments (`<daemon_base_dir>/envs`).
+///
+/// Re-exported from `runtimed_client` (originally defined there because
+/// `runtimed-client` owns daemon-path conventions shared with the CLI and
+/// Python bindings).
+pub use runtimed_client::default_cache_dir;
+
+/// Walk up from a pool env's `venv_path` to the top-level
+/// `runtimed-{uv,conda,pixi}-*` directory.
+///
+/// Re-exported from `runtimed_client`.
+pub use runtimed_client::pool_env_root;
+
+/// Deterministic filename for a notebook's persisted Automerge doc.
+///
+/// Re-exported from `notebook_doc` (behind the `persistence` feature).
+pub use notebook_doc::notebook_doc_filename;
+
+// ---------------------------------------------------------------------------
+// Local helpers — moved from daemon.rs / notebook_sync_server.rs.
+// ---------------------------------------------------------------------------
+
+/// Maximum number of snapshots to keep per notebook hash.
+const MAX_SNAPSHOTS_PER_NOTEBOOK: usize = 5;
+
+/// Snapshot a persisted automerge doc before deleting it.
+///
+/// Copies the file to `{docs_dir}/snapshots/{stem}-{millis}.automerge`
+/// and prunes old snapshots beyond `MAX_SNAPSHOTS_PER_NOTEBOOK`.
+///
+/// Returns `true` if the snapshot was created successfully. The caller
+/// should only delete the original file when this returns `true`.
+pub(crate) fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bool {
+    let Some(stem) = persist_path.file_stem().and_then(|s| s.to_str()) else {
+        return false;
+    };
+
+    let snapshots_dir = docs_dir.join("snapshots");
+    if let Err(e) = std::fs::create_dir_all(&snapshots_dir) {
+        warn!(
+            "[notebook-sync] Failed to create snapshots dir {:?}: {}",
+            snapshots_dir, e
+        );
+        return false;
+    }
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let snapshot_name = format!("{}-{}.automerge", stem, timestamp);
+    let snapshot_path = snapshots_dir.join(&snapshot_name);
+
+    match std::fs::copy(persist_path, &snapshot_path) {
+        Ok(_) => {
+            info!(
+                "[notebook-sync] Snapshotted persisted doc before refresh: {:?}",
+                snapshot_path
+            );
+        }
+        Err(e) => {
+            warn!(
+                "[notebook-sync] Failed to snapshot {:?}: {}",
+                persist_path, e
+            );
+            return false;
+        }
+    }
+
+    // Prune old snapshots for this hash (keep most recent MAX_SNAPSHOTS_PER_NOTEBOOK)
+    let prefix = format!("{}-", stem);
+    let mut snapshots: Vec<_> = std::fs::read_dir(&snapshots_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".automerge"))
+        })
+        .collect();
+
+    if snapshots.len() > MAX_SNAPSHOTS_PER_NOTEBOOK {
+        // Sort by filename (which embeds timestamp) — ascending order
+        snapshots.sort_by_key(|e| e.file_name());
+        for entry in &snapshots[..snapshots.len() - MAX_SNAPSHOTS_PER_NOTEBOOK] {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+
+    true
+}
+
+/// Normalize a user-supplied save target: append `.ipynb` if missing, reject
+/// relative paths, and return the path that `save_notebook_to_disk` will use.
+pub(crate) fn normalize_save_target(target: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(target);
+    if path.is_relative() {
+        return Err(format!(
+            "Relative paths are not supported for save: '{}'. Please provide an absolute path.",
+            target
+        ));
+    }
+    Ok(if target.ends_with(".ipynb") {
+        path
+    } else {
+        PathBuf::from(format!("{}.ipynb", target))
+    })
+}
+
+/// Returns true if `path` looks like a bare UUID with no extension and no
+/// parent components — the shape daemon-side code produces for untitled
+/// notebooks. Used as a guard before treating a path string as a real file.
+pub(crate) fn looks_like_untitled_notebook_path(path: &str) -> bool {
+    let candidate = Path::new(path);
+    candidate.components().count() == 1
+        && candidate.extension().is_none()
+        && uuid::Uuid::parse_str(path).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_uuid_looks_untitled() {
+        assert!(looks_like_untitled_notebook_path(
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(!looks_like_untitled_notebook_path(
+            "/tmp/550e8400-e29b-41d4-a716-446655440000"
+        ));
+        assert!(!looks_like_untitled_notebook_path(
+            "550e8400-e29b-41d4-a716-446655440000.ipynb"
+        ));
+    }
+
+    #[test]
+    fn normalize_save_target_appends_extension() {
+        let result = normalize_save_target("/tmp/foo").unwrap();
+        assert_eq!(result, PathBuf::from("/tmp/foo.ipynb"));
+    }
+
+    #[test]
+    fn normalize_save_target_preserves_extension() {
+        let result = normalize_save_target("/tmp/foo.ipynb").unwrap();
+        assert_eq!(result, PathBuf::from("/tmp/foo.ipynb"));
+    }
+
+    #[test]
+    fn normalize_save_target_rejects_relative() {
+        assert!(normalize_save_target("foo.ipynb").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Path helpers were scattered across `daemon.rs` (5.7k lines) and `notebook_sync_server.rs` (15.6k lines) with no shared home. Each caller reached into a different upstream crate — `runtimed-client` for cache/pool paths, `runt-workspace` for the socket, `notebook-doc` for the doc filename — via a direct absolute import, plus two local path helpers buried in the god files. Small drift risk and a real navigation hazard.

Collect the single source of truth into `crates/runtimed/src/paths.rs`.

## Changes

New module `crates/runtimed/src/paths.rs`:

- **Re-exports** (single entry point, upstream crates untouched):
  - `default_socket_path` (from `runt_workspace`)
  - `default_cache_dir` (from `runtimed_client`)
  - `pool_env_root` (from `runtimed_client`)
  - `notebook_doc_filename` (from `notebook_doc`, `persistence` feature)
- **Moved** (behaviour-preserving, private → `pub(crate)`):
  - `snapshot_before_delete` (from `notebook_sync_server.rs:1215`)
  - `normalize_save_target` (from `notebook_sync_server.rs:8729`)
  - `looks_like_untitled_notebook_path` (from `daemon.rs:4648`, plus its inline `#[cfg(test)]` block)

All in-crate call sites now go through `crate::paths::*`. No logic changes.

## Scope note

The task spec listed `default_socket_path`, `default_cache_dir`, and `pool_env_root` as living in `daemon.rs` and `notebook_doc_filename` as living in `notebook_sync_server.rs`. In reality they live upstream (`runt-workspace`, `runtimed-client`, `notebook-doc`) and the god files only import them. The task also says "don't touch `crates/runtimed-client/src/` path helpers" — so I kept the upstream definitions in place and made `paths.rs` a single-entry-point re-export hub instead of a new copy. The only function that actually lived locally from the list is `snapshot_before_delete`.

**Moved: 3.** Re-exported: 4. Total entries surfaced through `crate::paths::*`: 7.

## Follow-up candidates (not in this PR)

Other free helpers in the two god files that don't cleanly fit "paths" but could use a dedicated home in a future pass:

- `is_untitled_notebook` in `notebook_sync_server.rs` — UUID-string predicate, belongs with notebook-id utilities
- `canonical_target_path` and `try_claim_path` in `notebook_sync_server.rs` — save-path logic that pairs with `normalize_save_target`; could move to `paths` or a dedicated `save_path` helper
- `sanitize_peer_label`, `formatter_actor` in `notebook_sync_server.rs` — string helpers unrelated to paths
- Private path-ish helpers in `process_groups.rs` (`registry_path`, `legacy_registry_path`) and `project_file.rs` (`default_conda_envs_dir`, `conda_python_path`) are already in focused modules — leave them.

## Codex review

`codex review --base main` from the worktree kept failing with "currently experiencing high demand" over four retries (session ids `019dad21…`, `019dad23…`, `019dad24…`, `019dad25…`). Opening as draft so the review can be re-run when the API recovers; marking ready once it returns a clean verdict.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p runtimed --all-targets` — clean
- [x] `cargo test -p runtimed --lib` — 380 passed, 0 failed
- [x] `cargo test -p runtimed --tests` — 25 + 11 + 1 passed across integration suites
- [x] `cargo xtask lint --fix` — no diff against this PR (pre-existing `runtimed-node` clippy hit is unrelated)
- [ ] `codex review --base main` — API outage during attempts, pending retry
