### PR TITLE
fix(plugins): marketplace name tracks channel instead of "notebook"

### DIFF
--- a/scripts/assemble-plugin-dist.sh
+++ b/scripts/assemble-plugin-dist.sh
@@ -35,7 +35,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 channel=""
 binaries_dir=""
 out_dir=""
-marketplace_name="notebook"
+marketplace_name=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -58,6 +58,11 @@ done
 [[ -n "$binaries_dir" ]] || { echo "--binaries-dir required" >&2; exit 2; }
 [[ -n "$out_dir" ]] || { echo "--out-dir required" >&2; exit 2; }
 
+# Marketplace name defaults to the plugin name for the channel. It's what
+# users see when they run `/plugin marketplace add <repo>` and what they
+# type after `@` in `/plugin install <plugin>@<marketplace>`. Calling it
+# "notebook" overloaded the label with the MCP server's name (which IS
+# "notebook" — that one's correct) and made the install confusing.
 case "$channel" in
   stable)
     plugin_name="nteract"
@@ -70,6 +75,8 @@ case "$channel" in
     exit 2
     ;;
 esac
+
+[[ -n "$marketplace_name" ]] || marketplace_name="$plugin_name"
 
 source_plugin="$REPO_ROOT/plugins/$plugin_name"
 [[ -d "$source_plugin" ]] || { echo "source plugin not found: $source_plugin" >&2; exit 1; }


### PR DESCRIPTION
Follow-up to #2029.

## Summary

The marketplace name was defaulted to `"notebook"`, which meant Claude Code displayed:

```
/plugin marketplace add nteract/claude-plugin-nightly
→ Successfully added marketplace: notebook
/plugin install nteract-nightly@notebook
```

The `notebook` label was meant to name the MCP server (correct — that's what the server operates on) but got overloaded onto the marketplace itself. Confusing.

Default the marketplace name to the plugin name for the channel:

- Stable → `nteract`
- Nightly → `nteract-nightly`

User-facing result:

```
/plugin marketplace add nteract/claude-plugin-nightly
→ Successfully added marketplace: nteract-nightly
/plugin install nteract-nightly@nteract-nightly
```

The tool-approval prompt still reads `plugin:nteract-nightly:notebook - <tool>`, which is correct — the inner `notebook` is the MCP server name from `.mcp.json`'s `mcpServers.notebook`, which genuinely describes what the server does.

## Test plan

- [x] Assembly script exercised with both channels, marketplace.json + README verified
- [ ] Next nightly release repopulates `nteract/claude-plugin-nightly/main` with the corrected name
- [ ] Users who `/plugin marketplace add`'d during the ~8-hour window between #2029 merging and this PR see the display name update on next release (no re-install needed)