### PR TITLE
fix(daemon): accept v2 clients on v3 daemon for upgrade compat

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -161,6 +161,10 @@ pub const PROTOCOL_V3: &str = "v3";
 /// bootstrap/readiness and is not wire-compatible with v2 clients.
 pub const PROTOCOL_VERSION: u32 = 3;
 
+/// Minimum protocol version accepted by v3 daemons for backward compatibility.
+/// v2 clients are served without SESSION_CONTROL frames.
+pub const MIN_PROTOCOL_VERSION: u32 = 2;
+
 /// Magic bytes identifying the runtimed protocol.
 /// Sent as the first 4 bytes of every connection, before the handshake frame.
 pub const MAGIC: [u8; 4] = [0xC0, 0xDE, 0x01, 0xAC];

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1510,74 +1510,85 @@ impl Daemon {
         // 0x00 = old protocol (4-byte big-endian length prefix for any
         // reasonable handshake size). This allows the daemon upgrade to succeed
         // even when the old app is still verifying daemon health.
-        let handshake_bytes = tokio::time::timeout(std::time::Duration::from_secs(10), async {
-            // Peek at first byte to detect protocol version
-            let mut first_byte = [0u8; 1];
-            tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte)
-                .await
-                .map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
-                        anyhow::anyhow!("connection closed before preamble")
-                    } else {
-                        anyhow::anyhow!("preamble read: {}", e)
-                    }
-                })?;
-
-            if first_byte[0] == connection::MAGIC[0] {
-                // New protocol: read remaining 4 bytes of preamble (3 more magic + 1 version)
-                let mut rest = [0u8; 4];
-                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut rest)
+        let (handshake_bytes, client_protocol_version) =
+            tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                // Peek at first byte to detect protocol version
+                let mut first_byte = [0u8; 1];
+                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte)
                     .await
-                    .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
+                    .map_err(|e| {
+                        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                            anyhow::anyhow!("connection closed before preamble")
+                        } else {
+                            anyhow::anyhow!("preamble read: {}", e)
+                        }
+                    })?;
 
-                if rest[..3] != connection::MAGIC[1..] {
-                    anyhow::bail!(
-                        "invalid magic bytes: expected {:02X?}, got {:02X?}",
-                        connection::MAGIC,
-                        [&first_byte[..], &rest[..3]].concat()
-                    );
-                }
+                if first_byte[0] == connection::MAGIC[0] {
+                    // New protocol: read remaining 4 bytes of preamble (3 more magic + 1 version)
+                    let mut rest = [0u8; 4];
+                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut rest)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
 
-                let version = rest[3];
-                if version != connection::PROTOCOL_VERSION as u8 {
-                    anyhow::bail!(
-                        "protocol version mismatch: expected {}, got {}",
-                        connection::PROTOCOL_VERSION,
+                    if rest[..3] != connection::MAGIC[1..] {
+                        anyhow::bail!(
+                            "invalid magic bytes: expected {:02X?}, got {:02X?}",
+                            connection::MAGIC,
+                            [&first_byte[..], &rest[..3]].concat()
+                        );
+                    }
+
+                    let version = rest[3];
+                    if version < connection::MIN_PROTOCOL_VERSION as u8
+                        || version > connection::PROTOCOL_VERSION as u8
+                    {
+                        anyhow::bail!(
+                            "unsupported protocol version: got {}, supported range [{}, {}]",
+                            version,
+                            connection::MIN_PROTOCOL_VERSION,
+                            connection::PROTOCOL_VERSION
+                        );
+                    }
+                    if version < connection::PROTOCOL_VERSION as u8 {
+                        tracing::info!(
+                        "[runtimed] v{} client connected, serving without session-control frames",
                         version
                     );
+                    }
+
+                    // Read the JSON handshake frame
+                    let bytes = connection::recv_control_frame(&mut stream)
+                        .await
+                        .context("handshake read error")?
+                        .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
+                    Ok((bytes, version))
+                } else {
+                    // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
+                    // big-endian length prefix. Read remaining 3 length bytes.
+                    tracing::debug!("[runtimed] Legacy client detected (no magic preamble)");
+                    let mut len_rest = [0u8; 3];
+                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("legacy length read: {}", e))?;
+
+                    let len_bytes = [first_byte[0], len_rest[0], len_rest[1], len_rest[2]];
+                    let len = u32::from_be_bytes(len_bytes) as usize;
+
+                    if len > 64 * 1024 {
+                        anyhow::bail!("legacy handshake frame too large: {} bytes", len);
+                    }
+
+                    let mut buf = vec![0u8; len];
+                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut buf)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("legacy handshake read: {}", e))?;
+
+                    Ok((buf, connection::MIN_PROTOCOL_VERSION as u8))
                 }
