### PR TITLE
fix(sift): use not_in exclusion filters for high-cardinality categories

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -429,7 +429,7 @@ CI rejects PRs that fail formatting. Run this before every commit:
 cargo xtask lint --fix
 ```
 
-This formats Rust, lints/formats TypeScript/JavaScript with Biome, and lints/formats Python with ruff.
+This formats Rust, lints/formats TypeScript/JavaScript with vp (Vite+ unified toolchain), and lints/formats Python with ruff.
 
 Use [conventional commits](https://www.conventionalcommits.org/) for commit messages and PR titles:
 

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7d4a5bd9f0a922976198a7ea7b630b280a1b3988697be7902b3f7dcbbfc9010
-size 4076290
+oid sha256:5e17dd97651bf71f4a59f13b3c4dfa298438f84cebe25128e19b00d05658ca8a
+size 4079721

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7d4a5bd9f0a922976198a7ea7b630b280a1b3988697be7902b3f7dcbbfc9010
-size 4076290
+oid sha256:5e17dd97651bf71f4a59f13b3c4dfa298438f84cebe25128e19b00d05658ca8a
+size 4079721

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -1463,6 +1463,8 @@ enum FilterSpec {
     Range { col: usize, min: f64, max: f64 },
     #[serde(rename = "set")]
     Set { col: usize, values: Vec<String> },
+    #[serde(rename = "not_in")]
+    NotIn { col: usize, values: Vec<String> },
     #[serde(rename = "boolean")]
     Boolean { col: usize, value: bool },
 }
@@ -1484,11 +1486,13 @@ pub fn store_filter_rows(handle: u32, filters_js: JsValue) -> Result<Vec<u32>, J
             .map_err(|e| JsValue::from_str(&e));
     }
 
-    // Pre-build HashSets for set filters
+    // Pre-build HashSets for set and not_in filters
     let set_lookups: Vec<Option<HashSet<&str>>> = filters
         .iter()
         .map(|f| match f {
-            FilterSpec::Set { values, .. } => Some(values.iter().map(|s| s.as_str()).collect()),
+            FilterSpec::Set { values, .. } | FilterSpec::NotIn { values, .. } => {
+                Some(values.iter().map(|s| s.as_str()).collect())
+            }
             _ => None,
         })
         .collect();
@@ -1500,6 +1504,7 @@ pub fn store_filter_rows(handle: u32, filters_js: JsValue) -> Result<Vec<u32>, J
             let col_idx = match filter {
                 FilterSpec::Range { col, .. } => *col,
                 FilterSpec::Set { col, .. } => *col,
+                FilterSpec::NotIn { col, .. } => *col,
                 FilterSpec::Boolean { col, .. } => *col,
             };
             if concat_cols[col_idx].is_none() {
@@ -1538,6 +1543,17 @@ pub fn store_filter_rows(handle: u32, filters_js: JsValue) -> Result<Vec<u32>, J
                             let s = get_string_value(arr.as_ref(), row);
                             if let Some(ref lookup) = set_lookups[fi] {
                                 if !lookup.contains(s.as_str()) {
+                                    continue 'row;
+                                }
+                            }
+                        }
+                    }
+                    FilterSpec::NotIn { col, .. } => {
+                        if let Some(ref arr) = concat_cols[*col] {
+                            let s = get_string_value(arr.as_ref(), row);
+                            if let Some(ref lookup) = set_lookups[fi] {
+                                // Inverted logic: skip row if value IS in the exclusion set
+                                if lookup.contains(s.as_str()) {
                                     continue 'row;
                                 }
                             }

--- a/packages/sift/src/filter-schema.ts
+++ b/packages/sift/src/filter-schema.ts
@@ -246,6 +246,9 @@ export function columnFiltersToPredicates(
       case "set":
         predicates.push({ column: col, op: "in", value: [...f.values] });
         break;
+      case "not-in":
+        predicates.push({ column: col, op: "not_in", value: [...f.values] });
+        break;
       case "boolean":
         predicates.push({ column: col, op: "eq", value: f.value });
         break;
@@ -272,6 +275,9 @@ export function engineStateToExplorerState(state: TableEngineState): ExplorerSta
         break;
       case "set":
         filters.push({ column, op: "in", value: [...filter.values] });
+        break;
+      case "not-in":
+        filters.push({ column, op: "not_in", value: [...filter.values] });
         break;
       case "boolean":
         filters.push({ column, op: "eq", value: filter.value });

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -9,6 +9,7 @@
 export type FilterSpecJson =
   | { kind: "range"; col: number; min: number; max: number }
   | { kind: "set"; col: number; values: string[] }
+  | { kind: "not_in"; col: number; values: string[] }
   | { kind: "boolean"; col: number; value: boolean };
 
 type PredicateModule = {

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -605,10 +605,12 @@ const POPOVER_MAX_VISIBLE = 8;
 function CategoryPopoverContent({
   allCategories,
   activeSet,
+  exclusionSet,
   onFilter,
 }: {
   allCategories: CategoryEntry[];
   activeSet: Set<string> | null;
+  exclusionSet: Set<string> | null;
   onFilter: FilterCallback;
 }) {
   const [searchInput, setSearchInput] = useState("");
@@ -649,45 +651,60 @@ function CategoryPopoverContent({
   const first = Math.floor(scrollTop / POPOVER_ROW_HEIGHT);
   const last = Math.min(filtered.length - 1, first + visibleCount + 1);
 
-  const allSelected = activeSet === null;
-  const selectedCount = activeSet ? activeSet.size : allCategories.length;
+  const allSelected = activeSet === null && exclusionSet === null;
+  const selectedCount = exclusionSet
+    ? allCategories.length - exclusionSet.size
+    : activeSet
+      ? activeSet.size
+      : allCategories.length;
 
   function toggleItem(label: string) {
-    if (activeSet === null) {
-      // No filter active = every value is implicitly selected. A click
-      // here means "uncheck this one" — subtract it from the full set.
-      // Without this, the handler below would treat the click as
-      // "there's no set yet, add just this" and invert the user's
-      // intent to a 1-selected filter.
-      const next = new Set(allCategories.map((c) => c.label));
-      next.delete(label);
-      onFilter({ kind: "set", values: next });
+    // Case 1: No filter active (null) — start exclusion filter
+    if (activeSet === null && exclusionSet === null) {
+      onFilter({ kind: "not-in", values: new Set([label]) });
       return;
     }
-    if (activeSet.has(label)) {
-      const next = new Set(activeSet);
-      next.delete(label);
-      // Empty out to a real empty-set filter ("None"), not to `null`
-      // (which means "no filter = show everything"). In the popover
-      // checkbox UI, unchecking the last checked row is semantically
-      // "select nothing", and should match what the "None" button
-      // produces - row count drops to 0 rather than jumping back to
-      // the full dataset.
-      onFilter({ kind: "set", values: next });
-    } else {
-      const next = new Set(activeSet);
-      next.add(label);
-      // Re-checking the last unchecked row refills the set to the full
-      // universe. Collapse that back to `null` ("no filter = show
-      // everything") rather than holding an explicit all-selected
-      // filter. Otherwise the filter pill sticks around on a no-op
-      // filter, the header reports "Filtered to N of N", and any
-      // category added to the data later would be silently excluded
-      // by the frozen set.
-      if (next.size >= allCategories.length) {
-        onFilter(null);
+
+    // Case 2: Exclusion filter active — add/remove from exclusion set
+    if (exclusionSet !== null) {
+      if (exclusionSet.has(label)) {
+        // Re-checking an excluded item: remove from exclusion set
+        const next = new Set(exclusionSet);
+        next.delete(label);
+        if (next.size === 0) {
+          // All items re-checked: collapse to "no filter"
+          onFilter(null);
+        } else {
+          onFilter({ kind: "not-in", values: next });
+        }
       } else {
+        // Unchecking a non-excluded item: add to exclusion set
+        const next = new Set(exclusionSet);
+        next.add(label);
+        // If everything is excluded, collapse to empty-set filter
+        if (next.size >= allCategories.length) {
+          onFilter({ kind: "set", values: new Set<string>() });
+        } else {
+          onFilter({ kind: "not-in", values: next });
+        }
+      }
+      return;
+    }
+
+    // Case 3: Inclusion filter active — add/remove from inclusion set
+    if (activeSet !== null) {
+      if (activeSet.has(label)) {
+        const next = new Set(activeSet);
+        next.delete(label);
         onFilter({ kind: "set", values: next });
+      } else {
+        const next = new Set(activeSet);
+        next.add(label);
+        if (next.size >= allCategories.length) {
+          onFilter(null);
+        } else {
+          onFilter({ kind: "set", values: next });
+        }
       }
     }
   }
@@ -734,7 +751,9 @@ function CategoryPopoverContent({
             const idx = first + i;
             const cat = filtered[idx];
             if (!cat) return null;
-            const checked = allSelected || (activeSet?.has(cat.label) ?? false);
+            const checked =
+              allSelected ||
+              (exclusionSet ? !exclusionSet.has(cat.label) : activeSet?.has(cat.label) ?? false);
             return (
               <label
                 key={cat.label}
@@ -806,6 +825,7 @@ function CategoricalBars({
   }
 
   const activeSet = activeFilter?.kind === "set" ? activeFilter.values : null;
+  const exclusionSet = activeFilter?.kind === "not-in" ? activeFilter.values : null;
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -826,7 +846,12 @@ function CategoricalBars({
                 key={item.label}
                 className={`sift-cat-row sift-cat-clickable`}
                 style={{
-                  opacity: activeSet && !isActive && !item.isOthers ? 0.3 : 1,
+                  opacity: (() => {
+                    if (item.isOthers) return 1;
+                    if (exclusionSet) return exclusionSet.has(item.label) ? 0.3 : 1;
+                    if (activeSet) return activeSet.has(item.label) ? 1 : 0.3;
+                    return 1;
+                  })(),
                 }}
                 onClick={
                   item.isOthers
@@ -838,9 +863,18 @@ function CategoricalBars({
                         // inside CategoryPopoverContent — those are checkboxes
                         // and need the implicit-full-set subtract behavior —
                         // clicking a bar while nothing is filtered should
-                        // filter to that single category. That's the existing
-                        // incremental-add path working as intended.
-                        if (activeSet?.has(item.label)) {
+                        // filter to that single category.
+                        if (exclusionSet) {
+                          if (exclusionSet.has(item.label)) {
+                            const next = new Set(exclusionSet);
+                            next.delete(item.label);
+                            onFilter(next.size > 0 ? { kind: "not-in", values: next } : null);
+                          } else {
+                            const next = new Set(exclusionSet);
+                            next.add(item.label);
+                            onFilter({ kind: "not-in", values: next });
+                          }
+                        } else if (activeSet?.has(item.label)) {
                           const next = new Set(activeSet);
                           next.delete(item.label);
                           onFilter(next.size > 0 ? { kind: "set", values: next } : null);
@@ -876,6 +910,7 @@ function CategoricalBars({
         <CategoryPopoverContent
           allCategories={unfilteredAllCategories ?? summary.allCategories}
           activeSet={activeSet}
+          exclusionSet={exclusionSet}
           onFilter={onFilter}
         />
       </PopoverContent>

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -753,7 +753,7 @@ function CategoryPopoverContent({
             if (!cat) return null;
             const checked =
               allSelected ||
-              (exclusionSet ? !exclusionSet.has(cat.label) : activeSet?.has(cat.label) ?? false);
+              (exclusionSet ? !exclusionSet.has(cat.label) : (activeSet?.has(cat.label) ?? false));
             return (
               <label
                 key={cat.label}
@@ -840,7 +840,6 @@ function CategoricalBars({
       <PopoverAnchor asChild>
         <div className="sift-cat-summary">
           {items.map((item) => {
-            const isActive = activeSet ? activeSet.has(item.label) : true;
             const row = (
               <div
                 key={item.label}

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -102,8 +102,9 @@ export type TableData = {
 
 export type RangeFilter = { kind: "range"; min: number; max: number };
 export type SetFilter = { kind: "set"; values: Set<string> };
+export type NotInFilter = { kind: "not-in"; values: Set<string> };
 export type BooleanFilter = { kind: "boolean"; value: boolean };
-export type ColumnFilter = RangeFilter | SetFilter | BooleanFilter | null;
+export type ColumnFilter = RangeFilter | SetFilter | NotInFilter | BooleanFilter | null;
 
 export type TableEngineState = {
   sort: { column: string; direction: "asc" | "desc" } | null;

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -302,6 +302,12 @@ export function createTable(
           if (!f.values.has(s)) return false;
           break;
         }
+        case "not-in": {
+          const s = data.getCell(dataRow, c);
+          // Inverted: exclude row if value IS in the exclusion set
+          if (f.values.has(s)) return false;
+          break;
+        }
         case "boolean": {
           if (Boolean(raw) !== f.value) return false;
           break;
@@ -1775,6 +1781,11 @@ export function createTable(
         const vals = [...f.values];
         if (vals.length === 1) return vals[0];
         return `${vals.length} values`;
+      }
+      case "not-in": {
+        const vals = [...f.values];
+        if (vals.length === 1) return `not ${vals[0]}`;
+        return `not ${vals.length} values`;
       }
       case "boolean":
         return f.value ? "Yes" : "No";

--- a/packages/sift/src/wasm-table-data.ts
+++ b/packages/sift/src/wasm-table-data.ts
@@ -256,6 +256,9 @@ export function createWasmTableData(
           case "set":
             specs.push({ kind: "set", col: c, values: Array.from(f.values) });
             break;
+          case "not-in":
+            specs.push({ kind: "not_in", col: c, values: Array.from(f.values) });
+            break;
           case "boolean":
             specs.push({ kind: "boolean", col: c, value: f.value });
             break;


### PR DESCRIPTION
Fixes #1864

## Summary

Implements `not_in` exclusion filters for the category popover. When unchecking from "all selected" state, the filter now emits `{ kind: "not-in", values: Set([label]) }` instead of freezing N-1 items in an inclusion set.

## Problem (from #1864)

The old approach had two bugs:

1. **Streaming correctness**: Categories added after uncheck were silently excluded (not in the frozen set)
2. **High-cardinality performance**: Unchecking one value from 30k categories created a 29,999-item Set

## Solution

Add exclusion filter support at every layer:

### WASM (Rust)
- `FilterSpec::NotIn { col, values }` variant in `store.rs`
- Inverted logic: skip row if value **is** in the exclusion set
- Shares HashSet pre-build with `FilterSpec::Set`

### TypeScript
- `NotInFilter` type in `table.ts`
- `not_in` case in `wasm-table-data.ts` filterRows
- `FilterSpecJson` extended in `predicate.ts`

### UI
- `CategoryPopoverContent` accepts both `activeSet` and `exclusionSet`
- `toggleItem` handles three cases: null → exclusion, exclusion → exclusion/null/inclusion, inclusion → inclusion/null
- Checkbox rendering: `checked = !exclusionSet.has(label)`
- Category bar opacity and clicks updated for exclusion filters
- Selected count: `allCategories.length - exclusionSet.size`

## Testing

Manual testing with high-cardinality category columns (dataset picker in Sift demo).

## Future work

Filter pill rendering could show "everything except X, Y" for exclusion filters (currently shows raw JSON structure).