### PR TITLE
feat(telemetry): add opt-out daily heartbeat pings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,10 @@ uv run nteract   # Alternative: finds and launches runt mcp
 - Use the default nightly flow for normal repo development. Opt into stable only when you are specifically validating stable branding, stable socket/cache paths, or stable app-launch behavior.
 - `cargo xtask dev-daemon`, `cargo xtask notebook`, `cargo xtask run`, `cargo xtask run-mcp`, and `cargo xtask dev-mcp` all follow `RUNT_BUILD_CHANNEL`.
 
+### Telemetry
+
+Anonymous daily heartbeat pings are sent to `telemetry.runtimed.com`. See `docs/telemetry.md` for the full schema, retention policy, and opt-out paths. Dev and CI builds never send telemetry: `RUNTIMED_DEV=1`, `CI=1`, and `NTERACT_TELEMETRY_DISABLE=1` all suppress pings. The shared telemetry module lives in `crates/runtimed-client/src/telemetry.rs`.
+
 ### Python API Notes
 
 - **`Output.data` is typed by MIME kind**: `str` for text MIME types, `bytes` for binary (raw bytes, no base64), `dict` for JSON MIME types. Image outputs include a synthesized `text/llm+plain` key with blob URLs.

--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -160,6 +160,7 @@ export default function App() {
   const [page, setPage] = useState<1 | 2>(1);
   const [runtime, setRuntime] = useState<Runtime | null>(null);
   const [pythonEnv, setPythonEnv] = useState<PythonEnv | null>(null);
+  const [telemetryEnabled, setTelemetryEnabled] = useState(true);
   const [steps, setSteps] = useState<SetupStep[]>([
     { id: "daemon", label: "Installing runtime daemon", status: "in_progress" },
     { id: "tools", label: "Preparing environments", status: "pending" },
@@ -291,6 +292,10 @@ export default function App() {
         value: pythonEnv,
       });
       await invoke("set_synced_setting", {
+        key: "telemetry_enabled",
+        value: telemetryEnabled,
+      });
+      await invoke("set_synced_setting", {
         key: "onboarding_completed",
         value: true,
       });
@@ -316,7 +321,7 @@ export default function App() {
       console.error("Failed to save onboarding settings:", e);
       setErrorMessage("Failed to save settings. Please try again.");
     }
-  }, [daemonReady, poolReady, runtime, pythonEnv]);
+  }, [daemonReady, poolReady, runtime, pythonEnv, telemetryEnabled]);
 
   // Skip onboarding when daemon failed - use current selections or defaults
   const handleSkip = useCallback(async () => {
@@ -426,6 +431,41 @@ export default function App() {
               </Button>
               <PageDots current={2} total={2} />
               <div className="w-[60px]" /> {/* Spacer for centering */}
+            </div>
+
+            {/* Telemetry disclosure */}
+            <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50 border border-border/50">
+              <div className="space-y-0.5 pr-4">
+                <p className="text-sm font-medium">Anonymous usage data</p>
+                <p className="text-xs text-muted-foreground">
+                  One daily ping with version, platform, and architecture. No personal data.{" "}
+                  <a
+                    href="https://nteract.io/docs/telemetry"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
+                  >
+                    Learn more
+                  </a>
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={telemetryEnabled}
+                onClick={() => setTelemetryEnabled(!telemetryEnabled)}
+                className={cn(
+                  "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+                  telemetryEnabled ? "bg-primary" : "bg-muted-foreground/30",
+                )}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
+                    telemetryEnabled ? "translate-x-5" : "translate-x-0",
+                  )}
+                />
+              </button>
             </div>
 
             {/* Get Started button */}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4308,6 +4308,11 @@ pub fn run(
             )?;
             app.set_menu(menu)?;
 
+            // Fire-and-forget app telemetry heartbeat
+            tokio::spawn(async {
+                runtimed::telemetry::heartbeat_once("app", "telemetry_last_app_ping_at").await;
+            });
+
             let has_session_to_clear = restored_session.is_some();
 
             // Ensure runtimed is running (required for daemon-only mode)

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4308,11 +4308,6 @@ pub fn run(
             )?;
             app.set_menu(menu)?;
 
-            // Fire-and-forget app telemetry heartbeat
-            tokio::spawn(async {
-                runtimed::telemetry::heartbeat_once("app", "telemetry_last_app_ping_at").await;
-            });
-
             let has_session_to_clear = restored_session.is_some();
 
             // Ensure runtimed is running (required for daemon-only mode)
@@ -4359,6 +4354,16 @@ pub fn run(
                 // Check if CLI symlinks are current and silently update if stale.
                 // This handles app reinstalls, bundle path changes, and channel switches.
                 cli_install::ensure_cli_current(&app_for_daemon);
+
+                if daemon_available {
+                    tokio::spawn(async {
+                        runtimed::telemetry::heartbeat_once(
+                            "app",
+                            "telemetry_last_app_ping_at",
+                        )
+                        .await;
+                    });
+                }
 
                 // Start settings sync subscription (reconnects automatically)
                 // Spawn as separate task since it runs forever

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -106,6 +106,24 @@ pub fn load_settings() -> SyncedSettings {
             .get("bootstrap_dx")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.bootstrap_dx),
+        install_id: json
+            .get("install_id")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_default(),
+        telemetry_enabled: json
+            .get("telemetry_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true),
+        telemetry_last_daemon_ping_at: json
+            .get("telemetry_last_daemon_ping_at")
+            .and_then(|v| v.as_u64()),
+        telemetry_last_app_ping_at: json
+            .get("telemetry_last_app_ping_at")
+            .and_then(|v| v.as_u64()),
+        telemetry_last_mcp_ping_at: json
+            .get("telemetry_last_mcp_ping_at")
+            .and_then(|v| v.as_u64()),
     }
 }
 
@@ -141,6 +159,7 @@ mod tests {
             conda_pool_size: 3,
             pixi_pool_size: 2,
             bootstrap_dx: false,
+            ..SyncedSettings::default()
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -296,6 +315,7 @@ mod tests {
             conda_pool_size: defaults.conda_pool_size,
             pixi_pool_size: defaults.pixi_pool_size,
             bootstrap_dx: defaults.bootstrap_dx,
+            ..defaults
         };
         // Valid fields are preserved
         assert_eq!(settings.theme, ThemeMode::Dark);

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -839,7 +839,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         runt_mcp::daemon_watch::watch(daemon_conn, watch_socket, session, peer_label).await
     });
 
