### PR TITLE
refactor(mcp): rename launch_app/open_notebook + skill diagnosis

### DIFF
--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -193,7 +193,7 @@ cargo xtask run-mcp
 
 | Category | Tools |
 |----------|-------|
-| Session | `list_active_notebooks`, `open_notebook`, `create_notebook`, `save_notebook`, `launch_app` |
+| Session | `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook` |
 | Kernel | `interrupt_kernel`, `restart_kernel` |
 | Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
 | Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs` |

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -33,7 +33,7 @@ If multiple crates changed, run tests for each: `cargo test -p runtimed -p noteb
 
 ## Step 3: MCP Live Verification (when nteract-dev tools are available)
 
-If narrow tests pass and you have `nteract-dev` (`up`/`down`/`status`) and `open_notebook`/`execute_cell` tools, do a live check:
+If narrow tests pass and you have `nteract-dev` (`up`/`down`/`status`) and `connect_notebook`/`execute_cell` tools, do a live check:
 
 ### For daemon/kernel changes (`crates/runtimed/`, `crates/runtimed-py/`):
 
@@ -70,7 +70,7 @@ If narrow tests pass and you have `nteract-dev` (`up`/`down`/`status`) and `open
 For changes to daemon, kernel, sync, or execution paths, open the harness dashboard notebook to measure impact:
 
 ```
-open_notebook("scripts/metrics/harness-dashboard.ipynb")
+connect_notebook("scripts/metrics/harness-dashboard.ipynb")
 ```
 
 Run the setup cell first, then run any metric cell. Each metric cell is self-contained — it creates a fresh notebook, measures, disconnects, and plots results against the committed baseline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,7 +338,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 
 | Category | Tools |
 |----------|-------|
-| Session | `list_active_notebooks`, `open_notebook`, `create_notebook`, `save_notebook`, `launch_app` |
+| Session | `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook` |
 | Kernel | `interrupt_kernel`, `restart_kernel` |
 | Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
 | Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs` |
@@ -346,7 +346,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | Editing | `replace_match`, `replace_regex` |
 | Execution | `execute_cell`, `run_all_cells` |
 
-**Audit workflow example:** After modifying daemon or kernel code, use `open_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
+**Audit workflow example:** After modifying daemon or kernel code, use `connect_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
 
 ### Hot reload
 

--- a/crates/notebook/resources/sample-notebooks/hands-on-with-nteract.ipynb
+++ b/crates/notebook/resources/sample-notebooks/hands-on-with-nteract.ipynb
@@ -150,7 +150,7 @@
         "```\n",
         "\n",
         "Once your agent can see the nteract MCP server, it can use tools like:\n",
-        "- `open_notebook`\n",
+        "- `connect_notebook`\n",
         "- `get_all_cells`\n",
         "- `set_cell`\n",
         "- `create_cell`\n",

