### PR TITLE
docs(readme): add Install Extension for Claude (Desktop) flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ For pre-release builds (updated daily):
 /plugin install nightly@nteract
 ```
 
+### Install in Claude Desktop
+
+If you use the nteract desktop app with Claude Desktop, there's a one-click install path. In the menu bar, choose **nteract → Install Extension for Claude...**
+
+![nteract menu showing 'Install Extension for Claude...'](https://img.runt.run/install-claude-extension.png)
+
+The desktop app builds a `.mcpb` bundle at runtime (manifest, icons, `nteract-mcp` binary) and hands it to Claude Desktop, which prompts you to confirm the install. Requires the nteract desktop app; Claude Desktop picks up the bundle from there.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Closes #2038.

## Summary

The nteract desktop app has a **nteract → Install Extension for Claude...** menu item that builds a `.mcpb` bundle at runtime and hands it to Claude Desktop (one click, no CLI, no plugin marketplace). It's the easiest install path for users who already have the desktop app and want Claude Desktop — and we had no doc for it.

Adds a short **Install in Claude Desktop** section to the README's MCP Server area, right after the existing Claude Code plugin-marketplace section. Three paragraphs, a screenshot of the menu, and a sentence on what the bundle actually carries.

Screenshot hosted on `img.runt.run` with a stable key (`install-claude-extension.png`) so future updates to the screenshot can overwrite without churning the URL.

## Test plan

- [x] `cargo xtask lint` clean
- [ ] GitHub renders the image correctly (sanity-check on the PR page)