-    let heartbeat_handle = tokio::spawn(async {
+    tokio::spawn(async {
         runtimed_client::telemetry::heartbeat_loop("mcp", "telemetry_last_mcp_ping_at").await;
     });
 
@@ -859,7 +859,6 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             std::process::exit(code);
         }
-        _ = heartbeat_handle => {}
     }
 
     Ok(())

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -438,6 +438,19 @@ enum ConfigCommands {
         /// New value. For list keys (e.g. uv.default_packages): JSON array '["pandas","numpy"]' or comma-separated 'pandas,numpy'
         value: String,
     },
+    /// Manage anonymous usage telemetry
+    #[command(subcommand)]
+    Telemetry(TelemetryCommands),
+}
+
+#[derive(Subcommand)]
+enum TelemetryCommands {
+    /// Show telemetry status, install ID, last ping times, and blocking gates
+    Status,
+    /// Enable anonymous usage telemetry
+    Enable,
+    /// Disable anonymous usage telemetry
+    Disable,
 }
 
 /// Valid top-level and dotted settings keys. Used to reject typos.
@@ -826,6 +839,10 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         runt_mcp::daemon_watch::watch(daemon_conn, watch_socket, session, peer_label).await
     });
 
+    let heartbeat_handle = tokio::spawn(async {
+        runtimed_client::telemetry::heartbeat_loop("mcp", "telemetry_last_mcp_ping_at").await;
+    });
+
     tokio::select! {
         result = handle.waiting() => {
             // MCP client disconnected — normal shutdown
@@ -842,6 +859,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             std::process::exit(code);
         }
+        _ = heartbeat_handle => {}
     }
 
     Ok(())
@@ -4367,7 +4385,111 @@ async fn config_command(command: Option<ConfigCommands>) -> Result<()> {
             std::fs::write(&settings_path, &json_str)?;
             println!("Updated {key} in {}", settings_path.display());
         }
+        Some(ConfigCommands::Telemetry(cmd)) => {
+            telemetry_command(cmd, &settings_path).await?;
+        }
     }
