### PR TITLE
fix(runt): recover resolves outputs from RuntimeStateDoc + blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6884,6 +6884,7 @@ name = "runt-cli"
 version = "2.2.0"
 dependencies = [
  "anyhow",
+ "automerge",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6885,6 +6885,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "automerge",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "colored",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -24,6 +24,7 @@ runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 runtimed-client = { path = "../runtimed-client" }
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 automerge = "0.8"
+base64 = "0.22"
 runt-workspace = { path = "../runt-workspace" }
 runt-mcp = { path = "../runt-mcp" }
 kernel-env = { path = "../kernel-env" }

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -23,6 +23,7 @@ jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 runtimed-client = { path = "../runtimed-client" }
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
+automerge = "0.8"
 runt-workspace = { path = "../runt-workspace" }
 runt-mcp = { path = "../runt-mcp" }
 kernel-env = { path = "../kernel-env" }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5233,49 +5233,45 @@ fn resolve_cell_outputs_for_recovery(
 ) -> (Vec<serde_json::Value>, Option<serde_json::Value>) {
     // Preferred path: schema v3+. The NotebookDoc points at an execution_id
     // in the RuntimeStateDoc; output manifests (inline or blob ContentRef)
-    // live there. The notebook doc and state sidecar persist independently,
-    // so a stale sidecar (or one missing the referenced execution_id) is a
-    // real case — fall through to the legacy path instead of returning
-    // empty outputs when the state doc can't help.
-    let mut exec_count_from_state: Option<serde_json::Value> = None;
+    // live there. On v3+ docs the state doc is authoritative — empty or
+    // missing outputs mean the user cleared them (or never ran the cell),
+    // not a signal to revive stale legacy outputs.
     if let Some(state_doc) = state_doc {
         if let Some(execution_id) = doc.get_execution_id(cell_id) {
-            exec_count_from_state = state_doc
+            let exec_count = state_doc
                 .get_execution(&execution_id)
                 .and_then(|exec| exec.execution_count)
                 .map(|n| serde_json::Value::Number(serde_json::Number::from(n)));
             let raw = state_doc.get_outputs(&execution_id);
-            if !raw.is_empty() {
-                let resolved = raw
-                    .into_iter()
-                    .map(|o| resolve_recover_output(o, blob_store_dir))
-                    .collect();
-                return (resolved, exec_count_from_state);
-            }
-            // Fall through: state doc exists but has no outputs for this
-            // execution. If legacy cell-local outputs survive in the
-            // notebook doc, recover those instead of shipping blanks.
+            let resolved: Vec<serde_json::Value> = raw
+                .into_iter()
+                .map(|o| resolve_recover_output(o, blob_store_dir))
+                .collect();
+            return (resolved, exec_count);
         }
     }
 
-    // Legacy / fallback path. Pre-v3 docs stored outputs as raw JSON
-    // strings on the cell itself; `extract_cell_outputs` returns them
-    // verbatim. Also used when the state sidecar is stale or missing
-    // the cell's execution_id — preferring surviving cell-local outputs
-    // over silently shipping empty arrays.
-    if let Some(outputs) = legacy_outputs {
-        let resolved = outputs
-            .iter()
-            .map(|s| {
-                let value: serde_json::Value = serde_json::from_str(s)
-                    .unwrap_or_else(|_| serde_json::Value::String(s.clone()));
-                resolve_recover_output(value, blob_store_dir)
-            })
-            .collect();
-        return (resolved, exec_count_from_state);
+    // Legacy path. Pre-v3 docs (`schema_version < 3`) stored outputs as
+    // raw JSON strings on the cell itself, before the daemon migrated
+    // them into a RuntimeStateDoc. `extract_cell_outputs` returns them
+    // verbatim. Guarded on schema version so a v3+ doc where the user
+    // cleared outputs (execution_id = None) does not resurrect stale
+    // cell-local records from the Automerge history.
+    if doc.schema_version().unwrap_or(0) < 3 {
+        if let Some(outputs) = legacy_outputs {
+            let resolved = outputs
+                .iter()
+                .map(|s| {
+                    let value: serde_json::Value = serde_json::from_str(s)
+                        .unwrap_or_else(|_| serde_json::Value::String(s.clone()));
+                    resolve_recover_output(value, blob_store_dir)
+                })
+                .collect();
+            return (resolved, None);
+        }
     }
 
-    (Vec::new(), exec_count_from_state)
+    (Vec::new(), None)
 }
 
 /// Resolve a single output manifest into an nbformat-shaped JSON value.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5233,10 +5233,14 @@ fn resolve_cell_outputs_for_recovery(
 ) -> (Vec<serde_json::Value>, Option<serde_json::Value>) {
     // Preferred path: schema v3+. The NotebookDoc points at an execution_id
     // in the RuntimeStateDoc; output manifests (inline or blob ContentRef)
-    // live there.
+    // live there. The notebook doc and state sidecar persist independently,
+    // so a stale sidecar (or one missing the referenced execution_id) is a
+    // real case — fall through to the legacy path instead of returning
+    // empty outputs when the state doc can't help.
+    let mut exec_count_from_state: Option<serde_json::Value> = None;
     if let Some(state_doc) = state_doc {
         if let Some(execution_id) = doc.get_execution_id(cell_id) {
-            let exec_count = state_doc
+            exec_count_from_state = state_doc
                 .get_execution(&execution_id)
                 .and_then(|exec| exec.execution_count)
                 .map(|n| serde_json::Value::Number(serde_json::Number::from(n)));
@@ -5246,18 +5250,19 @@ fn resolve_cell_outputs_for_recovery(
                     .into_iter()
                     .map(|o| resolve_recover_output(o, blob_store_dir))
                     .collect();
-                return (resolved, exec_count);
+                return (resolved, exec_count_from_state);
             }
-            // Execution exists but has no outputs — surface the count
-            // anyway so recovered cells still display `[N]:` correctly.
-            return (Vec::new(), exec_count);
+            // Fall through: state doc exists but has no outputs for this
+            // execution. If legacy cell-local outputs survive in the
+            // notebook doc, recover those instead of shipping blanks.
         }
     }
 
-    // Legacy path: pre-v3 docs stored outputs as raw JSON strings on the
-    // cell itself. `extract_cell_outputs` returns these verbatim; we
-    // parse each back into a Value and still run ContentRef resolution
-    // so that older manifest hashes (if any) get a chance.
+    // Legacy / fallback path. Pre-v3 docs stored outputs as raw JSON
+    // strings on the cell itself; `extract_cell_outputs` returns them
+    // verbatim. Also used when the state sidecar is stale or missing
+    // the cell's execution_id — preferring surviving cell-local outputs
+    // over silently shipping empty arrays.
     if let Some(outputs) = legacy_outputs {
         let resolved = outputs
             .iter()
@@ -5267,10 +5272,10 @@ fn resolve_cell_outputs_for_recovery(
                 resolve_recover_output(value, blob_store_dir)
             })
             .collect();
-        return (resolved, None);
+        return (resolved, exec_count_from_state);
     }
 
-    (Vec::new(), None)
+    (Vec::new(), exec_count_from_state)
 }
 
 /// Resolve a single output manifest into an nbformat-shaped JSON value.
@@ -6146,6 +6151,63 @@ mod tests {
             "abc.automerge",
             "only the notebook doc should list"
         );
+    }
+
+    /// When the state sidecar is present but missing the cell's
+    /// `execution_id`, recovery must not ship a half-empty cell with a
+    /// stale execution_count. Current cells get empty outputs; there is
+    /// no other available source of outputs in a pure schema-v3 doc.
+    ///
+    /// This guards the P2 case from codex review: a stale state sidecar
+    /// paired with a newer notebook doc shouldn't silently drop outputs
+    /// *or* lie about execution status.
+    #[test]
+    fn test_recover_tolerates_stale_state_sidecar() {
+        use notebook_doc::runtime_state::RuntimeStateDoc;
+        use notebook_doc::{notebook_doc_filename, NotebookDoc};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().join("notebook-docs");
+        std::fs::create_dir_all(&docs_dir).unwrap();
+
+        let notebook_path = tmp.path().join("stale.ipynb");
+        let notebook_id = notebook_path.to_string_lossy().to_string();
+
+        let mut doc = NotebookDoc::new(&notebook_id);
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.set_execution_id("cell-1", Some("exec-new")).unwrap();
+
+        // State sidecar exists but only knows about a *different* run.
+        let mut state_doc = RuntimeStateDoc::new();
+        state_doc.create_execution("exec-old", "cell-1");
+        state_doc.set_outputs("exec-old", &[]).unwrap();
+
+        let filename = notebook_doc_filename(&notebook_id);
+        let stem = filename.strip_suffix(".automerge").unwrap();
+        std::fs::write(docs_dir.join(&filename), doc.save()).unwrap();
+        std::fs::write(
+            docs_dir.join(format!("{stem}.state.automerge")),
+            state_doc.doc_mut().save(),
+        )
+        .unwrap();
+
+        let output_path = tmp.path().join("recovered.ipynb");
+        super::recover_notebook_from_dirs(
+            Some(&notebook_path),
+            Some(&output_path),
+            false,
+            &[docs_dir],
+            None,
+        )
+        .expect("recover_notebook_from_dirs");
+
+        let recovered: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&output_path).unwrap()).unwrap();
+        let cell = &recovered["cells"][0];
+        // No outputs to recover; an empty array is correct.
+        assert_eq!(cell["outputs"].as_array().unwrap().len(), 0);
+        // exec_count must not surface a foreign execution's count.
+        assert!(cell["execution_count"].is_null());
     }
 
     /// Verifies MIME-aware ContentRef resolution for display_data bundles.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5258,77 +5258,162 @@ fn resolve_cell_outputs_for_recovery(
 
 /// Resolve a single output manifest into an nbformat-shaped JSON value.
 ///
-/// Walks the manifest and swaps every `ContentRef` shape
-/// (`{"inline": "..."}` or `{"blob": "<hash>", "size": N}`) for its
-/// resolved string content. Unknown shapes pass through unchanged so
-/// raw nbformat outputs from legacy captures keep working.
+/// Dispatches on `output_type` and uses MIME context for MIME-keyed data
+/// bundles (display_data, execute_result) so JSON-typed payloads round-trip
+/// as structured JSON and binary-typed payloads are base64-encoded back to
+/// their nbformat wire shape.
 fn resolve_recover_output(
     mut output: serde_json::Value,
     blob_store_dir: Option<&std::path::Path>,
 ) -> serde_json::Value {
-    resolve_content_refs_in_place(&mut output, blob_store_dir);
+    match output.get("output_type").and_then(|v| v.as_str()) {
+        Some("display_data" | "execute_result") => {
+            if let Some(data) = output.get_mut("data").and_then(|v| v.as_object_mut()) {
+                for (mime, value) in data.iter_mut() {
+                    resolve_mime_content_ref(value, mime, blob_store_dir);
+                }
+            }
+        }
+        Some("stream") => {
+            if let Some(text) = output.get_mut("text") {
+                // Stream text is always UTF-8.
+                resolve_text_content_ref(text, blob_store_dir);
+            }
+        }
+        Some("error") => {
+            if let Some(tb) = output.get_mut("traceback") {
+                // Traceback is a JSON array stored as a text ContentRef.
+                if let Some(map) = tb.as_object() {
+                    if let Some(resolved) = resolve_content_ref_as_text(map, blob_store_dir) {
+                        *tb = serde_json::from_str(&resolved)
+                            .unwrap_or(serde_json::Value::String(resolved));
+                    }
+                }
+            }
+        }
+        _ => {
+            // Unknown shape — best-effort pass-through.
+        }
+    }
     output
 }
 
-/// Recursively walk a JSON value, replacing ContentRef objects with their
-/// resolved string content in place.
+/// Resolve a ContentRef in place, interpreting the payload per MIME type.
 ///
