### PR TITLE
chore: rename runt-proxy to nteract-mcp

### DIFF
--- a/.claude/plugins/nteract/.mcp.json
+++ b/.claude/plugins/nteract/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "notebook": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-runt-proxy",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-mcp",
       "args": [],
       "env": {
         "NTERACT_CHANNEL": "stable"

--- a/.claude/plugins/nteract/bin/nteract-mcp
+++ b/.claude/plugins/nteract/bin/nteract-mcp
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 channel="${NTERACT_CHANNEL:-stable}"
-binary_name="runt-proxy"
+binary_name="nteract-mcp"
 
 if [[ "$channel" == "nightly" ]]; then
   app_names=("nteract Nightly" "nteract-nightly" "nteract (Nightly)" "nteract")
@@ -29,7 +29,7 @@ case "$(uname -s)" in
     ;;
   MINGW*|MSYS*|CYGWIN*)
     local_app_data="${LOCALAPPDATA:-${HOME}/AppData/Local}"
-    binary_name="runt-proxy.exe"
+    binary_name="nteract-mcp.exe"
     for app_name in "${app_names[@]}"; do
       candidate_paths+=("${local_app_data}/${app_name}/${binary_name}")
       candidate_paths+=("${local_app_data}/Programs/${app_name}/${binary_name}")

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -49,7 +49,7 @@ When you change daemon code and want the system service to pick it up on a cloud
 cargo xtask install-nightly
 ```
 
-Builds runtimed + runt + runt-proxy (release), installs them to `~/.local/share/runt-nightly/bin/` with channel-suffixed names, writes + starts the systemd user unit on first install, upgrades in place on subsequent runs. On macOS it refuses by default — use the nteract Nightly app (it auto-updates). Pass `--on-macos` to override, `--replace-installed-app` if an app bundle is already present.
+Builds runtimed + runt + nteract-mcp (release), installs them to `~/.local/share/runt-nightly/bin/` with channel-suffixed names, writes + starts the systemd user unit on first install, upgrades in place on subsequent runs. On macOS it refuses by default — use the nteract Nightly app (it auto-updates). Pass `--on-macos` to override, `--replace-installed-app` if an app bundle is already present.
 
 Verify: `runt-nightly daemon status` or `cat ~/.cache/runt-nightly/daemon.json`.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,17 +274,17 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-            cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
+            cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-            cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+            cp target/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
           fi
 
       - name: Check tool caches are up to date
@@ -306,10 +306,10 @@ jobs:
           path: |
             target/release/runtimed
             target/release/runt
-            target/release/runt-proxy
+            target/release/nteract-mcp
             crates/notebook/binaries/runtimed-*
             crates/notebook/binaries/runt-*
-            crates/notebook/binaries/runt-proxy-*
+            crates/notebook/binaries/nteract-mcp-*
           retention-days: 1
 
       - name: Build Tauri E2E app
@@ -320,7 +320,7 @@ jobs:
           mkdir -p target/release/binaries
           cp crates/notebook/binaries/runtimed-* target/release/binaries/
           cp crates/notebook/binaries/runt-* target/release/binaries/
-          cp crates/notebook/binaries/runt-proxy-* target/release/binaries/
+          cp crates/notebook/binaries/nteract-mcp-* target/release/binaries/
 
       - name: Upload E2E app
         uses: actions/upload-artifact@v4
@@ -454,17 +454,17 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
             cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-            cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
+            cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-            cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+            cp target/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
           fi
 
       - name: Clippy

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -167,23 +167,23 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
 
           mkdir -p crates/notebook/binaries target/release/binaries
 
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+          cp target/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
           cp target/release/runtimed "target/release/binaries/runtimed-$TARGET"
           cp target/release/runt "target/release/binaries/runt-$TARGET"
-          cp target/release/runt-proxy "target/release/binaries/runt-proxy-$TARGET"
+          cp target/release/nteract-mcp "target/release/binaries/nteract-mcp-$TARGET"
 
       - name: Build external binaries (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           $target = (rustc --print host-tuple).Trim()
 
           New-Item -ItemType Directory -Force crates/notebook/binaries | Out-Null
@@ -191,10 +191,10 @@ jobs:
 
           Copy-Item target/release/runtimed.exe "crates/notebook/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "crates/notebook/binaries/runt-$target.exe"
-          Copy-Item target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$target.exe"
+          Copy-Item target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$target.exe"
           Copy-Item target/release/runtimed.exe "target/release/binaries/runtimed-$target.exe"
           Copy-Item target/release/runt.exe "target/release/binaries/runt-$target.exe"
-          Copy-Item target/release/runt-proxy.exe "target/release/binaries/runt-proxy-$target.exe"
+          Copy-Item target/release/nteract-mcp.exe "target/release/binaries/nteract-mcp-$target.exe"
 
       - name: Build notebook app (no bundle)
         working-directory: crates/notebook

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -297,12 +297,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+          cp target/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -463,12 +463,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release --target x86_64-apple-darwin -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release --target x86_64-apple-darwin -p runtimed -p runt-cli -p nteract-mcp
           TARGET="x86_64-apple-darwin"
           mkdir -p crates/notebook/binaries
           cp target/x86_64-apple-darwin/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/x86_64-apple-darwin/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/x86_64-apple-darwin/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+          cp target/x86_64-apple-darwin/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -610,12 +610,12 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
           cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
-          cp target/release/runt-proxy.exe "crates/notebook/binaries/runt-proxy-$TARGET.exe"
+          cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
@@ -734,12 +734,12 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p runt-proxy
+          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
           cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
-          cp target/release/runt-proxy "crates/notebook/binaries/runt-proxy-$TARGET"
+          cp target/release/nteract-mcp "crates/notebook/binaries/nteract-mcp-$TARGET"
 
       - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 **Critical:** The `env -i` wrapper on nteract-nightly and nteract is required to prevent direnv's env vars from leaking into these MCP servers. Without it, they will incorrectly connect to the dev daemon instead of the system daemon.
 
 **This system's nightly installation:**
-- Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly,runt-proxy-nightly}`
-- Symlinks: `/usr/local/bin/{runtimed-nightly,runt-nightly,runt-proxy-nightly}` → the install dir
+- Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}`
+- Symlinks: `/usr/local/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}` → the install dir
 - Daemon socket: `~/.cache/runt-nightly/runtimed.sock`
 - Install command: `cargo xtask install-nightly` (refuses on macOS and when an app bundle is installed — see § `install-nightly` below)
 - Version: Built from source, updated after each PR merge
@@ -383,7 +383,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | `nteract-predicate` | Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram) — backs Sift (the `@nteract/sift` viewer; `nteract/dx` is the Python sender) |
 | `sift-wasm` | WASM bindings for `nteract-predicate` — used by `@nteract/sift` |
 | `mcp-supervisor` | `nteract-dev` MCP server — proxies `runt mcp` and adds dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) |
-| `runt-proxy` | Resilient MCP proxy for `runt mcp` — shipped as a sidecar in the nteract desktop app and inside the `.mcpb` Claude Desktop extension |
+| `nteract-mcp` | Resilient MCP proxy for `runt mcp` — shipped as a sidecar in the nteract desktop app and inside the `.mcpb` Claude Desktop extension |
 | `xtask` | Build system orchestration |
 
 ## Build System (`cargo xtask`)
@@ -407,7 +407,7 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask build-dmg` | Build a DMG bundle (CI/release packaging) |
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
 | | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
