### PR TITLE
feat(notebook-sync): add explicit session status bootstrap

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -157,6 +157,7 @@ function AppContent() {
   const {
     cellIds,
     isLoading,
+    loadError,
     focusedCellId,
     setFocusedCellId,
     addCell,
@@ -1322,6 +1323,7 @@ function AppContent() {
           <NotebookView
             cellIds={cellIds}
             isLoading={isLoading}
+            loadError={loadError}
             runtime={runtime}
             onFocusCell={setFocusedCellId}
             onExecuteCell={handleExecuteCell}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -37,6 +37,7 @@ import { RawCell } from "./RawCell";
 interface NotebookViewProps {
   cellIds: string[];
   isLoading?: boolean;
+  loadError?: string | null;
   runtime?: Runtime | null;
   onFocusCell: (cellId: string) => void;
   onExecuteCell: (cellId: string) => void;
@@ -342,6 +343,7 @@ function SortableCell({
 function NotebookViewContent({
   cellIds,
   isLoading = false,
+  loadError = null,
   runtime = "python",
   onFocusCell,
   onExecuteCell,
@@ -757,9 +759,19 @@ function NotebookViewContent({
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-cell-count={cellIds.length}
     >
+      {loadError ? (
+        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          Notebook failed to finish loading: {loadError}
+        </div>
+      ) : null}
       {cellIds.length === 0 ? (
         isLoading ? (
           <CellSkeleton />
+        ) : loadError ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center text-destructive">
+            <p className="text-sm font-medium">Notebook load failed</p>
+            <p className="mt-1 max-w-xl text-xs text-muted-foreground">{loadError}</p>
+          </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
             <p className="text-sm">Empty notebook</p>

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,6 +1,6 @@
 import { useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { NotebookTransport, SyncableHandle } from "runtimed";
+import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
 import { DEFAULT_MIME_PRIORITY, SyncEngine } from "runtimed";
 import { concatMap, from, switchMap } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
@@ -90,10 +90,13 @@ export function useAutomergeNotebook() {
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const handleRef = useRef<NotebookHandle | null>(null);
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
+  const interactiveReadyRef = useRef(false);
+  const latestSessionStatusRef = useRef<SessionStatus | null>(null);
 
   // SyncEngine and transport refs — stable across re-renders.
   const engineRef = useRef<SyncEngine | null>(null);
@@ -212,6 +215,9 @@ export function useAutomergeNotebook() {
     }
     setNotebookHandle(handle);
 
+    interactiveReadyRef.current = false;
+    latestSessionStatusRef.current = null;
+    setLoadError(null);
     setIsLoading(true);
 
     // Flush initial sync message through the engine.
@@ -254,42 +260,55 @@ export function useAutomergeNotebook() {
 
     // ── Subscribe to SyncEngine observables ───────────────────────
 
+    const sessionStatusSub = engine.sessionStatus$.subscribe((status) => {
+      latestSessionStatusRef.current = status;
+
+      if (status.initial_load.phase === "failed") {
+        logger.warn("[automerge-notebook] Initial load failed:", status.initial_load.reason);
+        setLoadError(status.initial_load.reason);
+        setIsLoading(false);
+        return;
+      }
+
+      setLoadError(null);
+      if (interactiveReadyRef.current) {
+        setIsLoading(status.initial_load.phase === "streaming");
+      }
+    });
+
     // Initial sync completion → full materialization.
     const initialSyncSub = engine.initialSyncComplete$.subscribe(() => {
-      logger.info("[automerge-notebook] Initial sync complete, materializing");
+      logger.info("[automerge-notebook] Notebook interactive, materializing");
       const handle = handleRef.current;
       if (handle) {
         materializeCells(handle)
           .then(() => {
+            interactiveReadyRef.current = true;
             // Seed the cell -> execution_id pointer store from the doc.
-            // `cellChanges$` doesn't emit during `awaitingInitialSync`,
-            // so without this every `useCellOutputs(cellId)` would see
-            // `execution_id === null` until some later incremental
-            // changeset arrived - existing notebooks would render empty
-            // outputs on open.
+            // Seed pointers for the current snapshot once the daemon says
+            // the notebook replica is interactive.
             const cellIdList = [...handle.get_cell_ids()];
             updateCellExecutionPointersFromHandle(handle, cellIdList);
             // Seed the outputs / executions stores straight from the
-            // notebook doc. `initialSyncComplete$` fires on notebook-doc
-            // sync completion but does not wait for the RuntimeStateDoc
-            // sync, so without this a notebook reopened with existing
-            // outputs would render empty under `useCellOutputs` until
-            // the runtime-state frame arrives. The runtime-state
-            // projection below overwrites these defaults with
-            // authoritative status/success/execution_count values as
-            // soon as the doc lands.
+            // notebook doc. `initialSyncComplete$` fires when the
+            // notebook doc is interactive, not when RuntimeStateDoc is
+            // necessarily finished bootstrapping, so this preserves
+            // existing eager output visibility until the authoritative
+            // runtime-state projection lands.
             seedOutputStoresFromHandle(handle, cellIdList);
             // Project whatever RuntimeState snapshot has landed so far
             // on top. If the runtime-state frame arrived first this is
             // the authoritative pass; otherwise it's a no-op that the
             // runtimeState$ subscription will redo on the next tick.
             projectRuntimeStateToExecutions(getRuntimeState());
-            setIsLoading(false);
+            const status = latestSessionStatusRef.current;
+            setIsLoading(status ? status.initial_load.phase === "streaming" : false);
             notifyMetadataChanged();
-            logger.info("[automerge-notebook] Initial materialization done");
+            logger.info("[automerge-notebook] Interactive materialization done");
           })
           .catch((err: unknown) => {
             logger.warn("[automerge-notebook] initial materialize failed:", err);
+            setLoadError(err instanceof Error ? err.message : String(err));
             setIsLoading(false);
           });
       } else {
@@ -368,6 +387,7 @@ export function useAutomergeNotebook() {
     void bootstrap().catch((error) => {
       logger.error("[automerge-notebook] Bootstrap failed", error);
       if (!cancelled) {
+        setLoadError(error instanceof Error ? error.message : String(error));
         setIsLoading(false);
       }
     });
@@ -385,6 +405,7 @@ export function useAutomergeNotebook() {
           resetPoolState();
           outputCacheRef.current.clear();
           setIsLoading(true);
+          setLoadError(null);
           return from(
             bootstrap().catch((err: unknown) => {
               logger.error("[automerge-notebook] lifecycle bootstrap failed:", err);
@@ -430,6 +451,7 @@ export function useAutomergeNotebook() {
       // unsubscribes the frame listener this hook installed.
 
       initialSyncSub.unsubscribe();
+      sessionStatusSub.unsubscribe();
       cellChangesSub.unsubscribe();
       broadcastsSub.unsubscribe();
       presenceSub.unsubscribe();
@@ -664,6 +686,7 @@ export function useAutomergeNotebook() {
     cloneNotebook,
     dirty,
     setDirty,
+    loadError,
     updateOutputByDisplayId,
     applyExecutionCountFromDaemon,
     setCellSourceHidden,

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -26,9 +26,7 @@ import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
   diffExecutions,
   type ExecutionState,
-  type RuntimeState,
   resetRuntimeState,
-  setRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
@@ -290,11 +288,6 @@ export function useDaemonKernel({
 
         case "env_progress":
           break;
-
-        case "runtime_state_snapshot": {
-          setRuntimeState(broadcast.state as RuntimeState);
-          break;
-        }
 
         case "kernel_error": {
           callbacksRef.current.onKernelError?.(broadcast.error);

--- a/apps/notebook/src/lib/frame-types.ts
+++ b/apps/notebook/src/lib/frame-types.ts
@@ -24,4 +24,6 @@ export const frame_types = {
   RUNTIME_STATE_SYNC: 0x05,
   /** PoolStateSync message (binary Automerge sync for PoolDoc, global). */
   POOL_STATE_SYNC: 0x06,
+  /** SessionControl message (JSON, server-originated connection status). */
+  SESSION_CONTROL: 0x07,
 } as const;

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -226,43 +226,6 @@ export type DaemonBroadcast =
       };
     }
   | {
-      event: "runtime_state_snapshot";
-      state: {
-        kernel: {
-          status: string;
-          starting_phase: string;
-          name: string;
-          language: string;
-          env_source: string;
-        };
-        queue: {
-          executing: { cell_id: string; execution_id: string } | null;
-          queued: { cell_id: string; execution_id: string }[];
-        };
-        env: {
-          in_sync: boolean;
-          added: string[];
-          removed: string[];
-          channels_changed: boolean;
-          deno_changed: boolean;
-        };
-        trust: {
-          status: string;
-          needs_approval: boolean;
-        };
-        last_saved: string | null;
-        executions: Record<
-          string,
-          {
-            cell_id: string;
-            status: string;
-            execution_count: number | null;
-            success: boolean | null;
-          }
-        >;
-      };
-    }
-  | {
       event: "notebook_autosaved";
       path: string;
     }

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:515a3368d41e816a1a21c5056bb5ad9e5aec20ef36a80f24ab452bd3ee30b993
-size 1680476
+oid sha256:c1f06ee0824072c6498e4437c5abd7f0de3e971e2498110c21a96f2065a3bf94
+size 1712829

--- a/crates/notebook-doc/src/frame_types.rs
+++ b/crates/notebook-doc/src/frame_types.rs
@@ -34,3 +34,7 @@ pub const RUNTIME_STATE_SYNC: u8 = 0x05;
 /// Daemon-authoritative — client changes are stripped on receive.
 /// Unlike RuntimeStateSync (per-notebook), this is global (one per daemon).
 pub const POOL_STATE_SYNC: u8 = 0x06;
+
+/// Session-control message (JSON).
+/// Carries per-connection sync/readiness status emitted by the daemon.
+pub const SESSION_CONTROL: u8 = 0x07;

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -25,6 +25,7 @@
 //! - `0x01`: NotebookRequest (JSON)
 //! - `0x02`: NotebookResponse (JSON)
 //! - `0x03`: NotebookBroadcast (JSON)
+//! - `0x07`: SessionControl (JSON, server-originated)
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -149,18 +150,16 @@ pub enum Handshake {
     },
 }
 
-/// Protocol version constant (string for backwards compatibility).
+/// Protocol version constants (strings for handshake compatibility).
 pub const PROTOCOL_V2: &str = "v2";
+pub const PROTOCOL_V3: &str = "v3";
 
 /// Numeric protocol version for version negotiation.
 /// Increment this when making breaking protocol changes.
 ///
-/// The request/response envelope change (`NotebookRequestEnvelope` /
-/// `NotebookResponseEnvelope` with an optional `id` correlation field)
-/// is JSON-wire-compatible — the id is `Option<String>` and serde
-/// ignores unknown fields by default — so mixed v2/new deployments
-/// interoperate. No version bump is needed for that change.
-pub const PROTOCOL_VERSION: u32 = 2;
+/// Protocol v3 adds explicit session-control status frames for notebook
+/// bootstrap/readiness and is not wire-compatible with v2 clients.
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Magic bytes identifying the runtimed protocol.
 /// Sent as the first 4 bytes of every connection, before the handshake frame.
@@ -239,7 +238,7 @@ pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Res
 /// Used by the `NotebookSync` handshake variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Protocol version string (currently always "v2").
+    /// Protocol version string (currently always "v3").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     /// Clients can compare this against their expected version.
@@ -257,7 +256,7 @@ pub struct ProtocolCapabilities {
 /// Contains notebook_id derived by the daemon (from path or generated env_id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version string (currently always "v2").
+    /// Protocol version string (currently always "v3").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -303,6 +302,8 @@ pub enum NotebookFrameType {
     RuntimeStateSync = notebook_doc::frame_types::RUNTIME_STATE_SYNC,
     /// PoolDoc sync message (binary Automerge sync, global).
     PoolStateSync = notebook_doc::frame_types::POOL_STATE_SYNC,
+    /// Session-control message (JSON, server-originated connection status).
+    SessionControl = notebook_doc::frame_types::SESSION_CONTROL,
 }
 
 impl TryFrom<u8> for NotebookFrameType {
@@ -318,6 +319,7 @@ impl TryFrom<u8> for NotebookFrameType {
             frame_types::PRESENCE => Ok(Self::Presence),
             frame_types::RUNTIME_STATE_SYNC => Ok(Self::RuntimeStateSync),
             frame_types::POOL_STATE_SYNC => Ok(Self::PoolStateSync),
+            frame_types::SESSION_CONTROL => Ok(Self::SessionControl),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("unknown notebook frame type: 0x{:02x}", value),
@@ -758,7 +760,7 @@ mod tests {
 
         // With version info
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V2.into(),
+            protocol: PROTOCOL_V3.into(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some("0.1.0+abc123".into()),
             notebook_id: "/home/user/notebook.ipynb".into(),

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -232,7 +232,7 @@ pub enum SaveErrorKind {
 /// used but kept as a free escape hatch.
 ///
 /// Wire shape is flattened: `{"id":"...","action":"execute_cell","cell_id":"..."}`.
-/// Introduced at `PROTOCOL_VERSION = 3`.
+/// Formalized in protocol v3.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookRequestEnvelope {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -252,6 +252,52 @@ pub struct NotebookResponseEnvelope {
     pub id: Option<String>,
     #[serde(flatten)]
     pub response: NotebookResponse,
+}
+
+/// Session-control messages sent by the daemon on the notebook sync socket.
+///
+/// These frames are connection-local and ordered relative to Automerge sync
+/// frames. They are not room broadcasts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionControlMessage {
+    SyncStatus(SessionSyncStatusWire),
+}
+
+/// Full connection bootstrap/readiness snapshot.
+///
+/// The daemon emits the full current state on each transition rather than
+/// sending partial deltas.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionSyncStatusWire {
+    pub notebook_doc: NotebookDocPhaseWire,
+    pub runtime_state: RuntimeStatePhaseWire,
+    pub initial_load: InitialLoadPhaseWire,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum NotebookDocPhaseWire {
+    Pending,
+    Syncing,
+    Interactive,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStatePhaseWire {
+    Pending,
+    Syncing,
+    Ready,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum InitialLoadPhaseWire {
+    NotNeeded,
+    Streaming,
+    Ready,
+    Failed { reason: String },
 }
 
 /// Requests sent from notebook app to daemon for notebook operations.
@@ -622,14 +668,6 @@ pub enum NotebookBroadcast {
 
     /// Notebook was autosaved to disk by the daemon.
     NotebookAutosaved { path: String },
-
-    /// Eager RuntimeState snapshot sent during connection setup.
-    ///
-    /// Bypasses the Automerge sync handshake so the client has kernel
-    /// status immediately (prevents "not_started" → "idle" jump).
-    RuntimeStateSnapshot {
-        state: notebook_doc::runtime_state::RuntimeState,
-    },
 }
 
 // ── Runtime agent protocol types ──────────────────────────────────────────

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -1,4 +1,4 @@
-//! Connection handshake and initial Automerge sync.
+//! Connection handshake and sync-task bootstrap.
 //!
 //! All connect variants use [`NotebookDoc::bootstrap()`] to create the
 //! initial local document.  This seeds the doc with the standard notebook
@@ -9,26 +9,23 @@
 //! encoding or actor settings.
 //!
 //! Establishes a connection to the runtimed daemon, performs the protocol
-//! handshake, and runs the initial Automerge sync exchange to populate
-//! the local document replica.
+//! handshake, bootstraps empty local docs, and then hands post-handshake
+//! socket ownership to the background sync task.
 //!
 //! Platform-specific stream creation (Unix socket or Windows named pipe)
 //! is handled internally. The handshake and sync logic is generic over
 //! `AsyncRead + AsyncWrite`.
 
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-
-use automerge::sync::{self, SyncDoc};
+use automerge::sync;
 use automerge::AutoCommit;
 use log::{debug, info};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
-    self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities,
-    TypedNotebookFrame, PROTOCOL_V2,
+    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V3,
 };
 use notebook_protocol::protocol::NotebookBroadcast;
 
@@ -38,6 +35,7 @@ use crate::relay::RelayHandle;
 use crate::relay_task;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
+use crate::status::SyncStatus;
 use crate::sync_task;
 
 /// Result of connecting to a notebook room.
@@ -47,9 +45,6 @@ pub struct ConnectResult {
 
     /// Receiver for kernel/execution broadcasts from the daemon.
     pub broadcast_rx: crate::BroadcastReceiver,
-
-    /// Initial cells in the document after sync.
-    pub cells: Vec<notebook_doc::CellSnapshot>,
 
     /// Initial metadata string (legacy format, for handshake compat).
     pub initial_metadata: Option<String>,
@@ -65,9 +60,6 @@ pub struct OpenResult {
 
     /// Connection info from the daemon (notebook_id, trust status, etc).
     pub info: NotebookConnectionInfo,
-
-    /// Initial cells in the document after sync.
-    pub cells: Vec<notebook_doc::CellSnapshot>,
 }
 
 /// Result of creating a new notebook.
@@ -80,9 +72,6 @@ pub struct CreateResult {
 
     /// Connection info from the daemon (notebook_id, trust status, etc).
     pub info: NotebookConnectionInfo,
-
-    /// Initial cells in the document after sync.
-    pub cells: Vec<notebook_doc::CellSnapshot>,
 }
 
 /// Result of opening a notebook as a relay (no local document).
@@ -158,9 +147,8 @@ macro_rules! connect_stream {
 
 /// Connect to a notebook room by ID.
 ///
-/// Performs the protocol handshake and initial Automerge sync. Returns a
-/// `DocHandle` for direct document access and a broadcast receiver for
-/// kernel events.
+/// Performs the protocol handshake, spawns the background sync task, and
+/// returns a `DocHandle` plus a broadcast receiver for kernel events.
 ///
 /// `actor_label` sets the Automerge actor identity **before** initial sync
 /// so that even the bootstrap operations are attributed to the caller
@@ -192,7 +180,7 @@ pub async fn connect_with_options(
     // Send handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V2.to_string()),
+        protocol: Some(PROTOCOL_V3.to_string()),
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         initial_metadata: initial_metadata.clone(),
     };
@@ -207,57 +195,23 @@ pub async fn connect_with_options(
     let caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)?;
     check_daemon_protocol_version(&caps);
 
-    // Initial Automerge sync exchange — start from the standard notebook
-    // skeleton so load_incremental takes the incremental path.
-    // Set the actor before sync so all ops (including bootstrap) are
-    // attributed to the caller, not a random UUID.
+    // Start from the standard notebook skeleton so the background sync task
+    // owns the entire bootstrap from the first post-handshake frame onward.
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
         actor_label,
     );
-    let mut doc = bootstrap.into_inner();
-    let mut peer_state = sync::State::new();
-    let mut pending_broadcasts = Vec::new();
-    let mut pending_state_sync_frames = Vec::new();
-
-    do_initial_sync(
-        &mut reader,
-        &mut writer,
-        &mut doc,
-        &mut peer_state,
-        &mut pending_broadcasts,
-        &mut pending_state_sync_frames,
-    )
-    .await?;
-
-    info!(
-        "[notebook-sync] Connected to room {} ({} cells)",
-        notebook_id,
-        notebook_doc::get_cells_from_doc(&doc).len()
-    );
-
-    // Read initial state before splitting
-    let cells = notebook_doc::get_cells_from_doc(&doc);
-    let initial_metadata_snapshot = notebook_doc::get_metadata_snapshot_from_doc(&doc)
-        .and_then(|s| serde_json::to_string(&s).ok());
+    let doc = bootstrap.into_inner();
+    let peer_state = sync::State::new();
 
     // Build the shared state and channels
-    build_and_spawn(
-        doc,
-        peer_state,
-        notebook_id,
-        pending_broadcasts,
-        pending_state_sync_frames,
-        reader,
-        writer,
-    )
-    .await
-    .map(|(handle, broadcast_rx)| ConnectResult {
-        handle,
-        broadcast_rx,
-        cells,
-        initial_metadata: initial_metadata_snapshot,
-    })
+    build_and_spawn(doc, peer_state, notebook_id, reader, writer)
+        .await
+        .map(|(handle, broadcast_rx)| ConnectResult {
+            handle,
+            broadcast_rx,
+            initial_metadata,
+        })
 }
 
 /// Connect and open an existing notebook file.
@@ -294,51 +248,20 @@ pub async fn connect_open(
 
     let notebook_id = info.notebook_id.clone();
 
-    // Initial Automerge sync exchange — start from the standard notebook
-    // skeleton so load_incremental takes the incremental path.
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
         actor_label,
     );
-    let mut doc = bootstrap.into_inner();
-    let mut peer_state = sync::State::new();
-    let mut pending_broadcasts = Vec::new();
-    let mut pending_state_sync_frames = Vec::new();
+    let doc = bootstrap.into_inner();
+    let peer_state = sync::State::new();
 
-    do_initial_sync(
-        &mut reader,
-        &mut writer,
-        &mut doc,
-        &mut peer_state,
-        &mut pending_broadcasts,
-        &mut pending_state_sync_frames,
-    )
-    .await?;
-
-    info!(
-        "[notebook-sync] Opened notebook {} ({} cells)",
-        notebook_id,
-        notebook_doc::get_cells_from_doc(&doc).len()
-    );
-
-    let cells = notebook_doc::get_cells_from_doc(&doc);
-
-    build_and_spawn(
-        doc,
-        peer_state,
-        notebook_id,
-        pending_broadcasts,
-        pending_state_sync_frames,
-        reader,
-        writer,
-    )
-    .await
-    .map(|(handle, broadcast_rx)| OpenResult {
-        handle,
-        broadcast_rx,
-        info,
-        cells,
-    })
+    build_and_spawn(doc, peer_state, notebook_id, reader, writer)
+        .await
+        .map(|(handle, broadcast_rx)| OpenResult {
+            handle,
+            broadcast_rx,
+            info,
+        })
 }
 
 /// Connect and create a new notebook.
@@ -404,51 +327,20 @@ async fn connect_create_inner(
 
     let notebook_id = info.notebook_id.clone();
 
-    // Initial Automerge sync exchange — start from the standard notebook
-    // skeleton so load_incremental takes the incremental path.
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
         actor_label,
     );
-    let mut doc = bootstrap.into_inner();
-    let mut peer_state = sync::State::new();
-    let mut pending_broadcasts = Vec::new();
-    let mut pending_state_sync_frames = Vec::new();
+    let doc = bootstrap.into_inner();
+    let peer_state = sync::State::new();
 
-    do_initial_sync(
-        &mut reader,
-        &mut writer,
-        &mut doc,
-        &mut peer_state,
-        &mut pending_broadcasts,
-        &mut pending_state_sync_frames,
-    )
-    .await?;
-
-    info!(
-        "[notebook-sync] Created notebook {} ({} cells)",
-        notebook_id,
-        notebook_doc::get_cells_from_doc(&doc).len()
-    );
-
-    let cells = notebook_doc::get_cells_from_doc(&doc);
-
-    build_and_spawn(
-        doc,
-        peer_state,
-        notebook_id,
-        pending_broadcasts,
-        pending_state_sync_frames,
-        reader,
-        writer,
-    )
-    .await
-    .map(|(handle, broadcast_rx)| CreateResult {
-        handle,
-        broadcast_rx,
-        info,
-        cells,
-    })
+    build_and_spawn(doc, peer_state, notebook_id, reader, writer)
+        .await
+        .map(|(handle, broadcast_rx)| CreateResult {
+            handle,
+            broadcast_rx,
+            info,
+        })
 }
 
 // =========================================================================
@@ -463,10 +355,8 @@ async fn build_and_spawn<R, W>(
     doc: AutoCommit,
     peer_state: sync::State,
     notebook_id: String,
-    pending_broadcasts: Vec<NotebookBroadcast>,
-    pending_state_sync_frames: Vec<Vec<u8>>,
-    mut reader: R,
-    mut writer: W,
+    reader: R,
+    writer: W,
 ) -> Result<(DocHandle, crate::BroadcastReceiver), SyncError>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -474,84 +364,6 @@ where
 {
     let mut shared_state = SharedDocState::new(doc, notebook_id.clone());
     shared_state.peer_state = peer_state;
-    let mut pending_frames = Vec::<TypedNotebookFrame>::new();
-
-    // Complete the RuntimeStateDoc sync handshake inline so the doc is
-    // fully populated before we return the handle. The Automerge sync
-    // protocol is multi-round: the daemon's initial message contains only
-    // heads/bloom; the actual document data arrives after we reply.
-    //
-    // 1. Apply buffered frames from do_initial_sync
-    // 2. Send reply messages to the daemon
-    // 3. Receive follow-up frames until convergence (100ms timeout)
-    //
-    // Mixed frame types can legitimately arrive here under load. In
-    // particular, a late notebook AutomergeSync frame may show up after
-    // do_initial_sync's timeout but before this inline RuntimeStateDoc sync
-    // finishes. We must hand those frames off to the steady-state sync task
-    // instead of consuming and dropping them here.
-    {
-        // Step 1: Apply buffered frames
-        for frame_payload in &pending_state_sync_frames {
-            if let Ok(msg) = sync::Message::decode(frame_payload) {
-                let _ = shared_state.receive_state_sync_message(msg);
-            }
-        }
-
-        // Step 2: Send replies
-        while let Some(reply) = shared_state.generate_state_sync_message() {
-            connection::send_typed_frame(
-                &mut writer,
-                NotebookFrameType::RuntimeStateSync,
-                &reply.encode(),
-            )
-            .await?;
-        }
-
-        // Step 3: Receive follow-up frames until convergence
-        loop {
-            match tokio::time::timeout(
-                Duration::from_millis(100),
-                connection::recv_typed_frame(&mut reader),
-            )
-            .await
-            {
-                Ok(Ok(Some(frame))) if frame.frame_type == NotebookFrameType::RuntimeStateSync => {
-                    if let Ok(msg) = sync::Message::decode(&frame.payload) {
-                        let _ = shared_state.receive_state_sync_message(msg);
-                    }
-                    // Reply to each round
-                    while let Some(reply) = shared_state.generate_state_sync_message() {
-                        connection::send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::RuntimeStateSync,
-                            &reply.encode(),
-                        )
-                        .await?;
-                    }
-                }
-                Ok(Ok(Some(frame))) => {
-                    // Non-RuntimeStateSync frame — buffer it in arrival order
-                    // and let the steady-state sync task process it before
-                    // reading new frames from the socket.
-                    pending_frames.push(frame);
-                    break;
-                }
-                Ok(Ok(None)) => {
-                    return Err(SyncError::Protocol(
-                        "Connection closed during RuntimeStateDoc sync".into(),
-                    ));
-                }
-                Ok(Err(e)) => {
-                    return Err(SyncError::Io(e));
-                }
-                Err(_) => {
-                    // Timeout — RuntimeStateDoc sync converged
-                    break;
-                }
-            }
-        }
-    }
 
     let shared = Arc::new(Mutex::new(shared_state));
 
@@ -562,14 +374,10 @@ where
 
     let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
     let snapshot_tx = Arc::new(snapshot_tx);
+    let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
     let (changed_tx, changed_rx) = mpsc::unbounded_channel();
     let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
     let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
-
-    // Send any broadcasts received during initial sync
-    for bc in pending_broadcasts {
-        let _ = broadcast_tx.send(bc);
-    }
 
     let handle = DocHandle::new(
         Arc::clone(&shared),
@@ -577,6 +385,7 @@ where
         cmd_tx,
         Arc::clone(&snapshot_tx),
         snapshot_rx,
+        status_rx,
         notebook_id.clone(),
     );
 
@@ -585,8 +394,8 @@ where
         changed_rx,
         cmd_rx,
         snapshot_tx: Arc::clone(&snapshot_tx),
+        status_tx,
         broadcast_tx,
-        pending_frames,
     };
 
     let notebook_id_for_task = notebook_id;
@@ -612,9 +421,10 @@ where
 /// Open a notebook as a relay — transparent byte pipe, no local document.
 ///
 /// Performs the handshake only (preamble + OpenNotebook + receive info).
-/// Does NOT call `do_initial_sync` — the daemon's initial sync message
-/// stays in the socket buffer and gets piped to the frontend by the relay
-/// task. The frontend (WASM) owns the sync protocol.
+/// Does not perform any bootstrap sync on the client side — the daemon's
+/// initial sync and session-status frames stay in the socket buffer and get
+/// piped to the frontend by the relay task. The frontend (WASM) owns the
+/// sync protocol.
 ///
 /// This eliminates the 100ms convergence floor and wasted doc allocation
 /// that the full-peer `connect_open` incurs.
@@ -734,7 +544,7 @@ pub async fn connect_relay(
     // Send notebook sync handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V2.to_string()),
+        protocol: Some(PROTOCOL_V3.to_string()),
         initial_metadata: None,
         working_dir: None,
     };
@@ -742,7 +552,7 @@ pub async fn connect_relay(
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive protocol capabilities (v2 handshake)
+    // Receive protocol capabilities (v3 handshake)
     let caps_data = connection::recv_frame(&mut reader)
         .await?
         .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
@@ -799,115 +609,6 @@ where
     });
 
     handle
-}
-
-/// Perform the initial Automerge sync exchange after handshake.
-///
-/// Exchanges sync messages with the daemon until the local document is
-/// caught up. Also buffers any broadcasts received during sync.
-async fn do_initial_sync<R, W>(
-    reader: &mut R,
-    writer: &mut W,
-    doc: &mut AutoCommit,
-    peer_state: &mut sync::State,
-    pending_broadcasts: &mut Vec<NotebookBroadcast>,
-    pending_state_sync_frames: &mut Vec<Vec<u8>>,
-) -> Result<(), SyncError>
-where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
-{
-    // Receive the daemon's first sync message
-    let first_frame = connection::recv_typed_frame(reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during initial sync".into()))?;
-
-    if first_frame.frame_type != NotebookFrameType::AutomergeSync {
-        return Err(SyncError::Protocol(format!(
-            "Expected AutomergeSync frame, got {:?}",
-            first_frame.frame_type
-        )));
-    }
-
-    // Apply and respond
-    let msg = sync::Message::decode(&first_frame.payload)
-        .map_err(|e| SyncError::Protocol(format!("Decode sync message: {}", e)))?;
-    doc.sync()
-        .receive_sync_message(peer_state, msg)
-        .map_err(|e| SyncError::Protocol(format!("Apply sync message: {}", e)))?;
-
-    // Generate reply
-    if let Some(reply) = doc.sync().generate_sync_message(peer_state) {
-        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &reply.encode())
-            .await?;
-    }
-
-    // Continue receiving until we hit a timeout (convergence)
-    let mut rounds = 0;
-    loop {
-        match tokio::time::timeout(
-            Duration::from_millis(100),
-            connection::recv_typed_frame(reader),
-        )
-        .await
-        {
-            Ok(Ok(Some(frame))) => match frame.frame_type {
-                NotebookFrameType::AutomergeSync => {
-                    let msg = sync::Message::decode(&frame.payload)
-                        .map_err(|e| SyncError::Protocol(format!("Decode sync: {}", e)))?;
-                    doc.sync()
-                        .receive_sync_message(peer_state, msg)
-                        .map_err(|e| SyncError::Protocol(format!("Apply sync: {}", e)))?;
-
-                    if let Some(reply) = doc.sync().generate_sync_message(peer_state) {
-                        connection::send_typed_frame(
-                            writer,
-                            NotebookFrameType::AutomergeSync,
-                            &reply.encode(),
-                        )
-                        .await?;
-                    }
-                    rounds += 1;
-                }
-                NotebookFrameType::Broadcast => {
-                    // Buffer broadcasts received during initial sync
-                    if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
-                        pending_broadcasts.push(bc);
-                    }
-                }
-                NotebookFrameType::RuntimeStateSync => {
-                    // Buffer RuntimeStateSync frames — they'll be applied to
-                    // SharedDocState after it's created (do_initial_sync only
-                    // has the notebook doc, not the RuntimeStateDoc).
-                    pending_state_sync_frames.push(frame.payload);
-                }
-                _ => {
-                    debug!(
-                        "[notebook-sync] Ignoring {:?} frame during initial sync",
-                        frame.frame_type
-                    );
-                }
-            },
-            Ok(Ok(None)) => {
-                return Err(SyncError::Protocol(
-                    "Connection closed during initial sync".into(),
-                ));
-            }
-            Ok(Err(e)) => {
-                return Err(SyncError::Io(e));
-            }
-            Err(_) => {
-                // Timeout — sync converged
-                debug!(
-                    "[notebook-sync] Initial sync converged after {} rounds",
-                    rounds
-                );
-                break;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 /// Log version info from a daemon's `ProtocolCapabilities` response.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -560,11 +560,6 @@ pub async fn connect_relay(
         .map_err(|e| SyncError::Protocol(format!("Parse capabilities: {}", e)))?;
     check_daemon_protocol_version(&caps);
 
-    // Receive initial metadata frame (may be empty)
-    let _initial_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-
     info!(
         "[relay] Connected to {} (relay mode, no initial sync)",
         notebook_id

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -652,7 +652,8 @@ impl DocHandle {
             .await
     }
 
-    /// Wait until initial notebook load has either completed or was not needed.
+    /// Wait until the daemon explicitly reports that initial notebook load
+    /// either completed or was not needed.
     pub async fn await_initial_load_ready(&self) -> Result<(), SyncError> {
         self.wait_for_status(|status| {
             matches!(

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -41,6 +41,9 @@ use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
+use crate::status::{
+    ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase, SyncStatus,
+};
 use crate::sync_task::SyncCommand;
 
 /// A handle to a synced notebook document.
@@ -82,6 +85,9 @@ pub struct DocHandle {
     /// Watch channel receiver for reading the latest snapshot.
     snapshot_rx: watch::Receiver<NotebookSnapshot>,
 
+    /// Watch channel receiver for connection/bootstrap status.
+    status_rx: watch::Receiver<SyncStatus>,
+
     /// The notebook identifier.
     notebook_id: String,
 }
@@ -104,6 +110,7 @@ impl DocHandle {
         cmd_tx: mpsc::Sender<SyncCommand>,
         snapshot_tx: Arc<watch::Sender<NotebookSnapshot>>,
         snapshot_rx: watch::Receiver<NotebookSnapshot>,
+        status_rx: watch::Receiver<SyncStatus>,
         notebook_id: String,
     ) -> Self {
         Self {
@@ -112,6 +119,7 @@ impl DocHandle {
             cmd_tx,
             snapshot_tx,
             snapshot_rx,
+            status_rx,
             notebook_id,
         }
     }
@@ -590,6 +598,74 @@ impl DocHandle {
             .await
             .map_err(|_| SyncError::Disconnected)?;
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    fn readiness_error(status: &SyncStatus) -> Option<SyncError> {
+        if status.connection == ConnectionState::Disconnected {
+            return Some(SyncError::Disconnected);
+        }
+        match &status.initial_load {
+            InitialLoadPhase::Failed { reason } => Some(SyncError::Protocol(format!(
+                "Initial notebook load failed: {}",
+                reason
+            ))),
+            _ => None,
+        }
+    }
+
+    async fn wait_for_status<F>(&self, predicate: F) -> Result<(), SyncError>
+    where
+        F: Fn(&SyncStatus) -> bool,
+    {
+        let mut rx = self.status_rx.clone();
+        loop {
+            let status = rx.borrow().clone();
+            if predicate(&status) {
+                return Ok(());
+            }
+            if let Some(err) = Self::readiness_error(&status) {
+                return Err(err);
+            }
+            rx.changed().await.map_err(|_| SyncError::Disconnected)?;
+        }
+    }
+
+    /// Return the latest connection/bootstrap status.
+    pub fn status(&self) -> SyncStatus {
+        self.status_rx.borrow().clone()
+    }
+
+    /// Subscribe to status changes.
+    pub fn subscribe_status(&self) -> watch::Receiver<SyncStatus> {
+        self.status_rx.clone()
+    }
+
+    /// Wait until the notebook document is interactive.
+    pub async fn await_notebook_interactive(&self) -> Result<(), SyncError> {
+        self.wait_for_status(|status| status.notebook_doc == NotebookDocPhase::Interactive)
+            .await
+    }
+
+    /// Wait until RuntimeStateDoc bootstrap is ready.
+    pub async fn await_runtime_state_ready(&self) -> Result<(), SyncError> {
+        self.wait_for_status(|status| status.runtime_state == RuntimeStatePhase::Ready)
+            .await
+    }
+
+    /// Wait until initial notebook load has either completed or was not needed.
+    pub async fn await_initial_load_ready(&self) -> Result<(), SyncError> {
+        self.wait_for_status(|status| {
+            matches!(
+                status.initial_load,
+                InitialLoadPhase::NotNeeded | InitialLoadPhase::Ready
+            )
+        })
+        .await
+    }
+
+    /// Wait until notebook doc, runtime state, and initial load are ready.
+    pub async fn await_session_ready(&self) -> Result<(), SyncError> {
+        self.wait_for_status(SyncStatus::session_ready).await
     }
 
     /// Get all connected peer IDs and labels, sorted by peer ID for stable ordering.

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -59,6 +59,7 @@ pub mod relay;
 pub mod relay_task;
 mod shared;
 mod snapshot;
+pub mod status;
 pub mod sync_task;
 
 pub use broadcast::BroadcastReceiver;
@@ -71,6 +72,9 @@ pub use handle::DocHandle;
 pub use relay::RelayHandle;
 pub use shared::SharedDocState;
 pub use snapshot::NotebookSnapshot;
+pub use status::{
+    ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase, SyncStatus,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -5,8 +5,8 @@
 //! the frontend owns the sync state and the relay just forwards bytes.
 //!
 //! This eliminates the "dual sync" problem where both the relay and the WASM
-//! generate sync messages on the same daemon connection, and removes the 100ms
-//! convergence floor from `do_initial_sync` (which the relay never calls).
+//! generate sync messages on the same daemon connection. The relay never owns
+//! bootstrap or readiness heuristics; it only forwards daemon frames.
 //!
 //! ## API surface
 //!

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -139,6 +139,9 @@ where
                 } => {
                     let ft = NotebookFrameType::try_from(frame_type);
                     let result = match ft {
+                        Ok(NotebookFrameType::SessionControl) => Err(SyncError::Protocol(
+                            "SessionControl is daemon-originated only".into(),
+                        )),
                         Ok(ft) => connection::send_typed_frame(&mut writer, ft, &payload)
                             .await
                             .map_err(SyncError::Io),
@@ -273,7 +276,8 @@ fn route_incoming_frame(
 
 /// Pipe a daemon frame to the frontend.
 ///
-/// Forwards sync, broadcast, presence, runtime-state, pool-state, AND
+/// Forwards sync, broadcast, presence, runtime-state, pool-state,
+/// session-control, AND
 /// response (`0x02`) frames. Frontend requests rely on `0x02` reaching the
 /// JS side so the frontend's pending map can correlate the response.
 ///
@@ -286,6 +290,7 @@ fn pipe_frame(frame_tx: &mpsc::UnboundedSender<Vec<u8>>, frame: &connection::Typ
         | NotebookFrameType::Presence
         | NotebookFrameType::RuntimeStateSync
         | NotebookFrameType::PoolStateSync
+        | NotebookFrameType::SessionControl
         | NotebookFrameType::Response => {
             let mut bytes = vec![frame.frame_type as u8];
             bytes.extend_from_slice(&frame.payload);

--- a/crates/notebook-sync/src/status.rs
+++ b/crates/notebook-sync/src/status.rs
@@ -1,0 +1,109 @@
+//! Explicit connection/bootstrap status for a synced notebook handle.
+
+use notebook_protocol::protocol::{
+    InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire, SessionSyncStatusWire,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NotebookDocPhase {
+    Pending,
+    Syncing,
+    Interactive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RuntimeStatePhase {
+    Pending,
+    Syncing,
+    Ready,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InitialLoadPhase {
+    NotNeeded,
+    Streaming,
+    Ready,
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncStatus {
+    pub connection: ConnectionState,
+    pub notebook_doc: NotebookDocPhase,
+    pub runtime_state: RuntimeStatePhase,
+    pub initial_load: InitialLoadPhase,
+}
+
+impl SyncStatus {
+    pub fn connected_pending() -> Self {
+        Self {
+            connection: ConnectionState::Connected,
+            notebook_doc: NotebookDocPhase::Pending,
+            runtime_state: RuntimeStatePhase::Pending,
+            initial_load: InitialLoadPhase::NotNeeded,
+        }
+    }
+
+    pub fn session_ready(&self) -> bool {
+        self.notebook_doc == NotebookDocPhase::Interactive
+            && self.runtime_state == RuntimeStatePhase::Ready
+            && matches!(
+                self.initial_load,
+                InitialLoadPhase::NotNeeded | InitialLoadPhase::Ready
+            )
+    }
+}
+
+impl Default for SyncStatus {
+    fn default() -> Self {
+        Self::connected_pending()
+    }
+}
+
+impl From<NotebookDocPhaseWire> for NotebookDocPhase {
+    fn from(value: NotebookDocPhaseWire) -> Self {
+        match value {
+            NotebookDocPhaseWire::Pending => Self::Pending,
+            NotebookDocPhaseWire::Syncing => Self::Syncing,
+            NotebookDocPhaseWire::Interactive => Self::Interactive,
+        }
+    }
+}
+
+impl From<RuntimeStatePhaseWire> for RuntimeStatePhase {
+    fn from(value: RuntimeStatePhaseWire) -> Self {
+        match value {
+            RuntimeStatePhaseWire::Pending => Self::Pending,
+            RuntimeStatePhaseWire::Syncing => Self::Syncing,
+            RuntimeStatePhaseWire::Ready => Self::Ready,
+        }
+    }
+}
+
+impl From<InitialLoadPhaseWire> for InitialLoadPhase {
+    fn from(value: InitialLoadPhaseWire) -> Self {
+        match value {
+            InitialLoadPhaseWire::NotNeeded => Self::NotNeeded,
+            InitialLoadPhaseWire::Streaming => Self::Streaming,
+            InitialLoadPhaseWire::Ready => Self::Ready,
+            InitialLoadPhaseWire::Failed { reason } => Self::Failed { reason },
+        }
+    }
+}
+
+impl From<SessionSyncStatusWire> for SyncStatus {
+    fn from(value: SessionSyncStatusWire) -> Self {
+        Self {
+            connection: ConnectionState::Connected,
+            notebook_doc: value.notebook_doc.into(),
+            runtime_state: value.runtime_state.into(),
+            initial_load: value.initial_load.into(),
+        }
+    }
+}

--- a/crates/notebook-sync/src/status.rs
+++ b/crates/notebook-sync/src/status.rs
@@ -46,7 +46,11 @@ impl SyncStatus {
             connection: ConnectionState::Connected,
             notebook_doc: NotebookDocPhase::Pending,
             runtime_state: RuntimeStatePhase::Pending,
-            initial_load: InitialLoadPhase::NotNeeded,
+            // No SessionControl frame has arrived yet, so treat initial load as
+            // non-terminal until the daemon explicitly says `NotNeeded` or
+            // `Ready`. This prevents readiness waiters from succeeding before
+            // bootstrap state is actually known.
+            initial_load: InitialLoadPhase::Streaming,
         }
     }
 

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -24,16 +24,20 @@ use std::time::Duration;
 use automerge::sync;
 use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use notebook_protocol::connection::{self, NotebookFrameType};
-use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+use notebook_protocol::protocol::{
+    NotebookBroadcast, NotebookRequest, NotebookResponse, SessionControlMessage,
+    SessionSyncStatusWire,
+};
 
 use automerge::AutoCommit;
 
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
+use crate::status::{ConnectionState, InitialLoadPhase, SyncStatus};
 
 /// Rebuild a `SharedDocState` after an automerge panic by round-tripping
 /// save→load to clear corrupted internal indices, then resetting the
@@ -124,12 +128,11 @@ pub struct SyncTaskConfig {
     /// Watch sender for publishing snapshots after applying remote changes.
     pub snapshot_tx: Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
 
+    /// Watch sender for publishing connection/bootstrap status.
+    pub status_tx: watch::Sender<SyncStatus>,
+
     /// Broadcast sender for kernel/execution events from the daemon.
     pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
-
-    /// Frames observed during connect-time bootstrap after the notebook doc
-    /// sync completed but before the background task took over the socket.
-    pub pending_frames: Vec<connection::TypedNotebookFrame>,
 }
 
 /// Run the sync task.
@@ -153,27 +156,13 @@ where
     };
 
     let mut loop_count: u64 = 0;
+    let mut saw_session_status = false;
 
     // Track last metadata for change detection (used for SyncUpdate-like behavior)
     let mut _last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
         let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
         notebook_doc::get_metadata_snapshot_from_doc(&state.doc)
     };
-
-    // Connect-time bootstrap may have already read a late notebook sync frame
-    // while finishing RuntimeStateDoc convergence. Replay those frames before
-    // we start polling the socket so no notebook updates are lost.
-    for frame in std::mem::take(&mut config.pending_frames) {
-        handle_incoming_frame(
-            &frame,
-            &config.doc,
-            &mut writer,
-            &config.snapshot_tx,
-            &config.broadcast_tx,
-            &notebook_id,
-        )
-        .await;
-    }
 
     loop {
         loop_count += 1;
@@ -247,8 +236,10 @@ where
                             &config.doc,
                             &mut writer,
                             &config.snapshot_tx,
+                            &config.status_tx,
                             &config.broadcast_tx,
                             &notebook_id,
+                            &mut saw_session_status,
                         )
                         .await;
                     }
@@ -288,10 +279,12 @@ where
                             &mut reader,
                             &mut writer,
                             &config.snapshot_tx,
+                            &config.status_tx,
                             &config.broadcast_tx,
                             req_broadcast_tx.as_ref(),
                             &request,
                             &notebook_id,
+                            &mut saw_session_status,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -303,8 +296,10 @@ where
                             &mut reader,
                             &mut writer,
                             &config.snapshot_tx,
+                            &config.status_tx,
                             &config.broadcast_tx,
                             &notebook_id,
+                            &mut saw_session_status,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -316,8 +311,10 @@ where
                             &mut reader,
                             &mut writer,
                             &config.snapshot_tx,
+                            &config.status_tx,
                             &config.broadcast_tx,
                             &notebook_id,
+                            &mut saw_session_status,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -344,8 +341,10 @@ where
                         &config.doc,
                         &mut writer,
                         &config.snapshot_tx,
+                        &config.status_tx,
                         &config.broadcast_tx,
                         &notebook_id,
+                        &mut saw_session_status,
                     )
                     .await;
                 }
@@ -367,6 +366,8 @@ where
         }
     }
 
+    mark_disconnected(&config.status_tx);
+
     info!(
         "[notebook-sync] Stopped for {} after {} loop iterations",
         notebook_id, loop_count
@@ -383,8 +384,10 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
     doc: &Arc<Mutex<SharedDocState>>,
     writer: &mut W,
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &watch::Sender<SyncStatus>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
+    saw_session_status: &mut bool,
 ) {
     match frame.frame_type {
         NotebookFrameType::AutomergeSync => {
@@ -610,6 +613,25 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
                 notebook_id
             );
         }
+
+        NotebookFrameType::SessionControl => {
+            let message = match serde_json::from_slice::<SessionControlMessage>(&frame.payload) {
+                Ok(message) => message,
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to parse SessionControl for {}: {}",
+                        notebook_id, e
+                    );
+                    return;
+                }
+            };
+
+            match message {
+                SessionControlMessage::SyncStatus(status) => {
+                    apply_sync_status(status_tx, notebook_id, saw_session_status, status);
+                }
+            }
+        }
     }
 }
 
@@ -623,10 +645,12 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut R,
     writer: &mut W,
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &watch::Sender<SyncStatus>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
     notebook_id: &str,
+    saw_session_status: &mut bool,
 ) -> Result<NotebookResponse, SyncError> {
     // Serialize and send the request
     let payload =
@@ -650,9 +674,11 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             reader,
             writer,
             snapshot_tx,
+            status_tx,
             broadcast_tx,
             req_broadcast_tx,
             notebook_id,
+            saw_session_status,
         ),
     )
     .await;
@@ -670,9 +696,11 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut R,
     writer: &mut W,
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &watch::Sender<SyncStatus>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     notebook_id: &str,
+    saw_session_status: &mut bool,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = connection::recv_typed_frame(reader)
@@ -769,8 +797,17 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             // acknowledges. A dropped RuntimeStateSync causes permanent sync
             // stall for RuntimeStateDoc (no execution results, no status updates).
             _ => {
-                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
-                    .await;
+                handle_incoming_frame(
+                    &frame,
+                    doc,
+                    writer,
+                    snapshot_tx,
+                    status_tx,
+                    broadcast_tx,
+                    notebook_id,
+                    saw_session_status,
+                )
+                .await;
             }
         }
     }
@@ -785,8 +822,10 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut R,
     writer: &mut W,
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &watch::Sender<SyncStatus>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
+    saw_session_status: &mut bool,
 ) -> Result<(), SyncError> {
     for round in 0..5 {
         // Generate and send sync message
@@ -822,8 +861,17 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
-                    .await;
+                handle_incoming_frame(
+                    &frame,
+                    doc,
+                    writer,
+                    snapshot_tx,
+                    status_tx,
+                    broadcast_tx,
+                    notebook_id,
+                    saw_session_status,
+                )
+                .await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(
@@ -861,8 +909,10 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut R,
     writer: &mut W,
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &watch::Sender<SyncStatus>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
+    saw_session_status: &mut bool,
 ) -> Result<(), SyncError> {
     // Send our state doc heads so the daemon knows what we have.
     let msg_bytes = {
@@ -884,8 +934,17 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
-                    .await;
+                handle_incoming_frame(
+                    &frame,
+                    doc,
+                    writer,
+                    snapshot_tx,
+                    status_tx,
+                    broadcast_tx,
+                    notebook_id,
+                    saw_session_status,
+                )
+                .await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(
@@ -914,61 +973,177 @@ fn publish_snapshot(
     let _ = snapshot_tx.send(snapshot);
 }
 
+fn mark_disconnected(status_tx: &watch::Sender<SyncStatus>) {
+    let mut next = status_tx.borrow().clone();
+    if next.connection != ConnectionState::Disconnected {
+        next.connection = ConnectionState::Disconnected;
+        let _ = status_tx.send(next);
+    }
+}
+
+fn initial_load_transition_valid(current: &InitialLoadPhase, next: &InitialLoadPhase) -> bool {
+    match current {
+        InitialLoadPhase::NotNeeded => matches!(next, InitialLoadPhase::NotNeeded),
+        InitialLoadPhase::Streaming => matches!(
+            next,
+            InitialLoadPhase::Streaming | InitialLoadPhase::Ready | InitialLoadPhase::Failed { .. }
+        ),
+        InitialLoadPhase::Ready => matches!(next, InitialLoadPhase::Ready),
+        InitialLoadPhase::Failed { .. } => matches!(next, InitialLoadPhase::Failed { .. }),
+    }
+}
+
+fn apply_sync_status(
+    status_tx: &watch::Sender<SyncStatus>,
+    notebook_id: &str,
+    saw_session_status: &mut bool,
+    incoming_wire: SessionSyncStatusWire,
+) {
+    let current = status_tx.borrow().clone();
+    let mut incoming: SyncStatus = incoming_wire.into();
+    incoming.connection = current.connection;
+
+    if !*saw_session_status {
+        let _ = status_tx.send(incoming);
+        *saw_session_status = true;
+        return;
+    }
+
+    let mut next = current.clone();
+
+    if incoming.notebook_doc >= current.notebook_doc {
+        next.notebook_doc = incoming.notebook_doc;
+    } else {
+        warn!(
+            "[notebook-sync] Ignoring regressing notebook_doc status for {}: {:?} -> {:?}",
+            notebook_id, current.notebook_doc, incoming.notebook_doc
+        );
+    }
+
+    if incoming.runtime_state >= current.runtime_state {
+        next.runtime_state = incoming.runtime_state;
+    } else {
+        warn!(
+            "[notebook-sync] Ignoring regressing runtime_state status for {}: {:?} -> {:?}",
+            notebook_id, current.runtime_state, incoming.runtime_state
+        );
+    }
+
+    if initial_load_transition_valid(&current.initial_load, &incoming.initial_load) {
+        next.initial_load = incoming.initial_load;
+    } else {
+        warn!(
+            "[notebook-sync] Ignoring invalid initial_load status for {}: {:?} -> {:?}",
+            notebook_id, current.initial_load, incoming.initial_load
+        );
+    }
+
+    if next != current {
+        let _ = status_tx.send(next);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use notebook_doc::{NotebookDoc, TextEncoding};
+    use notebook_protocol::protocol::{
+        InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire,
+    };
     use tokio::sync::{broadcast, mpsc, watch};
 
     #[tokio::test]
-    async fn pending_notebook_sync_frames_are_replayed_before_socket_reads() {
-        let mut daemon = NotebookDoc::new_with_actor("pending-frame-test", "runtimed");
-        daemon.add_cell(0, "cell-1", "code").unwrap();
-        daemon
-            .update_source("cell-1", "print('late sync')")
-            .unwrap();
+    async fn first_session_status_accepts_streaming_initial_load() {
+        let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let mut saw = false;
 
-        let mut daemon_peer_state = sync::State::new();
-        let mut client = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "test");
-        let mut client_peer_state = sync::State::new();
-
-        let first_msg = daemon
-            .generate_sync_message(&mut daemon_peer_state)
-            .unwrap();
-        client
-            .receive_sync_message(&mut client_peer_state, first_msg)
-            .unwrap();
-        assert_eq!(
-            client.cell_count(),
-            0,
-            "bootstrap client should still need a follow-up sync frame",
+        apply_sync_status(
+            &status_tx,
+            "test-notebook",
+            &mut saw,
+            SessionSyncStatusWire {
+                notebook_doc: NotebookDocPhaseWire::Pending,
+                runtime_state: RuntimeStatePhaseWire::Pending,
+                initial_load: InitialLoadPhaseWire::Streaming,
+            },
         );
 
-        let client_reply = client
-            .generate_sync_message(&mut client_peer_state)
-            .unwrap();
-        daemon
-            .receive_sync_message(&mut daemon_peer_state, client_reply)
-            .unwrap();
-        let late_msg = daemon
-            .generate_sync_message(&mut daemon_peer_state)
-            .unwrap();
+        let status = status_rx.borrow().clone();
+        assert!(saw);
+        assert_eq!(status.initial_load, InitialLoadPhase::Streaming);
+    }
 
-        let mut shared_state =
-            SharedDocState::new(client.into_inner(), "pending-frame-test".into());
-        shared_state.peer_state = client_peer_state;
-        let shared = Arc::new(Mutex::new(shared_state));
+    #[tokio::test]
+    async fn regressing_session_status_components_are_ignored() {
+        let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let mut saw = false;
 
+        apply_sync_status(
+            &status_tx,
+            "test-notebook",
+            &mut saw,
+            SessionSyncStatusWire {
+                notebook_doc: NotebookDocPhaseWire::Interactive,
+                runtime_state: RuntimeStatePhaseWire::Ready,
+                initial_load: InitialLoadPhaseWire::Streaming,
+            },
+        );
+
+        apply_sync_status(
+            &status_tx,
+            "test-notebook",
+            &mut saw,
+            SessionSyncStatusWire {
+                notebook_doc: NotebookDocPhaseWire::Syncing,
+                runtime_state: RuntimeStatePhaseWire::Syncing,
+                initial_load: InitialLoadPhaseWire::NotNeeded,
+            },
+        );
+
+        let status = status_rx.borrow().clone();
+        assert_eq!(
+            status.notebook_doc,
+            crate::status::NotebookDocPhase::Interactive
+        );
+        assert_eq!(
+            status.runtime_state,
+            crate::status::RuntimeStatePhase::Ready
+        );
+        assert_eq!(status.initial_load, InitialLoadPhase::Streaming);
+
+        apply_sync_status(
+            &status_tx,
+            "test-notebook",
+            &mut saw,
+            SessionSyncStatusWire {
+                notebook_doc: NotebookDocPhaseWire::Interactive,
+                runtime_state: RuntimeStatePhaseWire::Ready,
+                initial_load: InitialLoadPhaseWire::Ready,
+            },
+        );
+
+        assert_eq!(
+            status_rx.borrow().initial_load.clone(),
+            InitialLoadPhase::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn run_marks_status_disconnected_on_exit() {
+        let shared = Arc::new(Mutex::new(SharedDocState::new(
+            notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+            "test-notebook".into(),
+        )));
         let initial_snapshot = {
             let state = shared.lock().unwrap();
             NotebookSnapshot::from_doc(&state.doc)
         };
         let (snapshot_tx, _snapshot_rx) = watch::channel(initial_snapshot);
         let snapshot_tx = Arc::new(snapshot_tx);
-        let (_broadcast_tx, _broadcast_rx) = broadcast::channel::<NotebookBroadcast>(8);
+        let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
         let (changed_tx, changed_rx) = mpsc::unbounded_channel();
         let (cmd_tx, cmd_rx) = mpsc::channel(1);
+        let (broadcast_tx, _broadcast_rx) = broadcast::channel::<NotebookBroadcast>(8);
         drop(changed_tx);
         drop(cmd_tx);
 
@@ -978,24 +1153,14 @@ mod tests {
                 changed_rx,
                 cmd_rx,
                 snapshot_tx,
-                broadcast_tx: _broadcast_tx,
-                pending_frames: vec![connection::TypedNotebookFrame {
-                    frame_type: NotebookFrameType::AutomergeSync,
-                    payload: late_msg.encode(),
-                }],
+                status_tx,
+                broadcast_tx,
             },
             tokio::io::empty(),
             tokio::io::sink(),
         )
         .await;
 
-        let cell_count = {
-            let state = shared.lock().unwrap();
-            notebook_doc::get_cells_from_doc(&state.doc).len()
-        };
-        assert_eq!(
-            cell_count, 1,
-            "pending notebook frame should populate the cells map"
-        );
+        assert_eq!(status_rx.borrow().connection, ConnectionState::Disconnected);
     }
 }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -135,6 +135,15 @@ pub struct SyncTaskConfig {
     pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
 }
 
+struct SyncFrameContext<'a> {
+    doc: &'a Arc<Mutex<SharedDocState>>,
+    snapshot_tx: &'a Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    status_tx: &'a watch::Sender<SyncStatus>,
+    broadcast_tx: &'a broadcast::Sender<NotebookBroadcast>,
+    notebook_id: &'a str,
+    saw_session_status: &'a mut bool,
+}
+
 /// Run the sync task.
 ///
 /// This is spawned as a background tokio task. It runs until the socket
@@ -231,16 +240,15 @@ where
                 .await
                 {
                     Ok(Ok(Some(frame))) => {
-                        handle_incoming_frame(
-                            &frame,
-                            &config.doc,
-                            &mut writer,
-                            &config.snapshot_tx,
-                            &config.status_tx,
-                            &config.broadcast_tx,
-                            &notebook_id,
-                            &mut saw_session_status,
-                        )
+                        SyncFrameContext {
+                            doc: &config.doc,
+                            snapshot_tx: &config.snapshot_tx,
+                            status_tx: &config.status_tx,
+                            broadcast_tx: &config.broadcast_tx,
+                            notebook_id: &notebook_id,
+                            saw_session_status: &mut saw_session_status,
+                        }
+                        .handle_incoming_frame(&frame, &mut writer)
                         .await;
                     }
                     Ok(Ok(None)) => {
@@ -275,16 +283,18 @@ where
                         broadcast_tx: req_broadcast_tx,
                     } => {
                         let result = send_request_impl(
-                            &config.doc,
                             &mut reader,
                             &mut writer,
-                            &config.snapshot_tx,
-                            &config.status_tx,
-                            &config.broadcast_tx,
                             req_broadcast_tx.as_ref(),
                             &request,
-                            &notebook_id,
-                            &mut saw_session_status,
+                            &mut SyncFrameContext {
+                                doc: &config.doc,
+                                snapshot_tx: &config.snapshot_tx,
+                                status_tx: &config.status_tx,
+                                broadcast_tx: &config.broadcast_tx,
+                                notebook_id: &notebook_id,
+                                saw_session_status: &mut saw_session_status,
+                            },
                         )
                         .await;
                         let _ = reply.send(result);
@@ -292,14 +302,16 @@ where
 
                     SyncCommand::ConfirmSync { reply } => {
                         let result = confirm_sync_impl(
-                            &config.doc,
                             &mut reader,
                             &mut writer,
-                            &config.snapshot_tx,
-                            &config.status_tx,
-                            &config.broadcast_tx,
-                            &notebook_id,
-                            &mut saw_session_status,
+                            &mut SyncFrameContext {
+                                doc: &config.doc,
+                                snapshot_tx: &config.snapshot_tx,
+                                status_tx: &config.status_tx,
+                                broadcast_tx: &config.broadcast_tx,
+                                notebook_id: &notebook_id,
+                                saw_session_status: &mut saw_session_status,
+                            },
                         )
                         .await;
                         let _ = reply.send(result);
@@ -307,14 +319,16 @@ where
 
                     SyncCommand::ConfirmStateSync { reply } => {
                         let result = confirm_state_sync_impl(
-                            &config.doc,
                             &mut reader,
                             &mut writer,
-                            &config.snapshot_tx,
-                            &config.status_tx,
-                            &config.broadcast_tx,
-                            &notebook_id,
-                            &mut saw_session_status,
+                            &mut SyncFrameContext {
+                                doc: &config.doc,
+                                snapshot_tx: &config.snapshot_tx,
+                                status_tx: &config.status_tx,
+                                broadcast_tx: &config.broadcast_tx,
+                                notebook_id: &notebook_id,
+                                saw_session_status: &mut saw_session_status,
+                            },
                         )
                         .await;
                         let _ = reply.send(result);
@@ -336,16 +350,15 @@ where
             // ─── Incoming frame from daemon ────────────────────────────────
             SelectResult::Frame(frame_result) => match frame_result {
                 Ok(Some(frame)) => {
-                    handle_incoming_frame(
-                        &frame,
-                        &config.doc,
-                        &mut writer,
-                        &config.snapshot_tx,
-                        &config.status_tx,
-                        &config.broadcast_tx,
-                        &notebook_id,
-                        &mut saw_session_status,
-                    )
+                    SyncFrameContext {
+                        doc: &config.doc,
+                        snapshot_tx: &config.snapshot_tx,
+                        status_tx: &config.status_tx,
+                        broadcast_tx: &config.broadcast_tx,
+                        notebook_id: &notebook_id,
+                        saw_session_status: &mut saw_session_status,
+                    }
+                    .handle_incoming_frame(&frame, &mut writer)
                     .await;
                 }
                 Ok(None) => {
@@ -379,256 +392,265 @@ where
 // =========================================================================
 
 /// Handle an incoming typed frame from the daemon.
-async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
-    frame: &connection::TypedNotebookFrame,
-    doc: &Arc<Mutex<SharedDocState>>,
-    writer: &mut W,
-    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
-    status_tx: &watch::Sender<SyncStatus>,
-    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
-    notebook_id: &str,
-    saw_session_status: &mut bool,
-) {
-    match frame.frame_type {
-        NotebookFrameType::AutomergeSync => {
-            let msg = match sync::Message::decode(&frame.payload) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    warn!(
-                        "[notebook-sync] Failed to decode sync message for {}: {}",
-                        notebook_id, e
-                    );
-                    return;
-                }
-            };
+impl SyncFrameContext<'_> {
+    async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
+        &mut self,
+        frame: &connection::TypedNotebookFrame,
+        writer: &mut W,
+    ) {
+        match frame.frame_type {
+            NotebookFrameType::AutomergeSync => {
+                let msg = match sync::Message::decode(&frame.payload) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to decode sync message for {}: {}",
+                            self.notebook_id, e
+                        );
+                        return;
+                    }
+                };
 
-            // Apply and generate ack — lock held only for Automerge operations.
-            //
-            // The receive_sync_message call is wrapped in catch_unwind because
-            // automerge 0.7 has a known panic in BatchApply::apply when the
-            // internal patch log actor table gets out of order during concurrent
-            // sync (automerge/automerge#1187). Without catch_unwind, the panic
-            // poisons the Mutex and renders the session permanently unusable.
-            // By catching it, the MutexGuard drops normally and subsequent
-            // operations can still succeed.
-            let ack_bytes = {
-                let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-                let recv_result =
-                    std::panic::catch_unwind(AssertUnwindSafe(|| state.receive_sync_message(msg)));
-                match recv_result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => {
-                        warn!(
-                            "[notebook-sync] Failed to apply sync message for {}: {}",
-                            notebook_id, e
-                        );
-                        return;
-                    }
-                    Err(panic_payload) => {
-                        let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
-                            s.as_str()
-                        } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                            s
-                        } else {
-                            "unknown panic"
-                        };
-                        warn!(
-                            "[notebook-sync] Automerge panicked during sync for {} \
+                // Apply and generate ack — lock held only for Automerge operations.
+                //
+                // The receive_sync_message call is wrapped in catch_unwind because
+                // automerge 0.7 has a known panic in BatchApply::apply when the
+                // internal patch log actor table gets out of order during concurrent
+                // sync (automerge/automerge#1187). Without catch_unwind, the panic
+                // poisons the Mutex and renders the session permanently unusable.
+                // By catching it, the MutexGuard drops normally and subsequent
+                // operations can still succeed.
+                let ack_bytes = {
+                    let mut state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
+                    let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        state.receive_sync_message(msg)
+                    }));
+                    match recv_result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            warn!(
+                                "[notebook-sync] Failed to apply sync message for {}: {}",
+                                self.notebook_id, e
+                            );
+                            return;
+                        }
+                        Err(panic_payload) => {
+                            let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
+                                s.as_str()
+                            } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                                s
+                            } else {
+                                "unknown panic"
+                            };
+                            warn!(
+                                "[notebook-sync] Automerge panicked during sync for {} \
                              (upstream bug automerge/automerge#1187): {}",
-                            notebook_id, msg
-                        );
-                        // Rebuild doc via save→load to clear corrupted indices,
-                        // then reset peer state to force a fresh sync handshake.
-                        rebuild_shared_doc_state(&mut state);
-                        return;
+                                self.notebook_id, msg
+                            );
+                            // Rebuild doc via save→load to clear corrupted indices,
+                            // then reset peer state to force a fresh sync handshake.
+                            rebuild_shared_doc_state(&mut state);
+                            return;
+                        }
                     }
-                }
-                // Guard generate_sync_message — the collector can also panic
-                // with MissingOps even after a successful receive.
-                match std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    state.generate_sync_message().map(|msg| msg.encode())
-                })) {
-                    Ok(bytes) => bytes,
-                    Err(_) => {
-                        warn!(
+                    // Guard generate_sync_message — the collector can also panic
+                    // with MissingOps even after a successful receive.
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
+                        state.generate_sync_message().map(|msg| msg.encode())
+                    })) {
+                        Ok(bytes) => bytes,
+                        Err(_) => {
+                            warn!(
                             "[notebook-sync] Automerge panicked in generate_sync_message for {} \
                              (upstream MissingOps bug)",
-                            notebook_id
+                            self.notebook_id
                         );
-                        rebuild_shared_doc_state(&mut state);
-                        None
-                    }
-                }
-            };
-
-            // Publish snapshot immediately (before sending ack — readers see changes fast)
-            publish_snapshot(doc, snapshot_tx);
-
-            // Send ack if needed (outside the lock — never hold across I/O)
-            if let Some(bytes) = ack_bytes {
-                if let Err(e) =
-                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
-                        .await
-                {
-                    warn!(
-                        "[notebook-sync] Failed to send sync ack for {}: {}",
-                        notebook_id, e
-                    );
-                }
-            }
-        }
-
-        NotebookFrameType::Broadcast => {
-            match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
-                Ok(bc) => {
-                    let _ = broadcast_tx.send(bc);
-                }
-                Err(e) => {
-                    warn!(
-                        "[notebook-sync] Failed to parse broadcast for {}: {}",
-                        notebook_id, e
-                    );
-                }
-            }
-        }
-
-        NotebookFrameType::Presence => {
-            use notebook_doc::presence::{decode_message, validate_frame_size, PresenceMessage};
-
-            if let Err(e) = validate_frame_size(&frame.payload) {
-                debug!(
-                    "[notebook-sync] Dropping oversized presence frame for {}: {}",
-                    notebook_id, e
-                );
-                return;
-            }
-
-            match decode_message(&frame.payload) {
-                Ok(msg) => {
-                    let now_ms = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
-                    let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-                    match msg {
-                        PresenceMessage::Update {
-                            peer_id,
-                            peer_label,
-                            actor_label,
-                            data,
-                        } => {
-                            let label = peer_label.as_deref().unwrap_or(&peer_id);
-                            state.presence.update_peer(
-                                &peer_id,
-                                label,
-                                actor_label.as_deref(),
-                                data,
-                                now_ms,
-                            );
-                        }
-                        PresenceMessage::Snapshot { peers, .. } => {
-                            state.presence.apply_snapshot(&peers, now_ms);
-                        }
-                        PresenceMessage::Left { peer_id } => {
-                            state.presence.remove_peer(&peer_id);
-                        }
-                        PresenceMessage::Heartbeat { peer_id } => {
-                            state.presence.mark_seen(&peer_id, now_ms);
-                        }
-                        PresenceMessage::ClearChannel { peer_id, channel } => {
-                            state.presence.clear_channel(&peer_id, channel);
+                            rebuild_shared_doc_state(&mut state);
+                            None
                         }
                     }
+                };
+
+                // Publish snapshot immediately (before sending ack — readers see changes fast)
+                publish_snapshot(self.doc, self.snapshot_tx);
+
+                // Send ack if needed (outside the lock — never hold across I/O)
+                if let Some(bytes) = ack_bytes {
+                    if let Err(e) = connection::send_typed_frame(
+                        writer,
+                        NotebookFrameType::AutomergeSync,
+                        &bytes,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to send sync ack for {}: {}",
+                            self.notebook_id, e
+                        );
+                    }
                 }
-                Err(e) => {
+            }
+
+            NotebookFrameType::Broadcast => {
+                match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                    Ok(bc) => {
+                        let _ = self.broadcast_tx.send(bc);
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to parse broadcast for {}: {}",
+                            self.notebook_id, e
+                        );
+                    }
+                }
+            }
+
+            NotebookFrameType::Presence => {
+                use notebook_doc::presence::{
+                    decode_message, validate_frame_size, PresenceMessage,
+                };
+
+                if let Err(e) = validate_frame_size(&frame.payload) {
                     debug!(
-                        "[notebook-sync] Failed to decode presence for {}: {}",
-                        notebook_id, e
+                        "[notebook-sync] Dropping oversized presence frame for {}: {}",
+                        self.notebook_id, e
                     );
+                    return;
+                }
+
+                match decode_message(&frame.payload) {
+                    Ok(msg) => {
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+                        let mut state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
+                        match msg {
+                            PresenceMessage::Update {
+                                peer_id,
+                                peer_label,
+                                actor_label,
+                                data,
+                            } => {
+                                let label = peer_label.as_deref().unwrap_or(&peer_id);
+                                state.presence.update_peer(
+                                    &peer_id,
+                                    label,
+                                    actor_label.as_deref(),
+                                    data,
+                                    now_ms,
+                                );
+                            }
+                            PresenceMessage::Snapshot { peers, .. } => {
+                                state.presence.apply_snapshot(&peers, now_ms);
+                            }
+                            PresenceMessage::Left { peer_id } => {
+                                state.presence.remove_peer(&peer_id);
+                            }
+                            PresenceMessage::Heartbeat { peer_id } => {
+                                state.presence.mark_seen(&peer_id, now_ms);
+                            }
+                            PresenceMessage::ClearChannel { peer_id, channel } => {
+                                state.presence.clear_channel(&peer_id, channel);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            "[notebook-sync] Failed to decode presence for {}: {}",
+                            self.notebook_id, e
+                        );
+                    }
                 }
             }
-        }
 
-        NotebookFrameType::Response => {
-            // Unexpected outside of a request/response cycle
-            warn!(
-                "[notebook-sync] Unexpected Response frame for {} in background loop",
-                notebook_id
-            );
-        }
+            NotebookFrameType::Response => {
+                // Unexpected outside of a request/response cycle
+                warn!(
+                    "[notebook-sync] Unexpected Response frame for {} in background loop",
+                    self.notebook_id
+                );
+            }
 
-        NotebookFrameType::Request => {
-            warn!(
-                "[notebook-sync] Unexpected Request frame from daemon for {}",
-                notebook_id
-            );
-        }
+            NotebookFrameType::Request => {
+                warn!(
+                    "[notebook-sync] Unexpected Request frame from daemon for {}",
+                    self.notebook_id
+                );
+            }
 
-        NotebookFrameType::RuntimeStateSync => {
-            let msg = match sync::Message::decode(&frame.payload) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    warn!(
-                        "[notebook-sync] Failed to decode RuntimeStateSync for {}: {}",
-                        notebook_id, e
-                    );
-                    return;
+            NotebookFrameType::RuntimeStateSync => {
+                let msg = match sync::Message::decode(&frame.payload) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to decode RuntimeStateSync for {}: {}",
+                            self.notebook_id, e
+                        );
+                        return;
+                    }
+                };
+
+                // Apply and generate reply — same pattern as AutomergeSync
+                let reply_bytes = {
+                    let mut state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
+                    if let Err(e) = state.receive_state_sync_message(msg) {
+                        warn!(
+                            "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
+                            self.notebook_id, e
+                        );
+                        return;
+                    }
+                    state.generate_state_sync_message().map(|msg| msg.encode())
+                };
+
+                if let Some(bytes) = reply_bytes {
+                    if let Err(e) = connection::send_typed_frame(
+                        writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &bytes,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to send RuntimeStateSync reply for {}: {}",
+                            self.notebook_id, e
+                        );
+                    }
                 }
-            };
+            }
 
-            // Apply and generate reply — same pattern as AutomergeSync
-            let reply_bytes = {
-                let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-                if let Err(e) = state.receive_state_sync_message(msg) {
-                    warn!(
-                        "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
-                        notebook_id, e
-                    );
-                    return;
-                }
-                state.generate_state_sync_message().map(|msg| msg.encode())
-            };
+            NotebookFrameType::PoolStateSync => {
+                // PoolDoc sync is handled by the frontend WASM layer, not the Python client.
+                // Ignore in the Python sync task.
+                debug!(
+                    "[notebook-sync] Ignoring PoolStateSync frame for {} (handled by frontend)",
+                    self.notebook_id
+                );
+            }
 
-            if let Some(bytes) = reply_bytes {
-                if let Err(e) = connection::send_typed_frame(
-                    writer,
-                    NotebookFrameType::RuntimeStateSync,
-                    &bytes,
-                )
-                .await
+            NotebookFrameType::SessionControl => {
+                let message = match serde_json::from_slice::<SessionControlMessage>(&frame.payload)
                 {
-                    warn!(
-                        "[notebook-sync] Failed to send RuntimeStateSync reply for {}: {}",
-                        notebook_id, e
-                    );
-                }
-            }
-        }
+                    Ok(message) => message,
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to parse SessionControl for {}: {}",
+                            self.notebook_id, e
+                        );
+                        return;
+                    }
+                };
 
-        NotebookFrameType::PoolStateSync => {
-            // PoolDoc sync is handled by the frontend WASM layer, not the Python client.
-            // Ignore in the Python sync task.
-            debug!(
-                "[notebook-sync] Ignoring PoolStateSync frame for {} (handled by frontend)",
-                notebook_id
-            );
-        }
-
-        NotebookFrameType::SessionControl => {
-            let message = match serde_json::from_slice::<SessionControlMessage>(&frame.payload) {
-                Ok(message) => message,
-                Err(e) => {
-                    warn!(
-                        "[notebook-sync] Failed to parse SessionControl for {}: {}",
-                        notebook_id, e
-                    );
-                    return;
-                }
-            };
-
-            match message {
-                SessionControlMessage::SyncStatus(status) => {
-                    apply_sync_status(status_tx, notebook_id, saw_session_status, status);
+                match message {
+                    SessionControlMessage::SyncStatus(status) => {
+                        apply_sync_status(
+                            self.status_tx,
+                            self.notebook_id,
+                            self.saw_session_status,
+                            status,
+                        );
+                    }
                 }
             }
         }
@@ -639,18 +661,12 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
 ///
 /// While waiting, also processes AutomergeSync and Broadcast frames that arrive
 /// interleaved with the response.
-#[allow(clippy::too_many_arguments)]
 async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
     writer: &mut W,
-    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
-    status_tx: &watch::Sender<SyncStatus>,
-    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
-    notebook_id: &str,
-    saw_session_status: &mut bool,
+    ctx: &mut SyncFrameContext<'_>,
 ) -> Result<NotebookResponse, SyncError> {
     // Serialize and send the request
     let payload =
@@ -669,17 +685,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     // Wait for a Response frame, processing other frames that arrive meanwhile
     let result = tokio::time::timeout(
         Duration::from_secs(timeout_secs),
-        wait_for_response(
-            doc,
-            reader,
-            writer,
-            snapshot_tx,
-            status_tx,
-            broadcast_tx,
-            req_broadcast_tx,
-            notebook_id,
-            saw_session_status,
-        ),
+        wait_for_response(reader, writer, req_broadcast_tx, ctx),
     )
     .await;
 
@@ -692,15 +698,10 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
 /// Wait for a Response frame from the daemon, processing other frames.
 async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
     writer: &mut W,
-    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
-    status_tx: &watch::Sender<SyncStatus>,
-    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
-    notebook_id: &str,
-    saw_session_status: &mut bool,
+    ctx: &mut SyncFrameContext<'_>,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = connection::recv_typed_frame(reader)
@@ -721,7 +722,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                     .map_err(|e| SyncError::Protocol(format!("Decode sync: {}", e)))?;
 
                 let ack_bytes = {
-                    let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+                    let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
 
                     // Guard both receive and generate against automerge panics
                     let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
@@ -732,7 +733,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                         Ok(Err(e)) => {
                             warn!(
                                 "[notebook-sync] receive_sync_message error in wait_for_response for {}: {}",
-                                notebook_id, e
+                                ctx.notebook_id, e
                             );
                             continue;
                         }
@@ -747,7 +748,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                             warn!(
                                 "[notebook-sync] Automerge panicked in wait_for_response for {} \
                                  (upstream bug): {}",
-                                notebook_id, msg
+                                ctx.notebook_id, msg
                             );
                             rebuild_shared_doc_state(&mut state);
                             continue;
@@ -761,7 +762,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                         Err(_) => {
                             warn!(
                                 "[notebook-sync] generate_sync_message panicked in wait_for_response for {}",
-                                notebook_id
+                                ctx.notebook_id
                             );
                             rebuild_shared_doc_state(&mut state);
                             None
@@ -769,7 +770,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                     }
                 };
 
-                publish_snapshot(doc, snapshot_tx);
+                publish_snapshot(ctx.doc, ctx.snapshot_tx);
 
                 if let Some(bytes) = ack_bytes {
                     connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
@@ -786,7 +787,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                         let _ = tx.send(bc.clone());
                     }
                     // Also send to the main broadcast channel
-                    let _ = broadcast_tx.send(bc);
+                    let _ = ctx.broadcast_tx.send(bc);
                 }
             }
 
@@ -797,17 +798,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             // acknowledges. A dropped RuntimeStateSync causes permanent sync
             // stall for RuntimeStateDoc (no execution results, no status updates).
             _ => {
-                handle_incoming_frame(
-                    &frame,
-                    doc,
-                    writer,
-                    snapshot_tx,
-                    status_tx,
-                    broadcast_tx,
-                    notebook_id,
-                    saw_session_status,
-                )
-                .await;
+                ctx.handle_incoming_frame(&frame, writer).await;
             }
         }
     }
@@ -818,19 +809,14 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 /// Performs sync rounds until our local heads are in the peer's shared_heads,
 /// or until we've done 5 rounds (best-effort).
 async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
     writer: &mut W,
-    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
-    status_tx: &watch::Sender<SyncStatus>,
-    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
-    notebook_id: &str,
-    saw_session_status: &mut bool,
+    ctx: &mut SyncFrameContext<'_>,
 ) -> Result<(), SyncError> {
     for round in 0..5 {
         // Generate and send sync message
         let (msg_bytes, our_heads, shared_heads) = {
-            let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
             let our_heads = state.doc.get_heads();
             let shared = state.peer_state.shared_heads.clone();
             let msg = state.generate_sync_message().map(|m| m.encode());
@@ -841,7 +827,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         if our_heads.is_empty() || our_heads.iter().all(|h| shared_heads.contains(h)) {
             debug!(
                 "[notebook-sync] Sync confirmed for {} after {} rounds",
-                notebook_id, round
+                ctx.notebook_id, round
             );
             return Ok(());
         }
@@ -861,17 +847,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(
-                    &frame,
-                    doc,
-                    writer,
-                    snapshot_tx,
-                    status_tx,
-                    broadcast_tx,
-                    notebook_id,
-                    saw_session_status,
-                )
-                .await;
+                ctx.handle_incoming_frame(&frame, writer).await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(
@@ -885,7 +861,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 // Timeout — try next round
                 debug!(
                     "[notebook-sync] confirm_sync round {} timed out for {}",
-                    round, notebook_id
+                    round, ctx.notebook_id
                 );
             }
         }
@@ -894,7 +870,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     // Best-effort: likely confirmed even if heads don't fully match
     debug!(
         "[notebook-sync] confirm_sync: heads not fully confirmed after 5 rounds for {}",
-        notebook_id
+        ctx.notebook_id
     );
     Ok(())
 }
@@ -905,18 +881,13 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 /// to negotiate. We send our current heads (so the daemon can reply with
 /// anything we're missing) and then drain frames with a short timeout.
 async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
     writer: &mut W,
-    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
-    status_tx: &watch::Sender<SyncStatus>,
-    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
-    notebook_id: &str,
-    saw_session_status: &mut bool,
+    ctx: &mut SyncFrameContext<'_>,
 ) -> Result<(), SyncError> {
     // Send our state doc heads so the daemon knows what we have.
     let msg_bytes = {
-        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
         state.generate_state_sync_message().map(|m| m.encode())
     };
     if let Some(bytes) = msg_bytes {
@@ -934,17 +905,7 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(
-                    &frame,
-                    doc,
-                    writer,
-                    snapshot_tx,
-                    status_tx,
-                    broadcast_tx,
-                    notebook_id,
-                    saw_session_status,
-                )
-                .await;
+                ctx.handle_incoming_frame(&frame, writer).await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -14,7 +14,9 @@ mod tests {
     use crate::handle::DocHandle;
     use crate::shared::SharedDocState;
     use crate::snapshot::NotebookSnapshot;
-    use crate::status::SyncStatus;
+    use crate::status::{
+        ConnectionState, InitialLoadPhase, NotebookDocPhase, RuntimeStatePhase, SyncStatus,
+    };
 
     /// Create a DocHandle wired up with channels but no sync task.
     /// Good for testing the handle's local behavior in isolation.
@@ -46,6 +48,37 @@ mod tests {
         );
 
         (handle, changed_rx, cmd_rx)
+    }
+
+    fn test_handle_with_status() -> (
+        DocHandle,
+        watch::Sender<SyncStatus>,
+        mpsc::UnboundedReceiver<()>,
+        mpsc::Receiver<crate::sync_task::SyncCommand>,
+    ) {
+        // Use NotebookDoc::new() to get a properly initialized doc with schema
+        let nd = notebook_doc::NotebookDoc::new("test-notebook");
+        let doc = nd.into_inner();
+        let shared = Arc::new(Mutex::new(SharedDocState::new(doc, "test-notebook".into())));
+
+        let initial_snapshot = NotebookSnapshot::empty();
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+        let snapshot_tx = Arc::new(snapshot_tx);
+        let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+
+        let handle = DocHandle::new(
+            shared,
+            changed_tx,
+            cmd_tx,
+            snapshot_tx,
+            snapshot_rx,
+            status_rx,
+            "test-notebook".into(),
+        );
+
+        (handle, status_tx, changed_rx, cmd_rx)
     }
 
     #[test]
@@ -216,6 +249,38 @@ mod tests {
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0].id, "cell-a");
         assert_eq!(cells[1].id, "cell-b");
+    }
+
+    #[tokio::test]
+    async fn await_initial_load_ready_waits_for_explicit_session_status() {
+        let (handle, status_tx, _changed_rx, _cmd_rx) = test_handle_with_status();
+
+        let ready = tokio::time::timeout(
+            std::time::Duration::from_millis(20),
+            handle.await_initial_load_ready(),
+        )
+        .await;
+        assert!(
+            ready.is_err(),
+            "await_initial_load_ready should not succeed before the daemon sends SessionControl"
+        );
+
+        status_tx
+            .send(SyncStatus {
+                connection: ConnectionState::Connected,
+                notebook_doc: NotebookDocPhase::Pending,
+                runtime_state: RuntimeStatePhase::Pending,
+                initial_load: InitialLoadPhase::NotNeeded,
+            })
+            .unwrap();
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            handle.await_initial_load_ready(),
+        )
+        .await
+        .expect("await_initial_load_ready should finish after explicit NotNeeded status")
+        .expect("explicit NotNeeded status should be treated as ready");
     }
 
     #[test]

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -14,6 +14,7 @@ mod tests {
     use crate::handle::DocHandle;
     use crate::shared::SharedDocState;
     use crate::snapshot::NotebookSnapshot;
+    use crate::status::SyncStatus;
 
     /// Create a DocHandle wired up with channels but no sync task.
     /// Good for testing the handle's local behavior in isolation.
@@ -30,6 +31,7 @@ mod tests {
         let initial_snapshot = NotebookSnapshot::empty();
         let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
         let snapshot_tx = Arc::new(snapshot_tx);
+        let (_status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
         let (changed_tx, changed_rx) = mpsc::unbounded_channel();
         let (cmd_tx, cmd_rx) = mpsc::channel(32);
 
@@ -39,6 +41,7 @@ mod tests {
             cmd_tx,
             snapshot_tx,
             snapshot_rx,
+            status_rx,
             "test-notebook".into(),
         );
 
@@ -605,6 +608,7 @@ mod tests {
         let initial_snapshot = NotebookSnapshot::empty();
         let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
         let snapshot_tx = Arc::new(snapshot_tx);
+        let (_status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
         let (changed_tx, changed_rx) = mpsc::unbounded_channel();
         let (cmd_tx, cmd_rx) = mpsc::channel(32);
 
@@ -614,6 +618,7 @@ mod tests {
             cmd_tx,
             snapshot_tx,
             snapshot_rx,
+            status_rx,
             "test-notebook".into(),
         );
 

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -192,17 +192,45 @@ async fn rejoin(
             .filter(|p| std::path::Path::new(p.as_str()).exists());
 
         let result = if let Some(path) = use_path {
-            notebook_sync::connect::connect_open(
+            match notebook_sync::connect::connect_open(
                 socket_path.to_path_buf(),
                 PathBuf::from(path),
                 &label,
             )
             .await
-            .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), r.info.notebook_id))
+            {
+                Ok(r) => {
+                    let handle = r.handle;
+                    let broadcast_rx = r.broadcast_rx;
+                    if let Err(e) = handle.await_initial_load_ready().await {
+                        Err(e)
+                    } else {
+                        let cell_count = handle.get_cells().len();
+                        Ok((handle, broadcast_rx, cell_count, r.info.notebook_id))
+                    }
+                }
+                Err(e) => Err(e),
+            }
         } else {
-            notebook_sync::connect::connect(socket_path.to_path_buf(), notebook_id.clone(), &label)
-                .await
-                .map(|r| (r.handle, r.broadcast_rx, r.cells.len(), notebook_id.clone()))
+            match notebook_sync::connect::connect(
+                socket_path.to_path_buf(),
+                notebook_id.clone(),
+                &label,
+            )
+            .await
+            {
+                Ok(r) => {
+                    let handle = r.handle;
+                    let broadcast_rx = r.broadcast_rx;
+                    if let Err(e) = handle.await_initial_load_ready().await {
+                        Err(e)
+                    } else {
+                        let cell_count = handle.get_cells().len();
+                        Ok((handle, broadcast_rx, cell_count, notebook_id.clone()))
+                    }
+                }
+                Err(e) => Err(e),
+            }
         };
 
         match result {

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -292,8 +292,9 @@ pub async fn open_notebook(
             Ok(result) => {
                 let handle = &result.handle;
                 let notebook_id = handle.notebook_id().to_string();
-
-                let _ = handle.confirm_sync().await;
+                if let Err(e) = handle.await_session_ready().await {
+                    return tool_error(&format!("Notebook opened but did not become ready: {}", e));
+                }
 
                 let runtime_info = collect_runtime_info(handle).await;
                 let deps = get_dependencies(handle);
@@ -358,8 +359,12 @@ pub async fn open_notebook(
         {
             Ok(result) => {
                 let handle = &result.handle;
-
-                let _ = handle.confirm_sync().await;
+                if let Err(e) = handle.await_session_ready().await {
+                    return tool_error(&format!(
+                        "Notebook connected but did not become ready: {}",
+                        e
+                    ));
+                }
 
                 let runtime_info = collect_runtime_info(handle).await;
                 let deps = get_dependencies(handle);
@@ -427,6 +432,10 @@ pub async fn create_notebook(
     .await
     {
         Ok(result) => {
+            if let Err(e) = result.handle.await_session_ready().await {
+                return tool_error(&format!("Notebook created but did not become ready: {}", e));
+            }
+
             let notebook_id = result.handle.notebook_id().to_string();
 
             // Announce presence so the peer is visible immediately

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -280,6 +280,12 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
     .await
     .map_err(to_napi_err)?;
 
+    result
+        .handle
+        .await_session_ready()
+        .await
+        .map_err(to_napi_err)?;
+
     let notebook_id = result.info.notebook_id.clone();
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
 
@@ -317,6 +323,12 @@ pub async fn open_notebook(
         notebook_sync::connect::connect(socket_path.clone(), notebook_id.clone(), &actor_label)
             .await
             .map_err(to_napi_err)?;
+
+    result
+        .handle
+        .await_session_ready()
+        .await
+        .map_err(to_napi_err)?;
 
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -260,6 +260,74 @@ fn hydrate_kernel_state(state: &mut SessionState) {
     }
 }
 
+/// Wait for an auto-launched kernel to become usable after notebook creation.
+///
+/// `create_notebook(runtime=...)` is expected to return a session that can
+/// execute immediately. The protocol-v3 session-ready barrier only covers
+/// document/bootstrap sync, so a newly created notebook can still be in the
+/// daemon's kernel `starting` phase. For cold Deno starts this can outlive the
+/// first `execute_cell()` timeout even though the kernel eventually comes up.
+async fn ensure_create_runtime_ready(
+    state: &Arc<Mutex<SessionState>>,
+    timeout: std::time::Duration,
+) -> PyResult<()> {
+    let start = tokio::time::Instant::now();
+    let mut forced_launch = false;
+
+    loop {
+        let (status, runtime) = {
+            let st = state.lock().await;
+            let handle = st
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+            let status = handle
+                .get_runtime_state()
+                .ok()
+                .map(|rs| rs.kernel.status)
+                .unwrap_or_else(|| "not_started".to_string());
+            (status, st.runtime.clone())
+        };
+
+        match status.as_str() {
+            "idle" | "busy" => {
+                let mut st = state.lock().await;
+                hydrate_kernel_state(&mut st);
+                return Ok(());
+            }
+            "starting" => {
+                if start.elapsed() >= timeout {
+                    return Err(to_py_err(format!(
+                        "Kernel did not become ready within {} seconds",
+                        timeout.as_secs()
+                    )));
+                }
+            }
+            "error" => {
+                return Err(to_py_err(
+                    "Kernel auto-launch failed during notebook creation",
+                ));
+            }
+            _ => {
+                if !forced_launch {
+                    start_kernel(state, &runtime, "auto", None).await?;
+                    forced_launch = true;
+                    continue;
+                }
+
+                if start.elapsed() >= timeout {
+                    return Err(to_py_err(format!(
+                        "Kernel did not become ready within {} seconds",
+                        timeout.as_secs()
+                    )));
+                }
+            }
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
 /// Connect and open an existing notebook file.
 ///
 /// Returns (notebook_id, populated SessionState, NotebookConnectionInfo).
@@ -384,6 +452,12 @@ pub(crate) async fn connect_create(
     };
 
     hydrate_kernel_state(&mut state);
+
+    let state_arc = Arc::new(Mutex::new(state));
+    ensure_create_runtime_ready(&state_arc, std::time::Duration::from_secs(180)).await?;
+    let state = Arc::try_unwrap(state_arc)
+        .map_err(|_| to_py_err("Failed to unwrap session state"))?
+        .into_inner();
 
     Ok((notebook_id, state, connection_info))
 }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -181,6 +181,11 @@ pub(crate) async fn connect_with_socket(
         notebook_sync::connect::connect(socket_path.clone(), notebook_id.to_string(), &actor_label)
             .await
             .map_err(to_py_err)?;
+    result
+        .handle
+        .await_session_ready()
+        .await
+        .map_err(to_py_err)?;
 
     // Resolve blob paths from daemon info
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
@@ -275,6 +280,11 @@ pub(crate) async fn connect_open(
         notebook_sync::connect::connect_open(socket_path.clone(), PathBuf::from(path), label)
             .await
             .map_err(to_py_err)?;
+    result
+        .handle
+        .await_session_ready()
+        .await
+        .map_err(to_py_err)?;
 
     let notebook_id = result.info.notebook_id.clone();
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
@@ -344,6 +354,11 @@ pub(crate) async fn connect_create(
     )
     .await
     .map_err(to_py_err)?;
+    result
+        .handle
+        .await_session_ready()
+        .await
+        .map_err(to_py_err)?;
 
     let notebook_id = result.info.notebook_id.clone();
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -262,11 +262,10 @@ fn hydrate_kernel_state(state: &mut SessionState) {
 
 /// Wait for an auto-launched kernel to become usable after notebook creation.
 ///
-/// `create_notebook(runtime=...)` is expected to return a session that can
-/// execute immediately. The protocol-v3 session-ready barrier only covers
-/// document/bootstrap sync, so a newly created notebook can still be in the
-/// daemon's kernel `starting` phase. For cold Deno starts this can outlive the
-/// first `execute_cell()` timeout even though the kernel eventually comes up.
+/// This is currently used only for runtimes whose create contract expects a
+/// ready-to-execute kernel on return. Python notebook creation is looser:
+/// project-file auto-launch can legitimately fail or defer while the session
+/// itself is still usable for later explicit kernel start.
 async fn ensure_create_runtime_ready(
     state: &Arc<Mutex<SessionState>>,
     timeout: std::time::Duration,
@@ -454,7 +453,9 @@ pub(crate) async fn connect_create(
     hydrate_kernel_state(&mut state);
 
     let state_arc = Arc::new(Mutex::new(state));
-    ensure_create_runtime_ready(&state_arc, std::time::Duration::from_secs(180)).await?;
+    if runtime == "deno" {
+        ensure_create_runtime_ready(&state_arc, std::time::Duration::from_secs(180)).await?;
+    }
     let state = Arc::try_unwrap(state_arc)
         .map_err(|_| to_py_err("Failed to unwrap session state"))?
         .into_inner();

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -80,6 +80,44 @@ impl OutputChangeset {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SessionControlMessage {
+    SyncStatus(SessionSyncStatusWire),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SessionSyncStatusWire {
+    pub notebook_doc: NotebookDocPhaseWire,
+    pub runtime_state: RuntimeStatePhaseWire,
+    pub initial_load: InitialLoadPhaseWire,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotebookDocPhaseWire {
+    Pending,
+    Syncing,
+    Interactive,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStatePhaseWire {
+    Pending,
+    Syncing,
+    Ready,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum InitialLoadPhaseWire {
+    NotNeeded,
+    Streaming,
+    Ready,
+    Failed { reason: String },
+}
+
 /// Event returned from `receive_frame()` for the frontend to handle.
 ///
 /// Converted directly to a JS object via `serde-wasm-bindgen` — no JSON
@@ -116,6 +154,11 @@ pub enum FrameEvent {
     Presence {
         /// The decoded presence message (decoded from CBOR, passed through as-is).
         payload: serde_json::Value,
+    },
+    /// Connection-local session status from the daemon.
+    SessionControl {
+        /// Full bootstrap/readiness snapshot for this socket.
+        status: SessionSyncStatusWire,
     },
     /// Runtime state document was synced — frontend should update runtime state UI.
     RuntimeStateSyncApplied {
@@ -1705,6 +1748,22 @@ impl NotebookHandle {
                     }
                 };
                 events.push(FrameEvent::Presence { payload: value });
+            }
+            frame_types::SESSION_CONTROL => {
+                let msg = match serde_json::from_slice::<SessionControlMessage>(payload) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        web_sys::console::warn_1(
+                            &format!("[wasm] session_control frame parse failed: {e}").into(),
+                        );
+                        return JsValue::UNDEFINED;
+                    }
+                };
+                match msg {
+                    SessionControlMessage::SyncStatus(status) => {
+                        events.push(FrameEvent::SessionControl { status });
+                    }
+                }
             }
             frame_types::RUNTIME_STATE_SYNC => {
                 // Apply daemon's RuntimeStateDoc sync message to our local replica.

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -80,6 +80,34 @@ Deno.test("NotebookHandle: add cell and read back", () => {
   handle.free();
 });
 
+Deno.test("NotebookHandle: receive_frame decodes session_control", () => {
+  const handle = new NotebookHandle("test-status");
+  const payload = new TextEncoder().encode(
+    JSON.stringify({
+      type: "sync_status",
+      notebook_doc: "pending",
+      runtime_state: "syncing",
+      initial_load: { phase: "streaming" },
+    }),
+  );
+  const frame = new Uint8Array(1 + payload.length);
+  frame[0] = 0x07;
+  frame.set(payload, 1);
+
+  const events = handle.receive_frame(frame);
+  assertExists(events);
+  assertEquals(events.length, 1);
+  assertEquals(events[0], {
+    type: "session_control",
+    status: {
+      notebook_doc: "pending",
+      runtime_state: "syncing",
+      initial_load: { phase: "streaming" },
+    },
+  });
+  handle.free();
+});
+
 Deno.test("NotebookHandle: update source with Text CRDT", () => {
   const handle = new NotebookHandle("test-nb");
   handle.add_cell(0, "cell-1", "code");

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1743,7 +1743,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V2, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
@@ -1774,7 +1774,7 @@ impl Daemon {
             error: String,
         ) -> anyhow::Result<()> {
             let response = NotebookConnectionInfo {
-                protocol: PROTOCOL_V2.to_string(),
+                protocol: PROTOCOL_V3.to_string(),
                 protocol_version: Some(PROTOCOL_VERSION),
                 daemon_version: Some(crate::daemon_version().to_string()),
                 notebook_id: String::new(),
@@ -2017,7 +2017,7 @@ impl Daemon {
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
-            protocol: PROTOCOL_V2.to_string(),
+            protocol: PROTOCOL_V3.to_string(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some(crate::daemon_version().to_string()),
             notebook_id: room.id.to_string(),
@@ -2068,7 +2068,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V2, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,
         };
 
         info!(
@@ -2143,7 +2143,7 @@ impl Daemon {
             }
             let (mut reader, mut writer) = tokio::io::split(stream);
             let response = NotebookConnectionInfo {
-                protocol: PROTOCOL_V2.to_string(),
+                protocol: PROTOCOL_V3.to_string(),
                 protocol_version: Some(PROTOCOL_VERSION),
                 daemon_version: Some(crate::daemon_version().to_string()),
                 notebook_id: String::new(),
@@ -2163,7 +2163,7 @@ impl Daemon {
         // provided a notebook_id_hint — room.id is the canonical source.
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
-            protocol: PROTOCOL_V2.to_string(),
+            protocol: PROTOCOL_V3.to_string(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some(crate::daemon_version().to_string()),
             notebook_id: room.id.to_string(),

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -515,10 +515,10 @@ where
         }
     }
 
-    // Send capabilities response (v2 protocol) unless already sent via NotebookConnectionInfo
+    // Send capabilities response (v3 protocol) unless already sent via NotebookConnectionInfo
     if !skip_capabilities {
         let caps = connection::ProtocolCapabilities {
-            protocol: connection::PROTOCOL_V2.to_string(),
+            protocol: connection::PROTOCOL_V3.to_string(),
             protocol_version: Some(connection::PROTOCOL_VERSION),
             daemon_version: Some(crate::daemon_version().to_string()),
         };
@@ -529,20 +529,6 @@ where
     // whether the sync loop exits with Ok or Err.
     let peer_id = uuid::Uuid::new_v4().to_string();
 
-    // Pre-send the initial notebook-doc AutomergeSync frame BEFORE entering
-    // the background sync loop. This guarantees the first AutomergeSync
-    // frame is on the wire before the client's `do_initial_sync` starts
-    // ticking its 100ms-per-frame convergence timeout.
-    // Without this ordering, under CI load a spawned-but-unscheduled handler
-    // task can race with the client's timeout, flaking tests like
-    // `test_pipe_mode_forwards_sync_frames`.
-    //
-    // State/pool/presence initial syncs stay inside `run_sync_loop_v2`
-    // because they must run AFTER streaming load populates per-cell
-    // outputs in the RuntimeStateDoc, and AFTER the broadcast channels
-    // are subscribed.
-    let initial_sync_state = send_initial_notebook_doc_sync(&mut writer, &room).await?;
-
     let result = run_sync_loop_v2(
         &mut reader,
         &mut writer,
@@ -552,7 +538,6 @@ where
         daemon.clone(),
         needs_load.as_deref(),
         &peer_id,
-        initial_sync_state,
     )
     .await;
 
@@ -996,8 +981,31 @@ pub(crate) fn sanitize_peer_label(raw: Option<&str>, fallback: &str) -> String {
     }
 }
 
-/// State carried from the pre-send initial notebook-doc sync into the
-/// steady-state loop.
+async fn send_session_status<W>(
+    writer: &mut W,
+    notebook_doc: notebook_protocol::protocol::NotebookDocPhaseWire,
+    runtime_state: notebook_protocol::protocol::RuntimeStatePhaseWire,
+    initial_load: notebook_protocol::protocol::InitialLoadPhaseWire,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    connection::send_typed_json_frame(
+        writer,
+        NotebookFrameType::SessionControl,
+        &notebook_protocol::protocol::SessionControlMessage::SyncStatus(
+            notebook_protocol::protocol::SessionSyncStatusWire {
+                notebook_doc,
+                runtime_state,
+                initial_load,
+            },
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// State carried from the initial notebook-doc sync into the steady-state loop.
 ///
 /// See [`send_initial_notebook_doc_sync`]. `peer_state` tracks what the
 /// daemon has already advertised about the notebook doc so subsequent
@@ -1015,26 +1023,9 @@ impl InitialSyncState {
     }
 }
 
-/// Generate and send the initial notebook-doc AutomergeSync frame before
-/// entering the background sync loop.
+/// Generate and send the initial notebook-doc AutomergeSync frame.
 ///
-/// Runs synchronously as part of the handshake path so the first
-/// AutomergeSync frame is on the wire before the client's `do_initial_sync`
-/// starts ticking its 100ms-per-frame convergence timeout. Without this
-/// ordering, under CI load the per-connection handler can be
-/// spawned-but-not-yet-scheduled while the client is already timing out
-/// waiting for the first sync frame, which flakes
-/// `test_pipe_mode_forwards_sync_frames` and similar sync-sensitive tests.
-///
-/// Only the notebook-doc frame is pre-sent. The RuntimeStateDoc/PoolDoc
-/// initial syncs and the eager RuntimeStateSnapshot/presence broadcasts
-/// continue to run inside `run_sync_loop_v2` AFTER `streaming_load_cells`
-/// populates per-cell outputs, and AFTER the broadcast channels are
-/// subscribed. Pre-sending those here would either advertise an empty
-/// state doc or drop auto-launch broadcasts that land between pre-send
-/// and subscription.
-///
-/// Returns the `peer_state` so the steady-state loop (and streaming load)
+/// Returns the `peer_state` so the rest of bootstrap (and streaming load)
 /// continues from the same baseline and emits correct deltas.
 pub(crate) async fn send_initial_notebook_doc_sync<W>(
     writer: &mut W,
@@ -1079,11 +1070,6 @@ where
 ///
 /// Handles both Automerge sync messages and NotebookRequest messages.
 /// This protocol supports daemon-owned kernel execution (Phase 8).
-///
-/// The caller must have already run [`send_initial_notebook_doc_sync`] and
-/// pass the resulting [`InitialSyncState`] via `initial_sync_state` so the
-/// streaming load and steady-state loop continue on the same notebook-doc
-/// `peer_state`.
 #[allow(clippy::too_many_arguments)]
 async fn run_sync_loop_v2<R, W>(
     reader: &mut R,
@@ -1094,63 +1080,13 @@ async fn run_sync_loop_v2<R, W>(
     daemon: std::sync::Arc<crate::daemon::Daemon>,
     needs_load: Option<&Path>,
     peer_id: &str,
-    initial_sync_state: InitialSyncState,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    let InitialSyncState { mut peer_state } = initial_sync_state;
-
-    // Streaming load: add cells in batches and sync after each batch so
-    // the frontend renders progressively. This runs before we subscribe
-    // to changed_rx to avoid backlog from our own notifications.
-    //
-    // The initial AutomergeSync frame generated before this loop used the
-    // empty-doc peer_state; streaming_load_cells continues on the same
-    // peer_state so each batch emits a delta against what the client has
-    // already been told about. streaming_load_cells also writes synthetic
-    // execution outputs into the RuntimeStateDoc — that's why the initial
-    // RuntimeStateDoc sync below runs AFTER load, not before.
-    if let Some(load_path) = needs_load {
-        if room.try_start_loading() {
-            match streaming_load_cells(reader, writer, room, load_path, &mut peer_state).await {
-                Ok(count) => {
-                    room.finish_loading();
-                    info!(
-                        "[notebook-sync] Streaming load complete: {} cells from {}",
-                        count,
-                        load_path.display()
-                    );
-                }
-                Err(e) => {
-                    room.finish_loading();
-                    // Clear partial cells so the next connection can retry
-                    {
-                        let mut doc = room.doc.write().await;
-                        let _ = doc.clear_all_cells();
-                    }
-                    // Notify other peers so they converge to the cleared state
-                    let _ = room.changed_tx.send(());
-                    warn!(
-                        "[notebook-sync] Streaming load failed for {}: {}",
-                        load_path.display(),
-                        e
-                    );
-                    return Err(anyhow::anyhow!("Streaming load failed: {}", e));
-                }
-            }
-        }
-        // If we lost the race (try_start_loading returned false), another
-        // connection is loading. We'll pick up cells via changed_rx below.
-    }
-
-    // Subscribe to change notifications BEFORE sending the state/pool
-    // initial syncs and eager snapshots, so any writes that land between
-    // the snapshot read and the select loop are still delivered to this
-    // peer as steady-state deltas. Without this, an auto-launch broadcast
-    // (kernel status, env progress) fired during connection setup could
-    // fall into the gap between "snapshot read" and "subscribe".
+    // Subscribe before sending bootstrap traffic so any writes that land
+    // during connection setup are still observed as steady-state deltas.
     let mut changed_rx = room.changed_tx.subscribe();
     let mut kernel_broadcast_rx = room.kernel_broadcast_tx.subscribe();
     let mut presence_rx = room.presence_tx.subscribe();
@@ -1159,10 +1095,36 @@ where
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
     let mut pool_changed_rx = daemon.pool_doc_changed.subscribe();
 
+    let mut notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Pending;
+    let mut runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Pending;
+    let mut initial_load_phase = if needs_load.is_some() {
+        notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
+    } else {
+        notebook_protocol::protocol::InitialLoadPhaseWire::NotNeeded
+    };
+
+    send_session_status(
+        writer,
+        notebook_doc_phase,
+        runtime_state_phase,
+        initial_load_phase.clone(),
+    )
+    .await?;
+
+    let InitialSyncState { mut peer_state } = send_initial_notebook_doc_sync(writer, room).await?;
+    notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Syncing;
+    send_session_status(
+        writer,
+        notebook_doc_phase,
+        runtime_state_phase,
+        initial_load_phase.clone(),
+    )
+    .await?;
+
     let mut state_peer_state = sync::State::new();
     let mut pool_peer_state = sync::State::new();
 
-    // Phase 1.1: Initial RuntimeStateDoc sync — encode inside lock, send outside.
+    // Initial RuntimeStateDoc sync — encode inside lock, send outside.
     // Uses bounded generation to compact atomically if the message would exceed
     // the 100 MiB frame limit.
     let initial_state_encoded = {
@@ -1193,8 +1155,64 @@ where
     if let Some(encoded) = initial_state_encoded {
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
     }
+    runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Syncing;
+    send_session_status(
+        writer,
+        notebook_doc_phase,
+        runtime_state_phase,
+        initial_load_phase.clone(),
+    )
+    .await?;
 
-    // Phase 1.1b: Initial PoolDoc sync — global pool state
+    // Streaming load: add cells in batches and sync after each batch so the
+    // frontend can observe progressive notebook-doc updates.
+    if let Some(load_path) = needs_load {
+        if room.try_start_loading() {
+            match streaming_load_cells(reader, writer, room, load_path, &mut peer_state).await {
+                Ok(count) => {
+                    room.finish_loading();
+                    info!(
+                        "[notebook-sync] Streaming load complete: {} cells from {}",
+                        count,
+                        load_path.display()
+                    );
+                    initial_load_phase = notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
+                    send_session_status(
+                        writer,
+                        notebook_doc_phase,
+                        runtime_state_phase,
+                        initial_load_phase.clone(),
+                    )
+                    .await?;
+                }
+                Err(e) => {
+                    room.finish_loading();
+                    {
+                        let mut doc = room.doc.write().await;
+                        let _ = doc.clear_all_cells();
+                    }
+                    let _ = room.changed_tx.send(());
+                    warn!(
+                        "[notebook-sync] Streaming load failed for {}: {}",
+                        load_path.display(),
+                        e
+                    );
+                    send_session_status(
+                        writer,
+                        notebook_doc_phase,
+                        runtime_state_phase,
+                        notebook_protocol::protocol::InitialLoadPhaseWire::Failed {
+                            reason: e.clone(),
+                        },
+                    )
+                    .await?;
+                    return Err(anyhow::anyhow!("Streaming load failed: {}", e));
+                }
+            }
+        }
+    }
+
+    // Initial PoolDoc sync — global pool state
     let initial_pool_encoded = {
         let mut pool_doc = daemon.pool_doc.write().await;
         match catch_automerge_panic("initial-pool-sync", || {
@@ -1215,23 +1233,6 @@ where
     };
     if let Some(encoded) = initial_pool_encoded {
         connection::send_typed_frame(writer, NotebookFrameType::PoolStateSync, &encoded).await?;
-    }
-
-    // Phase 1.2: Eagerly send RuntimeState snapshot so the client has
-    // kernel status immediately, without waiting for Automerge sync convergence.
-    // The sync handshake takes multiple roundtrips; by the time it completes,
-    // transient states like starting phases may have already passed.
-    {
-        let state = {
-            let sd = room.state_doc.read().await;
-            sd.read_state()
-        };
-        connection::send_typed_json_frame(
-            writer,
-            NotebookFrameType::Broadcast,
-            &NotebookBroadcast::RuntimeStateSnapshot { state },
-        )
-        .await?;
     }
 
     // Phase 1.5 (removed): CommSync broadcast is no longer needed.
@@ -1362,6 +1363,20 @@ where
                                         writer,
                                         NotebookFrameType::AutomergeSync,
                                         &encoded,
+                                    )
+                                    .await?;
+                                }
+
+                                if notebook_doc_phase
+                                    != notebook_protocol::protocol::NotebookDocPhaseWire::Interactive
+                                {
+                                    notebook_doc_phase =
+                                        notebook_protocol::protocol::NotebookDocPhaseWire::Interactive;
+                                    send_session_status(
+                                        writer,
+                                        notebook_doc_phase,
+                                        runtime_state_phase,
+                                        initial_load_phase.clone(),
                                     )
                                     .await?;
                                 }
@@ -1591,6 +1606,20 @@ where
                                     )
                                     .await?;
                                 }
+
+                                if runtime_state_phase
+                                    != notebook_protocol::protocol::RuntimeStatePhaseWire::Ready
+                                {
+                                    runtime_state_phase =
+                                        notebook_protocol::protocol::RuntimeStatePhaseWire::Ready;
+                                    send_session_status(
+                                        writer,
+                                        notebook_doc_phase,
+                                        runtime_state_phase,
+                                        initial_load_phase.clone(),
+                                    )
+                                    .await?;
+                                }
                             }
 
                             NotebookFrameType::PoolStateSync => {
@@ -1646,7 +1675,9 @@ where
                                 }
                             }
 
-                            NotebookFrameType::Response | NotebookFrameType::Broadcast => {
+                            NotebookFrameType::Response
+                            | NotebookFrameType::Broadcast
+                            | NotebookFrameType::SessionControl => {
                                 // Clients shouldn't send these
                                 warn!(
                                     "[notebook-sync] Unexpected frame type from client: {:?}",
@@ -1690,6 +1721,24 @@ where
                         writer,
                         NotebookFrameType::AutomergeSync,
                         &encoded,
+                    )
+                    .await?;
+                }
+
+                if matches!(
+                    initial_load_phase,
+                    notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
+                ) && !room
+                    .is_loading
+                    .load(std::sync::atomic::Ordering::Acquire)
+                {
+                    initial_load_phase =
+                        notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
+                    send_session_status(
+                        writer,
+                        notebook_doc_phase,
+                        runtime_state_phase,
+                        initial_load_phase.clone(),
                     )
                     .await?;
                 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -130,6 +130,13 @@ async fn wait_for_cells_map(handle: &notebook_sync::DocHandle, timeout: Duration
     false
 }
 
+async fn wait_for_session_ready(handle: &notebook_sync::DocHandle, timeout: Duration) -> bool {
+    matches!(
+        tokio::time::timeout(timeout, handle.await_session_ready()).await,
+        Ok(Ok(()))
+    )
+}
+
 #[cfg(unix)]
 type LegacyPoolStream = tokio::net::UnixStream;
 
@@ -427,14 +434,13 @@ async fn test_notebook_sync_via_unified_socket() {
     let notebook_id_1 = result1.info.notebook_id.clone();
     let client1 = result1.handle;
 
+    assert!(
+        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        "client1 should reach session-ready state within 2s"
+    );
+
     let cells = client1.get_cells();
     assert!(cells.is_empty(), "new notebook should have no cells");
-
-    // Wait for the daemon's document structure (cells map) to sync to the client.
-    // connect_create() returns after the initial handshake, but the background sync
-    // task may not have delivered the cells Map yet.
-    let mut watcher = client1.subscribe();
-    let _ = tokio::time::timeout(Duration::from_secs(2), watcher.changed()).await;
 
     // Add a cell from client1
     client1.add_cell_after("cell-1", "code", None).unwrap();
@@ -445,6 +451,11 @@ async fn test_notebook_sync_via_unified_socket() {
         .await
         .expect("client2 should connect")
         .handle;
+
+    assert!(
+        wait_for_session_ready(&client2, Duration::from_secs(2)).await,
+        "client2 should reach session-ready state within 2s"
+    );
 
     let cells = client2.get_cells();
     assert_eq!(cells.len(), 1, "client2 should see the cell from client1");
@@ -457,6 +468,11 @@ async fn test_notebook_sync_via_unified_socket() {
         .await
         .expect("client3 should connect")
         .handle;
+
+    assert!(
+        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        "client3 should reach session-ready state within 2s"
+    );
 
     let cells = client3.get_cells();
     assert!(cells.is_empty(), "different notebook should have no cells");
@@ -491,23 +507,28 @@ async fn test_notebook_sync_cross_window_propagation() {
         .unwrap()
         .handle;
 
-    // Wait for the daemon's document structure (cells map) to sync to client1.
-    let mut watcher1 = client1.subscribe();
-    let _ = tokio::time::timeout(Duration::from_secs(2), watcher1.changed()).await;
+    assert!(
+        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        "client1 should reach session-ready state within 2s"
+    );
+    assert!(
+        wait_for_session_ready(&client2, Duration::from_secs(2)).await,
+        "client2 should reach session-ready state within 2s"
+    );
+
+    let mut watcher = client2.subscribe();
 
     // Client1 adds a cell
     client1.add_cell_after("c1", "code", None).unwrap();
     client1.update_source("c1", "x = 42").unwrap();
+    client1.confirm_sync().await.unwrap();
 
     // Client2 should receive the changes
-    let mut watcher = client2.subscribe();
-    let _ = tokio::time::timeout(Duration::from_millis(500), watcher.changed()).await;
-    let cells = client2.get_cells();
-    assert!(!cells.is_empty(), "client2 should receive propagated cells");
-
-    // May need additional recv rounds for full convergence
-    let mut final_cells = cells;
-    for _ in 0..5 {
+    let mut final_cells = client2.get_cells();
+    for _ in 0..10 {
+        if final_cells.iter().any(|c| c.id == "c1") {
+            break;
+        }
         match tokio::time::timeout(Duration::from_millis(200), watcher.changed()).await {
             Ok(Ok(())) => final_cells = client2.get_cells(),
             _ => break,
@@ -561,11 +582,10 @@ async fn test_untitled_notebook_persists_through_eviction() {
             .unwrap()
             .handle;
 
-        // Wait for the daemon's document structure (cells map) to arrive via
-        // background sync — connect_create returns after handshake but the Map
-        // may not be delivered yet on slow CI runners.
-        let mut watcher = client1.subscribe();
-        let _ = tokio::time::timeout(Duration::from_secs(2), watcher.changed()).await;
+        assert!(
+            wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+            "client1 should reach session-ready state within 2s"
+        );
 
         client1.add_cell_after("c1", "code", None).unwrap();
         client1.update_source("c1", "persisted = True").unwrap();
@@ -573,6 +593,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
             .add_cell_after("c2", "markdown", Some("c1"))
             .unwrap();
         client1.update_source("c2", "# Hello World").unwrap();
+        client1.confirm_sync().await.unwrap();
 
         // Both clients drop here — the room should be evicted from memory
     }
@@ -618,6 +639,11 @@ async fn test_untitled_notebook_persists_through_eviction() {
         .await
         .expect("should reconnect after room eviction")
         .handle;
+
+    assert!(
+        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        "reconnected client should reach session-ready state within 2s"
+    );
 
     let cells = client3.get_cells();
     assert_eq!(
@@ -678,8 +704,10 @@ async fn test_eviction_flushes_before_reconnect() {
         notebook_id = result.info.notebook_id.clone();
         let client = result.handle;
 
-        let mut watcher = client.subscribe();
-        let _ = tokio::time::timeout(Duration::from_secs(2), watcher.changed()).await;
+        assert!(
+            wait_for_session_ready(&client, Duration::from_secs(2)).await,
+            "client should reach session-ready state within 2s"
+        );
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "race_test = 1").unwrap();
@@ -689,6 +717,7 @@ async fn test_eviction_flushes_before_reconnect() {
         client
             .update_source("c3", "# Race regression guard")
             .unwrap();
+        client.confirm_sync().await.unwrap();
     }
 
     // Reconnect fast — no sleep. The fix's flush-and-ack ensures the room's
@@ -748,9 +777,10 @@ async fn test_notebook_cell_delete_propagation() {
     let notebook_id = result.info.notebook_id.clone();
     let client1 = result.handle;
 
-    // Wait for the daemon's document structure (cells map) to sync to client1.
-    let mut watcher1 = client1.subscribe();
-    let _ = tokio::time::timeout(Duration::from_secs(2), watcher1.changed()).await;
+    assert!(
+        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        "client1 should reach session-ready state within 2s"
+    );
 
     client1.add_cell_after("keep-1", "code", None).unwrap();
     client1
@@ -762,6 +792,7 @@ async fn test_notebook_cell_delete_propagation() {
     client1.update_source("keep-1", "a = 1").unwrap();
     client1.update_source("to-delete", "b = 2").unwrap();
     client1.update_source("keep-2", "c = 3").unwrap();
+    client1.confirm_sync().await.unwrap();
 
     // Client2 joins and verifies all three cells
     let client2 = connect::connect(socket_path.clone(), notebook_id, "test")
@@ -790,6 +821,7 @@ async fn test_notebook_cell_delete_propagation() {
 
     // Client1 deletes the middle cell
     client1.delete_cell("to-delete").unwrap();
+    client1.confirm_sync().await.unwrap();
 
     // Client2 receives the deletion
     let mut watcher = client2.subscribe();
@@ -855,12 +887,17 @@ async fn test_multiple_notebooks_concurrent_isolation() {
     let nb_b = nb_b.handle;
     let nb_c = nb_c.handle;
 
-    // Wait for the daemon's document structure (cells map) to sync to each client.
-    let (mut wa, mut wb, mut wc) = (nb_a.subscribe(), nb_b.subscribe(), nb_c.subscribe());
-    let _ = tokio::join!(
-        tokio::time::timeout(Duration::from_secs(2), wa.changed()),
-        tokio::time::timeout(Duration::from_secs(2), wb.changed()),
-        tokio::time::timeout(Duration::from_secs(2), wc.changed()),
+    assert!(
+        wait_for_session_ready(&nb_a, Duration::from_secs(2)).await,
+        "alpha notebook should reach session-ready state within 2s"
+    );
+    assert!(
+        wait_for_session_ready(&nb_b, Duration::from_secs(2)).await,
+        "beta notebook should reach session-ready state within 2s"
+    );
+    assert!(
+        wait_for_session_ready(&nb_c, Duration::from_secs(2)).await,
+        "gamma notebook should reach session-ready state within 2s"
     );
 
     // Add cells to each notebook
@@ -879,6 +916,11 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         .unwrap();
     nb_c.add_cell_after("gamma-3", "code", Some("gamma-2"))
         .unwrap();
+    let _ = tokio::join!(
+        nb_a.confirm_sync(),
+        nb_b.confirm_sync(),
+        nb_c.confirm_sync()
+    );
 
     // Verify each notebook is isolated by connecting fresh clients
     let (fresh_a, fresh_b, fresh_c) = tokio::join!(
@@ -887,12 +929,29 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         connect::connect(socket_path.clone(), id_c, "test"),
     );
 
-    let cells_a = fresh_a.unwrap().handle.get_cells();
+    let handle_a = fresh_a.unwrap().handle;
+    let handle_b = fresh_b.unwrap().handle;
+    let handle_c = fresh_c.unwrap().handle;
+
+    assert!(
+        wait_for_session_ready(&handle_a, Duration::from_secs(2)).await,
+        "alpha client should reach session-ready state within 2s"
+    );
+    assert!(
+        wait_for_session_ready(&handle_b, Duration::from_secs(2)).await,
+        "beta client should reach session-ready state within 2s"
+    );
+    assert!(
+        wait_for_session_ready(&handle_c, Duration::from_secs(2)).await,
+        "gamma client should reach session-ready state within 2s"
+    );
+
+    let cells_a = handle_a.get_cells();
     assert_eq!(cells_a.len(), 1, "alpha should have 1 cell");
     assert_eq!(cells_a[0].id, "alpha-1");
     assert_eq!(cells_a[0].source, "print('alpha')");
 
-    let cells_b = fresh_b.unwrap().handle.get_cells();
+    let cells_b = handle_b.get_cells();
     assert_eq!(cells_b.len(), 2, "beta should have 2 cells");
     assert!(cells_b
         .iter()
@@ -901,7 +960,7 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         .iter()
         .any(|c| c.id == "beta-2" && c.source == "x = 99"));
 
-    let cells_c = fresh_c.unwrap().handle.get_cells();
+    let cells_c = handle_c.get_cells();
     assert_eq!(cells_c.len(), 3, "gamma should have 3 cells");
     assert!(cells_c
         .iter()
@@ -973,7 +1032,6 @@ async fn test_streaming_load_via_open_notebook() {
         .await
         .expect("should connect and open notebook");
     let handle = result.handle;
-    let initial_cells = result.cells;
     let info = result.info;
 
     // Handshake reports 0 cells (streaming load is deferred)
@@ -981,9 +1039,8 @@ async fn test_streaming_load_via_open_notebook() {
     assert!(info.error.is_none());
 
     // The sync task runs in the background. Wait for cells to arrive.
-    // In pipe mode, initial_cells may be empty; cells come via sync.
     let start = std::time::Instant::now();
-    let mut cells = initial_cells;
+    let mut cells = handle.get_cells();
     while cells.len() < 7 && start.elapsed() < Duration::from_secs(5) {
         sleep(Duration::from_millis(50)).await;
         cells = handle.get_cells();
@@ -1315,6 +1372,10 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     .await
     .unwrap()
     .handle;
+    assert!(
+        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
+        "initial sync did not deliver the cells map within 2s"
+    );
     client2.add_cell_after("bc-cell", "code", None).unwrap();
     client2.update_source("bc-cell", "x = 1").unwrap();
 
@@ -1334,19 +1395,21 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     );
 
     // Every piped frame must have a valid type byte from the forwarded set:
-    // AutomergeSync, Broadcast, Presence, or RuntimeStateSync — never Request or Response.
+    // AutomergeSync, Broadcast, Presence, RuntimeStateSync, PoolStateSync,
+    // or SessionControl — never Request or Response.
     let allowed_types = [
         frame_types::AUTOMERGE_SYNC,
         frame_types::BROADCAST,
         frame_types::PRESENCE,
         frame_types::RUNTIME_STATE_SYNC,
         frame_types::POOL_STATE_SYNC,
+        frame_types::SESSION_CONTROL,
     ];
     for (i, frame) in frames.iter().enumerate() {
         assert!(!frame.is_empty(), "frame {} should not be empty", i);
         assert!(
             allowed_types.contains(&frame[0]),
-            "frame {} has unexpected type byte 0x{:02x} — only AUTOMERGE_SYNC, BROADCAST, PRESENCE, RUNTIME_STATE_SYNC, and POOL_STATE_SYNC are piped",
+            "frame {} has unexpected type byte 0x{:02x} — only AUTOMERGE_SYNC, BROADCAST, PRESENCE, RUNTIME_STATE_SYNC, POOL_STATE_SYNC, and SESSION_CONTROL are piped",
             i,
             frame[0]
         );
@@ -1540,6 +1603,10 @@ async fn test_pipe_mode_preserves_frame_order() {
     .await
     .unwrap()
     .handle;
+    assert!(
+        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        "third client should reach session-ready state within 2s"
+    );
     let cells = client3.get_cells();
     assert_eq!(cells.len(), 3, "third client should see all 3 cells");
     assert_eq!(cells[0].id, "cell-1");

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1337,6 +1337,49 @@ async fn test_pipe_mode_forwards_sync_frames() {
 }
 
 #[tokio::test]
+async fn test_pipe_mode_preserves_initial_session_status_frame() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+
+    let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+
+    let _result = connect::connect_relay(
+        socket_path.clone(),
+        "00000000-0000-0000-0000-000000000011".to_string(),
+        frame_tx,
+    )
+    .await
+    .unwrap();
+
+    let first_frame = tokio::time::timeout(Duration::from_secs(2), frame_rx.recv())
+        .await
+        .expect("relay should receive an initial daemon frame")
+        .expect("relay channel should stay open");
+
+    assert!(
+        !first_frame.is_empty(),
+        "initial relayed frame should include a type byte"
+    );
+    assert_eq!(
+        first_frame[0],
+        frame_types::SESSION_CONTROL,
+        "relay should preserve the daemon's initial SessionControl frame"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -15,7 +15,13 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import type { FrameListener, NotebookRequest, NotebookResponse, NotebookTransport } from "runtimed";
+import {
+  FrameType,
+  type FrameListener,
+  type NotebookRequest,
+  type NotebookResponse,
+  type NotebookTransport,
+} from "runtimed";
 
 const FRAME_TYPE_REQUEST = 0x01;
 const FRAME_TYPE_RESPONSE = 0x02;
@@ -54,6 +60,9 @@ export class TauriTransport implements NotebookTransport {
   }
 
   async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    if (frameType === FrameType.SESSION_CONTROL) {
+      throw new Error("SESSION_CONTROL is server-originated only");
+    }
     const frame = new Uint8Array(1 + payload.length);
     frame[0] = frameType;
     frame.set(payload, 1);

--- a/packages/runtimed/src/broadcast-types.ts
+++ b/packages/runtimed/src/broadcast-types.ts
@@ -6,8 +6,6 @@
  * the untyped `broadcasts$` observable into typed sub-streams.
  */
 
-import type { RuntimeState } from "./runtime-state";
-
 // ── Broadcast interfaces ────────────────────────────────────────────
 
 export interface OutputBroadcast {
@@ -42,19 +40,13 @@ export interface KernelErrorBroadcast {
   error: string;
 }
 
-export interface RuntimeStateSnapshotBroadcast {
-  event: "runtime_state_snapshot";
-  state: RuntimeState;
-}
-
 /** Union of all known broadcast types with an `event` field. */
 export type KnownBroadcast =
   | OutputBroadcast
   | DisplayUpdateBroadcast
   | OutputsClearedBroadcast
   | CommBroadcast
-  | KernelErrorBroadcast
-  | RuntimeStateSnapshotBroadcast;
+  | KernelErrorBroadcast;
 
 // ── Type guards ─────────────────────────────────────────────────────
 
@@ -85,10 +77,4 @@ export function isCommBroadcast(payload: unknown): payload is CommBroadcast {
 
 export function isKernelErrorBroadcast(payload: unknown): payload is KernelErrorBroadcast {
   return hasBroadcastEvent(payload) && payload.event === "kernel_error";
-}
-
-export function isRuntimeStateSnapshotBroadcast(
-  payload: unknown,
-): payload is RuntimeStateSnapshotBroadcast {
-  return hasBroadcastEvent(payload) && payload.event === "runtime_state_snapshot";
 }

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -91,6 +91,10 @@ export class DirectTransport implements NotebookTransport {
       throw new Error("DirectTransport: not connected");
     }
 
+    if (frameType === FrameType.SESSION_CONTROL) {
+      throw new Error("DirectTransport: SESSION_CONTROL is server-originated only");
+    }
+
     if (this.simulateFailure) {
       this.sendFailureCount++;
       throw new Error("DirectTransport: simulated send failure");

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -23,6 +23,7 @@
 
 import { FrameType } from "./transport";
 import type { NotebookTransport, FrameListener } from "./transport";
+import type { SessionStatus } from "./handle";
 
 // ── Server handle interface ──────────────────────────────────────────
 
@@ -171,6 +172,23 @@ export class DirectTransport implements NotebookTransport {
     const frame = new Uint8Array(1 + payload.length);
     frame[0] = FrameType.PRESENCE;
     frame.set(payload, 1);
+    this.deliver(Array.from(frame));
+  }
+
+  /**
+   * Push a server-originated session status frame to all client subscribers.
+   */
+  pushSessionStatus(status: SessionStatus): void {
+    const json = JSON.stringify({
+      type: "sync_status",
+      notebook_doc: status.notebook_doc,
+      runtime_state: status.runtime_state,
+      initial_load: status.initial_load,
+    });
+    const bytes = new TextEncoder().encode(json);
+    const frame = new Uint8Array(1 + bytes.length);
+    frame[0] = FrameType.SESSION_CONTROL;
+    frame.set(bytes, 1);
     this.deliver(Array.from(frame));
   }
 

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -12,6 +12,24 @@
 
 import type { CellChangeset } from "./cell-changeset";
 
+// ── Session status ───────────────────────────────────────────────────
+
+export type NotebookDocPhase = "pending" | "syncing" | "interactive";
+
+export type RuntimeStatePhase = "pending" | "syncing" | "ready";
+
+export type InitialLoadPhase =
+  | { phase: "not_needed" }
+  | { phase: "streaming" }
+  | { phase: "ready" }
+  | { phase: "failed"; reason: string };
+
+export interface SessionStatus {
+  notebook_doc: NotebookDocPhase;
+  runtime_state: RuntimeStatePhase;
+  initial_load: InitialLoadPhase;
+}
+
 // ── FrameEvent ───────────────────────────────────────────────────────
 
 /** Attribution for text changes, produced by WASM sync. */
@@ -30,6 +48,7 @@ export interface TextAttribution {
  * - `sync_applied` — Automerge sync message applied successfully
  * - `broadcast` — Daemon broadcast (kernel status, output, etc.)
  * - `presence` — Remote peer presence update
+ * - `session_control` — Connection-local readiness / bootstrap status
  * - `runtime_state_sync_applied` — RuntimeStateDoc sync applied
  * - `sync_error` — Sync failed, doc rebuilt + sync state normalized, reply restarts negotiation
  * - `runtime_state_sync_error` — RuntimeState sync failed, same recovery pattern
@@ -46,6 +65,8 @@ export interface FrameEvent {
   payload?: unknown;
   /** RuntimeState from RuntimeStateSyncApplied. */
   state?: unknown;
+  /** Connection-local session status from SESSION_CONTROL frames. */
+  status?: SessionStatus;
   /** Cell IDs whose outputs changed in RuntimeStateDoc (from WASM-side diff). */
   output_changed_cells?: string[];
   /**
@@ -67,7 +88,7 @@ export interface SyncableHandle {
    * Process an inbound frame from the daemon.
    *
    * Returns an array of typed events (sync_applied, broadcast, presence,
-   * runtime_state_sync_applied, unknown).
+   * session_control, runtime_state_sync_applied, unknown).
    */
   receive_frame(bytes: Uint8Array): FrameEvent[] | null;
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -14,7 +14,15 @@ export type { NotebookTransport, FrameListener } from "./transport";
 export { FrameType, type FrameTypeValue } from "./transport";
 
 // Handle
-export type { SyncableHandle, FrameEvent, TextAttribution } from "./handle";
+export type {
+  SyncableHandle,
+  FrameEvent,
+  InitialLoadPhase,
+  NotebookDocPhase,
+  RuntimeStatePhase,
+  SessionStatus,
+  TextAttribution,
+} from "./handle";
 
 // Cell changeset
 export {
@@ -52,12 +60,10 @@ export {
   isKernelErrorBroadcast,
   isOutputBroadcast,
   isOutputsClearedBroadcast,
-  isRuntimeStateSnapshotBroadcast,
   type KernelErrorBroadcast,
   type KnownBroadcast,
   type OutputBroadcast,
   type OutputsClearedBroadcast,
-  type RuntimeStateSnapshotBroadcast,
 } from "./broadcast-types";
 
 // Comm diffing

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -4,7 +4,7 @@
  * Owns all sync state between a local WASM NotebookHandle and the daemon:
  *   - Inbound frame processing (WASM demux → typed events)
  *   - Inline sync reply with rollback on transport failure
- *   - Initial sync handshake with retry
+ *   - Explicit session-status tracking for notebook/runtime/load readiness
  *   - Coalescing buffer (32ms) for cell changesets
  *   - RuntimeStateDoc sync + execution lifecycle diffing
  *   - Debounced outbound flush of local CRDT mutations
@@ -29,8 +29,6 @@ import {
   share,
   Subject,
   Subscription,
-  switchMap,
-  timer,
 } from "rxjs";
 
 import {
@@ -44,7 +42,6 @@ import {
   isKernelErrorBroadcast,
   isOutputBroadcast,
   isOutputsClearedBroadcast,
-  isRuntimeStateSnapshotBroadcast,
 } from "./broadcast-types";
 import { type CellChangeset, mergeChangesets } from "./cell-changeset";
 import {
@@ -55,7 +52,7 @@ import {
   diffComms,
 } from "./comm-diff";
 import { type KernelStatus, kernelStatus$ as deriveKernelStatus$ } from "./derived-state";
-import type { FrameEvent, SyncableHandle } from "./handle";
+import type { FrameEvent, InitialLoadPhase, SessionStatus, SyncableHandle } from "./handle";
 import type { PoolState } from "./pool-state";
 import {
   type ExecutionTransition,
@@ -70,9 +67,6 @@ import type { NotebookTransport } from "./transport";
 
 /** Coalescing window for incoming sync frames (ms). */
 const COALESCE_MS = 32;
-
-/** Timeout before retrying sync if initial sync hasn't produced cells (ms). */
-const SYNC_RETRY_MS = 3000;
 
 /** Debounce interval for outbound source sync (ms). */
 const FLUSH_DEBOUNCE_MS = 20;
@@ -92,6 +86,14 @@ const nullLogger: SyncEngineLogger = {
   warn() {},
   error() {},
 };
+
+function initialLoadPhaseName(phase: InitialLoadPhase): InitialLoadPhase["phase"] {
+  return phase.phase;
+}
+
+function formatSessionStatus(status: SessionStatus): string {
+  return `notebook=${status.notebook_doc} runtime=${status.runtime_state} load=${initialLoadPhaseName(status.initial_load)}`;
+}
 
 // ── Comm state helpers ───────────────────────────────────────────────
 
@@ -232,7 +234,7 @@ export class SyncEngine {
   private readonly opts: Required<Pick<SyncEngineOptions, "getHandle" | "transport" | "logger">> &
     Pick<SyncEngineOptions, "scheduler">;
   private subscription: Subscription | null = null;
-  private awaitingInitialSync = true;
+  private latestSessionStatus: SessionStatus | null = null;
   private prevExecutions: Record<string, ExecutionState> = {};
   private commDiffState: CommDiffState = { comms: {}, json: {} };
   private lastRuntimeState: RuntimeState | null = null;
@@ -334,12 +336,15 @@ export class SyncEngine {
    */
   readonly commChanges$: Observable<CommChanges>;
 
+  /** Ordered bootstrap/readiness status emitted by the daemon. */
+  readonly sessionStatus$: Observable<SessionStatus>;
+
   /**
-   * Fires each time the initial sync handshake completes (daemon has
-   * sent document content). Emits once per bootstrap cycle — after
-   * `resetForBootstrap()`, the next `changed:true` frame triggers
-   * another emission. Consumers should do a full materialization in
-   * response.
+   * Fires each time the notebook document becomes interactive.
+   *
+   * Emits once per bootstrap cycle when `SessionStatus.notebook_doc`
+   * first reaches `interactive`. Consumers should do a full
+   * materialization in response.
    */
   readonly initialSyncComplete$: Observable<void>;
 
@@ -350,6 +355,7 @@ export class SyncEngine {
   private readonly _runtimeState$ = new Subject<RuntimeState>();
   private readonly _poolState$ = new Subject<PoolState>();
   private readonly _executionTransitions$ = new Subject<ExecutionTransition[]>();
+  private readonly _sessionStatus$ = new ReplaySubject<SessionStatus>(1);
   private readonly _initialSyncComplete$ = new Subject<void>();
   private readonly _commChanges$ = new Subject<CommChanges>();
   private readonly _outputIdChanges$ = new Subject<{
@@ -371,6 +377,7 @@ export class SyncEngine {
     this.runtimeState$ = this._runtimeState$.asObservable();
     this.poolState$ = this._poolState$.asObservable();
     this.executionTransitions$ = this._executionTransitions$.asObservable();
+    this.sessionStatus$ = this._sessionStatus$.asObservable();
     this.initialSyncComplete$ = this._initialSyncComplete$.asObservable();
     this.commChanges$ = this._commChanges$.asObservable();
     this.outputIdChanges$ = this._outputIdChanges$.asObservable();
@@ -404,16 +411,6 @@ export class SyncEngine {
       this.frameIn$.next(payload);
     });
     sub.add(() => unlisten());
-
-    // ReplaySubject(1) so the initial .next() replays to late subscribers.
-    // A plain Subject would lose the emission since the retry subscriber
-    // is wired up after this point — leaving the retry timer permanently
-    // unarmed when no sync frames arrive (see #1417).
-    const retrySync$ = new ReplaySubject<void>(1);
-    sub.add(() => retrySync$.complete());
-
-    // Arm the retry timer immediately
-    retrySync$.next();
 
     // Subject bridging sync_applied events into the coalescing buffer
     const materialize$ = new Subject<CellChangeset | null>();
@@ -456,7 +453,27 @@ export class SyncEngine {
       share(),
     );
 
-    // ── Sub-pipeline: sync_applied → initial sync / coalesce ──────
+    // ── Sub-pipeline: session_control ──────────────────────────────
+
+    sub.add(
+      frameEvents$
+        .pipe(filter((e) => e.type === "session_control" && e.status != null))
+        .subscribe((e) => {
+          const next = e.status as SessionStatus;
+          const previous = this.latestSessionStatus;
+          this.latestSessionStatus = next;
+          this._sessionStatus$.next(next);
+
+          if (previous?.notebook_doc !== "interactive" && next.notebook_doc === "interactive") {
+            log.info(`[sync-engine] notebook interactive (${formatSessionStatus(next)})`);
+            this._initialSyncComplete$.next();
+          } else {
+            log.debug(`[sync-engine] session status: ${formatSessionStatus(next)}`);
+          }
+        }),
+    );
+
+    // ── Sub-pipeline: sync_applied → coalesce ─────────────────────
 
     sub.add(
       frameEvents$
@@ -487,21 +504,6 @@ export class SyncEngine {
                 });
             }
 
-            // Initial sync
-            if (this.awaitingInitialSync) {
-              if (e.changed) {
-                this.awaitingInitialSync = false;
-                log.info("[sync-engine] Initial sync complete");
-                this._initialSyncComplete$.next();
-              } else {
-                log.debug("[sync-engine] Initial sync round (awaiting content)");
-              }
-              // Restart retry timer on handshake rounds
-              retrySync$.next();
-              return EMPTY;
-            }
-
-            // Steady-state: push changeset into coalescing buffer
             if (e.changed) {
               const cs = e.changeset;
               if (cs) {
@@ -519,20 +521,6 @@ export class SyncEngine {
           }),
         )
         .subscribe(),
-    );
-
-    // ── Sync retry timer ──────────────────────────────────────────
-
-    sub.add(
-      retrySync$
-        .pipe(
-          switchMap(() => timer(SYNC_RETRY_MS, this.opts.scheduler)),
-          filter(() => this.awaitingInitialSync),
-        )
-        .subscribe(() => {
-          log.info("[sync-engine] Retrying sync after timeout");
-          this.resetAndResync();
-        }),
     );
 
     // ── Coalescing buffer → cellChanges$ ──────────────────────────
@@ -590,18 +578,6 @@ export class SyncEngine {
         .subscribe((e) => this._presence$.next(e.payload)),
     );
 
-    // ── Sub-pipeline: runtime_state_snapshot broadcast ─────────────
-    //
-    // Eager snapshot from connection setup — apply immediately so the
-    // client has kernel status before the Automerge sync handshake completes.
-
-    sub.add(
-      this.broadcasts$.pipe(filter(isRuntimeStateSnapshotBroadcast)).subscribe((snapshot) => {
-        this._runtimeState$.next(snapshot.state);
-        this.projectComms(snapshot.state);
-      }),
-    );
-
     // ── Sub-pipeline: sync error recovery ──────────────────────────
 
     // Notebook doc sync error: send recovery reply + trigger materialization
@@ -619,14 +595,8 @@ export class SyncEngine {
         }
         // If the doc advanced before the error (partial apply),
         // trigger a full materialization so the UI reflects the
-        // recovered state. Also complete initial sync if pending.
+        // recovered state.
         if (e.changed) {
-          if (this.awaitingInitialSync) {
-            this.awaitingInitialSync = false;
-            log.info("[sync-engine] Initial sync completed via error recovery");
-            this._initialSyncComplete$.next();
-          }
-          // null changeset = full materialization needed
           materialize$.next(null);
         }
       }),
@@ -1137,8 +1107,9 @@ export class SyncEngine {
   /**
    * Reset sync state and resend the initial sync message.
    *
-   * Used when the initial handshake stalls — resets the WASM handle's
-   * sync state so `flush_local_changes()` produces a fresh request.
+   * Manual recovery helper for tests and explicit resync flows. Resets
+   * the WASM handle's sync state so `flush_local_changes()` produces a
+   * fresh request.
    */
   resetAndResync(): void {
     const handle = this.opts.getHandle();
@@ -1150,12 +1121,12 @@ export class SyncEngine {
   /**
    * Reset the engine for a new bootstrap cycle (e.g. daemon:ready).
    *
-   * Clears the initial sync gate and execution tracking state so the
-   * next round of frames is treated as a fresh connection.
+   * Clears status / execution tracking so the next round of frames is
+   * treated as a fresh connection.
    */
   resetForBootstrap(): void {
     this.opts.logger.info("[sync-engine] Resetting for bootstrap");
-    this.awaitingInitialSync = true;
+    this.latestSessionStatus = null;
     this.prevExecutions = {};
     this.commDiffState = { comms: {}, json: {} };
     this.lastRuntimeState = null;

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -31,6 +31,8 @@ export const FrameType = {
   RUNTIME_STATE_SYNC: 0x05,
   /** PoolStateSync message (binary Automerge sync for PoolDoc, global). */
   POOL_STATE_SYNC: 0x06,
+  /** SessionControl message (JSON, server-originated connection status). */
+  SESSION_CONTROL: 0x07,
 } as const;
 
 export type FrameTypeValue = (typeof FrameType)[keyof typeof FrameType];

--- a/packages/runtimed/tests/broadcast-types.test.ts
+++ b/packages/runtimed/tests/broadcast-types.test.ts
@@ -16,7 +16,6 @@ import {
   isKernelErrorBroadcast,
   isOutputBroadcast,
   isOutputsClearedBroadcast,
-  isRuntimeStateSnapshotBroadcast,
 } from "../src/broadcast-types";
 
 // All guards share `hasBroadcastEvent` — exercise the invalid-payload
@@ -40,7 +39,6 @@ const GUARDS = [
   ["isOutputsClearedBroadcast", isOutputsClearedBroadcast, "outputs_cleared"],
   ["isCommBroadcast", isCommBroadcast, "comm"],
   ["isKernelErrorBroadcast", isKernelErrorBroadcast, "kernel_error"],
-  ["isRuntimeStateSnapshotBroadcast", isRuntimeStateSnapshotBroadcast, "runtime_state_snapshot"],
 ] as const;
 
 describe("broadcast type guards", () => {

--- a/packages/runtimed/tests/fixture-integration.test.ts
+++ b/packages/runtimed/tests/fixture-integration.test.ts
@@ -151,8 +151,19 @@ async function setupFixtureSync(scenario: string) {
       });
     });
 
+    transport.pushSessionStatus({
+      notebook_doc: "pending",
+      runtime_state: "pending",
+      initial_load: { phase: "not_needed" },
+    });
+
     // Kick off the handshake
     engine.flush();
+    transport.pushSessionStatus({
+      notebook_doc: "syncing",
+      runtime_state: "syncing",
+      initial_load: { phase: "not_needed" },
+    });
 
     // Run sync rounds until convergence
     for (let i = 0; i < 20; i++) {
@@ -160,6 +171,12 @@ async function setupFixtureSync(scenario: string) {
       if (!pushed) break;
       await Promise.resolve();
     }
+
+    transport.pushSessionStatus({
+      notebook_doc: "interactive",
+      runtime_state: "ready",
+      initial_load: { phase: "not_needed" },
+    });
 
     await syncComplete;
   }
@@ -401,11 +418,26 @@ describe("fixture-based integration: daemon-authored docs through WASM sync", ()
           resolve();
         });
       });
+      transport.pushSessionStatus({
+        notebook_doc: "pending",
+        runtime_state: "pending",
+        initial_load: { phase: "not_needed" },
+      });
       engine.flush();
+      transport.pushSessionStatus({
+        notebook_doc: "syncing",
+        runtime_state: "syncing",
+        initial_load: { phase: "not_needed" },
+      });
       for (let i = 0; i < 20; i++) {
         if (!transport.pushServerChanges()) break;
         await Promise.resolve();
       }
+      transport.pushSessionStatus({
+        notebook_doc: "interactive",
+        runtime_state: "ready",
+        initial_load: { phase: "not_needed" },
+      });
       await syncComplete;
 
       // Subscribe to changesets and make an incremental server change

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -14,7 +14,7 @@ import { DirectTransport } from "../src/direct-transport";
 import { FrameType } from "../src/transport";
 import { mergeChangesets } from "../src/cell-changeset";
 import { diffExecutions, getExecutionCountForCell } from "../src/runtime-state";
-import type { SyncableHandle, FrameEvent } from "../src/handle";
+import type { SessionStatus, SyncableHandle, FrameEvent } from "../src/handle";
 import type { CellChangeset } from "../src/cell-changeset";
 import type { RuntimeState } from "../src/runtime-state";
 
@@ -72,6 +72,26 @@ function presenceEvent(payload: unknown): FrameEvent {
 
 function runtimeStateSyncEvent(state: RuntimeState): FrameEvent {
   return { type: "runtime_state_sync_applied", changed: true, state };
+}
+
+function sessionStatusEvent(status: SessionStatus): FrameEvent {
+  return { type: "session_control", status };
+}
+
+function pendingStatus(): SessionStatus {
+  return {
+    notebook_doc: "pending",
+    runtime_state: "pending",
+    initial_load: { phase: "not_needed" },
+  };
+}
+
+function interactiveStatus(): SessionStatus {
+  return {
+    notebook_doc: "interactive",
+    runtime_state: "ready",
+    initial_load: { phase: "ready" },
+  };
 }
 
 function makeRuntimeState(
@@ -173,9 +193,9 @@ describe("SyncEngine", () => {
   // ── Initial sync ──────────────────────────────────────────────
 
   describe("initial sync", () => {
-    it("emits initialSyncComplete$ when changed:true arrives", () => {
+    it("emits initialSyncComplete$ when notebook_doc becomes interactive", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: true }),
+        sessionStatusEvent(interactiveStatus()),
       ]);
 
       const engine = createEngine();
@@ -191,9 +211,9 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
-    it("does not emit initialSyncComplete$ on changed:false", () => {
+    it("does not emit initialSyncComplete$ before interactive status arrives", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: false }),
+        sessionStatusEvent(pendingStatus()),
       ]);
 
       const engine = createEngine();
@@ -211,57 +231,73 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
-    it("retries sync after timeout when initial sync stalls", () => {
-      // First frame: changed:false (handshake, no content)
-      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: false }),
+    it("emits sessionStatus$ snapshots in order", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+        sessionStatusEvent(pendingStatus()),
       ]);
-
-      // flush_local_changes returns a sync message for the retry
-      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
-        new Uint8Array([1, 2, 3]),
-      );
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+        sessionStatusEvent({
+          notebook_doc: "syncing",
+          runtime_state: "syncing",
+          initial_load: { phase: "streaming" },
+        }),
+      ]);
 
       const engine = createEngine();
       engine.start();
-      transport.deliver(Array.from([0x00, 1, 2, 3]));
 
-      // Advance past the 3s retry timeout
-      advanceBy(scheduler, 3100);
+      const statuses: SessionStatus[] = [];
+      engine.sessionStatus$.subscribe((status) => statuses.push(status));
 
-      // Engine should have called reset_sync_state + flush for retry
-      expect(handle.reset_sync_state).toHaveBeenCalled();
+      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([0x07, 2]));
+
+      expect(statuses).toEqual([
+        pendingStatus(),
+        {
+          notebook_doc: "syncing",
+          runtime_state: "syncing",
+          initial_load: { phase: "streaming" },
+        },
+      ]);
       engine.stop();
     });
 
-    it("handshake round restarts the retry timer via switchMap", () => {
-      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: false }),
-      ]);
-      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
-        new Uint8Array([1, 2, 3]),
-      );
+    it("emits cell changes before initialSyncComplete$ when sync frames arrive first", () => {
+      const changeset: CellChangeset = {
+        changed: [{ cell_id: "cell-1", fields: { source: true } }],
+        added: [],
+        removed: [],
+        order_changed: false,
+      };
+      (handle.receive_frame as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce([syncAppliedEvent({ changed: true, changeset })])
+        .mockReturnValueOnce([
+          sessionStatusEvent({
+            notebook_doc: "interactive",
+            runtime_state: "syncing",
+            initial_load: { phase: "streaming" },
+          }),
+        ]);
 
       const engine = createEngine();
       engine.start();
 
-      // First handshake round at t=0 — arms the 3s retry timer
+      const materialized: Array<CellChangeset | null> = [];
+      let completed = false;
+      engine.cellChanges$.subscribe((cs) => materialized.push(cs));
+      engine.initialSyncComplete$.subscribe(() => {
+        completed = true;
+      });
+
       transport.deliver(Array.from([0x00, 1]));
+      advanceBy(scheduler, 40);
 
-      // Advance 2.5s — timer not yet fired
-      advanceBy(scheduler, 2500);
-      expect(handle.reset_sync_state).not.toHaveBeenCalled();
+      expect(materialized).toEqual([changeset]);
+      expect(completed).toBe(false);
 
-      // Another handshake round restarts the 3s timer (switchMap)
-      transport.deliver(Array.from([0x00, 2]));
-
-      // Advance 2.5s more (5s total, but only 2.5s since last round)
-      advanceBy(scheduler, 2500);
-      expect(handle.reset_sync_state).not.toHaveBeenCalled();
-
-      // Advance 1s more (3.5s since last round — past 3s timeout)
-      advanceBy(scheduler, 1000);
-      expect(handle.reset_sync_state).toHaveBeenCalled();
+      transport.deliver(Array.from([0x07, 1]));
+      expect(completed).toBe(true);
       engine.stop();
     });
   });
@@ -339,8 +375,7 @@ describe("SyncEngine", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          // First call: initial sync
-          return [syncAppliedEvent({ changed: true })];
+          return [sessionStatusEvent(interactiveStatus())];
         }
         // Subsequent calls: steady-state changes
         return [
@@ -359,8 +394,8 @@ describe("SyncEngine", () => {
       const engine = createEngine();
       engine.start();
 
-      // Complete initial sync
-      transport.deliver(Array.from([0x00, 1]));
+      // Enter interactive state explicitly before steady-state sync frames.
+      transport.deliver(Array.from([0x07, 1]));
 
       // Subscribe to cell changes
       const emissions: (CellChangeset | null)[] = [];
@@ -385,7 +420,7 @@ describe("SyncEngine", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return [syncAppliedEvent({ changed: true })];
+          return [sessionStatusEvent(interactiveStatus())];
         }
         return [syncAppliedEvent({ changed: true })]; // no changeset
       });
@@ -393,8 +428,7 @@ describe("SyncEngine", () => {
       const engine = createEngine();
       engine.start();
 
-      // Complete initial sync
-      transport.deliver(Array.from([0x00, 1]));
+      transport.deliver(Array.from([0x07, 1]));
 
       const emissions: (CellChangeset | null)[] = [];
       engine.cellChanges$.subscribe((cs) => emissions.push(cs));
@@ -433,7 +467,7 @@ describe("SyncEngine", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return [syncAppliedEvent({ changed: true })]; // initial sync
+          return [sessionStatusEvent(interactiveStatus())];
         }
         // Return different changesets for each subsequent frame
         return [syncAppliedEvent({ changed: true, changeset: changesets[callCount - 2] })];
@@ -442,8 +476,7 @@ describe("SyncEngine", () => {
       const engine = createEngine();
       engine.start();
 
-      // Complete initial sync
-      transport.deliver(Array.from([0x00, 1]));
+      transport.deliver(Array.from([0x07, 1]));
 
       const emissions: (CellChangeset | null)[] = [];
       engine.cellChanges$.subscribe((cs) => emissions.push(cs));
@@ -479,7 +512,7 @@ describe("SyncEngine", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return [syncAppliedEvent({ changed: true })]; // initial sync
+          return [sessionStatusEvent(interactiveStatus())];
         }
         return [
           syncAppliedEvent({
@@ -496,7 +529,7 @@ describe("SyncEngine", () => {
 
       const engine = createEngine();
       engine.start();
-      transport.deliver(Array.from([0x00, 1])); // initial sync
+      transport.deliver(Array.from([0x07, 1])); // interactive status
 
       const emissions: (CellChangeset | null)[] = [];
       engine.cellChanges$.subscribe((cs) => emissions.push(cs));
@@ -519,7 +552,7 @@ describe("SyncEngine", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          return [syncAppliedEvent({ changed: true })]; // initial sync
+          return [sessionStatusEvent(interactiveStatus())];
         }
         if (callCount === 2) {
           // Valid changeset
@@ -541,7 +574,7 @@ describe("SyncEngine", () => {
 
       const engine = createEngine();
       engine.start();
-      transport.deliver(Array.from([0x00, 1])); // initial sync
+      transport.deliver(Array.from([0x07, 1])); // interactive status
 
       const emissions: (CellChangeset | null)[] = [];
       engine.cellChanges$.subscribe((cs) => emissions.push(cs));
@@ -820,9 +853,9 @@ describe("SyncEngine", () => {
   // ── resetForBootstrap ─────────────────────────────────────────
 
   describe("resetForBootstrap", () => {
-    it("emits initialSyncComplete$ again after resetForBootstrap + changed:true", () => {
+    it("emits initialSyncComplete$ again after resetForBootstrap + interactive status", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: true }),
+        sessionStatusEvent(interactiveStatus()),
       ]);
 
       const engine = createEngine();
@@ -834,20 +867,18 @@ describe("SyncEngine", () => {
         emitCount++;
       });
 
-      // Complete first initial sync
-      transport.deliver(Array.from([0x00, 1]));
+      transport.deliver(Array.from([0x07, 1]));
       expect(emitCount).toBe(1);
 
       // Simulate daemon:ready — reset for a new bootstrap cycle
       engine.resetForBootstrap();
 
-      // Second initial sync should emit again
-      transport.deliver(Array.from([0x00, 2]));
+      transport.deliver(Array.from([0x07, 2]));
       expect(emitCount).toBe(2);
       engine.stop();
     });
 
-    it("does not emit cellChanges$ during initial sync phase", () => {
+    it("continues emitting cellChanges$ before and after resetForBootstrap", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         return [
           syncAppliedEvent({
@@ -870,23 +901,21 @@ describe("SyncEngine", () => {
         cellChangeCount++;
       });
 
-      // First frame completes initial sync — should NOT go to cellChanges$
+      // Bootstrap sync frames now flow through the normal materialization path.
       transport.deliver(Array.from([0x00, 1]));
-      advanceBy(scheduler, 50);
-      expect(cellChangeCount).toBe(0);
-
-      // After initial sync, steady-state frames go to cellChanges$
-      transport.deliver(Array.from([0x00, 2]));
       advanceBy(scheduler, 50);
       expect(cellChangeCount).toBe(1);
 
-      // Reset for bootstrap — back to initial sync phase
+      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([0x00, 2]));
+      advanceBy(scheduler, 50);
+      expect(cellChangeCount).toBe(2);
+
       engine.resetForBootstrap();
 
-      // This frame should NOT go to cellChanges$ (awaiting initial sync)
       transport.deliver(Array.from([0x00, 3]));
       advanceBy(scheduler, 50);
-      expect(cellChangeCount).toBe(1); // unchanged
+      expect(cellChangeCount).toBe(3);
       engine.stop();
     });
   });
@@ -1015,12 +1044,11 @@ describe("SyncEngine", () => {
     }
 
     /**
-     * Helper: complete initial sync so the engine enters steady state.
+     * Helper: enter interactive state so the engine is in steady state.
      * Sets up handle.receive_frame to route runtime state frames via the registry,
-     * and automerge sync frames through the standard initial sync path.
+     * and automerge sync frames through the standard steady-state path.
      */
     function setupWithInitialSync(): SyncEngine {
-      let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation((bytes: Uint8Array) => {
         // Route based on frame type byte
         const frameType = bytes[0];
@@ -1033,19 +1061,17 @@ describe("SyncEngine", () => {
           return [];
         }
 
-        // Automerge sync frame
-        callCount++;
-        if (callCount === 1) {
-          return [syncAppliedEvent({ changed: true })];
+        if (frameType === 0x07) {
+          return [sessionStatusEvent(interactiveStatus())];
         }
+
         return [syncAppliedEvent({ changed: true })];
       });
 
       const engine = createEngine();
       engine.start();
 
-      // Complete initial sync
-      transport.deliver(Array.from([0x00, 1]));
+      transport.deliver(Array.from([0x07, 1]));
 
       return engine;
     }
@@ -1292,7 +1318,7 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
-    it("completes initial sync on sync_error with changed=true", () => {
+    it("does not complete initialSyncComplete$ on sync_error without session status", () => {
       handle = createMockHandle({
         receive_frame: vi.fn(() => [{ type: "sync_error", changed: true } as FrameEvent]),
       });
@@ -1307,7 +1333,7 @@ describe("SyncEngine", () => {
       transport.deliver([0x00, 0x99]);
       advanceBy(scheduler, 1);
 
-      expect(initialSyncCompleted).toBe(true);
+      expect(initialSyncCompleted).toBe(false);
       engine.stop();
     });
 
@@ -1805,6 +1831,15 @@ describe("DirectTransport", () => {
     await expect(
       transport.sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
     ).rejects.toThrow("not connected");
+  });
+
+  it("rejects outbound SESSION_CONTROL frames", async () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    await expect(
+      transport.sendFrame(FrameType.SESSION_CONTROL, new Uint8Array([1])),
+    ).rejects.toThrow("SESSION_CONTROL is server-originated only");
   });
 
   it("pushBroadcast delivers broadcast frame", () => {

--- a/packages/runtimed/tests/wasm-harness.ts
+++ b/packages/runtimed/tests/wasm-harness.ts
@@ -212,8 +212,21 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
         });
       });
 
+      // Test transport only simulates Automerge frames, so bootstrap status
+      // needs to be synthesized to mirror the daemon's session-control FSM.
+      transport.pushSessionStatus({
+        notebook_doc: "pending",
+        runtime_state: "pending",
+        initial_load: { phase: "not_needed" },
+      });
+
       // Kick off the handshake: client → server → client
       engine.flush();
+      transport.pushSessionStatus({
+        notebook_doc: "syncing",
+        runtime_state: "syncing",
+        initial_load: { phase: "not_needed" },
+      });
 
       // Run sync rounds until the handshake completes.
       // Each round: push server response → engine processes → may generate reply
@@ -223,6 +236,12 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
         // Give the engine a tick to process
         await Promise.resolve();
       }
+
+      transport.pushSessionStatus({
+        notebook_doc: "interactive",
+        runtime_state: "ready",
+        initial_load: { phase: "not_needed" },
+      });
 
       await syncComplete;
     },

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2423,9 +2423,11 @@ class TestCreateNotebook:
         assert info.needs_trust_approval is False
 
     async def test_create_deno_notebook(self, client):
-        """Creating Deno notebook sets correct runtime."""
+        """Creating Deno notebook returns after the auto-launched kernel is usable."""
         session = await client.create_notebook(runtime="deno")
         assert await session.is_connected()
+        assert await session.kernel_started()
+        assert await session.kernel_type() == "deno"
 
         # Has zero cells (frontend creates the first cell locally)
         cells = await session.get_cells()


### PR DESCRIPTION
## Summary
- add protocol v3 `SESSION_CONTROL` frames and explicit notebook, runtime-state, and initial-load readiness phases so bootstrap is state-driven instead of timeout-driven
- move post-handshake socket ownership into the sync task and server peer FSM, update relay/WASM/TS/frontend to consume session status, and remove `RuntimeStateSnapshot`
- keep MCP, Python, and Node session APIs eager-ready by awaiting readiness internally while updating integration coverage to use explicit readiness barriers

## QA
- [ ] Open a notebook with many cells and confirm content can appear before loading clears, then loading clears only after the initial load finishes
- [ ] Trigger a notebook load failure and confirm the frontend shows the load-failure UI instead of hanging in a loading state
- [ ] Reconnect an active session or use relay/pipe mode and confirm notebook state and runtime state rehydrate without dropped frames

## UI
- [ ] Add screenshot or gif for progressive notebook loading state
- [ ] Add screenshot or gif for notebook load failure state

_PR submitted by @rgbkrk's agent, Quill_