-
-                // Read the JSON handshake frame
-                connection::recv_control_frame(&mut stream)
-                    .await
-                    .context("handshake read error")?
-                    .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))
-            } else {
-                // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
-                // big-endian length prefix. Read remaining 3 length bytes.
-                tracing::debug!("[runtimed] Legacy client detected (no magic preamble)");
-                let mut len_rest = [0u8; 3];
-                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("legacy length read: {}", e))?;
-
-                let len_bytes = [first_byte[0], len_rest[0], len_rest[1], len_rest[2]];
-                let len = u32::from_be_bytes(len_bytes) as usize;
-
-                if len > 64 * 1024 {
-                    anyhow::bail!("legacy handshake frame too large: {} bytes", len);
-                }
-
-                let mut buf = vec![0u8; len];
-                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut buf)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("legacy handshake read: {}", e))?;
-
-                Ok(buf)
-            }
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
         match handshake {
@@ -1678,19 +1689,30 @@ impl Daemon {
                     false, // Send ProtocolCapabilities for legacy NotebookSync handshake
                     None,  // No streaming load for legacy handshake
                     false, // Not a newly-created notebook at path
+                    client_protocol_version,
                 )
                 .await
             }
             Handshake::Blob => self.handle_blob_connection(stream).await,
-            Handshake::OpenNotebook { path } => self.handle_open_notebook(stream, path).await,
+            Handshake::OpenNotebook { path } => {
+                self.handle_open_notebook(stream, path, client_protocol_version)
+                    .await
+            }
             Handshake::CreateNotebook {
                 runtime,
                 working_dir,
                 notebook_id,
                 ephemeral,
             } => {
-                self.handle_create_notebook(stream, runtime, working_dir, notebook_id, ephemeral)
-                    .await
+                self.handle_create_notebook(
+                    stream,
+                    runtime,
+                    working_dir,
+                    notebook_id,
+                    ephemeral,
+                    client_protocol_version,
+                )
+                .await
             }
             Handshake::RuntimeAgent {
                 notebook_id,
@@ -1738,7 +1760,12 @@ impl Daemon {
     /// Daemon loads the .ipynb file, derives notebook_id, creates room, populates doc.
     /// If the file doesn't exist, creates a new empty notebook at that path.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
-    async fn handle_open_notebook<S>(self: Arc<Self>, stream: S, path: String) -> anyhow::Result<()>
+    async fn handle_open_notebook<S>(
+        self: Arc<Self>,
+        stream: S,
+        path: String,
+        client_protocol_version: u8,
+    ) -> anyhow::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
@@ -1839,6 +1866,7 @@ impl Daemon {
                         Some(dir_path),
                         None,
                         None,
+                        client_protocol_version,
                     )
                     .await;
             }
@@ -2048,6 +2076,7 @@ impl Daemon {
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             needs_load,
             created_new_at_path, // Enable auto-launch for notebooks created at non-existent paths
+            client_protocol_version,
         )
         .await
     }
