### PR TITLE
docs: replace Biome reference with vp in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Run this command before every commit. CI will reject PRs that fail formatting ch
 cargo xtask lint --fix
 ```
 
-This formats Rust, lints/formats TypeScript/JavaScript with Biome, and lints/formats Python with ruff.
+This formats Rust, lints/formats TypeScript/JavaScript with vp (Vite+ unified toolchain), and lints/formats Python with ruff.
 
 For CI-style check-only mode: `cargo xtask lint`
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2022 — replaces the remaining "Biome" reference in AGENTS.md with "vp (Vite+ unified toolchain)". The repo uses vp for JS/TS linting/formatting, not Biome directly.

## Changes

- AGENTS.md line 214: `Biome` → `vp (Vite+ unified toolchain)`

## Context

CLAUDE.md and contributing/development.md were already updated in PR #2022. This PR catches the same outdated reference in AGENTS.md.