### PR TITLE
fix(plugin): unset RUNTIMED_DEV/WORKSPACE_PATH before exec

### DIFF
--- a/plugins/nteract-nightly/bin/nteract-runt-proxy
+++ b/plugins/nteract-nightly/bin/nteract-runt-proxy
@@ -43,6 +43,11 @@ case "$(uname -s)" in
     ;;
 esac
 
+# RUNTIMED_DEV / RUNTIMED_WORKSPACE_PATH are set by the nteract/desktop
+# .envrc for developers. They must not leak into the MCP proxy, which
+# should always talk to the installed daemon, not a dev workspace.
+unset RUNTIMED_DEV RUNTIMED_WORKSPACE_PATH
+
 for candidate in "${candidate_paths[@]}"; do
   if [[ -f "$candidate" ]]; then
     exec "$candidate" "$@"

--- a/plugins/nteract/bin/nteract-runt-proxy
+++ b/plugins/nteract/bin/nteract-runt-proxy
@@ -43,6 +43,11 @@ case "$(uname -s)" in
     ;;
 esac
 
+# RUNTIMED_DEV / RUNTIMED_WORKSPACE_PATH are set by the nteract/desktop
+# .envrc for developers. They must not leak into the MCP proxy, which
+# should always talk to the installed daemon, not a dev workspace.
+unset RUNTIMED_DEV RUNTIMED_WORKSPACE_PATH
+
 for candidate in "${candidate_paths[@]}"; do
   if [[ -f "$candidate" ]]; then
     exec "$candidate" "$@"


### PR DESCRIPTION
## Summary

- Scrub `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` before the plugin's proxy execs `runt-proxy`. These are set by the repo's `.envrc` for developers; if the plugin is invoked from anywhere those vars leak in (any child shell started from the desktop checkout), the MCP proxy would silently target a dev workspace instead of the installed daemon.
- Applied to both `plugins/nteract/bin/nteract-runt-proxy` and `plugins/nteract-nightly/bin/nteract-runt-proxy`.

This mirrors the `env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH` pattern the standalone `~/.mcp.json` config used before we packaged the plugin.

## Test plan

- [x] Ran proxy with `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=/tmp/foo NTERACT_CHANNEL=nightly ./plugins/nteract/bin/nteract-runt-proxy` and confirmed the exec'd binary starts with `channel=nightly, compiled=nightly` (no dev-workspace override)
- [ ] Regression: install the plugin, invoke from a normal shell, confirm nothing changed for users who never had these vars