### PR TITLE
fix(runt-mcp): UTF-8 safe string truncation in debug logger

### DIFF
--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -220,6 +220,18 @@ impl ServerHandler for NteractMcp {
     }
 }
 
+/// Truncate a string at the given byte limit, snapping to the nearest valid
+/// UTF-8 character boundary via [`str::floor_char_boundary`].
+///
+/// Returns the full string unchanged if it's within the limit.
+fn safe_truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..s.floor_char_boundary(max_bytes)])
+    }
+}
+
 /// Analyze and log an MCP tool response for SDK crash investigation.
 ///
 /// Logs payload size, content summary, problematic bytes, and timing at debug
@@ -248,14 +260,7 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
             for (i, item) in call_result.content.iter().enumerate() {
                 let serialized_item = serde_json::to_string(item).unwrap_or_default();
                 let item_bytes = serialized_item.len();
-                let preview = if serialized_item.len() > 200 {
-                    format!(
-                        "{}...",
-                        &serialized_item[..serialized_item.floor_char_boundary(200)]
-                    )
-                } else {
-                    serialized_item
-                };
+                let preview = safe_truncate(&serialized_item, 200);
                 item_summaries.push(format!("  [{i}] {item_bytes}B: {preview}"));
             }
 
@@ -282,11 +287,7 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                         .as_ref()
                         .and_then(|sc| serde_json::to_string(sc).ok())
                         .unwrap_or_default();
