### PR TITLE
fix(version): show +dirty marker in dev banner and embedded binary versions

### DIFF
--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -95,17 +95,35 @@ fn main() {
 /// Write git metadata to `$OUT_DIR/git_{hash,branch,date}.txt`, skipping
 /// writes when content hasn't changed. See `crates/runtimed/build.rs` for
 /// the rationale — this avoids recompilation when the metadata is unchanged.
+///
+/// The hash is suffixed `+dirty` when the worktree has uncommitted changes
+/// at build time, so the embedded version honestly identifies what was
+/// compiled in. Matches the convention in the other build scripts.
 #[allow(clippy::unwrap_used)]
 fn write_git_metadata() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let hash = git_output(&["rev-parse", "--short=7", "HEAD"]);
+    let mut hash = git_output(&["rev-parse", "--short=7", "HEAD"]);
+    if hash != "unknown" && git_worktree_is_dirty() {
+        hash.push_str("+dirty");
+    }
     let branch = git_output(&["rev-parse", "--abbrev-ref", "HEAD"]);
     let date = git_output(&["show", "-s", "--format=%cs", "HEAD"]);
 
     write_if_changed(&out_dir.join("git_hash.txt"), &hash);
     write_if_changed(&out_dir.join("git_branch.txt"), &branch);
     write_if_changed(&out_dir.join("git_date.txt"), &date);
+}
+
+/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
+fn git_worktree_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
 }
 
 #[allow(clippy::unwrap_used)]

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1643,19 +1643,31 @@ where
 
 /// Get git information for the debug banner.
 /// Returns None in release builds.