-| | `cargo xtask install-nightly` | Install runtimed + runt + runt-proxy as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
+| | `cargo xtask install-nightly` | Install runtimed + runt + nteract-mcp as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
 | MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask dev-mcp` | Direct `runt mcp` (no proxy, no auto-restart) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nteract-mcp"
+version = "0.1.1"
+dependencies = [
+ "dirs",
+ "rmcp",
+ "runt-mcp-proxy",
+ "runt-workspace",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nteract-predicate"
 version = "0.1.1"
 dependencies = [
@@ -6950,19 +6963,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "runt-proxy"
-version = "0.1.1"
-dependencies = [
- "dirs",
- "rmcp",
- "runt-mcp-proxy",
- "runt-workspace",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
     "crates/mcp-supervisor",
     "crates/runt-mcp",
     "crates/runt-mcp-proxy",
-    "crates/runt-proxy",
+    "crates/nteract-mcp",
     "crates/repr-llm",
     "crates/nteract-predicate",
     "crates/sift-wasm",

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo xtask dev
 | Lint (check) | `cargo xtask lint` | Check formatting and linting across Rust, JS/TS, Python |
 | Lint (fix) | `cargo xtask lint --fix` | Auto-fix formatting and linting |
 | Dev daemon | `cargo xtask dev-daemon` | Run per-worktree dev daemon |
-| Install nightly (Linux/headless) | `cargo xtask install-nightly` | Build + install runtimed + runt + runt-proxy as the local nightly. Refuses on macOS and when an app bundle is installed. |
+| Install nightly (Linux/headless) | `cargo xtask install-nightly` | Build + install runtimed + runt + nteract-mcp as the local nightly. Refuses on macOS and when an app bundle is installed. |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
 | Generate icons | `cargo xtask icons [source.png]` | Generate icon variants from source image |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -100,7 +100,7 @@ On Linux cloud boxes and headless dev environments:
 cargo xtask install-nightly
 ```
 
