### PR TITLE
fix(sift-wasm): accept ISO-8601 timestamps, null on type mismatch

### DIFF
--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46fff2d4c7e38c2cd8040db5f1066e9604efd9739fb570e397c150abc34d4db8
-size 4514503
+oid sha256:598af9cbc92373723790a39ee5d8670e5e33e1dce36a38aff719b40d00cc0811
+size 4518259

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a27409d322174d292fac1c12e4a15c22ecb2735538644b9bdf618b1705e3f611
-size 4510490
+oid sha256:46fff2d4c7e38c2cd8040db5f1066e9604efd9739fb570e397c150abc34d4db8
+size 4514503

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:598af9cbc92373723790a39ee5d8670e5e33e1dce36a38aff719b40d00cc0811
-size 4518259
+oid sha256:223dc1136bed54cd7ad326159b3d6ebfbdd3a4ef30d8958efdae70734aaf47df
+size 4517312

--- a/crates/sift-wasm/pkg/sift_wasm.js
+++ b/crates/sift-wasm/pkg/sift_wasm.js
@@ -957,6 +957,10 @@ function __wbg_get_imports() {
             const ret = getObject(arg0).call(getObject(arg1));
             return addHeapObject(ret);
         }, arguments); },
+        __wbg_call_a24592a6f349a97e: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
+            return addHeapObject(ret);
+        }, arguments); },
         __wbg_done_9158f7cc8751ba32: function(arg0) {
             const ret = getObject(arg0).done;
             return ret;
@@ -1014,6 +1018,16 @@ function __wbg_get_imports() {
             let result;
             try {
                 result = getObject(arg0) instanceof Map;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_instanceof_Object_7c99480a1cdfb911: function(arg0) {
+            let result;
+            try {
+                result = getObject(arg0) instanceof Object;
             } catch (_) {
                 result = false;
             }
@@ -1097,6 +1111,22 @@ function __wbg_get_imports() {
             const len1 = WASM_VECTOR_LEN;
             getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
             getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg_static_accessor_GLOBAL_8cfadc87a297ca02: function() {
+            const ret = typeof global === 'undefined' ? null : global;
+            return isLikeNone(ret) ? 0 : addHeapObject(ret);
+        },
+        __wbg_static_accessor_GLOBAL_THIS_602256ae5c8f42cf: function() {
+            const ret = typeof globalThis === 'undefined' ? null : globalThis;
+            return isLikeNone(ret) ? 0 : addHeapObject(ret);
+        },
+        __wbg_static_accessor_SELF_e445c1c7484aecc3: function() {
+            const ret = typeof self === 'undefined' ? null : self;
+            return isLikeNone(ret) ? 0 : addHeapObject(ret);
+        },
+        __wbg_static_accessor_WINDOW_f20e8576ef1e0f17: function() {
+            const ret = typeof window === 'undefined' ? null : window;
+            return isLikeNone(ret) ? 0 : addHeapObject(ret);
         },
         __wbg_value_ee3a06f4579184fa: function(arg0) {
             const ret = getObject(arg0).value;

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46fff2d4c7e38c2cd8040db5f1066e9604efd9739fb570e397c150abc34d4db8
-size 4514503
+oid sha256:598af9cbc92373723790a39ee5d8670e5e33e1dce36a38aff719b40d00cc0811
+size 4518259

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a27409d322174d292fac1c12e4a15c22ecb2735538644b9bdf618b1705e3f611
-size 4510490
+oid sha256:46fff2d4c7e38c2cd8040db5f1066e9604efd9739fb570e397c150abc34d4db8
+size 4514503

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:598af9cbc92373723790a39ee5d8670e5e33e1dce36a38aff719b40d00cc0811
-size 4518259
+oid sha256:223dc1136bed54cd7ad326159b3d6ebfbdd3a4ef30d8958efdae70734aaf47df
+size 4517312

--- a/crates/sift-wasm/src/writer.rs
+++ b/crates/sift-wasm/src/writer.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use arrow::array::builder::{
     BinaryBuilder, BooleanBuilder, Date32Builder, Float64Builder, Int64Builder, StringBuilder,
     TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
-    TimestampSecondBuilder,
 };
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
@@ -119,11 +118,21 @@ impl SqliteDeclared {
     }
 
     /// Arrow type to use in the output Parquet schema.
+    ///
+    /// Note on seconds: Parquet's `TIMESTAMP` logical type only supports
+    /// MILLIS / MICROS / NANOS — there is no TIMESTAMP_SECONDS. If we emit
+    /// `Timestamp(Second, None)` arrow-rs writes a bare `INT64` with no
+    /// logical annotation, so consumers like DuckDB see a plain bigint
+    /// instead of a timestamp. We therefore promote `TimestampSecond` to
+    /// `Timestamp(Millisecond, None)` and scale numeric seconds-domain
+    /// inputs ×1000 in `build_column`. The `TimestampSecond` variant name
+    /// still accurately describes the SQLite-side input scale.
     pub fn to_arrow(self) -> DataType {
         match self {
             Self::Boolean => DataType::Boolean,
-            Self::TimestampSecond => DataType::Timestamp(TimeUnit::Second, None),
-            Self::TimestampMilli => DataType::Timestamp(TimeUnit::Millisecond, None),
+            Self::TimestampSecond | Self::TimestampMilli => {
+                DataType::Timestamp(TimeUnit::Millisecond, None)
+            }
             Self::TimestampMicro => DataType::Timestamp(TimeUnit::Microsecond, None),
             Self::TimestampNano => DataType::Timestamp(TimeUnit::Nanosecond, None),
             Self::Date => DataType::Date32,
@@ -137,10 +146,22 @@ impl SqliteDeclared {
             Self::RealAffinity | Self::NumericAffinity => DataType::Float64,
         }
     }
-}
 
-fn sqlite_type_to_arrow(declared: &str) -> DataType {
-    SqliteDeclared::parse(declared).to_arrow()
+    /// How many of this variant's input units equal one second. Used to
+    /// rescale numeric SQLite values (e.g. Unix seconds vs. Unix ms) to
+    /// whatever unit `to_arrow()` chose for the Parquet column.
+    ///
+    /// Returns 0 for non-temporal variants (they never hit the timestamp
+    /// builder, but 0 keeps the `i64` type uniform).
+    fn input_units_per_second(self) -> i64 {
+        match self {
+            Self::TimestampSecond => 1,
+            Self::TimestampMilli => 1_000,
+            Self::TimestampMicro => 1_000_000,
+            Self::TimestampNano => 1_000_000_000,
+            _ => 0,
+        }
+    }
 }
 
 /// Build a Parquet file directly from SQLite query results. The caller
@@ -171,9 +192,10 @@ pub fn write_parquet_from_sqlite(
     let mut arrays: Vec<ArrayRef> = Vec::with_capacity(columns.len());
 
     for col in &columns {
-        let dt = sqlite_type_to_arrow(&col.ty);
+        let declared = SqliteDeclared::parse(&col.ty);
+        let dt = declared.to_arrow();
         fields.push(Field::new(&col.name, dt.clone(), true));
-        let array = build_column(&col.name, &dt, &rows, n)?;
+        let array = build_column(&col.name, declared, &dt, &rows, n)?;
         arrays.push(array);
     }
 
@@ -305,6 +327,7 @@ fn web_sys_console_warn(_msg: &str) {
 /// errors — those are programmer bugs, not data.
 fn build_column(
     name: &str,
+    declared: SqliteDeclared,
     dt: &DataType,
     rows: &js_sys::Array,
     n: usize,
@@ -393,31 +416,27 @@ fn build_column(
             }
             Arc::new(b.finish())
         }
-        DataType::Timestamp(TimeUnit::Second, _) => {
-            let mut b = TimestampSecondBuilder::with_capacity(n);
-            for i in 0..n {
-                append_timestamp_cell(&mut b, &key, rows, i, name, 1, &mut stats)?;
-            }
-            Arc::new(b.finish())
-        }
         DataType::Timestamp(TimeUnit::Millisecond, _) => {
             let mut b = TimestampMillisecondBuilder::with_capacity(n);
+            let col = TimestampColumn::new(name, declared.input_units_per_second(), 1_000);
             for i in 0..n {
-                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000, &mut stats)?;
+                append_timestamp_cell(&mut b, &col, rows, i, &mut stats)?;
             }
             Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Microsecond, _) => {
             let mut b = TimestampMicrosecondBuilder::with_capacity(n);
+            let col = TimestampColumn::new(name, declared.input_units_per_second(), 1_000_000);
             for i in 0..n {
-                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000_000, &mut stats)?;
+                append_timestamp_cell(&mut b, &col, rows, i, &mut stats)?;
             }
             Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Nanosecond, _) => {
             let mut b = TimestampNanosecondBuilder::with_capacity(n);
+            let col = TimestampColumn::new(name, declared.input_units_per_second(), 1_000_000_000);
             for i in 0..n {
-                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000_000_000, &mut stats)?;
+                append_timestamp_cell(&mut b, &col, rows, i, &mut stats)?;
             }
             Arc::new(b.finish())
         }
@@ -477,54 +496,89 @@ fn build_column(
     Ok(array)
 }
 
-/// Convert a cell value to an Arrow timestamp at the given unit, using the
-/// caller-supplied multiplier to scale seconds → the target unit when the
-/// source is an ISO-8601 string. Numbers/bigints pass through as-is (the
-/// caller is already quoting the unit in the Arrow schema).
+/// Per-column state for building a timestamp column. Bundled so the
+/// per-cell function stays within clippy's argument count.
+struct TimestampColumn<'a> {
+    /// Column name (used for error messages + mismatch logs).
+    name: &'a str,
+    /// JS string key used to pluck the value out of each row object.
+    key: JsValue,
+    /// How many SQLite-side numeric input units equal one second.
+    /// 1 for `TIMESTAMP`, 1000 for `DATETIME`/`TIMESTAMP_MS`, etc. Comes
+    /// from `SqliteDeclared::input_units_per_second`.
+    input_per_second: i64,
+    /// How many of the Arrow builder's units equal one second. 1_000 for
+    /// Millisecond, 1_000_000 for Microsecond, 1_000_000_000 for Nanosecond.
+    output_per_second: i64,
+}
+
+impl<'a> TimestampColumn<'a> {
+    fn new(name: &'a str, input_per_second: i64, output_per_second: i64) -> Self {
+        Self {
+            name,
+            key: JsValue::from_str(name),
+            input_per_second,
+            output_per_second,
+        }
+    }
+
+    /// Scale numeric input → output. `output_per_second ≥ input_per_second`
+    /// in every combination we produce, so this is an integer multiply.
+    fn numeric_scale(&self) -> i64 {
+        if self.input_per_second == 0 {
+            1
+        } else {
+            self.output_per_second / self.input_per_second
+        }
+    }
+}
+
+/// Convert a cell value to an Arrow timestamp at the output unit.
 ///
-/// `per_second`: 1 for seconds, 1_000 for millis, 1_000_000 for micros,
-/// 1_000_000_000 for nanos.
+/// Numeric inputs are scaled by `output_per_second / input_per_second`
+/// (integer division is safe — the builder unit is always ≥ the input
+/// unit). String inputs go through `naive_datetime_from_str` to get
+/// (seconds, subsec_nanos) and scale into output units.
 fn append_timestamp_cell<B>(
     builder: &mut B,
-    key: &JsValue,
+    col: &TimestampColumn<'_>,
     rows: &js_sys::Array,
     i: usize,
-    name: &str,
-    per_second: i64,
     stats: &mut MismatchStats,
 ) -> Result<(), JsError>
 where
     B: TimestampAppender,
 {
-    let v = get_cell(rows, i, key, name)?;
+    let scale_num = col.numeric_scale();
+    let v = get_cell(rows, i, &col.key, col.name)?;
     if v.is_null() || v.is_undefined() {
         builder.append_null();
     } else if let Some(f) = v.as_f64() {
-        builder.append_value(f as i64);
+        builder.append_value((f as i64) * scale_num);
     } else if let Ok(big) = v.clone().try_into() {
-        builder.append_value(big);
+        let big: i64 = big;
+        builder.append_value(big * scale_num);
     } else if let Some(s) = v.as_string() {
         match naive_datetime_from_str(&s) {
             Some(dt) => {
                 let seconds = dt.and_utc().timestamp();
                 let nanos = i64::from(dt.and_utc().timestamp_subsec_nanos());
-                let value = match per_second {
-                    1 => seconds,
+                let value = match col.output_per_second {
                     1_000 => seconds * 1_000 + nanos / 1_000_000,
                     1_000_000 => seconds * 1_000_000 + nanos / 1_000,
                     1_000_000_000 => seconds * 1_000_000_000 + nanos,
-                    _ => seconds * per_second,
+                    _ => seconds * col.output_per_second,
                 };
                 builder.append_value(value);
             }
             None => {
-                stats.record(name, i, &format!("unparseable timestamp string {s:?}"));
+                stats.record(col.name, i, &format!("unparseable timestamp string {s:?}"));
                 builder.append_null();
             }
         }
     } else {
         stats.record(
-            name,
+            col.name,
             i,
             &format!(
                 "expected number/bigint/ISO-8601 string, got {:?}",
@@ -536,20 +590,14 @@ where
     Ok(())
 }
 
-/// Uniform interface for the four timestamp builders so
-/// `append_timestamp_cell` doesn't have to be duplicated per unit.
+/// Uniform interface for the three timestamp builders so
+/// `append_timestamp_cell` doesn't have to be duplicated per unit. There is
+/// intentionally no impl for `TimestampSecondBuilder` — Parquet has no
+/// TIMESTAMP_SECONDS logical type, so we promote seconds inputs to
+/// milliseconds in `SqliteDeclared::to_arrow`.
 trait TimestampAppender {
     fn append_value(&mut self, v: i64);
     fn append_null(&mut self);
-}
-
-impl TimestampAppender for TimestampSecondBuilder {
-    fn append_value(&mut self, v: i64) {
-        self.append_value(v);
-    }
-    fn append_null(&mut self) {
-        self.append_null();
-    }
 }
 
 impl TimestampAppender for TimestampMillisecondBuilder {
@@ -656,9 +704,11 @@ mod tests {
     #[test]
     fn maps_to_expected_arrow_types() {
         assert_eq!(SqliteDeclared::Boolean.to_arrow(), DataType::Boolean);
+        // TimestampSecond promotes to Millisecond in Parquet (no
+        // TIMESTAMP_SECONDS logical type exists).
         assert_eq!(
             SqliteDeclared::TimestampSecond.to_arrow(),
-            DataType::Timestamp(TimeUnit::Second, None)
+            DataType::Timestamp(TimeUnit::Millisecond, None)
         );
         assert_eq!(
             SqliteDeclared::TimestampMilli.to_arrow(),

--- a/crates/sift-wasm/src/writer.rs
+++ b/crates/sift-wasm/src/writer.rs
@@ -20,7 +20,7 @@ use arrow::array::builder::{
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::ipc::reader::StreamReader;
-use chrono::{NaiveDate, NaiveDateTime};
+use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
@@ -196,18 +196,39 @@ fn date32_from_str(s: &str) -> Option<i32> {
 }
 
 /// Parse a SQLite datetime string into a `NaiveDateTime` (treated as UTC).
-/// Accepts common shapes: `YYYY-MM-DD HH:MM:SS[.fff]`, ISO-8601 with `T`,
-/// optional trailing `Z`, optional fractional seconds. Returns `None` for
-/// anything we don't recognize — caller writes a null.
+/// Accepts the shapes SQLite drivers actually emit:
+///
+/// - Naive:  `YYYY-MM-DD HH:MM:SS[.fff]`, `YYYY-MM-DDTHH:MM:SS[.fff]`
+/// - Trailing `Z` (UTC)
+/// - RFC 3339 with numeric offset: `2026-04-21T12:34:56+02:00`, `...-07:00`
+///
+/// Offset-qualified values are normalized to UTC so the resulting naive
+/// timestamp represents the same instant. Returns `None` for anything we
+/// don't recognize — caller writes a null.
 fn naive_datetime_from_str(s: &str) -> Option<NaiveDateTime> {
-    let trimmed = s.trim_end_matches('Z');
+    let trimmed = s.trim();
+
+    // Offset-qualified first: `+HH:MM`, `-HH:MM`, `+HHMM`, `Z`.
+    if let Ok(dt) = DateTime::parse_from_rfc3339(trimmed) {
+        return Some(dt.naive_utc());
+    }
+    if let Ok(dt) = DateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%.f%:z") {
+        return Some(dt.naive_utc());
+    }
+    if let Ok(dt) = DateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%:z") {
+        return Some(dt.naive_utc());
+    }
+
+    // Naive fallbacks (and `Z`-suffixed values that parse_from_rfc3339 missed
+    // due to missing seconds precision, etc.).
+    let naive = trimmed.trim_end_matches('Z');
     for fmt in [
         "%Y-%m-%dT%H:%M:%S%.f",
         "%Y-%m-%dT%H:%M:%S",
         "%Y-%m-%d %H:%M:%S%.f",
         "%Y-%m-%d %H:%M:%S",
     ] {
-        if let Ok(dt) = NaiveDateTime::parse_from_str(trimmed, fmt) {
+        if let Ok(dt) = NaiveDateTime::parse_from_str(naive, fmt) {
             return Some(dt);
         }
     }

--- a/crates/sift-wasm/src/writer.rs
+++ b/crates/sift-wasm/src/writer.rs
@@ -20,7 +20,7 @@ use arrow::array::builder::{
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::ipc::reader::StreamReader;
-use chrono::NaiveDate;
+use chrono::{NaiveDate, NaiveDateTime};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
@@ -189,14 +189,99 @@ fn get_cell(rows: &js_sys::Array, i: usize, key: &JsValue, name: &str) -> Result
     js_sys::Reflect::get(&row, key).map_err(|_| JsError::new(&format!("missing {name} at row {i}")))
 }
 
-fn date32_from_str(s: &str) -> Result<i32, JsError> {
-    let d = NaiveDate::parse_from_str(s, "%Y-%m-%d")
-        .map_err(|e| JsError::new(&format!("date parse '{s}': {e}")))?;
-    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)
-        .ok_or_else(|| JsError::new("epoch date unavailable"))?;
-    Ok((d - epoch).num_days() as i32)
+fn date32_from_str(s: &str) -> Option<i32> {
+    let d = NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()?;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)?;
+    Some((d - epoch).num_days() as i32)
 }
 
+/// Parse a SQLite datetime string into a `NaiveDateTime` (treated as UTC).
+/// Accepts common shapes: `YYYY-MM-DD HH:MM:SS[.fff]`, ISO-8601 with `T`,
+/// optional trailing `Z`, optional fractional seconds. Returns `None` for
+/// anything we don't recognize — caller writes a null.
+fn naive_datetime_from_str(s: &str) -> Option<NaiveDateTime> {
+    let trimmed = s.trim_end_matches('Z');
+    for fmt in [
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+    ] {
+        if let Ok(dt) = NaiveDateTime::parse_from_str(trimmed, fmt) {
+            return Some(dt);
+        }
+    }
+    None
+}
+
+/// Tracks how many cells in one column were coerced to null because their
+/// runtime storage class didn't match the column's declared type. SQLite
+/// allows this (affinity is non-enforcing); we prefer "null this cell" over
+/// "reject the whole partition" so one stray row can't kill an export.
+///
+/// A single summary is emitted to `console.warn` per column at the end.
+#[derive(Default)]
+struct MismatchStats {
+    nulled: usize,
+    first_example: Option<String>,
+}
+
+impl MismatchStats {
+    fn record(&mut self, column: &str, index: usize, reason: &str) {
+        self.nulled += 1;
+        if self.first_example.is_none() {
+            self.first_example = Some(format!("{column}[{index}]: {reason}"));
+        }
+    }
+
+    fn flush(&self, column: &str) {
+        if self.nulled == 0 {
+            return;
+        }
+        let msg = match &self.first_example {
+            Some(example) => format!(
+                "sift-wasm: nulled {} cell(s) in column {:?} due to type mismatch (first: {})",
+                self.nulled, column, example
+            ),
+            None => format!(
+                "sift-wasm: nulled {} cell(s) in column {:?} due to type mismatch",
+                self.nulled, column
+            ),
+        };
+        web_sys_console_warn(&msg);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn web_sys_console_warn(msg: &str) {
+    let Ok(global) = js_sys::global().dyn_into::<js_sys::Object>() else {
+        return;
+    };
+    let Ok(console) = js_sys::Reflect::get(&global, &JsValue::from_str("console")) else {
+        return;
+    };
+    let Ok(warn) = js_sys::Reflect::get(&console, &JsValue::from_str("warn")) else {
+        return;
+    };
+    let Ok(warn_fn) = warn.dyn_into::<js_sys::Function>() else {
+        return;
+    };
+    let _ = warn_fn.call1(&console, &JsValue::from_str(msg));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn web_sys_console_warn(_msg: &str) {
+    // Native tests: silently. The test harness asserts nullability directly.
+}
+
+/// Build one column from a JS array of row objects.
+///
+/// Behavior on type mismatch: the SQLite affinity system is permissive, so
+/// a value whose runtime storage class doesn't match the column's declared
+/// type is written as **null** rather than failing the whole export. A
+/// single `console.warn` summary is emitted per column if any cells were
+/// nulled. Structural errors (missing column in a row) are still hard
+/// errors — those are programmer bugs, not data.
 fn build_column(
     name: &str,
     dt: &DataType,
@@ -204,7 +289,9 @@ fn build_column(
     n: usize,
 ) -> Result<ArrayRef, JsError> {
     let key = JsValue::from_str(name);
-    match dt {
+    let mut stats = MismatchStats::default();
+
+    let array: ArrayRef = match dt {
         DataType::Utf8 => {
             let mut b = StringBuilder::with_capacity(n, n * 32);
             for i in 0..n {
@@ -214,13 +301,15 @@ fn build_column(
                 } else if let Some(s) = v.as_string() {
                     b.append_value(s);
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected string, got {:?}",
-                        v.js_typeof()
-                    )));
+                    stats.record(
+                        name,
+                        i,
+                        &format!("expected string, got {:?}", v.js_typeof()),
+                    );
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Int64 => {
             let mut b = Int64Builder::with_capacity(n);
@@ -233,13 +322,15 @@ fn build_column(
                 } else if let Ok(big) = v.clone().try_into() {
                     b.append_value(big);
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bigint, got {:?}",
-                        v.js_typeof()
-                    )));
+                    stats.record(
+                        name,
+                        i,
+                        &format!("expected number/bigint, got {:?}", v.js_typeof()),
+                    );
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Float64 => {
             let mut b = Float64Builder::with_capacity(n);
@@ -250,13 +341,15 @@ fn build_column(
                 } else if let Some(f) = v.as_f64() {
                     b.append_value(f);
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number, got {:?}",
-                        v.js_typeof()
-                    )));
+                    stats.record(
+                        name,
+                        i,
+                        &format!("expected number, got {:?}", v.js_typeof()),
+                    );
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Boolean => {
             let mut b = BooleanBuilder::with_capacity(n);
@@ -264,90 +357,48 @@ fn build_column(
                 let v = get_cell(rows, i, &key, name)?;
                 if v.is_null() || v.is_undefined() {
                     b.append_null();
-                } else if let Some(f) = v.as_f64() {
-                    b.append_value(f != 0.0);
                 } else if let Some(bl) = v.as_bool() {
                     b.append_value(bl);
+                } else if let Some(f) = v.as_f64() {
+                    b.append_value(f != 0.0);
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bool (SQLite bool), got {:?}",
-                        v.js_typeof()
-                    )));
+                    stats.record(
+                        name,
+                        i,
+                        &format!("expected bool/number, got {:?}", v.js_typeof()),
+                    );
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Second, _) => {
             let mut b = TimestampSecondBuilder::with_capacity(n);
             for i in 0..n {
-                let v = get_cell(rows, i, &key, name)?;
-                if v.is_null() || v.is_undefined() {
-                    b.append_null();
-                } else if let Some(f) = v.as_f64() {
-                    b.append_value(f as i64);
-                } else if let Ok(big) = v.clone().try_into() {
-                    b.append_value(big);
-                } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bigint unix seconds"
-                    )));
-                }
+                append_timestamp_cell(&mut b, &key, rows, i, name, 1, &mut stats)?;
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Millisecond, _) => {
             let mut b = TimestampMillisecondBuilder::with_capacity(n);
             for i in 0..n {
-                let v = get_cell(rows, i, &key, name)?;
-                if v.is_null() || v.is_undefined() {
-                    b.append_null();
-                } else if let Some(f) = v.as_f64() {
-                    b.append_value(f as i64);
-                } else if let Ok(big) = v.clone().try_into() {
-                    b.append_value(big);
-                } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bigint unix milliseconds"
-                    )));
-                }
+                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000, &mut stats)?;
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Microsecond, _) => {
             let mut b = TimestampMicrosecondBuilder::with_capacity(n);
             for i in 0..n {
-                let v = get_cell(rows, i, &key, name)?;
-                if v.is_null() || v.is_undefined() {
-                    b.append_null();
-                } else if let Some(f) = v.as_f64() {
-                    b.append_value(f as i64);
-                } else if let Ok(big) = v.clone().try_into() {
-                    b.append_value(big);
-                } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bigint unix microseconds"
-                    )));
-                }
+                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000_000, &mut stats)?;
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Timestamp(TimeUnit::Nanosecond, _) => {
             let mut b = TimestampNanosecondBuilder::with_capacity(n);
             for i in 0..n {
-                let v = get_cell(rows, i, &key, name)?;
-                if v.is_null() || v.is_undefined() {
-                    b.append_null();
-                } else if let Some(f) = v.as_f64() {
-                    b.append_value(f as i64);
-                } else if let Ok(big) = v.clone().try_into() {
-                    b.append_value(big);
-                } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected number/bigint unix nanoseconds"
-                    )));
-                }
+                append_timestamp_cell(&mut b, &key, rows, i, name, 1_000_000_000, &mut stats)?;
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Date32 => {
             let mut b = Date32Builder::with_capacity(n);
@@ -356,16 +407,25 @@ fn build_column(
                 if v.is_null() || v.is_undefined() {
                     b.append_null();
                 } else if let Some(s) = v.as_string() {
-                    b.append_value(date32_from_str(&s)?);
+                    match date32_from_str(&s) {
+                        Some(d) => b.append_value(d),
+                        None => {
+                            stats.record(name, i, &format!("unparseable date string {s:?}"));
+                            b.append_null();
+                        }
+                    }
                 } else if let Some(f) = v.as_f64() {
                     b.append_value(f as i32);
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected 'YYYY-MM-DD' string or days-since-epoch number"
-                    )));
+                    stats.record(
+                        name,
+                        i,
+                        "expected 'YYYY-MM-DD' string or days-since-epoch number",
+                    );
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
         DataType::Binary => {
             let mut b = BinaryBuilder::with_capacity(n, n * 64);
@@ -379,16 +439,122 @@ fn build_column(
                 } else if let Ok(u8) = v.clone().dyn_into::<js_sys::Uint8Array>() {
                     b.append_value(u8.to_vec().as_slice());
                 } else {
-                    return Err(JsError::new(&format!(
-                        "{name}[{i}]: expected ArrayBuffer or Uint8Array for BLOB"
-                    )));
+                    stats.record(name, i, "expected ArrayBuffer or Uint8Array for BLOB");
+                    b.append_null();
                 }
             }
-            Ok(Arc::new(b.finish()))
+            Arc::new(b.finish())
         }
-        other => Err(JsError::new(&format!(
-            "unsupported Arrow type {other:?} for column {name}"
-        ))),
+        other => {
+            return Err(JsError::new(&format!(
+                "unsupported Arrow type {other:?} for column {name}"
+            )));
+        }
+    };
+
+    stats.flush(name);
+    Ok(array)
+}
+
+/// Convert a cell value to an Arrow timestamp at the given unit, using the
+/// caller-supplied multiplier to scale seconds → the target unit when the
+/// source is an ISO-8601 string. Numbers/bigints pass through as-is (the
+/// caller is already quoting the unit in the Arrow schema).
+///
+/// `per_second`: 1 for seconds, 1_000 for millis, 1_000_000 for micros,
+/// 1_000_000_000 for nanos.
+fn append_timestamp_cell<B>(
+    builder: &mut B,
+    key: &JsValue,
+    rows: &js_sys::Array,
+    i: usize,
+    name: &str,
+    per_second: i64,
+    stats: &mut MismatchStats,
+) -> Result<(), JsError>
+where
+    B: TimestampAppender,
+{
+    let v = get_cell(rows, i, key, name)?;
+    if v.is_null() || v.is_undefined() {
+        builder.append_null();
+    } else if let Some(f) = v.as_f64() {
+        builder.append_value(f as i64);
+    } else if let Ok(big) = v.clone().try_into() {
+        builder.append_value(big);
+    } else if let Some(s) = v.as_string() {
+        match naive_datetime_from_str(&s) {
+            Some(dt) => {
+                let seconds = dt.and_utc().timestamp();
+                let nanos = i64::from(dt.and_utc().timestamp_subsec_nanos());
+                let value = match per_second {
+                    1 => seconds,
+                    1_000 => seconds * 1_000 + nanos / 1_000_000,
+                    1_000_000 => seconds * 1_000_000 + nanos / 1_000,
+                    1_000_000_000 => seconds * 1_000_000_000 + nanos,
+                    _ => seconds * per_second,
+                };
+                builder.append_value(value);
+            }
+            None => {
+                stats.record(name, i, &format!("unparseable timestamp string {s:?}"));
+                builder.append_null();
+            }
+        }
+    } else {
+        stats.record(
+            name,
+            i,
+            &format!(
+                "expected number/bigint/ISO-8601 string, got {:?}",
+                v.js_typeof()
+            ),
+        );
+        builder.append_null();
+    }
+    Ok(())
+}
+
+/// Uniform interface for the four timestamp builders so
+/// `append_timestamp_cell` doesn't have to be duplicated per unit.
+trait TimestampAppender {
+    fn append_value(&mut self, v: i64);
+    fn append_null(&mut self);
+}
+
+impl TimestampAppender for TimestampSecondBuilder {
+    fn append_value(&mut self, v: i64) {
+        self.append_value(v);
+    }
+    fn append_null(&mut self) {
+        self.append_null();
+    }
+}
+
+impl TimestampAppender for TimestampMillisecondBuilder {
+    fn append_value(&mut self, v: i64) {
+        self.append_value(v);
+    }
+    fn append_null(&mut self) {
+        self.append_null();
+    }
+}
+
+impl TimestampAppender for TimestampMicrosecondBuilder {
+    fn append_value(&mut self, v: i64) {
+        self.append_value(v);
+    }
+    fn append_null(&mut self) {
+        self.append_null();
+    }
+}
+
+impl TimestampAppender for TimestampNanosecondBuilder {
+    fn append_value(&mut self, v: i64) {
+        self.append_value(v);
+    }
+    fn append_null(&mut self) {
+        self.append_null();
     }
 }
 

--- a/crates/sift-wasm/tests/writer_sqlite.rs
+++ b/crates/sift-wasm/tests/writer_sqlite.rs
@@ -10,11 +10,12 @@ use std::sync::Arc;
 
 use arrow::array::{
     Array, BooleanArray, Date32Array, Float64Array, Int64Array, RecordBatch, StringArray,
-    TimestampSecondArray,
+    TimestampMillisecondArray,
 };
 use arrow::datatypes::{DataType, TimeUnit};
 use bytes::Bytes;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::basic::LogicalType;
 use serde::Serialize;
 use sift_wasm::write_parquet_from_sqlite;
 use wasm_bindgen::JsValue;
@@ -43,6 +44,9 @@ fn sqlite_round_trip_preserves_richer_types() {
 
     let rows = to_js(&serde_json::json!([
         {
+            // received_at is Unix seconds (SQLite TIMESTAMP convention).
+            // We scale ×1000 so Parquet can carry it as a TIMESTAMP_MILLIS
+            // logical type (Parquet has no TIMESTAMP_SECONDS).
             "id": 1, "label": "alpha", "ratio": 0.5,
             "active": 1, "received_at": 1_776_831_852_i64,
             "day": "2026-04-20"
@@ -63,6 +67,23 @@ fn sqlite_round_trip_preserves_richer_types() {
         .expect("parquet reader builder");
     let schema = Arc::clone(builder.schema());
 
+    // Assert the Parquet *physical* schema carries a TIMESTAMP logical type
+    // annotation. The Arrow schema we read above could otherwise report a
+    // timestamp even when the physical schema has no annotation (arrow-rs
+    // embeds an `ARROW:schema` metadata blob), so downstream consumers like
+    // DuckDB / Polars / pyarrow's non-Arrow-aware paths wouldn't recognize
+    // it. This is the invariant that catches the seconds→int64 regression.
+    let parquet_meta = builder.metadata();
+    let received_descr = parquet_meta.file_metadata().schema_descr().column(4);
+    assert!(
+        matches!(
+            received_descr.logical_type(),
+            Some(LogicalType::Timestamp { .. })
+        ),
+        "received_at must carry a Parquet TIMESTAMP logical type, got {:?}",
+        received_descr.logical_type()
+    );
+
     // Schema must carry the richer types — not VARCHAR-for-everything.
     assert_eq!(schema.field(0).name(), "id");
     assert_eq!(schema.field(0).data_type(), &DataType::Int64);
@@ -75,7 +96,7 @@ fn sqlite_round_trip_preserves_richer_types() {
     assert_eq!(schema.field(4).name(), "received_at");
     assert_eq!(
         schema.field(4).data_type(),
-        &DataType::Timestamp(TimeUnit::Second, None)
+        &DataType::Timestamp(TimeUnit::Millisecond, None)
     );
     assert_eq!(schema.field(5).name(), "day");
     assert_eq!(schema.field(5).data_type(), &DataType::Date32);
@@ -119,13 +140,14 @@ fn sqlite_round_trip_preserves_richer_types() {
     assert!(active.value(0));
     assert!(!active.value(1));
 
+    // Seconds input (1_776_831_852) scales ×1000 into Millisecond builder.
     let received = batch
         .column(4)
         .as_any()
-        .downcast_ref::<TimestampSecondArray>()
-        .expect("timestamp(s)");
-    assert_eq!(received.value(0), 1_776_831_852);
-    assert_eq!(received.value(1), 1_776_918_252);
+        .downcast_ref::<TimestampMillisecondArray>()
+        .expect("timestamp(ms)");
+    assert_eq!(received.value(0), 1_776_831_852_000);
+    assert_eq!(received.value(1), 1_776_918_252_000);
 
     let day = batch
         .column(5)
@@ -230,33 +252,35 @@ fn sqlite_text_timestamps_round_trip() {
 
     assert_eq!(batch.num_rows(), 2);
 
+    // TIMESTAMP promotes to Millisecond in Parquet; string-parsed seconds
+    // are scaled to ms. 2026-04-21 12:34:56 UTC → 1_776_774_896_000.
     let ts_s = batch
         .column(0)
         .as_any()
-        .downcast_ref::<TimestampSecondArray>()
-        .expect("timestamp(s)");
-    // 2026-04-21 12:34:56 UTC → 1,776,774,896
-    assert_eq!(ts_s.value(0), 1_776_774_896);
-    assert_eq!(ts_s.value(1), 1_776_774_896);
+        .downcast_ref::<TimestampMillisecondArray>()
+        .expect("timestamp(ms)");
+    assert_eq!(ts_s.value(0), 1_776_774_896_000);
+    assert_eq!(ts_s.value(1), 1_776_774_896_000);
 
     let ts_ms = batch
         .column(1)
         .as_any()
-        .downcast_ref::<arrow::array::TimestampMillisecondArray>()
+        .downcast_ref::<TimestampMillisecondArray>()
         .expect("timestamp(ms)");
     assert_eq!(ts_ms.value(0), 1_776_774_896_789);
     assert_eq!(ts_ms.value(1), 1_776_774_896_000);
 
+    // TIMESTAMPTZ also promotes to Millisecond; both offset-qualified values
+    // normalize to the same UTC instant.
     let ts_tz = batch
         .column(2)
         .as_any()
-        .downcast_ref::<TimestampSecondArray>()
-        .expect("timestamptz (second)");
-    // Both offset-qualified values normalize to the same UTC instant.
+        .downcast_ref::<TimestampMillisecondArray>()
+        .expect("timestamptz (ms)");
     assert!(!ts_tz.is_null(0), "positive offset must parse, not null");
     assert!(!ts_tz.is_null(1), "negative offset must parse, not null");
-    assert_eq!(ts_tz.value(0), 1_776_774_896);
-    assert_eq!(ts_tz.value(1), 1_776_774_896);
+    assert_eq!(ts_tz.value(0), 1_776_774_896_000);
+    assert_eq!(ts_tz.value(1), 1_776_774_896_000);
 }
 
 /// P2: SQLite rows whose runtime storage class doesn't match the declared
@@ -322,8 +346,8 @@ fn sqlite_mismatch_nulls_the_cell_not_the_export() {
     let ts = batch
         .column(3)
         .as_any()
-        .downcast_ref::<TimestampSecondArray>()
-        .expect("timestamp(s)");
+        .downcast_ref::<TimestampMillisecondArray>()
+        .expect("timestamp(ms)");
     assert!(!ts.is_null(0));
     assert!(ts.is_null(1), "unparseable timestamp string should null");
     assert!(!ts.is_null(2));

--- a/crates/sift-wasm/tests/writer_sqlite.rs
+++ b/crates/sift-wasm/tests/writer_sqlite.rs
@@ -192,16 +192,28 @@ fn sqlite_nulls_round_trip() {
 
 /// P1: text-encoded SQLite timestamps (the common case — SQLite stores
 /// TIMESTAMP/DATETIME as ISO-8601 text in practice) round-trip instead of
-/// rejecting the export.
+/// rejecting the export. Covers naive forms, trailing `Z`, and numeric
+/// offsets (`TIMESTAMPTZ` with `+HH:MM`/`-HH:MM`).
 #[wasm_bindgen_test]
 fn sqlite_text_timestamps_round_trip() {
     let pragma = to_js(&serde_json::json!([
-        {"name": "ts_s",  "type": "TIMESTAMP"},
-        {"name": "ts_ms", "type": "DATETIME"},
+        {"name": "ts_s",   "type": "TIMESTAMP"},
+        {"name": "ts_ms",  "type": "DATETIME"},
+        {"name": "ts_tz",  "type": "TIMESTAMPTZ"},
     ]));
     let rows = to_js(&serde_json::json!([
-        {"ts_s": "2026-04-21 12:34:56",     "ts_ms": "2026-04-21T12:34:56.789"},
-        {"ts_s": "2026-04-21T12:34:56Z",    "ts_ms": "2026-04-21 12:34:56"},
+        {
+            "ts_s": "2026-04-21 12:34:56",
+            "ts_ms": "2026-04-21T12:34:56.789",
+            // 14:34:56+02:00 == 12:34:56Z
+            "ts_tz": "2026-04-21T14:34:56+02:00"
+        },
+        {
+            "ts_s": "2026-04-21T12:34:56Z",
+            "ts_ms": "2026-04-21 12:34:56",
+            // 05:34:56-07:00 == 12:34:56Z
+            "ts_tz": "2026-04-21T05:34:56-07:00"
+        },
     ]));
 
     let parquet = write_parquet_from_sqlite(pragma, rows).expect("write_parquet_from_sqlite");
@@ -234,6 +246,17 @@ fn sqlite_text_timestamps_round_trip() {
         .expect("timestamp(ms)");
     assert_eq!(ts_ms.value(0), 1_776_774_896_789);
     assert_eq!(ts_ms.value(1), 1_776_774_896_000);
+
+    let ts_tz = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<TimestampSecondArray>()
+        .expect("timestamptz (second)");
+    // Both offset-qualified values normalize to the same UTC instant.
+    assert!(!ts_tz.is_null(0), "positive offset must parse, not null");
+    assert!(!ts_tz.is_null(1), "negative offset must parse, not null");
+    assert_eq!(ts_tz.value(0), 1_776_774_896);
+    assert_eq!(ts_tz.value(1), 1_776_774_896);
 }
 
 /// P2: SQLite rows whose runtime storage class doesn't match the declared

--- a/crates/sift-wasm/tests/writer_sqlite.rs
+++ b/crates/sift-wasm/tests/writer_sqlite.rs
@@ -189,3 +189,119 @@ fn sqlite_nulls_round_trip() {
     assert_eq!(labels.value(0), "alpha");
     assert!(labels.is_null(1));
 }
+
+/// P1: text-encoded SQLite timestamps (the common case — SQLite stores
+/// TIMESTAMP/DATETIME as ISO-8601 text in practice) round-trip instead of
+/// rejecting the export.
+#[wasm_bindgen_test]
+fn sqlite_text_timestamps_round_trip() {
+    let pragma = to_js(&serde_json::json!([
+        {"name": "ts_s",  "type": "TIMESTAMP"},
+        {"name": "ts_ms", "type": "DATETIME"},
+    ]));
+    let rows = to_js(&serde_json::json!([
+        {"ts_s": "2026-04-21 12:34:56",     "ts_ms": "2026-04-21T12:34:56.789"},
+        {"ts_s": "2026-04-21T12:34:56Z",    "ts_ms": "2026-04-21 12:34:56"},
+    ]));
+
+    let parquet = write_parquet_from_sqlite(pragma, rows).expect("write_parquet_from_sqlite");
+
+    let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(parquet))
+        .expect("parquet reader")
+        .build()
+        .expect("build reader");
+    let batch = reader
+        .into_iter()
+        .next()
+        .expect("one batch")
+        .expect("batch ok");
+
+    assert_eq!(batch.num_rows(), 2);
+
+    let ts_s = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<TimestampSecondArray>()
+        .expect("timestamp(s)");
+    // 2026-04-21 12:34:56 UTC → 1,776,774,896
+    assert_eq!(ts_s.value(0), 1_776_774_896);
+    assert_eq!(ts_s.value(1), 1_776_774_896);
+
+    let ts_ms = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<arrow::array::TimestampMillisecondArray>()
+        .expect("timestamp(ms)");
+    assert_eq!(ts_ms.value(0), 1_776_774_896_789);
+    assert_eq!(ts_ms.value(1), 1_776_774_896_000);
+}
+
+/// P2: SQLite rows whose runtime storage class doesn't match the declared
+/// affinity produce null for that cell, not a whole-export failure.
+/// Codex flagged this: `INTEGER` columns with legacy/permissive data can
+/// return text; we null-on-mismatch rather than abort.
+#[wasm_bindgen_test]
+fn sqlite_mismatch_nulls_the_cell_not_the_export() {
+    let pragma = to_js(&serde_json::json!([
+        {"name": "id",    "type": "INTEGER"},
+        {"name": "ratio", "type": "REAL"},
+        {"name": "day",   "type": "DATE"},
+        {"name": "ts",    "type": "TIMESTAMP"},
+    ]));
+    let rows = to_js(&serde_json::json!([
+        {"id": 1,     "ratio": 0.5,  "day": "2026-04-20",  "ts": 1_777_000_000_i64},
+        {"id": "abc", "ratio": "x",  "day": "not-a-date",  "ts": "also not a timestamp"},
+        {"id": 3,     "ratio": 1.25, "day": "2026-04-22",  "ts": "2026-04-22 00:00:00"},
+    ]));
+
+    let parquet = write_parquet_from_sqlite(pragma, rows).expect("write_parquet_from_sqlite");
+    let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(parquet))
+        .expect("parquet reader")
+        .build()
+        .expect("build reader");
+    let batch = reader
+        .into_iter()
+        .next()
+        .expect("one batch")
+        .expect("batch ok");
+
+    assert_eq!(batch.num_rows(), 3);
+
+    let ids = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("int64");
+    assert!(!ids.is_null(0));
+    assert_eq!(ids.value(0), 1);
+    assert!(ids.is_null(1), "text 'abc' in INTEGER column should null");
+    assert!(!ids.is_null(2));
+    assert_eq!(ids.value(2), 3);
+
+    let ratio = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .expect("float64");
+    assert!(!ratio.is_null(0));
+    assert!(ratio.is_null(1), "text 'x' in REAL column should null");
+    assert!(!ratio.is_null(2));
+
+    let day = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<Date32Array>()
+        .expect("date32");
+    assert!(!day.is_null(0));
+    assert!(day.is_null(1), "unparseable date string should null");
+    assert!(!day.is_null(2));
+
+    let ts = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<TimestampSecondArray>()
+        .expect("timestamp(s)");
+    assert!(!ts.is_null(0));
+    assert!(ts.is_null(1), "unparseable timestamp string should null");
+    assert!(!ts.is_null(2));
+}


### PR DESCRIPTION
Follow-up to #2032 addressing Codex review findings plus a follow-on bug surfaced during ETL integration testing.

## Summary

Four fixes to `write_parquet_from_sqlite`, all "output has to be correct for real consumers":

- **P1 — text-encoded timestamps round-trip.** SQLite commonly stores `TIMESTAMP` / `DATETIME` as ISO-8601 text, not Unix epochs. The three timestamp builders (Millisecond / Microsecond / Nanosecond) now accept strings via `chrono::NaiveDateTime::parse_from_str` across the common shapes (T/space separator, optional trailing `Z`, optional fractional seconds) and scale seconds to the target unit. Numeric epochs still pass through.

- **P1 extended — offset-qualified timestamps.** `TIMESTAMPTZ` columns with `+HH:MM` / `-HH:MM` offsets were being silently nulled. `naive_datetime_from_str` now tries RFC 3339 first, then space-separated offset forms, then the naive parsers. Offset-qualified values are normalized to UTC so the stored timestamp represents the same instant.

- **P2 — null on type mismatch, not whole-export failure.** SQLite's affinity system is permissive — an `INTEGER` column can legally return text. The builders now `append_null` on a type mismatch and the function returns the valid rows. A single `console.warn` per column summarizes how many cells were nulled, with the first example. Structural errors (missing key, missing PRAGMA, unsupported Arrow type) stay hard errors — those are programmer bugs, not data.

- **TimestampSecond → Parquet milliseconds.** Parquet's `TIMESTAMP` logical type has no SECONDS variant. Emitting `Timestamp(Second, None)` made arrow-rs write a bare `INT64` with no logical annotation, so DuckDB / Polars / pyarrow saw the column as a plain bigint. `SqliteDeclared::TimestampSecond.to_arrow()` now returns `Timestamp(Millisecond, None)` and the builder scales numeric Unix-seconds inputs ×1000. The variant name stays — it still accurately describes the SQLite-side input scale.

The stance is opinionated on strictness (no silent text→number coercion) but forgiving on reach: one stray row can't kill an export.

## Notes for reviewers

- New `TimestampAppender` trait + `TimestampColumn` struct give the three timestamp builders a uniform append surface and bundle the per-cell config (input/output unit, column name) so `append_timestamp_cell` stays under clippy's argument limit.
- Added a Parquet **physical** schema assertion in `sqlite_round_trip_preserves_richer_types`: `matches!(col.logical_type(), Some(LogicalType::Timestamp { .. }))`. The earlier Arrow-schema readback could miss a regression that stripped the annotation (arrow-rs recovers types from an embedded `ARROW:schema` blob), so we now also verify the Parquet metadata itself.
- `web_sys_console_warn` routes through `js_sys::Reflect::get` rather than pulling in the `web-sys` dep — the warning is best-effort. Native target (`cargo test`) stubs it as a no-op; assertions inspect nullability directly.

## Verification

- [x] `cargo test -p sift-wasm` — 5 native tests passing (3 parser unit + 2 IPC round-trip)
- [x] `wasm-pack test --node crates/sift-wasm` — 4 wasm tests passing:
  - `sqlite_round_trip_preserves_richer_types` (now with Parquet logical-type assertion)
  - `sqlite_nulls_round_trip`
  - `sqlite_text_timestamps_round_trip` (naive + trailing-Z + `+02:00` + `-07:00`)
  - `sqlite_mismatch_nulls_the_cell_not_the_export`
- [x] `cargo clippy -p sift-wasm --all-targets -- -D warnings` — clean on native + wasm32
- [x] `cargo fmt --all --check` — clean
- [x] `cargo xtask wasm` — `pkg/` + `crates/runt-mcp/assets/plugins/sift_wasm.wasm` rebuilt
- [x] **Validated end-to-end in the ETL pipeline** — DuckDB reads `TIMESTAMP` columns as native timestamps

## Review history

- Round 1 Codex review surfaced P1 (text timestamps) + P2 (whole-export failure on mismatch).
- Round 2 Codex review surfaced offset-qualified ISO timestamps silently nulling.
- ETL agent surfaced the seconds→INT64 Parquet logical-type gap.
- Round 3 Codex review: no regressions.