### PR TITLE
fix(xtask): bump runt-workspace dep budget for recent files feature

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2900,7 +2900,7 @@ fn cmd_check_dep_budget() {
     // Budgets are unique crate counts (deduplicated, excluding the root crate).
     const BUDGETS: &[(&str, usize)] = &[
         ("xtask", 30),
-        ("runt-workspace", 25),
+        ("runt-workspace", 35),
         ("runt-trust", 50),
         ("notebook-doc", 110),
         ("kernel-launch", 175),


### PR DESCRIPTION
The recent files feature added serde/serde_json/sha2 to `runt-workspace`, pushing it from 16 → 27 unique deps. The budget check (added in #2003) correctly caught this. Bump 25 → 35.

_PR submitted by @rgbkrk's agent Quill, via Zed_