@@ -2063,6 +2092,7 @@ impl Daemon {
         working_dir: Option<String>,
         notebook_id_hint: Option<String>,
         ephemeral: Option<bool>,
+        client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin,
@@ -2196,6 +2226,7 @@ impl Daemon {
             true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             None,  // No streaming load - doc was just created with empty cell
             false, // UUID-based new notebook, handled by is_new_notebook check
+            client_protocol_version,
         )
         .await
     }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -335,6 +335,9 @@ pub async fn handle_notebook_sync_connection<R, W>(
     // True if this is a newly-created notebook at a non-existent path.
     // Used to enable auto-launch for notebooks created via `runt notebook newfile.ipynb`.
     created_new_at_path: bool,
+    // Protocol version from the client preamble. v2 clients don't understand
+    // SessionControl frames, so we skip them when this is < 3.
+    client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -515,11 +518,17 @@ where
         }
     }
 
-    // Send capabilities response (v3 protocol) unless already sent via NotebookConnectionInfo
+    // Send capabilities response unless already sent via NotebookConnectionInfo.
+    // v2 clients expect PROTOCOL_V2 and don't understand session-control frames.
     if !skip_capabilities {
+        let (proto_str, proto_ver) = if client_protocol_version >= 3 {
+            (connection::PROTOCOL_V3, connection::PROTOCOL_VERSION)
+        } else {
+            (connection::PROTOCOL_V2, 2)
+        };
         let caps = connection::ProtocolCapabilities {
-            protocol: connection::PROTOCOL_V3.to_string(),
-            protocol_version: Some(connection::PROTOCOL_VERSION),
+            protocol: proto_str.to_string(),
+            protocol_version: Some(proto_ver),
             daemon_version: Some(crate::daemon_version().to_string()),
         };
         connection::send_json_frame(&mut writer, &caps).await?;
@@ -538,6 +547,7 @@ where
         daemon.clone(),
         needs_load.as_deref(),
         &peer_id,
+        client_protocol_version,
     )
     .await;
 
@@ -1080,6 +1090,7 @@ async fn run_sync_loop_v2<R, W>(
     daemon: std::sync::Arc<crate::daemon::Daemon>,
     needs_load: Option<&Path>,
     peer_id: &str,
+    client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -1103,23 +1114,27 @@ where
         notebook_protocol::protocol::InitialLoadPhaseWire::NotNeeded
     };
 
-    send_session_status(
-        writer,
-        notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase.clone(),
-    )
-    .await?;
+    if client_protocol_version >= 3 {
+        send_session_status(
+            writer,
+            notebook_doc_phase,
+            runtime_state_phase,
+            initial_load_phase.clone(),
+        )
+        .await?;
+    }
 
     let InitialSyncState { mut peer_state } = send_initial_notebook_doc_sync(writer, room).await?;
     notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Syncing;
-    send_session_status(
-        writer,
-        notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase.clone(),
-    )
-    .await?;
+    if client_protocol_version >= 3 {
+        send_session_status(
+            writer,
+            notebook_doc_phase,
+            runtime_state_phase,
+            initial_load_phase.clone(),
+        )
+        .await?;
+    }
 
     let mut state_peer_state = sync::State::new();
     let mut pool_peer_state = sync::State::new();
@@ -1156,13 +1171,15 @@ where
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
     }
     runtime_state_phase = notebook_protocol::protocol::RuntimeStatePhaseWire::Syncing;
-    send_session_status(
-        writer,
-        notebook_doc_phase,
-        runtime_state_phase,
-        initial_load_phase.clone(),
-    )
-    .await?;
+    if client_protocol_version >= 3 {
+        send_session_status(
+            writer,
+            notebook_doc_phase,
+            runtime_state_phase,
+            initial_load_phase.clone(),
+        )
+        .await?;
+    }
 
     // Streaming load: add cells in batches and sync after each batch so the
     // frontend can observe progressive notebook-doc updates.
@@ -1177,13 +1194,15 @@ where
                         load_path.display()
                     );
                     initial_load_phase = notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
