### PR TITLE
docs: lead with plugin install; slim PyPI README to a stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,36 +22,28 @@ The `runt` CLI and `runtimed` Python bindings ship with the app and stay up to d
 | `runtimed` (Python) | Python bindings for the daemon (ships with the app) |
 ## MCP Server
 
-The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents get 27 tools for working with notebooks — executing code, reading and writing cells, managing dependencies, and collaborating in real-time alongside humans in the desktop app.
+The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents can run code, read and write cells, manage dependencies, and collaborate with humans in real-time — watching the notebook update live in the desktop app while the agent works.
 
-The MCP server ships with the desktop app as `runt mcp`.
+### Install the Claude Code plugin
 
-### Quick Start
-
-#### Claude Code
-
-```bash
-# Stable
-claude mcp add nteract -- runt mcp
-
-# Nightly
-claude mcp add nteract-nightly -- runt-nightly mcp
+```
+/plugin marketplace add nteract/claude-plugin
+/plugin install nteract@nteract
 ```
 
-#### Manual JSON config
+Pin a specific version:
 
-```json
-{
-  "mcpServers": {
-    "nteract": {
-      "command": "runt",
-      "args": ["mcp"]
-    }
-  }
-}
+```
+/plugin install nteract@nteract --ref v2.3.0
 ```
 
-The `runt` CLI ships with the desktop app. Use `runt` (stable) or `runt-nightly` directly — no PyPI install needed.
+The plugin ships the right `nteract-mcp` binary for your platform (macOS arm64/x64, Linux x64, Windows x64) — no separate install needed. `main` of `nteract/claude-plugin` always points at the latest stable release.
+
+For pre-release builds (updated daily):
+
+```
+/plugin install nightly@nteract
+```
 
 ## Usage
 
@@ -118,7 +110,7 @@ nteract/desktop
 │   └── mcp-supervisor/    # nteract-dev MCP server (proxies runt mcp + adds dev tools)
 ├── python/                 # Python packages
 │   ├── runtimed/          # PyPI: runtimed (Python bindings for daemon)
-│   ├── nteract/           # PyPI: nteract (MCP server)
+│   ├── nteract/           # PyPI: nteract (thin wrapper that launches `runt mcp`)
 │   └── gremlin/           # Stress-testing agent for nteract notebooks (not published)
 ├── docs/                   # User-facing documentation
 └── contributing/           # Developer guides

--- a/python/nteract/CHANGELOG.md
+++ b/python/nteract/CHANGELOG.md
@@ -2,17 +2,14 @@
 
 ## 2.0.0 (unreleased)
 
