### PR TITLE
fix(structured): never inline binary MIMEs in structured content

### DIFF
--- a/apps/mcp-app/src/components/mime-renderer.tsx
+++ b/apps/mcp-app/src/components/mime-renderer.tsx
@@ -70,7 +70,10 @@ function PluginRenderer({
 
     // Load plugin via <script> tag and fetch/parse data in parallel
     const pluginPromise = loadPluginForMime(mime, blobBaseUrl) ?? Promise.resolve();
-    // Parse data: try JSON (for plotly/vega specs), fall back to raw string (for markdown/latex)
+
+    // Binary plugins (parquet/sift) expect a URL and fetch data themselves.
+    // Text/JSON plugins (plotly, vega, markdown) need fetched + parsed content.
+    const isBinaryPlugin = mime === "application/vnd.apache.parquet";
     const parseData = (text: string) => {
       try {
         return JSON.parse(text);
@@ -78,9 +81,11 @@ function PluginRenderer({
         return text;
       }
     };
-    const dataPromise = isBlobUrl(raw)
-      ? fetchBlobText(raw).then(parseData)
-      : Promise.resolve(parseData(raw));
+    const dataPromise = isBinaryPlugin
+      ? Promise.resolve(raw)
+      : isBlobUrl(raw)
+        ? fetchBlobText(raw).then(parseData)
+        : Promise.resolve(parseData(raw));
 
     Promise.all([pluginPromise, dataPromise])
       .then(([, parsedData]) => {

--- a/apps/mcp-app/src/lib/mime-priority.ts
+++ b/apps/mcp-app/src/lib/mime-priority.ts
@@ -6,6 +6,8 @@ export const MIME_PRIORITY: readonly string[] = [
   // Visualizations (highest priority — rich interactive content)
   "application/vnd.plotly.v1+json",
   "application/geo+json",
+  // Data tables (parquet → Sift renderer)
+  "application/vnd.apache.parquet",
   // Rich text
   "text/html",
   "text/markdown",

--- a/apps/mcp-app/src/lib/plugin-loader.ts
+++ b/apps/mcp-app/src/lib/plugin-loader.ts
@@ -24,6 +24,7 @@ const MIME_TO_PLUGIN: Record<string, PluginInfo> = {
   "text/latex": { name: "markdown", hasCss: true },
   "application/vnd.plotly.v1+json": { name: "plotly", hasCss: false },
   "application/geo+json": { name: "leaflet", hasCss: true },
+  "application/vnd.apache.parquet": { name: "sift", hasCss: true },
 };
 
 const VEGA_PLUGIN: PluginInfo = { name: "vega", hasCss: false };

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -9,6 +9,7 @@
 //! ContentRef entries and emit blob URLs for blob-stored content. Zero blob
 //! fetches — structured content is always compact.
 
+use notebook_doc::mime::MimeKind;
 use runtimed_client::output_resolver;
 use serde_json::{json, Value};
 
@@ -176,14 +177,26 @@ fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String
 
                     let meta = output_resolver::content_ref_meta(content_ref);
 
-                    let json_value = if meta.is_inline {
-                        // Inline content — extract the value directly
-                        content_ref.get("inline").cloned()
-                    } else if let Some(hash) = meta.blob_hash {
-                        // Blob-stored content — emit blob URL
+                    // Images are binary but their inline form is base64,
+                    // which renderers handle as data: URIs. Non-image binary
+                    // MIMEs (parquet, audio, video, application/octet-stream)
+                    // produce garbled text when inlined as JSON strings.
+                    let is_non_renderable_binary = notebook_doc::mime::mime_kind(mime)
+                        == MimeKind::Binary
+                        && !mime.starts_with("image/");
+
+                    let json_value = if let Some(hash) = meta.blob_hash {
+                        // Blob-stored content — always emit blob URL regardless
+                        // of MIME kind. The renderer or client fetches as needed.
                         blob_base_url
                             .as_ref()
                             .map(|base| Value::String(format!("{}/blob/{}", base, hash)))
+                    } else if meta.is_inline && !is_non_renderable_binary {
+                        // Inline text/JSON/image content — extract directly.
+                        // Non-renderable binary (parquet, audio, etc.) is
+                        // silently dropped; the client falls back to
+                        // text/plain or text/llm+plain.
+                        content_ref.get("inline").cloned()
                     } else {
                         None
                     };
@@ -417,6 +430,95 @@ mod tests {
         });
         let result = manifest_output_to_structured(&manifest, &None);
         assert!(result.get("output_id").is_none());
+    }
+
+    #[test]
+    fn structured_binary_mime_never_inlined() {
+        // Binary MIMEs like parquet must never leak as inline text in
+        // structured content — they render as garbled bytes in Cowork
+        // and any other client that displays the JSON.
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.apache.parquet": inline_ref("PAR1\x00\x00binary garbage"),
+                "text/plain": inline_ref("DataFrame(5 rows)"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
+        // Parquet should be excluded (binary, inline — no blob URL to emit)
+        assert!(
+            !data.contains_key("application/vnd.apache.parquet"),
+            "binary MIME should not be inlined in structured content"
+        );
+        // Text fallback still present
+        assert_eq!(data["text/plain"], "DataFrame(5 rows)");
+    }
+
+    #[test]
+    fn structured_binary_mime_blob_url_still_works() {
+        // Binary MIMEs stored as blobs should still emit blob URLs
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.apache.parquet": blob_ref("pq_hash", 100_000),
+                "text/plain": inline_ref("DataFrame(5 rows)"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
+        assert_eq!(
+            data["application/vnd.apache.parquet"],
+            "http://localhost:9999/blob/pq_hash"
+        );
+    }
+
+    #[test]
+    fn structured_image_inline_passes_through() {
+        // Images are binary but inline as base64 which renderers handle
+        // as data: URIs. They must NOT be suppressed.
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "image/png": inline_ref("iVBORw0KGgoAAAA...base64..."),
+                "text/plain": inline_ref("<Figure>"),
+            },
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
+        assert_eq!(
+            data["image/png"], "iVBORw0KGgoAAAA...base64...",
+            "inline base64 images should pass through for data: URI rendering"
+        );
+        assert_eq!(data["text/plain"], "<Figure>");
+    }
+
+    #[test]
+    fn structured_audio_inline_suppressed() {
+        // Audio is binary and NOT renderable as a data: URI in this context
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "audio/wav": inline_ref("RIFF....binary"),
+                "text/plain": inline_ref("<Audio>"),
+            },
+        });
+        let result = manifest_output_to_structured(&manifest, &None);
+        let data = result["data"]
+            .as_object()
+            .expect("data should be an object");
+        assert!(
+            !data.contains_key("audio/wav"),
+            "non-image binary should not be inlined"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related fixes for parquet output appearing as garbled binary in Cowork (Claude Desktop's MCP App renderer).

### 1. Backend: gate binary MIMEs in structured_content

`manifest_output_to_structured()` inlined ContentRef values without checking MIME kind. Non-renderable binary MIMEs (parquet, audio, video) leaked raw bytes as JSON strings. Now they only appear as blob URLs. Images (base64) are exempt since renderers handle them as data: URIs.

### 2. Frontend: wire Sift into the MCP App renderer

The MCP App (`apps/mcp-app/`) had no registration for `application/vnd.apache.parquet`. Even with correct blob URLs, the renderer fell through to `FetchAndRender` which fetched the blob as text and displayed garbled bytes.

Added:
- `application/vnd.apache.parquet` in `MIME_TO_PLUGIN` (sift renderer, with CSS)
- Parquet in `MIME_PRIORITY` (above text/html so it's preferred when both exist)
- `PluginRenderer` passes blob URLs through directly for binary plugins (sift expects a URL and fetches parquet bytes itself; text/JSON plugins still get fetched+parsed content)

The nteract desktop app was unaffected — its iframe renderer already had sift in `PLUGIN_MIME_TYPES` and uses a different data-resolution path.

## Files changed

| File | Change |
|---|---|
| `crates/runt-mcp/src/structured.rs` | Gate inline insertion on MIME kind; 4 new tests |
| `apps/mcp-app/src/lib/plugin-loader.ts` | Register parquet → sift plugin |
| `apps/mcp-app/src/lib/mime-priority.ts` | Add parquet to priority list |
| `apps/mcp-app/src/components/mime-renderer.tsx` | Binary plugins receive URL directly instead of fetched text |

## Tests

- `structured_binary_mime_never_inlined` — parquet inline content excluded
- `structured_binary_mime_blob_url_still_works` — parquet blob hash emits URL
- `structured_image_inline_passes_through` — image/png base64 NOT suppressed
- `structured_audio_inline_suppressed` — audio/wav inline content excluded

## Test plan

- [x] `cargo xtask lint` clean
- [x] `cargo xtask clippy` clean
- [x] `cargo test -p runt-mcp` — 87 tests passing (25 structured, +4 new)
- [ ] Cowork: `df.head()` with parquet output shows Sift data table instead of raw bytes