### PR TITLE
chore: clean up schema migration machinery (v1–v3 are pre-release)

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -13,7 +13,7 @@ paths:
 Two independent version numbers, separate from the artifact version:
 
 - **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `2`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes.
-- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `2`) -- governs Automerge document compatibility. Bump when document structure changes.
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) -- governs Automerge document compatibility. Bump when document structure changes.
 
 These are just incrementing integers that evolve independently from each other and from the artifact version.
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -7,7 +7,7 @@ This document describes the wire protocol between notebook clients (frontend WAS
 Two independent version numbers handle compatibility, separate from the artifact version:
 
 - **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `2`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes.
-- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `2`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes (v2 switched cells from an ordered list to a fractional-indexed map).
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes. The current schema stores cells as a fractional-indexed `Map` and keeps outputs in `RuntimeStateDoc` keyed by `execution_id`, with per-output `output_id` UUIDs on manifests. Future bumps MUST ship a `migrate_vN_to_v(N+1)` function that preserves user data — v1–v3 were pre-release and the v4 load path discards older docs on load, which is only safe because no real user data lives at those versions.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol or schema bump doesn't automatically force a major version bump — that depends on whether the change is user-facing.
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -25,7 +25,7 @@ Standard semver rules apply:
 Two independent version numbers handle compatibility, separate from the artifact version:
 
 - **Protocol version** (`PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`) — governs wire compatibility. Validated by the magic bytes preamble at connection time. Bump when the framing, handshake shape, or message serialization format changes.
-- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — governs Automerge document compatibility. Stored in the doc root. Bump when the document structure changes (v2 switched cells from an ordered list to a fractional-indexed map).
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — governs Automerge document compatibility. Stored in the doc root. Bump when the document structure changes. Every bump MUST ship a matching `migrate_vN_to_v(N+1)` function that preserves user data. The pre-release v1–v3 schemas are discarded on load by v4; do not take that as a template for real migrations.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol bump doesn't force a major version bump — it depends on whether the change is user-facing.
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -685,41 +685,6 @@ impl NotebookDoc {
         }
     }
 
