### PR TITLE
fix(notebook): gitignore nteract-mcp sidecar binaries

### DIFF
--- a/crates/notebook/binaries/.gitignore
+++ b/crates/notebook/binaries/.gitignore
@@ -1,3 +1,4 @@
 # Ignore all external binaries (built by xtask)
+nteract-mcp-*
 runtimed-*
 runt-*


### PR DESCRIPTION
## Summary

- Adds `nteract-mcp-*` to `crates/notebook/binaries/.gitignore` so built sidecar binaries don't show as untracked.