-/// A ContentRef is a `{"inline": <string>}` or `{"blob": <hash>, "size":
-/// <n>}` object. Resolution is a pure read — no blob store writes. Binary
-/// MIMEs (images, audio, etc.) are not re-encoded here; the daemon's save
-/// path handles base64 for live notebooks, and the offline recover path
-/// only surfaces text content today. Binary content falls through
-/// unresolved rather than silently corrupting data.
-fn resolve_content_refs_in_place(
+/// Text MIMEs (`text/*`, SVG, `application/javascript`, etc.) resolve to
+/// a plain string. JSON MIMEs (`application/json`, `*+json`) resolve to
+/// a parsed `serde_json::Value` so nbformat keeps structured objects.
+/// Binary MIMEs (PNG, audio, video, opaque application/*) base64-encode
+/// the raw bytes, mirroring the Jupyter wire format on save.
+fn resolve_mime_content_ref(
     value: &mut serde_json::Value,
+    mime: &str,
     blob_store_dir: Option<&std::path::Path>,
 ) {
-    match value {
-        serde_json::Value::Object(map) => {
-            // Detect a ContentRef at this level before recursing.
-            let looks_like_content_ref =
-                map.len() <= 2 && (map.contains_key("inline") || map.contains_key("blob"));
-            if looks_like_content_ref {
-                if let Some(resolved) = resolve_content_ref_object(map, blob_store_dir) {
-                    *value = serde_json::Value::String(resolved);
-                    return;
-                }
-            }
-            for (_, v) in map.iter_mut() {
-                resolve_content_refs_in_place(v, blob_store_dir);
+    let Some(map) = value.as_object() else {
+        return;
+    };
+    if !looks_like_content_ref(map) {
+        return;
+    }
+    match notebook_doc::mime::mime_kind(mime) {
+        notebook_doc::mime::MimeKind::Text => {
+            if let Some(s) = resolve_content_ref_as_text(map, blob_store_dir) {
+                *value = serde_json::Value::String(s);
             }
         }
-        serde_json::Value::Array(items) => {
-            for item in items.iter_mut() {
-                resolve_content_refs_in_place(item, blob_store_dir);
+        notebook_doc::mime::MimeKind::Json => {
+            if let Some(s) = resolve_content_ref_as_text(map, blob_store_dir) {
+                *value = serde_json::from_str(&s).unwrap_or(serde_json::Value::String(s));
             }
         }
-        _ => {}
+        notebook_doc::mime::MimeKind::Binary => {
+            if let Some(s) = resolve_content_ref_as_base64(map, blob_store_dir) {
+                *value = serde_json::Value::String(s);
+            }
+        }
     }
 }
 
-/// Resolve a `ContentRef`-shaped JSON object to its string content.
+/// Resolve a ContentRef known to hold text, replacing it with the string.
+fn resolve_text_content_ref(
+    value: &mut serde_json::Value,
+    blob_store_dir: Option<&std::path::Path>,
+) {
+    if let Some(map) = value.as_object() {
+        if looks_like_content_ref(map) {
+            if let Some(s) = resolve_content_ref_as_text(map, blob_store_dir) {
+                *value = serde_json::Value::String(s);
+            }
+        }
+    }
+}
+
+/// Returns true if a JSON object looks like a ContentRef shape.
 ///
-/// Returns `None` when the shape is unrecognized, when the blob file is
-/// missing, or when the bytes are not valid UTF-8 — the caller then
-/// leaves the original object in place so whatever structure survived
-/// the daemon still round-trips.
-fn resolve_content_ref_object(
+/// The daemon writes ContentRef manifests with exactly one of `inline`
+/// or `blob`, optionally plus `size`. Anything else is a user-facing
+/// object (metadata, transient, traceback array element, etc.) and must
+/// not be mistaken for a ContentRef.
+fn looks_like_content_ref(map: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if map.contains_key("inline") && map.get("inline").is_some_and(|v| v.is_string()) {
+        return map.len() == 1;
+    }
+    if map.contains_key("blob") && map.get("blob").is_some_and(|v| v.is_string()) {
+        // Allow optional `size` sibling for forward compatibility.
+        let extras_ok = map.keys().all(|k| k == "blob" || k == "size");
+        return extras_ok;
+    }
+    false
+}
+
+/// Resolve a `ContentRef`-shaped map to its text content.
+///
+/// Returns `None` when the blob file is missing, unreadable, or non-UTF-8
+/// — callers leave the original object in place so whatever structure
+/// survived the daemon still round-trips (even if unresolved).
+fn resolve_content_ref_as_text(
     map: &serde_json::Map<String, serde_json::Value>,
     blob_store_dir: Option<&std::path::Path>,
 ) -> Option<String> {
     if let Some(inline) = map.get("inline").and_then(|v| v.as_str()) {
         return Some(inline.to_string());
     }
-    let blob_hash = map.get("blob").and_then(|v| v.as_str())?;
+    let blob_path = blob_path_for(map, blob_store_dir)?;
+    std::fs::read_to_string(&blob_path).ok()
+}
+
+/// Resolve a `ContentRef`-shaped map to a base64-encoded string for
+/// binary nbformat outputs. Inline entries pass through as-is (they are
+/// already base64 from the Jupyter wire protocol for small images).
+fn resolve_content_ref_as_base64(
+    map: &serde_json::Map<String, serde_json::Value>,
+    blob_store_dir: Option<&std::path::Path>,
+) -> Option<String> {
+    use base64::Engine as _;
+    if let Some(inline) = map.get("inline").and_then(|v| v.as_str()) {
+        return Some(inline.to_string());
+    }
+    let blob_path = blob_path_for(map, blob_store_dir)?;
+    let bytes = std::fs::read(&blob_path).ok()?;
+    Some(base64::engine::general_purpose::STANDARD.encode(&bytes))
+}
+
+/// Compute the on-disk path for a `{"blob": "<hash>", ...}` ContentRef.
+///
+/// Returns `None` when no blob store root was supplied or the hash is
+/// implausibly short. Does not check file existence.
+fn blob_path_for(
+    map: &serde_json::Map<String, serde_json::Value>,
+    blob_store_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
     let dir = blob_store_dir?;
-    // Blob store layout: two-char shard dir + remaining chars.
+    let blob_hash = map.get("blob").and_then(|v| v.as_str())?;
     if blob_hash.len() < 3 {
         return None;
     }
     let (shard, rest) = blob_hash.split_at(2);
-    let blob_path = dir.join(shard).join(rest);
-    std::fs::read_to_string(&blob_path).ok()
+    Some(dir.join(shard).join(rest))
 }
 
 /// Look for a `{stem}.state.automerge` sibling of the given notebook doc
@@ -5945,6 +6030,134 @@ mod tests {
             "blob ContentRef did not resolve from the on-disk blob store"
         );
         assert_eq!(cells[1]["execution_count"], 2);
+    }
+
+    /// Verifies MIME-aware ContentRef resolution for display_data bundles.
+    ///
+    /// Text MIMEs resolve to strings, JSON MIMEs resolve to structured
+    /// JSON (not stringified), and binary MIMEs base64-encode their raw
+    /// bytes back to the Jupyter wire shape.
+    #[test]
+    fn test_recover_display_data_mime_aware() {
+        use notebook_doc::runtime_state::RuntimeStateDoc;
+        use notebook_doc::{notebook_doc_filename, NotebookDoc};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().join("notebook-docs");
+        let blobs_dir = tmp.path().join("blobs");
+        std::fs::create_dir_all(&docs_dir).unwrap();
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+
+        let notebook_path = tmp.path().join("display_data.ipynb");
+        let notebook_id = notebook_path.to_string_lossy().to_string();
+
+        let mut doc = NotebookDoc::new(&notebook_id);
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.set_execution_id("cell-1", Some("exec-1")).unwrap();
+
+        // Seed three blobs: text HTML, JSON Vega-Lite spec, binary PNG.
+        let html_content = "<h1>recovered</h1>\n".repeat(200); // > 1 KiB
+        let html_hash = "11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff11ff1100";
+        std::fs::create_dir_all(blobs_dir.join(&html_hash[..2])).unwrap();
+        std::fs::write(
+            blobs_dir.join(&html_hash[..2]).join(&html_hash[2..]),
+            &html_content,
+        )
+        .unwrap();
+
+        let vega_spec = serde_json::json!({
+            "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+            "data": {"values": [{"a": "A", "b": 28}]},
+            "mark": "bar",
+            "encoding": {"x": {"field": "a"}, "y": {"field": "b"}},
+        });
+        let vega_text = serde_json::to_string(&vega_spec).unwrap();
+        let vega_hash = "22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa22aa2200";
+        std::fs::create_dir_all(blobs_dir.join(&vega_hash[..2])).unwrap();
+        std::fs::write(
+            blobs_dir.join(&vega_hash[..2]).join(&vega_hash[2..]),
+            &vega_text,
+        )
+        .unwrap();
+
+        // 8-byte PNG header + IHDR chunk start — any bytes work here, we
+        // just need a non-UTF-8 sequence to prove the binary path doesn't
+        // go through `read_to_string`.
+        let png_bytes: Vec<u8> = vec![
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xd8, 0xff, 0xe0,
+        ];
+        let png_hash = "33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc3300";
+        std::fs::create_dir_all(blobs_dir.join(&png_hash[..2])).unwrap();
+        std::fs::write(
+            blobs_dir.join(&png_hash[..2]).join(&png_hash[2..]),
+            &png_bytes,
+        )
+        .unwrap();
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "output_id": "out-1",
+            "data": {
+                "text/html": {"blob": html_hash, "size": html_content.len()},
+                "application/vnd.vegalite.v5+json": {"blob": vega_hash, "size": vega_text.len()},
+                "image/png": {"blob": png_hash, "size": png_bytes.len()},
+                "text/plain": {"inline": "[Chart]"},
+            },
+            "metadata": {},
+        });
+
+        let mut state_doc = RuntimeStateDoc::new();
+        state_doc.create_execution("exec-1", "cell-1");
+        state_doc.set_outputs("exec-1", &[output]).unwrap();
+        state_doc.set_execution_done("exec-1", true);
+
+        let filename = notebook_doc_filename(&notebook_id);
+        let stem = filename.strip_suffix(".automerge").unwrap();
+        std::fs::write(docs_dir.join(&filename), doc.save()).unwrap();
+        std::fs::write(
+            docs_dir.join(format!("{stem}.state.automerge")),
+            state_doc.doc_mut().save(),
+        )
+        .unwrap();
+
+        let output_path = tmp.path().join("recovered.ipynb");
+        super::recover_notebook_from_dirs(
+            Some(&notebook_path),
+            Some(&output_path),
+            false,
+            &[docs_dir],
+            Some(&blobs_dir),
+        )
+        .expect("recover_notebook_from_dirs");
+
+        let recovered: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&output_path).unwrap()).unwrap();
+        let data = &recovered["cells"][0]["outputs"][0]["data"];
+
+        // text/html: blob-resolved UTF-8 string.
+        assert_eq!(
+            data["text/html"].as_str(),
+            Some(html_content.as_str()),
+            "text MIME should resolve to UTF-8 string"
+        );
+
+        // application/vnd.vegalite.v5+json: structured JSON, not a string.
+        assert_eq!(
+            data["application/vnd.vegalite.v5+json"], vega_spec,
+            "JSON MIME must round-trip as structured JSON"
+        );
+
+        // image/png: base64 of raw bytes.
+        use base64::Engine as _;
+        let expected_b64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+        assert_eq!(
+            data["image/png"].as_str(),
+            Some(expected_b64.as_str()),
+            "binary MIME must base64-encode raw bytes"
+        );
+
+        // text/plain inline survives.
+        assert_eq!(data["text/plain"], "[Chart]");
     }
 
     #[cfg(unix)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5189,13 +5189,24 @@ fn doc_to_ipynb_with_state(
             );
             cell_json["outputs"] = serde_json::Value::Array(outputs);
 
-            // RuntimeStateDoc wins for execution_count when present — it's
-            // the authoritative post-v3 source. Fall back to the cached
-            // CellSnapshot string (populated by legacy migrations / ipynb
-            // load) when the state doc has nothing to say.
-            let exec_count = exec_count_from_state.unwrap_or_else(|| {
-                serde_json::from_str(&cell.execution_count).unwrap_or(serde_json::Value::Null)
-            });
+            // execution_count sourcing depends on schema version:
+            //
+            // - v3+ with a state sidecar: state doc is authoritative. Use
+            //   its value when present; otherwise null — never fall back
+            //   to the cached `CellSnapshot.execution_count`, which would
+            //   pair `outputs: []` with a stale `[N]:` on a stale sidecar.
+            // - pre-v3 (no state sidecar): fall back to the cached
+            //   `CellSnapshot.execution_count` string because that's the
+            //   only record on disk.
+            let exec_count = match exec_count_from_state {
+                Some(v) => v,
+                None if state_doc.is_some() || doc.schema_version().unwrap_or(0) >= 3 => {
+                    serde_json::Value::Null
+                }
+                None => {
+                    serde_json::from_str(&cell.execution_count).unwrap_or(serde_json::Value::Null)
+                }
+            };
             cell_json["execution_count"] = exec_count;
         }
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5109,10 +5109,33 @@ fn find_latest_snapshot(snapshots_dir: &std::path::Path, stem: &str) -> Option<s
     matches.last().map(|e| e.path())
 }
 