-First release from `nteract/desktop`. The `nteract` Python package is now an MCP server for AI agents to interact with Jupyter notebooks through runt/runtimed.
+First release from `nteract/desktop`. The `nteract` package is now a thin wrapper that locates and launches the `runt mcp` server that ships with the [nteract desktop app](https://nteract.io).
 
 ### Highlights
 
-- **MCP server** — `nteract` runs as a stdio MCP server, compatible with Claude, ChatGPT, Gemini, OpenCode, and any MCP-capable agent
-- **Notebook lifecycle** — `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`
-- **Cell operations** — `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs`
-- **Targeted editing** — `replace_match` (literal find-and-replace) and `replace_regex` (regex-based) for surgical cell edits without rewriting entire sources
-- **Execution** — `execute_cell`, `run_all_cells`, `interrupt_kernel`, `restart_kernel`
-- **Dependencies** — `get_dependencies`, `add_dependency`, `remove_dependency`, `sync_environment` with UV and Conda support
-- **Resources** — `notebook://cells`, `notebook://cell/{cell_id}`, `notebook://cells/by-index/{index}`, `notebook://cell/{cell_id}/outputs`, `notebook://status`, `notebook://rooms` for read-only state access
+- AI-collaborative Jupyter notebooks over MCP. Works with Claude, ChatGPT, Gemini, and any MCP-capable agent.
+- Agents can create, open, and save notebooks; read, write, and execute cells with live output; and manage Python dependencies with UV or Conda.
+- Real-time collaboration with a human in the nteract desktop app — both sides see the same notebook update as it changes.
+- Recommended install is the Claude Code plugin at [`nteract/claude-plugin`](https://github.com/nteract/claude-plugin). This PyPI package exists as an alternative for `uvx`-based workflows.
 
 ### Breaking changes from 1.x
 

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -1,165 +1,42 @@
 # nteract
 
-A convenience wrapper that finds and launches `runt mcp` — the MCP server shipped with the [nteract desktop app](https://nteract.io).
+AI-collaborative Jupyter notebooks. The MCP server ships with the [nteract desktop app](https://nteract.io) — this PyPI package is a thin wrapper that finds and launches `runt mcp` from your app install.
 
-**[Download the nteract desktop app](https://nteract.io)** — you'll need it to see notebooks, collaborate with agents, and manage environments.
+## Install the plugin (recommended)
 
-> The recommended way to add the MCP server is `runt mcp` directly. This PyPI package is a convenience for users who prefer `uvx`.
+In Claude Code:
 
-### Quick Start
-
-The MCP server ships with the desktop app. After installing, use `runt mcp` directly:
-
-#### Claude Code
-
-```bash
-# Stable
-claude mcp add nteract -- runt mcp
-
-# Nightly
-claude mcp add nteract-nightly -- runt-nightly mcp
+```
+/plugin marketplace add nteract/claude-plugin
+/plugin install nteract@nteract
 ```
 
-#### Manual JSON config
+The plugin ships the right binary for your platform — no app install required for the plugin itself. Pair it with the [nteract desktop app](https://nteract.io) to see the notebook update live while an agent works.
 
-```json
-{
-  "mcpServers": {
-    "nteract": {
-      "command": "runt",
-      "args": ["mcp"]
-    }
-  }
-}
-```
+## Install via uvx (alternative)
 
-#### Via this PyPI package
-
-If `runt` isn't on your PATH, this package finds it in the app bundle:
+If you'd rather go through `uvx`:
 
 ```bash
 claude mcp add nteract -- uvx nteract
 ```
 
-That's it. Now Claude can execute Python code, create visualizations, and work with your data.
+That will run this PyPI package, which locates `runt mcp` from your nteract desktop install and exec's it.
 
-## What is this?
+## What you get
 
-nteract is an MCP (Model Context Protocol) server that connects AI assistants like Claude to Jupyter notebooks. It enables:
+With nteract connected to Claude, you can:
 
-- **Code execution**: Run Python in a persistent kernel
-- **Real-time collaboration**: Watch the AI work in the nteract desktop app
-- **Shared state**: Multiple agents can work on the same notebook
-- **Environment management**: Automatic Python environment setup
+- Create, open, and save notebooks by path or session ID
+- Read, write, and execute cells with live output streaming
+- Manage Python dependencies (UV and Conda)
+- Watch the notebook update in real-time in the desktop app while an agent works
+- Hand a notebook back and forth with a human collaborator
 
-## Example
+## Related
 
-Ask Claude:
-
-> "Help me visualize my log data"
-
-Claude will:
-1. Connect to a notebook session
-2. Write and execute code
-3. Generate visualizations
-4. Show you the results
-
-You can open the same notebook in the [nteract desktop app](https://nteract.io) to see changes in real-time and collaborate with the AI.
-
-## Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `list_active_notebooks` | List all open notebook sessions |
-| `connect_notebook` | Attach to a notebook — pass a file path to load from disk, or a notebook_id to join a running session |
-| `create_notebook` | Create a new notebook |
-| `save_notebook` | Save notebook to disk as .ipynb file |
-| `show_notebook` | Open the notebook in the nteract desktop app (no-op on headless hosts) |
-| `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
-| `execute_cell` | Run a specific cell (returns partial results after timeout) |
-| `run_all_cells` | Queue all code cells for execution |
-| `set_cell` | Update a cell's source and/or type |
-| `get_cell` | Get a cell by ID with outputs |
-| `get_all_cells` | View all cells in the notebook |
-| `replace_match` | Targeted literal text find-and-replace in a cell |
-| `replace_regex` | Regex-based find-and-replace in a cell |
-| `move_cell` | Reorder a cell within the notebook |
-| `clear_outputs` | Clear a cell's outputs |
-| `delete_cell` | Remove a cell from the notebook |
-| `set_cells_source_hidden` | Show/hide cell source |
-| `set_cells_outputs_hidden` | Show/hide cell outputs |
-| `add_cell_tags` | Add tags to cells |
-| `remove_cell_tags` | Remove tags from cells |
-| `interrupt_kernel` | Interrupt the currently executing cell |
-| `restart_kernel` | Restart kernel with updated dependencies |
-| `show_notebook` | Open the notebook in the nteract desktop app (disabled with `--no-show`) |
-| `add_dependency` | Add a Python package dependency |
-| `remove_dependency` | Remove a dependency |
-| `get_dependencies` | List current dependencies |
-| `sync_environment` | Hot-install new deps without restart |
-
-### CLI Flags
-
-| Flag | Description |
-|------|-------------|
-| `--version` | Print version and exit |
-| `--nightly` | Use `runt-nightly` (nightly daemon and app) |
-| `--stable` | Use `runt` (stable daemon and app, default) |
-| `--legacy` | Use the built-in Python MCP server instead of `runt mcp` |
-
-By default, `nteract` finds and exec's the installed `runt` (or `runt-nightly`) binary. The `--legacy` flag falls back to the built-in Python MCP server.
-
-## Architecture
-
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Claude    │────▶│   nteract   │────▶│   runtimed  │
-│  (or other  │     │ MCP Server  │     │   daemon    │
-│     AI)     │     │             │     │             │
-└─────────────┘     └─────────────┘     └──────┬──────┘
-                                               │
-                    ┌─────────────┐             │
-                    │   nteract   │◀────────────┘
-                    │ Desktop App │  (real-time sync)
-                    └─────────────┘
-```
-
-- **nteract** (this package): MCP server for AI assistants
-- **runtimed**: Low-level daemon and Python bindings ([docs](https://github.com/nteract/desktop))
-- **nteract desktop**: Native app for humans to collaborate with AI
-
-## Real-time Collaboration
-
-The magic of nteract is that AI and humans share the same notebook:
-
-1. AI connects via MCP and runs code
-2. Human opens the same notebook in nteract desktop
-3. Changes sync instantly via CRDT
-4. Both see the same kernel state
-
-This enables workflows like:
-- AI does initial analysis, human refines
-- Human writes code, AI debugs errors
-- Multiple AI agents collaborate on complex tasks
-
-## Development
-
-```bash
-# Clone
-git clone https://github.com/nteract/desktop
-cd desktop/python/nteract
-
-# Install dependencies
-uv sync
-
-# Run tests
-uv run pytest
-```
-
-## Related Projects
-
-- [nteract/desktop](https://github.com/nteract/desktop) - Native desktop app
-- [runtimed on PyPI](https://pypi.org/project/runtimed/) - Low-level Python bindings
+- [nteract/desktop](https://github.com/nteract/desktop) — desktop app, daemon, and plugin source
+- [runtimed on PyPI](https://pypi.org/project/runtimed/) — low-level Python bindings for the daemon
 
 ## License
 


### PR DESCRIPTION
Now that the plugin-marketplace flow is live (#2029 + #2031) and the PyPI nteract package is a thin wrapper around `runt mcp`, bring the docs in line.

## README.md

- MCP Server section leads with `/plugin marketplace add nteract/claude-plugin` + `/plugin install nteract@nteract`. Covers version pinning and `nightly@nteract`.
- Drops the `claude mcp add` + manual-JSON snippets. Those flows still work but shouldn't be the headline path.
- Drops the specific tool count ("27 tools" was wrong; actual is 26 and drifts as we split scopes). Describes behaviors instead.
- Fixes the `python/nteract/` project-structure line — it's a wrapper around `runt mcp`, not the MCP server itself.

## python/nteract/README.md

Rewritten as a short SEO page:
- Opens with "AI-collaborative Jupyter notebooks" and points at the desktop app + plugin marketplace.
- Retains one-line `uvx nteract` install for the PyPI-first workflow.
- Drops the full 26-row tool table.
- Drops the ASCII architecture diagram and dev-setup block.

## python/nteract/CHANGELOG.md

- 2.0.0 highlights rewritten behaviorally (not a tool enumeration).
- Pointer to the plugin as the recommended install path.
- Breaking-changes-from-1.x note retained.

## Test plan

- [x] `cargo xtask lint` clean
- [ ] Skim renders on GitHub