### PR TITLE
docs: fix stale rattler references after kernel-launch cleanup

### DIFF
--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -177,7 +177,7 @@ Every kernel runs in a separate **runtime agent subprocess** (`runtimed runtime-
 **Implications:**
 - Clients request kernel launch; they don't spawn kernels directly
 - Environment selection is the daemon's decision based on notebook metadata
-- Tool availability is the daemon's responsibility (bootstrap via rattler if needed)
+- Tool availability is the daemon's responsibility (bootstrap via GitHub releases if needed)
 - Clients are stateless with respect to runtime resources
 - Each kernel is sandboxable at the OS level (process isolation enables future cgroup/seatbelt)
 - Runtime agents can survive temporary disconnection and sync outputs on reconnect

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -16,7 +16,7 @@ Notebook opened
   │
   ├─ Check notebook kernelspec ────────── metadata.kernelspec.name
   │   │
-  │   ├─ "deno" ───────────────────────── Launch Deno kernel (bootstrap via rattler)
+  │   ├─ "deno" ───────────────────────── Launch Deno kernel (bootstrap via GitHub releases)
   │   │
   │   ├─ "python" / "python3" ─────────── Resolve Python environment:
   │   │   │
@@ -41,7 +41,7 @@ Kernel launching is handled by the `runtimed` daemon, which manages both Python 
 
 ### Tool Bootstrapping
 
-Tools (deno, uv, ruff) are automatically installed from conda-forge if not found on PATH:
+Tools (deno, uv, ruff, pixi) are automatically downloaded from GitHub releases if not found on PATH:
 
 ```rust
 use kernel_launch::tools;
@@ -558,7 +558,7 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 | File | Role |
 |------|------|
 | `crates/kernel-launch/src/lib.rs` | Public API for kernel launching |
-| `crates/kernel-launch/src/tools.rs` | Tool bootstrapping (deno, uv, ruff) via rattler |
+| `crates/kernel-launch/src/tools.rs` | Tool bootstrapping (deno, uv, ruff, pixi) via GitHub releases |
 
 ### Daemon (Kernel Management)
 

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -12,7 +12,7 @@ The daemon uses `tracing` with `tracing-subscriber` (layered subscribers for std
 use tracing::{debug, info, warn, error};
 ```
 
-Dependencies that use the `log` crate (runtimelib, automerge, rattler, etc.) are automatically bridged into the tracing subscriber via `tracing-log`.
+Dependencies that use the `log` crate (runtimelib, automerge, etc.) are automatically bridged into the tracing subscriber via `tracing-log`.
 
 ### Tauri app (notebook crate)
 

--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -1,7 +1,7 @@
 //! Deno environment detection and configuration for notebook environments.
 //!
 //! This module handles:
-//! - Detecting if Deno is installed (or bootstrapping via rattler if not)
+//! - Detecting if Deno is installed (or downloading from GitHub releases if not)
 //! - Finding deno.json/deno.jsonc configuration files
 //! - Extracting Deno configuration from notebook metadata
 //! - Managing Deno permissions for kernel execution

--- a/crates/notebook/src/environment_yml.rs
+++ b/crates/notebook/src/environment_yml.rs
@@ -242,7 +242,7 @@ pub fn create_environment_yml_info(
     }
 }
 
-/// Convert an EnvironmentYmlConfig to CondaDependencies for use with rattler.
+/// Convert an EnvironmentYmlConfig to CondaDependencies for use with the conda solver.
 pub fn convert_to_conda_dependencies(config: &EnvironmentYmlConfig) -> CondaDependencies {
     CondaDependencies {
         dependencies: config.dependencies.clone(),

--- a/crates/notebook/src/pixi.rs
+++ b/crates/notebook/src/pixi.rs
@@ -294,7 +294,7 @@ pub fn create_pixi_info(config: &PixiConfig, notebook_path: &Path) -> PixiInfo {
     }
 }
 
-/// Convert a PixiConfig to CondaDependencies for use with rattler.
+/// Convert a PixiConfig to CondaDependencies for use with the conda solver.
 pub fn convert_to_conda_dependencies(config: &PixiConfig) -> CondaDependencies {
     CondaDependencies {
         dependencies: config.dependencies.clone(),

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides the client-facing API for runtimed: IPC client,
 //! settings sync, daemon discovery, service management, and shared types.
 //! It does NOT include any server-side daemon code or heavy dependencies
-//! like rattler, kernel-env, or kernel-launch.
+//! like kernel-env or kernel-launch.
 //!
 //! ## Crate consumers
 //!

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -85,7 +85,7 @@ pub enum PythonEnvType {
     /// Use uv for Python package management (fast, pip-compatible)
     #[default]
     Uv,
-    /// Use conda/rattler for Python package management (supports conda packages)
+    /// Use conda for Python package management (supports conda packages)
     Conda,
     /// Use pixi for Python package management (conda + pip unified)
     Pixi,


### PR DESCRIPTION
Fix stale references to rattler in comments and docs that described tool bootstrapping (deno, uv, ruff, pixi). Since #1998, tools download from GitHub releases — rattler is no longer involved.

Rattler references in `runtimed` and `kernel-env` are still accurate (conda env management) and left unchanged.

8 files, all comment/doc changes, no code changes.

_PR submitted by @rgbkrk's agent Quill, via Zed_