+    Ok(())
+}
+
+async fn telemetry_command(command: TelemetryCommands, settings_path: &Path) -> Result<()> {
+    match command {
+        TelemetryCommands::Status => {
+            let settings = read_settings_from_file(settings_path)?;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            println!(
+                "Telemetry: {}",
+                if settings.telemetry_enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
+
+            if settings.install_id.is_empty() {
+                println!("Install ID: (not yet generated)");
+            } else {
+                println!("Install ID: {}", settings.install_id);
+            }
+
+            fn format_ping(ts: Option<u64>, now: u64) -> String {
+                match ts {
+                    None => "never".to_string(),
+                    Some(t) => {
+                        let ago = now.saturating_sub(t);
+                        if ago < 60 {
+                            format!("{ago}s ago")
+                        } else if ago < 3600 {
+                            format!("{}m ago", ago / 60)
+                        } else {
+                            format!("{}h ago", ago / 3600)
+                        }
+                    }
+                }
+            }
+
+            println!(
+                "Last daemon ping: {}",
+                format_ping(settings.telemetry_last_daemon_ping_at, now)
+            );
+            println!(
+                "Last app ping: {}",
+                format_ping(settings.telemetry_last_app_ping_at, now)
+            );
+            println!(
+                "Last MCP ping: {}",
+                format_ping(settings.telemetry_last_mcp_ping_at, now)
+            );
+
+            let gates = runtimed_client::telemetry::blocking_gates(
+                settings.telemetry_enabled,
+                settings.onboarding_completed,
+                None, // show env-level gates, not per-source throttle
+                now,
+            );
+            if gates.is_empty() {
+                println!("\nNo blocking gates - telemetry will send on next check.");
+            } else {
+                println!("\nBlocking gates (telemetry suppressed):");
+                for gate in &gates {
+                    println!("  - {gate}");
+                }
+            }
+        }
+        TelemetryCommands::Enable => {
+            write_telemetry_enabled(settings_path, true)?;
+            println!("Telemetry enabled.");
+        }
+        TelemetryCommands::Disable => {
+            write_telemetry_enabled(settings_path, false)?;
+            println!("Telemetry disabled. Existing data ages out after 400 days.");
+            println!("See docs/telemetry.md for retention details.");
+        }
+    }
+    Ok(())
+}
+
+fn write_telemetry_enabled(settings_path: &Path, enabled: bool) -> Result<()> {
+    let mut json_value = if settings_path.exists() {
+        let content = std::fs::read_to_string(settings_path)?;
+        serde_json::from_str::<serde_json::Value>(&content)?
+    } else {
+        serde_json::to_value(runtimed::settings_doc::SyncedSettings::default())?
+    };
+    if let Some(obj) = json_value.as_object_mut() {
+        obj.insert(
+            "telemetry_enabled".to_string(),
+            serde_json::Value::Bool(enabled),
+        );
+    }
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(settings_path, serde_json::to_string_pretty(&json_value)?)?;
     Ok(())
 }
 

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -39,6 +39,7 @@ pub mod service;
 pub mod settings_doc;
 pub mod singleton;
 pub mod sync_client;
+pub mod telemetry;
 
 // ============================================================================
 // Development Mode and Worktree Isolation

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -248,6 +248,28 @@ pub struct SyncedSettings {
     /// feature flags are added.
     #[serde(default)]
     pub bootstrap_dx: bool,
+
+    // ── Telemetry ───────────────────────────────────────────────────
+    /// Opaque per-install UUIDv4. Generated on first heartbeat, persisted in
+    /// settings. Not derived from any identifying data.
+    #[serde(default)]
+    pub install_id: String,
+
+    /// Master telemetry switch. When false, no heartbeat pings are sent.
+    #[serde(default = "default_telemetry_enabled")]
+    pub telemetry_enabled: bool,
+
+    /// Unix-seconds timestamp of the last successful daemon heartbeat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_last_daemon_ping_at: Option<u64>,
+
+    /// Unix-seconds timestamp of the last successful app heartbeat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_last_app_ping_at: Option<u64>,
+
+    /// Unix-seconds timestamp of the last successful MCP heartbeat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_last_mcp_ping_at: Option<u64>,
 }
 
 impl SyncedSettings {
@@ -275,8 +297,17 @@ impl Default for SyncedSettings {
             conda_pool_size: DEFAULT_CONDA_POOL_SIZE,
             pixi_pool_size: DEFAULT_PIXI_POOL_SIZE,
             bootstrap_dx: false,
+            install_id: String::new(),
+            telemetry_enabled: true,
+            telemetry_last_daemon_ping_at: None,
+            telemetry_last_app_ping_at: None,
+            telemetry_last_mcp_ping_at: None,
         }
     }
+}
+
+fn default_telemetry_enabled() -> bool {
+    true
 }
 
 fn default_keep_alive_secs() -> u64 {
@@ -290,6 +321,19 @@ fn default_conda_pool_size() -> u64 {
 }
 fn default_pixi_pool_size() -> u64 {
     DEFAULT_PIXI_POOL_SIZE
+}
+
+/// Ensure an `install_id` exists in the settings doc, generating one if needed.
+/// Returns the (possibly freshly-generated) install ID.
+pub fn ensure_install_id(settings: &mut SettingsDoc) -> String {
+    if let Some(existing) = settings.get("install_id") {
+        if !existing.is_empty() {
+            return existing;
+        }
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    settings.put("install_id", &id);
+    id
 }
 
 /// Generate a JSON Schema string for the settings file.
@@ -362,6 +406,10 @@ impl SettingsDoc {
             "pixi_pool_size",
             defaults.pixi_pool_size as i64,
         );
+
+        // Telemetry defaults (install_id left empty until first heartbeat)
+        let _ = doc.put(automerge::ROOT, "install_id", "");
+        let _ = doc.put(automerge::ROOT, "telemetry_enabled", true);
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -462,6 +510,34 @@ impl SettingsDoc {
         // bootstrap_dx: boolean
         if let Some(enabled) = json.get("bootstrap_dx").and_then(|v| v.as_bool()) {
             settings.put_bool("bootstrap_dx", enabled);
+        }
+
+        // Telemetry fields
+        if let Some(id) = json.get("install_id").and_then(|v| v.as_str()) {
+            if !id.is_empty() {
+                settings.put("install_id", id);
+            }
+        }
+        if let Some(enabled) = json.get("telemetry_enabled").and_then(|v| v.as_bool()) {
+            settings.put_bool("telemetry_enabled", enabled);
+        }
+        if let Some(ts) = json
+            .get("telemetry_last_daemon_ping_at")
+            .and_then(|v| v.as_u64())
+        {
+            settings.put_u64("telemetry_last_daemon_ping_at", ts);
+        }
+        if let Some(ts) = json
+            .get("telemetry_last_app_ping_at")
+            .and_then(|v| v.as_u64())
+        {
+            settings.put_u64("telemetry_last_app_ping_at", ts);
+        }
+        if let Some(ts) = json
+            .get("telemetry_last_mcp_ping_at")
+            .and_then(|v| v.as_u64())
+        {
+            settings.put_u64("telemetry_last_mcp_ping_at", ts);
         }
 
         // Pool sizes (numeric values, import from JSON if present)
@@ -863,6 +939,11 @@ impl SettingsDoc {
             bootstrap_dx: self
                 .get_bool("bootstrap_dx")
                 .unwrap_or(defaults.bootstrap_dx),
+            install_id: self.get("install_id").unwrap_or_default(),
+            telemetry_enabled: self.get_bool("telemetry_enabled").unwrap_or(true),
+            telemetry_last_daemon_ping_at: self.get_u64("telemetry_last_daemon_ping_at"),
+            telemetry_last_app_ping_at: self.get_u64("telemetry_last_app_ping_at"),
+            telemetry_last_mcp_ping_at: self.get_u64("telemetry_last_mcp_ping_at"),
         }
     }
 
@@ -992,6 +1073,35 @@ impl SettingsDoc {
                 );
                 self.put_bool("bootstrap_dx", enabled);
                 changed = true;
+            }
+        }
+
+        // Telemetry fields
+        if let Some(id) = json.get("install_id").and_then(|v| v.as_str()) {
+            if !id.is_empty() {
+                let current = self.get("install_id");
+                if current.as_deref() != Some(id) {
+                    self.put("install_id", id);
+                    changed = true;
+                }
+            }
+        }
+        if let Some(enabled) = json.get("telemetry_enabled").and_then(|v| v.as_bool()) {
+            if self.get_bool("telemetry_enabled") != Some(enabled) {
+                self.put_bool("telemetry_enabled", enabled);
+                changed = true;
+            }
+        }
+        for key in &[
+            "telemetry_last_daemon_ping_at",
+            "telemetry_last_app_ping_at",
+            "telemetry_last_mcp_ping_at",
+        ] {
+            if let Some(ts) = json.get(key).and_then(|v| v.as_u64()) {
+                if self.get_u64(key) != Some(ts) {
+                    self.put_u64(key, ts);
+                    changed = true;
+                }
             }
         }
 

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -452,6 +452,11 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         conda_pool_size: get_u64("conda_pool_size").unwrap_or(defaults.conda_pool_size),
         pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(defaults.pixi_pool_size),
         bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
