### PR TITLE
fix(mcp-proxy): respawn child after transport closes (follow-up to #2004)

### DIFF
--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -80,3 +80,101 @@ pub async fn spawn_child(
 
     Ok(client)
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression test for the post-`exit(75)` respawn gap.
+    //!
+    //! `RunningService::is_closed()` in rmcp 1.4 returns true only when the
+    //! handle has been consumed by `.waiting()` OR the cancellation token
+    //! has been cancelled — neither happens when the child process exits on
+    //! its own. `is_transport_closed()` (via `Peer::is_transport_closed`)
+    //! *does* flip when the service loop breaks because the transport
+    //! reader returned None.
+    //!
+    //! This matters for `proxy.rs`: the monitor loop and the
+    //! `forward_tool_call` fallback use this check to decide whether the
+    //! child is gone and a restart is needed. Using `is_closed()` wedges
+    //! the proxy after a daemon-upgrade exit(75) — the child is dead but
+    //! the proxy never respawns it. See the lab finding on PR #2004.
+    use super::*;
+    use rmcp::{ServerHandler, ServiceExt};
+    use std::time::{Duration, Instant};
+
+    /// Minimal `ServerHandler` — all methods use rmcp's defaults.
+    struct NoopServer;
+    impl ServerHandler for NoopServer {}
+
+    /// Bring up a `RunningChild` over an in-memory duplex pipe, then drop
+    /// the server side. The client's service loop should observe EOF on
+    /// read and break out.
+    async fn dead_transport_child() -> RunningChild {
+        let (server_side, client_side) = tokio::io::duplex(1024);
+
+        // Server handshake + hold the transport alive until we drop it.
+        let server_handle = tokio::spawn(async move {
+            let server = NoopServer.serve(server_side).await.expect("serve server");
+            // Park until the client disconnects.
+            let _ = server.waiting().await;
+        });
+
+        let handler = ChildClientHandler {
+            upstream_name: "test".to_string(),
+            upstream_title: None,
+        };
+        let client = handler
+            .serve(client_side)
+            .await
+            .expect("client handshake completes");
+
+        // Kill the server. Its service task ends, stdout half of the duplex
+        // closes, the client's `transport.receive()` returns None, and the
+        // client service loop breaks with `QuitReason::Closed`.
+        server_handle.abort();
+
+        client
+    }
+
+    /// Wait until `cond` returns true or `deadline` elapses.
+    async fn wait_for(deadline: Duration, mut cond: impl FnMut() -> bool) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            if cond() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cond()
+    }
+
+    #[tokio::test]
+    async fn is_transport_closed_flips_when_child_exits() {
+        let client = dead_transport_child().await;
+        let closed = wait_for(Duration::from_secs(2), || client.is_transport_closed()).await;
+        assert!(
+            closed,
+            "is_transport_closed() must flip to true when the child's stdio closes"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_closed_does_not_flip_on_child_exit() {
+        // Documents the rmcp 1.4 behavior that motivated the swap: even
+        // after the transport dies, `is_closed()` remains false because
+        // the `handle` Option still holds the (now-finished) JoinHandle
+        // and nobody has cancelled the token. If this ever changes
+        // upstream we can drop the workaround — and this test will fail
+        // loudly to tell us.
+        let client = dead_transport_child().await;
+        // Give the loop ample time to tear down.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            client.is_transport_closed(),
+            "precondition: transport should be closed by now"
+        );
+        assert!(
+            !client.is_closed(),
+            "rmcp 1.4's is_closed() is expected to stay false; the proxy must not rely on it"
+        );
+    }
+}

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -441,17 +441,22 @@ impl McpProxy {
                 tokio::time::sleep(Duration::from_millis(proxy.config.monitor_poll_interval_ms))
                     .await;
 
-                // Check if child is closed
-                let is_closed = {
+                // `is_transport_closed()` flips when the rmcp service loop
+                // breaks because the child's stdout hit EOF (i.e. the
+                // process exited). Don't use `is_closed()` here: it only
+                // reports "someone consumed the handle via .waiting()" or
+                // "the cancellation token was cancelled," neither of which
+                // happens on a natural child exit. See child::tests.
+                let transport_closed = {
                     let state = proxy.state.read().await;
                     state
                         .child_client
                         .as_ref()
-                        .map(|c| c.is_closed())
+                        .map(|c| c.is_transport_closed())
                         .unwrap_or(true)
                 };
 
-                if !is_closed {
+                if !transport_closed {
                     continue;
                 }
 
@@ -507,7 +512,10 @@ impl McpProxy {
             }
             Err(e) => {
                 let state = self.state.read().await;
-                let child_alive = state.child_client.as_ref().is_some_and(|c| !c.is_closed());
+                let child_alive = state
+                    .child_client
+                    .as_ref()
+                    .is_some_and(|c| !c.is_transport_closed());
                 drop(state);
                 if child_alive {
                     warn!("Tool call failed but child still connected, not restarting: {e}");
@@ -554,7 +562,10 @@ impl McpProxy {
             Ok(result) => return Ok(result),
             Err(e) => {
                 let state = self.state.read().await;
-                let child_alive = state.child_client.as_ref().is_some_and(|c| !c.is_closed());
+                let child_alive = state
+                    .child_client
+                    .as_ref()
+                    .is_some_and(|c| !c.is_transport_closed());
                 drop(state);
                 if child_alive {
                     return Err(e);


### PR DESCRIPTION
Follow-up to #2004 based on the [lab smoke finding](https://github.com/nteract/desktop/pull/2004#issuecomment-4291230026): primary wedge is fixed, but the daemon-upgrade path still wedges after `exit(75)`.

## Root cause

rmcp 1.4's `RunningService::is_closed()` returns true only when:

1. Someone consumed the handle via `.waiting()` (the proxy never does — it stores the handle in `ProxyState`), OR
2. The `CancellationToken` was explicitly cancelled (the proxy doesn't cancel on child exit)

Neither fires when the child exits naturally. So after `runt-nightly mcp` logs `Daemon upgraded, exiting for restart (exit code 75)` and the rmcp service loop breaks out on EOF, `is_closed()` keeps returning false. Both the child-monitor poll loop and the `forward_tool_call` fallback gate their respawn on `is_closed()`, so neither fires. Result: every tool call returns `Transport closed` indefinitely.

The right signal is `Peer::is_transport_closed()` (`RunningService: Deref<Target=Peer>`, so it's already reachable on `RunningChild`). It flips true when the peer→service mpsc channel closes — which happens when the service loop exits, which happens when the child's stdout hits EOF.

## Changes

| File | Change |
|---|---|
| `crates/runt-mcp-proxy/src/proxy.rs` | Swap `is_closed()` → `is_transport_closed()` at 3 sites: monitor poll, `forward_tool_call` fallback, `forward_read_resource` fallback |
| `crates/runt-mcp-proxy/src/child.rs` | +98 lines of tests |

## Tests

Two new tokio tests in `child::tests` (both passing):

- `is_transport_closed_flips_when_child_exits` — spins up a `RunningChild` over `tokio::io::duplex`, aborts the server side, asserts `is_transport_closed()` becomes true within 2s.
- `is_closed_does_not_flip_on_child_exit` — documents rmcp 1.4's behavior. Asserts `is_transport_closed()` is true but `is_closed()` stays false after the same teardown. If upstream ever fixes `is_closed()`, this test fails loudly and we can remove the workaround.

No external processes, no daemon, no flake surface — just duplex pipes.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `cargo xtask clippy` clean
- [x] `cargo test -p runt-mcp-proxy` — 85 passed (+2 from baseline)
- [ ] Lab re-test of the upgrade path: bump daemon version, confirm proxy respawns child cleanly after `exit(75)` without the "Transport closed" loop

## Notes

Small, surgical. Doesn't touch #2004's design choices or the health loop deletion. The name `is_closed()` is [misleading in rmcp 1.4](https://docs.rs/rmcp/1.4.0/rmcp/service/struct.RunningService.html#method.is_closed) — worth an upstream issue, but not blocking.