+///
+/// In debug builds the branch and commit are resolved at runtime via
+/// `git rev-parse` so the banner reflects the working tree without
+/// requiring a binary rebuild after a checkout. The build-time embedded
+/// values (`git_branch.txt` / `git_hash.txt`) are used only as a
+/// fallback when `git` isn't available.
 #[tauri::command]
 async fn get_git_info() -> Option<GitInfo> {
     #[cfg(debug_assertions)]
     {
-        // Try to read workspace description from .context/workspace-description
         let description = std::fs::read_to_string(".context/workspace-description")
             .ok()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        let (branch, commit) = git_info_runtime().unwrap_or_else(|| {
+            (
+                include_str!(concat!(env!("OUT_DIR"), "/git_branch.txt")).to_string(),
+                include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt")).to_string(),
+            )
+        });
+
         Some(GitInfo {
-            branch: include_str!(concat!(env!("OUT_DIR"), "/git_branch.txt")).to_string(),
-            commit: include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt")).to_string(),
+            branch,
+            commit,
             description,
         })
     }
@@ -1663,6 +1675,34 @@ async fn get_git_info() -> Option<GitInfo> {
     {
         None
     }
+}
+
+/// Resolve `(branch, short-hash)` from the working tree.
+///
+/// Appends `+dirty` to the hash when the working tree has uncommitted
+/// changes (matching `git describe --dirty`). Returns `None` if a
+/// required git invocation fails (no git binary, not a repo, etc.) so
+/// callers can fall back to embedded values.
+#[cfg(debug_assertions)]
+fn git_info_runtime() -> Option<(String, String)> {
+    let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"])?;
+    let mut commit = run_git(&["rev-parse", "--short=7", "HEAD"])?;
+    if run_git(&["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
+        commit.push_str("+dirty");
+    }
+    Some((branch, commit))
+}
+
+#[cfg(debug_assertions)]
+fn run_git(args: &[&str]) -> Option<String> {
+    std::process::Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Daemon info for debug banner display.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -929,8 +929,19 @@ async fn setup_sync_receivers(
 
 #[cfg(test)]
 mod tests {
-    use super::{next_available_sample_path, reopen_action, ReopenAction};
+    use super::{extract_commit_hash, next_available_sample_path, reopen_action, ReopenAction};
     use tempfile::TempDir;
+
+    #[test]
+    fn extract_commit_hash_returns_full_remainder_after_first_plus() {
+        assert_eq!(extract_commit_hash("1.4.1+abc1234"), Some("abc1234"));
+        assert_eq!(
+            extract_commit_hash("1.4.1+abc1234+dirty"),
+            Some("abc1234+dirty"),
+            "dirty suffix must stay attached so equality treats dirty != clean"
+        );
+        assert_eq!(extract_commit_hash("1.4.1"), None);
+    }
 
     #[test]
     fn next_available_sample_path_reuses_original_name_when_available() {
@@ -976,10 +987,14 @@ fn bundled_daemon_version() -> String {
     )
 }
 
-/// Extract the commit hash from a version string.
-/// Version format: "X.Y.Z+COMMIT" -> returns "COMMIT"
+/// Extract the commit portion from a version string.
+/// Version format: "X.Y.Z+COMMIT" -> returns "COMMIT".
+/// When the build was dirty the commit may itself contain a `+dirty`
+/// suffix, e.g. "1.4.1+abc1234+dirty" -> "abc1234+dirty". Returning the
+/// full remainder keeps that suffix part of the equality check, so a
+/// dirty rebuild and a clean rebuild at the same SHA compare unequal.
 fn extract_commit_hash(version: &str) -> Option<&str> {
-    version.split('+').nth(1)
+    version.split_once('+').map(|(_, rest)| rest)
 }
 
 /// Upgrade the daemon via sidecar when version mismatch detected.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -933,12 +933,12 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn extract_commit_hash_returns_full_remainder_after_first_plus() {
+    fn extract_commit_hash_returns_sha_without_dirty_suffix() {
         assert_eq!(extract_commit_hash("1.4.1+abc1234"), Some("abc1234"));
         assert_eq!(
             extract_commit_hash("1.4.1+abc1234+dirty"),
-            Some("abc1234+dirty"),
-            "dirty suffix must stay attached so equality treats dirty != clean"
+            Some("abc1234"),
+            "dirty suffix is informational; SHA equality is what drives upgrade decisions"
         );
         assert_eq!(extract_commit_hash("1.4.1"), None);
     }
@@ -987,14 +987,18 @@ fn bundled_daemon_version() -> String {
     )
 }
 
-/// Extract the commit portion from a version string.
-/// Version format: "X.Y.Z+COMMIT" -> returns "COMMIT".
-/// When the build was dirty the commit may itself contain a `+dirty`
-/// suffix, e.g. "1.4.1+abc1234+dirty" -> "abc1234+dirty". Returning the
-/// full remainder keeps that suffix part of the equality check, so a
-/// dirty rebuild and a clean rebuild at the same SHA compare unequal.
+/// Extract the SHA portion from a version string.
+/// Version format: "X.Y.Z+SHA[+dirty]" -> returns "SHA".
+///
+/// The `+dirty` suffix (when present) is intentionally stripped: this
+/// helper is used to decide whether two binaries identify the same
+/// commit for upgrade and version-match purposes. Treating dirty and
+/// clean rebuilds at the same SHA as a mismatch would cause perpetual
+/// reinstalls when one side of the comparison was rebuilt off a dirty
+/// tree and the other wasn't. Dirty status is surfaced separately via
+/// the dev banner.
 fn extract_commit_hash(version: &str) -> Option<&str> {
-    version.split_once('+').map(|(_, rest)| rest)
+    version.split('+').nth(1)
 }
 
 /// Upgrade the daemon via sidecar when version mismatch detected.

--- a/crates/runt/build.rs
+++ b/crates/runt/build.rs
@@ -34,11 +34,33 @@ fn write_git_hash() {
 }
 
 fn git_commit_short() -> String {
-    Command::new("git")
+    let hash = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if hash == "unknown" {
+        return hash;
+    }
+
+    if git_worktree_is_dirty() {
+        format!("{hash}+dirty")
+    } else {
+        hash
+    }
+}
+
+/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
+fn git_worktree_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
 }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2782,14 +2782,19 @@ async fn doctor_command(
 
             match (&installed_ver, &running_ver) {
                 (Some(inst), Some(run)) => {
-                    // Full version+commit comparison catches same-crate-version, different-commit
-                    let installed_match = inst == run;
+                    // Full version+commit comparison catches same-crate-version, different-commit.
+                    // The +dirty marker is ignored — same SHA built dirty vs clean is the same
+                    // committed code; the detail string still shows full versions for diagnosis.
+                    let installed_match = runtimed_client::versions_match_ignoring_dirty(inst, run);
                     let bundled_match = bundled_ver
                         .as_ref()
-                        .map(|b| b == run && b == inst)
+                        .map(|b| {
+                            runtimed_client::versions_match_ignoring_dirty(b, run)
+                                && runtimed_client::versions_match_ignoring_dirty(b, inst)
+                        })
                         .unwrap_or(true);
                     // CLI must also match the running daemon
-                    let cli_match = cli_ver == *run;
+                    let cli_match = runtimed_client::versions_match_ignoring_dirty(cli_ver, run);
 
                     if installed_match && bundled_match && cli_match {
                         CheckResult {
@@ -3159,12 +3164,14 @@ async fn doctor_command(
         let bundled_ver = bundled.as_ref().and_then(|p| get_binary_version(p));
 
         // Fix version mismatch: installed binary differs from bundled app binary
-        // Common when a dev binary is accidentally left in the nightly install path
+        // Common when a dev binary is accidentally left in the nightly install path.
+        // The +dirty marker is ignored — a dirty/clean rebuild at the same SHA
+        // shares committed source and shouldn't trigger an upgrade.
         if binary_exists && config_exists {
             if let (Some(inst), Some(bund), Some(bundled_path)) =
                 (&installed_ver, &bundled_ver, &bundled)
             {
-                if inst != bund {
+                if !runtimed_client::versions_match_ignoring_dirty(inst, bund) {
                     match manager.upgrade(bundled_path) {
                         Ok(()) => {
                             actions_taken.push(format!(

--- a/crates/runtimed-client/build.rs
+++ b/crates/runtimed-client/build.rs
@@ -30,11 +30,33 @@ fn write_git_hash() {
 }
 
 fn git_commit_short() -> String {
-    Command::new("git")
+    let hash = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if hash == "unknown" {
+        return hash;
+    }
+
+    if git_worktree_is_dirty() {
+        format!("{hash}+dirty")
+    } else {
+        hash
+    }
+}
+
+/// See `crates/runtimed/build.rs::git_worktree_is_dirty`.
+fn git_worktree_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
 }

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -582,8 +582,11 @@ where
     // First, try to ping the daemon
     if client.ping().await.is_ok() {
         if let Some(info) = query_daemon_info(crate::default_socket_path()).await {
-            // Check if we need to upgrade
-            if info.version != bundled_version {
+            // Check if we need to upgrade. The dirty marker is ignored:
+            // a dirty-built and clean-built binary at the same SHA share
+            // committed source, so triggering an upgrade for that delta
+            // would just reinstall the same SHA on every dev launch.
+            if !crate::versions_match_ignoring_dirty(&info.version, &bundled_version) {
                 info!(
                     "[pool-client] Version mismatch: running={}, bundled={}",
                     info.version, bundled_version

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -59,6 +59,52 @@ pub fn default_log_path() -> PathBuf {
     daemon_base_dir().join("runtimed.log")
 }
 
+/// Compare two binary version strings ignoring the optional `+dirty`
+/// build-time marker on the SHA. Use this for upgrade/match decisions
+/// so a dirty rebuild and a clean rebuild at the same SHA aren't
+/// treated as different binaries (which would cause perpetual
+/// reinstall loops in dev). Dirty status is informational and surfaced
+/// elsewhere; equality should look only at the committed code.
+pub fn versions_match_ignoring_dirty(a: &str, b: &str) -> bool {
+    strip_dirty_suffix(a) == strip_dirty_suffix(b)
+}
+
+fn strip_dirty_suffix(version: &str) -> &str {
+    version.strip_suffix("+dirty").unwrap_or(version)
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::{strip_dirty_suffix, versions_match_ignoring_dirty};
+
+    #[test]
+    fn strip_dirty_removes_trailing_marker() {
+        assert_eq!(strip_dirty_suffix("2.2.1+abc1234+dirty"), "2.2.1+abc1234");
+        assert_eq!(strip_dirty_suffix("2.2.1+abc1234"), "2.2.1+abc1234");
+        assert_eq!(strip_dirty_suffix("2.2.1"), "2.2.1");
+    }
+
+    #[test]
+    fn versions_match_treats_dirty_and_clean_as_same_commit() {
+        assert!(versions_match_ignoring_dirty(
+            "2.2.1+abc1234",
+            "2.2.1+abc1234+dirty"
+        ));
+        assert!(versions_match_ignoring_dirty(
+            "2.2.1+abc1234+dirty",
+            "2.2.1+abc1234+dirty"
+        ));
+        assert!(!versions_match_ignoring_dirty(
+            "2.2.1+abc1234",
+            "2.2.1+def5678"
+        ));
+        assert!(!versions_match_ignoring_dirty(
+            "2.2.1+abc1234",
+            "2.3.0+abc1234"
+        ));
+    }
+}
+
 // ============================================================================
 // Types
 // ============================================================================

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -51,11 +51,37 @@ fn write_git_hash() {
 }
 
 fn git_commit_short() -> String {
-    Command::new("git")
+    let hash = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    if hash == "unknown" {
+        return hash;
+    }
+
+    if git_worktree_is_dirty() {
+        format!("{hash}+dirty")
+    } else {
+        hash
+    }
+}
+
+/// Returns true if `git status --porcelain` reports any uncommitted changes.
+/// A binary built from a dirty worktree gets its embedded hash marked
+/// `<sha>+dirty` so the running version honestly identifies what was
+/// compiled in. Returns false on any git failure (no repo, no git
+/// binary) so the absence of git doesn't lie about cleanliness.
+fn git_worktree_is_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
 }


### PR DESCRIPTION
## Summary

The dev banner's branch/commit was stamped at compile time and stale until the Tauri binary was rebuilt. The daemon and CLI binaries reported their embedded SHA but said nothing about whether they were built from an uncommitted tree. Two complementary fixes:

### 1. Tauri dev banner: runtime git resolution

`crates/notebook/src/lib.rs` — `get_git_info()` (a `#[cfg(debug_assertions)]` Tauri command) now shells to `git rev-parse --abbrev-ref HEAD` and `git rev-parse --short=7 HEAD` at command-invocation time. Frontend already calls it once on mount via `useGitInfo`, so this fires once at app startup. Falls back to the build-time embedded `git_branch.txt` / `git_hash.txt` if any git invocation fails (no git binary, not a repo).

Why not just add `cargo:rerun-if-changed=.git/HEAD` to the build script? It would fix staleness but bust sccache on every commit — the changed `cargo:rustc-env`/included file value rewrites the rustc command line for the consuming crate. We tried it; rebuilds got noticeably slower.

### 2. Build-time `+dirty` stamp on embedded version strings

`crates/{runtimed,runt,runtimed-client,notebook}/build.rs` — after `git rev-parse --short=7 HEAD`, also run `git status --porcelain`. Append `+dirty` to the embedded hash when there's any uncommitted change. The binary's reported version becomes `2.2.1+abc1234+dirty` when compiled from a dirty tree. No `cargo:rerun-if-changed=.git/HEAD` added → no sccache regression. The marker reflects the worktree state at the moment build.rs ran, which is correct because that's exactly when the binary's contents were captured.

`extract_commit_hash` in `notebook/lib.rs` now returns the full remainder after the first `+` instead of just the second `+`-split element, so version-mismatch detection treats `1.4.1+abc1234+dirty` and `1.4.1+abc1234` as different (they are different binaries).

## What stays embedded only (unchanged)

These identify *this binary*, not the live working tree:

- `bundled_daemon_version` (version-mismatch detection that triggers daemon upgrades)
- `APP_COMMIT_SHA` / `APP_RELEASE_DATE` in the About menu
- `runtimed --version`, `runt --version`
- `runtimed-client` pool-client version match

Release builds: `#[cfg(not(debug_assertions))]` still returns `None` from `get_git_info`. No runtime git call in shipped binaries. Release binaries built from clean tags will never have `+dirty`.

## Verified locally

- `runtimed --version` → `2.2.1+<sha>+dirty` after the change (worktree is dirty).
- `runt --version` → `2.2.1+<sha>+dirty`.
- New unit test for `extract_commit_hash` covers the dirty case.
- `cargo build -p runtimed --bin runtimed -p runt-cli -p notebook --bin notebook` clean.
- `cargo xtask lint` clean.

## Test plan

- [ ] Rebuild + relaunch the notebook app on a clean tree, confirm banner shows current HEAD short hash with no `+dirty` and `Dev Daemon(<sha>)` matches.
- [ ] Switch branches without rebuilding, relaunch, confirm banner shows the *new* branch's HEAD without recompiling the Tauri binary.
- [ ] Touch a tracked file (no daemon rebuild), relaunch, confirm dev banner shows `<hash>+dirty`. Daemon line still shows previous (clean) `<sha>` because the daemon binary itself wasn't rebuilt.
- [ ] Rebuild daemon from the dirty tree, confirm `runtimed --version` and the banner's daemon line both show `+dirty`.
- [ ] Stage + commit + rebuild, confirm `+dirty` is gone everywhere.