-This builds `runtimed`, `runt`, and `runt-proxy` in release mode and installs all three into `~/.local/share/runt-nightly/bin/` with channel-suffixed names (`runtimed-nightly`, `runt-nightly`, `runt-proxy-nightly`). On first run it writes the systemd user unit and starts it; on subsequent runs it upgrades in place. After the initial install the command prints the follow-up `sudo ln -sf` symlink commands for `/usr/local/bin/` and the `sudo loginctl enable-linger` step that keeps the user service alive across logout.
+This builds `runtimed`, `runt`, and `nteract-mcp` in release mode and installs all three into `~/.local/share/runt-nightly/bin/` with channel-suffixed names (`runtimed-nightly`, `runt-nightly`, `nteract-mcp-nightly`). On first run it writes the systemd user unit and starts it; on subsequent runs it upgrades in place. After the initial install the command prints the follow-up `sudo ln -sf` symlink commands for `/usr/local/bin/` and the `sudo loginctl enable-linger` step that keeps the user service alive across logout.
 
 It refuses by default on macOS (the desktop app manages its own daemon via SMAppService — reinstalling from source out of the app bundle is a footgun) and when an nteract app bundle is already installed on any platform. Override respectively with `--on-macos` and `--replace-installed-app` if you really mean it.
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2470,7 +2470,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // 2b: Fast-path check — only build if binary doesn't exist.
         // If it exists, skip to child spawn immediately (file watcher will
