### PR TITLE
fix(widgets): respect bar_style and bar_color on progress bars

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -9,10 +9,7 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-      className,
-    )}
+    className={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
     {...props}
   >
     <ProgressPrimitive.Indicator

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -9,10 +9,14 @@ const Progress = React.forwardRef<
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
-    className={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className,
+    )}
     {...props}
   >
     <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
       className="h-full w-full flex-1 bg-primary transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />

--- a/src/components/widgets/controls/float-progress.tsx
+++ b/src/components/widgets/controls/float-progress.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
-import { useWidgetModelValue } from "../widget-store-context";
+import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 
 export function FloatProgress({ modelId, className }: WidgetComponentProps) {
   // Subscribe to individual state keys
@@ -17,15 +17,25 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
   const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
   const description = useWidgetModelValue<string>(modelId, "description");
   const barStyle =
-    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(modelId, "bar_style") ?? "";
+    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(
+      modelId,
+      "bar_style",
+    ) ?? "";
   const orientation =
-    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ?? "horizontal";
+    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ??
+    "horizontal";
+
+  // bar_color lives on the ProgressStyleModel, referenced by the "style" key
+  const styleRef = useWidgetModelValue<string>(modelId, "style");
+  const styleModelId = styleRef ? parseModelRef(styleRef) : undefined;
+  const barColor =
+    useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
 
   // Calculate percentage
   const range = max - min;
   const percentage = range > 0 ? ((value - min) / range) * 100 : 0;
 
-  // Map bar_style to Tailwind classes
+  // Map bar_style to Tailwind classes targeting the Radix indicator via data-slot
   const barStyleClasses: Record<string, string> = {
     success: "[&>[data-slot=progress-indicator]]:bg-green-500",
     info: "[&>[data-slot=progress-indicator]]:bg-blue-500",
@@ -34,6 +44,11 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
   };
 
   const isVertical = orientation === "vertical";
+
+  // bar_color (explicit CSS color from ProgressStyleModel) takes precedence over bar_style
+  const progressStyle = barColor
+    ? ({ "--progress-bar-color": barColor } as React.CSSProperties)
+    : undefined;
 
   return (
     <div
@@ -50,8 +65,11 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
         value={percentage}
         className={cn(
           isVertical ? "h-32 w-2" : "flex-1 min-w-24",
-          barStyle && barStyleClasses[barStyle],
+          barColor
+            ? "[&>[data-slot=progress-indicator]]:bg-[var(--progress-bar-color)]"
+            : barStyle && barStyleClasses[barStyle],
         )}
+        style={progressStyle}
       />
     </div>
   );

--- a/src/components/widgets/controls/float-progress.tsx
+++ b/src/components/widgets/controls/float-progress.tsx
@@ -17,19 +17,14 @@ export function FloatProgress({ modelId, className }: WidgetComponentProps) {
   const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
   const description = useWidgetModelValue<string>(modelId, "description");
   const barStyle =
-    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(
-      modelId,
-      "bar_style",
-    ) ?? "";
+    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(modelId, "bar_style") ?? "";
   const orientation =
-    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ??
-    "horizontal";
+    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ?? "horizontal";
 
   // bar_color lives on the ProgressStyleModel, referenced by the "style" key
   const styleRef = useWidgetModelValue<string>(modelId, "style");
   const styleModelId = styleRef ? parseModelRef(styleRef) : undefined;
-  const barColor =
-    useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
+  const barColor = useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
 
   // Calculate percentage
   const range = max - min;

--- a/src/components/widgets/controls/int-progress.tsx
+++ b/src/components/widgets/controls/int-progress.tsx
@@ -7,8 +7,9 @@
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
+import type { CSSProperties } from "react";
 import type { WidgetComponentProps } from "../widget-registry";
-import { useWidgetModelValue } from "../widget-store-context";
+import { parseModelRef, useWidgetModelValue } from "../widget-store-context";
 
 export function IntProgress({ modelId, className }: WidgetComponentProps) {
   // Subscribe to individual state keys
@@ -17,15 +18,25 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
   const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
   const description = useWidgetModelValue<string>(modelId, "description");
   const barStyle =
-    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(modelId, "bar_style") ?? "";
+    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(
+      modelId,
+      "bar_style",
+    ) ?? "";
   const orientation =
-    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ?? "horizontal";
+    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ??
+    "horizontal";
+
+  // bar_color lives on the ProgressStyleModel, referenced by the "style" key
+  const styleRef = useWidgetModelValue<string>(modelId, "style");
+  const styleModelId = styleRef ? parseModelRef(styleRef) : undefined;
+  const barColor =
+    useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
 
   // Calculate percentage
   const range = max - min;
   const percentage = range > 0 ? ((value - min) / range) * 100 : 0;
 
-  // Map bar_style to Tailwind classes
+  // Map bar_style to Tailwind classes targeting the Radix indicator via data-slot
   const barStyleClasses: Record<string, string> = {
     success: "[&>[data-slot=progress-indicator]]:bg-green-500",
     info: "[&>[data-slot=progress-indicator]]:bg-blue-500",
@@ -34,6 +45,11 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
   };
 
   const isVertical = orientation === "vertical";
+
+  // bar_color (from ProgressStyleModel) takes precedence over bar_style
+  const progressStyle: CSSProperties | undefined = barColor
+    ? ({ "--progress-bar-color": barColor } as CSSProperties)
+    : undefined;
 
   return (
     <div
@@ -50,8 +66,11 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
         value={percentage}
         className={cn(
           isVertical ? "h-32 w-2" : "flex-1 min-w-24",
-          barStyle && barStyleClasses[barStyle],
+          barColor
+            ? "[&>[data-slot=progress-indicator]]:bg-[var(--progress-bar-color)]"
+            : barStyle && barStyleClasses[barStyle],
         )}
+        style={progressStyle}
       />
     </div>
   );

--- a/src/components/widgets/controls/int-progress.tsx
+++ b/src/components/widgets/controls/int-progress.tsx
@@ -18,19 +18,14 @@ export function IntProgress({ modelId, className }: WidgetComponentProps) {
   const max = useWidgetModelValue<number>(modelId, "max") ?? 100;
   const description = useWidgetModelValue<string>(modelId, "description");
   const barStyle =
-    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(
-      modelId,
-      "bar_style",
-    ) ?? "";
+    useWidgetModelValue<"success" | "info" | "warning" | "danger" | "">(modelId, "bar_style") ?? "";
   const orientation =
-    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ??
-    "horizontal";
+    useWidgetModelValue<"horizontal" | "vertical">(modelId, "orientation") ?? "horizontal";
 
   // bar_color lives on the ProgressStyleModel, referenced by the "style" key
   const styleRef = useWidgetModelValue<string>(modelId, "style");
   const styleModelId = styleRef ? parseModelRef(styleRef) : undefined;
-  const barColor =
-    useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
+  const barColor = useWidgetModelValue<string | null>(styleModelId ?? "", "bar_color") ?? null;
 
   // Calculate percentage
   const range = max - min;


### PR DESCRIPTION
The `[&>[data-slot=progress-indicator]]` Tailwind selectors on `FloatProgress` and `IntProgress` were silently failing — the Radix `Progress.Indicator` didn't have a `data-slot` attribute. So `bar_style='success'` (sent by HuggingFace datasets, tqdm, etc.) was ignored and bars stayed the default color.

**Fixes:**

1. Added `data-slot="progress-indicator"` to the shared `Progress` UI component so the existing selectors match
2. Wired up `bar_color` from the ipywidgets `ProgressStyleModel` (resolved via the `style` model ref → `parseModelRef`) using a CSS variable, with precedence over `bar_style`

Tested with HuggingFace `datasets` download bars (`bar_style='success'` → green) and a manual `FloatProgress` animating from `info` (blue) to `success` (green).

_PR submitted by @rgbkrk's agent Quill, via Zed_