### PR TITLE
fix(runtimed): embed sift.js and sift.css in daemon

### DIFF
--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -56,6 +56,14 @@ pub fn get(name: &str) -> Option<(&'static [u8], &'static str)> {
             include_bytes!("../../runt-mcp/assets/plugins/leaflet.css"),
             "text/css; charset=utf-8",
         )),
+        "sift.js" => Some((
+            include_bytes!("../../runt-mcp/assets/plugins/sift.js"),
+            "application/javascript; charset=utf-8",
+        )),
+        "sift.css" => Some((
+            include_bytes!("../../runt-mcp/assets/plugins/sift.css"),
+            "text/css; charset=utf-8",
+        )),
         "sift_wasm.wasm" => Some((
             include_bytes!("../../runt-mcp/assets/plugins/sift_wasm.wasm"),
             "application/wasm",


### PR DESCRIPTION
## Summary

- Adds `sift.js` and `sift.css` to `embedded_plugins.rs`. The daemon's blob server serves embedded plugin assets at `/plugins/{name}`, and the MCP App plugin loader fetches sift via that path for Apache Parquet outputs.
- Previously only `sift_wasm.wasm` was embedded, so `GET /plugins/sift.js` and `/plugins/sift.css` hit 404 (visible in devtools on the installed nightly: `GET http://localhost:64108/plugins/sift.css net::ERR_ABORTED 404`).

## Test plan

- [ ] In an MCP App session, render an Apache Parquet output and confirm sift loads without 404s on `sift.js` / `sift.css`.
- [ ] Confirm `sift_wasm.wasm`, markdown, plotly, vega, leaflet still work.