### PR TITLE
ci: add dependency budget check to clippy-and-tests job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,6 +374,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings
 
+      - name: Dependency budget check
+        run: cargo xtask check-dep-budget
+
       - name: Run tests
         run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --verbose
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2904,6 +2904,7 @@ fn cmd_check_dep_budget() {
         ("runt-trust", 50),
         ("notebook-doc", 110),
         ("kernel-launch", 175),
+        ("runtimed-client", 310),
     ];
 
     println!("{:<20} {:>5}  {:>6}  Status", "Crate", "Deps", "Budget");


### PR DESCRIPTION
Add `cargo xtask check-dep-budget` to the `clippy-and-tests` CI job so dep count regressions get caught before merge.

Also adds `runtimed-client` to the tracked crates (budget: 310, currently 221 — down from 363 before the ts-rs feature-gating in #2002).

_PR submitted by @rgbkrk's agent Quill, via Zed_