### PR TITLE
refactor: OutputChangeset with inline narrowed manifests

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -21,7 +21,7 @@ import {
   useCellIds,
 } from "../lib/notebook-cells";
 import {
-  applyOutputIdChanges,
+  applyOutputChangeset,
   projectRuntimeStateToExecutions,
   resetRuntimeStoresProjection,
   seedOutputStoresFromHandle,
@@ -38,12 +38,7 @@ import { cloneNotebookFile, openNotebookFile, saveNotebook } from "../lib/notebo
 import { emitBroadcast, emitPresence, subscribeBroadcast } from "../lib/notebook-frame-bus";
 import { notifyMetadataChanged, setNotebookHandle } from "../lib/notebook-metadata";
 import { type PoolState, resetPoolState, setPoolState } from "../lib/pool-state";
-import {
-  type RuntimeState,
-  getRuntimeState,
-  resetRuntimeState,
-  setRuntimeState,
-} from "../lib/runtime-state";
+import { getRuntimeState, resetRuntimeState, setRuntimeState } from "../lib/runtime-state";
 import { fromTauriEvent } from "../lib/tauri-rx";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
@@ -288,11 +283,7 @@ export function useAutomergeNotebook() {
             // on top. If the runtime-state frame arrived first this is
             // the authoritative pass; otherwise it's a no-op that the
             // runtimeState$ subscription will redo on the next tick.
-            const rs = getRuntimeState();
-            projectRuntimeStateToExecutions(
-              rs as unknown as { executions?: Record<string, unknown> },
-              handle,
-            );
+            projectRuntimeStateToExecutions(getRuntimeState());
             setIsLoading(false);
             notifyMetadataChanged();
             logger.info("[automerge-notebook] Initial materialization done");
@@ -354,29 +345,19 @@ export function useAutomergeNotebook() {
     // <OutputArea> subscribe at execution granularity instead of at the
     // cell granularity. See lib/notebook-executions.ts.
     const runtimeStateSub = engine.runtimeState$.subscribe((state) => {
-      const typed = state as RuntimeState;
-      setRuntimeState(typed);
-      projectRuntimeStateToExecutions(
-        typed as unknown as { executions?: Record<string, unknown> },
-        handleRef.current,
-      );
+      setRuntimeState(state);
+      projectRuntimeStateToExecutions(state);
     });
 
-    // Per-output changes → outputs store. Stream appends only touch the
-    // affected output's subscribers, keeping parent cell components still.
-    const outputIdChangesSub = engine.outputIdChanges$.subscribe(
-      ({ changed_ids, removed_ids, state }) => {
-        if (changed_ids.length === 0 && removed_ids.length === 0) return;
-        void applyOutputIdChanges(
-          handleRef.current,
-          changed_ids,
-          removed_ids,
-          state as unknown as { executions?: Record<string, { outputs?: unknown[] }> },
-          getBlobPort(),
-          outputCacheRef.current,
-        ).catch((err) => logger.warn("[automerge-notebook] output store projection failed:", err));
-      },
-    );
+    // Per-output changes → outputs store. WASM narrows each manifest
+    // before emitting, so stream appends only touch the affected
+    // output's subscribers and no second state-doc walk is needed.
+    const outputIdChangesSub = engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
+      if (changed.length === 0 && removed_ids.length === 0) return;
+      void applyOutputChangeset(changed, removed_ids).catch((err) =>
+        logger.warn("[automerge-notebook] output store projection failed:", err),
+      );
+    });
 
     // Pool state → store.
     const poolStateSub = engine.poolState$.subscribe((state) => setPoolState(state as PoolState));

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -593,7 +593,7 @@ describe("materializeChangeset", () => {
   it("updates cell store chrome fields without rebuilding outputs", async () => {
     // After Phase C-lite, the frame pipeline's incremental path no longer
     // resolves uncached manifest objects — that work belongs to the
-    // per-output store (see `applyOutputIdChanges`). When a chrome field
+    // per-output store (see `applyOutputChangeset`). When a chrome field
     // (here: `source`) changes alongside `outputs`, the cell store is
     // still updated with the new source, but outputs are carried forward
     // from whatever `materializeCellFromWasm` returns (cache-only).

--- a/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
+++ b/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import {
   getCellExecutionId,
@@ -16,11 +17,16 @@ afterEach(() => {
   resetNotebookOutputs();
 });
 
+function stateWith(
+  executions: RuntimeState["executions"],
+): RuntimeState {
+  return { ...DEFAULT_RUNTIME_STATE, executions };
+}
+
 describe("projectRuntimeStateToExecutions", () => {
   it("captures same-length output_id replacements (e.g. clear_output(wait=True))", () => {
-    // First tick: single output with id "old"
-    projectRuntimeStateToExecutions({
-      executions: {
+    projectRuntimeStateToExecutions(
+      stateWith({
         "exec-1": {
           cell_id: "cell-1",
           execution_count: 1,
@@ -30,14 +36,14 @@ describe("projectRuntimeStateToExecutions", () => {
             { output_id: "old", output_type: "stream", name: "stdout", text: "a" },
           ],
         },
-      },
-    });
+      }),
+    );
     expect(getExecutionById("exec-1")?.output_ids).toEqual(["old"]);
 
     // Second tick: same length, different output_id - must not be skipped
     // by the scalar fingerprint.
-    projectRuntimeStateToExecutions({
-      executions: {
+    projectRuntimeStateToExecutions(
+      stateWith({
         "exec-1": {
           cell_id: "cell-1",
           execution_count: 1,
@@ -47,74 +53,39 @@ describe("projectRuntimeStateToExecutions", () => {
             { output_id: "new", output_type: "stream", name: "stdout", text: "b" },
           ],
         },
-      },
-    });
+      }),
+    );
     expect(getExecutionById("exec-1")?.output_ids).toEqual(["new"]);
   });
 
-  it("seeds the outputs store for legacy outputs without a non-empty output_id", () => {
-    const rawOutput = {
-      output_id: "",
-      output_type: "stream",
-      name: "stdout",
-      text: "legacy output",
-    };
-    projectRuntimeStateToExecutions({
-      executions: {
+  it("drops outputs with empty output_id from the execution snapshot", () => {
+    // Daemon invariant: `create_manifest` (and the error-path fallback in
+    // `outputs_to_manifest_refs`) always stamp an `output_id`. If an
+    // un-stamped manifest ever reaches the frontend, the projection
+    // filters it out rather than inventing a synthetic key.
+    projectRuntimeStateToExecutions(
+      stateWith({
         "exec-legacy": {
           cell_id: "cell-legacy",
           execution_count: 1,
           status: "done",
           success: true,
-          outputs: [rawOutput],
+          outputs: [
+            { output_id: "", output_type: "stream", name: "stdout", text: "x" },
+            { output_id: "real-id", output_type: "stream", name: "stdout", text: "y" },
+          ],
         },
-      },
-    });
+      }),
+    );
 
     const snap = getExecutionById("exec-legacy");
-    expect(snap?.output_ids).toEqual(["legacy:exec-legacy:0"]);
-    const stored = getOutputById("legacy:exec-legacy:0");
-    expect(stored).toBeTruthy();
-    expect((stored as { text: string }).text).toBe("legacy output");
-  });
-
-  it("produces distinct synthesized ids for multiple empty-id outputs", () => {
-    const a = {
-      output_id: "",
-      output_type: "stream",
-      name: "stdout",
-      text: "alpha",
-    };
-    const b = {
-      output_id: "",
-      output_type: "stream",
-      name: "stdout",
-      text: "beta",
-    };
-    projectRuntimeStateToExecutions({
-      executions: {
-        "exec-x": {
-          cell_id: "c",
-          execution_count: 1,
-          status: "done",
-          success: true,
-          outputs: [a, b],
-        },
-      },
-    });
-    const snap = getExecutionById("exec-x");
-    expect(snap?.output_ids).toEqual(["legacy:exec-x:0", "legacy:exec-x:1"]);
-    expect((getOutputById("legacy:exec-x:0") as { text: string }).text).toBe(
-      "alpha",
-    );
-    expect((getOutputById("legacy:exec-x:1") as { text: string }).text).toBe(
-      "beta",
-    );
+    expect(snap?.output_ids).toEqual(["real-id"]);
+    expect(getOutputById("real-id")).toBeUndefined();
   });
 
   it("evicts trimmed executions on the next tick", () => {
-    projectRuntimeStateToExecutions({
-      executions: {
+    projectRuntimeStateToExecutions(
+      stateWith({
         "exec-1": {
           cell_id: "cell-1",
           execution_count: 1,
@@ -122,13 +93,13 @@ describe("projectRuntimeStateToExecutions", () => {
           success: true,
           outputs: [],
         },
-      },
-    });
+      }),
+    );
     setCellExecutionPointer("cell-1", "exec-1");
     expect(getExecutionById("exec-1")).toBeTruthy();
 
     // Tick with the execution removed
-    projectRuntimeStateToExecutions({ executions: {} });
+    projectRuntimeStateToExecutions(stateWith({}));
     expect(getExecutionById("exec-1")).toBeUndefined();
     expect(getCellExecutionId("cell-1")).toBeNull();
   });

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -144,7 +144,7 @@ export async function materializeChangeset(
 
     if (!chromeChanged) {
       // Output-only change — the outputs store already has the new data
-      // from `applyOutputIdChanges`. Still warm the plugin cache for any
+      // from `applyOutputChangeset`. Still warm the plugin cache for any
       // rich MIME types so <OutputArea> renders without waiting for async
       // loads, but don't touch the cell store.
       if (fields.outputs) {

--- a/apps/notebook/src/lib/notebook-outputs.ts
+++ b/apps/notebook/src/lib/notebook-outputs.ts
@@ -24,7 +24,7 @@ import {
 //   _outputMap    — output manifest by output_id
 //   subscribers   — per-output set of callbacks
 //
-// Writers: the frame pipeline, fed by `RuntimeStateSyncApplied.output_changed_ids`
+// Writers: the frame pipeline, fed by `RuntimeStateSyncApplied.output_changeset`
 // from the WASM handle. See `frame-pipeline.ts` for the dispatch path.
 // ---------------------------------------------------------------------------
 

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -5,37 +5,19 @@
  * Splitting this out of `useAutomergeNotebook` keeps the hook focused on
  * React wiring and avoids pulling the outputs store's imports into the
  * materialization pipeline.
- */
-
-import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-import { refreshBlobPort } from "./blob-port";
-import { logger } from "./logger";
-import { getBlobPort } from "./blob-port";
-
-/**
- * Route a raw manifest through WASM's narrowing pipeline.
  *
- * The RuntimeState snapshot carries outputs in their un-narrowed on-the-
- * wire shape: all MIME types, raw `{inline}`/`{blob}` ContentRefs. WASM's
- * `narrow_raw_output` applies MIME priority filtering and resolves binary
- * blob refs to `{url}` variants (using the current blob port). Without
- * this hop, binary types outside the `looksLikeBinaryMime` safety net —
- * e.g., `application/vnd.apache.parquet` — fall through the text-blob
- * async path in `resolveContentRef` and get corrupted. Returns the raw
- * value unchanged if WASM is unavailable or the narrowing fails, so the
- * downstream resolver can still make a best-effort render.
+ * `output_id` is a daemon-side invariant — `create_manifest` always
+ * stamps one (and `outputs_to_manifest_refs` stamps a fallback on the
+ * error path). Every output that reaches the frontend has a real id, so
+ * there is no synthetic `legacy:<eid>:<idx>` key in these stores.
  */
-function narrowThroughWasm(handle: NotebookHandle | null, raw: unknown): unknown {
-  if (!handle) return raw;
-  try {
-    const narrowed = handle.narrow_raw_output(raw);
-    return narrowed === undefined ? raw : narrowed;
-  } catch (err) {
-    logger.warn("[outputs-store] narrow_raw_output failed:", err);
-    return raw;
-  }
-}
+
+import type { ExecutionState, RuntimeState } from "runtimed";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import { getBlobPort, refreshBlobPort } from "./blob-port";
+import { logger } from "./logger";
 import {
+  type OutputManifest,
   resolveManifest,
   resolveManifestSync,
 } from "./manifest-resolution";
@@ -66,82 +48,46 @@ let _knownExecutionIds: Set<string> = new Set();
 
 /**
  * Previously-seen scalar fingerprint per execution (`status`, count, success,
- * and output-list length). Lets the projection short-circuit on untouched
+ * and output_id list). Lets the projection short-circuit on untouched
  * executions instead of rebuilding `output_ids` for every execution on
  * every tick — critical because `runtimeState$` emits once per stream
  * append.
  */
 const _prevExecutionFingerprint: Map<string, string> = new Map();
 
-/**
- * Normalize an output's effective id for the per-output store.
- *
- * Most outputs carry a daemon-stamped UUID in `output_id`. Some legacy
- * fixtures (see `packages/runtimed/tests/fixtures`) and in-flight
- * outputs whose manifest is still being built carry an empty string.
- * Those outputs still need a stable key so `useCellOutputs` can resolve
- * them - we synthesize one using the execution id + position.
- */
-function effectiveOutputId(
-  execution_id: string,
-  index: number,
-  raw: unknown,
-): string {
-  if (raw && typeof raw === "object") {
-    const oid = (raw as { output_id?: unknown }).output_id;
-    if (typeof oid === "string" && oid.length > 0) return oid;
-  }
-  return `legacy:${execution_id}:${index}`;
+function extractOutputId(output: unknown): string | null {
+  if (!output || typeof output !== "object") return null;
+  const oid = (output as { output_id?: unknown }).output_id;
+  return typeof oid === "string" && oid.length > 0 ? oid : null;
 }
 
-function collectExecutionOutputIds(
-  execution_id: string,
-  raw: { outputs?: unknown[] },
-): string[] {
+function collectExecutionOutputIds(raw: ExecutionState): string[] {
   const ids: string[] = [];
-  if (Array.isArray(raw.outputs)) {
-    for (let i = 0; i < raw.outputs.length; i++) {
-      ids.push(effectiveOutputId(execution_id, i, raw.outputs[i]));
-    }
+  if (!raw.outputs) return ids;
+  for (const output of raw.outputs) {
+    const oid = extractOutputId(output);
+    if (oid) ids.push(oid);
   }
   return ids;
 }
 
-function executionFingerprint(
-  execution_id: string,
-  raw: {
-    cell_id?: string;
-    execution_count?: number | null;
-    status?: string;
-    success?: boolean | null;
-    outputs?: unknown[];
-  },
-): string {
+function executionFingerprint(raw: ExecutionState): string {
   // Include the ordered `output_id` list so same-length replacements
   // (e.g. `clear_output(wait=True)` or a remove+add that keeps the list
   // length constant) still invalidate the snapshot. Without this, the
   // outputs store drifts past the execution's canonical pointer list and
   // `useCellOutputs` resolves stale entries.
-  const ids = collectExecutionOutputIds(execution_id, raw);
-  return `${raw.cell_id ?? ""}|${raw.execution_count ?? ""}|${raw.status ?? ""}|${raw.success ?? ""}|${ids.join(",")}`;
+  const ids = collectExecutionOutputIds(raw);
+  return `${raw.cell_id}|${raw.execution_count ?? ""}|${raw.status}|${raw.success ?? ""}|${ids.join(",")}`;
 }
 
-function buildExecutionSnapshot(
-  execution_id: string,
-  raw: {
-    cell_id?: string;
-    execution_count?: number | null;
-    status?: string;
-    success?: boolean | null;
-    outputs?: unknown[];
-  },
-): ExecutionSnapshot {
+function buildExecutionSnapshot(raw: ExecutionState): ExecutionSnapshot {
   return {
-    cell_id: raw.cell_id ?? "",
-    execution_count: raw.execution_count ?? null,
-    status: raw.status ?? "",
-    success: raw.success ?? null,
-    output_ids: collectExecutionOutputIds(execution_id, raw),
+    cell_id: raw.cell_id,
+    execution_count: raw.execution_count,
+    status: raw.status,
+    success: raw.success,
+    output_ids: collectExecutionOutputIds(raw),
   };
 }
 
@@ -160,29 +106,14 @@ function buildExecutionSnapshot(
  * it flows through a separate path (see
  * `updateCellExecutionPointersFromHandle`).
  */
-export function projectRuntimeStateToExecutions(
-  state: {
-    executions?: Record<string, unknown>;
-  },
-  handle: NotebookHandle | null = null,
-): void {
-  const execs = state.executions;
+export function projectRuntimeStateToExecutions(state: RuntimeState): void {
   const nextIds = new Set<string>();
-  if (execs) {
-    for (const [execution_id, raw] of Object.entries(execs)) {
-      const entry = raw as Parameters<typeof executionFingerprint>[1];
-      nextIds.add(execution_id);
-      const fp = executionFingerprint(execution_id, entry);
-      if (_prevExecutionFingerprint.get(execution_id) === fp) continue;
-      _prevExecutionFingerprint.set(execution_id, fp);
-      setExecution(execution_id, buildExecutionSnapshot(execution_id, entry));
-      // Fallback seeding for outputs that don't carry a non-empty
-      // `output_id` (legacy fixtures, in-flight manifests). The
-      // `outputIdChanges$` stream only covers real output ids, so
-      // without this the outputs store would miss them and
-      // `useCellOutputs` would render empty.
-      seedLegacyOutputsForExecution(execution_id, entry, handle);
-    }
+  for (const [execution_id, entry] of Object.entries(state.executions)) {
+    nextIds.add(execution_id);
+    const fp = executionFingerprint(entry);
+    if (_prevExecutionFingerprint.get(execution_id) === fp) continue;
+    _prevExecutionFingerprint.set(execution_id, fp);
+    setExecution(execution_id, buildExecutionSnapshot(entry));
   }
 
   // Evict executions the daemon dropped. Keeps the store from drifting
@@ -196,62 +127,6 @@ export function projectRuntimeStateToExecutions(
     for (const eid of removed) _prevExecutionFingerprint.delete(eid);
   }
   _knownExecutionIds = nextIds;
-}
-
-/**
- * Seed the outputs store for an execution whose outputs lack proper
- * `output_id` values. Real daemon-stamped ids flow through the
- * `outputIdChanges$` pipeline; this is the fallback for legacy snapshots
- * and fixtures. We synthesize a deterministic id (`legacy:<exec>:<idx>`)
- * and push whatever we can resolve synchronously (inline data, plain
- * JupyterOutput shapes). Manifest entries that need async blob fetches
- * are kicked to the async path below so they land as soon as they
- * resolve, without blocking the projection tick.
- */
-function seedLegacyOutputsForExecution(
-  execution_id: string,
-  raw: { outputs?: unknown[] },
-  handle: NotebookHandle | null,
-): void {
-  if (!Array.isArray(raw.outputs)) return;
-  const pendingAsync: Array<{ synthesized: string; raw: unknown }> = [];
-  for (let i = 0; i < raw.outputs.length; i++) {
-    const output = raw.outputs[i];
-    if (!output || typeof output !== "object") continue;
-    const oidField = (output as { output_id?: unknown }).output_id;
-    if (typeof oidField === "string" && oidField.length > 0) continue;
-    const synthesized = `legacy:${execution_id}:${i}`;
-    // Skip if we already have a matching resolved value for this key.
-    const existing = getOutputById(synthesized);
-    if (existing && existing === output) continue;
-
-    const narrowed = narrowThroughWasm(handle, output);
-    const sync = tryResolveSync(narrowed, getBlobPort(), new Map());
-    if (sync) {
-      setOutput(synthesized, sync);
-      continue;
-    }
-    // Needs async blob resolution (manifest with blob ContentRefs).
-    pendingAsync.push({ synthesized, raw: narrowed });
-  }
-  if (pendingAsync.length === 0) return;
-  void (async () => {
-    let port = getBlobPort();
-    if (port === null) port = await refreshBlobPort();
-    if (port === null) return;
-    for (const { synthesized, raw: rawOutput } of pendingAsync) {
-      if (!isOutputManifest(rawOutput)) continue;
-      try {
-        const resolved = await resolveManifest(rawOutput, port);
-        setOutput(synthesized, resolved);
-      } catch (err) {
-        logger.warn(
-          `[outputs-store] failed to resolve legacy output ${synthesized}:`,
-          err,
-        );
-      }
-    }
-  })();
 }
 
 /**
@@ -275,18 +150,13 @@ export function seedOutputStoresFromHandle(
     if (rawOutputs.length === 0) continue;
 
     const output_ids: string[] = [];
-    for (let i = 0; i < rawOutputs.length; i++) {
-      const output = rawOutputs[i];
-      const oidField =
-        output && typeof output === "object"
-          ? (output as { output_id?: unknown }).output_id
-          : undefined;
-      output_ids.push(
-        typeof oidField === "string" && oidField.length > 0
-          ? oidField
-          : `legacy:${executionId}:${i}`,
-      );
+    for (const output of rawOutputs) {
+      if (!output || typeof output !== "object") continue;
+      const oid = (output as { output_id?: unknown }).output_id;
+      if (typeof oid === "string" && oid.length > 0) output_ids.push(oid);
     }
+    if (output_ids.length === 0) continue;
+
     // Build a minimal execution snapshot. We don't have status / success
     // in the notebook doc (those live in RuntimeStateDoc) - fill them in
     // as defaults so `useExecution` resolves to something; the runtime-
@@ -307,12 +177,11 @@ export function seedOutputStoresFromHandle(
       const output = rawOutputs[i];
       if (!output || typeof output !== "object") continue;
       const oid = output_ids[i];
+      if (!oid) continue;
       const existing = getOutputById(oid);
       if (existing === output) continue;
-      const sync = tryResolveSync(output, getBlobPort(), new Map());
-      if (sync) {
-        setOutput(oid, sync);
-      }
+      const sync = tryResolveSync(output, getBlobPort());
+      if (sync) setOutput(oid, sync);
     }
   }
 }
@@ -337,115 +206,65 @@ export function updateCellExecutionPointersFromHandle(
 // ── Outputs store projection ─────────────────────────────────────────
 
 /**
- * Resolve and push a batch of `output_id`s into the outputs store.
+ * Apply the per-output changeset emitted by WASM.
  *
- * Reads each output from the WASM handle (narrows to the active MIME
- * priority set), resolves any blob ContentRefs, and writes the result to
- * the per-output store. Cache hits take the sync path; misses go through
- * `resolveManifest` (one blob fetch per text ref; binary refs become URLs).
+ * `changed` carries `(output_id, narrowed_manifest)` pairs — manifests
+ * are already MIME-narrowed and have binary ContentRefs resolved to
+ * `{url}` variants. The only remaining work here is fetching text blob
+ * refs (which still require an HTTP round trip) before handing the
+ * fully-resolved `JupyterOutput` to the store.
  *
- * Unknown output_ids (handle returns undefined) are skipped. Removed output
- * IDs are dropped from the store via `deleteOutputs`.
+ * Removed output_ids are dropped from the store.
  */
-export async function applyOutputIdChanges(
-  handle: NotebookHandle | null,
-  changed_ids: string[],
+export async function applyOutputChangeset(
+  changed: Array<[string, unknown]>,
   removed_ids: string[],
-  state: {
-    executions?: Record<string, { outputs?: unknown[] }>;
-  },
-  blobPort: number | null,
-  cache: Map<string, JupyterOutput>,
 ): Promise<void> {
   if (removed_ids.length > 0) {
     deleteOutputs(removed_ids);
   }
-  if (changed_ids.length === 0) return;
+  if (changed.length === 0) return;
 
-  // Pluck the changed manifests out of the RuntimeState snapshot we
-  // already have in hand. Avoids `handle.get_output_by_id()` per id,
-  // which would re-clone and walk the entire state doc each call. Each
-  // raw manifest is still routed through `narrow_raw_output` so MIME
-  // narrowing + ContentRef resolution match what `get_output_by_id`
-  // would have produced — required for correct rendering of binary
-  // types outside the `looksLikeBinaryMime` safety net (parquet, etc.).
-  const byId = indexOutputsById(state);
-  const pending: Array<{ output_id: string; raw: unknown }> = [];
-  for (const output_id of changed_ids) {
-    const raw = byId.get(output_id);
-    if (raw === undefined) continue;
-    pending.push({ output_id, raw: narrowThroughWasm(handle, raw) });
-  }
-
-  // `output_changed_ids` only fires when an output's manifest changes. If
-  // the first stream/error lands before blob-port discovery resolves, we
-  // must resolve the port on-demand here — otherwise manifest-backed
-  // outputs silently disappear from the store until the next append.
-  let port = blobPort;
-  if (port === null && pending.some(({ raw }) => isOutputManifest(raw))) {
+  // Stream/display-update manifests with text blob refs need the blob
+  // port to resolve. Fetch it on demand so a race between the first
+  // manifest and blob-port discovery doesn't drop outputs on the floor.
+  let port = getBlobPort();
+  if (port === null && changed.some(([, raw]) => isOutputManifest(raw))) {
     port = await refreshBlobPort();
   }
 
-  for (const { output_id, raw } of pending) {
-    const sync = tryResolveSync(raw, port, cache);
+  for (const [output_id, raw] of changed) {
+    const sync = tryResolveSync(raw, port);
     if (sync) {
       setOutput(output_id, sync);
-    } else if (port !== null) {
-      try {
-        const resolved = await resolveManifest(
-          raw as Parameters<typeof resolveManifest>[0],
-          port,
-        );
-        setOutput(output_id, resolved);
-      } catch (err) {
-        logger.warn(
-          `[outputs-store] Failed to resolve output ${output_id}:`,
-          err,
-        );
-      }
-    } else {
+      continue;
+    }
+    if (port === null) {
       logger.warn(
         `[outputs-store] blob port unavailable; deferring output ${output_id}`,
+      );
+      continue;
+    }
+    if (!isOutputManifest(raw)) continue;
+    try {
+      const resolved = await resolveManifest(raw, port);
+      setOutput(output_id, resolved);
+    } catch (err) {
+      logger.warn(
+        `[outputs-store] Failed to resolve output ${output_id}:`,
+        err,
       );
     }
   }
 }
 
-/**
- * Flat `output_id -> manifest` map built from a RuntimeState snapshot.
- *
- * Walks every execution's outputs once per tick. Used by the outputs-store
- * projection and by `applyOutputIdChanges` to avoid per-id WASM reads.
- */
-function indexOutputsById(state: {
-  executions?: Record<string, { outputs?: unknown[] }>;
-}): Map<string, unknown> {
-  const result = new Map<string, unknown>();
-  const execs = state.executions;
-  if (!execs) return result;
-  for (const raw of Object.values(execs)) {
-    const outputs = (raw as { outputs?: unknown[] }).outputs;
-    if (!Array.isArray(outputs)) continue;
-    for (const output of outputs) {
-      if (output && typeof output === "object") {
-        const oid = (output as { output_id?: unknown }).output_id;
-        if (typeof oid === "string" && oid.length > 0) {
-          result.set(oid, output);
-        }
-      }
-    }
-  }
-  return result;
-}
-
 function tryResolveSync(
   raw: unknown,
   blobPort: number | null,
-  _cache: Map<string, JupyterOutput>,
 ): JupyterOutput | null {
   if (isOutputManifest(raw)) {
     if (blobPort === null) return null;
-    return resolveManifestSync(raw, blobPort);
+    return resolveManifestSync(raw as OutputManifest, blobPort);
   }
   // Plain JupyterOutput object — no refs, no resolution needed.
   if (typeof raw === "object" && raw !== null && "output_type" in raw) {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -374,18 +374,6 @@ export class NotebookHandle {
      */
     move_cell(cell_id: string, after_cell_id?: string | null): string;
     /**
-     * Apply MIME narrowing + ContentRef resolution to a raw output manifest.
-     *
-     * The runtime-state snapshot carries manifests in their un-narrowed
-     * on-the-wire shape (all MIME types, raw `{inline}`/`{blob}` refs).
-     * The output-store projection uses this to re-apply the same
-     * narrowing logic `get_output_by_id` does, but without a per-id
-     * `read_state()` walk — callers pass the raw manifest they already
-     * have and get back a manifest ready for the renderer. Returns
-     * `undefined` when the input can't be deserialized.
-     */
-    narrow_raw_output(raw: any): any;
-    /**
      * Create a new empty notebook document.
      */
     constructor(notebook_id: string);
@@ -700,7 +688,6 @@ export interface InitOutput {
     readonly notebookhandle_load: (a: number, b: number, c: number) => void;
     readonly notebookhandle_load_state_doc: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_move_cell: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-    readonly notebookhandle_narrow_raw_output: (a: number, b: number) => number;
     readonly notebookhandle_new: (a: number, b: number) => number;
     readonly notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
     readonly notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -1189,23 +1189,6 @@ export class NotebookHandle {
         }
     }
     /**
-     * Apply MIME narrowing + ContentRef resolution to a raw output manifest.
-     *
-     * The runtime-state snapshot carries manifests in their un-narrowed
-     * on-the-wire shape (all MIME types, raw `{inline}`/`{blob}` refs).
-     * The output-store projection uses this to re-apply the same
-     * narrowing logic `get_output_by_id` does, but without a per-id
-     * `read_state()` walk — callers pass the raw manifest they already
-     * have and get back a manifest ready for the renderer. Returns
-     * `undefined` when the input can't be deserialized.
-     * @param {any} raw
-     * @returns {any}
-     */
-    narrow_raw_output(raw) {
-        const ret = wasm.notebookhandle_narrow_raw_output(this.__wbg_ptr, addHeapObject(raw));
-        return takeObject(ret);
-    }
-    /**
      * Create a new empty notebook document.
      * @param {string} notebook_id
      */

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbb844355807b4ba30bb84cb8d712ac012dbf1a70be877323bc4263117a06d17
-size 1678757
+oid sha256:4ae6d9a23ce1529f823bfe887babab8b49175ec91c7cc4627ce598c5b0d3b431
+size 1680609

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -62,7 +62,6 @@ export const notebookhandle_get_runtime_state: (a: number) => number;
 export const notebookhandle_load: (a: number, b: number, c: number) => void;
 export const notebookhandle_load_state_doc: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_move_cell: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-export const notebookhandle_narrow_raw_output: (a: number, b: number) => number;
 export const notebookhandle_new: (a: number, b: number) => number;
 export const notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
 export const notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -2365,10 +2365,15 @@ pub fn extract_output_id(output: &serde_json::Value) -> Option<String> {
 }
 
 /// Result of a per-output-id diff between two execution snapshots.
+///
+/// Each changed entry carries the full (un-narrowed) manifest so callers
+/// can emit it directly without re-reading the state doc.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OutputIdDiff {
-    /// Output IDs that were added or whose manifest changed.
-    pub changed_output_ids: Vec<String>,
+    /// Added or modified outputs, paired `(output_id, manifest)`. Manifest
+    /// is the raw on-the-wire shape from `ExecutionState::outputs`; callers
+    /// apply MIME narrowing + ContentRef resolution before handing to the UI.
+    pub changed: Vec<(String, serde_json::Value)>,
     /// Output IDs that were removed (present in `prev`, absent now).
     pub removed_output_ids: Vec<String>,
 }
@@ -2377,17 +2382,20 @@ pub struct OutputIdDiff {
 ///
 /// Walks every current execution's output list, extracts per-output manifests
 /// keyed by `output_id`, and compares them to the previous snapshot. Returns
-/// the changed + removed output_ids plus the new `output_id -> manifest`
-/// snapshot so callers can track state between sync frames.
+/// `(diff, new_snapshot)`. The diff carries `(id, manifest)` pairs for
+/// changed entries so callers can emit the manifest directly without a
+/// second lookup against the state doc. The new snapshot is the updated
+/// `output_id -> manifest` map the caller should persist for the next diff.
 ///
-/// Outputs without an `output_id` (legacy / synthesized) are skipped here —
-/// they still get picked up by `diff_execution_outputs` at the cell level.
+/// Outputs without an `output_id` are skipped. The daemon invariant is that
+/// `create_manifest` always stamps one; if an un-stamped manifest reaches
+/// this function, that is a bug upstream.
 pub fn diff_output_ids(
     prev: &HashMap<String, serde_json::Value>,
     current_executions: &HashMap<String, ExecutionState>,
 ) -> (OutputIdDiff, HashMap<String, serde_json::Value>) {
     let mut new_snapshot: HashMap<String, serde_json::Value> = HashMap::new();
-    let mut changed = Vec::new();
+    let mut changed: Vec<(String, serde_json::Value)> = Vec::new();
 
     for exec in current_executions.values() {
         for output in &exec.outputs {
@@ -2399,7 +2407,7 @@ pub fn diff_output_ids(
                 Some(prev_output) => prev_output != output,
             };
             if is_changed {
-                changed.push(oid.clone());
+                changed.push((oid.clone(), output.clone()));
             }
             new_snapshot.insert(oid, output.clone());
         }
@@ -2413,7 +2421,7 @@ pub fn diff_output_ids(
 
     (
         OutputIdDiff {
-            changed_output_ids: changed,
+            changed,
             removed_output_ids: removed,
         },
         new_snapshot,

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -19,7 +19,7 @@ use notebook_doc::runtime_state::{
     RuntimeState, RuntimeStateDoc,
 };
 use notebook_doc::{CellSnapshot, NotebookDoc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 /// Serialize a Rust value to a `JsValue`, forcing maps to plain JS Objects.
@@ -56,6 +56,28 @@ pub struct TextAttribution {
     pub deleted: usize,
     /// Actor label(s) that contributed to this sync batch.
     pub actors: Vec<String>,
+}
+
+/// Per-output diff emitted alongside `RuntimeStateSyncApplied`.
+///
+/// `changed` carries `(output_id, narrowed_manifest)` pairs — manifests
+/// are already MIME-narrowed + ContentRef-resolved, so the frontend's
+/// outputs store writes them in directly. Mirrors the `CellChangeset`
+/// model: WASM owns both the diff and the view projection for outputs.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct OutputChangeset {
+    /// Added or modified outputs `(output_id, manifest)`, in no particular order.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub changed: Vec<(String, serde_json::Value)>,
+    /// Output IDs no longer present in any execution.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub removed: Vec<String>,
+}
+
+impl OutputChangeset {
+    pub fn is_empty(&self) -> bool {
+        self.changed.is_empty() && self.removed.is_empty()
+    }
 }
 
 /// Event returned from `receive_frame()` for the frontend to handle.
@@ -106,19 +128,17 @@ pub enum FrameEvent {
         /// Cell IDs whose outputs changed in this sync frame.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         output_changed_cells: Vec<String>,
-        /// Output IDs that were added or modified in this sync frame.
+        /// Per-output diff for this sync frame. Added or modified outputs
+        /// arrive here with their narrowed manifest inline; the frontend's
+        /// outputs store can write them straight in with no second
+        /// lookup against the state doc.
         ///
         /// Keyed by the `output_id` field on each output manifest (UUIDv4
-        /// stamped by the daemon). The frontend's outputs store uses this
-        /// to notify per-output subscribers without touching parent cells.
-        /// Outputs without an `output_id` (legacy) are skipped here and
-        /// still covered by `output_changed_cells`.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        output_changed_ids: Vec<String>,
-        /// Output IDs that no longer appear in any execution (cleared or
-        /// replaced). The frontend's outputs store drops these.
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        output_removed_ids: Vec<String>,
+        /// stamped by the daemon). Removed output_ids are carried alongside
+        /// so the store can drop them.
+        #[serde(skip_serializing_if = "OutputChangeset::is_empty")]
+        #[serde(default)]
+        output_changeset: OutputChangeset,
     },
     /// Sync error recovered — doc rebuilt and sync state normalized.
     ///
@@ -191,7 +211,7 @@ pub struct NotebookHandle {
     prev_execution_outputs: std::collections::HashMap<String, Vec<serde_json::Value>>,
     /// Previous per-`output_id` manifest snapshot. Used alongside
     /// `prev_execution_outputs` to produce the finer-grained per-output
-    /// diff emitted on `RuntimeStateSyncApplied.output_changed_ids`.
+    /// diff emitted on `RuntimeStateSyncApplied.output_changeset`.
     prev_output_by_id: std::collections::HashMap<String, serde_json::Value>,
     /// Pool state doc — daemon-authoritative, global, synced read-only.
     pool_doc: PoolDoc,
@@ -667,23 +687,6 @@ impl NotebookHandle {
             }
         }
         JsValue::UNDEFINED
-    }
-
-    /// Apply MIME narrowing + ContentRef resolution to a raw output manifest.
-    ///
-    /// The runtime-state snapshot carries manifests in their un-narrowed
-    /// on-the-wire shape (all MIME types, raw `{inline}`/`{blob}` refs).
-    /// The output-store projection uses this to re-apply the same
-    /// narrowing logic `get_output_by_id` does, but without a per-id
-    /// `read_state()` walk — callers pass the raw manifest they already
-    /// have and get back a manifest ready for the renderer. Returns
-    /// `undefined` when the input can't be deserialized.
-    pub fn narrow_raw_output(&self, raw: JsValue) -> JsValue {
-        let Ok(value) = serde_wasm_bindgen::from_value::<serde_json::Value>(raw) else {
-            return JsValue::UNDEFINED;
-        };
-        let narrowed = self.narrow_output_data(value);
-        serialize_to_js(&narrowed).unwrap_or(JsValue::UNDEFINED)
     }
 
     /// Set the MIME type priority list for output selection.
@@ -1757,7 +1760,7 @@ impl NotebookHandle {
                 // changes (stream append, display update, error). `state` is
                 // Some iff `changed` is true, so this also covers the
                 // `changed` branch without a separate check.
-                let (output_changed_cells, output_changed_ids, output_removed_ids) =
+                let (output_changed_cells, output_changeset) =
                     if let Some(current_state) = state.as_ref() {
                         let (changed_cells, new_snapshot) = diff_execution_outputs(
                             &self.prev_execution_outputs,
@@ -1768,21 +1771,31 @@ impl NotebookHandle {
                         let (id_diff, new_id_snapshot) =
                             diff_output_ids(&self.prev_output_by_id, &current_state.executions);
                         self.prev_output_by_id = new_id_snapshot;
+
+                        // Narrow each changed manifest inline so the frontend
+                        // writes directly into the outputs store with no
+                        // second snapshot walk.
+                        let changed: Vec<(String, serde_json::Value)> = id_diff
+                            .changed
+                            .into_iter()
+                            .map(|(id, manifest)| (id, self.narrow_output_data(manifest)))
+                            .collect();
                         (
                             changed_cells,
-                            id_diff.changed_output_ids,
-                            id_diff.removed_output_ids,
+                            OutputChangeset {
+                                changed,
+                                removed: id_diff.removed_output_ids,
+                            },
                         )
                     } else {
-                        (Vec::new(), Vec::new(), Vec::new())
+                        (Vec::new(), OutputChangeset::default())
                     };
 
                 events.push(FrameEvent::RuntimeStateSyncApplied {
                     changed,
                     state,
                     output_changed_cells,
-                    output_changed_ids,
-                    output_removed_ids,
+                    output_changeset,
                 });
             }
             frame_types::POOL_STATE_SYNC => {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1371,7 +1371,7 @@ impl KernelConnection for JupyterKernel {
                                                         "[jupyter-kernel] Failed to create error manifest: {}",
                                                         e
                                                     );
-                                                    nbformat_value.clone()
+                                                    crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
                                                 }
                                             };
 
@@ -1833,7 +1833,7 @@ impl KernelConnection for JupyterKernel {
                                                             "[jupyter-kernel] Failed to create page manifest: {}",
                                                             e
                                                         );
-                                                            nbformat_value.clone()
+                                                            crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
                                                         }
                                                     };
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1148,7 +1148,7 @@ impl KernelConnection for JupyterKernel {
                                                         "[jupyter-kernel] Failed to create manifest: {}",
                                                         e
                                                     );
-                                                    nbformat_value.clone()
+                                                    crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
                                                 }
                                             };
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7539,26 +7539,7 @@ async fn outputs_to_manifest_refs(
             Ok(manifest) => manifest.to_json(),
             Err(e) => {
                 warn!("[notebook-sync] Failed to create output manifest: {}", e);
-                // Stamp an output_id on the fallback so the frontend's
-                // per-output store always has a valid key. Without this,
-                // a manifest-creation failure on disk load would emit an
-                // output with no output_id and the WASM OutputChangeset
-                // path would silently drop it.
-                let mut fallback = output_value.clone();
-                if let Some(obj) = fallback.as_object_mut() {
-                    let needs_id = obj
-                        .get("output_id")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.is_empty())
-                        .unwrap_or(true);
-                    if needs_id {
-                        obj.insert(
-                            "output_id".to_string(),
-                            serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
-                        );
-                    }
-                }
-                fallback
+                fallback_output_with_id(output_value)
             }
         };
         refs.push(output_ref);
@@ -7770,9 +7751,32 @@ async fn output_value_to_manifest_ref(
         Ok(manifest) => manifest.to_json(),
         Err(e) => {
             warn!("[streaming-load] Failed to create output manifest: {}", e);
-            output.clone()
+            fallback_output_with_id(output)
         }
     }
+}
+
+/// Ensure a raw output carries a non-empty `output_id` before it lands in
+/// RuntimeStateDoc. Used by every call site that falls back to the raw
+/// input on `create_manifest` failure — the frontend's per-output store
+/// drops outputs without a real id, so the daemon invariant has to hold
+/// on the error path too.
+pub(crate) fn fallback_output_with_id(output: &serde_json::Value) -> serde_json::Value {
+    let mut fallback = output.clone();
+    if let Some(obj) = fallback.as_object_mut() {
+        let needs_id = obj
+            .get("output_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.is_empty())
+            .unwrap_or(true);
+        if needs_id {
+            obj.insert(
+                "output_id".to_string(),
+                serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
+            );
+        }
+    }
+    fallback
 }
 
 /// Placeholder for draining incoming sync replies during streaming load.
@@ -8932,6 +8936,49 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use uuid::Uuid;
+
+    #[test]
+    fn fallback_output_stamps_id_when_missing() {
+        let raw = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "hi\n",
+        });
+        let out = fallback_output_with_id(&raw);
+        let id = out
+            .get("output_id")
+            .and_then(|v| v.as_str())
+            .expect("output_id set");
+        assert!(!id.is_empty(), "fallback must stamp a non-empty id");
+        // Rest of the payload passes through untouched.
+        assert_eq!(out["output_type"], "stream");
+        assert_eq!(out["name"], "stdout");
+    }
+
+    #[test]
+    fn fallback_output_preserves_existing_id() {
+        let raw = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "existing-id",
+        });
+        let out = fallback_output_with_id(&raw);
+        assert_eq!(out["output_id"], "existing-id");
+    }
+
+    #[test]
+    fn fallback_output_replaces_empty_id() {
+        let raw = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "",
+        });
+        let out = fallback_output_with_id(&raw);
+        let id = out
+            .get("output_id")
+            .and_then(|v| v.as_str())
+            .expect("output_id set");
+        assert!(!id.is_empty());
+        assert_ne!(id, "");
+    }
 
     #[test]
     fn test_sanitize_peer_label_basic() {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7539,7 +7539,26 @@ async fn outputs_to_manifest_refs(
             Ok(manifest) => manifest.to_json(),
             Err(e) => {
                 warn!("[notebook-sync] Failed to create output manifest: {}", e);
-                output_value.clone()
+                // Stamp an output_id on the fallback so the frontend's
+                // per-output store always has a valid key. Without this,
+                // a manifest-creation failure on disk load would emit an
+                // output with no output_id and the WASM OutputChangeset
+                // path would silently drop it.
+                let mut fallback = output_value.clone();
+                if let Some(obj) = fallback.as_object_mut() {
+                    let needs_id = obj
+                        .get("output_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.is_empty())
+                        .unwrap_or(true);
+                    if needs_id {
+                        obj.insert(
+                            "output_id".to_string(),
+                            serde_json::Value::String(uuid::Uuid::new_v4().to_string()),
+                        );
+                    }
+                }
+                fallback
             }
         };
         refs.push(output_ref);

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -48,10 +48,16 @@ export interface FrameEvent {
   state?: unknown;
   /** Cell IDs whose outputs changed in RuntimeStateDoc (from WASM-side diff). */
   output_changed_cells?: string[];
-  /** Output IDs added or modified, keyed by the UUIDv4 the daemon stamps. */
-  output_changed_ids?: string[];
-  /** Output IDs no longer present in any execution (cleared or replaced). */
-  output_removed_ids?: string[];
+  /**
+   * Per-output diff for RuntimeStateSyncApplied events. Each `changed` entry
+   * is `[output_id, narrowed_manifest]` — manifests are already MIME-narrowed
+   * + ContentRef-resolved so the frontend's outputs store can write them
+   * directly. `removed` lists output_ids no longer present in any execution.
+   */
+  output_changeset?: {
+    changed?: Array<[string, unknown]>;
+    removed?: string[];
+  };
 }
 
 // ── SyncableHandle ───────────────────────────────────────────────────

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -44,7 +44,13 @@ export interface ExecutionState {
   status: "queued" | "running" | "done" | "error";
   execution_count: number | null;
   success: boolean | null;
-  outputs?: string[];
+  /**
+   * Output manifests in emission order, as the WASM runtime-state snapshot
+   * exposes them. Each entry is the raw on-the-wire manifest (un-narrowed,
+   * with `{inline}`/`{blob}` ContentRefs). Resolved manifests live in the
+   * per-output store, not here.
+   */
+  outputs?: unknown[];
 }
 
 /** Snapshot of a comm channel from RuntimeStateDoc. */

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -283,20 +283,18 @@ export class SyncEngine {
   /**
    * Per-output changes emitted from the WASM runtime-state sync path.
    *
-   * `changed_ids` covers new or mutated outputs, `removed_ids` covers
-   * outputs no longer present in any execution. `state` is the RuntimeState
-   * snapshot that produced these deltas so consumers can pluck the
-   * changed manifests out of its executions map without asking the WASM
-   * handle per-id (each of those calls re-reads the entire state doc).
+   * `changed` pairs carry the output_id with its already-narrowed manifest
+   * (WASM applied MIME priority + ContentRef resolution). `removed_ids`
+   * covers outputs no longer present in any execution. Consumers route
+   * these into the per-output React store; no second state-doc lookup is
+   * needed, so a stream append on one output only touches its own
+   * `<Output>` subscriber.
    *
-   * Consumers route these into the per-output React store so a stream
-   * append on one output does not re-render every component under the
-   * parent cell. See `apps/notebook/src/lib/notebook-outputs.ts`.
+   * See `apps/notebook/src/lib/notebook-outputs.ts`.
    */
   readonly outputIdChanges$: Observable<{
-    changed_ids: string[];
+    changed: Array<[string, unknown]>;
     removed_ids: string[];
-    state: RuntimeState;
   }>;
 
   /**
@@ -355,9 +353,8 @@ export class SyncEngine {
   private readonly _initialSyncComplete$ = new Subject<void>();
   private readonly _commChanges$ = new Subject<CommChanges>();
   private readonly _outputIdChanges$ = new Subject<{
-    changed_ids: string[];
+    changed: Array<[string, unknown]>;
     removed_ids: string[];
-    state: RuntimeState;
   }>();
 
   constructor(opts: SyncEngineOptions) {
@@ -719,13 +716,15 @@ export class SyncEngine {
 
               // Per-output-id projection. Feeds the outputs store so single
               // output appends only notify their own `<Output>` subscriber.
-              const changedOutputIds = e.output_changed_ids ?? [];
-              const removedOutputIds = e.output_removed_ids ?? [];
-              if (changedOutputIds.length > 0 || removedOutputIds.length > 0) {
+              // Manifests arrive already narrowed from WASM — the store
+              // writes them in directly.
+              const changeset = e.output_changeset;
+              const changedPairs = changeset?.changed ?? [];
+              const removedOutputIds = changeset?.removed ?? [];
+              if (changedPairs.length > 0 || removedOutputIds.length > 0) {
                 this._outputIdChanges$.next({
-                  changed_ids: changedOutputIds,
+                  changed: changedPairs,
                   removed_ids: removedOutputIds,
-                  state,
                 });
               }
 


### PR DESCRIPTION
## Diagnosis

PR #1997 shipped the per-output re-render pipeline but left two gaps:

1. **Snapshot walk per tick.** WASM emitted `output_changed_ids: string[]`; the frontend walked the RuntimeState snapshot per-id to pluck manifests back out and re-apply MIME narrowing via `narrow_raw_output`. O(total_outputs) JS work every stream append, and the narrowing only landed as a band-aid after parquet rendering broke.
2. **Legacy output_id scaffolding.** The projection had a `legacy:<eid>:<idx>` synthesis path for outputs without an `output_id`. Dead code on the hot path (daemon `create_manifest` always stamps a UUID), but existed because `outputs_to_manifest_refs` plus four sites in `jupyter_kernel.rs` had fallbacks that returned the raw input on manifest failure without stamping an id.

## Direction

Fold both into the `CellChangeset` model WASM already uses for cells.

### `OutputChangeset` carries narrowed manifests inline

- `OutputIdDiff::changed` now holds `Vec<(String, serde_json::Value)>` — id paired with its manifest.
- `FrameEvent::RuntimeStateSyncApplied` replaces `output_changed_ids`/`output_removed_ids` with a single `output_changeset: OutputChangeset { changed, removed }`.
- WASM narrows each changed manifest via `narrow_output_data` before emitting — MIME priority filtering and binary-blob-to-URL resolution happen once, in Rust.
- `outputIdChanges$` loses its `state` payload. The projection writes manifests straight into the per-output store.
- `applyOutputIdChanges` → `applyOutputChangeset`. No handle, no state, no `indexOutputsById`, no `narrow_raw_output` hop.

### `output_id` is a daemon invariant end-to-end

- `fallback_output_with_id(raw)` centralizes the "stamp a UUID if missing" logic. Three call sites now route through it:
  - `outputs_to_manifest_refs` (disk load)
  - `output_value_to_manifest_ref` (streaming load)
  - Three `nbformat_value.clone()` sites in `jupyter_kernel.rs` (live IOPub error branch, display-data error branch, Page payload handler)
- Other `create_manifest` sites in `jupyter_kernel.rs` either `continue` on failure or gate on `if let Ok(...)`, so no unstamped manifest reaches RuntimeStateDoc.
- The frontend's per-output projection drops outputs with empty `output_id` instead of synthesizing `legacy:<eid>:<idx>` keys.

### Incidental cleanups

- `ExecutionState.outputs` typed as `unknown[]` instead of `string[]` — reflects the actual manifest shape WASM exposes, eliminating `as unknown as` casts at call sites.
- `projectRuntimeStateToExecutions` takes `RuntimeState` directly.
- `narrow_raw_output` WASM export removed (no consumers).

## Scale

`+252 / −458 LOC`, 1087 frontend unit tests pass, 50 output_store tests pass, clippy clean.

## Test plan

- [x] Rust: `cargo test -p notebook-doc` (355 pass), `cargo test -p runtimed --lib output_store::` (50 pass), `cargo test -p runtimed --lib tests::fallback_output` (3 new tests pass).
- [x] Frontend: `pnpm test:run` (1087 pass / 3 skipped).
- [x] Clippy: `cargo clippy --workspace --all-targets` clean.
- [x] Lint: `cargo xtask lint --fix` clean.
- [ ] Smoke: parquet, matplotlib, inline image, stream output, widget render.
- [ ] Codex review (round 3 in flight at open).
