### PR TITLE
refactor: remove CellSnapshot.outputs vestige; outputs live in RuntimeStateDoc

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -237,10 +237,10 @@ export class NotebookHandle {
      * Each element is a structured output manifest (with MIME bundles and
      * ContentRef blob/inline refs). Returns undefined if the cell doesn't exist.
      *
-     * Outputs now live in the RuntimeStateDoc keyed by execution_id. This
-     * method reads the cell's `execution_id` from the notebook doc, then
-     * looks up outputs in the state doc — providing a transparent facade
-     * for all existing callers.
+     * Outputs live in the RuntimeStateDoc keyed by execution_id. This method
+     * reads the cell's `execution_id` from the notebook doc, then looks up
+     * outputs in the state doc — the dedicated outputs lookup that replaces
+     * the old "read the snapshot and inspect `snapshot.outputs`" path.
      */
     get_cell_outputs(cell_id: string): any;
     /**
@@ -257,14 +257,20 @@ export class NotebookHandle {
     get_cell_type(cell_id: string): string | undefined;
     /**
      * Get all cells as an array of JsCell objects.
+     *
+     * Outputs are fetched from `RuntimeStateDoc` keyed by each cell's
+     * `execution_id`. Cells without an execution_id or with empty outputs
+     * return an empty outputs vec.
      */
     get_cells(): JsCell[];
     /**
      * Get all cells as a JSON string (for bulk materialization).
      *
-     * Populates each cell's outputs from the RuntimeStateDoc via
-     * the cell's execution_id, since NotebookDoc.get_cells() returns
-     * empty outputs (outputs moved to RuntimeStateDoc in #1343).
+     * Serializes the same shape as `get_cells()` but as a single JSON
+     * string — cheaper to cross the WASM boundary than many individual
+     * property getters. Outputs are fetched from `RuntimeStateDoc` keyed
+     * by each cell's `execution_id`; `CellSnapshot` itself no longer
+     * carries outputs.
      */
     get_cells_json(): string;
     /**

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -777,10 +777,10 @@ export class NotebookHandle {
      * Each element is a structured output manifest (with MIME bundles and
      * ContentRef blob/inline refs). Returns undefined if the cell doesn't exist.
      *
-     * Outputs now live in the RuntimeStateDoc keyed by execution_id. This
-     * method reads the cell's `execution_id` from the notebook doc, then
-     * looks up outputs in the state doc — providing a transparent facade
-     * for all existing callers.
+     * Outputs live in the RuntimeStateDoc keyed by execution_id. This method
+     * reads the cell's `execution_id` from the notebook doc, then looks up
+     * outputs in the state doc — the dedicated outputs lookup that replaces
+     * the old "read the snapshot and inspect `snapshot.outputs`" path.
      * @param {string} cell_id
      * @returns {any}
      */
@@ -861,6 +861,10 @@ export class NotebookHandle {
     }
     /**
      * Get all cells as an array of JsCell objects.
+     *
+     * Outputs are fetched from `RuntimeStateDoc` keyed by each cell's
+     * `execution_id`. Cells without an execution_id or with empty outputs
+     * return an empty outputs vec.
      * @returns {JsCell[]}
      */
     get_cells() {
@@ -879,9 +883,11 @@ export class NotebookHandle {
     /**
      * Get all cells as a JSON string (for bulk materialization).
      *
-     * Populates each cell's outputs from the RuntimeStateDoc via
-     * the cell's execution_id, since NotebookDoc.get_cells() returns
-     * empty outputs (outputs moved to RuntimeStateDoc in #1343).
+     * Serializes the same shape as `get_cells()` but as a single JSON
+     * string — cheaper to cross the WASM boundary than many individual
+     * property getters. Outputs are fetched from `RuntimeStateDoc` keyed
+     * by each cell's `execution_id`; `CellSnapshot` itself no longer
+     * carries outputs.
      * @returns {string}
      */
     get_cells_json() {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7a64287c5865f7b0d985fa5a7299d64ad08d966dc804e73b29d6799fa830d9c
-size 1669510
+oid sha256:7eb9fb0eeeb37c24a0e066737e36393ac5d93b594bbec5ebbb675b202132373b
+size 1669635

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -93,6 +93,12 @@ pub struct StreamOutputState {
 }
 
 /// Snapshot of a single cell's state, suitable for serialization.
+///
+/// `CellSnapshot` represents only the fields that live in the notebook
+/// Automerge document. Outputs moved to `RuntimeStateDoc` in schema v3
+/// and are looked up separately, keyed by the cell's `execution_id`.
+/// Callers that need outputs should use a dedicated lookup such as
+/// `DocHandle::get_cell_outputs(cell_id)` or `DocHandle::get_all_outputs()`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CellSnapshot {
     pub id: String,
@@ -104,8 +110,6 @@ pub struct CellSnapshot {
     pub source: String,
     /// JSON-encoded execution count: a number string like "5" or "null"
     pub execution_count: String,
-    /// Inline output manifests (structured JSON with ContentRef blob/inline refs)
-    pub outputs: Vec<serde_json::Value>,
     /// Cell metadata (arbitrary JSON object, preserves unknown keys)
     #[serde(default = "default_empty_object")]
     pub metadata: serde_json::Value,
@@ -755,10 +759,10 @@ impl NotebookDoc {
             self.doc
                 .put(&cell_obj, "execution_count", cell.execution_count.as_str())?;
 
-            let outputs_id = self.doc.put_object(&cell_obj, "outputs", ObjType::List)?;
-            for (j, output) in cell.outputs.iter().enumerate() {
-                insert_json_at_index(&mut self.doc, &outputs_id, j, output)?;
-            }
+            // Outputs moved to RuntimeStateDoc in schema v3. The v1→v2 step
+            // no longer carries them — a subsequent v2→v3 migration step
+            // moves any pre-existing outputs into RuntimeStateDoc via
+            // `extract_cell_outputs` before callers reach this point.
 
             if cell.metadata != serde_json::Value::Object(serde_json::Map::new()) {
                 let meta_str =
@@ -2022,9 +2026,8 @@ impl NotebookDoc {
             .and_then(|text_id| self.doc.text(&text_id).ok())
             .unwrap_or_default();
 
-        // Outputs live in RuntimeStateDoc, not in the notebook doc.
-        // DocHandle and WASM populate CellSnapshot.outputs from RuntimeStateDoc.
-        let outputs = vec![];
+        // Outputs live in RuntimeStateDoc, keyed by execution_id. Callers
+        // that need them must fetch explicitly (see DocHandle::get_cell_outputs).
 
         // Read metadata (native Automerge map with legacy string fallback)
         let metadata = read_cell_metadata(&self.doc, cell_obj);
@@ -2052,7 +2055,6 @@ impl NotebookDoc {
             position,
             source,
             execution_count,
-            outputs,
             metadata,
             resolved_assets,
         })
@@ -2564,15 +2566,7 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 })
                 .unwrap_or_default();
 
-            let outputs = match doc.get(&cell_obj, "outputs").ok().flatten() {
-                Some((automerge::Value::Object(ObjType::List), list_id)) => {
-                    let len = doc.length(&list_id);
-                    (0..len)
-                        .filter_map(|j| read_json_value(doc, &list_id, j))
-                        .collect()
-                }
-                _ => vec![],
-            };
+            // Outputs live in RuntimeStateDoc, keyed by execution_id.
 
             // Read metadata (native Automerge map with legacy string fallback)
             let metadata = read_cell_metadata(doc, &cell_obj);
@@ -2599,7 +2593,6 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 position,
                 source,
                 execution_count,
-                outputs,
                 metadata,
                 resolved_assets,
             })
@@ -2873,7 +2866,6 @@ mod tests {
         assert_eq!(cell.cell_type, "code");
         assert_eq!(cell.source, "");
         assert_eq!(cell.execution_count, "null");
-        assert!(cell.outputs.is_empty());
     }
 
     #[test]
@@ -3879,8 +3871,9 @@ mod tests {
         let cells = doc.get_cells();
         assert_eq!(cells.len(), 1);
         assert_eq!(cells[0].execution_count, "5");
-        // outputs are no longer read from the notebook doc (always vec![])
-        assert!(cells[0].outputs.is_empty());
+        // Outputs no longer live on CellSnapshot — they're keyed by
+        // execution_id in RuntimeStateDoc. The migration path drops the
+        // legacy per-cell `outputs` list entirely.
     }
 
     #[test]

--- a/crates/notebook-doc/src/pep723.rs
+++ b/crates/notebook-doc/src/pep723.rs
@@ -318,7 +318,6 @@ print(os.getcwd())"#;
             source: source.to_string(),
             position: position.to_string(),
             execution_count: "null".to_string(),
-            outputs: vec![],
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
         }

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -674,11 +674,10 @@ impl DocHandle {
     /// the returned map. Prefer this over calling [`Self::get_cell_outputs`]
     /// in a loop — it walks the doc once.
     pub fn get_all_outputs(&self) -> std::collections::HashMap<String, Vec<serde_json::Value>> {
-        let mut map = std::collections::HashMap::new();
-        let state = match self.doc.lock() {
-            Ok(guard) => guard,
-            Err(_) => return map,
-        };
+        // Snapshot the cell ids first so we never hold the watch-channel
+        // borrow across the shared doc lock. Another task calling `with_doc`
+        // acquires the doc lock and then publishes to the watch channel —
+        // holding both locks in the reverse order here would deadlock.
         let cell_ids: Vec<String> = self
             .snapshot_rx
             .borrow()
@@ -686,15 +685,19 @@ impl DocHandle {
             .iter()
             .map(|c| c.id.clone())
             .collect();
-        for cell_id in cell_ids {
-            if let Some(eid) = read_execution_id(&state.doc, &cell_id) {
+        // Poisoned shared state returns empty — matches the silent-fallback
+        // pattern used elsewhere in this handle for mutex-locked reads.
+        let Ok(state) = self.doc.lock() else {
+            return std::collections::HashMap::new();
+        };
+        cell_ids
+            .into_iter()
+            .filter_map(|cell_id| {
+                let eid = read_execution_id(&state.doc, &cell_id)?;
                 let outputs = state.state_doc.get_outputs(&eid);
-                if !outputs.is_empty() {
-                    map.insert(cell_id, outputs);
-                }
-            }
-        }
-        map
+                (!outputs.is_empty()).then_some((cell_id, outputs))
+            })
+            .collect()
     }
 
     /// Get the typed notebook metadata from the latest snapshot.

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -409,19 +409,13 @@ impl DocHandle {
     }
 
     /// Get a single cell by ID from the latest snapshot.
+    ///
+    /// Outputs are not included — they live in `RuntimeStateDoc` keyed by
+    /// `execution_id`. Call [`Self::get_cell_outputs`] or
+    /// [`Self::get_all_outputs`] alongside this method when you need them.
     pub fn get_cell(&self, cell_id: &str) -> Option<notebook_doc::CellSnapshot> {
         let snapshot = self.snapshot_rx.borrow();
-        let mut cell = snapshot.cells.iter().find(|c| c.id == cell_id).cloned()?;
-        // Populate outputs from RuntimeStateDoc via execution_id facade
-        if let Ok(state) = self.doc.lock() {
-            if let Some(eid) = read_execution_id(&state.doc, cell_id) {
-                let outputs = state.state_doc.get_outputs(&eid);
-                if !outputs.is_empty() {
-                    cell.outputs = outputs;
-                }
-            }
-        }
-        Some(cell)
+        snapshot.cells.iter().find(|c| c.id == cell_id).cloned()
     }
 
     /// Get the ordered list of cell IDs from the latest snapshot.
@@ -664,21 +658,43 @@ impl DocHandle {
         self.snapshot_rx.borrow().clone()
     }
 
-    /// Get all cells from the latest snapshot with outputs from RuntimeStateDoc.
+    /// Get all cells from the latest snapshot.
+    ///
+    /// Outputs are not included — they live in `RuntimeStateDoc` keyed by
+    /// `execution_id`. Call [`Self::get_all_outputs`] alongside this method
+    /// when you need them.
     pub fn get_cells(&self) -> Vec<notebook_doc::CellSnapshot> {
-        let mut cells = self.snapshot_rx.borrow().cells.as_ref().clone();
-        // Populate outputs from RuntimeStateDoc for each cell
-        if let Ok(state) = self.doc.lock() {
-            for cell in &mut cells {
-                if let Some(eid) = read_execution_id(&state.doc, &cell.id) {
-                    let outputs = state.state_doc.get_outputs(&eid);
-                    if !outputs.is_empty() {
-                        cell.outputs = outputs;
-                    }
+        self.snapshot_rx.borrow().cells.as_ref().clone()
+    }
+
+    /// Get outputs for every cell that currently has an execution_id.
+    ///
+    /// Outputs are looked up in `RuntimeStateDoc` keyed by `execution_id`.
+    /// Cells without an execution_id or with empty outputs are omitted from
+    /// the returned map. Prefer this over calling [`Self::get_cell_outputs`]
+    /// in a loop — it walks the doc once.
+    pub fn get_all_outputs(&self) -> std::collections::HashMap<String, Vec<serde_json::Value>> {
+        let mut map = std::collections::HashMap::new();
+        let state = match self.doc.lock() {
+            Ok(guard) => guard,
+            Err(_) => return map,
+        };
+        let cell_ids: Vec<String> = self
+            .snapshot_rx
+            .borrow()
+            .cells
+            .iter()
+            .map(|c| c.id.clone())
+            .collect();
+        for cell_id in cell_ids {
+            if let Some(eid) = read_execution_id(&state.doc, &cell_id) {
+                let outputs = state.state_doc.get_outputs(&eid);
+                if !outputs.is_empty() {
+                    map.insert(cell_id, outputs);
                 }
             }
         }
-        cells
+        map
     }
 
     /// Get the typed notebook metadata from the latest snapshot.

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -987,14 +987,16 @@ mod integration_tests {
             .await
             .expect("confirm_sync after exec");
 
-        // Read outputs from the Automerge doc (source of truth)
-        // Outputs are stored as manifest hashes (blob references) or raw JSON —
-        // the important thing is that they exist after execution.
+        // Read outputs via the explicit lookup — outputs now live in
+        // RuntimeStateDoc keyed by execution_id, not on CellSnapshot.
         let snap = handle.snapshot();
         let cell = snap.get_cell("cell-exec").expect("cell should exist");
 
+        let outputs = handle
+            .get_cell_outputs("cell-exec")
+            .expect("Cell should have outputs after execution");
         assert!(
-            !cell.outputs.is_empty(),
+            !outputs.is_empty(),
             "Cell should have outputs after execution"
         );
 

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -133,16 +133,21 @@ pub async fn execute_and_wait(
             comms.as_ref(),
         )
         .await
-    } else if let Some(cell_snapshot) = handle.get_cell(cell_id) {
-        output_resolver::resolve_cell_outputs_for_llm(
-            &cell_snapshot.outputs,
-            blob_base_url,
-            blob_store_path,
-            comms.as_ref(),
-        )
-        .await
     } else {
-        Vec::new()
+        // Outputs live in RuntimeStateDoc keyed by execution_id. Fetch via
+        // the explicit lookup — CellSnapshot no longer carries them.
+        let raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
+        if raw_outputs.is_empty() {
+            Vec::new()
+        } else {
+            output_resolver::resolve_cell_outputs_for_llm(
+                &raw_outputs,
+                blob_base_url,
+                blob_store_path,
+                comms.as_ref(),
+            )
+            .await
+        }
     };
 
     // Determine status from outputs if we didn't get it from RuntimeState

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -55,7 +55,7 @@ pub async fn get_cell(
 
     // No presence on read — get_cell is read-only, shouldn't move the cursor.
 
-    let mut cell = match handle.get_cell(cell_id) {
+    let cell = match handle.get_cell(cell_id) {
         Some(c) => c,
         None => return tool_error(&format!("Cell not found: {cell_id}")),
     };
@@ -63,19 +63,22 @@ pub async fn get_cell(
     // Get execution_count from RuntimeStateDoc (the source of truth)
     let ec = get_cell_execution_count_from_runtime(&handle, cell_id);
 
+    // Outputs live in RuntimeStateDoc keyed by execution_id. Fetch them
+    // via the dedicated lookup rather than reading a (now-gone) field
+    // on CellSnapshot.
+    let mut raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
+
     // If the cell has been executed but outputs haven't synced yet,
     // force a sync round-trip to process pending RuntimeStateSync frames.
-    if cell.outputs.is_empty() && !ec.is_empty() {
+    if raw_outputs.is_empty() && !ec.is_empty() {
         let _ = handle.confirm_sync().await;
-        if let Some(c) = handle.get_cell(cell_id) {
-            cell = c;
-        }
+        raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
     }
 
     // Resolve outputs (with widget state synthesis)
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = output_resolver::resolve_cell_outputs_for_llm(
-        &cell.outputs,
+        &raw_outputs,
         &server.blob_base_url,
         &server.blob_store_path,
         comms.as_ref(),
@@ -154,10 +157,14 @@ pub async fn get_all_cells(
     };
     let slice = &cells[start.min(cells.len())..end.min(cells.len())];
 
-    // Build cell status map, execution count map, and comms from RuntimeState
+    // Build cell status map, execution count map, and comms from RuntimeState.
+    // Outputs live in RuntimeStateDoc keyed by execution_id; fetch them in
+    // bulk once so large notebooks don't pay O(N) state-doc reads.
     let cell_status_map = build_cell_status_map(&handle);
     let cell_ec_map = build_cell_execution_count_map(&handle);
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
+    let outputs_by_cell = handle.get_all_outputs();
+    let empty_outputs: Vec<serde_json::Value> = Vec::new();
 
     match format {
         "json" => {
@@ -165,11 +172,12 @@ pub async fn get_all_cells(
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec: Option<i64> = cell_ec_map.get(&cell.id).and_then(|s| s.parse().ok());
+                let raw_outputs = outputs_by_cell.get(&cell.id).unwrap_or(&empty_outputs);
 
                 // Resolve outputs through the output resolver so that
                 // text/llm+plain is synthesized and viz specs are summarized.
                 let resolved = output_resolver::resolve_cell_outputs_for_llm(
-                    &cell.outputs,
+                    raw_outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
                     comms.as_ref(),
@@ -205,8 +213,9 @@ pub async fn get_all_cells(
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec = cell_ec_map.get(&cell.id).map(String::as_str);
+                let raw_outputs = outputs_by_cell.get(&cell.id).unwrap_or(&empty_outputs);
                 let outputs = output_resolver::resolve_cell_outputs_for_llm(
-                    &cell.outputs,
+                    raw_outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
                     comms.as_ref(),
@@ -247,9 +256,10 @@ pub async fn get_all_cells(
                     status,
                     preview_chars,
                 );
-                if include_outputs && !cell.outputs.is_empty() {
+                let raw_outputs = outputs_by_cell.get(&cell.id).unwrap_or(&empty_outputs);
+                if include_outputs && !raw_outputs.is_empty() {
                     let outputs = output_resolver::resolve_cell_outputs_for_llm(
-                        &cell.outputs,
+                        raw_outputs,
                         &server.blob_base_url,
                         &server.blob_store_path,
                         comms.as_ref(),

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -229,14 +229,17 @@ pub async fn run_all_cells(
         // Extract the inner "cell" object — cell_structured_content_from_manifests
         // returns {"cell": {...}, "blob_base_url": "..."} but the multi-cell
         // wrapper expects CellData directly in the cells[] array.
+        // Outputs live in RuntimeStateDoc, keyed by execution_id; fetch them
+        // alongside the snapshot.
         let cell_snapshot = handle.get_cell(&cell.id);
         if let Some(snap) = cell_snapshot {
-            if !snap.outputs.is_empty() {
+            let snap_outputs = handle.get_cell_outputs(&cell.id).unwrap_or_default();
+            if !snap_outputs.is_empty() {
                 let wrapped = crate::structured::cell_structured_content_from_manifests(
                     &snap.id,
                     &snap.cell_type,
                     &snap.source,
-                    &snap.outputs,
+                    &snap_outputs,
                     exec.execution_count,
                     display_status,
                     &server.blob_base_url,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -459,9 +459,12 @@ pub async fn build_execution_result(
 
     // Build structured content directly from manifest Values + blob URLs.
     // No blob fetches — inline ContentRefs pass through, blobs become URLs.
+    // Outputs live in RuntimeStateDoc, keyed by execution_id, so we fetch
+    // them separately from the cell snapshot.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let structured_content = if let Some(snap) = cell_snapshot {
-        if snap.outputs.is_empty() {
+        let outputs = handle.get_cell_outputs(&result.cell_id).unwrap_or_default();
+        if outputs.is_empty() {
             None
         } else {
             let ec_str = cell_read::get_cell_execution_count_from_runtime(handle, &snap.id);
@@ -474,7 +477,7 @@ pub async fn build_execution_result(
                 &snap.id,
                 &snap.cell_type,
                 &snap.source,
-                &snap.outputs,
+                &outputs,
                 ec,
                 &result.status,
                 &server.blob_base_url,

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5026,6 +5026,13 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
 
     match client.inspect_notebook(&notebook_id).await {
         Ok(result) => {
+            let empty_outputs: Vec<serde_json::Value> = Vec::new();
+            let cell_outputs = |cell_id: &str| -> &Vec<serde_json::Value> {
+                result
+                    .outputs_by_cell
+                    .get(cell_id)
+                    .unwrap_or(&empty_outputs)
+            };
             if json_output {
                 // Full JSON output
                 let output = serde_json::json!({
@@ -5033,10 +5040,11 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
                     "source": result.source,
                     "kernel_info": result.kernel_info,
                     "cells": result.cells.iter().map(|c| {
+                        let outs = cell_outputs(&c.id);
                         let outputs_info: Vec<serde_json::Value> = if full_outputs {
-                            c.outputs.clone()
+                            outs.clone()
                         } else {
-                            c.outputs.iter().map(|o| {
+                            outs.iter().map(|o| {
                                 let size = serde_json::to_string(o).map(|s| s.len()).unwrap_or(0);
                                 if let Some(otype) = o.get("output_type").and_then(|v| v.as_str()) {
                                     serde_json::json!({
@@ -5092,17 +5100,18 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
                         format!("[{}]", cell.execution_count)
                     };
 
+                    let outs = cell_outputs(&cell.id);
                     println!(
                         "{:2}. {} {:8} | {} | outputs: {}",
                         i + 1,
                         exec_count,
                         cell.cell_type,
                         source_preview,
-                        cell.outputs.len()
+                        outs.len()
                     );
 
-                    if full_outputs && !cell.outputs.is_empty() {
-                        for (j, output) in cell.outputs.iter().enumerate() {
+                    if full_outputs && !outs.is_empty() {
+                        for (j, output) in outs.iter().enumerate() {
                             println!(
                                 "      output[{}]: {}",
                                 j,

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -54,6 +54,10 @@ use tokio::net::windows::named_pipe::ClientOptions;
 pub struct InspectResult {
     pub notebook_id: String,
     pub cells: Vec<crate::notebook_doc::CellSnapshot>,
+    /// Outputs keyed by cell_id. Outputs live in `RuntimeStateDoc` keyed
+    /// by `execution_id` and travel alongside the cell snapshot rather
+    /// than on it. Cells without outputs are absent from the map.
+    pub outputs_by_cell: std::collections::HashMap<String, Vec<serde_json::Value>>,
     pub source: String,
     pub kernel_info: Option<crate::protocol::NotebookKernelInfo>,
 }
@@ -327,11 +331,13 @@ impl PoolClient {
             Response::NotebookState {
                 notebook_id,
                 cells,
+                outputs_by_cell,
                 source,
                 kernel_info,
             } => Ok(InspectResult {
                 notebook_id,
                 cells,
+                outputs_by_cell,
                 source,
                 kernel_info,
             }),

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -149,6 +149,12 @@ pub enum Response {
         notebook_id: String,
         /// Cell snapshots from the Automerge doc.
         cells: Vec<crate::notebook_doc::CellSnapshot>,
+        /// Outputs keyed by cell_id. Outputs live in `RuntimeStateDoc`
+        /// keyed by `execution_id`, so they travel here as a parallel map
+        /// rather than on `CellSnapshot`. Only cells with non-empty outputs
+        /// appear.
+        #[serde(default)]
+        outputs_by_cell: std::collections::HashMap<String, Vec<serde_json::Value>>,
         /// Whether this was loaded from a live room or from disk.
         source: String,
         /// Kernel info if a kernel is running.

--- a/crates/runtimed-client/src/resolved_output.rs
+++ b/crates/runtimed-client/src/resolved_output.rs
@@ -237,7 +237,6 @@ mod tests {
             position: "80".into(),
             source: "print('hi')".into(),
             execution_count: "null".into(),
-            outputs: vec![],
             metadata,
             resolved_assets: HashMap::new(),
         }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -848,7 +848,7 @@ pub(crate) async fn set_cell_type(
 
 /// Get a single cell by ID, with resolved outputs.
 pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<Cell> {
-    let (snapshot, blob_base_url, blob_store_path, comms) = {
+    let (snapshot, raw_outputs, blob_base_url, blob_store_path, comms) = {
         let st = state.lock().await;
         let handle = st
             .handle
@@ -862,12 +862,15 @@ pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
         let snapshot = handle
             .get_cell(cell_id)
             .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))?;
+        // Outputs live in RuntimeStateDoc — fetch them alongside the snapshot
+        // so downstream resolution sees the latest manifests.
+        let raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
 
-        (snapshot, blob_base_url, blob_store_path, comms)
+        (snapshot, raw_outputs, blob_base_url, blob_store_path, comms)
     };
 
     let outputs = output_resolver::resolve_cell_outputs(
-        &snapshot.outputs,
+        &raw_outputs,
         &blob_base_url,
         &blob_store_path,
         comms.as_ref(),
@@ -879,7 +882,7 @@ pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
 
 /// Get all cells with resolved outputs.
 pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<Cell>> {
-    let (snapshots, blob_base_url, blob_store_path, comms) = {
+    let (snapshots, mut outputs_by_cell, blob_base_url, blob_store_path, comms) = {
         let st = state.lock().await;
         let handle = st
             .handle
@@ -890,14 +893,24 @@ pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<
         let blob_store_path = st.blob_store_path.clone();
         let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
         let snapshots = handle.get_cells();
+        // Outputs live in RuntimeStateDoc. Fetch them once in bulk rather
+        // than a lookup per cell — avoids O(N) roundtrips for large notebooks.
+        let outputs_by_cell = handle.get_all_outputs();
 
-        (snapshots, blob_base_url, blob_store_path, comms)
+        (
+            snapshots,
+            outputs_by_cell,
+            blob_base_url,
+            blob_store_path,
+            comms,
+        )
     };
 
     let mut cells = Vec::with_capacity(snapshots.len());
     for snapshot in snapshots {
+        let raw_outputs = outputs_by_cell.remove(&snapshot.id).unwrap_or_default();
         let outputs = output_resolver::resolve_cell_outputs(
-            &snapshot.outputs,
+            &raw_outputs,
             &blob_base_url,
             &blob_store_path,
             comms.as_ref(),
@@ -1442,6 +1455,7 @@ pub(crate) async fn collect_outputs(
     // carry an execution_id pointer and outputs are keyed by execution_id
     // in the RuntimeStateDoc.
     let mut snapshot = None;
+    let mut raw_outputs_out: Vec<serde_json::Value> = Vec::new();
     let mut blob_base_url_out = None;
     let mut blob_store_path_out = None;
     let mut comms_out = None;
@@ -1462,8 +1476,9 @@ pub(crate) async fn collect_outputs(
                 cell_id
             ))
         })?;
+        let raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
 
-        let has_outputs = !snap.outputs.is_empty();
+        let has_outputs = !raw_outputs.is_empty();
         let has_ec = snap.execution_count != "null" && !snap.execution_count.is_empty();
 
         if has_outputs || has_ec || attempt >= 4 {
@@ -1471,6 +1486,7 @@ pub(crate) async fn collect_outputs(
             blob_store_path_out = blob_store_path.clone();
             comms_out = handle.get_runtime_state().ok().map(|rs| rs.comms);
             snapshot = Some(snap);
+            raw_outputs_out = raw_outputs;
             break;
         }
 
@@ -1483,7 +1499,7 @@ pub(crate) async fn collect_outputs(
     let execution_count = snapshot.execution_count.parse::<i64>().ok();
 
     let outputs = output_resolver::resolve_cell_outputs(
-        &snapshot.outputs,
+        &raw_outputs_out,
         &blob_base_url_out,
         &blob_store_path_out,
         comms_out.as_ref(),

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -253,19 +253,21 @@ impl JsCell {
     }
 }
 
-impl From<(usize, CellSnapshot)> for JsCell {
-    fn from((index, snap): (usize, CellSnapshot)) -> Self {
-        JsCell {
-            index,
-            id: snap.id,
-            cell_type: snap.cell_type,
-            position: snap.position,
-            source: snap.source,
-            execution_count: snap.execution_count,
-            outputs: snap.outputs,
-            metadata: snap.metadata,
-            resolved_assets: snap.resolved_assets,
-        }
+/// Build a `JsCell` from a `CellSnapshot` and the cell's outputs fetched
+/// separately from `RuntimeStateDoc`. Outputs no longer travel on
+/// `CellSnapshot` — callers resolve them explicitly via
+/// `state_doc.get_outputs(execution_id)`.
+fn js_cell_from_parts(index: usize, snap: CellSnapshot, outputs: Vec<serde_json::Value>) -> JsCell {
+    JsCell {
+        index,
+        id: snap.id,
+        cell_type: snap.cell_type,
+        position: snap.position,
+        source: snap.source,
+        execution_count: snap.execution_count,
+        outputs,
+        metadata: snap.metadata,
+        resolved_assets: snap.resolved_assets,
     }
 }
 
@@ -481,34 +483,49 @@ impl NotebookHandle {
     }
 
     /// Get all cells as an array of JsCell objects.
+    ///
+    /// Outputs are fetched from `RuntimeStateDoc` keyed by each cell's
+    /// `execution_id`. Cells without an execution_id or with empty outputs
+    /// return an empty outputs vec.
     pub fn get_cells(&self) -> Vec<JsCell> {
         self.doc
             .get_cells()
             .into_iter()
             .enumerate()
-            .map(JsCell::from)
+            .map(|(index, snap)| {
+                let outputs = self.fetch_and_narrow_outputs(&snap.id);
+                js_cell_from_parts(index, snap, outputs)
+            })
             .collect()
     }
 
     /// Get all cells as a JSON string (for bulk materialization).
     ///
-    /// Populates each cell's outputs from the RuntimeStateDoc via
-    /// the cell's execution_id, since NotebookDoc.get_cells() returns
-    /// empty outputs (outputs moved to RuntimeStateDoc in #1343).
+    /// Serializes the same shape as `get_cells()` but as a single JSON
+    /// string — cheaper to cross the WASM boundary than many individual
+    /// property getters. Outputs are fetched from `RuntimeStateDoc` keyed
+    /// by each cell's `execution_id`; `CellSnapshot` itself no longer
+    /// carries outputs.
     pub fn get_cells_json(&self) -> String {
-        let mut cells = self.doc.get_cells();
-        for cell in &mut cells {
-            if let Some(eid) = self.doc.get_execution_id(&cell.id) {
-                let outputs = self.state_doc.get_outputs(&eid);
-                if !outputs.is_empty() {
-                    cell.outputs = outputs
-                        .into_iter()
-                        .map(|o| self.narrow_output_data(o))
-                        .collect();
-                }
-            }
+        #[derive(serde::Serialize)]
+        struct CellWithOutputs<'a> {
+            #[serde(flatten)]
+            snapshot: &'a CellSnapshot,
+            outputs: Vec<serde_json::Value>,
         }
-        serde_json::to_string(&cells).unwrap_or_else(|_| "[]".to_string())
+
+        let cells = self.doc.get_cells();
+        let combined: Vec<CellWithOutputs<'_>> = cells
+            .iter()
+            .map(|snap| {
+                let outputs = self.fetch_and_narrow_outputs(&snap.id);
+                CellWithOutputs {
+                    snapshot: snap,
+                    outputs,
+                }
+            })
+            .collect();
+        serde_json::to_string(&combined).unwrap_or_else(|_| "[]".to_string())
     }
 
     // ── Per-cell granular accessors ─────────────────────────────────
@@ -536,29 +553,16 @@ impl NotebookHandle {
     /// Each element is a structured output manifest (with MIME bundles and
     /// ContentRef blob/inline refs). Returns undefined if the cell doesn't exist.
     ///
-    /// Outputs now live in the RuntimeStateDoc keyed by execution_id. This
-    /// method reads the cell's `execution_id` from the notebook doc, then
-    /// looks up outputs in the state doc — providing a transparent facade
-    /// for all existing callers.
+    /// Outputs live in the RuntimeStateDoc keyed by execution_id. This method
+    /// reads the cell's `execution_id` from the notebook doc, then looks up
+    /// outputs in the state doc — the dedicated outputs lookup that replaces
+    /// the old "read the snapshot and inspect `snapshot.outputs`" path.
     pub fn get_cell_outputs(&self, cell_id: &str) -> JsValue {
-        let outputs = match self.doc.get_execution_id(cell_id) {
-            Some(eid) => {
-                let out = self.state_doc.get_outputs(&eid);
-                if out.is_empty() {
-                    None
-                } else {
-                    Some(
-                        out.into_iter()
-                            .map(|o| self.narrow_output_data(o))
-                            .collect::<Vec<_>>(),
-                    )
-                }
-            }
-            None => None,
-        };
-        match outputs {
-            Some(outputs) => serialize_to_js(&outputs).unwrap_or(JsValue::UNDEFINED),
-            None => JsValue::UNDEFINED,
+        let outputs = self.fetch_and_narrow_outputs(cell_id);
+        if outputs.is_empty() {
+            JsValue::UNDEFINED
+        } else {
+            serialize_to_js(&outputs).unwrap_or(JsValue::UNDEFINED)
         }
     }
 
@@ -575,6 +579,24 @@ impl NotebookHandle {
     /// Call after init and whenever the daemon restarts with a new port.
     pub fn set_blob_port(&mut self, port: u16) {
         self.blob_port = Some(port);
+    }
+
+    /// Fetch a cell's outputs from `RuntimeStateDoc` via its `execution_id`
+    /// and narrow the data bundles to the active MIME priority set.
+    ///
+    /// Returns an empty vec when the cell has no `execution_id` or the
+    /// state doc has no outputs for that id. This is the canonical path
+    /// for all output reads on the WASM side — `CellSnapshot` no longer
+    /// carries outputs.
+    fn fetch_and_narrow_outputs(&self, cell_id: &str) -> Vec<serde_json::Value> {
+        let Some(eid) = self.doc.get_execution_id(cell_id) else {
+            return Vec::new();
+        };
+        self.state_doc
+            .get_outputs(&eid)
+            .into_iter()
+            .map(|o| self.narrow_output_data(o))
+            .collect()
     }
 
     /// Narrow an output manifest's data bundle to the winning MIME type,
@@ -687,7 +709,10 @@ impl NotebookHandle {
             .into_iter()
             .enumerate()
             .find(|(_, c)| c.id == cell_id)
-            .map(JsCell::from)
+            .map(|(index, snap)| {
+                let outputs = self.fetch_and_narrow_outputs(&snap.id);
+                js_cell_from_parts(index, snap, outputs)
+            })
     }
 
     /// Add a new cell at the given index (backward-compatible API).

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2610,10 +2610,7 @@ impl Daemon {
                             .collect();
                         (cells, eids)
                     };
-                    let outputs_by_cell: std::collections::HashMap<
-                        String,
-                        Vec<serde_json::Value>,
-                    > = {
+                    let outputs_by_cell: std::collections::HashMap<String, Vec<serde_json::Value>> = {
                         let state_doc = room.state_doc.read().await;
                         eids_by_cell
                             .into_iter()

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2597,20 +2597,18 @@ impl Daemon {
                 };
                 if let Some(room) = maybe_room {
                     // Outputs live in RuntimeStateDoc keyed by execution_id.
-                    // Collect the execution_id map under the doc read guard,
+                    // Collect cells + execution_ids under one doc read guard,
                     // drop it, then look up outputs under the state_doc read
                     // guard. Never hold both at once — the tokio-mutex lint
                     // forbids guards across .await.
-                    let cells = {
+                    let (cells, eids_by_cell) = {
                         let doc = room.doc.read().await;
-                        doc.get_cells()
-                    };
-                    let eids_by_cell: std::collections::HashMap<String, String> = {
-                        let doc = room.doc.read().await;
-                        cells
+                        let cells = doc.get_cells();
+                        let eids: std::collections::HashMap<String, String> = cells
                             .iter()
                             .filter_map(|c| doc.get_execution_id(&c.id).map(|e| (c.id.clone(), e)))
-                            .collect()
+                            .collect();
+                        (cells, eids)
                     };
                     let outputs_by_cell: std::collections::HashMap<
                         String,
@@ -2621,11 +2619,7 @@ impl Daemon {
                             .into_iter()
                             .filter_map(|(cell_id, eid)| {
                                 let outputs = state_doc.get_outputs(&eid);
-                                if outputs.is_empty() {
-                                    None
-                                } else {
-                                    Some((cell_id, outputs))
-                                }
+                                (!outputs.is_empty()).then_some((cell_id, outputs))
                             })
                             .collect()
                     };

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2596,10 +2596,39 @@ impl Daemon {
                         .and_then(|uuid| rooms.get(&uuid).cloned())
                 };
                 if let Some(room) = maybe_room {
+                    // Outputs live in RuntimeStateDoc keyed by execution_id.
+                    // Collect the execution_id map under the doc read guard,
+                    // drop it, then look up outputs under the state_doc read
+                    // guard. Never hold both at once — the tokio-mutex lint
+                    // forbids guards across .await.
                     let cells = {
                         let doc = room.doc.read().await;
                         doc.get_cells()
-                    }; // doc read lock dropped
+                    };
+                    let eids_by_cell: std::collections::HashMap<String, String> = {
+                        let doc = room.doc.read().await;
+                        cells
+                            .iter()
+                            .filter_map(|c| doc.get_execution_id(&c.id).map(|e| (c.id.clone(), e)))
+                            .collect()
+                    };
+                    let outputs_by_cell: std::collections::HashMap<
+                        String,
+                        Vec<serde_json::Value>,
+                    > = {
+                        let state_doc = room.state_doc.read().await;
+                        eids_by_cell
+                            .into_iter()
+                            .filter_map(|(cell_id, eid)| {
+                                let outputs = state_doc.get_outputs(&eid);
+                                if outputs.is_empty() {
+                                    None
+                                } else {
+                                    Some((cell_id, outputs))
+                                }
+                            })
+                            .collect()
+                    };
                     let kernel_info = room.kernel_info().await.map(|(kt, es, status)| {
                         crate::protocol::NotebookKernelInfo {
                             kernel_type: kt,
@@ -2610,6 +2639,7 @@ impl Daemon {
                     Response::NotebookState {
                         notebook_id,
                         cells,
+                        outputs_by_cell,
                         source: "live_room".to_string(),
                         kernel_info,
                     }
@@ -2622,9 +2652,26 @@ impl Daemon {
                             Ok(data) => match crate::notebook_doc::NotebookDoc::load(&data) {
                                 Ok(doc) => {
                                     let cells = doc.get_cells();
+                                    // Persisted docs may carry legacy pre-v3
+                                    // outputs (extract_cell_outputs returns
+                                    // empty for current-schema docs).
+                                    let mut outputs_by_cell: std::collections::HashMap<
+                                        String,
+                                        Vec<serde_json::Value>,
+                                    > = std::collections::HashMap::new();
+                                    for (cell_id, legacy) in doc.extract_cell_outputs() {
+                                        let parsed: Vec<serde_json::Value> = legacy
+                                            .into_iter()
+                                            .filter_map(|s| serde_json::from_str(&s).ok())
+                                            .collect();
+                                        if !parsed.is_empty() {
+                                            outputs_by_cell.insert(cell_id, parsed);
+                                        }
+                                    }
                                     Response::NotebookState {
                                         notebook_id,
                                         cells,
+                                        outputs_by_cell,
                                         source: "persisted_file".to_string(),
                                         kernel_info: None,
                                     }
@@ -3099,14 +3146,15 @@ pub(crate) fn blob_gc_grace() -> std::time::Duration {
 /// Walk a persisted notebook-doc `.automerge` file and collect blob refs.
 ///
 /// Mirrors the in-memory mark phase: we load the saved document, read its
-/// cells, and pull blob refs from `cell.outputs` (inline manifests) and
-/// `cell.resolved_assets` (markdown image refs). Returns `None` if the
-/// file cannot be read or decoded — the caller logs and moves on.
+/// cells, pull blob refs from legacy pre-v3 outputs (via
+/// `extract_cell_outputs`), and from `cell.resolved_assets` (markdown
+/// image refs). Returns `None` if the file cannot be read or decoded —
+/// the caller logs and moves on.
 ///
-/// Note: `RuntimeStateDoc` is not persisted to disk separately; the
-/// notebook doc's `cell.outputs` (legacy pre-v3 layout, plus future
-/// `.ipynb`-backed outputs from spec 2) is the on-disk record of blob
-/// references for a closed room.
+/// Note: `RuntimeStateDoc` is not persisted to disk separately. Current
+/// schema-v3+ notebook docs store outputs in RuntimeStateDoc while the
+/// room is loaded; once evicted, those outputs are discarded. Only
+/// legacy docs still carry on-disk output refs.
 pub(crate) async fn collect_hashes_from_persisted_doc(
     path: &Path,
     hashes: &mut std::collections::HashSet<String>,
@@ -3131,10 +3179,20 @@ pub(crate) async fn collect_hashes_from_persisted_doc(
             return false;
         }
     };
-    for cell in doc.get_cells() {
-        for output in &cell.outputs {
-            collect_blob_hashes(output, hashes);
+    // Legacy pre-v3 notebook docs carry outputs on the cell itself; new docs
+    // store outputs in RuntimeStateDoc and leave the cell shape alone.
+    // `extract_cell_outputs` returns the legacy, JSON-encoded list when
+    // present. For current-schema persisted docs this returns an empty vec,
+    // which is fine — those docs have no ephemeral blobs to mark anyway
+    // (outputs are only alive while a room is loaded).
+    for (_cell_id, legacy_outputs) in doc.extract_cell_outputs() {
+        for raw in legacy_outputs {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) {
+                collect_blob_hashes(&value, hashes);
+            }
         }
+    }
+    for cell in doc.get_cells() {
         for hash in cell.resolved_assets.values() {
             hashes.insert(hash.clone());
         }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7402,19 +7402,6 @@ pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) -> bool {
 /// Must be larger than the debounce window (500ms) to reliably skip self-writes.
 const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 
-/// Parse cells from a Jupyter notebook JSON object.
-///
-/// Returns `Some(cells)` if parsing succeeded (including empty `cells: []`),
-/// or `None` if the `cells` key is missing or invalid (parse failure).
-///
-/// The source field can be either a string or an array of strings (lines).
-/// We normalize it to a single string.
-///
-/// For older notebooks (pre-nbformat 4.5) that don't have cell IDs, we generate
-/// stable fallback IDs based on the cell index. This prevents data loss when
-/// merging changes from externally-generated notebooks.
-///
-/// Positions are generated incrementally using fractional indexing.
 /// Parsed result of an `.ipynb` file: cell snapshots and the outputs pulled
 /// from disk, keyed by cell id.
 ///
@@ -7427,6 +7414,19 @@ pub(crate) struct ParsedIpynbCells {
     pub outputs_by_cell: HashMap<String, Vec<serde_json::Value>>,
 }
 
+/// Parse cells from a Jupyter notebook JSON object.
+///
+/// Returns `Some(ParsedIpynbCells)` if parsing succeeded (including empty
+/// `cells: []`), or `None` if the `cells` key is missing or invalid.
+///
+/// The source field can be either a string or an array of strings (lines).
+/// We normalize it to a single string.
+///
+/// For older notebooks (pre-nbformat 4.5) that don't have cell IDs, we generate
+/// stable fallback IDs based on the cell index. This prevents data loss when
+/// merging changes from externally-generated notebooks.
+///
+/// Positions are generated incrementally using fractional indexing.
 fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedIpynbCells> {
     use loro_fractional_index::FractionalIndex;
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7415,13 +7415,26 @@ const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 /// merging changes from externally-generated notebooks.
 ///
 /// Positions are generated incrementally using fractional indexing.
-fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>> {
+/// Parsed result of an `.ipynb` file: cell snapshots and the outputs pulled
+/// from disk, keyed by cell id.
+///
+/// `CellSnapshot` no longer carries outputs (outputs live in `RuntimeStateDoc`
+/// keyed by `execution_id`). Callers that need both pieces — notebook load,
+/// external-edit merge — receive them here as two parallel structures and
+/// thread the outputs map separately.
+pub(crate) struct ParsedIpynbCells {
+    pub cells: Vec<CellSnapshot>,
+    pub outputs_by_cell: HashMap<String, Vec<serde_json::Value>>,
+}
+
+fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedIpynbCells> {
     use loro_fractional_index::FractionalIndex;
 
     let cells_json = json.get("cells").and_then(|c| c.as_array())?;
 
     // Generate positions incrementally
     let mut prev_position: Option<FractionalIndex> = None;
+    let mut outputs_by_cell: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
 
     let parsed_cells = cells_json
         .iter()
@@ -7466,12 +7479,17 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>>
                 _ => "null".to_string(),
             };
 
-            // Outputs: keep as serde_json::Value
+            // Outputs travel alongside the snapshot, not on it — they're
+            // destined for RuntimeStateDoc, keyed by execution_id, once the
+            // caller mints a synthetic execution for this cell.
             let outputs: Vec<serde_json::Value> = cell
                 .get("outputs")
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
+            if !outputs.is_empty() {
+                outputs_by_cell.insert(id.clone(), outputs);
+            }
 
             // Cell metadata (preserves all fields, normalize to object)
             let metadata = match cell.get("metadata") {
@@ -7485,14 +7503,16 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>>
                 position: position_str,
                 source,
                 execution_count,
-                outputs,
                 metadata,
                 resolved_assets: std::collections::HashMap::new(),
             }
         })
         .collect();
 
-    Some(parsed_cells)
+    Some(ParsedIpynbCells {
+        cells: parsed_cells,
+        outputs_by_cell,
+    })
 }
 
 /// Parse nbformat attachment payloads from a .ipynb JSON value.
@@ -7585,9 +7605,11 @@ fn should_resolve_markdown_assets(cell_type: &str) -> bool {
 
 /// Cell data parsed for streaming load.
 ///
-/// Unlike `CellSnapshot` which stores outputs as `Vec<String>` (JSON strings),
-/// this stores outputs as `serde_json::Value` to avoid the serialize→parse
-/// round-trip when processing through `create_manifest`.
+/// Unlike `CellSnapshot` — which no longer carries outputs at all (they live
+/// in `RuntimeStateDoc` keyed by `execution_id`) — this struct pairs the
+/// cell fields with its parsed outputs in one value. Outputs are kept as
+/// `serde_json::Value` to avoid the serialize→parse round-trip when
+/// processing through `create_manifest`.
 struct StreamingCell {
     id: String,
     cell_type: String,
@@ -8011,8 +8033,13 @@ pub async fn load_notebook_from_disk_with_state_doc(
     let json: serde_json::Value =
         serde_json::from_str(&content).map_err(|e| format!("Invalid notebook JSON: {}", e))?;
 
-    // Parse cells
-    let cells = parse_cells_from_ipynb(&json)
+    // Parse cells. Outputs come back in a parallel map keyed by cell_id —
+    // they're destined for RuntimeStateDoc, keyed by a freshly-minted
+    // synthetic execution_id per cell.
+    let ParsedIpynbCells {
+        cells,
+        outputs_by_cell,
+    } = parse_cells_from_ipynb(&json)
         .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
     let nbformat_attachments = parse_nbformat_attachments_from_ipynb(&json);
 
@@ -8024,15 +8051,16 @@ pub async fn load_notebook_from_disk_with_state_doc(
             .map_err(|e| format!("Failed to update source: {}", e))?;
         // Parse execution_count from the .ipynb cell snapshot
         let parsed_ec: Option<i64> = cell.execution_count.parse::<i64>().ok();
-        let has_outputs = !cell.outputs.is_empty();
+        let cell_outputs = outputs_by_cell.get(&cell.id);
+        let has_outputs = cell_outputs.map(|o| !o.is_empty()).unwrap_or(false);
         let has_ec = parsed_ec.is_some();
 
         // Create a synthetic execution entry in RuntimeStateDoc if the cell
         // has outputs or an execution_count. The execution_id links the cell
         // to its outputs and execution_count in RuntimeStateDoc.
         if has_outputs || has_ec {
-            let output_refs = if has_outputs {
-                outputs_to_manifest_refs(&cell.outputs, blob_store).await
+            let output_refs = if let Some(outs) = cell_outputs.filter(|o| !o.is_empty()) {
+                outputs_to_manifest_refs(outs, blob_store).await
             } else {
                 Vec::new()
             };
@@ -8216,6 +8244,7 @@ fn build_new_notebook_metadata(
 async fn apply_ipynb_changes(
     room: &NotebookRoom,
     external_cells: &[CellSnapshot],
+    external_outputs: &HashMap<String, Vec<serde_json::Value>>,
     external_attachments: &HashMap<String, serde_json::Value>,
     has_running_kernel: bool,
 ) -> bool {
@@ -8229,10 +8258,10 @@ async fn apply_ipynb_changes(
     // the doc's existing manifest hashes work correctly.
     let converted_outputs: HashMap<String, Vec<serde_json::Value>> = {
         let mut map = HashMap::new();
-        for cell in external_cells {
-            if !cell.outputs.is_empty() {
-                let refs = outputs_to_manifest_refs(&cell.outputs, &room.blob_store).await;
-                map.insert(cell.id.clone(), refs);
+        for (cell_id, raw_outputs) in external_outputs {
+            if !raw_outputs.is_empty() {
+                let refs = outputs_to_manifest_refs(raw_outputs, &room.blob_store).await;
+                map.insert(cell_id.clone(), refs);
             }
         }
         map
@@ -8823,8 +8852,11 @@ pub(crate) fn spawn_notebook_file_watcher(
 
                             // Parse cells from the .ipynb
                             // None = parse failure (missing cells key), Some([]) = valid empty notebook
-                            let external_cells = match parse_cells_from_ipynb(&json) {
-                                Some(cells) => cells,
+                            let ParsedIpynbCells {
+                                cells: external_cells,
+                                outputs_by_cell: external_outputs,
+                            } = match parse_cells_from_ipynb(&json) {
+                                Some(parsed) => parsed,
                                 None => {
                                     warn!(
                                         "[notebook-watch] Cannot parse cells from {:?} - skipping",
@@ -8843,6 +8875,7 @@ pub(crate) fn spawn_notebook_file_watcher(
                             let cells_changed = apply_ipynb_changes(
                                 &room,
                                 &external_cells,
+                                &external_outputs,
                                 &external_attachments,
                                 has_kernel,
                             )
@@ -9910,7 +9943,8 @@ mod tests {
             ]
         });
 
-        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+        let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+        let cells = &parsed.cells;
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0].id, "cell-1");
         assert_eq!(cells[0].cell_type, "code");
@@ -9920,6 +9954,8 @@ mod tests {
         assert_eq!(cells[1].cell_type, "markdown");
         assert_eq!(cells[1].source, "# Title\nBody");
         assert_eq!(cells[1].execution_count, "null");
+        // Empty `outputs` arrays on disk produce no entries in the outputs map.
+        assert!(parsed.outputs_by_cell.is_empty());
     }
 
     #[test]
@@ -9942,7 +9978,8 @@ mod tests {
             ]
         });
 
-        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+        let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
+        let cells = &parsed.cells;
         assert_eq!(cells.len(), 2);
         // Should generate fallback IDs based on index
         assert_eq!(cells[0].id, "__external_cell_0");
@@ -9957,8 +9994,9 @@ mod tests {
         let json = serde_json::json!({
             "cells": []
         });
-        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid empty notebook");
-        assert!(cells.is_empty());
+        let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid empty notebook");
+        assert!(parsed.cells.is_empty());
+        assert!(parsed.outputs_by_cell.is_empty());
     }
 
     #[test]
@@ -9998,7 +10036,14 @@ mod tests {
         // Apply empty external cells - should delete all cells (we have
         // a save baseline confirming cell-1 was on disk before)
         let external_cells = vec![];
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), false).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+        .await;
         assert!(changed, "Should apply changes to clear all cells");
 
         // Verify all cells were deleted
@@ -10027,12 +10072,18 @@ mod tests {
             position: "80".to_string(),
             source: String::new(),
             execution_count: "42".to_string(),
-            outputs: vec![],
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
         }];
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), false).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+        .await;
         assert!(changed, "Should detect execution_count change");
 
         // execution_count is now in RuntimeStateDoc via synthetic execution_id
@@ -10071,12 +10122,18 @@ mod tests {
             position: "80".to_string(),
             source: "new source".to_string(),
             execution_count: "5".to_string(),
-            outputs: vec![],
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
         }];
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), true).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            true,
+        )
+        .await;
         assert!(changed, "Should apply source change");
 
         let cells = {
@@ -10112,7 +10169,6 @@ mod tests {
                 position: "80".to_string(),
                 source: String::new(),
                 execution_count: "null".to_string(),
-                outputs: vec![],
                 metadata: serde_json::json!({}),
                 resolved_assets: std::collections::HashMap::new(),
             },
@@ -10122,13 +10178,24 @@ mod tests {
                 position: "81".to_string(),
                 source: "print('new')".to_string(),
                 execution_count: "42".to_string(),
-                outputs: vec![serde_json::json!({"output_type":"execute_result"})],
                 metadata: serde_json::json!({}),
                 resolved_assets: std::collections::HashMap::new(),
             },
         ];
+        let mut external_outputs: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+        external_outputs.insert(
+            "new-cell".to_string(),
+            vec![serde_json::json!({"output_type":"execute_result"})],
+        );
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), true).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &external_outputs,
+            &HashMap::new(),
+            true,
+        )
+        .await;
         assert!(changed, "Should add new cell");
 
         let cells = {
@@ -10194,7 +10261,6 @@ mod tests {
                 position: "80".to_string(),
                 source: "a = 10".to_string(),
                 execution_count: "1".to_string(),
-                outputs: vec![],
                 metadata: serde_json::json!({}),
                 resolved_assets: std::collections::HashMap::new(),
             },
@@ -10204,13 +10270,19 @@ mod tests {
                 position: "81".to_string(),
                 source: "b = 20".to_string(),
                 execution_count: "2".to_string(),
-                outputs: vec![],
                 metadata: serde_json::json!({}),
                 resolved_assets: std::collections::HashMap::new(),
             },
         ];
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), false).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+        .await;
         assert!(changed, "Should detect wholesale replacement");
 
         let cells = {
@@ -10262,12 +10334,18 @@ mod tests {
             position: "80".to_string(),
             source: "x = 1".to_string(),
             execution_count: "null".to_string(),
-            outputs: vec![],
             metadata: serde_json::json!({}),
             resolved_assets: std::collections::HashMap::new(),
         }];
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), false).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+        .await;
         assert!(changed);
 
         let cells = {
@@ -10317,7 +10395,14 @@ mod tests {
         // External file has 0 cells (the autosave wrote an empty notebook)
         let external_cells: Vec<CellSnapshot> = vec![];
 
-        let changed = apply_ipynb_changes(&room, &external_cells, &HashMap::new(), false).await;
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+        .await;
         // No changes should be applied — cells preserved
         assert!(
             !changed,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1010,13 +1010,18 @@ async fn test_streaming_load_via_open_notebook() {
     assert_eq!(cells[6].source, "import os");
 
     // Outputs live in RuntimeStateDoc (separate Automerge doc synced via
-    // frame type 0x05). Poll for convergence — if it arrives, verify hashes.
+    // frame type 0x05) and are looked up via `handle.get_cell_outputs`.
+    // Poll for convergence — if it arrives, verify hashes.
     let start = std::time::Instant::now();
+    let mut c0_outputs: Vec<serde_json::Value> = Vec::new();
     while start.elapsed() < Duration::from_secs(10) {
         sleep(Duration::from_millis(100)).await;
         cells = handle.get_cells();
-        if !cells.is_empty() && !cells[0].outputs.is_empty() {
-            break;
+        if !cells.is_empty() {
+            c0_outputs = handle.get_cell_outputs(&cells[0].id).unwrap_or_default();
+            if !c0_outputs.is_empty() {
+                break;
+            }
         }
     }
 
@@ -1024,17 +1029,17 @@ async fn test_streaming_load_via_open_notebook() {
     // On slow CI runners, the sync may not complete within the timeout.
     // The output pipeline is verified end-to-end by the fixture integration
     // tests and manual testing — this checks the streaming load path specifically.
-    if !cells[0].outputs.is_empty() {
-        let output = &cells[0].outputs[0];
+    if !c0_outputs.is_empty() {
+        let output = &c0_outputs[0];
         assert!(
             output.get("output_type").is_some(),
             "output should be a manifest object with output_type, got: {}",
             output
         );
-        assert_eq!(cells[3].outputs.len(), 1, "c4 should have 1 output");
-        let c4_output = &cells[3].outputs[0];
+        let c4_outputs = handle.get_cell_outputs(&cells[3].id).unwrap_or_default();
+        assert_eq!(c4_outputs.len(), 1, "c4 should have 1 output");
         assert!(
-            c4_output.get("output_type").is_some(),
+            c4_outputs[0].get("output_type").is_some(),
             "c4 output should be a manifest object with output_type"
         );
     }
@@ -1043,8 +1048,14 @@ async fn test_streaming_load_via_open_notebook() {
     assert_eq!(cells[0].execution_count, "1");
     assert_eq!(cells[2].execution_count, "3");
 
-    // Verify c7 (no outputs) has empty outputs list
-    assert!(cells[6].outputs.is_empty(), "c7 should have no outputs");
+    // Verify c7 (no outputs) has no outputs
+    assert!(
+        handle
+            .get_cell_outputs(&cells[6].id)
+            .unwrap_or_default()
+            .is_empty(),
+        "c7 should have no outputs"
+    );
 
     // Shutdown
     pool_client.shutdown().await.ok();


### PR DESCRIPTION
## Diagnosis

`CellSnapshot.outputs` has been a field that lied since schema v3. `NotebookDoc::read_cell` wrote `outputs = vec![]` (always empty) and downstream code in `DocHandle`, Python bindings, and WASM backfilled it from `RuntimeStateDoc` via `execution_id`. The populate-empty-then-backfill dance is vestigial and made it possible to read a `CellSnapshot` and silently get stale or empty outputs.

Outputs live in `RuntimeStateDoc`. Callers that need outputs should say so explicitly.

## What changed

Drop the field. Replace backfill with explicit lookups.

- `notebook-doc`: `CellSnapshot` no longer carries outputs. `read_cell` stops writing the empty vec.
- `notebook-sync::DocHandle`: adds `get_cell_outputs(cell_id)` and a bulk `get_all_outputs() -> HashMap<String, Vec<Output>>` for callers that need many at once.
- `runtimed-py`: Python bindings fetch outputs via the explicit methods. `Notebook.cells` / `cell.outputs` still work for user scripts; the internal plumbing just stopped pretending the data came from the notebook doc.
- `runtimed-wasm`: `get_cells_json` preserves the flat JSON shape the frontend expects by using a local serializer struct, but sources outputs from the new lookup path. No frontend change required.
- `runt-mcp`: `get_cell` / `get_all_cells` use the new methods. Bulk form for `get_all_cells` to avoid O(N) state-doc roundtrips on large notebooks.
- `runtimed`: `parse_cells_from_ipynb` returns `ParsedIpynbCells { cells, outputs_by_cell }` so loaded outputs travel beside the snapshots rather than on them. `apply_ipynb_changes`, `load_notebook_from_disk_with_state_doc`, and `InspectNotebook` RPC updated to the new shape.
- Daemon GC: marks blob refs from legacy pre-v3 persisted outputs via `extract_cell_outputs`. Current-schema docs discard outputs on eviction, so they have no persisted refs to mark.

## Self-review simplification pass

Three tightenings on top of the main change:

1. `DocHandle::get_all_outputs` snapshots cell ids from the watch channel before taking the doc lock — `with_doc` acquires the doc lock then publishes to the watch channel, so holding the watch borrow across the doc lock would be a classic lock-order deadlock. Comment added to keep that order explicit.
2. `daemon::InspectNotebook` live-room path reads cells and execution ids from a single doc lock guard, ordered before the state-doc guard so neither is held across `.await` (tokio-mutex lint clean).
3. Restored the orphaned `parse_cells_from_ipynb` doc comment that got attached to the new `ParsedIpynbCells` struct during extraction.

## API break

Python users reading `cell.outputs` on `runtimed.Notebook.cells` still work — the Python wrapper fetches outputs via the explicit path internally. No user-facing API break.

## Verification

- `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p notebook-doc --lib`, `cargo test -p notebook-sync --lib`, `cargo test -p runtimed --lib`, `cargo test -p runtimed --test integration`: all green
- `cargo test -p runtimed --test tokio_mutex_lint`: green (no guards across `.await`)
- `wasm-pack build crates/runtimed-wasm`: regenerated, committed

## Stats

`git diff --shortstat origin/main..HEAD`: 20 files, +475 / -220 (net +255).

Not a deletion win per se; this is a shape change that adds explicit lookup methods in several places to replace the single-field backfill. The readability and correctness wins are the payoff — no more silent staleness from a field that claimed to have outputs.

## Test plan

- [ ] `cargo test --workspace`
- [ ] Manual: open a saved notebook with outputs via the app; confirm outputs render (WASM `get_cells_json` path)
- [ ] Python: `Notebook.cells[i].outputs` returns the expected outputs (Python bindings path)
- [ ] `runt inspect <path>` shows outputs for saved notebooks (RPC path)