-    /// Migrate from schema v2 to v3: outputs moved to RuntimeStateDoc.
-    ///
-    /// This migration just bumps the schema version. Cell outputs are
-    /// **not** deleted from the doc (Automerge tombstones would bloat it);
-    /// `read_cell()` simply ignores the outputs field. Schema v1 docs
-    /// (cells as List) predate the `.automerge` files that exist in the
-    /// wild and are no longer supported — `load_or_create_inner` starts
-    /// the migration chain at v2→v3.
-    pub fn migrate_v2_to_v3(&mut self) -> Result<(), AutomergeError> {
-        if self.schema_version().unwrap_or(0) >= 3 {
-            return Ok(());
-        }
-        self.doc
-            .put(automerge::ROOT, "schema_version", SCHEMA_VERSION)?;
-        #[cfg(feature = "persistence")]
-        info!("[notebook-doc] Migrated schema v2 → v3 (outputs moved to RuntimeStateDoc)");
-        Ok(())
-    }
-
-    /// Migrate from schema v3 to v4: addressable outputs with `output_id`.
-    ///
-    /// The notebook doc itself doesn't change — outputs live in RuntimeStateDoc.
-    /// This just bumps the schema version so the daemon knows to mint `output_id`s
-    /// for legacy outputs during RuntimeStateDoc population.
-    pub fn migrate_v3_to_v4(&mut self) -> Result<(), AutomergeError> {
-        if self.schema_version().unwrap_or(0) >= 4 {
-            return Ok(());
-        }
-        self.doc
-            .put(automerge::ROOT, "schema_version", SCHEMA_VERSION)?;
-        #[cfg(feature = "persistence")]
-        info!("[notebook-doc] Migrated schema v3 → v4 (addressable outputs with output_id)");
-        Ok(())
-    }
-
     /// Create a client-side bootstrap document for sync.
     ///
     /// Every client — WASM frontend, Python bindings, future Swift, etc. —

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -825,52 +825,28 @@ impl NotebookDoc {
                     Ok(doc) => {
                         let mut loaded = Self { doc };
                         let version = loaded.schema_version().unwrap_or(1);
-                        if version < SCHEMA_VERSION {
-                            info!(
-                                "[notebook-doc] Migrating schema v{} → v{} at {:?} for {}",
-                                version, SCHEMA_VERSION, path, notebook_id
-                            );
-                            let mut ok = true;
-                            if version < 2 {
-                                warn!(
-                                    "[notebook-doc] v1 schema is no longer supported for {}. \
-                                     Creating fresh doc.",
-                                    notebook_id
-                                );
-                                ok = false;
-                            }
-                            if ok && version < 3 {
-                                if let Err(e) = loaded.migrate_v2_to_v3() {
-                                    warn!(
-                                        "[notebook-doc] v2→v3 migration failed for {}: {}. Creating fresh doc.",
-                                        notebook_id, e
-                                    );
-                                    ok = false;
-                                }
-                            }
-                            if ok && version < 4 {
-                                if let Err(e) = loaded.migrate_v3_to_v4() {
-                                    warn!(
-                                        "[notebook-doc] v3→v4 migration failed for {}: {}. Creating fresh doc.",
-                                        notebook_id, e
-                                    );
-                                    ok = false;
-                                }
-                            }
-                            if ok {
-                                info!("[notebook-doc] Migration complete for {}", notebook_id);
-                                if let Some(label) = actor_label {
-                                    loaded.set_actor(label);
-                                }
-                                return loaded;
-                            }
-                        } else {
+                        if version == SCHEMA_VERSION {
                             info!("[notebook-doc] Loaded from {:?} for {}", path, notebook_id);
                             if let Some(label) = actor_label {
                                 loaded.set_actor(label);
                             }
                             return loaded;
                         }
+                        // CRITICAL: one-time cleanup for pre-release schemas
+                        // (v1–v3 predate nteract 2.0). All current users are on
+                        // v4, so dropping older docs on the floor is safe here
+                        // by historical accident, not by policy.
+                        //
+                        // DO NOT COPY THIS PATTERN FOR FUTURE SCHEMA BUMPS.
+                        // Any real migration (v4 → v5 onward) MUST implement a
+                        // `migrate_vN_to_v(N+1)` function that preserves user
+                        // data. Falling back to a fresh doc is a data-loss
+                        // operation and only acceptable when there is no
+                        // meaningful data to lose.
+                        warn!(
+                            "[notebook-doc] Rejecting schema v{} notebook at {:?} for {}; only v{} is supported. Starting fresh untitled notebook.",
+                            version, path, notebook_id, SCHEMA_VERSION
+                        );
                     }
                     Err(e) => {
                         warn!(

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -9,11 +9,15 @@
 //! copy in a "room"; each connected notebook window holds a local replica
 //! that syncs via the Automerge sync protocol.
 //!
-//! ## Document schema (v2)
+//! ## Document schema (v4)
+//!
+//! Outputs live in `RuntimeStateDoc` (keyed by `execution_id`) with
+//! per-output `output_id` UUIDs on their manifests — they are not stored
+//! in the notebook doc itself.
 //!
 //! ```text
 //! ROOT/
-//!   schema_version: u64           ← Document schema version (2 = fractional-indexed map cells)
+//!   schema_version: u64           ← Document schema version (currently 4)
 //!   notebook_id: Str
 //!   cells/                        ← Map keyed by cell ID (O(1) lookup)
 //!     {cell_id}/
@@ -22,8 +26,6 @@
 //!       position: Str             ← Fractional index hex string for ordering
 //!       source: Text              ← Automerge Text CRDT (character-level merging)
 //!       execution_count: Str      ← JSON-encoded i32 or "null"
-//!       outputs/                  ← List of Str
-//!         [j]: Str                ← JSON-encoded Jupyter output (Phase 5: manifest hash)
 //!       metadata/                 ← Map (native Automerge types, legacy: JSON string fallback)
 //!       resolved_assets/          ← Map of markdown asset ref -> blob hash
 //!   metadata/                     ← Map
@@ -51,15 +53,20 @@ use std::collections::HashMap;
 /// Current document schema version.
 ///
 /// Bump this when making incompatible changes to the Automerge document
-/// structure (e.g., switching cells from an ordered list to a fractional-indexed map).
+/// structure. Future bumps MUST ship a matching `migrate_vN_to_v(N+1)`
+/// function that preserves user data — see the "one-time cleanup"
+/// comment in `load_or_create_inner` for why the current fallback path
+/// is not a template.
 ///
+/// History:
 /// - **1** — Original schema: `cells` is an ordered `List` of `Map`.
 /// - **2** — Fractional indexing: `cells` is a `Map` keyed by cell ID, each cell has a `position` field.
-/// - **3** — Outputs moved to RuntimeStateDoc: cell outputs are no longer stored in the notebook
-///   doc. Existing outputs are extracted during migration so the caller can create synthetic
-///   execution entries in RuntimeStateDoc.
-/// - **4** — Addressable outputs: `OutputManifest` gains a required `output_id` (UUIDv4) field.
-///   Daemon mints IDs on emission; legacy outputs get IDs on first load.
+/// - **3** — Outputs moved to RuntimeStateDoc: cell outputs are no longer stored in the notebook doc.
+/// - **4** — Addressable outputs: `OutputManifest` carries a required `output_id` (UUIDv4).
+///   Outputs live in RuntimeStateDoc keyed by `execution_id`; manifests carry `output_id`.
+///
+/// v1–v3 predate the nteract 2.0 pre-release series and are no longer
+/// supported. `load_or_create_inner` discards pre-v4 documents on load.
 pub const SCHEMA_VERSION: u64 = 4;
 
 use automerge::sync;
@@ -693,9 +700,7 @@ impl NotebookDoc {
     ///
     /// ```text
     /// ROOT/
-    ///   schema_version: 2
-    ///   cells: {}          (empty Map)
-    ///   metadata: {}       (empty Map)
+    ///   schema_version: <SCHEMA_VERSION>  (scalar only — no cells/metadata maps)
     /// ```
     ///
     /// Both parameters are required:

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -813,10 +813,17 @@ impl NotebookDoc {
                         // data. Falling back to a fresh doc is a data-loss
                         // operation and only acceptable when there is no
                         // meaningful data to lose.
+                        //
+                        // Belt-and-suspenders: rename the unexpected-version doc
+                        // to `{path}.corrupt` before we replace it. That leaves
+                        // the original bytes on disk for manual recovery if a
+                        // future downgrade ever lands someone here (e.g. user
+                        // runs a newer build once, then rolls back).
                         warn!(
-                            "[notebook-doc] Rejecting schema v{} notebook at {:?} for {}; only v{} is supported. Starting fresh untitled notebook.",
+                            "[notebook-doc] Rejecting schema v{} notebook at {:?} for {}; only v{} is supported. Preserving as .corrupt and starting fresh untitled notebook.",
                             version, path, notebook_id, SCHEMA_VERSION
                         );
+                        Self::preserve_corrupt(path);
                     }
                     Err(e) => {
                         warn!(

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -208,11 +208,11 @@ The daemon holds the canonical document, persisted to `~/.cache/runt/settings.au
 
 Each open notebook gets a "room" in the daemon. Multiple windows editing the same notebook sync through the room's canonical document.
 
-**Document schema** (Automerge CRDT):
+**Document schema** (Automerge CRDT, currently v4):
 
 ```
 ROOT/
-  schema_version: u64           <- Document schema version (2 = fractional-indexed map cells)
+  schema_version: u64           <- Document schema version (currently 4)
   notebook_id: Str
   cells/                        <- Map keyed by cell ID (O(1) lookup)
     {cell_id}/
@@ -221,19 +221,23 @@ ROOT/
       position: Str             <- Fractional index hex string for ordering
       source: Text              <- Automerge Text CRDT (character-level merging)
       execution_count: Str      <- JSON-encoded i32 or "null"
-      outputs/                  <- List of Str
-        [j]: Str                <- JSON-encoded Jupyter output (manifest hash)
-      metadata: Str             <- JSON-encoded cell metadata object
+      metadata/                 <- Native Automerge map (legacy: JSON string fallback)
+      resolved_assets/          <- Map of markdown asset ref -> blob hash
   metadata/                     <- Map
     runtime: Str
-    notebook_metadata: Str      <- JSON-encoded NotebookMetadataSnapshot
+    kernelspec/                 <- Native Automerge map
+    language_info/              <- Native Automerge map
+    runt/                       <- Native Automerge map
+    notebook_metadata: Str      <- Legacy JSON mirror (dual-written)
 ```
+
+Outputs live in `RuntimeStateDoc` (separate Automerge doc, frame type `0x05`) keyed by `execution_id`, with each manifest carrying an `output_id` UUID for addressable references. They are not stored in the notebook doc.
 
 Cell ordering uses fractional indexing via the `position` field. Cells are sorted lexicographically by `position`, with `cell_id` as a tiebreaker for the (rare) case where two cells receive the same fractional index.
 
 **Design decisions**:
 - Cell `source` uses `ObjType::Text` for proper concurrent edit merging. `update_source()` uses Automerge's `update_text()` (Myers diff internally) for efficient character-level patches.
-- `outputs` are write-once from a single actor (the kernel), so they don't need CRDT text semantics. Stored as JSON strings now. Phase 6 changes these to output manifest hashes.
+- Outputs are write-once from the runtime agent, keyed by `execution_id` in `RuntimeStateDoc` so they never touch the notebook doc's CRDT ops.
 - `execution_count` is a string for JSON serialization consistency.
 
 ### Room architecture
@@ -897,7 +901,7 @@ If latency becomes an issue during rapid output bursts (e.g., training loops), t
 
 ### Schema versioning: lightweight, not a framework
 
-The notebook doc root contains a `schema_version: u64` field. Current docs are v4 (cells as a `Map` with fractional indexing, outputs in RuntimeStateDoc, per-output `output_id`). `load_or_create_inner` runs the `migrate_v2_to_v3` and `migrate_v3_to_v4` steps on load when needed. Schema v1 (cells as a `List`) predates the `.automerge` files that exist in the wild and is no longer supported — loading a v1 doc produces a fresh doc with a warning. No formal migration framework — the schema is simple enough that version-checking `if` branches suffice.
+The notebook doc root contains a `schema_version: u64` field. Current docs are v4 (cells as a `Map` with fractional indexing, outputs in `RuntimeStateDoc` keyed by `execution_id`, per-output `output_id` UUIDs on manifests). `load_or_create_inner` only accepts v4 docs; anything else drops to a fresh doc with a loud warning. v1–v3 predate the nteract 2.0 pre-release series and have no real users, so dropping them is a no-op in practice — **not** a template for future bumps. Any v5 schema MUST ship a `migrate_v4_to_v5` function that preserves user data. No formal migration framework — the schema is simple enough that version-checking `if` branches suffice, but the branch is only correct when the migration actually carries data forward.
 
 For output manifests, the `output_type` field provides structural versioning. New fields can be added without breaking old readers.
 


### PR DESCRIPTION
## Summary

Schema migration machinery left behind by #1988 and #1990. `migrate_v2_to_v3` and `migrate_v3_to_v4` had been reduced to pure `schema_version++` no-ops, the outdated-doc handler still chained them, and several docs were still stuck describing v2 as "current". v1–v3 predate the nteract 2.0 pre-release series and have no real users, so the unused migration plumbing can come out.

## Why this is safe (Kyle's context)

v1–v3 schemas all predate nteract 2.0. Every current user is on v4. Pre-v4 docs in the wild are effectively non-existent; anything still sitting in a crash-recovery cache is disposable. The old `migrate_vN_to_v(N+1)` functions were not actually carrying user data forward. They only bumped the `schema_version` scalar. Any meaningful schema-upgrade work (outputs moved to `RuntimeStateDoc`, `output_id` minting) already happens at read/capture time rather than at load time.

## Four phases, four commits

1. `refactor(notebook-doc): collapse load_or_create_inner version branch`. Replace the chained `version < SCHEMA_VERSION` / `ok = false` ladder with a single equality check. Documents exactly one in-line invariant: this fresh-doc fallback is pre-release cleanup only; future `v(N)→v(N+1)` bumps MUST ship a real `migrate_vN_to_v(N+1)` function.
2. `refactor(notebook-doc): delete migrate_v2_to_v3 and migrate_v3_to_v4 version-bumpers`. Both functions were dead after phase 1. Nothing outside this file ever called them, so this is a clean delete.
3. `fix(notebook-doc): preserve unexpected-version docs as .corrupt before replacing`. First codex pass flagged that an exact-version check would silently overwrite a future-version doc on a downgrade. Before returning the fresh `NotebookDoc`, rename the offending bytes to `{path}.corrupt` (same treatment we already give unreadable bytes). No CRDT work, just a belt-and-suspenders move so the recovery path is on disk.
4. `docs: refresh schema version references to v4`. Module-level doc, `SCHEMA_VERSION` history block, `bootstrap()` skeleton comment, plus `contributing/protocol.md`, `contributing/releasing.md`, and `docs/runtimed.md`. Drop the stale "Phase 6" output-manifest note from `docs/runtimed.md`.

## SCHEMA_VERSION audit (Phase 3)

Grepped every `schema_version` / `SCHEMA_VERSION` callsite in `crates/`, `apps/`, `python/`, `packages/` to see if anything else conditions on the version:

| Callsite | Decision |
|---|---|
| `notebook-doc::lib.rs` `SCHEMA_VERSION = 4`, `schema_version()` accessor, `doc.put(… SCHEMA_VERSION)` in `new_inner()` and `bootstrap()` | Keep. Writes the current version, no branching. |
| `notebook-doc::lib.rs` `version == SCHEMA_VERSION` in `load_or_create_inner` | Keep. The collapsed check from this PR. |
| `notebook-doc::lib.rs` tests asserting `Some(SCHEMA_VERSION)` | Keep. Regression tests for bootstrap writes. |
| `notebook-doc::metadata.rs` `pub schema_version: String`, value `"1"` | Unrelated. This is the nbformat `NotebookMetadataSnapshot.schema_version` field (nbformat v1). Not our Automerge schema. |
| `notebook::lib.rs` `schema_version: "1".to_string()` (3 callsites) | Same. nbformat. |
| `notebook::session.rs` `CURRENT_SCHEMA_VERSION: u32 = 1` | Unrelated. `SessionState` persistence format version, separate axis. |
| `runtimed::notebook_sync_server.rs` `schema_version: "1"` (7 callsites) | Same. nbformat. |
| `apps/notebook/src/lib/notebook-metadata.ts` `schema_version: string` | Same. nbformat interface. |

Zero live branches condition on our Automerge schema version outside the one collapsed in this PR. No "mixed-version" handling hidden elsewhere, so Phase 3 collapses into Phase 2 with no extra commit.

## Do not copy this pattern

The in-code comment is blunt because the policy is blunt: falling back to a fresh doc on schema mismatch is only safe here because v1–v3 carry no real user data. **Any v4 → v5 bump MUST implement `migrate_v4_to_v5`** that preserves cells, source text, metadata, and positions. The codex reviewer correctly flagged that an exact-version check is a data-loss path in the general case; commit 3 renames the file to `.corrupt` before replacement so users always have a manual recovery path, but the real fix for future bumps is a real migration function.

## Files not edited

- `.claude/rules/protocol.md:16` still says `currently 2`. The agent sandbox denied the edit on rule files. Needs a manual one-liner bump to `currently 4` with the same "migrations must preserve data" caveat I added to `contributing/protocol.md`.

## Test plan

- [x] `cargo xtask lint --fix`. Rust + JS/TS + Python clean.
- [x] `cargo check --workspace`.
- [x] `cargo test -p notebook-doc --lib --features persistence`. 353 passed.
- [x] `cargo test -p runtimed --lib`. 381 passed.
- [x] `cargo test -p runtimed --test integration`. 25 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`. Clean.
- [x] `codex review --base main`. P1 finding from the first pass (downgrade data-loss) addressed by commit 3; the remaining P1 ("preserve v2/v3 upgrade path") is the deliberate policy decision this PR documents.
