### PR TITLE
fix(runtimed-py): update .pyi stub for new create_notebook params

### DIFF
--- a/python/runtimed/src/runtimed/_internals.pyi
+++ b/python/runtimed/src/runtimed/_internals.pyi
@@ -415,6 +415,8 @@ class NativeAsyncClient:
         runtime: str = "python",
         working_dir: str | None = None,
         peer_label: str | None = None,
+        package_manager: str | None = None,
+        dependencies: list[str] | None = None,
     ) -> Coroutine[Any, Any, AsyncSession]: ...
     def join_notebook(
         self,


### PR DESCRIPTION
## Summary

Updates the `_internals.pyi` type stub to match the new `create_notebook` signature from #2037. Adds `package_manager` and `dependencies` parameters.

## Test plan

- [x] `uv run ty check python/` passes