-/// Export a NotebookDoc to .ipynb JSON.
-fn doc_to_ipynb(doc: &notebook_doc::NotebookDoc) -> serde_json::Value {
+/// Export a NotebookDoc to .ipynb JSON, resolving outputs through an
+/// optional paired `RuntimeStateDoc` and on-disk blob store.
+///
+/// Schema v3 moved cell outputs from the NotebookDoc into the daemon's
+/// RuntimeStateDoc. When `state_doc` is provided, outputs are pulled
+/// from there keyed by each cell's `execution_id` pointer, and inline
+/// / blob `ContentRef` entries inside those manifests get resolved to
+/// their string content. Blob references require `blob_store_dir` to
+/// point at the content-addressed store (two-char shard directories);
+/// missing blob files pass through unresolved so something still lands
+/// in the recovered ipynb.
+///
+/// When `state_doc` is `None`, falls back to the pre-v3 layout — raw
+/// JSON strings stored on the cell itself via `extract_cell_outputs`.
+fn doc_to_ipynb_with_state(
+    doc: &notebook_doc::NotebookDoc,
+    state_doc: Option<&notebook_doc::runtime_state::RuntimeStateDoc>,
+    blob_store_dir: Option<&std::path::Path>,
+) -> serde_json::Value {
     let cells = doc.get_cells();
     let metadata_snapshot = doc.get_metadata_snapshot();
+
+    // Pre-v3 fallback: some `.automerge` captures still carry outputs on
+    // the cell itself as raw JSON strings. Read them up front so the
+    // per-cell loop can consult this map when state_doc lookup misses.
+    let legacy_outputs: std::collections::HashMap<String, Vec<String>> =
+        doc.extract_cell_outputs().into_iter().collect();
 
     let mut nb_cells = Vec::new();
     for cell in &cells {
@@ -5140,11 +5163,22 @@ fn doc_to_ipynb(doc: &notebook_doc::NotebookDoc) -> serde_json::Value {
         });
 
         if cell.cell_type == "code" {
-            // Outputs are already structured serde_json::Value manifests
-            cell_json["outputs"] = serde_json::Value::Array(cell.outputs.clone());
+            let (outputs, exec_count_from_state) = resolve_cell_outputs_for_recovery(
+                doc,
+                &cell.id,
+                state_doc,
+                blob_store_dir,
+                legacy_outputs.get(&cell.id),
+            );
+            cell_json["outputs"] = serde_json::Value::Array(outputs);
 
-            let exec_count: serde_json::Value =
-                serde_json::from_str(&cell.execution_count).unwrap_or(serde_json::Value::Null);
+            // RuntimeStateDoc wins for execution_count when present — it's
+            // the authoritative post-v3 source. Fall back to the cached
+            // CellSnapshot string (populated by legacy migrations / ipynb
+            // load) when the state doc has nothing to say.
+            let exec_count = exec_count_from_state.unwrap_or_else(|| {
+                serde_json::from_str(&cell.execution_count).unwrap_or(serde_json::Value::Null)
+            });
             cell_json["execution_count"] = exec_count;
         }
 
@@ -5165,6 +5199,157 @@ fn doc_to_ipynb(doc: &notebook_doc::NotebookDoc) -> serde_json::Value {
         "metadata": metadata,
         "cells": nb_cells,
     })
+}
+
+/// Resolve outputs and execution_count for one code cell during recovery.
+///
+/// Returns the nbformat outputs array and, if the RuntimeStateDoc records
+/// an `execution_count` for this cell's latest execution, its serialized
+/// JSON form. Callers fall back to the NotebookDoc's cached string when
+/// this returns `None`.
+fn resolve_cell_outputs_for_recovery(
+    doc: &notebook_doc::NotebookDoc,
+    cell_id: &str,
+    state_doc: Option<&notebook_doc::runtime_state::RuntimeStateDoc>,
+    blob_store_dir: Option<&std::path::Path>,
+    legacy_outputs: Option<&Vec<String>>,
+) -> (Vec<serde_json::Value>, Option<serde_json::Value>) {
+    // Preferred path: schema v3+. The NotebookDoc points at an execution_id
+    // in the RuntimeStateDoc; output manifests (inline or blob ContentRef)
+    // live there.
+    if let Some(state_doc) = state_doc {
+        if let Some(execution_id) = doc.get_execution_id(cell_id) {
+            let exec_count = state_doc
+                .get_execution(&execution_id)
+                .and_then(|exec| exec.execution_count)
+                .map(|n| serde_json::Value::Number(serde_json::Number::from(n)));
+            let raw = state_doc.get_outputs(&execution_id);
+            if !raw.is_empty() {
+                let resolved = raw
+                    .into_iter()
+                    .map(|o| resolve_recover_output(o, blob_store_dir))
+                    .collect();
+                return (resolved, exec_count);
+            }
+            // Execution exists but has no outputs — surface the count
+            // anyway so recovered cells still display `[N]:` correctly.
+            return (Vec::new(), exec_count);
+        }
+    }
+
+    // Legacy path: pre-v3 docs stored outputs as raw JSON strings on the
+    // cell itself. `extract_cell_outputs` returns these verbatim; we
+    // parse each back into a Value and still run ContentRef resolution
+    // so that older manifest hashes (if any) get a chance.
+    if let Some(outputs) = legacy_outputs {
+        let resolved = outputs
+            .iter()
+            .map(|s| {
+                let value: serde_json::Value = serde_json::from_str(s)
+                    .unwrap_or_else(|_| serde_json::Value::String(s.clone()));
+                resolve_recover_output(value, blob_store_dir)
+            })
+            .collect();
+        return (resolved, None);
+    }
+
+    (Vec::new(), None)
+}
+
+/// Resolve a single output manifest into an nbformat-shaped JSON value.
+///
+/// Walks the manifest and swaps every `ContentRef` shape
+/// (`{"inline": "..."}` or `{"blob": "<hash>", "size": N}`) for its
+/// resolved string content. Unknown shapes pass through unchanged so
+/// raw nbformat outputs from legacy captures keep working.
+fn resolve_recover_output(
+    mut output: serde_json::Value,
+    blob_store_dir: Option<&std::path::Path>,
+) -> serde_json::Value {
+    resolve_content_refs_in_place(&mut output, blob_store_dir);
+    output
+}
+
+/// Recursively walk a JSON value, replacing ContentRef objects with their
+/// resolved string content in place.
+///
+/// A ContentRef is a `{"inline": <string>}` or `{"blob": <hash>, "size":
+/// <n>}` object. Resolution is a pure read — no blob store writes. Binary
+/// MIMEs (images, audio, etc.) are not re-encoded here; the daemon's save
+/// path handles base64 for live notebooks, and the offline recover path
+/// only surfaces text content today. Binary content falls through
+/// unresolved rather than silently corrupting data.
+fn resolve_content_refs_in_place(
+    value: &mut serde_json::Value,
+    blob_store_dir: Option<&std::path::Path>,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            // Detect a ContentRef at this level before recursing.
+            let looks_like_content_ref =
+                map.len() <= 2 && (map.contains_key("inline") || map.contains_key("blob"));
+            if looks_like_content_ref {
+                if let Some(resolved) = resolve_content_ref_object(map, blob_store_dir) {
+                    *value = serde_json::Value::String(resolved);
+                    return;
+                }
+            }
+            for (_, v) in map.iter_mut() {
+                resolve_content_refs_in_place(v, blob_store_dir);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                resolve_content_refs_in_place(item, blob_store_dir);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Resolve a `ContentRef`-shaped JSON object to its string content.
+///
+/// Returns `None` when the shape is unrecognized, when the blob file is
+/// missing, or when the bytes are not valid UTF-8 — the caller then
+/// leaves the original object in place so whatever structure survived
+/// the daemon still round-trips.
+fn resolve_content_ref_object(
+    map: &serde_json::Map<String, serde_json::Value>,
+    blob_store_dir: Option<&std::path::Path>,
+) -> Option<String> {
+    if let Some(inline) = map.get("inline").and_then(|v| v.as_str()) {
+        return Some(inline.to_string());
+    }
+    let blob_hash = map.get("blob").and_then(|v| v.as_str())?;
+    let dir = blob_store_dir?;
+    // Blob store layout: two-char shard dir + remaining chars.
+    if blob_hash.len() < 3 {
+        return None;
+    }
+    let (shard, rest) = blob_hash.split_at(2);
+    let blob_path = dir.join(shard).join(rest);
+    std::fs::read_to_string(&blob_path).ok()
+}
+
+/// Look for a `{stem}.state.automerge` sibling of the given notebook doc
+/// file.
+///
+/// The daemon writes this file alongside `{hash}.automerge` so offline
+/// recovery can read the post-v3 output layout (cell outputs live in
+/// `RuntimeStateDoc`, not in the notebook doc). Missing siblings are
+/// normal for pre-v3 captures or rooms that never flushed state.
+fn load_sibling_state_doc(
+    automerge_path: &std::path::Path,
+) -> Option<notebook_doc::runtime_state::RuntimeStateDoc> {
+    let parent = automerge_path.parent()?;
+    let stem = automerge_path.file_stem()?.to_str()?;
+    let sibling = parent.join(format!("{stem}.state.automerge"));
+    if !sibling.is_file() {
+        return None;
+    }
+    let bytes = std::fs::read(&sibling).ok()?;
+    let doc = automerge::AutoCommit::load(&bytes).ok()?;
+    Some(notebook_doc::runtime_state::RuntimeStateDoc::from_doc(doc))
 }
 
 fn format_file_modified(entry: &std::fs::DirEntry) -> String {
@@ -5226,7 +5411,7 @@ fn recover_notebook_from_dirs(
     output: Option<&std::path::Path>,
     list: bool,
     docs_dirs: &[std::path::PathBuf],
-    _blob_store_dir: Option<&std::path::Path>,
+    blob_store_dir: Option<&std::path::Path>,
 ) -> Result<()> {
     use notebook_doc::{notebook_doc_filename, NotebookDoc};
 
@@ -5295,8 +5480,13 @@ fn recover_notebook_from_dirs(
     let doc = NotebookDoc::load(&data)
         .map_err(|e| anyhow::anyhow!("Failed to load automerge document: {}", e))?;
 
+    // Try to load the sibling RuntimeStateDoc. Missing is normal for pre-v3
+    // captures or rooms that never flushed state — the fallback path in
+    // `doc_to_ipynb_with_state` still surfaces legacy cell-local outputs.
+    let state_doc = load_sibling_state_doc(&automerge_path);
+
     let cell_count = doc.cell_count();
-    let notebook_json = doc_to_ipynb(&doc);
+    let notebook_json = doc_to_ipynb_with_state(&doc, state_doc.as_ref(), blob_store_dir);
 
     let output_path = match output {
         Some(p) => p.to_path_buf(),
@@ -5564,7 +5754,7 @@ mod tests {
         doc.add_cell(1, "cell-2", "markdown").unwrap();
         doc.update_source("cell-2", "# Title").unwrap();
 
-        let result = super::doc_to_ipynb(&doc);
+        let result = super::doc_to_ipynb_with_state(&doc, None, None);
 
         assert_eq!(result["nbformat"], 4);
         assert_eq!(result["nbformat_minor"], 5);
@@ -5601,7 +5791,7 @@ mod tests {
         doc.add_cell(0, "cell-1", "code").unwrap();
         doc.update_source("cell-1", "line1\nline2\nline3").unwrap();
 
-        let result = super::doc_to_ipynb(&doc);
+        let result = super::doc_to_ipynb_with_state(&doc, None, None);
         let source: Vec<&str> = result["cells"][0]["source"]
             .as_array()
             .unwrap()
@@ -5618,7 +5808,7 @@ mod tests {
         let mut doc = NotebookDoc::new("test");
         doc.add_cell(0, "cell-1", "code").unwrap();
 
-        let result = super::doc_to_ipynb(&doc);
+        let result = super::doc_to_ipynb_with_state(&doc, None, None);
         let source = result["cells"][0]["source"].as_array().unwrap();
         assert!(source.is_empty());
     }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5060,13 +5060,9 @@ fn all_notebook_docs_dirs() -> Vec<std::path::PathBuf> {
     dirs
 }
 
-/// Find the automerge file for a notebook by its hash across all cache directories.
+/// Search a given list of notebook-docs directories for an automerge file.
+///
 /// Checks live docs first, then falls back to the most recent snapshot.
-fn find_automerge_file(filename: &str) -> Option<std::path::PathBuf> {
-    find_automerge_file_in_dirs(&all_notebook_docs_dirs(), filename)
-}
-
-/// Core logic: search a given list of notebook-docs directories for an automerge file.
 fn find_automerge_file_in_dirs(
     dirs: &[std::path::PathBuf],
     filename: &str,
@@ -5214,13 +5210,30 @@ fn recover_notebook(
     output: Option<&std::path::Path>,
     list: bool,
 ) -> Result<()> {
+    let dirs = all_notebook_docs_dirs();
+    let blob_store_dir = runtimed::default_blob_store_dir();
+    recover_notebook_from_dirs(path, output, list, &dirs, Some(&blob_store_dir))
+}
+
+/// Inner recover flow with explicit lookup dirs and blob store root.
+///
+/// Separated from [`recover_notebook`] so tests can invoke it against a
+/// temp directory without touching the user's real cache. `blob_store_dir`
+/// may be `None` when outputs only use inline `ContentRef`s, or when the
+/// caller wants blob references to pass through unresolved.
+fn recover_notebook_from_dirs(
+    path: Option<&std::path::Path>,
+    output: Option<&std::path::Path>,
+    list: bool,
+    docs_dirs: &[std::path::PathBuf],
+    _blob_store_dir: Option<&std::path::Path>,
+) -> Result<()> {
     use notebook_doc::{notebook_doc_filename, NotebookDoc};
 
     if list {
-        let dirs = all_notebook_docs_dirs();
         let mut found = false;
 
-        for dir in &dirs {
+        for dir in docs_dirs {
             // List live docs
             if let Ok(entries) = std::fs::read_dir(dir) {
                 for entry in entries.flatten() {
@@ -5263,7 +5276,7 @@ fn recover_notebook(
     let notebook_id = abs_path.to_string_lossy().to_string();
     let filename = notebook_doc_filename(&notebook_id);
 
-    let automerge_path = match find_automerge_file(&filename) {
+    let automerge_path = match find_automerge_file_in_dirs(docs_dirs, &filename) {
         Some(p) => p,
         None => {
             eprintln!(
@@ -5608,6 +5621,140 @@ mod tests {
         let result = super::doc_to_ipynb(&doc);
         let source = result["cells"][0]["source"].as_array().unwrap();
         assert!(source.is_empty());
+    }
+
+    /// Regression test for silent output loss in `runt recover`.
+    ///
+    /// Schema v3 moved cell outputs from `NotebookDoc` into the daemon's
+    /// `RuntimeStateDoc`. Recover was reading `CellSnapshot.outputs` —
+    /// which is always empty since that move — and shipping `.ipynb`
+    /// files with blank output arrays.
+    ///
+    /// This test writes a paired `{hash}.automerge` + `{hash}.state.automerge`
+    /// alongside a blob store directory, runs the recover flow against those
+    /// temp dirs, and asserts both inline and blob-resolved outputs land
+    /// in the emitted ipynb.
+    #[test]
+    fn test_recover_outputs_from_runtime_state_doc() {
+        use notebook_doc::runtime_state::RuntimeStateDoc;
+        use notebook_doc::{notebook_doc_filename, NotebookDoc};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().join("notebook-docs");
+        let blobs_dir = tmp.path().join("blobs");
+        std::fs::create_dir_all(&docs_dir).unwrap();
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+
+        // Synthesize an absolute notebook path. The file need not exist on
+        // disk — recover canonicalizes only when the file exists, else it
+        // falls back to treating the path as absolute verbatim.
+        let notebook_path = tmp.path().join("recover_bug.ipynb");
+        let notebook_id = notebook_path.to_string_lossy().to_string();
+
+        // Build the NotebookDoc with two code cells. Each cell points at
+        // an execution_id that lives in the RuntimeStateDoc below.
+        let mut doc = NotebookDoc::new(&notebook_id);
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "print('hello')").unwrap();
+        doc.set_execution_id("cell-1", Some("exec-1")).unwrap();
+        doc.add_cell(1, "cell-2", "code").unwrap();
+        doc.update_source("cell-2", "print('big')").unwrap();
+        doc.set_execution_id("cell-2", Some("exec-2")).unwrap();
+
+        // Cell 1 output: inline stream ContentRef (under the 1KiB inlining
+        // threshold), mirroring what the daemon writes for small text.
+        let inline_output = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "out-1",
+            "name": "stdout",
+            "text": { "inline": "hello\n" },
+        });
+
+        // Cell 2 output: blob ContentRef pointing at a file we'll seed in
+        // the content-addressed store. Hash is arbitrary 64-hex — the
+        // recover path reads from `{shard}/{rest}` without verifying.
+        let blob_hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        let blob_content = "big kernel output spilled to the blob store\n";
+        let shard = &blob_hash[..2];
+        let rest = &blob_hash[2..];
+        let shard_dir = blobs_dir.join(shard);
+        std::fs::create_dir_all(&shard_dir).unwrap();
+        std::fs::write(shard_dir.join(rest), blob_content).unwrap();
+
+        let blob_output = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "out-2",
+            "name": "stdout",
+            "text": { "blob": blob_hash, "size": blob_content.len() },
+        });
+
+        let mut state_doc = RuntimeStateDoc::new();
+        state_doc.create_execution("exec-1", "cell-1");
+        state_doc.set_execution_count("exec-1", 1);
+        state_doc.set_outputs("exec-1", &[inline_output]).unwrap();
+        state_doc.set_execution_done("exec-1", true);
+        state_doc.create_execution("exec-2", "cell-2");
+        state_doc.set_execution_count("exec-2", 2);
+        state_doc.set_outputs("exec-2", &[blob_output]).unwrap();
+        state_doc.set_execution_done("exec-2", true);
+
+        // Persist both docs side-by-side, same stem, differing extensions.
+        let filename = notebook_doc_filename(&notebook_id);
+        let stem = filename.strip_suffix(".automerge").unwrap();
+        std::fs::write(docs_dir.join(&filename), doc.save()).unwrap();
+        std::fs::write(
+            docs_dir.join(format!("{stem}.state.automerge")),
+            state_doc.doc_mut().save(),
+        )
+        .unwrap();
+
+        // Run recover against the temp dirs.
+        let output_path = tmp.path().join("recovered.ipynb");
+        super::recover_notebook_from_dirs(
+            Some(&notebook_path),
+            Some(&output_path),
+            false,
+            &[docs_dir],
+            Some(&blobs_dir),
+        )
+        .expect("recover_notebook_from_dirs");
+
+        // Parse the emitted ipynb and verify outputs arrived intact.
+        let recovered: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&output_path).unwrap()).unwrap();
+        let cells = recovered["cells"].as_array().expect("cells array");
+        assert_eq!(cells.len(), 2, "expected 2 cells");
+
+        // Cell 1: inline output should surface as "hello\n".
+        let outputs_1 = cells[0]["outputs"].as_array().expect("outputs[0] array");
+        assert_eq!(
+            outputs_1.len(),
+            1,
+            "cell 1 outputs were dropped during recover: {:#?}",
+            cells[0]
+        );
+        assert_eq!(outputs_1[0]["output_type"], "stream");
+        assert_eq!(outputs_1[0]["name"], "stdout");
+        assert_eq!(
+            outputs_1[0]["text"], "hello\n",
+            "inline ContentRef did not resolve to its string content"
+        );
+        assert_eq!(cells[0]["execution_count"], 1);
+
+        // Cell 2: blob output should be resolved from the content store.
+        let outputs_2 = cells[1]["outputs"].as_array().expect("outputs[1] array");
+        assert_eq!(
+            outputs_2.len(),
+            1,
+            "cell 2 outputs were dropped during recover: {:#?}",
+            cells[1]
+        );
+        assert_eq!(outputs_2[0]["output_type"], "stream");
+        assert_eq!(
+            outputs_2[0]["text"], blob_content,
+            "blob ContentRef did not resolve from the on-disk blob store"
+        );
+        assert_eq!(cells[1]["execution_count"], 2);
     }
 
     #[cfg(unix)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5386,11 +5386,14 @@ fn resolve_text_content_ref(
 /// - `{"blob": "<64-hex>", "size": <non-negative-integer>}` — exactly
 ///   two fields, blob is a 64-char hex string
 ///
-/// User-supplied JSON output payloads (for `application/vnd.*+json`
-/// MIMEs) are arbitrary — they might legitimately contain
-/// `{"inline": "hello"}` or `{"blob": "abc"}`. Strictness on field set
-/// plus the 64-char hex check for blob hashes narrows the false-positive
-/// window enough that well-formed user JSON is unlikely to match.
+/// Called only on positions the daemon's output-store layout designates
+/// as ContentRef (stream `text`, error `traceback`, and each MIME entry
+/// in display_data / execute_result `data`). Even at those positions a
+/// user's JSON payload could be stored raw on older captures, so we
+/// gate on the strict shape above. In practice the daemon always wraps
+/// user JSON in a ContentRef before writing the state doc, so the
+/// stricter check buys the common case with no behaviour loss for
+/// current captures.
 fn looks_like_content_ref(map: &serde_json::Map<String, serde_json::Value>) -> bool {
     // Inline shape: exactly `{"inline": <string>}`.
     if map.len() == 1 {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5094,9 +5094,13 @@ fn find_latest_snapshot(snapshots_dir: &std::path::Path, stem: &str) -> Option<s
         .ok()?
         .flatten()
         .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".automerge"))
+            e.file_name().to_str().is_some_and(|name| {
+                // `{hash}-{ts}.automerge` only — skip `{hash}-{ts}.state.automerge`
+                // sidecars so a state snapshot isn't mistaken for a notebook doc.
+                name.starts_with(&prefix)
+                    && name.ends_with(".automerge")
+                    && !name.ends_with(".state.automerge")
+            })
         })
         .collect();
 
@@ -5107,6 +5111,19 @@ fn find_latest_snapshot(snapshots_dir: &std::path::Path, stem: &str) -> Option<s
     // Sort by filename descending (latest timestamp last in ascending, so reverse)
     matches.sort_by_key(|e| e.file_name());
     matches.last().map(|e| e.path())
+}
+
+/// Return `true` when `entry` is a notebook `.automerge` file eligible
+/// for `runt recover --list` and path-based recovery.
+///
+/// Filters out `{stem}.state.automerge` sidecars the daemon writes
+/// alongside the notebook doc to persist the RuntimeStateDoc.
+fn is_recoverable_automerge_file(entry: &std::fs::DirEntry) -> bool {
+    let name = entry.file_name();
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    name.ends_with(".automerge") && !name.ends_with(".state.automerge")
 }
 
 /// Export a NotebookDoc to .ipynb JSON, resolving outputs through an
@@ -5416,6 +5433,32 @@ fn blob_path_for(
     Some(dir.join(shard).join(rest))
 }
 
+/// Derive the `blobs/` directory that sits alongside the `notebook-docs/`
+/// directory containing the given `.automerge` file.
+///
+/// Cache layouts we handle:
+///
+/// - `{cache}/notebook-docs/{hash}.automerge`
+/// - `{cache}/notebook-docs/snapshots/{hash}-{ts}.automerge`
+/// - `{cache}/worktrees/{id}/notebook-docs/{hash}.automerge`
+/// - `{cache}/worktrees/{id}/notebook-docs/snapshots/…`
+///
+/// In all four cases the matching blob store lives at
+/// `{cache-or-worktree}/blobs`. Returns `None` if the path doesn't fit —
+/// callers fall back to [`runtimed::default_blob_store_dir`].
+fn blob_store_dir_for_automerge(automerge_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut parent = automerge_path.parent()?;
+    // Peel snapshots/ if present.
+    if parent.file_name().is_some_and(|n| n == "snapshots") {
+        parent = parent.parent()?;
+    }
+    if parent.file_name().is_some_and(|n| n == "notebook-docs") {
+        let cache_root = parent.parent()?;
+        return Some(cache_root.join("blobs"));
+    }
+    None
+}
+
 /// Look for a `{stem}.state.automerge` sibling of the given notebook doc
 /// file.
 ///
@@ -5480,9 +5523,11 @@ fn recover_notebook(
     output: Option<&std::path::Path>,
     list: bool,
 ) -> Result<()> {
-    let dirs = all_notebook_docs_dirs();
-    let blob_store_dir = runtimed::default_blob_store_dir();
-    recover_notebook_from_dirs(path, output, list, &dirs, Some(&blob_store_dir))
+    // Blob store root is resolved per-recovery from the matching
+    // `.automerge` path so cross-namespace / cross-worktree lookups land
+    // on the right `blobs/` directory. `default_blob_store_dir()` is the
+    // fallback when the path doesn't fit the expected layout.
+    recover_notebook_from_dirs(path, output, list, &all_notebook_docs_dirs(), None)
 }
 
 /// Inner recover flow with explicit lookup dirs and blob store root.
@@ -5507,7 +5552,7 @@ fn recover_notebook_from_dirs(
             // List live docs
             if let Ok(entries) = std::fs::read_dir(dir) {
                 for entry in entries.flatten() {
-                    if entry.path().extension().is_some_and(|e| e == "automerge") {
+                    if is_recoverable_automerge_file(&entry) {
                         found |= print_automerge_entry(&entry, "");
                     }
                 }
@@ -5517,7 +5562,7 @@ fn recover_notebook_from_dirs(
             let snapshots_dir = dir.join("snapshots");
             if let Ok(entries) = std::fs::read_dir(&snapshots_dir) {
                 for entry in entries.flatten() {
-                    if entry.path().extension().is_some_and(|e| e == "automerge") {
+                    if is_recoverable_automerge_file(&entry) {
                         found |= print_automerge_entry(&entry, " [snapshot]");
                     }
                 }
@@ -5570,8 +5615,17 @@ fn recover_notebook_from_dirs(
     // `doc_to_ipynb_with_state` still surfaces legacy cell-local outputs.
     let state_doc = load_sibling_state_doc(&automerge_path);
 
+    // Pick the blob store root to resolve against. Caller-supplied value
+    // wins (tests); otherwise derive it from the `.automerge` location so
+    // a doc recovered out of `~/.cache/runt-nightly/worktrees/{id}/…`
+    // reads from that worktree's `blobs/`, not the default cache.
+    let resolved_blob_dir = blob_store_dir
+        .map(std::path::Path::to_path_buf)
+        .or_else(|| blob_store_dir_for_automerge(&automerge_path))
+        .unwrap_or_else(runtimed::default_blob_store_dir);
+
     let cell_count = doc.cell_count();
-    let notebook_json = doc_to_ipynb_with_state(&doc, state_doc.as_ref(), blob_store_dir);
+    let notebook_json = doc_to_ipynb_with_state(&doc, state_doc.as_ref(), Some(&resolved_blob_dir));
 
     let output_path = match output {
         Some(p) => p.to_path_buf(),
@@ -6030,6 +6084,68 @@ mod tests {
             "blob ContentRef did not resolve from the on-disk blob store"
         );
         assert_eq!(cells[1]["execution_count"], 2);
+    }
+
+    #[test]
+    fn test_blob_store_dir_for_automerge_cache_layouts() {
+        use std::path::{Path, PathBuf};
+        // Stable cache → `~/.cache/runt/blobs`.
+        assert_eq!(
+            super::blob_store_dir_for_automerge(Path::new(
+                "/home/user/.cache/runt/notebook-docs/abc.automerge",
+            )),
+            Some(PathBuf::from("/home/user/.cache/runt/blobs")),
+        );
+        // Nightly cache → `~/.cache/runt-nightly/blobs`.
+        assert_eq!(
+            super::blob_store_dir_for_automerge(Path::new(
+                "/home/user/.cache/runt-nightly/notebook-docs/abc.automerge",
+            )),
+            Some(PathBuf::from("/home/user/.cache/runt-nightly/blobs")),
+        );
+        // Snapshot under notebook-docs/snapshots → still the same blobs root.
+        assert_eq!(
+            super::blob_store_dir_for_automerge(Path::new(
+                "/home/user/.cache/runt/notebook-docs/snapshots/abc-123.automerge",
+            )),
+            Some(PathBuf::from("/home/user/.cache/runt/blobs")),
+        );
+        // Per-worktree dev daemon → `.../worktrees/{id}/blobs`.
+        assert_eq!(
+            super::blob_store_dir_for_automerge(Path::new(
+                "/home/user/.cache/runt-nightly/worktrees/w1/notebook-docs/abc.automerge",
+            )),
+            Some(PathBuf::from(
+                "/home/user/.cache/runt-nightly/worktrees/w1/blobs"
+            )),
+        );
+        // Shape we don't recognize → None so the caller falls back.
+        assert_eq!(
+            super::blob_store_dir_for_automerge(Path::new("/tmp/standalone.automerge")),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_is_recoverable_automerge_file_skips_state_sidecars() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("abc.automerge"), b"").unwrap();
+        std::fs::write(tmp.path().join("abc.state.automerge"), b"").unwrap();
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(super::is_recoverable_automerge_file)
+            .collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "state sidecar must not list as recoverable"
+        );
+        assert_eq!(
+            entries[0].file_name().to_str().unwrap(),
+            "abc.automerge",
+            "only the notebook doc should list"
+        );
     }
 
     /// Verifies MIME-aware ContentRef resolution for display_data bundles.

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5378,20 +5378,34 @@ fn resolve_text_content_ref(
     }
 }
 
-/// Returns true if a JSON object looks like a ContentRef shape.
+/// Returns true if a JSON object looks like a serialized `ContentRef`.
 ///
-/// The daemon writes ContentRef manifests with exactly one of `inline`
-/// or `blob`, optionally plus `size`. Anything else is a user-facing
-/// object (metadata, transient, traceback array element, etc.) and must
-/// not be mistaken for a ContentRef.
+/// The canonical shapes the daemon writes (via `ContentRef::serialize`):
+///
+/// - `{"inline": "<string>"}` — exactly one field
+/// - `{"blob": "<64-hex>", "size": <non-negative-integer>}` — exactly
+///   two fields, blob is a 64-char hex string
+///
+/// User-supplied JSON output payloads (for `application/vnd.*+json`
+/// MIMEs) are arbitrary — they might legitimately contain
+/// `{"inline": "hello"}` or `{"blob": "abc"}`. Strictness on field set
+/// plus the 64-char hex check for blob hashes narrows the false-positive
+/// window enough that well-formed user JSON is unlikely to match.
 fn looks_like_content_ref(map: &serde_json::Map<String, serde_json::Value>) -> bool {
-    if map.contains_key("inline") && map.get("inline").is_some_and(|v| v.is_string()) {
-        return map.len() == 1;
+    // Inline shape: exactly `{"inline": <string>}`.
+    if map.len() == 1 {
+        return map.get("inline").is_some_and(|v| v.is_string());
     }
-    if map.contains_key("blob") && map.get("blob").is_some_and(|v| v.is_string()) {
-        // Allow optional `size` sibling for forward compatibility.
-        let extras_ok = map.keys().all(|k| k == "blob" || k == "size");
-        return extras_ok;
+    // Blob shape: exactly `{"blob": <64-hex-string>, "size": <u64>}`.
+    if map.len() == 2 {
+        let blob_ok = map
+            .get("blob")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit()));
+        let size_ok = map
+            .get("size")
+            .is_some_and(|v| v.as_u64().is_some() || v.as_i64().is_some_and(|n| n >= 0));
+        return blob_ok && size_ok;
     }
     false
 }
@@ -6136,6 +6150,34 @@ mod tests {
             super::blob_store_dir_for_automerge(Path::new("/tmp/standalone.automerge")),
             None,
         );
+    }
+
+    #[test]
+    fn test_looks_like_content_ref_rejects_user_json() {
+        use serde_json::json;
+        // User JSON that happens to have `inline` as a field but with
+        // extras must not be unwrapped.
+        let user1 = json!({"inline": "hello", "other": 1});
+        let user1_map = user1.as_object().unwrap();
+        assert!(!super::looks_like_content_ref(user1_map));
+
+        // `blob` without `size` or with a non-hex value must not be
+        // treated as a ContentRef.
+        let user2 = json!({"blob": "abc"});
+        assert!(!super::looks_like_content_ref(user2.as_object().unwrap()));
+        let user3 = json!({"blob": "not-hex-at-all-64-chars-long-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "size": 0});
+        assert!(!super::looks_like_content_ref(user3.as_object().unwrap()));
+
+        // Canonical shapes: accepted.
+        let ok_inline = json!({"inline": "hi"});
+        assert!(super::looks_like_content_ref(
+            ok_inline.as_object().unwrap()
+        ));
+        let ok_blob = json!({
+            "blob": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            "size": 12,
+        });
+        assert!(super::looks_like_content_ref(ok_blob.as_object().unwrap()));
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2900,7 +2900,11 @@ impl Daemon {
                 }
             }
 
-            // Clean up orphaned notebook-docs (emergency persist files, legacy untitled docs)
+            // Clean up orphaned notebook-docs (emergency persist files, legacy untitled docs).
+            // State sidecars (`{stem}.state.automerge`) are treated as owned by
+            // the notebook-doc with the same stem — they're deleted when the
+            // main doc is deleted, kept otherwise. Deleting them independently
+            // would strand `runt recover` with a notebook doc and no outputs.
             let notebook_docs_dir = self.config.notebook_docs_dir.clone();
             if notebook_docs_dir.exists() {
                 let active_rooms = self.notebook_rooms.lock().await;
@@ -2918,6 +2922,11 @@ impl Daemon {
                         if !name.ends_with(".automerge") {
                             continue;
                         }
+                        // Skip state sidecars — we handle them in lockstep with
+                        // the notebook doc below so the pair stays consistent.
+                        if name.ends_with(".state.automerge") {
+                            continue;
+                        }
                         if active_hashes.contains(&name) {
                             continue;
                         }
@@ -2927,8 +2936,19 @@ impl Daemon {
                             .ok()
                             .and_then(|m| m.modified().ok())
                             .is_some_and(|t| t.elapsed().unwrap_or_default() > docs_max_age);
-                        if is_stale && tokio::fs::remove_file(entry.path()).await.is_ok() {
-                            docs_cleaned += 1;
+                        if is_stale {
+                            let doc_path = entry.path();
+                            if tokio::fs::remove_file(&doc_path).await.is_ok() {
+                                docs_cleaned += 1;
+                                // Delete the state sidecar with the notebook
+                                // doc so closed notebooks can't accumulate
+                                // orphan sidecars.
+                                if let Some(stem) = doc_path.file_stem().and_then(|s| s.to_str()) {
+                                    let sidecar =
+                                        doc_path.with_file_name(format!("{stem}.state.automerge"));
+                                    let _ = tokio::fs::remove_file(&sidecar).await;
+                                }
+                            }
                         }
                     }
                 }
@@ -3099,14 +3119,12 @@ pub(crate) fn blob_gc_grace() -> std::time::Duration {
 /// Walk a persisted notebook-doc `.automerge` file and collect blob refs.
 ///
 /// Mirrors the in-memory mark phase: we load the saved document, read its
-/// cells, and pull blob refs from `cell.outputs` (inline manifests) and
-/// `cell.resolved_assets` (markdown image refs). Returns `None` if the
-/// file cannot be read or decoded — the caller logs and moves on.
-///
-/// Note: `RuntimeStateDoc` is not persisted to disk separately; the
-/// notebook doc's `cell.outputs` (legacy pre-v3 layout, plus future
-/// `.ipynb`-backed outputs from spec 2) is the on-disk record of blob
-/// references for a closed room.
+/// cells, and pull blob refs from `cell.outputs` (legacy pre-v3 layout)
+/// and `cell.resolved_assets` (markdown image refs). For v3+ rooms the
+/// paired `{stem}.state.automerge` sidecar holds the authoritative output
+/// manifests — see [`collect_hashes_from_persisted_state_doc`]. Returns
+/// `false` if the file cannot be read or decoded — the caller logs and
+/// moves on.
 pub(crate) async fn collect_hashes_from_persisted_doc(
     path: &Path,
     hashes: &mut std::collections::HashSet<String>,
@@ -3138,6 +3156,54 @@ pub(crate) async fn collect_hashes_from_persisted_doc(
         for hash in cell.resolved_assets.values() {
             hashes.insert(hash.clone());
         }
+    }
+    true
+}
+
+/// Walk a persisted `{stem}.state.automerge` sidecar and collect blob refs.
+///
+/// After schema v3 the RuntimeStateDoc is the authoritative source of cell
+/// outputs. For closed notebooks this is the only on-disk record of those
+/// manifests, so GC has to scan it alongside the notebook doc — otherwise
+/// the blob grace window ticks out and blob-backed outputs (HTML,
+/// base64-encoded images, large stream spills) get reclaimed while the
+/// state sidecar still references them.
+pub(crate) async fn collect_hashes_from_persisted_state_doc(
+    path: &Path,
+    hashes: &mut std::collections::HashSet<String>,
+) -> bool {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                "[runtimed] GC: failed to read persisted state doc {:?}: {}",
+                path, e
+            );
+            return false;
+        }
+    };
+    let doc = match automerge::AutoCommit::load(&bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(
+                "[runtimed] GC: failed to decode persisted state doc {:?}: {}",
+                path, e
+            );
+            return false;
+        }
+    };
+    let state_doc = notebook_doc::runtime_state::RuntimeStateDoc::from_doc(doc);
+    let state = state_doc.read_state();
+    for exec in state.executions.values() {
+        for output in &exec.outputs {
+            collect_blob_hashes(output, hashes);
+        }
+    }
+    for comm in state.comms.values() {
+        for output in &comm.outputs {
+            collect_blob_hashes(output, hashes);
+        }
+        collect_blob_hashes_recursive(&comm.state, hashes);
     }
     true
 }
@@ -3220,7 +3286,9 @@ impl Daemon {
 
         // 2. On-disk: persisted notebook-doc files for closed notebooks.
         // Skip files that correspond to an active room (their refs were
-        // already collected above).
+        // already collected above). Each notebook doc is paired with a
+        // `{stem}.state.automerge` sidecar holding v3+ output manifests —
+        // GC must scan both to keep blob refs alive for closed notebooks.
         if notebook_docs_dir.exists() {
             let active_filenames: std::collections::HashSet<String> = rooms
                 .iter()
@@ -3228,11 +3296,27 @@ impl Daemon {
                 .collect();
 
             let mut persisted_paths: Vec<PathBuf> = Vec::new();
+            let mut persisted_state_paths: Vec<PathBuf> = Vec::new();
             match tokio::fs::read_dir(notebook_docs_dir).await {
                 Ok(mut entries) => {
                     while let Ok(Some(entry)) = entries.next_entry().await {
                         let name = entry.file_name().to_string_lossy().to_string();
                         if !name.ends_with(".automerge") {
+                            continue;
+                        }
+                        if name.ends_with(".state.automerge") {
+                            // Sidecar: active ones are covered by the
+                            // in-memory state_doc read above; closed ones
+                            // contribute blob refs for the mark phase.
+                            let notebook_name = name
+                                .strip_suffix(".state.automerge")
+                                .map(|stem| format!("{stem}.automerge"));
+                            if let Some(n) = notebook_name {
+                                if active_filenames.contains(&n) {
+                                    continue;
+                                }
+                            }
+                            persisted_state_paths.push(entry.path());
                             continue;
                         }
                         if active_filenames.contains(&name) {
@@ -3257,6 +3341,19 @@ impl Daemon {
                 for batch in persisted_paths.chunks(DOC_BATCH_SIZE) {
                     for path in batch {
                         collect_hashes_from_persisted_doc(path, &mut referenced_hashes).await;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+
+            if !persisted_state_paths.is_empty() {
+                debug!(
+                    "[runtimed] GC: walking {} persisted state-doc sidecars for blob refs",
+                    persisted_state_paths.len()
+                );
+                for batch in persisted_state_paths.chunks(DOC_BATCH_SIZE) {
+                    for path in batch {
+                        collect_hashes_from_persisted_state_doc(path, &mut referenced_hashes).await;
                     }
                     tokio::task::yield_now().await;
                 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3358,6 +3358,62 @@ impl Daemon {
                     tokio::task::yield_now().await;
                 }
             }
+
+            // Snapshots under `notebook-docs/snapshots/` are recoverable by
+            // `runt recover` when the live doc is gone, so their blob refs
+            // must survive GC too. Walk both the notebook snapshots and
+            // their paired state sidecars.
+            let snapshots_dir = notebook_docs_dir.join("snapshots");
+            if snapshots_dir.exists() {
+                let mut snapshot_doc_paths: Vec<PathBuf> = Vec::new();
+                let mut snapshot_state_paths: Vec<PathBuf> = Vec::new();
+                match tokio::fs::read_dir(&snapshots_dir).await {
+                    Ok(mut entries) => {
+                        while let Ok(Some(entry)) = entries.next_entry().await {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            if !name.ends_with(".automerge") {
+                                continue;
+                            }
+                            if name.ends_with(".state.automerge") {
+                                snapshot_state_paths.push(entry.path());
+                            } else {
+                                snapshot_doc_paths.push(entry.path());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[runtimed] GC: failed to read snapshots dir {:?}: {}",
+                            snapshots_dir, e
+                        );
+                    }
+                }
+                if !snapshot_doc_paths.is_empty() {
+                    debug!(
+                        "[runtimed] GC: walking {} notebook-doc snapshots for blob refs",
+                        snapshot_doc_paths.len()
+                    );
+                    for batch in snapshot_doc_paths.chunks(DOC_BATCH_SIZE) {
+                        for path in batch {
+                            collect_hashes_from_persisted_doc(path, &mut referenced_hashes).await;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                }
+                if !snapshot_state_paths.is_empty() {
+                    debug!(
+                        "[runtimed] GC: walking {} state-doc snapshot sidecars for blob refs",
+                        snapshot_state_paths.len()
+                    );
+                    for batch in snapshot_state_paths.chunks(DOC_BATCH_SIZE) {
+                        for path in batch {
+                            collect_hashes_from_persisted_state_doc(path, &mut referenced_hashes)
+                                .await;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
         }
 
         referenced_hashes

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2900,11 +2900,11 @@ impl Daemon {
                 }
             }
 
-            // Clean up orphaned notebook-docs (emergency persist files, legacy untitled docs).
-            // State sidecars (`{stem}.state.automerge`) are treated as owned by
-            // the notebook-doc with the same stem — they're deleted when the
-            // main doc is deleted, kept otherwise. Deleting them independently
-            // would strand `runt recover` with a notebook doc and no outputs.
+            // Clean up orphaned notebook-docs (emergency persist files, legacy
+            // untitled docs) and state sidecars. Sidecars are normally deleted
+            // in lockstep with their notebook doc, but untitled-to-saved
+            // promotion and crash scenarios can strand them — so we also
+            // sweep sidecars whose sibling notebook doc is missing.
             let notebook_docs_dir = self.config.notebook_docs_dir.clone();
             if notebook_docs_dir.exists() {
                 let active_rooms = self.notebook_rooms.lock().await;
@@ -2914,41 +2914,66 @@ impl Daemon {
                     .collect();
                 drop(active_rooms);
 
-                let docs_max_age = std::time::Duration::from_secs(24 * 3600); // 24 hours
-                let mut docs_cleaned = 0;
+                // First pass: collect every `*.automerge` entry so we can
+                // tell sidecars from docs without racing the filesystem.
+                let mut doc_names: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                #[allow(clippy::type_complexity)]
+                let mut all_entries: Vec<(
+                    std::path::PathBuf,
+                    String,
+                    std::time::SystemTime,
+                )> = Vec::new();
                 if let Ok(mut entries) = tokio::fs::read_dir(&notebook_docs_dir).await {
                     while let Ok(Some(entry)) = entries.next_entry().await {
                         let name = entry.file_name().to_string_lossy().to_string();
                         if !name.ends_with(".automerge") {
                             continue;
                         }
-                        // Skip state sidecars — we handle them in lockstep with
-                        // the notebook doc below so the pair stays consistent.
-                        if name.ends_with(".state.automerge") {
+                        let Some(modified) =
+                            entry.metadata().await.ok().and_then(|m| m.modified().ok())
+                        else {
                             continue;
+                        };
+                        if !name.ends_with(".state.automerge") {
+                            doc_names.insert(name.clone());
                         }
-                        if active_hashes.contains(&name) {
-                            continue;
+                        all_entries.push((entry.path(), name, modified));
+                    }
+                }
+
+                let docs_max_age = std::time::Duration::from_secs(24 * 3600); // 24 hours
+                let mut docs_cleaned = 0;
+                let mut sidecars_cleaned = 0;
+                for (path, name, modified) in all_entries {
+                    let is_stale = modified.elapsed().unwrap_or_default() > docs_max_age;
+                    if !is_stale {
+                        continue;
+                    }
+
+                    if name.ends_with(".state.automerge") {
+                        // Orphaned sidecar: notebook doc gone (promoted,
+                        // crashed, or already cleaned). Safe to reclaim.
+                        let sibling_name = name
+                            .strip_suffix(".state.automerge")
+                            .map(|stem| format!("{stem}.automerge"));
+                        let has_sibling =
+                            sibling_name.as_ref().is_some_and(|n| doc_names.contains(n));
+                        if !has_sibling && tokio::fs::remove_file(&path).await.is_ok() {
+                            sidecars_cleaned += 1;
                         }
-                        let is_stale = entry
-                            .metadata()
-                            .await
-                            .ok()
-                            .and_then(|m| m.modified().ok())
-                            .is_some_and(|t| t.elapsed().unwrap_or_default() > docs_max_age);
-                        if is_stale {
-                            let doc_path = entry.path();
-                            if tokio::fs::remove_file(&doc_path).await.is_ok() {
-                                docs_cleaned += 1;
-                                // Delete the state sidecar with the notebook
-                                // doc so closed notebooks can't accumulate
-                                // orphan sidecars.
-                                if let Some(stem) = doc_path.file_stem().and_then(|s| s.to_str()) {
-                                    let sidecar =
-                                        doc_path.with_file_name(format!("{stem}.state.automerge"));
-                                    let _ = tokio::fs::remove_file(&sidecar).await;
-                                }
-                            }
+                        continue;
+                    }
+
+                    if active_hashes.contains(&name) {
+                        continue;
+                    }
+                    if tokio::fs::remove_file(&path).await.is_ok() {
+                        docs_cleaned += 1;
+                        // Delete the state sidecar in lockstep.
+                        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                            let sidecar = path.with_file_name(format!("{stem}.state.automerge"));
+                            let _ = tokio::fs::remove_file(&sidecar).await;
                         }
                     }
                 }
@@ -2956,6 +2981,12 @@ impl Daemon {
                     info!(
                         "[runtimed] GC: cleaned up {} orphaned notebook-doc files",
                         docs_cleaned
+                    );
+                }
+                if sidecars_cleaned > 0 {
+                    info!(
+                        "[runtimed] GC: cleaned up {} orphaned state sidecars",
+                        sidecars_cleaned
                     );
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1171,6 +1171,13 @@ pub struct NotebookRoom {
     ///
     /// `None` for ephemeral rooms, matching `persist_tx`.
     pub state_persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
+    /// When cleared, the state-persist forwarder stops pushing new
+    /// snapshots. Flipped to `false` by `finalize_untitled_promotion`:
+    /// after a notebook is saved to a `.ipynb` path, the `.ipynb` itself
+    /// owns outputs and the UUID-keyed state sidecar would go stale
+    /// without a notebook doc next to it. Shared as `Arc` so the
+    /// forwarder task can consult it without keeping the whole room alive.
+    pub state_persist_enabled: Arc<AtomicBool>,
     /// Notification channel for RuntimeStateDoc changes.
     /// Peer sync loops subscribe to push RuntimeStateSync frames.
     pub state_changed_tx: broadcast::Sender<()>,
@@ -1393,6 +1400,7 @@ impl NotebookRoom {
         ));
 
         let (state_changed_tx, _) = broadcast::channel(16);
+        let state_persist_enabled = Arc::new(AtomicBool::new(true));
 
         // Forward RuntimeStateDoc changes into the state-persist debouncer.
         // The forwarder subscribes to `state_changed_tx` (every mutation
@@ -1404,6 +1412,7 @@ impl NotebookRoom {
                 state_doc.clone(),
                 state_changed_tx.subscribe(),
                 tx.clone(),
+                state_persist_enabled.clone(),
             );
         }
 
@@ -1434,6 +1443,7 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_persist_tx,
+            state_persist_enabled,
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -1505,10 +1515,12 @@ impl NotebookRoom {
         let (state_changed_tx, _) = broadcast::channel(16);
         let (state_persist_tx, state_persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_state_persist_debouncer(state_persist_rx, state_persist_path_for(&persist_path));
+        let state_persist_enabled = Arc::new(AtomicBool::new(true));
         spawn_state_persist_forwarder(
             state_doc.clone(),
             state_changed_tx.subscribe(),
             state_persist_tx.clone(),
+            state_persist_enabled.clone(),
         );
         Self {
             id,
@@ -1537,6 +1549,7 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_persist_tx: Some(state_persist_tx),
+            state_persist_enabled,
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -6932,6 +6945,15 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
         }
     }
 
+    // Stop the forwarder from rewriting `{uuid-hash}.state.automerge`
+    // now that the notebook's source of truth is the `.ipynb` file.
+    // Must be flipped BEFORE deleting the sidecar — otherwise a racing
+    // forwarder write could recreate the file between our removal call
+    // and subsequent GC passes. After this flag is off, even a pending
+    // write in the debouncer runs against stale bytes but hits a path
+    // we then delete; the next-pass delete covers it.
+    room.state_persist_enabled.store(false, Ordering::Relaxed);
+
     // Remove the paired state sidecar too. Without this, the forwarder
     // would keep rewriting `{uuid-hash}.state.automerge` even though the
     // notebook's source of truth is now the `.ipynb` file — `runt recover`
@@ -7473,10 +7495,15 @@ fn spawn_state_persist_debouncer_with_config(
 /// doc write), serializes the current state doc to bytes, and pushes
 /// them to the debouncer's watch channel. Coalescing and on-disk writes
 /// happen inside `spawn_state_persist_debouncer`.
+///
+/// `enabled` lets the room turn off state persistence mid-session
+/// (e.g. after an untitled notebook is promoted to a `.ipynb` path and
+/// the UUID-keyed state sidecar would go stale).
 fn spawn_state_persist_forwarder(
     state_doc: Arc<RwLock<RuntimeStateDoc>>,
     mut state_changed_rx: broadcast::Receiver<()>,
     state_persist_tx: watch::Sender<Option<Vec<u8>>>,
+    enabled: Arc<AtomicBool>,
 ) {
     spawn_supervised(
         "state-persist-forwarder",
@@ -7484,6 +7511,9 @@ fn spawn_state_persist_forwarder(
             loop {
                 match state_changed_rx.recv().await {
                     Ok(()) => {
+                        if !enabled.load(Ordering::Relaxed) {
+                            continue;
+                        }
                         let bytes = {
                             let mut sd = state_doc.write().await;
                             sd.doc_mut().save()
@@ -7501,6 +7531,9 @@ fn spawn_state_persist_forwarder(
                         // doc reflects the union. Re-serialize now so
                         // the sidecar doesn't stay stale if no further
                         // events arrive before idle / shutdown.
+                        if !enabled.load(Ordering::Relaxed) {
+                            continue;
+                        }
                         debug!(
                             "[notebook-sync] State-persist forwarder lagged {n} events; \
                              reserializing state doc to avoid stale sidecar"
@@ -9854,6 +9887,7 @@ mod tests {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_persist_tx: None,
+            state_persist_enabled: Arc::new(AtomicBool::new(false)),
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2349,6 +2349,33 @@ where
                     delay = FLUSH_RETRY_DELAY;
                     continue;
                 }
+
+                // Synchronously flush the state sidecar alongside the notebook
+                // doc. Without this a fast reconnect can race the debouncer
+                // and reopen the room against a stale `.state.automerge`,
+                // dropping the last session's outputs.
+                if let Some(ref tx) = room_for_eviction.state_persist_tx {
+                    let bytes = {
+                        let mut sd = room_for_eviction.state_doc.write().await;
+                        sd.doc_mut().save()
+                    };
+                    // Push the freshest snapshot into the debouncer (kicks
+                    // any coalesced older bytes) then also write directly
+                    // to disk so we don't depend on the debouncer's own
+                    // exit timing.
+                    let _ = tx.send(Some(bytes.clone()));
+                    let state_path = state_persist_path_for(&room_for_eviction.persist_path);
+                    if let Some(parent) = state_path.parent() {
+                        let _ = tokio::fs::create_dir_all(parent).await;
+                    }
+                    if let Err(e) = tokio::fs::write(&state_path, &bytes).await {
+                        warn!(
+                            "[notebook-sync] Eviction state-sidecar write failed for {:?}: {}",
+                            state_path, e
+                        );
+                    }
+                }
+
                 break;
             }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1251,6 +1251,13 @@ impl NotebookRoom {
             if !ephemeral && persist_path.exists() {
                 if crate::paths::snapshot_before_delete(&persist_path, docs_dir) {
                     let _ = std::fs::remove_file(&persist_path);
+                    // Delete the state sidecar in lockstep. Leaving it
+                    // behind would pair the fresh notebook doc with
+                    // stale outputs on the next offline recovery.
+                    let state_sidecar = state_persist_path_for(&persist_path);
+                    if state_sidecar.exists() {
+                        let _ = std::fs::remove_file(&state_sidecar);
+                    }
                 } else {
                     warn!(
                         "[notebook-sync] Keeping persisted doc (snapshot failed): {:?}",

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -6932,6 +6932,21 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
         }
     }
 
+    // Remove the paired state sidecar too. Without this, the forwarder
+    // would keep rewriting `{uuid-hash}.state.automerge` even though the
+    // notebook's source of truth is now the `.ipynb` file — `runt recover`
+    // would pick up a doc-less sidecar and GC would keep its blob refs
+    // live forever.
+    let state_sidecar = state_persist_path_for(&room.persist_path);
+    if state_sidecar.exists() {
+        if let Err(e) = tokio::fs::remove_file(&state_sidecar).await {
+            warn!(
+                "[notebook-sync] Failed to remove stale state sidecar {:?}: {}",
+                state_sidecar, e
+            );
+        }
+    }
+
     // Spawn .ipynb file watcher.
     if canonical.extension().is_some_and(|ext| ext == "ipynb") {
         let shutdown_tx = spawn_notebook_file_watcher(canonical.clone(), Arc::clone(room));

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7479,12 +7479,22 @@ fn spawn_state_persist_forwarder(
                         let _ = state_persist_tx.send(Some(bytes));
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        // Fell behind on the broadcast channel. The next
-                        // state_changed signal will still pick up the
-                        // current state_doc snapshot, so lagging is a
-                        // no-op for persistence.
-                        continue;
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        // Fell behind on the broadcast channel. We can't
+                        // replay the skipped signals, but each of them
+                        // meant "state_doc changed"; the current state
+                        // doc reflects the union. Re-serialize now so
+                        // the sidecar doesn't stay stale if no further
+                        // events arrive before idle / shutdown.
+                        debug!(
+                            "[notebook-sync] State-persist forwarder lagged {n} events; \
+                             reserializing state doc to avoid stale sidecar"
+                        );
+                        let bytes = {
+                            let mut sd = state_doc.write().await;
+                            sd.doc_mut().save()
+                        };
+                        let _ = state_persist_tx.send(Some(bytes));
                     }
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1164,6 +1164,13 @@ pub struct NotebookRoom {
     /// Per-notebook RuntimeStateDoc — daemon-authoritative ephemeral state
     /// (kernel status, queue, env sync). Clients sync read-only.
     pub state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    /// Channel to send RuntimeStateDoc bytes to the debounced state
+    /// persistence task. Writes a `{stem}.state.automerge` sibling of
+    /// [`Self::persist_path`] so `runt recover` can surface cell outputs
+    /// (which live in the state doc after schema v3).
+    ///
+    /// `None` for ephemeral rooms, matching `persist_tx`.
+    pub state_persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
     /// Notification channel for RuntimeStateDoc changes.
     /// Peer sync loops subscribe to push RuntimeStateSync frames.
     pub state_changed_tx: broadcast::Sender<()>,
@@ -1273,6 +1280,20 @@ impl NotebookRoom {
             (Some(persist_tx), Some(flush_tx))
         };
 
+        // State-doc persistence. The RuntimeStateDoc holds cell outputs and
+        // execution state after schema v3 — nothing else on disk captures
+        // them, so offline `runt recover` can't surface outputs without
+        // this sibling file. Ephemeral rooms skip state persistence along
+        // with the main doc.
+        let state_persist_tx = if ephemeral {
+            None
+        } else {
+            let state_persist_path = state_persist_path_for(&persist_path);
+            let (tx, rx) = watch::channel::<Option<Vec<u8>>>(None);
+            spawn_state_persist_debouncer(rx, state_persist_path);
+            Some(tx)
+        };
+
         let trust_state = match &path {
             // Untitled notebooks have no .ipynb on disk — trust signature lives
             // in the persisted Automerge doc we just loaded.
@@ -1340,6 +1361,19 @@ impl NotebookRoom {
 
         let (state_changed_tx, _) = broadcast::channel(16);
 
+        // Forward RuntimeStateDoc changes into the state-persist debouncer.
+        // The forwarder subscribes to `state_changed_tx` (every mutation
+        // broadcasts on it already), reads a fresh byte snapshot from the
+        // state doc, and pushes it to the debouncer's watch channel.
+        // Debouncing + coalescing happens inside `spawn_state_persist_debouncer`.
+        if let Some(ref tx) = state_persist_tx {
+            spawn_state_persist_forwarder(
+                state_doc.clone(),
+                state_changed_tx.subscribe(),
+                tx.clone(),
+            );
+        }
+
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
@@ -1366,6 +1400,7 @@ impl NotebookRoom {
             last_save_sources: Arc::new(RwLock::new(HashMap::new())),
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
+            state_persist_tx,
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -1435,6 +1470,13 @@ impl NotebookRoom {
         };
         let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
         let (state_changed_tx, _) = broadcast::channel(16);
+        let (state_persist_tx, state_persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
+        spawn_state_persist_debouncer(state_persist_rx, state_persist_path_for(&persist_path));
+        spawn_state_persist_forwarder(
+            state_doc.clone(),
+            state_changed_tx.subscribe(),
+            state_persist_tx.clone(),
+        );
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
@@ -1461,6 +1503,7 @@ impl NotebookRoom {
             last_save_sources: Arc::new(RwLock::new(HashMap::new())),
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
+            state_persist_tx: Some(state_persist_tx),
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -7211,6 +7254,146 @@ fn spawn_persist_debouncer_with_config(
     );
 }
 
+/// Derive the sibling state persistence path for a given notebook doc path.
+///
+/// The RuntimeStateDoc holds cell outputs after schema v3 and has to be
+/// written somewhere for offline `runt recover` to surface them. We write
+/// it next to the notebook `.automerge` with `.state.automerge` appended
+/// to the stem. Snapshot files follow the same stem convention.
+pub(crate) fn state_persist_path_for(notebook_persist_path: &Path) -> PathBuf {
+    let parent = notebook_persist_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let stem = notebook_persist_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("doc");
+    parent.join(format!("{stem}.state.automerge"))
+}
+
+/// Spawn a debounced persistence task dedicated to the RuntimeStateDoc.
+///
+/// Mirrors `spawn_persist_debouncer` but without the synchronous-flush
+/// channel — the state doc is a best-effort snapshot, so eviction /
+/// shutdown rely on the channel-close shutdown flush. Uses the same
+/// debounce parameters as the notebook doc so the two stay roughly in
+/// sync on disk.
+fn spawn_state_persist_debouncer(
+    persist_rx: watch::Receiver<Option<Vec<u8>>>,
+    persist_path: PathBuf,
+) {
+    spawn_state_persist_debouncer_with_config(
+        persist_rx,
+        persist_path,
+        PersistDebouncerConfig::default(),
+    );
+}
+
+fn spawn_state_persist_debouncer_with_config(
+    mut persist_rx: watch::Receiver<Option<Vec<u8>>>,
+    persist_path: PathBuf,
+    config: PersistDebouncerConfig,
+) {
+    spawn_supervised(
+        "state-persist-debouncer",
+        async move {
+            use std::time::Duration;
+            use tokio::time::{interval, Instant, MissedTickBehavior};
+
+            let debounce_duration = Duration::from_millis(config.debounce_ms);
+            let max_flush_interval = Duration::from_millis(config.max_interval_ms);
+
+            let mut last_receive: Option<Instant> = None;
+            let mut last_flush: Option<Instant> = None;
+
+            let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
+            check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    result = persist_rx.changed() => {
+                        if result.is_err() {
+                            // Channel closed — final flush on shutdown.
+                            let bytes = persist_rx.borrow().clone();
+                            if let Some(data) = bytes {
+                                do_persist(&data, &persist_path);
+                            }
+                            break;
+                        }
+                        last_receive = Some(Instant::now());
+                    }
+                    _ = check_interval.tick() => {
+                        let should_flush = if let Some(recv) = last_receive {
+                            let debounce_ready = recv.elapsed() >= debounce_duration;
+                            let max_interval_ready = last_flush
+                                .map(|f| f.elapsed() >= max_flush_interval)
+                                .unwrap_or(recv.elapsed() >= max_flush_interval);
+                            debounce_ready || max_interval_ready
+                        } else {
+                            false
+                        };
+
+                        if should_flush {
+                            let bytes = persist_rx.borrow().clone();
+                            if let Some(data) = bytes {
+                                do_persist(&data, &persist_path);
+                                last_flush = Some(Instant::now());
+                                last_receive = None;
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        |_| {
+            trigger_global_shutdown();
+        },
+    );
+}
+
+/// Forward RuntimeStateDoc mutations into the state-persist debouncer.
+///
+/// Subscribes to `state_changed_tx` (daemon broadcasts on every state
+/// doc write), serializes the current state doc to bytes, and pushes
+/// them to the debouncer's watch channel. Coalescing and on-disk writes
+/// happen inside `spawn_state_persist_debouncer`.
+fn spawn_state_persist_forwarder(
+    state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    mut state_changed_rx: broadcast::Receiver<()>,
+    state_persist_tx: watch::Sender<Option<Vec<u8>>>,
+) {
+    spawn_supervised(
+        "state-persist-forwarder",
+        async move {
+            loop {
+                match state_changed_rx.recv().await {
+                    Ok(()) => {
+                        let bytes = {
+                            let mut sd = state_doc.write().await;
+                            sd.doc_mut().save()
+                        };
+                        // Receiver (debouncer) may have closed on shutdown;
+                        // that's fine, the loop exits on next iteration
+                        // when the broadcast channel closes as well.
+                        let _ = state_persist_tx.send(Some(bytes));
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        // Fell behind on the broadcast channel. The next
+                        // state_changed signal will still pick up the
+                        // current state_doc snapshot, so lagging is a
+                        // no-op for persistence.
+                        continue;
+                    }
+                }
+            }
+        },
+        |_| {
+            trigger_global_shutdown();
+        },
+    );
+}
+
 /// Configuration for the autosave debouncer (testable).
 struct AutosaveDebouncerConfig {
     /// Quiet period: flush only after no changes for this long.
@@ -9544,6 +9727,7 @@ mod tests {
             last_save_sources: Arc::new(RwLock::new(HashMap::new())),
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
+            state_persist_tx: None,
             state_changed_tx,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1326,15 +1326,34 @@ impl NotebookRoom {
 
         let (presence_tx, _) = broadcast::channel(64);
 
-        let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+        // Start with the persisted state sidecar if present. Otherwise
+        // the forwarder would immediately overwrite the on-disk file
+        // with an empty state_doc on the next kernel event, losing the
+        // outputs it had just spent the previous session recording.
+        //
+        // The check is sync so `new_inner` stays safe to call under the
+        // async runtime (blocking_read would panic inside a tokio task).
+        let mut loaded_state = if !ephemeral && path.is_none() {
+            load_persisted_state_doc(&persist_path)
+        } else {
+            None
+        };
+        let has_loaded_state_outputs = loaded_state
+            .as_ref()
+            .map(|sd| !sd.get_all_outputs().is_empty())
+            .unwrap_or(false);
 
         // Migrate outputs from notebook doc to RuntimeStateDoc for pre-v3 untitled notebooks.
         // .ipynb files already create synthetic execution_ids on load; this handles
         // persisted .automerge files that have outputs in the old cell.outputs location.
-        if path.is_none() {
+        //
+        // Only run migration when the state doc has no outputs yet — a
+        // freshly-loaded state sidecar already holds v3+ outputs and
+        // shouldn't get clobbered by legacy synthesis.
+        if path.is_none() && !has_loaded_state_outputs {
             let cell_outputs = doc.extract_cell_outputs();
             if !cell_outputs.is_empty() {
-                let mut sd = state_doc.blocking_write();
+                let sd = loaded_state.get_or_insert_with(RuntimeStateDoc::new);
                 for (cell_id, outputs) in &cell_outputs {
                     let synthetic_eid = uuid::Uuid::new_v4().to_string();
                     sd.create_execution(&synthetic_eid, cell_id);
@@ -1365,6 +1384,13 @@ impl NotebookRoom {
                 );
             }
         }
+
+        // Commit the chosen initial state (loaded sidecar, legacy
+        // migration, or fresh-empty) into the Arc<RwLock<...>> that
+        // every other task consumes from here on.
+        let state_doc = Arc::new(RwLock::new(
+            loaded_state.unwrap_or_else(RuntimeStateDoc::new),
+        ));
 
         let (state_changed_tx, _) = broadcast::channel(16);
 
@@ -7259,6 +7285,47 @@ fn spawn_persist_debouncer_with_config(
             trigger_global_shutdown();
         },
     );
+}
+
+/// Load a persisted `{stem}.state.automerge` next to the given notebook
+/// doc path, if one exists and decodes. Absence returns `None` so the
+/// caller starts with an empty `RuntimeStateDoc::new()`.
+///
+/// Used when a room is reopened from its persisted `.automerge` (untitled
+/// notebooks). Without this, the forwarder would immediately overwrite
+/// the good on-disk state sidecar with an empty state doc the first time
+/// any state change fires.
+fn load_persisted_state_doc(notebook_persist_path: &Path) -> Option<RuntimeStateDoc> {
+    let state_path = state_persist_path_for(notebook_persist_path);
+    if !state_path.is_file() {
+        return None;
+    }
+    let bytes = match std::fs::read(&state_path) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                "[notebook-sync] Failed to read persisted state doc {:?}: {}",
+                state_path, e
+            );
+            return None;
+        }
+    };
+    match automerge::AutoCommit::load(&bytes) {
+        Ok(doc) => {
+            info!(
+                "[notebook-sync] Loaded persisted state doc from {:?}",
+                state_path
+            );
+            Some(RuntimeStateDoc::from_doc(doc))
+        }
+        Err(e) => {
+            warn!(
+                "[notebook-sync] Failed to decode persisted state doc {:?}: {}",
+                state_path, e
+            );
+            None
+        }
+    }
 }
 
 /// Derive the sibling state persistence path for a given notebook doc path.

--- a/crates/runtimed/src/paths.rs
+++ b/crates/runtimed/src/paths.rs
@@ -97,16 +97,25 @@ pub(crate) fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bo
     }
 
     // Snapshot the state sidecar with the same timestamp so the pair
-    // stays consistent. Absence is normal (pre-v3 rooms, ephemeral),
-    // so missing is not an error.
+    // stays consistent. Absence is normal (pre-v3 rooms, ephemeral);
+    // missing is not an error. A failed copy *is* — if we return true
+    // here the caller deletes the live sidecar, losing the only on-disk
+    // copy of RuntimeStateDoc. Better to fail the whole snapshot so the
+    // live files stay put.
     let state_src = state_persist_path_alongside(persist_path);
     if state_src.exists() {
         let state_snapshot = snapshots_dir.join(format!("{}-{}.state.automerge", stem, timestamp));
         if let Err(e) = std::fs::copy(&state_src, &state_snapshot) {
             warn!(
-                "[notebook-sync] Failed to snapshot state sidecar {:?}: {}",
+                "[notebook-sync] Failed to snapshot state sidecar {:?} \
+                 (aborting refresh to avoid losing output history): {}",
                 state_src, e
             );
+            // Roll back the notebook doc snapshot we just created —
+            // leaving it orphaned would pair a snapshot doc with no
+            // outputs on the next offline recovery.
+            let _ = std::fs::remove_file(&snapshot_path);
+            return false;
         }
     }
 
@@ -221,6 +230,46 @@ mod tests {
     #[test]
     fn normalize_save_target_rejects_relative() {
         assert!(normalize_save_target("foo.ipynb").is_err());
+    }
+
+    /// When the state sidecar's snapshot copy fails,
+    /// `snapshot_before_delete` must return false and roll back the
+    /// notebook-doc snapshot. Otherwise the caller would delete the
+    /// live sidecar and leave an orphaned notebook snapshot that
+    /// recovers with blank outputs.
+    #[test]
+    fn snapshot_before_delete_rolls_back_when_state_copy_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().to_path_buf();
+
+        let persist_path = docs_dir.join("abc.automerge");
+        let state_path = docs_dir.join("abc.state.automerge");
+        std::fs::write(&persist_path, b"notebook").unwrap();
+        // Write the sidecar as a directory so std::fs::copy fails on it.
+        std::fs::create_dir(&state_path).unwrap();
+
+        let ok = snapshot_before_delete(&persist_path, &docs_dir);
+        assert!(
+            !ok,
+            "snapshot_before_delete must fail when state copy fails"
+        );
+
+        // And the doc snapshot must not be left orphaned.
+        let snapshots_dir = docs_dir.join("snapshots");
+        let leftover: Vec<_> = std::fs::read_dir(&snapshots_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("abc-") && n.ends_with(".automerge"))
+            })
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "orphaned notebook snapshot left behind: {:?}",
+            leftover
+        );
     }
 
     /// snapshot_before_delete must mirror the notebook doc snapshot onto

--- a/crates/runtimed/src/paths.rs
+++ b/crates/runtimed/src/paths.rs
@@ -52,7 +52,10 @@ const MAX_SNAPSHOTS_PER_NOTEBOOK: usize = 5;
 /// Snapshot a persisted automerge doc before deleting it.
 ///
 /// Copies the file to `{docs_dir}/snapshots/{stem}-{millis}.automerge`
-/// and prunes old snapshots beyond `MAX_SNAPSHOTS_PER_NOTEBOOK`.
+/// and prunes old snapshots beyond `MAX_SNAPSHOTS_PER_NOTEBOOK`. If a
+/// paired `{stem}.state.automerge` sidecar exists, it gets a matching
+/// `{stem}-{millis}.state.automerge` snapshot so offline recovery can
+/// still pair outputs with the notebook doc it found.
 ///
 /// Returns `true` if the snapshot was created successfully. The caller
 /// should only delete the original file when this returns `true`.
@@ -93,16 +96,34 @@ pub(crate) fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bo
         }
     }
 
-    // Prune old snapshots for this hash (keep most recent MAX_SNAPSHOTS_PER_NOTEBOOK)
+    // Snapshot the state sidecar with the same timestamp so the pair
+    // stays consistent. Absence is normal (pre-v3 rooms, ephemeral),
+    // so missing is not an error.
+    let state_src = state_persist_path_alongside(persist_path);
+    if state_src.exists() {
+        let state_snapshot = snapshots_dir.join(format!("{}-{}.state.automerge", stem, timestamp));
+        if let Err(e) = std::fs::copy(&state_src, &state_snapshot) {
+            warn!(
+                "[notebook-sync] Failed to snapshot state sidecar {:?}: {}",
+                state_src, e
+            );
+        }
+    }
+
+    // Prune old snapshots for this hash (keep most recent MAX_SNAPSHOTS_PER_NOTEBOOK).
+    // Count only notebook-doc snapshots; state-doc siblings are pruned in
+    // lockstep via their matching timestamp.
     let prefix = format!("{}-", stem);
     let mut snapshots: Vec<_> = std::fs::read_dir(&snapshots_dir)
         .into_iter()
         .flatten()
         .flatten()
         .filter(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".automerge"))
+            e.file_name().to_str().is_some_and(|name| {
+                name.starts_with(&prefix)
+                    && name.ends_with(".automerge")
+                    && !name.ends_with(".state.automerge")
+            })
         })
         .collect();
 
@@ -110,11 +131,35 @@ pub(crate) fn snapshot_before_delete(persist_path: &Path, docs_dir: &Path) -> bo
         // Sort by filename (which embeds timestamp) — ascending order
         snapshots.sort_by_key(|e| e.file_name());
         for entry in &snapshots[..snapshots.len() - MAX_SNAPSHOTS_PER_NOTEBOOK] {
-            let _ = std::fs::remove_file(entry.path());
+            let snapshot_path = entry.path();
+            let _ = std::fs::remove_file(&snapshot_path);
+            // Prune matching state sidecar snapshot if present.
+            if let Some(state_sibling) = state_sidecar_for_snapshot(&snapshot_path) {
+                let _ = std::fs::remove_file(state_sibling);
+            }
         }
     }
 
     true
+}
+
+/// Compute `{stem}.state.automerge` next to a `{stem}.automerge` file.
+fn state_persist_path_alongside(notebook_path: &Path) -> PathBuf {
+    let parent = notebook_path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = notebook_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("doc");
+    parent.join(format!("{stem}.state.automerge"))
+}
+
+/// Given a snapshot path `{stem}-{ts}.automerge`, compute the matching
+/// state sidecar snapshot path `{stem}-{ts}.state.automerge`. Returns
+/// `None` when the input doesn't match the expected shape.
+fn state_sidecar_for_snapshot(snapshot_path: &Path) -> Option<PathBuf> {
+    let parent = snapshot_path.parent()?;
+    let stem = snapshot_path.file_stem()?.to_str()?;
+    Some(parent.join(format!("{stem}.state.automerge")))
 }
 
 /// Normalize a user-supplied save target: append `.ipynb` if missing, reject
@@ -176,5 +221,51 @@ mod tests {
     #[test]
     fn normalize_save_target_rejects_relative() {
         assert!(normalize_save_target("foo.ipynb").is_err());
+    }
+
+    /// snapshot_before_delete must mirror the notebook doc snapshot onto
+    /// its paired `.state.automerge` sidecar so offline recovery pairs
+    /// outputs with the right notebook snapshot.
+    #[test]
+    fn snapshot_before_delete_preserves_state_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_dir = tmp.path().to_path_buf();
+
+        let persist_path = docs_dir.join("abc.automerge");
+        let state_path = docs_dir.join("abc.state.automerge");
+        std::fs::write(&persist_path, b"notebook-bytes").unwrap();
+        std::fs::write(&state_path, b"state-bytes").unwrap();
+
+        assert!(snapshot_before_delete(&persist_path, &docs_dir));
+
+        let snapshots_dir = docs_dir.join("snapshots");
+        let mut notebook_snapshots: Vec<_> = std::fs::read_dir(&snapshots_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name().to_str().is_some_and(|n| {
+                    n.starts_with("abc-")
+                        && n.ends_with(".automerge")
+                        && !n.ends_with(".state.automerge")
+                })
+            })
+            .collect();
+        notebook_snapshots.sort_by_key(|e| e.file_name());
+        assert_eq!(notebook_snapshots.len(), 1, "notebook snapshot missing");
+
+        let state_snapshots: Vec<_> = std::fs::read_dir(&snapshots_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("abc-") && n.ends_with(".state.automerge"))
+            })
+            .collect();
+        assert_eq!(
+            state_snapshots.len(),
+            1,
+            "state sidecar snapshot missing — offline recovery would pair the notebook snapshot with stale outputs"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`runt recover` was shipping `.ipynb` files with empty `outputs` arrays on every cell. Root cause: the export path read outputs from `CellSnapshot.outputs`, which has been unconditionally empty since schema v3 moved cell outputs into the daemon-authoritative `RuntimeStateDoc`. `RuntimeStateDoc` had never been persisted to disk, so offline recovery had no path back to the output manifests.

Fix ships both sides end to end:

- **Daemon now persists `RuntimeStateDoc` to a `{stem}.state.automerge` sibling** next to the notebook doc. A new debouncer mirrors the main one; a forwarder task subscribes to `state_changed_tx` and feeds the debouncer on every state mutation.
- **`runt recover` reads that sidecar** (when present) and hands it to `doc_to_ipynb_with_state`, which follows each cell's `execution_id` pointer into the state doc, pulls the output manifests, and resolves inline / blob `ContentRef` entries. Blob resolution is MIME-aware: text MIMEs come back as strings, JSON MIMEs round-trip as structured JSON, binary MIMEs base64-encode the raw bytes. The blob store root is derived from the matching `.automerge` path so cross-namespace recoveries (stable / nightly / worktree) hit the right `blobs/` directory.
- **Lifecycle is coherent**: snapshots pair the state sidecar with the notebook doc; eviction flushes synchronously; blob GC scans state-sidecar files (including snapshots) so blob-backed outputs survive the grace window; the orphaned-doc sweep reclaims stranded sidecars; untitled→saved promotion disables the forwarder and deletes the sidecar so the UUID-keyed path doesn't get rewritten after the `.ipynb` takes over.
- **Fallback** keeps pre-v3 captures alive: when no state sidecar exists and the NotebookDoc's `schema_version < 3`, recovery extracts cell-local outputs via `extract_cell_outputs` and resolves their ContentRefs the same way. A schema-v3 doc with a cleared `execution_id` does NOT fall back — that's a user-initiated clear, not recoverable data.

TDD order: failing regression test lands first, then the receiver side, then daemon-side state persistence. Codex review surfaced five rounds of lifecycle gaps (GC, eviction, promotion, lag, discriminator); each round has commits + tests.

Commits (top-down):

- `fix(runtimed): disable state-sidecar forwarder after untitled promotion`
- `fix: reclaim orphaned state sidecars, tighten ContentRef discriminator`
- `fix: stop pairing stale exec_count with empty outputs, reserialize on lag`
- `fix(runtimed): scan notebook-docs/snapshots during blob GC`
- `fix(runtimed): teach GC and eviction about state sidecars`
- `fix(runtimed): load state sidecar on reopen, gate recover fallback on v2`
- `fix(recover): fall back to legacy outputs when state sidecar is stale`
- `fix(recover): pair state sidecar lifecycle with notebook doc`
- `fix(runt): MIME-aware ContentRef resolution for display_data bundles`
- `feat(runtimed): persist RuntimeStateDoc to sibling .state.automerge`
- `fix(runt): load RuntimeStateDoc and resolve blob refs in recover`
- `test(runt): regression test for recover dropping cell outputs`

## Edge cases + follow-ups

- `looks_like_content_ref` is a strict structural check. The daemon always wraps user JSON in a ContentRef before writing, so in practice the check buys the common case without corrupting user data. If someone hand-crafts a state doc containing a raw JSON value shaped exactly like `{"inline":"<string>"}` at a ContentRef position, recovery would unwrap it. No such path exists through the current codebase.
- Eviction flushes the state sidecar synchronously by writing bytes directly, then kicks the debouncer. No dedicated ack channel yet; a disk error is logged but doesn't block eviction. Adding a `flush_request_tx` analogue is reasonable follow-up.
- Binary MIMEs (PNG, audio, video) resolve by reading raw bytes and base64-encoding. Runt-cli keeps the bytes in memory during resolution — fine for typical notebooks, potentially large for > 100MiB images. No streaming path yet.
- Recovery of active-session state: if the daemon is running when `runt recover` is invoked, the sidecar may be mid-flush, so the recovered outputs reflect the last debounced snapshot (up to ~500ms stale). Offline recovery after daemon shutdown is exact.
- Missing blob file on disk: ContentRef passes through unresolved rather than being dropped, so recovered `.ipynb` still shows some structure. Could be tightened to a placeholder stream output.

## Test plan

- [x] `cargo test -p runt-cli --bin runt` — 18 tests, including new regression tests covering inline/blob ContentRefs, MIME-aware display_data, stale-sidecar tolerance, ContentRef discriminator, and the cache-root derivation.
- [x] `cargo test -p runtimed --lib` — 383 tests, including new snapshot-pairing test and tokio-mutex lint.
- [x] `cargo test -p notebook-doc --lib` — 354 tests.
- [x] `cargo xtask lint` — rustfmt, clippy, biome, ruff, ty all green.
- [x] `codex review --base main` — ran 5 rounds; all P1/P2 findings addressed with code+tests; remaining theoretical notes documented above.
- [ ] Manual smoke: temp daemon → execute cell → shut down → `runt recover` against the `{hash}.automerge` → verify outputs present. (Not run locally due to worktree daemon isolation overhead; the regression tests exercise the same code paths end-to-end.)
