### PR TITLE
chore(plugins): rename MCP server key to "notebook"

### DIFF
--- a/.claude/plugins/nteract/.mcp.json
+++ b/.claude/plugins/nteract/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "nteract": {
+    "notebook": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-runt-proxy",
       "args": [],
       "env": {

--- a/plugins/nteract-nightly/.mcp.json
+++ b/plugins/nteract-nightly/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "nteract-nightly": {
+    "notebook": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/runt-proxy",
       "args": [],
       "env": {

--- a/plugins/nteract/.mcp.json
+++ b/plugins/nteract/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "nteract": {
+    "notebook": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/runt-proxy",
       "args": [],
       "env": {


### PR DESCRIPTION
## Summary

Claude Code displays plugin MCP tools as `plugin:<plugin-name>:<server-name> - <tool>`. With the server key matching the plugin name today, every permission prompt reads:

```
plugin:nteract-nightly:nteract-nightly - create_notebook
```

The outer segment already identifies the plugin and channel. The inner segment should describe the server's domain. Rename the key to `notebook`:

```
plugin:nteract-nightly:notebook - create_notebook
```

Reads like an English sentence. Forward-compatible if we later ship a second MCP server inside the same plugin (daemon ops, diagnostics, blob store) — each gets its own name instead of jostling for `nteract-*`.

## Files

| File | Change |
|---|---|
| `plugins/nteract/.mcp.json` | `"nteract"` → `"notebook"` |
| `plugins/nteract-nightly/.mcp.json` | `"nteract-nightly"` → `"notebook"` |
| `.claude/plugins/nteract/.mcp.json` | `"nteract"` → `"notebook"` (repo-local install snapshot) |

Manual-registration docs (`README.md`, `python/nteract/README.md`) and the MCP Inspector config in `crates/xtask` are unchanged — those are `claude mcp add <name> -- runt mcp` flows where the user picks their own key.

## Test plan

- [ ] Install the plugin locally, confirm tool prompts now show `plugin:nteract[-nightly]:notebook - <tool>`
- [ ] `plugin:nteract-dev` (the repo-local dev server) unaffected — it's not plugin-installed