-        // rebuild on source changes). This matches runt-proxy's pattern.
+        // rebuild on source changes). This matches nteract-mcp's pattern.
         let runt_binary = cargo_binary(&project_root, "runt");
         if !runt_binary.exists() {
             info!("runt binary not found, building...");

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -42,7 +42,7 @@ fn maybe_disable_external_bin_for_local_checks() {
     let expected_sidecars = [
         target_sidecar_path(&manifest_dir, &target, "runtimed"),
         target_sidecar_path(&manifest_dir, &target, "runt"),
-        target_sidecar_path(&manifest_dir, &target, "runt-proxy"),
+        target_sidecar_path(&manifest_dir, &target, "nteract-mcp"),
     ];
 
     for path in &expected_sidecars {

--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -1,7 +1,7 @@
 //! Build and install the nteract .mcpb (Claude Desktop extension) from the running app.
 //!
 //! Creates a `.mcpb` ZIP archive at runtime from embedded assets (manifest,
-//! icons, runt-proxy binary), then opens it with the system handler so Claude
+//! icons, nteract-mcp binary), then opens it with the system handler so Claude
 //! Desktop shows the install prompt.
 
 use std::fs;
@@ -57,14 +57,14 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         "license": "BSD-3-Clause",
         "server": {
             "type": "binary",
-            "entry_point": "server/runt-proxy",
+            "entry_point": "server/nteract-mcp",
             "mcp_config": {
-                "command": "${__dirname}/server/runt-proxy",
+                "command": "${__dirname}/server/nteract-mcp",
                 "args": [],
                 "env": { "NTERACT_CHANNEL": channel },
                 "platform_overrides": {
                     "win32": {
-                        "command": "${__dirname}/server/runt-proxy.exe"
+                        "command": "${__dirname}/server/nteract-mcp.exe"
                     }
                 }
             }
@@ -126,22 +126,22 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         format!("Failed to write manifest.json: {e}")
     })?;
 
-    // ── 4. Copy runt-proxy binary from app sidecar ─────────────────────
+    // ── 4. Copy nteract-mcp binary from app sidecar ────────────────────
     let server_dir = staging.join("server");
     fs::create_dir_all(&server_dir).map_err(|e| {
         cleanup();
         format!("Failed to create server directory: {e}")
     })?;
 
-    let runt_proxy_binary = get_bundled_runt_proxy(app)?;
+    let nteract_mcp_binary = get_bundled_nteract_mcp(app)?;
     let binary_name = if cfg!(target_os = "windows") {
-        "runt-proxy.exe"
+        "nteract-mcp.exe"
     } else {
-        "runt-proxy"
+        "nteract-mcp"
     };
-    fs::copy(&runt_proxy_binary, server_dir.join(binary_name)).map_err(|e| {
+    fs::copy(&nteract_mcp_binary, server_dir.join(binary_name)).map_err(|e| {
         cleanup();
-        format!("Failed to copy runt-proxy binary: {e}")
+        format!("Failed to copy nteract-mcp binary: {e}")
     })?;
 
     // ── 5. Write icons (pre-sized 512x512, no runtime resize needed) ──
@@ -225,14 +225,14 @@ fn cli_on_path(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Find the bundled `runt-proxy` binary in the app's sidecar directory.
-fn get_bundled_runt_proxy(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+/// Find the bundled `nteract-mcp` binary in the app's sidecar directory.
+fn get_bundled_nteract_mcp(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     use tauri::Manager;
 
     let binary_name = if cfg!(target_os = "windows") {
-        "runt-proxy.exe"
+        "nteract-mcp.exe"
     } else {
-        "runt-proxy"
+        "nteract-mcp"
     };
 
     // Try the Tauri resource directory (where sidecars are bundled)
@@ -254,7 +254,7 @@ fn get_bundled_runt_proxy(app: &tauri::AppHandle) -> Result<PathBuf, String> {
             return Ok(candidate);
         }
 
-        // macOS: Contents/MacOS/runt-proxy
+        // macOS: Contents/MacOS/nteract-mcp
         #[cfg(target_os = "macos")]
         {
             let candidate = exe_dir.join(binary_name);
@@ -264,8 +264,8 @@ fn get_bundled_runt_proxy(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         }
     }
 
-    Err("runt-proxy binary not found in app bundle. \
-         The app may need to be rebuilt with runt-proxy as a sidecar."
+    Err("nteract-mcp binary not found in app bundle. \
+         The app may need to be rebuilt with nteract-mcp as a sidecar."
         .to_string())
 }
 

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -18,7 +18,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "externalBin": ["binaries/runtimed", "binaries/runt", "binaries/runt-proxy"],
+    "externalBin": ["binaries/runtimed", "binaries/runt", "binaries/nteract-mcp"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "runt-proxy"
+name = "nteract-mcp"
 version = "0.1.1"
 edition.workspace = true
-description = "Resilient MCP proxy for runt mcp. Ships as a sidecar in the nteract desktop app and inside the .mcpb Claude Desktop extension."
+description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true
 license.workspace = true
 publish = false
 
 [[bin]]
-name = "runt-proxy"
+name = "nteract-mcp"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -1,9 +1,10 @@
-//! runt-proxy — resilient MCP proxy for `runt mcp`.
+//! nteract-mcp — resilient MCP server for nteract.
 //!
-//! Ships as a sidecar in the nteract desktop app and inside the `.mcpb`
-//! Claude Desktop extension. Finds `runt` via `runt-workspace`, spawns
-//! `runt mcp` as a child, and proxies MCP over stdio with transparent
-//! restart on child death (daemon upgrade, crash, etc.).
+//! Ships as a sidecar in the nteract desktop app, inside the `.mcpb`
+//! Claude Desktop extension, and in the Claude Code plugin. Finds
+//! `runt` via `runt-workspace`, spawns `runt mcp` as a child, and
+//! proxies MCP over stdio with transparent restart on child death
+//! (daemon upgrade, crash, etc.).
 
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
@@ -143,7 +144,7 @@ async fn main() -> ExitCode {
     let binary_name = runt_workspace::cli_command_name();
 
     info!(
-        "runt-proxy starting (channel={channel}, compiled={})",
+        "nteract-mcp starting (channel={channel}, compiled={})",
         runt_workspace::channel_display_name()
     );
     if channel != runt_workspace::channel_display_name() {

--- a/crates/runt-mcp-proxy/src/lib.rs
+++ b/crates/runt-mcp-proxy/src/lib.rs
@@ -4,7 +4,7 @@
 //! forwards MCP tools/resources, and handles transparent restart on child death.
 //!
 //! Used by:
-//! - `runt-proxy` — shipped as a sidecar in the nteract app and inside the `.mcpb` Claude Desktop extension
+//! - `nteract-mcp` — shipped as a sidecar in the nteract app, inside the `.mcpb` Claude Desktop extension, and in the Claude Code plugin
 //! - `mcp-supervisor` — dev environment MCP proxy with file watching and build management
 
 // Allow `expect()` and `unwrap()` in tests

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -1,7 +1,7 @@
 //! Core MCP proxy — spawns a child, forwards tools/resources, handles restarts.
 //!
 //! The `McpProxy` struct manages the child process lifecycle and provides the
-//! core forwarding logic. It can be used standalone (by `runt-proxy`) or wrapped
+//! core forwarding logic. It can be used standalone (by `nteract-mcp`) or wrapped
 //! by `mcp-supervisor` which adds dev-specific tools and file watching.
 
 use std::collections::HashMap;
@@ -354,7 +354,7 @@ impl McpProxy {
                                  Exiting so the MCP client can restart with the new tool set."
                             );
                             state.should_exit = true;
-                            // Signal the exit so runt-proxy can shut down
+                            // Signal the exit so nteract-mcp can shut down
                             self.exit_signal.notify_waiters();
                         }
                     }
@@ -744,10 +744,10 @@ impl McpProxy {
 }
 
 // ---------------------------------------------------------------------------
-// ServerHandler — used when McpProxy is the top-level MCP server (runt-proxy)
+// ServerHandler — used when McpProxy is the top-level MCP server (nteract-mcp)
 // ---------------------------------------------------------------------------
 
-/// Standalone ServerHandler for `McpProxy`. Used by `runt-proxy` where the proxy
+/// Standalone ServerHandler for `McpProxy`. Used by `nteract-mcp` where the proxy
 /// IS the MCP server. The supervisor wraps this with its own ServerHandler that
 /// adds supervisor_* tools.
 impl ServerHandler for McpProxy {

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -43,7 +43,7 @@ pub fn load_cached_tools(cache_dir: &Path) -> Option<Vec<Tool>> {
 }
 
 /// Load the built-in tool cache (compiled into the binary).
-/// Used when no cache_dir is configured (e.g., runt-proxy).
+/// Used when no cache_dir is configured (e.g., nteract-mcp).
 pub fn load_builtin_tools() -> Option<Vec<Tool>> {
     match serde_json::from_str::<Vec<Tool>>(BUILTIN_TOOL_CACHE) {
         Ok(tools) => {

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -103,8 +103,8 @@ pub fn cli_command_name_for(channel: BuildChannel) -> &'static str {
 
 pub fn proxy_binary_basename_for(channel: BuildChannel) -> &'static str {
     match channel {
-        BuildChannel::Stable => "runt-proxy",
-        BuildChannel::Nightly => "runt-proxy-nightly",
+        BuildChannel::Stable => "nteract-mcp",
+        BuildChannel::Nightly => "nteract-mcp-nightly",
     }
 }
 
@@ -155,7 +155,7 @@ pub fn cli_command_name() -> &'static str {
     cli_command_name_for(build_channel())
 }
 
-/// Channel-specific runt-proxy binary base name (without extension).
+/// Channel-specific nteract-mcp binary base name (without extension).
 pub fn proxy_binary_basename() -> &'static str {
     proxy_binary_basename_for(build_channel())
 }

--- a/crates/runtimed-client/src/daemon_connection.rs
+++ b/crates/runtimed-client/src/daemon_connection.rs
@@ -8,7 +8,7 @@
 //! ground truth that the cached info is still valid.
 //!
 //! This supersedes per-lookup [`query_daemon_info`](crate::singleton::query_daemon_info)
-//! for long-running consumers (Tauri app, runt-proxy, runt-mcp-proxy). One-
+//! for long-running consumers (Tauri app, nteract-mcp, runt-mcp-proxy). One-
 //! shot CLI callers (e.g. `runt daemon status`) continue to use the
 //! existing helper.
 //!

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -876,7 +876,7 @@ impl Daemon {
 
         // Write `daemon.json` so older clients can still discover us.
         // Retained as a one-release compatibility shim for stale
-        // `runt-mcp` / `runt-proxy` proxies that predate `GetDaemonInfo`.
+        // `runt-mcp` / `nteract-mcp` proxies that predate `GetDaemonInfo`.
         // New consumers go through the socket (see
         // `runtimed_client::daemon_connection`). Target v2.4 for removal.
         if let Err(e) = self

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -781,7 +781,7 @@ fn cmd_build(rust_only: bool) {
     // anyway. By excluding notebook here, we still pre-warm the entire
     // dependency tree (all shared crates are built via the other targets),
     // and Phase 3 only needs to compile notebook + link.
-    println!("Building Rust targets (runtimed, runt, runt-proxy, mcp-supervisor)...");
+    println!("Building Rust targets (runtimed, runt, nteract-mcp, mcp-supervisor)...");
     run_cmd(
         "cargo",
         &[
@@ -791,7 +791,7 @@ fn cmd_build(rust_only: bool) {
             "-p",
             "runt-cli",
             "-p",
-            "runt-proxy",
+            "nteract-mcp",
             "-p",
             "mcp-supervisor",
         ],
@@ -800,7 +800,7 @@ fn cmd_build(rust_only: bool) {
     // Copy sidecar binaries for Tauri bundling
     copy_sidecar_binary("runtimed", false);
     copy_sidecar_binary("runt", false);
-    copy_sidecar_binary("runt-proxy", false);
+    copy_sidecar_binary("nteract-mcp", false);
 
     // Wait for pnpm install before starting frontend build
     if let Some(handle) = pnpm_handle {
@@ -2172,7 +2172,7 @@ fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
 fn build_runtimed_daemon(release: bool) {
     build_external_binary("runtimed", "runtimed", release);
     build_external_binary("runt-cli", "runt", release);
-    build_external_binary("runt-proxy", "runt-proxy", release);
+    build_external_binary("nteract-mcp", "nteract-mcp", release);
 }
 
 /// Build a binary and copy to binaries/ with target triple suffix for Tauri bundling.
@@ -2571,30 +2571,30 @@ fn cmd_mcpb(output: Option<&str>, variant: &str) {
     let dark_dest = staging_dir.join("icon-dark.png");
     resize_icon(dark_actual, &dark_dest.to_string_lossy());
 
-    // ── 4. Build and copy runt-proxy binary ─────────────────────────────────
+    // ── 4. Build and copy nteract-mcp binary ────────────────────────────────
     // Set RUNT_BUILD_CHANNEL so the binary knows its channel at compile time.
     let build_channel = match variant {
         "stable" => "stable",
         _ => "nightly",
     };
-    println!("Building runt-proxy (release, channel={build_channel})...");
+    println!("Building nteract-mcp (release, channel={build_channel})...");
     let mut build_cmd = Command::new("cargo");
-    build_cmd.args(["build", "-p", "runt-proxy", "--release"]);
+    build_cmd.args(["build", "-p", "nteract-mcp", "--release"]);
     build_cmd.env("RUNT_BUILD_CHANNEL", build_channel);
     let build_status = build_cmd.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run cargo build -p runt-proxy: {e}");
+        eprintln!("Failed to run cargo build -p nteract-mcp: {e}");
         exit(1);
     });
     if !build_status.success() {
-        eprintln!("cargo build -p runt-proxy --release failed");
+        eprintln!("cargo build -p nteract-mcp --release failed");
         let _ = fs::remove_dir_all(&staging_dir);
         exit(1);
     }
 
     let binary_name = if cfg!(target_os = "windows") {
-        "runt-proxy.exe"
+        "nteract-mcp.exe"
     } else {
-        "runt-proxy"
+        "nteract-mcp"
     };
     let built_binary = Path::new("target/release").join(binary_name);
     if !built_binary.exists() {
@@ -2609,7 +2609,7 @@ fn cmd_mcpb(output: Option<&str>, variant: &str) {
         exit(1);
     });
     fs::copy(&built_binary, server_dir.join(binary_name)).unwrap_or_else(|e| {
-        eprintln!("Failed to copy runt-proxy binary: {e}");
+        eprintln!("Failed to copy nteract-mcp binary: {e}");
         exit(1);
     });
 

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -43,16 +43,16 @@
     "url": "https://github.com/nteract/desktop"
   },
   "server": {
-    "entry_point": "server/runt-proxy",
+    "entry_point": "server/nteract-mcp",
     "mcp_config": {
       "args": [],
-      "command": "${__dirname}/server/runt-proxy",
+      "command": "${__dirname}/server/nteract-mcp",
       "env": {
         "NTERACT_CHANNEL": "nightly"
       },
       "platform_overrides": {
         "win32": {
-          "command": "${__dirname}/server/runt-proxy.exe"
+          "command": "${__dirname}/server/nteract-mcp.exe"
         }
       }
     },

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -43,16 +43,16 @@
     "url": "https://github.com/nteract/desktop"
   },
   "server": {
-    "entry_point": "server/runt-proxy",
+    "entry_point": "server/nteract-mcp",
     "mcp_config": {
       "args": [],
-      "command": "${__dirname}/server/runt-proxy",
+      "command": "${__dirname}/server/nteract-mcp",
       "env": {
         "NTERACT_CHANNEL": "stable"
       },
       "platform_overrides": {
         "win32": {
-          "command": "${__dirname}/server/runt-proxy.exe"
+          "command": "${__dirname}/server/nteract-mcp.exe"
         }
       }
     },

--- a/plugins/nteract-nightly/.mcp.json
+++ b/plugins/nteract-nightly/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "notebook": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/runt-proxy",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-mcp",
       "args": [],
       "env": {
         "NTERACT_CHANNEL": "nightly"

--- a/plugins/nteract-nightly/bin/.gitignore
+++ b/plugins/nteract-nightly/bin/.gitignore
@@ -1,3 +1,3 @@
 # Populated by scripts/install-nightly (dev path) or a release CI job (future).
 # The symlink is machine-specific.
-runt-proxy
+nteract-mcp

--- a/plugins/nteract/.mcp.json
+++ b/plugins/nteract/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "notebook": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/runt-proxy",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/nteract-mcp",
       "args": [],
       "env": {
         "NTERACT_CHANNEL": "stable"

--- a/plugins/nteract/bin/.gitignore
+++ b/plugins/nteract/bin/.gitignore
@@ -1,3 +1,3 @@
 # Populated by scripts/install-nightly (dev path) or a release CI job (future).
 # The symlink is machine-specific.
-runt-proxy
+nteract-mcp

--- a/scripts/install-nightly
+++ b/scripts/install-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build and install runtimed, runt, and runt-proxy as the local nightly install.
+# Build and install runtimed, runt, and nteract-mcp as the local nightly install.
 #
 # Linux-only. macOS devs use the nteract Nightly app bundle or `cargo xtask
 # dev-daemon`. Windows users install the app. This script is the path headless
@@ -31,9 +31,9 @@ SERVICE_UNIT="$SERVICE_NAME.service"
 
 echo "=== install-nightly ==="
 
-echo "Building runtimed, runt-cli, runt-proxy (release, channel=nightly)..."
+echo "Building runtimed, runt-cli, nteract-mcp (release, channel=nightly)..."
 RUNT_BUILD_CHANNEL=nightly cargo build --release \
-  -p runtimed -p runt-cli -p runt-proxy
+  -p runtimed -p runt-cli -p nteract-mcp
 
 mkdir -p "$INSTALL_DIR" "$SERVICE_DIR"
 
@@ -50,16 +50,16 @@ atomic_install() {
 
 atomic_install target/release/runtimed   "$INSTALL_DIR/runtimed-nightly"
 atomic_install target/release/runt       "$INSTALL_DIR/runt-nightly"
-atomic_install target/release/runt-proxy "$INSTALL_DIR/runt-proxy-nightly"
+atomic_install target/release/nteract-mcp "$INSTALL_DIR/nteract-mcp-nightly"
 
-# Link the nightly plugin's expected runt-proxy path to the just-installed
-# binary. The plugin's .mcp.json points at ${CLAUDE_PLUGIN_ROOT}/bin/runt-proxy
+# Link the nightly plugin's expected nteract-mcp path to the just-installed
+# binary. The plugin's .mcp.json points at ${CLAUDE_PLUGIN_ROOT}/bin/nteract-mcp
 # and Claude Code spawns it from the plugin-cache copy, so the link must
 # resolve from the cache location. `readlink -f` is Linux-specific.
 PLUGIN_BIN="$REPO_ROOT/plugins/nteract-nightly/bin"
 mkdir -p "$PLUGIN_BIN"
-ln -sfn "$INSTALL_DIR/runt-proxy-nightly" "$PLUGIN_BIN/runt-proxy"
-echo "Linked $PLUGIN_BIN/runt-proxy -> $INSTALL_DIR/runt-proxy-nightly"
+ln -sfn "$INSTALL_DIR/nteract-mcp-nightly" "$PLUGIN_BIN/nteract-mcp"
+echo "Linked $PLUGIN_BIN/nteract-mcp -> $INSTALL_DIR/nteract-mcp-nightly"
 
 # Write the systemd user unit. Matches the template in
 # crates/runtimed-client/src/service.rs::create_linux_systemd so future tweaks


### PR DESCRIPTION
## Summary

The product-facing MCP server binary becomes `nteract-mcp`. The old name `runt-proxy` was internal jargon ("proxy for runt mcp") and surfaced in every tool-approval prompt, dev-install flow, and MCPB manifest. `nteract-mcp` reads the way users think about the thing.

The library crate `runt-mcp-proxy` keeps its name — it's workspace-internal and its job (proxying `runt mcp` with restart semantics) is accurately described by the current name.

**Pure rename. No behavior changes.**

## Scope

| Area | Change |
|---|---|
| Crate | `crates/runt-proxy/` → `crates/nteract-mcp/` (dir, package, binary, workspace member) |
| Tauri | `tauri.conf.json` externalBin + `build.rs` expected sidecars |
| Runtime MCPB | `mcpb_install.rs` entry_point/command + `get_bundled_runt_proxy` → `get_bundled_nteract_mcp` |
| Static MCPB | `mcpb/manifest.{stable,nightly}.json` |
| Plugin manifests | `plugins/nteract/.mcp.json`, `plugins/nteract-nightly/.mcp.json`, `.claude/plugins/nteract/.mcp.json` |
| Local dispatch wrapper | `.claude/plugins/nteract/bin/nteract-runt-proxy` → `bin/nteract-mcp` (rename + internal var rename) |
| CI | `release-common.yml`, `build.yml`, `pr-binary-generation.yml` |
| Install script | `scripts/install-nightly` + channel symlink path |
| Workspace API | `runt_workspace::proxy_binary_basename_for` returns `nteract-mcp[-nightly]` |
| xtask | build + mcpb commands |
| Docs | `AGENTS.md`/`CLAUDE.md`, `README.md`, `contributing/runtimed.md`, daemon-dev skill |

## Upgrade note

After merge, `scripts/install-nightly` will install the new binary as `~/.local/share/runt-nightly/bin/nteract-mcp-nightly` and create `/usr/local/bin/nteract-mcp-nightly`. The old `runt-proxy-nightly` symlink is **not** auto-removed — on lab boxes, run `sudo rm /usr/local/bin/runt-proxy-nightly` after the first post-merge `install-nightly` run.

The nteract Desktop app bundle's `runt-proxy` sidecar becomes `nteract-mcp`. Existing installs keep working until the user installs the next release (MCP proxy continues running from its in-memory copy; new invocations resolve the new name).

## Test plan

- [x] `cargo check -p nteract-mcp -p runt-mcp-proxy -p runt-workspace -p notebook` clean
- [x] `cargo xtask lint --fix` clean
- [x] `cargo xtask clippy` clean
- [x] `cargo test -p nteract-mcp -p runt-mcp-proxy -p runt-workspace` passes (103 tests)
- [ ] CI passes (full release-common.yml path)
- [ ] Lab: re-run `scripts/install-nightly`, verify new binary lands, daemon + MCP tools work

## Follow-ups (separate PRs)

- `nteract/claude-plugin` + `nteract/claude-plugin-nightly` distribution repos ship the renamed binary. Needs PATs before CI push (see spike thread).