### PR TITLE
feat(notebook): add Open Recent submenu to File menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6988,7 +6988,10 @@ dependencies = [
  "core-foundation",
  "dirs",
  "hex",
+ "serde",
+ "serde_json",
  "sha2 0.11.0",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2090,6 +2090,9 @@ async fn save_notebook_as(
     sync_ready.update_cached_path(window.label(), Some(&saved_path.to_string_lossy()));
     dirty.store(false, Ordering::SeqCst);
 
+    // Promote the new path onto the Open Recent list so Save As destinations
+    // behave like any other opened notebook.
+    runt_workspace::recent::record_open(&saved_path);
     refresh_native_menu(window.app_handle(), registry.inner());
 
     // Restart the kernel only if one was already running. This preserves
@@ -2349,7 +2352,12 @@ fn open_notebook_window(
         },
         None,
     )
-    .map(|_| ())
+    .map(|_| ())?;
+    // Record the successful open on the MRU list and refresh the menu so every
+    // window's native menu reflects the new entry immediately.
+    runt_workspace::recent::record_open(path);
+    refresh_native_menu(app, registry);
+    Ok(())
 }
 
 /// Process a single file-open URL: focus existing window, reuse empty window, or open new.
@@ -3399,7 +3407,14 @@ fn window_menu_display_names(
 
 fn refresh_native_menu(app: &tauri::AppHandle, registry: &WindowNotebookRegistry) {
     let window_display_names = window_menu_display_names(app, registry);
-    match crate::menu::create_menu(app, &window_display_names) {
+    let recent = runt_workspace::recent::load_recent();
+    // Filter out entries whose file is no longer on disk so the submenu stays honest.
+    let live: Vec<_> = recent
+        .entries
+        .into_iter()
+        .filter(|e| e.path.try_exists().unwrap_or(false))
+        .collect();
+    match crate::menu::create_menu(app, &window_display_names, &live) {
         Ok(menu) => {
             if let Err(error) = app.set_menu(menu) {
                 warn!("[menu] Failed to update native menu: {}", error);
@@ -4221,7 +4236,17 @@ pub fn run(
             // Set up native menu bar
             let window_display_names =
                 window_menu_display_names(app.handle(), app.state::<WindowNotebookRegistry>().inner());
-            let menu = crate::menu::create_menu(app.handle(), &window_display_names)?;
+            let recent_startup = runt_workspace::recent::load_recent();
+            let recent_startup_live: Vec<_> = recent_startup
+                .entries
+                .into_iter()
+                .filter(|e| e.path.try_exists().unwrap_or(false))
+                .collect();
+            let menu = crate::menu::create_menu(
+                app.handle(),
+                &window_display_names,
+                &recent_startup_live,
+            )?;
             app.set_menu(menu)?;
 
             let has_session_to_clear = restored_session.is_some();
@@ -4449,6 +4474,45 @@ pub fn run(
                 return;
             }
             let registry = app.state::<WindowNotebookRegistry>();
+            if menu_id == crate::menu::MENU_OPEN_RECENT_CLEAR {
+                runt_workspace::recent::clear();
+                refresh_native_menu(app, registry.inner());
+                return;
+            }
+            if let Some(index) = crate::menu::index_for_open_recent_menu_item_id(menu_id) {
+                let recent = runt_workspace::recent::load_recent();
+                let Some(entry) = recent.entries.get(index).cloned() else {
+                    // The snapshot changed between paint and click; just rebuild.
+                    refresh_native_menu(app, registry.inner());
+                    return;
+                };
+                if !entry.path.try_exists().unwrap_or(false) {
+                    warn!(
+                        "[open-recent] Entry no longer exists: {}",
+                        entry.path.display()
+                    );
+                    runt_workspace::recent::remove_entry(&entry.path);
+                    refresh_native_menu(app, registry.inner());
+                    let app_handle = app.clone();
+                    let missing = entry.path.display().to_string();
+                    tauri::async_runtime::spawn(async move {
+                        tauri_plugin_dialog::DialogExt::dialog(&app_handle)
+                            .message(format!("Notebook no longer exists:\n{missing}"))
+                            .title("File Not Found")
+                            .kind(tauri_plugin_dialog::MessageDialogKind::Warning)
+                            .blocking_show();
+                    });
+                    return;
+                }
+                if let Err(e) = open_notebook_window(app, registry.inner(), &entry.path) {
+                    warn!(
+                        "[open-recent] Failed to open '{}': {}",
+                        entry.path.display(),
+                        e
+                    );
+                }
+                return;
+            }
             match menu_id {
                 crate::menu::MENU_NEW_NOTEBOOK => {
                     // Spawn notebook using the user's default runtime preference

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -4,6 +4,8 @@ use tauri::menu::{
 };
 use tauri::{AppHandle, Manager, Wry};
 
+use runt_workspace::recent::{RecentNotebook, RECENT_MAX_ENTRIES};
+
 pub struct BundledSampleNotebook {
     pub title: &'static str,
     pub file_name: &'static str,
@@ -19,6 +21,8 @@ pub const MENU_OPEN_SAMPLE: &str = "open_sample";
 pub const MENU_SAVE: &str = "save";
 pub const MENU_CLONE_NOTEBOOK: &str = "clone_notebook";
 pub const MENU_WINDOW_FOCUS_PREFIX: &str = "focus_window:";
+pub const MENU_OPEN_RECENT_PREFIX: &str = "open_recent:";
+pub const MENU_OPEN_RECENT_CLEAR: &str = "open_recent:clear";
 
 // Menu item IDs for zoom
 pub const MENU_ZOOM_IN: &str = "zoom_in";
@@ -75,6 +79,20 @@ pub fn window_label_for_menu_item_id(menu_id: &str) -> Option<&str> {
     menu_id.strip_prefix(MENU_WINDOW_FOCUS_PREFIX)
 }
 
+pub fn open_recent_menu_item_id(index: usize) -> String {
+    format!("{MENU_OPEN_RECENT_PREFIX}{index}")
+}
+
+/// Returns the index for an indexed `open_recent:N` menu id. The `open_recent:clear`
+/// id is explicitly not an index and returns `None`.
+pub fn index_for_open_recent_menu_item_id(menu_id: &str) -> Option<usize> {
+    let rest = menu_id.strip_prefix(MENU_OPEN_RECENT_PREFIX)?;
+    if rest == "clear" {
+        return None;
+    }
+    rest.parse().ok()
+}
+
 fn build_about_metadata() -> AboutMetadata<'static> {
     AboutMetadataBuilder::new()
         .name(Some(app_name()))
@@ -89,6 +107,7 @@ fn build_about_metadata() -> AboutMetadata<'static> {
 pub fn create_menu(
     app: &AppHandle,
     window_display_names: &HashMap<String, String>,
+    recent: &[RecentNotebook],
 ) -> tauri::Result<Menu<Wry>> {
     let menu = Menu::new(app)?;
     let about_metadata = build_about_metadata();
@@ -186,6 +205,37 @@ pub fn create_menu(
         true,
         None::<&str>,
     )?)?;
+
+    // Open Recent submenu — dynamic list, rebuilt on each `refresh_native_menu`.
+    let has_recent = !recent.is_empty();
+    let open_recent_submenu = Submenu::new(app, "Open Recent", has_recent)?;
+    for (idx, entry) in recent.iter().enumerate().take(RECENT_MAX_ENTRIES) {
+        let label = entry
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("<unknown>")
+            .to_string();
+        open_recent_submenu.append(&MenuItem::with_id(
+            app,
+            open_recent_menu_item_id(idx),
+            label,
+            true,
+            None::<&str>,
+        )?)?;
+    }
+    if has_recent {
+        open_recent_submenu.append(&PredefinedMenuItem::separator(app)?)?;
+    }
+    open_recent_submenu.append(&MenuItem::with_id(
+        app,
+        MENU_OPEN_RECENT_CLEAR,
+        "Clear Menu",
+        has_recent,
+        None::<&str>,
+    )?)?;
+    file_menu.append(&open_recent_submenu)?;
+
     file_menu.append(&PredefinedMenuItem::separator(app)?)?;
     file_menu.append(&MenuItem::with_id(
         app,
@@ -346,9 +396,10 @@ pub fn create_menu(
 #[cfg(test)]
 mod tests {
     use super::{
-        about_menu_label, app_name, build_about_metadata, window_label_for_menu_item_id,
-        window_menu_item_id, APP_COMMIT_SHA, APP_RELEASE_DATE, APP_VERSION,
-        BUNDLED_SAMPLE_NOTEBOOK,
+        about_menu_label, app_name, build_about_metadata, index_for_open_recent_menu_item_id,
+        open_recent_menu_item_id, window_label_for_menu_item_id, window_menu_item_id,
+        APP_COMMIT_SHA, APP_RELEASE_DATE, APP_VERSION, BUNDLED_SAMPLE_NOTEBOOK,
+        MENU_OPEN_RECENT_CLEAR,
     };
 
     #[test]
@@ -364,6 +415,23 @@ mod tests {
             assert_eq!(resolved, label);
         }
         assert!(window_label_for_menu_item_id("new_notebook").is_none());
+    }
+
+    #[test]
+    fn open_recent_ids_round_trip() {
+        for idx in [0usize, 1, 9, 42] {
+            let id = open_recent_menu_item_id(idx);
+            assert_eq!(index_for_open_recent_menu_item_id(&id), Some(idx));
+        }
+        // Clear is not an index.
+        assert_eq!(
+            index_for_open_recent_menu_item_id(MENU_OPEN_RECENT_CLEAR),
+            None
+        );
+        // Unrelated ids do not parse.
+        assert_eq!(index_for_open_recent_menu_item_id("new_notebook"), None);
+        assert_eq!(index_for_open_recent_menu_item_id("open_recent:"), None);
+        assert_eq!(index_for_open_recent_menu_item_id("open_recent:abc"), None);
     }
 
     #[test]

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -9,10 +9,15 @@ license.workspace = true
 [dependencies]
 dirs = "6"
 hex = "0.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
 sha2 = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -12,6 +12,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub mod recent;
+
 // ============================================================================
 // Build Channel Branding
 // ============================================================================

--- a/crates/runt-workspace/src/recent.rs
+++ b/crates/runt-workspace/src/recent.rs
@@ -1,0 +1,234 @@
+//! Most-recently-used notebook list persisted to `recent.json`.
+//!
+//! Sits next to [`crate::settings_json_path`] and [`crate::session_state_path`]:
+//! a dedicated file keeps the MRU list independent of `SyncedSettings`
+//! (Automerge) and of the session restore file.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::config_namespace;
+
+/// Cap on retained entries. Excess are dropped from the tail.
+pub const RECENT_MAX_ENTRIES: usize = 10;
+
+const RECENT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct RecentNotebook {
+    pub path: PathBuf,
+    /// Milliseconds since the Unix epoch.
+    pub last_opened_ms: u64,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct RecentNotebooks {
+    #[serde(default)]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub entries: Vec<RecentNotebook>,
+}
+
+/// Path to `recent.json`, sibling of `settings.json`.
+pub fn recent_notebooks_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(config_namespace())
+        .join("recent.json")
+}
+
+/// Load the MRU list from disk. Returns [`RecentNotebooks::default`] on any
+/// error (missing file, malformed JSON, I/O failure) — the list is soft state
+/// and should never block the app.
+pub fn load_recent() -> RecentNotebooks {
+    load_from(&recent_notebooks_path())
+}
+
+fn load_from(path: &Path) -> RecentNotebooks {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return RecentNotebooks::default();
+    };
+    serde_json::from_str(&contents).unwrap_or_default()
+}
+
+fn save_to(path: &Path, value: &RecentNotebooks) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
+    std::fs::write(path, format!("{json}\n"))
+}
+
+fn canonical_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Push `path` to the front of the MRU list (deduped by canonical path),
+/// truncate to [`RECENT_MAX_ENTRIES`], and persist. Returns the new list.
+pub fn record_open(path: &Path) -> RecentNotebooks {
+    record_open_in(&recent_notebooks_path(), path)
+}
+
+fn record_open_in(store: &Path, path: &Path) -> RecentNotebooks {
+    let mut recent = load_from(store);
+    let key = canonical_key(path);
+    recent.entries.retain(|e| canonical_key(&e.path) != key);
+    recent.entries.insert(
+        0,
+        RecentNotebook {
+            path: key,
+            last_opened_ms: now_ms(),
+        },
+    );
+    recent.entries.truncate(RECENT_MAX_ENTRIES);
+    recent.schema_version = RECENT_SCHEMA_VERSION;
+    let _ = save_to(store, &recent);
+    recent
+}
+
+/// Remove a single entry (matched by canonical path) and persist.
+pub fn remove_entry(path: &Path) -> RecentNotebooks {
+    remove_entry_in(&recent_notebooks_path(), path)
+}
+
+fn remove_entry_in(store: &Path, path: &Path) -> RecentNotebooks {
+    let mut recent = load_from(store);
+    let key = canonical_key(path);
+    recent.entries.retain(|e| canonical_key(&e.path) != key);
+    recent.schema_version = RECENT_SCHEMA_VERSION;
+    let _ = save_to(store, &recent);
+    recent
+}
+
+/// Drop every entry and persist.
+pub fn clear() -> RecentNotebooks {
+    clear_in(&recent_notebooks_path())
+}
+
+fn clear_in(store: &Path) -> RecentNotebooks {
+    let recent = RecentNotebooks {
+        schema_version: RECENT_SCHEMA_VERSION,
+        entries: Vec::new(),
+    };
+    let _ = save_to(store, &recent);
+    recent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp_store() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recent.json");
+        (dir, path)
+    }
+
+    #[test]
+    fn load_missing_returns_default() {
+        let (_dir, path) = tmp_store();
+        let recent = load_from(&path);
+        assert!(recent.entries.is_empty());
+        assert_eq!(recent.schema_version, 0);
+    }
+
+    #[test]
+    fn load_malformed_returns_default() {
+        let (_dir, path) = tmp_store();
+        fs::write(&path, "not json {{").unwrap();
+        let recent = load_from(&path);
+        assert!(recent.entries.is_empty());
+    }
+
+    #[test]
+    fn record_puts_newest_first() {
+        let (dir, path) = tmp_store();
+        let a = dir.path().join("a.ipynb");
+        let b = dir.path().join("b.ipynb");
+        fs::write(&a, "{}").unwrap();
+        fs::write(&b, "{}").unwrap();
+
+        record_open_in(&path, &a);
+        let recent = record_open_in(&path, &b);
+
+        assert_eq!(recent.entries.len(), 2);
+        assert_eq!(canonical_key(&recent.entries[0].path), canonical_key(&b));
+        assert_eq!(canonical_key(&recent.entries[1].path), canonical_key(&a));
+    }
+
+    #[test]
+    fn record_dedupes_by_canonical_path() {
+        let (dir, path) = tmp_store();
+        let a = dir.path().join("a.ipynb");
+        fs::write(&a, "{}").unwrap();
+
+        record_open_in(&path, &a);
+        let recent = record_open_in(&path, &a);
+
+        assert_eq!(recent.entries.len(), 1);
+    }
+
+    #[test]
+    fn record_truncates_to_max() {
+        let (dir, path) = tmp_store();
+        for i in 0..(RECENT_MAX_ENTRIES + 5) {
+            let p = dir.path().join(format!("nb-{i}.ipynb"));
+            fs::write(&p, "{}").unwrap();
+            record_open_in(&path, &p);
+        }
+        let recent = load_from(&path);
+        assert_eq!(recent.entries.len(), RECENT_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn remove_drops_entry() {
+        let (dir, path) = tmp_store();
+        let a = dir.path().join("a.ipynb");
+        let b = dir.path().join("b.ipynb");
+        fs::write(&a, "{}").unwrap();
+        fs::write(&b, "{}").unwrap();
+
+        record_open_in(&path, &a);
+        record_open_in(&path, &b);
+        let recent = remove_entry_in(&path, &a);
+
+        assert_eq!(recent.entries.len(), 1);
+        assert_eq!(canonical_key(&recent.entries[0].path), canonical_key(&b));
+    }
+
+    #[test]
+    fn clear_empties_list() {
+        let (dir, path) = tmp_store();
+        let a = dir.path().join("a.ipynb");
+        fs::write(&a, "{}").unwrap();
+        record_open_in(&path, &a);
+
+        let recent = clear_in(&path);
+        assert!(recent.entries.is_empty());
+
+        let reloaded = load_from(&path);
+        assert!(reloaded.entries.is_empty());
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let (dir, path) = tmp_store();
+        let a = dir.path().join("a.ipynb");
+        fs::write(&a, "{}").unwrap();
+        record_open_in(&path, &a);
+
+        let raw = fs::read_to_string(&path).unwrap();
+        let parsed: RecentNotebooks = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed.schema_version, RECENT_SCHEMA_VERSION);
+        assert_eq!(parsed.entries.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `File > Open Recent` submenu listing up to 10 most-recently-opened notebooks; clicking an entry focuses the existing window or opens a new one.
- Persists the MRU list to `~/Library/Application Support/nteract{,-nightly}/recent.json` (deduped by canonical path, capped at 10).
- Stale entries are filtered at menu-build time and auto-removed on click with a "File Not Found" dialog; includes a `Clear Menu` action.

<img width="801" height="495" alt="image" src="https://github.com/user-attachments/assets/cc322685-f220-45b5-89ab-c7408731b597" />

## Design notes
- New module `crates/runt-workspace/src/recent.rs` owns the data model and I/O (8 unit tests).
- Recording happens inside `open_notebook_window` (covers every entry point: File > Open, double-click, CLI arg, Open Recent itself) and in the `save_as` success path.
- Menu entries use index-encoded IDs (`open_recent:N`) — the handler re-reads `recent.json` at click time and looks up by index.
- `refresh_native_menu` calls `app.set_menu` which is app-wide, so every window's native menu updates after a single refresh.

## Test plan
- [ ] File > Open a notebook; close the window; File > Open Recent lists it; click to reopen.
- [ ] Open a second notebook; File > Open Recent shows both with the most-recent on top.
- [ ] Relaunch the app; the list persists.
- [ ] `mv` a recent target off disk; clicking it shows "File Not Found" and the entry disappears.
- [ ] File > Open Recent > Clear Menu empties the submenu.
- [ ] Save As to a new location; File > Open Recent lists the new path.
- [ ] Open two windows; opening notebook C in window 1 updates window 2's Open Recent.
- [ ] While notebook A is open, File > Open Recent > A focuses the existing window (no duplicate).

## Out of scope / follow-ups
- macOS `NSDocumentController.noteNewRecentDocumentURL` so the Dock right-click Recent list mirrors the in-app one.
- Parent-dir hint in the label (e.g. `analysis.ipynb — ~/projects/foo`).
- Exposing the recent list to the frontend (command palette / home screen).