-                    let sc_preview = if sc_preview.len() > 500 {
-                        format!("{}...", &sc_preview[..sc_preview.floor_char_boundary(500)])
-                    } else {
-                        sc_preview
-                    };
+                    let sc_preview = safe_truncate(&sc_preview, 500);
                     tracing::warn!("[mcp-response] {tool_name} structured_content: {sc_preview}");
                 }
             } else {
@@ -309,5 +310,175 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                 err.message,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{CallToolResult, Content};
+
+    // ── safe_truncate unit tests ─────────────────────────────────────
+
+    #[test]
+    fn safe_truncate_short_string_unchanged() {
+        let s = "hello";
+        assert_eq!(safe_truncate(s, 200), "hello");
+    }
+
+    #[test]
+    fn safe_truncate_ascii_at_limit() {
+        let s = "a".repeat(300);
+        let result = safe_truncate(&s, 200);
+        assert!(result.ends_with("..."));
+        // 200 ASCII chars + "..."
+        assert_eq!(result.len(), 203);
+    }
+
+    #[test]
+    fn safe_truncate_emdash_at_boundary() {
+        // Em-dash '—' is U+2014, encoded as 3 bytes: E2 80 94.
+        // Build a string where the em-dash straddles byte 200:
+        // 198 ASCII bytes + '—' (bytes 198..201) → cut at 200 lands inside the em-dash.
+        let mut s = "x".repeat(198);
+        s.push('—'); // bytes 198, 199, 200
+        s.push_str(&"y".repeat(100)); // pad to exceed 200
+        assert!(s.len() > 200);
+        assert!(!s.is_char_boundary(200)); // byte 200 is inside '—'
+
+        let result = safe_truncate(&s, 200);
+        assert!(result.ends_with("..."));
+        // floor_char_boundary(200) should snap back to 198 (before the em-dash)
+        assert_eq!(&result[..198], &"x".repeat(198));
+        // Verify result is valid UTF-8 (it is, since it's a String, but be explicit)
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn safe_truncate_box_drawing_at_boundary() {
+        // Box-drawing '═' is U+2550, encoded as 3 bytes: E2 95 90.
+        // Place it so byte 200 lands inside: 199 ASCII + '═' (bytes 199..202).
+        let mut s = "x".repeat(199);
+        s.push('═'); // bytes 199, 200, 201
+        s.push_str(&"y".repeat(100));
+        assert!(s.len() > 200);
+        assert!(!s.is_char_boundary(200));
+
+        let result = safe_truncate(&s, 200);
+        assert!(result.ends_with("..."));
+        // floor_char_boundary(200) snaps back to 199
+        assert_eq!(&result[..199], &"x".repeat(199));
+    }
+
+    #[test]
+    fn safe_truncate_cjk_at_boundary() {
+        // CJK '漢' is U+6F22, encoded as 3 bytes: E6 BC A2.
+        let mut s = "x".repeat(199);
+        s.push('漢');
+        s.push_str(&"y".repeat(100));
+        assert!(!s.is_char_boundary(200));
+
+        let result = safe_truncate(&s, 200);
+        assert!(result.ends_with("..."));
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn safe_truncate_emoji_4byte_at_boundary() {
+        // Emoji '🔬' is U+1F52C, encoded as 4 bytes: F0 9F 94 AC.
+        // 198 ASCII + emoji (bytes 198..202) → byte 200 is inside.
+        let mut s = "x".repeat(198);
+        s.push('🔬');
+        s.push_str(&"y".repeat(100));
+        assert!(!s.is_char_boundary(200));
+
+        let result = safe_truncate(&s, 200);
+        assert!(result.ends_with("..."));
+        // Snaps back to 198
+        assert_eq!(&result[..198], &"x".repeat(198));
+    }
+
+    #[test]
+    fn safe_truncate_500_byte_site() {
+        // Test the 500B truncation site with em-dashes straddling byte 500.
+        let mut s = "x".repeat(498);
+        s.push('—'); // bytes 498..501
+        s.push_str(&"y".repeat(100));
+        assert!(!s.is_char_boundary(500));
+
+        let result = safe_truncate(&s, 500);
+        assert!(result.ends_with("..."));
+        assert_eq!(&result[..498], &"x".repeat(498));
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    // ── log_mcp_response integration tests ───────────────────────────
+    //
+    // These call the private log_mcp_response directly to verify it
+    // doesn't panic when processing content with multi-byte UTF-8 at
+    // the truncation boundaries.
+
+    /// Build a text content item whose JSON serialization exceeds `min_bytes`,
+    /// with multi-byte characters (em-dashes) placed densely near the cut point
+    /// so the truncation is guaranteed to land inside one.
+    fn content_with_multibyte_near(min_bytes: usize) -> Content {
+        // JSON overhead for Content::text is ~30-40 bytes. Use em-dashes
+        // (3 bytes each) densely from byte ~(min_bytes - 50) onward to
+        // guarantee the cut point hits mid-character regardless of exact overhead.
+        let safe_prefix = min_bytes.saturating_sub(50);
+        let mut text = "A".repeat(safe_prefix);
+        // Fill the rest with em-dashes (3 bytes each) well past the limit
+        let emdash_count = (min_bytes + 100) / 3;
+        for _ in 0..emdash_count {
+            text.push('—');
+        }
+        Content::text(text)
+    }
+
+    #[test]
+    fn log_mcp_response_no_panic_on_multibyte_content_item() {
+        // The 200B truncation site: serialized content item > 200 bytes
+        // with em-dashes at the cut point.
+        let content = content_with_multibyte_near(200);
+        let result = CallToolResult::success(vec![content]);
+        let elapsed = Duration::from_millis(1);
+
+        // This panicked before the fix with:
+        // "byte index 200 is not a char boundary; it is inside '—'"
+        log_mcp_response("test_tool", elapsed, &Ok(result));
+    }
+
+    #[test]
+    fn log_mcp_response_no_panic_on_multibyte_structured_content() {
+        // The 500B truncation site: structured_content serialization > 500 bytes.
+        // Build a JSON value with em-dashes that exceeds 500 bytes when serialized.
+        let mut text = "B".repeat(450);
+        for _ in 0..100 {
+            text.push('—');
+        }
+        let structured = serde_json::json!({ "data": text });
+
+        let mut result = CallToolResult::success(vec![Content::text("ok")]);
+        result.structured_content = Some(serde_json::from_value(structured).unwrap());
+        // Force the warn path (which logs structured_content) by injecting a null byte
+        // into the main content so null_bytes > 0.
+        result.content = vec![Content::text("has\0null")];
+        let elapsed = Duration::from_millis(1);
+
+        log_mcp_response("test_tool", elapsed, &Ok(result));
+    }
+
+    #[test]
+    fn log_mcp_response_no_panic_on_box_drawing_content() {
+        // Real-world trigger: subscriber gremlin with box-drawing characters.
+        let mut text = String::new();
+        // Build a box-drawing table that exceeds 200 bytes when serialized
+        for _ in 0..40 {
+            text.push_str("╔═══╗\n║ x ║\n╚═══╝\n");
+        }
+        let result = CallToolResult::success(vec![Content::text(text)]);
+        let elapsed = Duration::from_millis(1);
+
+        log_mcp_response("test_tool", elapsed, &Ok(result));
     }
 }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -249,7 +249,10 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                 let serialized_item = serde_json::to_string(item).unwrap_or_default();
                 let item_bytes = serialized_item.len();
                 let preview = if serialized_item.len() > 200 {
-                    format!("{}...", &serialized_item[..200])
+                    format!(
+                        "{}...",
+                        &serialized_item[..serialized_item.floor_char_boundary(200)]
+                    )
                 } else {
                     serialized_item
                 };
@@ -280,7 +283,7 @@ fn log_mcp_response(tool_name: &str, elapsed: Duration, result: &Result<CallTool
                         .and_then(|sc| serde_json::to_string(sc).ok())
                         .unwrap_or_default();
                     let sc_preview = if sc_preview.len() > 500 {
-                        format!("{}...", &sc_preview[..500])
+                        format!("{}...", &sc_preview[..sc_preview.floor_char_boundary(500)])
                     } else {
                         sc_preview
                     };


### PR DESCRIPTION
## Summary

- Replace `&s[..200]` and `&s[..500]` byte slicing with `str::floor_char_boundary()` in `log_mcp_response` to prevent panics on multi-byte UTF-8 characters
- `floor_char_boundary()` is stable since Rust 1.80 (we're on 1.94)
- Two call sites fixed: content item preview (200B) and structured content preview (500B)

## Context

The debug logger in `log_mcp_response` serializes MCP tool responses to JSON and truncates long strings for logging. When multi-byte UTF-8 characters (em-dash `—`, box-drawing `╔═╗║`, CJK, emoji) straddle the byte-offset cut point, `&s[..200]` panics with `byte index 200 is not a char boundary`.

This crashes the MCP server process. Confirmed in automated testing with two independent triggers:
- **subscriber** gremlin: box-drawing characters at bytes 199–202
- **refiner** gremlin: em-dash at bytes 198–201

Both hit during `get_all_cells` responses containing these characters in cell content.

## Test plan

- [ ] `cargo xtask lint` passes (confirmed locally)
- [ ] Verify `floor_char_boundary` works at both sites with multi-byte content
- [ ] Gremlin suite replay: subscriber and refiner pass clean