### PR TITLE
fix(tests): tune CI-load timeouts for sync and execute flakes

### DIFF
--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -105,11 +105,24 @@ async fn wait_for_daemon(client: &PoolClient, timeout: Duration) -> bool {
 ///
 /// Per architecture rules (see `.claude/rules/architecture.md` § "No
 /// Independent `put_object` on Shared Keys"), only the daemon creates
-/// the `cells` / `metadata` maps at room creation — client peers receive
+/// the `cells` / `metadata` maps at room creation. Client peers receive
 /// them via sync. Mutations like `add_cell_after` panic with
 /// `InvalidObjId("cells map not found")` if called before that sync
 /// frame arrives, which is a flaky race under loaded CI. Poll the
 /// client's local Automerge doc until the cells map object is visible.
+///
+/// Why a client-side poll at all: `do_initial_sync` in
+/// `crates/notebook-sync/src/connect.rs` declares convergence via an
+/// idle-timeout heuristic (100ms of silence from the peer) rather than
+/// a protocol-level "initial sync complete" signal. Automerge sync
+/// frames can arrive in multiple rounds with arbitrary spacing; under
+/// loaded CI a 100ms gap can appear mid-sync, so `do_initial_sync`
+/// returns before the cells map frame has been applied. This helper is
+/// the test-side fallback. The proper fix is a protocol-level
+/// completion marker on the sync frames themselves, tracked as an
+/// architecture-review follow-up (see arch review task #8 measurement
+/// track). Until then the timeout needs enough slack to absorb a
+/// loaded CI runner mid-compile.
 async fn wait_for_cells_map(handle: &notebook_sync::DocHandle, timeout: Duration) -> bool {
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
@@ -1231,8 +1244,8 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // mutate it. Otherwise `add_cell_after` panics with
     // `InvalidObjId("cells map not found")` — a flake under loaded CI.
     assert!(
-        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
-        "initial sync did not deliver the cells map within 2s"
+        wait_for_cells_map(&client2, Duration::from_secs(10)).await,
+        "initial sync did not deliver the cells map within 10s"
     );
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2
@@ -1455,8 +1468,8 @@ async fn test_pipe_mode_preserves_frame_order() {
     // mutate it. Otherwise `add_cell_after` panics with
     // `InvalidObjId("cells map not found")` — a flake under loaded CI.
     assert!(
-        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
-        "initial sync did not deliver the cells map within 2s"
+        wait_for_cells_map(&client2, Duration::from_secs(10)).await,
+        "initial sync did not deliver the cells map within 10s"
     );
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1998,7 +1998,15 @@ class TestExecuteCell:
         cell = await notebook.cells.create("for i in range(3): print(f'line {i}')")
         await asyncio.sleep(0.5)
 
-        result = await cell.run(timeout_secs=30.0)
+        # timeout_secs=90.0 (not 30) across this file: on loaded CI runners
+        # (compile jobs running alongside), first-execute latency can stretch
+        # past 30s even though notebook.start() already blocks on kernel-idle.
+        # The kernel-boot cost is paid inside start(), but pool contention and
+        # I/O on a loaded runner can still slow the first roundtrip. The
+        # deeper fix is a kernel-ready signal that discriminates "idle" from
+        # "idle and warm," tracked as arch review task #8. Until then, a
+        # generous timeout matches observed CI reality.
+        result = await cell.run(timeout_secs=90.0)
 
         assert result.success, f"Expected success, got error: {result.error}"
         assert "line 0" in result.stdout
@@ -2012,7 +2020,7 @@ class TestExecuteCell:
         cell = await notebook.cells.create("raise ValueError('test error')")
         await asyncio.sleep(0.5)
 
-        result = await cell.run(timeout_secs=30.0)
+        result = await cell.run(timeout_secs=90.0)
 
         assert not result.success, "Expected failure"
         assert result.error is not None, "Expected error info"
@@ -2026,7 +2034,7 @@ class TestExecuteCell:
         cell = await notebook.cells.create("raise ValueError('persisted error')")
         await asyncio.sleep(0.5)
 
-        await cell.run(timeout_secs=30.0)
+        await cell.run(timeout_secs=90.0)
 
         error_outputs = [o for o in cell.outputs if o.output_type == "error"]
         assert len(error_outputs) > 0, "Error should be persisted in cell outputs"
@@ -2046,7 +2054,7 @@ class TestExecuteCell:
         assert len(execution.execution_id) == 36
         assert execution.cell_id == cell.id
 
-        result = await execution.result(timeout_secs=30.0)
+        result = await execution.result(timeout_secs=90.0)
         assert result.success
         assert "handle test" in result.stdout
 
@@ -2113,10 +2121,10 @@ class TestExecutionIdScoping:
         cell = await notebook.cells.create("print('run')")
         await asyncio.sleep(0.5)
 
-        r1 = await cell.run(timeout_secs=30.0)
+        r1 = await cell.run(timeout_secs=90.0)
         assert r1.success
 
-        r2 = await cell.run(timeout_secs=30.0)
+        r2 = await cell.run(timeout_secs=90.0)
         assert r2.success
 
         # execution_count is now in RuntimeStateDoc, not exposed via
@@ -2130,7 +2138,7 @@ class TestExecutionIdScoping:
         cell = await notebook.cells.create("print('scoped')")
         await asyncio.sleep(0.5)
 
-        result = await cell.run(timeout_secs=30.0)
+        result = await cell.run(timeout_secs=90.0)
 
         assert result.success
         assert "scoped" in result.stdout


### PR DESCRIPTION
## Diagnosis

Two integration tests flake under loaded CI runners. Same root cause theme: timing heuristics anchored in local-dev latency, which don't survive a compile job running in the same runner.

### `test_pipe_mode_forwards_sync_frames` (Rust)

Fails at `wait_for_cells_map(&client2, Duration::from_secs(2))`. The underlying limit is `do_initial_sync` in `crates/notebook-sync/src/connect.rs` (around line 799). It declares sync convergence via a 100ms idle-timeout heuristic, not a protocol-level "initial sync complete" signal. Automerge sync frames arrive in multiple rounds with arbitrary spacing; under load a 100ms gap can appear mid-sync and `do_initial_sync` returns before the daemon's `cells` map frame has been applied. The test-side `wait_for_cells_map` helper is a client-side fallback for exactly this race, but 2s isn't enough budget when a rustc invocation is saturating the box.

### `TestExecuteCell::test_cell_run_produces_outputs` and siblings (Python)

`cell.run(timeout_secs=30.0)` times out. Investigation of `notebook.start()` in `python/runtimed/src/runtimed/_notebook.py` and the corresponding Rust path (`session_core::start_kernel` -> `NotebookRequest::LaunchKernel` -> `RuntimeAgentRequest::LaunchKernel` -> `JupyterKernel::launch` followed by `state.set_idle()`) confirms that `start()` already blocks on kernel-idle before returning. The 30s timeout isn't paying for kernel boot. But on a loaded runner, pool contention and I/O can still push the first roundtrip past 30s. There's no pre-boot phase to move elsewhere, so the only honest fix is widening the budget.

## Why timeout bumps, not band-aids

The old values were anchored in unloaded local-dev latency. CI runs on box that's simultaneously compiling the workspace. Keeping the old 2s / 30s is the band-aid (false negatives on a healthy system); widening to match observed reality is the honest fix. Neither eliminates the underlying protocol-shaped limitation, but neither is pretending to.

## Changes

- `crates/runtimed/tests/integration.rs`: both `wait_for_cells_map(..., Duration::from_secs(2))` call sites bumped to 10s. Expanded the helper's doc comment to name the `do_initial_sync` idle-timeout heuristic and the protocol-level fix as arch-review follow-up.
- `python/runtimed/tests/test_daemon_integration.py`: every `timeout_secs=30.0` on `cell.run` / `execution.result` bumped to 90.0. One-time comment at the first site explaining the CI-load reality. The 120s warmup at line 1940 is untouched.

## Follow-ups (out of scope here)

- Protocol-level "initial sync complete" marker on the Automerge sync frames so `do_initial_sync` stops needing an idle-timeout heuristic. Tracked in arch review task #8 measurement track.
- Kernel-ready signal that distinguishes "idle" from "idle and warm," removing pool-contention slack from first-cell latency.

## Scope discipline

- Did not touch `do_initial_sync`.
- Did not touch pool warming or kernel-launch code.
- Did not change `notebook.start()` contract.
- No unrelated timeouts modified.

## Test plan

- [x] `cargo test -p runtimed --test integration test_pipe_mode_forwards_sync_frames` passes locally (unloaded, both 2s and 10s pass; change is for loaded CI).
- [x] `cargo xtask lint --fix` formats clean for touched crates. (Note: `runtimed-node` has a pre-existing clippy `implicit_saturating_sub` on `main` at `crates/runtimed-node/src/lib.rs:109` that's unrelated to this change.)
- [x] `codex review --base main`: clean, no findings.
- [ ] Watch CI for `test_pipe_mode_forwards_sync_frames` and `TestExecuteCell` reliability across the next few runs.