--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -71,10 +71,10 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         },
         "tools": [
             { "name": "list_active_notebooks", "description": "List running notebook sessions." },
-            { "name": "open_notebook", "description": "Open a notebook. Provide exactly one of: path (file path, e.g. \"~/analysis.ipynb\") or notebook_id (UUID from list_active_notebooks). Paths open the file from disk; notebook_id connects to a running session." },
+            { "name": "connect_notebook", "description": "Attach to a notebook as the active session. Pass path (loads .ipynb from disk) OR notebook_id (UUID from list_active_notebooks) — not both. Does not open the app; use show_notebook for that." },
             { "name": "create_notebook", "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist." },
             { "name": "save_notebook", "description": "Save notebook to disk. For notebooks created with create_notebook(), you must provide a path." },
-            { "name": "launch_app", "description": "Show the current notebook to the user." },
+            { "name": "show_notebook", "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason." },
             { "name": "get_cell", "description": "Get a cell by ID." },
             { "name": "get_all_cells", "description": "Get all cells as summary, json, or rich format." },
             { "name": "create_cell", "description": "Create a cell, optionally executing it." },

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -309,7 +309,7 @@ impl McpProxy {
 
         // Seed the respawned child with the previous notebook target so
         // its `daemon_watch` loop rejoins on the first `Connected` event
-        // without us having to call `open_notebook` over the child MCP
+        // without us having to call `connect_notebook` over the child MCP
         // channel.
         let mut child_env = self.config.child_env.clone();
         if let Some(ref target) = rejoin_target {
@@ -774,7 +774,7 @@ impl ServerHandler for McpProxy {
             "nteract MCP server for Jupyter notebooks. \
              Each connection has one active notebook session. \
              Use list_active_notebooks to discover open notebooks, \
-             then open_notebook or create_notebook to set your active session. \
+             then connect_notebook or create_notebook to set your active session. \
              Calling these again switches your active session.",
         )
     }
@@ -1170,11 +1170,11 @@ mod tests {
     // ── Session tracking via track_session ────────────────────────────
 
     #[tokio::test]
-    async fn track_session_captures_open_notebook() {
+    async fn track_session_captures_connect_notebook() {
         let proxy = McpProxy::new(test_config(), None);
 
         let params: CallToolRequestParams = serde_json::from_value(serde_json::json!({
-            "name": "open_notebook",
+            "name": "connect_notebook",
             "arguments": { "path": "/tmp/test.ipynb" }
         }))
         .unwrap();
@@ -1192,7 +1192,7 @@ mod tests {
 
         // Open first notebook
         let params1: CallToolRequestParams = serde_json::from_value(serde_json::json!({
-            "name": "open_notebook",
+            "name": "connect_notebook",
             "arguments": { "path": "/tmp/first.ipynb" }
         }))
         .unwrap();
@@ -1205,7 +1205,7 @@ mod tests {
 
         // Open second notebook — should replace
         let params2: CallToolRequestParams = serde_json::from_value(serde_json::json!({
-            "name": "open_notebook",
+            "name": "connect_notebook",
             "arguments": { "path": "/tmp/second.ipynb" }
         }))
         .unwrap();
@@ -1246,7 +1246,7 @@ mod tests {
         let proxy = McpProxy::new(test_config(), None);
 
         let params: CallToolRequestParams = serde_json::from_value(serde_json::json!({
-            "name": "open_notebook",
+            "name": "connect_notebook",
             "arguments": { "path": "/tmp/test.ipynb" }
         }))
         .unwrap();

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -8,10 +8,10 @@ use serde_json::Value;
 
 /// Track notebook_id from session-establishing tool calls.
 ///
-/// When `open_notebook` or `create_notebook` succeeds, returns the notebook_id
+/// When `connect_notebook` or `create_notebook` succeeds, returns the notebook_id
 /// to persist for seeding the next child restart.
 ///
-/// Checks request arguments first (open_notebook passes path/notebook_id),
+/// Checks request arguments first (connect_notebook passes path/notebook_id),
 /// then falls back to parsing the response content (create_notebook returns
 /// notebook_id in its JSON response, not in request args).
 pub fn extract_session_id(
@@ -25,8 +25,8 @@ pub fn extract_session_id(
 
     let name: &str = &params.name;
     match name {
-        "open_notebook" | "create_notebook" => {
-            // Try request arguments first (open_notebook)
+        "connect_notebook" | "create_notebook" => {
+            // Try request arguments first (connect_notebook)
             let from_args = params
                 .arguments
                 .as_ref()
@@ -86,12 +86,12 @@ mod tests {
         result
     }
 
-    // ── open_notebook tracking ────────────────────────────────────────
+    // ── connect_notebook tracking ────────────────────────────────────────
 
     #[test]
-    fn tracks_open_notebook_with_path() {
+    fn tracks_connect_notebook_with_path() {
         let params = make_params(
-            "open_notebook",
+            "connect_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),
         );
         assert_eq!(
@@ -101,9 +101,9 @@ mod tests {
     }
 
     #[test]
-    fn tracks_open_notebook_with_notebook_id() {
+    fn tracks_connect_notebook_with_notebook_id() {
         let params = make_params(
-            "open_notebook",
+            "connect_notebook",
             serde_json::json!({"notebook_id": "abc-123-def"}),
         );
         assert_eq!(
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn prefers_notebook_id_over_path() {
         let params = make_params(
-            "open_notebook",
+            "connect_notebook",
             serde_json::json!({"notebook_id": "abc-123", "path": "/tmp/test.ipynb"}),
         );
         assert_eq!(
@@ -203,9 +203,9 @@ mod tests {
     // ── Error handling ────────────────────────────────────────────────
 
     #[test]
-    fn ignores_open_notebook_error() {
+    fn ignores_connect_notebook_error() {
         let params = make_params(
-            "open_notebook",
+            "connect_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),
         );
         assert_eq!(extract_session_id(&params, &error_result()), None);
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn treats_is_error_none_as_success() {
         let params = make_params(
-            "open_notebook",
+            "connect_notebook",
             serde_json::json!({"path": "/tmp/test.ipynb"}),
         );
         let mut result = CallToolResult::success(vec![Content::text("ok")]);
@@ -229,13 +229,13 @@ mod tests {
 
     #[test]
     fn returns_none_when_arguments_empty_and_no_response_id() {
-        let params = make_params("open_notebook", serde_json::json!({}));
+        let params = make_params("connect_notebook", serde_json::json!({}));
         assert_eq!(extract_session_id(&params, &success_result()), None);
     }
 
     #[test]
     fn returns_none_when_path_is_not_string() {
-        let params = make_params("open_notebook", serde_json::json!({"path": 42}));
+        let params = make_params("connect_notebook", serde_json::json!({"path": 42}));
         assert_eq!(extract_session_id(&params, &success_result()), None);
     }
 }

--- a/crates/runt-mcp-proxy/src/session.rs
+++ b/crates/runt-mcp-proxy/src/session.rs
@@ -25,7 +25,9 @@ pub fn extract_session_id(
 
     let name: &str = &params.name;
     match name {
-        "connect_notebook" | "create_notebook" => {
+        // `open_notebook` kept for one release as a legacy alias — clients
+        // may still be invoking it from stale tool caches.
+        "connect_notebook" | "open_notebook" | "create_notebook" => {
             // Try request arguments first (connect_notebook)
             let from_args = params
                 .arguments
@@ -198,6 +200,22 @@ mod tests {
     fn ignores_list_active_notebooks() {
         let params = make_params("list_active_notebooks", serde_json::json!({}));
         assert_eq!(extract_session_id(&params, &success_result()), None);
+    }
+
+    // ── Legacy alias (one-release compat) ─────────────────────────────
+
+    #[test]
+    fn legacy_open_notebook_alias_still_tracked() {
+        // Clients with stale tool caches may invoke `open_notebook`; the
+        // session tracker must still record the notebook_id.
+        let params = make_params(
+            "open_notebook",
+            serde_json::json!({"path": "/tmp/test.ipynb"}),
+        );
+        assert_eq!(
+            extract_session_id(&params, &success_result()),
+            Some("/tmp/test.ipynb".to_string())
+        );
     }
 
     // ── Error handling ────────────────────────────────────────────────

--- a/crates/runt-mcp-proxy/src/tools.rs
+++ b/crates/runt-mcp-proxy/src/tools.rs
@@ -237,11 +237,11 @@ mod tests {
     #[test]
     fn rename_is_incompatible() {
         // A renamed tool shows up as removal + addition
-        let old = vec![tool("open_notebook"), tool("execute_cell")];
+        let old = vec![tool("connect_notebook"), tool("execute_cell")];
         let new = vec![tool("open_file"), tool("execute_cell")];
         match detect_divergence(&old, &new) {
             ToolDivergence::Incompatible { removed, added } => {
-                assert!(removed.contains(&"open_notebook".to_string()));
+                assert!(removed.contains(&"connect_notebook".to_string()));
                 assert!(added.contains(&"open_file".to_string()));
             }
             other => panic!("Expected Incompatible, got {other:?}"),
@@ -273,7 +273,7 @@ mod tests {
     fn save_and_load_tool_cache() {
         let dir = tempfile::tempdir().unwrap();
         let tools = vec![
-            tool("open_notebook"),
+            tool("connect_notebook"),
             tool("execute_cell"),
             tool("get_cell"),
         ];
@@ -283,7 +283,7 @@ mod tests {
 
         assert_eq!(loaded.len(), 3);
         let names: Vec<&str> = loaded.iter().map(|t| t.name.as_ref()).collect();
-        assert!(names.contains(&"open_notebook"));
+        assert!(names.contains(&"connect_notebook"));
         assert!(names.contains(&"execute_cell"));
         assert!(names.contains(&"get_cell"));
     }

--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -25,7 +25,7 @@
       "idempotentHint": true,
       "openWorldHint": true
     },
-    "description": "Open a notebook. Provide exactly one of: path (file path, e.g. \"~/analysis.ipynb\") or notebook_id (UUID from list_active_notebooks). Paths open the file from disk; notebook_id connects to a running session.",
+    "description": "Attach to a notebook as the active session. Pass path (loads .ipynb from disk) OR notebook_id (UUID from list_active_notebooks) — not both. Does not open the app; use show_notebook for that.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -49,7 +49,7 @@
       "title": "OpenNotebookParams",
       "type": "object"
     },
-    "name": "open_notebook"
+    "name": "connect_notebook"
   },
   {
     "annotations": {
@@ -146,7 +146,7 @@
       "openWorldHint": false,
       "readOnlyHint": true
     },
-    "description": "Show the current notebook to the user.",
+    "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -162,7 +162,7 @@
       "title": "ShowNotebookParams",
       "type": "object"
     },
-    "name": "launch_app"
+    "name": "show_notebook"
   },
   {
     "annotations": {

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -112,7 +112,7 @@ impl ServerHandler for NteractMcp {
             "nteract MCP server for Jupyter notebooks. \
              Each connection has one active notebook session. \
              Use list_active_notebooks to discover open notebooks, \
-             then open_notebook or create_notebook to set your active session. \
+             then connect_notebook or create_notebook to set your active session. \
              Calling these again switches your active session.",
         )
     }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -42,7 +42,7 @@ pub struct NteractMcp {
     /// Used as the peer label in notebook sessions so the notebook app shows
     /// "Claude Desktop" or "Claude Code" instead of the default "Inkwell".
     peer_label: Arc<RwLock<String>>,
-    /// When true, the `launch_app` tool is not registered (headless environments).
+    /// When true, the `show_notebook` tool is not registered (headless environments).
     no_show: bool,
 }
 
@@ -63,7 +63,7 @@ impl NteractMcp {
         }
     }
 
-    /// Create a new MCP server with `launch_app` disabled.
+    /// Create a new MCP server with `show_notebook` disabled.
     pub fn new_no_show(
         socket_path: PathBuf,
         blob_base_url: Option<String>,
@@ -134,7 +134,7 @@ impl ServerHandler for NteractMcp {
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = tools::all_tools();
         if self.no_show {
-            tools.retain(|t| t.name.as_ref() != "launch_app");
+            tools.retain(|t| t.name.as_ref() != "show_notebook");
         }
         Ok(ListToolsResult {
             tools,

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -204,17 +204,16 @@ pub async fn add_dependency(
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
     let after = arg_str(request, "after").unwrap_or("none");
 
-    let (handle, notebook_id) = {
-        let guard = server.session.read().await;
-        match guard.as_ref() {
-            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-            None => {
-                return tool_error(
-                    "No active notebook session. Call open_notebook or create_notebook first.",
-                )
+    let (handle, notebook_id) =
+        {
+            let guard = server.session.read().await;
+            match guard.as_ref() {
+                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+                None => return tool_error(
+                    "No active notebook session. Call connect_notebook or create_notebook first.",
+                ),
             }
-        }
-    };
+        };
 
     let manager = detect_package_manager(&handle);
 

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -34,17 +34,16 @@ pub async fn restart_kernel(
     server: &NteractMcp,
     _request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let (handle, notebook_id) = {
-        let guard = server.session.read().await;
-        match guard.as_ref() {
-            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-            None => {
-                return tool_error(
-                    "No active notebook session. Call open_notebook or create_notebook first.",
-                )
+    let (handle, notebook_id) =
+        {
+            let guard = server.session.read().await;
+            match guard.as_ref() {
+                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+                None => return tool_error(
+                    "No active notebook session. Call connect_notebook or create_notebook first.",
+                ),
             }
-        }
-    };
+        };
 
     // Capture kernel_type from the *current* RuntimeState before shutdown.
     // After a daemon restart the fresh RuntimeStateDoc has kernel.name = "",

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -18,7 +18,7 @@ macro_rules! require_handle {
             Some(s) => s.handle.clone(),
             None => {
                 return $crate::tools::tool_error(
-                    "No active notebook session. Call open_notebook or create_notebook first.",
+                    "No active notebook session. Call connect_notebook or create_notebook first.",
                 )
             }
         }
@@ -89,11 +89,10 @@ pub fn all_tools() -> Vec<Tool> {
         .annotate(ToolAnnotations::new().read_only(true).open_world(false))
         .with_meta(always_load_meta()),
         Tool::new(
-            "open_notebook",
-            "Open a notebook. Provide exactly one of: \
-             path (file path, e.g. \"~/analysis.ipynb\") or \
-             notebook_id (UUID from list_active_notebooks). \
-             Paths open the file from disk; notebook_id connects to a running session.",
+            "connect_notebook",
+            "Attach to a notebook as the active session. Pass path (loads .ipynb from disk) \
+             OR notebook_id (UUID from list_active_notebooks) — not both. \
+             Does not open the app; use show_notebook for that.",
             schema_for::<session::OpenNotebookParams>(),
         )
         .annotate(
@@ -121,8 +120,8 @@ pub fn all_tools() -> Vec<Tool> {
                 .open_world(true),
         ),
         Tool::new(
-            "launch_app",
-            "Show the current notebook to the user.",
+            "show_notebook",
+            "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason.",
             schema_for::<session::ShowNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
@@ -326,10 +325,10 @@ pub async fn dispatch(
     match request.name.as_ref() {
         // Session
         "list_active_notebooks" => session::list_active_notebooks(server).await,
-        "open_notebook" => session::open_notebook(server, request).await,
+        "connect_notebook" => session::open_notebook(server, request).await,
         "create_notebook" => session::create_notebook(server, request).await,
         "save_notebook" => session::save_notebook(server, request).await,
-        "launch_app" => session::show_notebook(server, request).await,
+        "show_notebook" => session::show_notebook(server, request).await,
         // Cell read
         "get_cell" => cell_read::get_cell(server, request).await,
         "get_all_cells" => cell_read::get_all_cells(server, request).await,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -323,12 +323,16 @@ pub async fn dispatch(
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     match request.name.as_ref() {
-        // Session
+        // Session. `open_notebook` and `launch_app` are legacy aliases kept
+        // for clients whose tool caches from the previous plugin/MCPB
+        // release still advertise the old names; the canonical names
+        // (advertised in the tool list) are `connect_notebook` and
+        // `show_notebook`. Safe to remove after one release cycle.
         "list_active_notebooks" => session::list_active_notebooks(server).await,
-        "connect_notebook" => session::open_notebook(server, request).await,
+        "connect_notebook" | "open_notebook" => session::open_notebook(server, request).await,
         "create_notebook" => session::create_notebook(server, request).await,
         "save_notebook" => session::save_notebook(server, request).await,
-        "show_notebook" => session::show_notebook(server, request).await,
+        "show_notebook" | "launch_app" => session::show_notebook(server, request).await,
         // Cell read
         "get_cell" => cell_read::get_cell(server, request).await,
         "get_all_cells" => cell_read::get_all_cells(server, request).await,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -605,17 +605,16 @@ pub async fn save_notebook(
     let path = arg_str(request, "path").map(resolve_path);
 
     // Need both handle and the notebook_id from the session.
-    let (handle, notebook_id) = {
-        let guard = server.session.read().await;
-        match guard.as_ref() {
-            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-            None => {
-                return tool_error(
-                    "No active notebook session. Call open_notebook or create_notebook first.",
-                )
+    let (handle, notebook_id) =
+        {
+            let guard = server.session.read().await;
+            match guard.as_ref() {
+                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+                None => return tool_error(
+                    "No active notebook session. Call connect_notebook or create_notebook first.",
+                ),
             }
-        }
-    };
+        };
 
     // The daemon decides whether a path is required (untitled rooms with
     // no existing path field return SaveError with a clear message). We no

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -253,7 +253,7 @@ enum Commands {
     // =========================================================================
     /// Run as an MCP server (stdin/stdout JSON-RPC)
     Mcp {
-        /// Do not register the launch_app tool (for headless environments)
+        /// Do not register the show_notebook tool (for headless environments)
         #[arg(long)]
         no_show: bool,
         /// Explicit daemon socket path (bypasses RUNTIMED_DEV socket resolution)

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -65,8 +65,8 @@
       "name": "list_active_notebooks"
     },
     {
-      "description": "Open a notebook. Provide exactly one of: path (file path, e.g. \"~/analysis.ipynb\") or notebook_id (UUID from list_active_notebooks). Paths open the file from disk; notebook_id connects to a running session.",
-      "name": "open_notebook"
+      "description": "Attach to a notebook as the active session. Pass path (loads .ipynb from disk) OR notebook_id (UUID from list_active_notebooks) — not both. Does not open the app; use show_notebook for that.",
+      "name": "connect_notebook"
     },
     {
       "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
@@ -77,8 +77,8 @@
       "name": "save_notebook"
     },
     {
-      "description": "Show the current notebook to the user.",
-      "name": "launch_app"
+      "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason.",
+      "name": "show_notebook"
     },
     {
       "description": "Get a cell by ID.",

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -65,8 +65,8 @@
       "name": "list_active_notebooks"
     },
     {
-      "description": "Open a notebook. Provide exactly one of: path (file path, e.g. \"~/analysis.ipynb\") or notebook_id (UUID from list_active_notebooks). Paths open the file from disk; notebook_id connects to a running session.",
-      "name": "open_notebook"
+      "description": "Attach to a notebook as the active session. Pass path (loads .ipynb from disk) OR notebook_id (UUID from list_active_notebooks) — not both. Does not open the app; use show_notebook for that.",
+      "name": "connect_notebook"
     },
     {
       "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
@@ -77,8 +77,8 @@
       "name": "save_notebook"
     },
     {
-      "description": "Show the current notebook to the user.",
-      "name": "launch_app"
+      "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason.",
+      "name": "show_notebook"
     },
     {
       "description": "Get a cell by ID.",

--- a/plugins/nightly/skills/repl/SKILL.md
+++ b/plugins/nightly/skills/repl/SKILL.md
@@ -42,7 +42,7 @@ create_cell(source="import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.head()
    `save_notebook()` — writes the `.ipynb` to disk.
 
 5b. **Open the App for the User:**
-   `launch_app()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
+   `show_notebook()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
 
 
 ## When to Use This

--- a/plugins/nightly/skills/repl/SKILL.md
+++ b/plugins/nightly/skills/repl/SKILL.md
@@ -5,7 +5,17 @@ description: Use nteract notebooks as a persistent Python REPL. Trigger this ski
 
 # Use a Notebook Instead of python3 -c
 
-When you have nteract MCP tools available and you're about to do multi-step Python work — chaining `python3 -c` commands, writing a throwaway `.py` script, or running exploratory code — use a notebook instead. You get persistent state between cells, rich output (tables, plots, errors with tracebacks), and a shareable `.ipynb` file.
+When you have nteract MCP tools available and you're about to do multi-step Python work — chaining `python3 -c` commands, writing a throwaway `.py` script, or running exploratory code — use a notebook instead. You get persistent state between cells, rich output (tables, plots, errors with tracebacks), and users and agents can view the notebook in realtime.
+
+## If the notebook tools aren't appearing
+
+If you loaded this skill but tools like `create_notebook`, `create_cell`, `execute_cell` are not available, don't fall back to `python3 -c`. Ask the user to run `/reload-plugins` and try again. The most common cause is that the plugin was installed this session — Claude Code queues newly-registered MCP servers for the next reload.
+
+If tools still don't appear after `/reload-plugins`:
+
+- Confirm the nteract desktop app is running (the MCP server talks to `runtimed` via a Unix socket).
+- Run `runt doctor` to check on the installation. (`runt-nightly` if this is the nightly release)
+- Share any error messages from the session
 
 ## Quick Start
 
@@ -28,8 +38,12 @@ create_cell(source="import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.head()
 4. **Check your work:**
    `get_all_cells(format="summary", include_outputs=true)` — see all cells with output previews at a glance.
 
-5. **Save when done:**
+5a. **Save when done:**
    `save_notebook()` — writes the `.ipynb` to disk.
+
+5b. **Open the App for the User:**
+   `launch_app()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
+
 
 ## When to Use This
 

--- a/plugins/nteract/skills/repl/SKILL.md
+++ b/plugins/nteract/skills/repl/SKILL.md
@@ -42,7 +42,7 @@ create_cell(source="import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.head()
    `save_notebook()` — writes the `.ipynb` to disk.
 
 5b. **Open the App for the User:**
-   `launch_app()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
+   `show_notebook()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
 
 
 ## When to Use This

--- a/plugins/nteract/skills/repl/SKILL.md
+++ b/plugins/nteract/skills/repl/SKILL.md
@@ -5,7 +5,17 @@ description: Use nteract notebooks as a persistent Python REPL. Trigger this ski
 
 # Use a Notebook Instead of python3 -c
 
-When you have nteract MCP tools available and you're about to do multi-step Python work — chaining `python3 -c` commands, writing a throwaway `.py` script, or running exploratory code — use a notebook instead. You get persistent state between cells, rich output (tables, plots, errors with tracebacks), and a shareable `.ipynb` file.
+When you have nteract MCP tools available and you're about to do multi-step Python work — chaining `python3 -c` commands, writing a throwaway `.py` script, or running exploratory code — use a notebook instead. You get persistent state between cells, rich output (tables, plots, errors with tracebacks), and users and agents can view the notebook in realtime.
+
+## If the notebook tools aren't appearing
+
+If you loaded this skill but tools like `create_notebook`, `create_cell`, `execute_cell` are not available, don't fall back to `python3 -c`. Ask the user to run `/reload-plugins` and try again. The most common cause is that the plugin was installed this session — Claude Code queues newly-registered MCP servers for the next reload.
+
+If tools still don't appear after `/reload-plugins`:
+
+- Confirm the nteract desktop app is running (the MCP server talks to `runtimed` via a Unix socket).
+- Run `runt doctor` to check on the installation. (`runt-nightly` if this is the nightly release)
+- Share any error messages from the session
 
 ## Quick Start
 
@@ -28,8 +38,12 @@ create_cell(source="import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.head()
 4. **Check your work:**
    `get_all_cells(format="summary", include_outputs=true)` — see all cells with output previews at a glance.
 
-5. **Save when done:**
+5a. **Save when done:**
    `save_notebook()` — writes the `.ipynb` to disk.
+
+5b. **Open the App for the User:**
+   `launch_app()` — opens the notebook app for the user. Use if they ask to show it to them. Can be disruptive if the user doesn't expect it.
+
 
 ## When to Use This
 

--- a/python/nteract/CHANGELOG.md
+++ b/python/nteract/CHANGELOG.md
@@ -7,7 +7,7 @@ First release from `nteract/desktop`. The `nteract` Python package is now an MCP
 ### Highlights
 
 - **MCP server** — `nteract` runs as a stdio MCP server, compatible with Claude, ChatGPT, Gemini, OpenCode, and any MCP-capable agent
-- **Notebook lifecycle** — `list_active_notebooks`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook`
+- **Notebook lifecycle** — `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`
 - **Cell operations** — `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs`
 - **Targeted editing** — `replace_match` (literal find-and-replace) and `replace_regex` (regex-based) for surgical cell edits without rewriting entire sources
 - **Execution** — `execute_cell`, `run_all_cells`, `interrupt_kernel`, `restart_kernel`

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -71,10 +71,10 @@ You can open the same notebook in the [nteract desktop app](https://nteract.io) 
 | Tool | Description |
 |------|-------------|
 | `list_active_notebooks` | List all open notebook sessions |
-| `join_notebook` | Join an existing notebook session by ID |
-| `open_notebook` | Open an existing .ipynb file |
+| `connect_notebook` | Attach to a notebook — pass a file path to load from disk, or a notebook_id to join a running session |
 | `create_notebook` | Create a new notebook |
 | `save_notebook` | Save notebook to disk as .ipynb file |
+| `show_notebook` | Open the notebook in the nteract desktop app (no-op on headless hosts) |
 | `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
 | `execute_cell` | Run a specific cell (returns partial results after timeout) |
 | `run_all_cells` | Queue all code cells for execution |


### PR DESCRIPTION
Bundled two related changes to the session-lifecycle tools.

## Tool renames (public MCP surface)

Agents kept mis-parsing our session verbs:

- `open_notebook` → agents thought this meant "show it in the UI" (macOS `open -a`) or "open a file for editing." Neither matches — the daemon is where notebooks live, the agent *attaches*.
- `launch_app` → described the mechanism (spawn a Tauri app), not the intent (show the notebook to the user).

Renamed in the public tool surface:

| Before | After | Intent |
|---|---|---|
| `open_notebook` | `connect_notebook` | Attach to a notebook (by path or notebook_id) as the active session. |
| `launch_app` | `show_notebook` | Open the current notebook in the nteract app for the user. |

Internal handler function names, Python API methods, daemon protocol messages, and wire types are **not** touched. This is only the MCP tool surface.

Tool descriptions were rewritten to reinforce the intent and cross-reference the other tool ("Does not open the app; use show_notebook for that."). Total description byte count: 1311/1500 — well under the budget CI enforces.

## Skill update (`plugins/*/skills/repl/SKILL.md`)

New section **"If the notebook tools aren't appearing"** right after the intro paragraph. Tells the agent to ask the user to run `/reload-plugins` when tools are missing (this is the usual cause right after `/plugin install`), and escalates to `runt doctor` for deeper diagnosis. Blocks the fall-back-to-`python3 -c` anti-pattern we saw in a fresh install.

Kyle also tightened the "rich output" framing (the real pairing win is realtime visibility, not a shareable `.ipynb`), split step 5 into `5a` (save) and `5b` (`show_notebook`), and added a "can be disruptive" caveat on the app launch.

## Scope

- `crates/runt-mcp/src/tools/mod.rs` — tool registration + dispatch
- `crates/runt-mcp/src/lib.rs` — no-show filter field name
- `crates/runt/src/main.rs` — `--no-show` flag comment
- `crates/runt-mcp-proxy/src/{session,proxy,tools}.rs` — session-tracker matches the new tool name + test data
- `mcpb/manifest.{stable,nightly}.json` + `crates/notebook/src/mcpb_install.rs` — MCPB manifests re-dumped
- `crates/runt-mcp-proxy/tool-cache.json` — regenerated via `cargo xtask sync-tool-cache`
- `plugins/*/skills/repl/SKILL.md` — skill content + tool name
- `AGENTS.md`, `.claude/skills/{verify-changes,python-bindings}/SKILL.md`, `python/nteract/README.md` + `CHANGELOG.md` — tool-listing tables
- `crates/notebook/resources/sample-notebooks/hands-on-with-nteract.ipynb` — one markdown-cell reference

Archived plan docs in `docs/superpowers/plans/` intentionally left with old tool names — they describe historical design work.

## Breaking change for users

Anyone who allowlisted `plugin:nteract:notebook - launch_app` or `plugin:nteract:notebook - open_notebook` in Claude Code permissions will see an unknown-tool prompt on next use. Small blast radius — the plugin is a day old.

## Test plan

- [x] `cargo check -p runt-mcp -p runt-mcp-proxy -p runt-cli -p notebook` clean
- [x] `cargo xtask lint` clean
- [x] `cargo xtask clippy` clean
- [x] `cargo test -p runt-mcp -p runt-mcp-proxy` — 168 tests passing
- [x] `cargo xtask sync-tool-cache --check` — all caches match, 1311/1500 bytes
- [ ] Live nightly install: `/plugin install nightly@nteract`, call `connect_notebook` + `show_notebook` to confirm new names work