### PR TITLE
fix(notebook-sync): add write timeout to prevent MCP deadlock on daemon socket stall

### DIFF
--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -29,6 +29,14 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use notebook_protocol::connection::{self, NotebookFrameType};
 use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
+/// Timeout for socket write operations.
+///
+/// If a `send_typed_frame` call blocks longer than this, the daemon
+/// connection is presumed dead (write buffer full, peer stopped
+/// reading) and the sync task should tear down rather than hang the
+/// entire MCP call chain indefinitely.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
 use automerge::AutoCommit;
 
 use crate::error::SyncError;
@@ -68,6 +76,33 @@ fn rebuild_shared_doc_state(state: &mut SharedDocState) {
             warn!("[notebook-sync] Failed to rebuild doc after panic: {}", e);
             state.peer_state = sync::State::new();
         }
+    }
+}
+
+/// Send a typed frame with [`WRITE_TIMEOUT`].
+///
+/// Returns `Err(io::ErrorKind::TimedOut)` if the write doesn't complete
+/// in time, which the caller converts to `SyncError::Io` (triggering a
+/// connection tear-down).
+async fn send_frame_bounded<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    frame_type: NotebookFrameType,
+    payload: &[u8],
+) -> std::io::Result<()> {
+    match tokio::time::timeout(
+        WRITE_TIMEOUT,
+        connection::send_typed_frame(writer, frame_type, payload),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_elapsed) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "send_typed_frame({:?}) blocked for >{:?} — daemon connection presumed dead",
+                frame_type, WRITE_TIMEOUT
+            ),
+        )),
     }
 }
 
@@ -200,12 +235,9 @@ where
                 };
 
                 if let Some(bytes) = msg_bytes {
-                    if let Err(e) = connection::send_typed_frame(
-                        &mut writer,
-                        NotebookFrameType::AutomergeSync,
-                        &bytes,
-                    )
-                    .await
+                    if let Err(e) =
+                        send_frame_bounded(&mut writer, NotebookFrameType::AutomergeSync, &bytes)
+                            .await
                     {
                         warn!(
                             "[notebook-sync] Failed to send sync message for {}: {}",
@@ -305,13 +337,10 @@ where
                     }
 
                     SyncCommand::SendPresence { data, reply } => {
-                        let result = connection::send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::Presence,
-                            &data,
-                        )
-                        .await
-                        .map_err(SyncError::Io);
+                        let result =
+                            send_frame_bounded(&mut writer, NotebookFrameType::Presence, &data)
+                                .await
+                                .map_err(SyncError::Io);
                         let _ = reply.send(result);
                     }
                 }
@@ -445,8 +474,7 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
             // Send ack if needed (outside the lock — never hold across I/O)
             if let Some(bytes) = ack_bytes {
                 if let Err(e) =
-                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
-                        .await
+                    send_frame_bounded(writer, NotebookFrameType::AutomergeSync, &bytes).await
                 {
                     warn!(
                         "[notebook-sync] Failed to send sync ack for {}: {}",
@@ -568,12 +596,8 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
             };
 
             if let Some(bytes) = reply_bytes {
-                if let Err(e) = connection::send_typed_frame(
-                    writer,
-                    NotebookFrameType::RuntimeStateSync,
-                    &bytes,
-                )
-                .await
+                if let Err(e) =
+                    send_frame_bounded(writer, NotebookFrameType::RuntimeStateSync, &bytes).await
                 {
                     warn!(
                         "[notebook-sync] Failed to send RuntimeStateSync reply for {}: {}",
@@ -613,7 +637,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     let payload =
         serde_json::to_vec(request).map_err(|e| SyncError::Serialization(e.to_string()))?;
 
-    connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
+    send_frame_bounded(writer, NotebookFrameType::Request, &payload)
         .await
         .map_err(SyncError::Io)?;
 
@@ -725,7 +749,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 publish_snapshot(doc, snapshot_tx);
 
                 if let Some(bytes) = ack_bytes {
-                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+                    send_frame_bounded(writer, NotebookFrameType::AutomergeSync, &bytes)
                         .await
                         .map_err(SyncError::Io)?;
                 }
@@ -790,7 +814,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
         // Send sync message if there is one
         if let Some(bytes) = msg_bytes {
-            connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+            send_frame_bounded(writer, NotebookFrameType::AutomergeSync, &bytes)
                 .await
                 .map_err(SyncError::Io)?;
         }
@@ -851,7 +875,7 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         state.generate_state_sync_message().map(|m| m.encode())
     };
     if let Some(bytes) = msg_bytes {
-        connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &bytes)
+        send_frame_bounded(writer, NotebookFrameType::RuntimeStateSync, &bytes)
             .await
             .map_err(SyncError::Io)?;
     }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -249,7 +249,8 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                 let serialized_item = serde_json::to_string(item).unwrap_or_default();
                 let item_bytes = serialized_item.len();
                 let preview = if serialized_item.len() > 200 {
-                    format!("{}...", &serialized_item[..200])
+                    let end = serialized_item.floor_char_boundary(200);
+                    format!("{}...", &serialized_item[..end])
                 } else {
                     serialized_item
                 };
@@ -280,7 +281,8 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                         .and_then(|sc| serde_json::to_string(sc).ok())
                         .unwrap_or_default();
                     let sc_preview = if sc_preview.len() > 500 {
-                        format!("{}...", &sc_preview[..500])
+                        let end = sc_preview.floor_char_boundary(500);
+                        format!("{}...", &sc_preview[..end])
                     } else {
                         sc_preview
                     };

--- a/crates/runtimed-node/src/parquet.rs
+++ b/crates/runtimed-node/src/parquet.rs
@@ -106,11 +106,7 @@ pub fn read_parquet_rows(
         }
 
         // Read rows from this batch
-        let start = if row_idx < offset {
-            offset - row_idx
-        } else {
-            0
-        };
+        let start = offset.saturating_sub(row_idx);
         let end = batch_rows.min(start + limit - rows.len());
 
         for r in start..end {


### PR DESCRIPTION
## Summary

- Add 5-second `WRITE_TIMEOUT` to all `send_typed_frame()` calls in `notebook-sync/src/sync_task.rs` via a new `send_frame_bounded()` helper
- Prevents indefinite MCP tool call hangs when the daemon socket stops reading (connection drop, process hang, kernel write buffer full)
- Fix pre-existing clippy `implicit_saturating_sub` warning in `runtimed-node/src/parquet.rs`

## Problem

All 8 `send_typed_frame()` call sites in the sync task had no write timeout. When the daemon stops reading, `writer.write_all()` blocks the sync task indefinitely, chaining through DocHandle → runt-mcp → rmcp → proxy → caller — an unrecoverable deadlock that silently freezes MCP tool calls like `create_cell(and_run=True)` for 40+ minutes.

The `timeout_secs` parameter on `create_cell`/`set_cell` was correctly wired into `await_execution_terminal`, but execution never reached that phase because the sync task was stuck on the socket write *before* the `ExecuteCell` request was even sent.

## Test plan

- [x] `cargo test -p notebook-sync` — 37/37 pass
- [x] `cargo xtask lint --fix` — all checks pass (Rust, JS/TS, Python)
- [x] `cargo xtask build --release` — full build succeeds
- [x] Nightly daemon installed and verified via `runt-nightly daemon status`
- [x] Gremlin suite replay: conda completed in 16 turns (was hung at 38), uv-data-scientist in 24 turns (was hung at 40), 17/19 gremlins clean, no deadlocks