-                    send_session_status(
-                        writer,
-                        notebook_doc_phase,
-                        runtime_state_phase,
-                        initial_load_phase.clone(),
-                    )
-                    .await?;
+                    if client_protocol_version >= 3 {
+                        send_session_status(
+                            writer,
+                            notebook_doc_phase,
+                            runtime_state_phase,
+                            initial_load_phase.clone(),
+                        )
+                        .await?;
+                    }
                 }
                 Err(e) => {
                     room.finish_loading();
@@ -1197,15 +1216,17 @@ where
                         load_path.display(),
                         e
                     );
-                    send_session_status(
-                        writer,
-                        notebook_doc_phase,
-                        runtime_state_phase,
-                        notebook_protocol::protocol::InitialLoadPhaseWire::Failed {
-                            reason: e.clone(),
-                        },
-                    )
-                    .await?;
+                    if client_protocol_version >= 3 {
+                        send_session_status(
+                            writer,
+                            notebook_doc_phase,
+                            runtime_state_phase,
+                            notebook_protocol::protocol::InitialLoadPhaseWire::Failed {
+                                reason: e.clone(),
+                            },
+                        )
+                        .await?;
+                    }
                     return Err(anyhow::anyhow!("Streaming load failed: {}", e));
                 }
             }
@@ -1372,13 +1393,15 @@ where
                                 {
                                     notebook_doc_phase =
                                         notebook_protocol::protocol::NotebookDocPhaseWire::Interactive;
-                                    send_session_status(
-                                        writer,
-                                        notebook_doc_phase,
-                                        runtime_state_phase,
-                                        initial_load_phase.clone(),
-                                    )
-                                    .await?;
+                                    if client_protocol_version >= 3 {
+                                        send_session_status(
+                                            writer,
+                                            notebook_doc_phase,
+                                            runtime_state_phase,
+                                            initial_load_phase.clone(),
+                                        )
+                                        .await?;
+                                    }
                                 }
 
                                 // Send to debounced persistence task
@@ -1612,13 +1635,15 @@ where
                                 {
                                     runtime_state_phase =
                                         notebook_protocol::protocol::RuntimeStatePhaseWire::Ready;
-                                    send_session_status(
-                                        writer,
-                                        notebook_doc_phase,
-                                        runtime_state_phase,
-                                        initial_load_phase.clone(),
-                                    )
-                                    .await?;
+                                    if client_protocol_version >= 3 {
+                                        send_session_status(
+                                            writer,
+                                            notebook_doc_phase,
+                                            runtime_state_phase,
+                                            initial_load_phase.clone(),
+                                        )
+                                        .await?;
+                                    }
                                 }
                             }
 
@@ -1734,13 +1759,15 @@ where
                 {
                     initial_load_phase =
                         notebook_protocol::protocol::InitialLoadPhaseWire::Ready;
-                    send_session_status(
-                        writer,
-                        notebook_doc_phase,
-                        runtime_state_phase,
-                        initial_load_phase.clone(),
-                    )
-                    .await?;
+                    if client_protocol_version >= 3 {
+                        send_session_status(
+                            writer,
+                            notebook_doc_phase,
+                            runtime_state_phase,
+                            initial_load_phase.clone(),
+                        )
+                        .await?;
+                    }
                 }
             }
 


### PR DESCRIPTION
The v3 daemon from #2018 hard-rejects v2 preambles. When the nightly auto-updater installs the new v3 daemon binary, the still-running v2 frontend tries to ping the daemon to verify health — and gets rejected every time. The upgrade times out with "Upgraded daemon did not become ready within timeout."

The fix: accept v2 clients gracefully.

- Preamble check accepts `[MIN_PROTOCOL_VERSION, PROTOCOL_VERSION]` range instead of exact match
- Thread `client_protocol_version` through `route_connection` → `handle_notebook_sync_connection` → `run_sync_loop_v2`
- Gate all `send_session_status` calls on `client_protocol_version >= 3` — v2 clients never see `SESSION_CONTROL` frames (type `0x07`) they can't parse
- Send v2-compatible `ProtocolCapabilities` back to v2 clients
- Legacy pre-2.0 clients (no magic preamble) continue to work as before

_PR submitted by @rgbkrk's agent Quill, via Zed_