+        install_id: get_str("install_id").unwrap_or_default(),
+        telemetry_enabled: get_bool("telemetry_enabled").unwrap_or(true),
+        telemetry_last_daemon_ping_at: get_u64("telemetry_last_daemon_ping_at"),
+        telemetry_last_app_ping_at: get_u64("telemetry_last_app_ping_at"),
+        telemetry_last_mcp_ping_at: get_u64("telemetry_last_mcp_ping_at"),
     }
 }
 

--- a/crates/runtimed-client/src/telemetry.rs
+++ b/crates/runtimed-client/src/telemetry.rs
@@ -1,0 +1,371 @@
+use serde::Serialize;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://telemetry.runtimed.com/v1/ping";
+const SEND_TIMEOUT: Duration = Duration::from_secs(3);
+const THROTTLE_SECS: u64 = 20 * 60 * 60; // 20 hours
+const LOOP_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
+
+fn endpoint() -> String {
+    std::env::var("NTERACT_TELEMETRY_ENDPOINT")
+        .unwrap_or_else(|_| DEFAULT_TELEMETRY_ENDPOINT.to_string())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HeartbeatPayload {
+    pub install_id: String,
+    pub source: String,
+    pub version: String,
+    pub channel: String,
+    pub platform: String,
+    pub arch: String,
+}
+
+pub fn detect_channel() -> &'static str {
+    match option_env!("RUNT_BUILD_CHANNEL") {
+        Some("stable") => "stable",
+        _ => "nightly",
+    }
+}
+
+pub fn detect_platform() -> Option<&'static str> {
+    match std::env::consts::OS {
+        "macos" => Some("macos"),
+        "linux" => Some("linux"),
+        "windows" => Some("windows"),
+        _ => None,
+    }
+}
+
+pub fn detect_arch() -> Option<&'static str> {
+    match std::env::consts::ARCH {
+        "x86_64" => Some("x86_64"),
+        "aarch64" => Some("arm64"),
+        _ => None,
+    }
+}
+
+pub fn is_telemetry_suppressed() -> bool {
+    if crate::is_dev_mode() {
+        return true;
+    }
+    if std::env::var("CI").is_ok() {
+        return true;
+    }
+    if std::env::var("NTERACT_TELEMETRY_DISABLE").is_ok() {
+        return true;
+    }
+    false
+}
+
+pub fn should_send(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> bool {
+    if !telemetry_enabled {
+        return false;
+    }
+    if !onboarding_completed {
+        return false;
+    }
+    if detect_platform().is_none() || detect_arch().is_none() {
+        return false;
+    }
+    if let Some(last) = last_ping_at {
+        if now_secs.saturating_sub(last) < THROTTLE_SECS {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn blocking_gates(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> Vec<&'static str> {
+    let mut gates = Vec::new();
+    if crate::is_dev_mode() {
+        gates.push("dev mode (RUNTIMED_DEV=1 or RUNTIMED_WORKSPACE_PATH set)");
+    }
+    if std::env::var("CI").is_ok() {
+        gates.push("CI environment detected");
+    }
+    if std::env::var("NTERACT_TELEMETRY_DISABLE").is_ok() {
+        gates.push("NTERACT_TELEMETRY_DISABLE is set");
+    }
+    if !telemetry_enabled {
+        gates.push("telemetry_enabled = false");
+    }
+    if !onboarding_completed {
+        gates.push("onboarding not completed");
+    }
+    if detect_platform().is_none() {
+        gates.push("unsupported platform");
+    }
+    if detect_arch().is_none() {
+        gates.push("unsupported architecture");
+    }
+    if let Some(last) = last_ping_at {
+        if now_secs.saturating_sub(last) < THROTTLE_SECS {
+            gates.push("throttled (last ping < 20h ago)");
+        }
+    }
+    gates
+}
+
+pub async fn send_heartbeat(
+    client: &reqwest::Client,
+    payload: &HeartbeatPayload,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let body = serde_json::to_vec(payload)?;
+    let resp = client
+        .post(endpoint())
+        .header("Content-Type", "application/json")
+        .timeout(SEND_TIMEOUT)
+        .body(body)
+        .send()
+        .await?;
+    if resp.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("telemetry ping returned {}", resp.status()).into())
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Shared heartbeat loop for long-running processes (daemon, MCP).
+///
+/// Checks every hour, sends if >20h since last ping. Reads and writes
+/// settings through the daemon's Automerge sync path when available,
+/// falling back to disk JSON.
+pub async fn heartbeat_loop(source: &str, timestamp_key: &str) {
+    if is_telemetry_suppressed() {
+        log::debug!("[telemetry] suppressed for source={source}, skipping heartbeat loop");
+        return;
+    }
+
+    let client = match reqwest::Client::builder().timeout(SEND_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("[telemetry] failed to build HTTP client: {e}");
+            return;
+        }
+    };
+
+    loop {
+        try_send(&client, source, timestamp_key).await;
+        tokio::time::sleep(LOOP_INTERVAL).await;
+    }
+}
+
+/// Single-shot heartbeat for processes that don't need a loop (e.g. the app).
+pub async fn heartbeat_once(source: &str, timestamp_key: &str) {
+    if is_telemetry_suppressed() {
+        log::debug!("[telemetry] suppressed for source={source}, skipping heartbeat");
+        return;
+    }
+
+    let client = match reqwest::Client::builder().timeout(SEND_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("[telemetry] failed to build HTTP client: {e}");
+            return;
+        }
+    };
+
+    try_send(&client, source, timestamp_key).await;
+}
+
+async fn try_send(client: &reqwest::Client, source: &str, timestamp_key: &str) {
+    let settings = match read_settings().await {
+        Some(s) => s,
+        None => return,
+    };
+
+    let now = now_secs();
+    let last_ping_at = match timestamp_key {
+        "telemetry_last_daemon_ping_at" => settings.telemetry_last_daemon_ping_at,
+        "telemetry_last_app_ping_at" => settings.telemetry_last_app_ping_at,
+        "telemetry_last_mcp_ping_at" => settings.telemetry_last_mcp_ping_at,
+        _ => None,
+    };
+
+    if !should_send(
+        settings.telemetry_enabled,
+        settings.onboarding_completed,
+        last_ping_at,
+        now,
+    ) {
+        return;
+    }
+
+    let install_id = if settings.install_id.is_empty() {
+        let id = uuid::Uuid::new_v4().to_string();
+        write_setting("install_id", &serde_json::Value::String(id.clone())).await;
+        id
+    } else {
+        settings.install_id
+    };
+
+    let Some(platform) = detect_platform() else {
+        return;
+    };
+    let Some(arch) = detect_arch() else {
+        return;
+    };
+
+    let payload = HeartbeatPayload {
+        install_id,
+        source: source.to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: detect_channel().to_string(),
+        platform: platform.to_string(),
+        arch: arch.to_string(),
+    };
+
+    match send_heartbeat(client, &payload).await {
+        Ok(()) => log::info!("[telemetry] sent heartbeat source={source}"),
+        Err(e) => log::warn!("[telemetry] heartbeat failed source={source}: {e}"),
+    }
+
+    // Update timestamp on both success and failure to prevent retry storms
+    write_setting(timestamp_key, &serde_json::Value::Number(now.into())).await;
+}
+
+async fn read_settings() -> Option<crate::settings_doc::SyncedSettings> {
+    match crate::sync_client::try_get_synced_settings().await {
+        Ok(settings) => Some(settings),
+        Err(_) => {
+            let path = crate::settings_json_path();
+            let contents = std::fs::read_to_string(&path).ok()?;
+            serde_json::from_str(&contents).ok()
+        }
+    }
+}
+
+async fn write_setting(key: &str, value: &serde_json::Value) {
+    let socket_path = crate::default_socket_path();
+    match crate::sync_client::SyncClient::connect_with_timeout(
+        socket_path,
+        Duration::from_millis(500),
+    )
+    .await
+    {
+        Ok(mut client) => {
+            if let Err(e) = client.put_value(key, value).await {
+                log::debug!("[telemetry] failed to write {key} via daemon: {e}");
+            }
+        }
+        Err(e) => {
+            log::debug!("[telemetry] daemon unavailable for write {key}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payload_shape() {
+        let payload = HeartbeatPayload {
+            install_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            source: "daemon".to_string(),
+            version: "1.2.3".to_string(),
+            channel: "nightly".to_string(),
+            platform: "macos".to_string(),
+            arch: "arm64".to_string(),
+        };
+        let json: serde_json::Value = serde_json::to_value(&payload).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.len(), 6);
+        assert!(obj.contains_key("install_id"));
+        assert!(obj.contains_key("source"));
+        assert!(obj.contains_key("version"));
+        assert!(obj.contains_key("channel"));
+        assert!(obj.contains_key("platform"));
+        assert!(obj.contains_key("arch"));
+    }
+
+    #[test]
+    fn test_channel_detection() {
+        let ch = detect_channel();
+        assert!(ch == "stable" || ch == "nightly");
+    }
+
+    #[test]
+    fn test_platform_detection() {
+        let p = detect_platform();
+        assert!(p.is_some(), "tests must run on a supported platform");
+    }
+
+    #[test]
+    fn test_arch_detection() {
+        let a = detect_arch();
+        assert!(a.is_some(), "tests must run on a supported arch");
+    }
+
+    #[test]
+    fn test_should_send_happy_path() {
+        assert!(should_send(true, true, None, 1000));
+    }
+
+    #[test]
+    fn test_should_send_disabled() {
+        assert!(!should_send(false, true, None, 1000));
+    }
+
+    #[test]
+    fn test_should_send_not_onboarded() {
+        assert!(!should_send(true, false, None, 1000));
+    }
+
+    #[test]
+    fn test_should_send_throttled() {
+        let now = 1_700_000_000u64;
+        let recent = now - (19 * 60 * 60); // 19 hours ago
+        assert!(!should_send(true, true, Some(recent), now));
+    }
+
+    #[test]
+    fn test_should_send_past_throttle() {
+        let now = 1_700_000_000u64;
+        let old = now - (21 * 60 * 60); // 21 hours ago
+        assert!(should_send(true, true, Some(old), now));
+    }
+
+    #[test]
+    fn test_blocking_gates_all_clear() {
+        // Can't fully test env-dependent gates in unit tests, but we can
+        // test the settings-based gates
+        let gates = blocking_gates(true, true, None, 1000);
+        // At minimum, settings-based gates should not fire
+        assert!(!gates.contains(&"telemetry_enabled = false"));
+        assert!(!gates.contains(&"onboarding not completed"));
+        assert!(!gates.contains(&"throttled (last ping < 20h ago)"));
+    }
+
+    #[test]
+    fn test_blocking_gates_disabled() {
+        let gates = blocking_gates(false, true, None, 1000);
+        assert!(gates.contains(&"telemetry_enabled = false"));
+    }
+
+    #[test]
+    fn test_blocking_gates_throttled() {
+        let now = 1_700_000_000u64;
+        let recent = now - (10 * 60 * 60);
+        let gates = blocking_gates(true, true, Some(recent), now);
+        assert!(gates.contains(&"throttled (last ping < 20h ago)"));
+    }
+}

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -611,7 +611,7 @@ pub struct Daemon {
     /// Singleton lock - kept alive while daemon is running.
     _lock: DaemonLock,
     /// Shared Automerge settings document.
-    settings: Arc<RwLock<SettingsDoc>>,
+    pub(crate) settings: Arc<RwLock<SettingsDoc>>,
     /// Broadcast channel to notify sync connections of settings changes.
     settings_changed: tokio::sync::broadcast::Sender<()>,
     /// Global Automerge pool state document (daemon-authoritative, ephemeral).

--- a/crates/runtimed/src/daemon_telemetry.rs
+++ b/crates/runtimed/src/daemon_telemetry.rs
@@ -33,12 +33,24 @@ async fn daemon_heartbeat_loop(daemon: Arc<Daemon>) {
 }
 
 async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Client) {
-    let (settings, install_id) = {
+    let (settings, install_id, id_was_generated) = {
         let mut settings_doc = daemon.settings.write().await;
+        let had_id = settings_doc
+            .get("install_id")
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
         let id = runtimed_client::settings_doc::ensure_install_id(&mut settings_doc);
+        let generated = !had_id;
+        if generated {
+            persist_settings(&mut settings_doc);
+        }
         let snapshot = settings_doc.get_all();
-        (snapshot, id)
+        (snapshot, id, generated)
     };
+
+    if id_was_generated {
+        tracing::info!("[telemetry] generated install_id");
+    }
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -75,7 +87,21 @@ async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Clien
         Err(e) => tracing::warn!("[telemetry] daemon heartbeat failed: {e}"),
     }
 
-    // Update timestamp on both success and failure
-    let mut settings_doc = daemon.settings.write().await;
-    settings_doc.put_u64("telemetry_last_daemon_ping_at", now);
+    // Update timestamp and persist to disk so it survives daemon restarts
+    {
+        let mut settings_doc = daemon.settings.write().await;
+        settings_doc.put_u64("telemetry_last_daemon_ping_at", now);
+        persist_settings(&mut settings_doc);
+    }
+}
+
+fn persist_settings(doc: &mut runtimed_client::settings_doc::SettingsDoc) {
+    let automerge_path = runtimed_client::default_settings_doc_path();
+    let json_path = runtimed_client::settings_json_path();
+    if let Err(e) = doc.save_to_file(&automerge_path) {
+        tracing::warn!("[telemetry] failed to save Automerge doc: {e}");
+    }
+    if let Err(e) = doc.save_json_mirror(&json_path) {
+        tracing::warn!("[telemetry] failed to write JSON mirror: {e}");
+    }
 }

--- a/crates/runtimed/src/daemon_telemetry.rs
+++ b/crates/runtimed/src/daemon_telemetry.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use crate::daemon::Daemon;
+use crate::task_supervisor::spawn_best_effort;
+
+pub fn spawn_daemon_heartbeat(daemon: Arc<Daemon>) {
+    spawn_best_effort("telemetry-heartbeat", async move {
+        daemon_heartbeat_loop(daemon).await;
+    });
+}
+
+async fn daemon_heartbeat_loop(daemon: Arc<Daemon>) {
+    if runtimed_client::telemetry::is_telemetry_suppressed() {
+        tracing::debug!("[telemetry] suppressed, skipping daemon heartbeat loop");
+        return;
+    }
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("[telemetry] failed to build HTTP client: {e}");
+            return;
+        }
+    };
+
+    loop {
+        try_send_daemon_heartbeat(&daemon, &client).await;
+        tokio::time::sleep(std::time::Duration::from_secs(60 * 60)).await;
+    }
+}
+
+async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Client) {
+    let (settings, install_id) = {
+        let mut settings_doc = daemon.settings.write().await;
+        let id = runtimed_client::settings_doc::ensure_install_id(&mut settings_doc);
+        let snapshot = settings_doc.get_all();
+        (snapshot, id)
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    if !runtimed_client::telemetry::should_send(
+        settings.telemetry_enabled,
+        settings.onboarding_completed,
+        settings.telemetry_last_daemon_ping_at,
+        now,
+    ) {
+        return;
+    }
+
+    let Some(platform) = runtimed_client::telemetry::detect_platform() else {
+        return;
+    };
+    let Some(arch) = runtimed_client::telemetry::detect_arch() else {
+        return;
+    };
+
+    let payload = runtimed_client::telemetry::HeartbeatPayload {
+        install_id,
+        source: "daemon".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        channel: runtimed_client::telemetry::detect_channel().to_string(),
+        platform: platform.to_string(),
+        arch: arch.to_string(),
+    };
+
+    match runtimed_client::telemetry::send_heartbeat(client, &payload).await {
+        Ok(()) => tracing::info!("[telemetry] sent daemon heartbeat"),
+        Err(e) => tracing::warn!("[telemetry] daemon heartbeat failed: {e}"),
+    }
+
+    // Update timestamp on both success and failure
+    let mut settings_doc = daemon.settings.write().await;
+    settings_doc.put_u64("telemetry_last_daemon_ping_at", now);
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -24,6 +24,7 @@ pub use runtimed_client::*;
 pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;
+pub mod daemon_telemetry;
 pub mod dx_blob_comm;
 pub mod embedded_plugins;
 pub mod inline_env;

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -430,6 +430,8 @@ async fn run_daemon(
         }
     };
 
+    runtimed::daemon_telemetry::spawn_daemon_heartbeat(daemon.clone());
+
     // Set up signal handlers for graceful shutdown with logging
     #[cfg(unix)]
     {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,72 @@
+# Telemetry
+
+nteract collects anonymous daily usage data to understand how many people use the app. This document describes exactly what is sent, what is not, and how to opt out.
+
+## What is sent
+
+Every heartbeat ping carries six fields:
+
+| Field | Example | Description |
+|---|---|---|
+| `install_id` | `550e8400-e29b-41d4-a716-446655440000` | Opaque UUIDv4 generated on first run. Not derived from any identifying data. |
+| `source` | `app`, `daemon`, `mcp` | Which process sent the ping. |
+| `version` | `2.2.1` | Release version. |
+| `channel` | `stable` or `nightly` | Release channel. |
+| `platform` | `macos`, `linux`, `windows` | OS family. |
+| `arch` | `arm64`, `x86_64` | CPU architecture. |
+
+The server adds `received_at` (unix timestamp) on its side.
+
+## What is never sent or stored
+
+- Hostname, username, home directory, or any filesystem path
+- Notebook contents, cell outputs, kernel names, or environment details
+- Dependency names or versions (Python, Node, R, system packages)
+- Hardware identifiers (MAC address, serial number, disk UUID)
+- Client IP address at rest - Cloudflare observes it briefly for rate limiting; the database does not store it
+- `User-Agent` or any HTTP header beyond `Content-Type`
+
+## How it works
+
+Three processes send heartbeats independently:
+
+- **app** - fires once per launch of the desktop GUI
+- **daemon** - checks hourly, sends if >20 hours since last ping
+- **mcp** - checks hourly, sends if >20 hours since last ping
+
+All pings go to `https://telemetry.runtimed.com/v1/ping` as a JSON POST. The endpoint enforces a 60 req/min rate limit per IP at the Cloudflare edge.
+
+## Emission gates
+
+A heartbeat is suppressed if any of these conditions hold:
+
+| Gate | Trigger |
+|---|---|
+| Dev mode | `RUNTIMED_DEV=1` or `RUNTIMED_WORKSPACE_PATH` is set |
+| CI | `CI` environment variable is set |
+| Kill switch | `NTERACT_TELEMETRY_DISABLE` environment variable is set |
+| Disabled | `telemetry_enabled = false` in settings |
+| Not onboarded | `onboarding_completed = false` (fresh install before first-run screen) |
+| Unsupported host | Platform or architecture not in the server's enum |
+| Throttled | Last ping for this source was less than 20 hours ago |
+
+## Opting out
+
+Three ways to disable telemetry, all equivalent:
+
+1. **Onboarding toggle** - the first-run screen includes a telemetry toggle (default: on). Flip it off before clicking "Get Started".
+
+2. **CLI** - run `runt config telemetry disable`. Check status with `runt config telemetry status`.
+
+3. **Environment variable** - set `NTERACT_TELEMETRY_DISABLE=1`. This is an emergency kill switch for locked-down deployments or CI images.
+
+There is no server-side delete endpoint. When you disable telemetry the client stops sending pings. Existing data ages out under the retention policy below.
+
+## Retention
+
+- **Raw pings**: kept for 400 days, then deleted by a nightly cleanup job.
+- **Daily aggregate counts**: kept indefinitely. These contain no `install_id` - only counts of distinct installs grouped by day, source, version, channel, platform, and arch.
+
+## Schema evolution
+
+New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).


### PR DESCRIPTION
## Summary

Wire the desktop app, daemon, and MCP server to send anonymous daily heartbeat pings to the deployed `telemetry.runtimed.com` endpoint. Each source (`app`, `daemon`, `mcp`) sends one ping per day with six fields: `install_id`, `source`, `version`, `channel`, `platform`, `arch`.

- Shared gate logic and payload builder in `runtimed-client` - long-running processes (daemon, MCP) loop hourly, app fires once per launch
- Opt-out via onboarding toggle, `runt config telemetry disable`, or `NTERACT_TELEMETRY_DISABLE=1`
- Dev mode, CI, and unfinished onboarding all suppress pings - no data sent before the user sees the disclosure
- `docs/telemetry.md` documents the full schema, retention (400-day raw, indefinite anonymized rollups), and all opt-out paths

## Verification

- [ ] `runt config telemetry status` shows expected gates and last-ping times
- [ ] `runt config telemetry disable` then restart daemon - confirm no ping fires
- [ ] `runt config telemetry enable` then restart daemon - confirm ping fires
- [ ] Fresh install: onboarding shows telemetry disclosure with toggle before "Get Started"
- [ ] Toggling telemetry off during onboarding persists as `telemetry_enabled: false`
- [ ] Under `RUNTIMED_DEV=1` (direnv), `runt config telemetry status` shows dev mode gate
- [ ] Point `NTERACT_TELEMETRY_ENDPOINT` at a local echo server, confirm POST body has exactly 6 keys
- [ ] Leave daemon running >20h (or clear `telemetry_last_daemon_ping_at`), confirm second ping fires

<!-- Screenshots of the onboarding telemetry disclosure toggle -->

_PR submitted by @rgbkrk's agent, Quill_