### PR TITLE
fix: validate and alias package_manager across APIs

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -158,6 +158,29 @@ pub enum Handshake {
     },
 }
 
+/// Validate and normalize a package manager string.
+///
+/// Accepted values (case-sensitive):
+///   - `"uv"`, `"conda"`, `"pixi"` - returned as-is
+///   - `"pip"` - aliased to `"uv"` (uv is the pip-compatible installer)
+///   - `"mamba"` - aliased to `"conda"` (we use rattler under the hood)
+///
+/// Returns `Ok(normalized)` for valid/aliased values, `Err(message)` for
+/// unrecognized input.
+pub fn normalize_package_manager(input: &str) -> Result<&'static str, String> {
+    match input {
+        "uv" => Ok("uv"),
+        "conda" => Ok("conda"),
+        "pixi" => Ok("pixi"),
+        "pip" => Ok("uv"),
+        "mamba" => Ok("conda"),
+        _ => Err(format!(
+            "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
+            input
+        )),
+    }
+}
+
 /// Protocol version constants (strings for handshake compatibility).
 pub const PROTOCOL_V2: &str = "v2";
 pub const PROTOCOL_V3: &str = "v3";
@@ -970,5 +993,25 @@ mod tests {
 
         let parsed: TestMsg = serde_json::from_slice(&frame.payload).unwrap();
         assert_eq!(parsed, msg);
+    }
+
+    #[test]
+    fn normalize_package_manager_valid() {
+        assert_eq!(normalize_package_manager("uv").unwrap(), "uv");
+        assert_eq!(normalize_package_manager("conda").unwrap(), "conda");
+        assert_eq!(normalize_package_manager("pixi").unwrap(), "pixi");
+    }
+
+    #[test]
+    fn normalize_package_manager_aliases() {
+        assert_eq!(normalize_package_manager("pip").unwrap(), "uv");
+        assert_eq!(normalize_package_manager("mamba").unwrap(), "conda");
+    }
+
+    #[test]
+    fn normalize_package_manager_rejects_unknown() {
+        let err = normalize_package_manager("npm").unwrap_err();
+        assert!(err.contains("Unsupported package manager 'npm'"));
+        assert!(err.contains("Supported: uv, conda, pixi"));
     }
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -421,16 +421,14 @@ pub async fn create_notebook(
     let ephemeral = arg_bool(request, "ephemeral").unwrap_or(true);
 
     let deps: Vec<String> = arg_string_array(request, "dependencies").unwrap_or_default();
-    let explicit_pkg_manager = arg_str(request, "package_manager");
-
-    if let Some(pm) = explicit_pkg_manager {
-        if !matches!(pm, "uv" | "conda" | "pixi") {
-            return tool_error(&format!(
-                "Invalid package_manager '{}'. Must be 'uv', 'conda', or 'pixi'.",
-                pm
-            ));
+    let explicit_pkg_manager = match arg_str(request, "package_manager") {
+        Some(pm) => {
+            let normalized = notebook_protocol::connection::normalize_package_manager(pm)
+                .map_err(|msg| McpError::invalid_params(msg, None))?;
+            Some(normalized)
         }
-    }
+        None => None,
+    };
 
     let prev = previous_notebook_id(server).await;
 
@@ -689,14 +687,20 @@ mod tests {
         assert_eq!(result, "pixi");
     }
 
-    /// Validation rejects invalid package_manager values.
+    /// Validation rejects unknown and aliases known package_manager values.
     #[test]
-    fn invalid_pkg_manager_values() {
+    fn package_manager_validation() {
+        use notebook_protocol::connection::normalize_package_manager;
+
+        // Direct values pass through
         for valid in ["uv", "conda", "pixi"] {
-            assert!(matches!(valid, "uv" | "conda" | "pixi"));
+            assert_eq!(normalize_package_manager(valid).unwrap(), valid);
         }
-        assert!(!matches!("mamba", "uv" | "conda" | "pixi"));
-        assert!(!matches!("pip", "uv" | "conda" | "pixi"));
+        // Aliases resolve
+        assert_eq!(normalize_package_manager("pip").unwrap(), "uv");
+        assert_eq!(normalize_package_manager("mamba").unwrap(), "conda");
+        // Unknown values are rejected
+        assert!(normalize_package_manager("npm").is_err());
     }
 
     /// save_notebook response must include notebook_id (unchanged UUID) and path.

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -214,6 +214,16 @@ impl AsyncClient {
             }
         }
 
+        // Validate and normalize package_manager before entering the async block
+        let normalized_pm = match &package_manager {
+            Some(pm) => {
+                let n = notebook_protocol::connection::normalize_package_manager(pm)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+                Some(n.to_string())
+            }
+            None => None,
+        };
+
         let label = peer_label.or_else(|| self.peer_label.clone());
         let socket_path = self.socket_path.clone();
         let runtime = runtime.to_string();
@@ -225,7 +235,7 @@ impl AsyncClient {
                 runtime,
                 working_dir_buf,
                 label,
-                package_manager,
+                normalized_pm,
                 deps,
             )
             .await

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -807,7 +807,12 @@ pub(crate) fn build_new_notebook_metadata(
             //   1. Explicit package_manager from the request
             //   2. No explicit manager - use default_python_env
             let effective_manager: &str = match package_manager {
-                Some(pm) => pm,
+                Some(pm) => {
+                    // Normalize aliases (e.g. "pip" -> "uv", "mamba" -> "conda").
+                    // If the value is unrecognized, fall through to "uv" as a
+                    // safe default - callers should validate before reaching here.
+                    notebook_protocol::connection::normalize_package_manager(pm).unwrap_or("uv")
+                }
                 None => match default_python_env {
                     crate::settings_doc::PythonEnvType::Conda => "conda",
                     crate::settings_doc::PythonEnvType::Pixi => "pixi",

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1018,6 +1018,22 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         "gamma client should reach session-ready state within 2s"
     );
 
+    // Wait for initial sync to deliver the cells map before reading.
+    // session_ready only guarantees status=Interactive, not that the
+    // snapshot watch channel has published cells from the sync frames.
+    assert!(
+        wait_for_cells_map(&handle_a, Duration::from_secs(2)).await,
+        "alpha sync did not deliver cells map within 2s"
+    );
+    assert!(
+        wait_for_cells_map(&handle_b, Duration::from_secs(2)).await,
+        "beta sync did not deliver cells map within 2s"
+    );
+    assert!(
+        wait_for_cells_map(&handle_c, Duration::from_secs(2)).await,
+        "gamma sync did not deliver cells map within 2s"
+    );
+
     let cells_a = handle_a.get_cells();
     assert_eq!(cells_a.len(), 1, "alpha should have 1 cell");
     assert_eq!(cells_a[0].id, "alpha-1");


### PR DESCRIPTION
## Summary

Adds `normalize_package_manager` to notebook-protocol with aliases:
- `pip` -> `uv` (uv is the pip-compatible installer)
- `mamba` -> `conda` (we use rattler under the hood)
- Unknown values get a clear error: "Unsupported package manager 'X'. Supported: uv, conda, pixi."

Applied in MCP `create_notebook`, Python `AsyncClient.create_notebook`, and `build_new_notebook_metadata`.

## Test plan

- [x] Unit tests for valid values, aliases, and rejection
- [x] `cargo check`, `cargo xtask lint --fix`, `cargo xtask clippy` pass