### PR TITLE
refactor: introduce PackageManager enum (PR 1 of 2)

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -28,7 +28,64 @@
 //! - `0x07`: SessionControl (JSON, server-originated)
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Supported package managers for Python notebooks.
+///
+/// The wire format is the lowercase variant name (`"uv"`, `"conda"`, `"pixi"`),
+/// matching the historical `normalize_package_manager` output. `parse()`
+/// additionally accepts `"pip"` (→ Uv) and `"mamba"` (→ Conda) aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageManager {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+impl PackageManager {
+    /// The canonical wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uv => "uv",
+            Self::Conda => "conda",
+            Self::Pixi => "pixi",
+        }
+    }
+
+    /// Parse a package manager name with alias support.
+    ///
+    /// Accepts `"uv"`, `"conda"`, `"pixi"` (canonical), plus `"pip"` (→ Uv)
+    /// and `"mamba"` (→ Conda).
+    pub fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "uv" => Ok(Self::Uv),
+            "conda" => Ok(Self::Conda),
+            "pixi" => Ok(Self::Pixi),
+            "pip" => Ok(Self::Uv),
+            "mamba" => Ok(Self::Conda),
+            _ => Err(format!(
+                "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
+                input
+            )),
+        }
+    }
+}
+
+impl fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PackageManager {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
 
 /// Maximum frame size for data frames: 100 MiB (matches blob size limit).
 const MAX_FRAME_SIZE: usize = 100 * 1024 * 1024;
@@ -1013,5 +1070,60 @@ mod tests {
         let err = normalize_package_manager("npm").unwrap_err();
         assert!(err.contains("Unsupported package manager 'npm'"));
         assert!(err.contains("Supported: uv, conda, pixi"));
+    }
+
+    #[test]
+    fn package_manager_as_str_round_trips() {
+        assert_eq!(PackageManager::Uv.as_str(), "uv");
+        assert_eq!(PackageManager::Conda.as_str(), "conda");
+        assert_eq!(PackageManager::Pixi.as_str(), "pixi");
+    }
+
+    #[test]
+    fn package_manager_parse_valid() {
+        assert_eq!(PackageManager::parse("uv").unwrap(), PackageManager::Uv);
+        assert_eq!(
+            PackageManager::parse("conda").unwrap(),
+            PackageManager::Conda
+        );
+        assert_eq!(PackageManager::parse("pixi").unwrap(), PackageManager::Pixi);
+    }
+
+    #[test]
+    fn package_manager_parse_aliases() {
+        assert_eq!(PackageManager::parse("pip").unwrap(), PackageManager::Uv);
+        assert_eq!(
+            PackageManager::parse("mamba").unwrap(),
+            PackageManager::Conda
+        );
+    }
+
+    #[test]
+    fn package_manager_parse_rejects_unknown() {
+        let err = PackageManager::parse("npm").unwrap_err();
+        assert!(err.contains("Unsupported package manager 'npm'"));
+        assert!(err.contains("Supported: uv, conda, pixi"));
+    }
+
+    #[test]
+    fn package_manager_fromstr_works() {
+        let pm: PackageManager = PackageManager::from_str("conda").unwrap();
+        assert_eq!(pm, PackageManager::Conda);
+        assert!(PackageManager::from_str("bogus").is_err());
+    }
+
+    #[test]
+    fn package_manager_display_matches_as_str() {
+        assert_eq!(format!("{}", PackageManager::Uv), "uv");
+        assert_eq!(format!("{}", PackageManager::Conda), "conda");
+        assert_eq!(format!("{}", PackageManager::Pixi), "pixi");
+    }
+
+    #[test]
+    fn package_manager_serde_is_lowercase() {
+        let json = serde_json::to_string(&PackageManager::Conda).unwrap();
+        assert_eq!(json, "\"conda\"");
+        let pm: PackageManager = serde_json::from_str("\"pixi\"").unwrap();
+        assert_eq!(pm, PackageManager::Pixi);
     }
 }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -204,11 +204,11 @@ pub enum Handshake {
         /// Defaults to false (backward compat). MCP agents use true for scratch compute.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         ephemeral: Option<bool>,
-        /// Package manager preference: "uv", "conda", or "pixi".
+        /// Package manager preference: uv, conda, or pixi.
         /// When set, the daemon creates only this manager's metadata section.
         /// When None, the daemon uses its default_python_env setting.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        package_manager: Option<String>,
+        package_manager: Option<PackageManager>,
         /// Dependencies to seed into notebook metadata before auto-launch.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         dependencies: Vec<String>,

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -34,30 +34,50 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Supported package managers for Python notebooks.
 ///
-/// The wire format is the lowercase variant name (`"uv"`, `"conda"`, `"pixi"`).
-/// `parse()` additionally accepts `"pip"` (→ Uv) and `"mamba"` (→ Conda) aliases.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// The canonical wire format is the lowercase variant name (`"uv"`, `"conda"`,
+/// `"pixi"`). `parse()` additionally accepts `"pip"` (→ Uv) and `"mamba"` (→
+/// Conda) as aliases at user-input boundaries.
+///
+/// Deserialization is permissive: unrecognized wire strings land in
+/// `Unknown(s)` rather than failing, so the `CreateNotebook` handshake stays
+/// forward-compatible and legacy aliases still decode. Resolve `Unknown`
+/// values to a canonical variant at use-site via `resolve()`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PackageManager {
     Uv,
     Conda,
     Pixi,
+    /// An unrecognized package manager string, carried verbatim from the wire.
+    ///
+    /// Produced only by `Deserialize` for non-canonical values; internal code
+    /// should call `resolve()` before matching. User-input boundaries (Python
+    /// API, MCP `create_notebook`, CLI) should call `parse()` instead, which
+    /// rejects unknowns up front.
+    Unknown(String),
 }
 
 impl PackageManager {
-    /// The canonical wire string.
-    pub fn as_str(&self) -> &'static str {
+    /// The wire string form.
+    ///
+    /// Canonical variants return their literal name; `Unknown(s)` returns the
+    /// raw string that was deserialized.
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Uv => "uv",
             Self::Conda => "conda",
             Self::Pixi => "pixi",
+            Self::Unknown(s) => s.as_str(),
         }
     }
 
     /// Parse a package manager name with alias support.
     ///
     /// Accepts `"uv"`, `"conda"`, `"pixi"` (canonical), plus `"pip"` (→ Uv)
-    /// and `"mamba"` (→ Conda).
+    /// and `"mamba"` (→ Conda). Returns `Err` for anything else.
+    ///
+    /// Use this at user-input boundaries where immediate validation is
+    /// desired. Wire deserialization is permissive and never errors — see
+    /// `Unknown`.
     pub fn parse(input: &str) -> Result<Self, String> {
         match input {
             "uv" => Ok(Self::Uv),
@@ -69,6 +89,23 @@ impl PackageManager {
                 "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
                 input
             )),
+        }
+    }
+
+    /// Fold to a canonical variant, resolving known aliases.
+    ///
+    /// `Uv`/`Conda`/`Pixi` pass through. `Unknown("pip")` → `Uv`,
+    /// `Unknown("mamba")` → `Conda`. Any other `Unknown(s)` returns `Err`.
+    ///
+    /// Call this at internal evaluation sites where the code needs one of the
+    /// three canonical variants. Error handling is up to the caller — the
+    /// daemon handshake path falls back to `default_python_env`, for example.
+    pub fn resolve(&self) -> Result<Self, String> {
+        match self {
+            Self::Uv => Ok(Self::Uv),
+            Self::Conda => Ok(Self::Conda),
+            Self::Pixi => Ok(Self::Pixi),
+            Self::Unknown(s) => Self::parse(s),
         }
     }
 }
@@ -83,6 +120,31 @@ impl FromStr for PackageManager {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse(s)
+    }
+}
+
+impl Serialize for PackageManager {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for PackageManager {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        // Permissive: unknown strings are captured rather than rejected, so
+        // the handshake stays forward-compatible and legacy aliases
+        // (`"pip"`, `"mamba"`) still decode. Internal callers fold aliases
+        // and reject genuine unknowns via `resolve()`.
+        if raw == "uv" {
+            Ok(Self::Uv)
+        } else if raw == "conda" {
+            Ok(Self::Conda)
+        } else if raw == "pixi" {
+            Ok(Self::Pixi)
+        } else {
+            Ok(Self::Unknown(raw))
+        }
     }
 }
 
@@ -1081,5 +1143,46 @@ mod tests {
         assert_eq!(json, "\"conda\"");
         let pm: PackageManager = serde_json::from_str("\"pixi\"").unwrap();
         assert_eq!(pm, PackageManager::Pixi);
+    }
+
+    #[test]
+    fn package_manager_deserialize_captures_unknown() {
+        // Aliases must decode (wire compatibility for legacy clients).
+        let pm: PackageManager = serde_json::from_str("\"pip\"").unwrap();
+        assert_eq!(pm, PackageManager::Unknown("pip".to_string()));
+        let pm: PackageManager = serde_json::from_str("\"mamba\"").unwrap();
+        assert_eq!(pm, PackageManager::Unknown("mamba".to_string()));
+        // Genuinely unknown values decode to Unknown, not an error.
+        let pm: PackageManager = serde_json::from_str("\"poetry\"").unwrap();
+        assert_eq!(pm, PackageManager::Unknown("poetry".to_string()));
+    }
+
+    #[test]
+    fn package_manager_unknown_round_trips_verbatim() {
+        let pm = PackageManager::Unknown("mamba".to_string());
+        let json = serde_json::to_string(&pm).unwrap();
+        assert_eq!(json, "\"mamba\"");
+        let decoded: PackageManager = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, pm);
+    }
+
+    #[test]
+    fn package_manager_resolve_folds_aliases() {
+        assert_eq!(PackageManager::Uv.resolve().unwrap(), PackageManager::Uv);
+        assert_eq!(
+            PackageManager::Unknown("pip".to_string())
+                .resolve()
+                .unwrap(),
+            PackageManager::Uv
+        );
+        assert_eq!(
+            PackageManager::Unknown("mamba".to_string())
+                .resolve()
+                .unwrap(),
+            PackageManager::Conda
+        );
+        assert!(PackageManager::Unknown("poetry".to_string())
+            .resolve()
+            .is_err());
     }
 }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -34,9 +34,8 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Supported package managers for Python notebooks.
 ///
-/// The wire format is the lowercase variant name (`"uv"`, `"conda"`, `"pixi"`),
-/// matching the historical `normalize_package_manager` output. `parse()`
-/// additionally accepts `"pip"` (→ Uv) and `"mamba"` (→ Conda) aliases.
+/// The wire format is the lowercase variant name (`"uv"`, `"conda"`, `"pixi"`).
+/// `parse()` additionally accepts `"pip"` (→ Uv) and `"mamba"` (→ Conda) aliases.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageManager {
@@ -213,29 +212,6 @@ pub enum Handshake {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         dependencies: Vec<String>,
     },
-}
-
-/// Validate and normalize a package manager string.
-///
-/// Accepted values (case-sensitive):
-///   - `"uv"`, `"conda"`, `"pixi"` - returned as-is
-///   - `"pip"` - aliased to `"uv"` (uv is the pip-compatible installer)
-///   - `"mamba"` - aliased to `"conda"` (we use rattler under the hood)
-///
-/// Returns `Ok(normalized)` for valid/aliased values, `Err(message)` for
-/// unrecognized input.
-pub fn normalize_package_manager(input: &str) -> Result<&'static str, String> {
-    match input {
-        "uv" => Ok("uv"),
-        "conda" => Ok("conda"),
-        "pixi" => Ok("pixi"),
-        "pip" => Ok("uv"),
-        "mamba" => Ok("conda"),
-        _ => Err(format!(
-            "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
-            input
-        )),
-    }
 }
 
 /// Protocol version constants (strings for handshake compatibility).
@@ -1050,26 +1026,6 @@ mod tests {
 
         let parsed: TestMsg = serde_json::from_slice(&frame.payload).unwrap();
         assert_eq!(parsed, msg);
-    }
-
-    #[test]
-    fn normalize_package_manager_valid() {
-        assert_eq!(normalize_package_manager("uv").unwrap(), "uv");
-        assert_eq!(normalize_package_manager("conda").unwrap(), "conda");
-        assert_eq!(normalize_package_manager("pixi").unwrap(), "pixi");
-    }
-
-    #[test]
-    fn normalize_package_manager_aliases() {
-        assert_eq!(normalize_package_manager("pip").unwrap(), "uv");
-        assert_eq!(normalize_package_manager("mamba").unwrap(), "conda");
-    }
-
-    #[test]
-    fn normalize_package_manager_rejects_unknown() {
-        let err = normalize_package_manager("npm").unwrap_err();
-        assert!(err.contains("Unsupported package manager 'npm'"));
-        assert!(err.contains("Supported: uv, conda, pixi"));
     }
 
     #[test]

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -275,7 +275,7 @@ pub async fn connect_create(
     working_dir: Option<PathBuf>,
     actor_label: &str,
     ephemeral: bool,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
 ) -> Result<CreateResult, SyncError> {
     connect_create_inner(
@@ -299,7 +299,7 @@ async fn connect_create_inner(
     notebook_id: Option<String>,
     actor_label: &str,
     ephemeral: bool,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
 ) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
@@ -318,7 +318,7 @@ async fn connect_create_inner(
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
         ephemeral: if ephemeral { Some(true) } else { None },
-        package_manager: package_manager.map(String::from),
+        package_manager,
         dependencies,
     };
     connection::send_json_frame(&mut writer, &handshake)
@@ -492,7 +492,7 @@ pub async fn connect_create_relay(
     notebook_id: Option<String>,
     frame_tx: mpsc::UnboundedSender<Vec<u8>>,
     ephemeral: bool,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
 ) -> Result<RelayCreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
@@ -511,7 +511,7 @@ pub async fn connect_create_relay(
             .map(|p| p.to_string_lossy().to_string()),
         notebook_id,
         ephemeral: if ephemeral { Some(true) } else { None },
-        package_manager: package_manager.map(String::from),
+        package_manager,
         dependencies,
     };
     connection::send_json_frame(&mut writer, &handshake)

--- a/crates/runt-mcp/src/project_file.rs
+++ b/crates/runt-mcp/src/project_file.rs
@@ -21,11 +21,12 @@ pub struct DetectedProjectFile {
 }
 
 impl DetectedProjectFile {
-    /// The package manager name (for `detect_package_manager` compatibility).
-    pub fn manager(&self) -> &'static str {
+    /// The package manager for this project file.
+    pub fn manager(&self) -> notebook_protocol::connection::PackageManager {
+        use notebook_protocol::connection::PackageManager;
         match self.kind {
-            ProjectFileKind::PyprojectToml => "uv",
-            ProjectFileKind::PixiToml => "pixi",
+            ProjectFileKind::PyprojectToml => PackageManager::Uv,
+            ProjectFileKind::PixiToml => PackageManager::Pixi,
         }
     }
 

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -45,19 +45,22 @@ pub struct SyncEnvironmentParams {}
 /// `create_notebook(package_manager=...)` or the UI), while env_source reflects
 /// what the daemon happened to auto-launch with (which may be the system default,
 /// not the notebook's intent).
-pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) -> String {
+pub(crate) fn detect_package_manager(
+    handle: &notebook_sync::handle::DocHandle,
+) -> notebook_protocol::connection::PackageManager {
+    use notebook_protocol::connection::PackageManager;
     // Priority 1: metadata declares which package manager section exists.
     // Check section existence, not just non-empty deps — an empty pixi section
     // means "this is a pixi notebook with no deps yet".
     if let Some(meta) = handle.get_notebook_metadata() {
         if meta.runt.pixi.is_some() {
-            return "pixi".to_string();
+            return PackageManager::Pixi;
         }
         if meta.runt.conda.is_some() {
-            return "conda".to_string();
+            return PackageManager::Conda;
         }
         if meta.runt.uv.is_some() {
-            return "uv".to_string();
+            return PackageManager::Uv;
         }
     }
     // Priority 2: env_source from running kernel (fallback for notebooks
@@ -65,33 +68,34 @@ pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) 
     if let Ok(state) = handle.get_runtime_state() {
         let src = &state.kernel.env_source;
         if src.starts_with("conda:") {
-            return "conda".to_string();
+            return PackageManager::Conda;
         }
         if src.starts_with("pixi:") {
-            return "pixi".to_string();
+            return PackageManager::Pixi;
         }
         if src.starts_with("uv:") {
-            return "uv".to_string();
+            return PackageManager::Uv;
         }
     }
     // Default
-    "uv".to_string()
+    PackageManager::Uv
 }
 
 /// Add a dependency using the appropriate package manager, return error string on failure.
 pub(crate) fn add_dep_for_manager(
     handle: &notebook_sync::handle::DocHandle,
     package: &str,
-    manager: &str,
+    manager: notebook_protocol::connection::PackageManager,
 ) -> Result<(), String> {
+    use notebook_protocol::connection::PackageManager;
     match manager {
-        "conda" => handle
+        PackageManager::Conda => handle
             .add_conda_dependency(package)
             .map_err(|e| format!("Failed to add conda dependency: {e}")),
-        "pixi" => handle
+        PackageManager::Pixi => handle
             .add_pixi_dependency(package)
             .map_err(|e| format!("Failed to add pixi dependency: {e}")),
-        _ => handle
+        PackageManager::Uv => handle
             .add_uv_dependency(package)
             .map_err(|e| format!("Failed to add uv dependency: {e}")),
     }
@@ -101,16 +105,17 @@ pub(crate) fn add_dep_for_manager(
 fn remove_dep_for_manager(
     handle: &notebook_sync::handle::DocHandle,
     package: &str,
-    manager: &str,
+    manager: notebook_protocol::connection::PackageManager,
 ) -> Result<bool, String> {
+    use notebook_protocol::connection::PackageManager;
     match manager {
-        "conda" => handle
+        PackageManager::Conda => handle
             .remove_conda_dependency(package)
             .map_err(|e| format!("Failed to remove conda dependency: {e}")),
-        "pixi" => handle
+        PackageManager::Pixi => handle
             .remove_pixi_dependency(package)
             .map_err(|e| format!("Failed to remove pixi dependency: {e}")),
-        _ => handle
+        PackageManager::Uv => handle
             .remove_uv_dependency(package)
             .map_err(|e| format!("Failed to remove uv dependency: {e}")),
     }
@@ -138,7 +143,7 @@ pub async fn add_dependency(
 
     let manager = detect_package_manager(&handle);
 
-    add_dep_for_manager(&handle, package, &manager)
+    add_dep_for_manager(&handle, package, manager)
         .map_err(|e| McpError::internal_error(e, None))?;
 
     // Ensure daemon has the metadata change before any follow-up action
@@ -147,12 +152,12 @@ pub async fn add_dependency(
     }
 
     // Read back current dependencies
-    let deps = get_deps_for_manager(&handle, &manager);
+    let deps = get_deps_for_manager(&handle, manager);
 
     let mut result = serde_json::json!({
         "dependencies": deps,
         "added": package,
-        "package_manager": manager,
+        "package_manager": manager.as_str(),
     });
 
     match after {
@@ -277,7 +282,7 @@ pub async fn remove_dependency(
 
     let manager = detect_package_manager(&handle);
 
-    let removed = remove_dep_for_manager(&handle, package, &manager)
+    let removed = remove_dep_for_manager(&handle, package, manager)
         .map_err(|e| McpError::internal_error(e, None))?;
 
     // Ensure daemon has the metadata change
@@ -285,13 +290,13 @@ pub async fn remove_dependency(
         tracing::warn!("confirm_sync failed after remove_dependency: {e}");
     }
 
-    let deps = get_deps_for_manager(&handle, &manager);
+    let deps = get_deps_for_manager(&handle, manager);
 
     let result = serde_json::json!({
         "dependencies": deps,
         "removed": package,
         "was_present": removed,
-        "package_manager": manager,
+        "package_manager": manager.as_str(),
     });
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
@@ -304,7 +309,7 @@ pub async fn get_dependencies(
     let handle = require_handle!(server);
 
     let manager = detect_package_manager(&handle);
-    let deps = get_deps_for_manager(&handle, &manager);
+    let deps = get_deps_for_manager(&handle, manager);
 
     // Include prewarmed packages from RuntimeStateDoc when available
     let prewarmed = handle
@@ -325,7 +330,7 @@ pub async fn get_dependencies(
 
     let mut result = serde_json::json!({
         "dependencies": deps,
-        "package_manager": manager,
+        "package_manager": manager.as_str(),
         "mode": mode,
     });
     if let Some(ref source) = env_source {
@@ -397,19 +402,23 @@ pub async fn sync_environment(
 /// Read dependencies for the detected package manager (pub for session.rs).
 pub(crate) fn get_deps_for_manager_pub(
     handle: &notebook_sync::handle::DocHandle,
-    manager: &str,
+    manager: notebook_protocol::connection::PackageManager,
 ) -> Vec<String> {
     get_deps_for_manager(handle, manager)
 }
 
 /// Read dependencies for the detected package manager.
-fn get_deps_for_manager(handle: &notebook_sync::handle::DocHandle, manager: &str) -> Vec<String> {
+fn get_deps_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: notebook_protocol::connection::PackageManager,
+) -> Vec<String> {
+    use notebook_protocol::connection::PackageManager;
     handle
         .get_notebook_metadata()
         .map(|m| match manager {
-            "conda" => m.conda_dependencies().to_vec(),
-            "pixi" => m.pixi_dependencies().to_vec(),
-            _ => m.uv_dependencies().to_vec(),
+            PackageManager::Conda => m.conda_dependencies().to_vec(),
+            PackageManager::Pixi => m.pixi_dependencies().to_vec(),
+            PackageManager::Uv => m.uv_dependencies().to_vec(),
         })
         .unwrap_or_default()
 }

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -82,10 +82,13 @@ pub(crate) fn detect_package_manager(
 }
 
 /// Add a dependency using the appropriate package manager, return error string on failure.
+///
+/// `Unknown` package managers fall back to Uv (same default as
+/// `detect_package_manager`) — consistent with the historical behavior.
 pub(crate) fn add_dep_for_manager(
     handle: &notebook_sync::handle::DocHandle,
     package: &str,
-    manager: notebook_protocol::connection::PackageManager,
+    manager: &notebook_protocol::connection::PackageManager,
 ) -> Result<(), String> {
     use notebook_protocol::connection::PackageManager;
     match manager {
@@ -95,17 +98,19 @@ pub(crate) fn add_dep_for_manager(
         PackageManager::Pixi => handle
             .add_pixi_dependency(package)
             .map_err(|e| format!("Failed to add pixi dependency: {e}")),
-        PackageManager::Uv => handle
+        PackageManager::Uv | PackageManager::Unknown(_) => handle
             .add_uv_dependency(package)
             .map_err(|e| format!("Failed to add uv dependency: {e}")),
     }
 }
 
 /// Remove a dependency using the appropriate package manager.
+///
+/// `Unknown` package managers fall back to Uv (same default as `add`).
 fn remove_dep_for_manager(
     handle: &notebook_sync::handle::DocHandle,
     package: &str,
-    manager: notebook_protocol::connection::PackageManager,
+    manager: &notebook_protocol::connection::PackageManager,
 ) -> Result<bool, String> {
     use notebook_protocol::connection::PackageManager;
     match manager {
@@ -115,7 +120,7 @@ fn remove_dep_for_manager(
         PackageManager::Pixi => handle
             .remove_pixi_dependency(package)
             .map_err(|e| format!("Failed to remove pixi dependency: {e}")),
-        PackageManager::Uv => handle
+        PackageManager::Uv | PackageManager::Unknown(_) => handle
             .remove_uv_dependency(package)
             .map_err(|e| format!("Failed to remove uv dependency: {e}")),
     }
@@ -143,7 +148,7 @@ pub async fn add_dependency(
 
     let manager = detect_package_manager(&handle);
 
-    add_dep_for_manager(&handle, package, manager)
+    add_dep_for_manager(&handle, package, &manager)
         .map_err(|e| McpError::internal_error(e, None))?;
 
     // Ensure daemon has the metadata change before any follow-up action
@@ -152,7 +157,7 @@ pub async fn add_dependency(
     }
 
     // Read back current dependencies
-    let deps = get_deps_for_manager(&handle, manager);
+    let deps = get_deps_for_manager(&handle, &manager);
 
     let mut result = serde_json::json!({
         "dependencies": deps,
@@ -282,7 +287,7 @@ pub async fn remove_dependency(
 
     let manager = detect_package_manager(&handle);
 
-    let removed = remove_dep_for_manager(&handle, package, manager)
+    let removed = remove_dep_for_manager(&handle, package, &manager)
         .map_err(|e| McpError::internal_error(e, None))?;
 
     // Ensure daemon has the metadata change
@@ -290,7 +295,7 @@ pub async fn remove_dependency(
         tracing::warn!("confirm_sync failed after remove_dependency: {e}");
     }
 
-    let deps = get_deps_for_manager(&handle, manager);
+    let deps = get_deps_for_manager(&handle, &manager);
 
     let result = serde_json::json!({
         "dependencies": deps,
@@ -309,7 +314,7 @@ pub async fn get_dependencies(
     let handle = require_handle!(server);
 
     let manager = detect_package_manager(&handle);
-    let deps = get_deps_for_manager(&handle, manager);
+    let deps = get_deps_for_manager(&handle, &manager);
 
     // Include prewarmed packages from RuntimeStateDoc when available
     let prewarmed = handle
@@ -402,7 +407,7 @@ pub async fn sync_environment(
 /// Read dependencies for the detected package manager (pub for session.rs).
 pub(crate) fn get_deps_for_manager_pub(
     handle: &notebook_sync::handle::DocHandle,
-    manager: notebook_protocol::connection::PackageManager,
+    manager: &notebook_protocol::connection::PackageManager,
 ) -> Vec<String> {
     get_deps_for_manager(handle, manager)
 }
@@ -410,7 +415,7 @@ pub(crate) fn get_deps_for_manager_pub(
 /// Read dependencies for the detected package manager.
 fn get_deps_for_manager(
     handle: &notebook_sync::handle::DocHandle,
-    manager: notebook_protocol::connection::PackageManager,
+    manager: &notebook_protocol::connection::PackageManager,
 ) -> Vec<String> {
     use notebook_protocol::connection::PackageManager;
     handle
@@ -418,7 +423,7 @@ fn get_deps_for_manager(
         .map(|m| match manager {
             PackageManager::Conda => m.conda_dependencies().to_vec(),
             PackageManager::Pixi => m.pixi_dependencies().to_vec(),
-            PackageManager::Uv => m.uv_dependencies().to_vec(),
+            PackageManager::Uv | PackageManager::Unknown(_) => m.uv_dependencies().to_vec(),
         })
         .unwrap_or_default()
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -686,22 +686,6 @@ mod tests {
         assert_eq!(result, "pixi");
     }
 
-    /// Validation rejects unknown and aliases known package_manager values.
-    #[test]
-    fn package_manager_validation() {
-        use notebook_protocol::connection::normalize_package_manager;
-
-        // Direct values pass through
-        for valid in ["uv", "conda", "pixi"] {
-            assert_eq!(normalize_package_manager(valid).unwrap(), valid);
-        }
-        // Aliases resolve
-        assert_eq!(normalize_package_manager("pip").unwrap(), "uv");
-        assert_eq!(normalize_package_manager("mamba").unwrap(), "conda");
-        // Unknown values are rejected
-        assert!(normalize_package_manager("npm").is_err());
-    }
-
     /// save_notebook response must include notebook_id (unchanged UUID) and path.
     /// Verify no previous_notebook_id or new_notebook_id fields exist in the
     /// response schema (structural test via serde_json shape).

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -438,7 +438,7 @@ pub async fn create_notebook(
         working_dir,
         &server.get_peer_label().await,
         ephemeral,
-        explicit_pkg_manager,
+        explicit_pkg_manager.clone(),
         deps.clone(),
     )
     .await
@@ -476,7 +476,7 @@ pub async fn create_notebook(
             let all_deps = {
                 let guard = server.session.read().await;
                 guard.as_ref().map_or_else(Vec::new, |s| {
-                    super::deps::get_deps_for_manager_pub(&s.handle, pkg_manager)
+                    super::deps::get_deps_for_manager_pub(&s.handle, &pkg_manager)
                 })
             };
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -423,9 +423,9 @@ pub async fn create_notebook(
     let deps: Vec<String> = arg_string_array(request, "dependencies").unwrap_or_default();
     let explicit_pkg_manager = match arg_str(request, "package_manager") {
         Some(pm) => {
-            let normalized = notebook_protocol::connection::normalize_package_manager(pm)
+            let parsed = notebook_protocol::connection::PackageManager::parse(pm)
                 .map_err(|msg| McpError::invalid_params(msg, None))?;
-            Some(normalized)
+            Some(parsed)
         }
         None => None,
     };
@@ -454,7 +454,7 @@ pub async fn create_notebook(
             crate::presence::announce(&result.handle, &peer_label).await;
 
             let pkg_manager: String = explicit_pkg_manager
-                .map(String::from)
+                .map(|pm| pm.as_str().to_string())
                 .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
 
             let session = NotebookSession {

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -453,8 +453,7 @@ pub async fn create_notebook(
             let peer_label = server.get_peer_label().await;
             crate::presence::announce(&result.handle, &peer_label).await;
 
-            let pkg_manager: String = explicit_pkg_manager
-                .map(|pm| pm.as_str().to_string())
+            let pkg_manager: notebook_protocol::connection::PackageManager = explicit_pkg_manager
                 .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
 
             let session = NotebookSession {
@@ -477,7 +476,7 @@ pub async fn create_notebook(
             let all_deps = {
                 let guard = server.session.read().await;
                 guard.as_ref().map_or_else(Vec::new, |s| {
-                    super::deps::get_deps_for_manager_pub(&s.handle, &pkg_manager)
+                    super::deps::get_deps_for_manager_pub(&s.handle, pkg_manager)
                 })
             };
 
@@ -486,7 +485,7 @@ pub async fn create_notebook(
                 "runtime": runtime_info,
                 "dependencies": all_deps,
                 "added_dependencies": deps,
-                "package_manager": pkg_manager,
+                "package_manager": pkg_manager.as_str(),
                 "ephemeral": ephemeral,
             });
 

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -214,15 +214,16 @@ impl AsyncClient {
             }
         }
 
-        // Validate and normalize package_manager before entering the async block
-        let normalized_pm = match &package_manager {
-            Some(pm) => {
-                let n = notebook_protocol::connection::normalize_package_manager(pm)
-                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
-                Some(n.to_string())
-            }
-            None => None,
-        };
+        // Validate and normalize package_manager before entering the async block.
+        // Python API accepts "uv"/"conda"/"pixi" plus aliases ("pip", "mamba").
+        let parsed_pm: Option<notebook_protocol::connection::PackageManager> =
+            match &package_manager {
+                Some(pm) => Some(
+                    notebook_protocol::connection::PackageManager::parse(pm)
+                        .map_err(pyo3::exceptions::PyValueError::new_err)?,
+                ),
+                None => None,
+            };
 
         let label = peer_label.or_else(|| self.peer_label.clone());
         let socket_path = self.socket_path.clone();
@@ -235,7 +236,7 @@ impl AsyncClient {
                 runtime,
                 working_dir_buf,
                 label,
-                normalized_pm,
+                parsed_pm,
                 deps,
             )
             .await

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -78,7 +78,7 @@ impl AsyncSession {
         runtime: String,
         working_dir: Option<PathBuf>,
         peer_label: Option<String>,
-        package_manager: Option<String>,
+        package_manager: Option<notebook_protocol::connection::PackageManager>,
         dependencies: Vec<String>,
     ) -> PyResult<Self> {
         let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
@@ -88,7 +88,7 @@ impl AsyncSession {
             &runtime,
             working_dir,
             actor_label.as_deref(),
-            package_manager.as_deref(),
+            package_manager,
             dependencies,
         )
         .await?;

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1020,7 +1020,7 @@ impl AsyncSession {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
             let snapshot = session_core::get_notebook_metadata(&state).await?;
-            Ok(session_core::get_metadata_env_type(&snapshot))
+            Ok(session_core::get_metadata_env_type(&snapshot).map(|pm| pm.as_str().to_string()))
         })
     }
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -140,15 +140,18 @@ pub(crate) fn get_settings(state: &SessionState) -> Option<runtimed::settings_do
 /// This checks if the metadata structure exists, not whether deps are non-empty.
 /// Pixi is checked first because a notebook with a pixi section should use
 /// pixi for dependency management even if uv/conda sections also exist.
-pub(crate) fn get_metadata_env_type(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
+pub(crate) fn get_metadata_env_type(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::PackageManager> {
+    use notebook_protocol::connection::PackageManager;
     if snapshot.runt.pixi.is_some() {
-        return Some("pixi".to_string());
+        return Some(PackageManager::Pixi);
     }
     if snapshot.runt.conda.is_some() {
-        return Some("conda".to_string());
+        return Some(PackageManager::Conda);
     }
     if snapshot.runt.uv.is_some() {
-        return Some("uv".to_string());
+        return Some(PackageManager::Uv);
     }
     None
 }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -409,7 +409,7 @@ pub(crate) async fn connect_create(
     runtime: &str,
     working_dir: Option<PathBuf>,
     actor_label: Option<&str>,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
 ) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
     let default_label;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2117,7 +2117,7 @@ impl Daemon {
         working_dir: Option<String>,
         notebook_id_hint: Option<String>,
         ephemeral: Option<bool>,
-        package_manager: Option<String>,
+        package_manager: Option<notebook_protocol::connection::PackageManager>,
         dependencies: Vec<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
@@ -2177,7 +2177,7 @@ impl Daemon {
                     &runtime,
                     default_python_env.clone(),
                     Some(&notebook_id),
-                    package_manager.as_deref(),
+                    package_manager,
                     &dependencies,
                 ) {
                     Ok(_) => {}

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -804,15 +804,31 @@ pub(crate) fn build_new_notebook_metadata(
         ),
         _ => {
             // Resolve which package manager section to create:
-            //   1. Explicit package_manager from the request
-            //   2. No explicit manager - use default_python_env
+            //   1. Explicit package_manager from the request — resolved via
+            //      `PackageManager::resolve()` so wire aliases ("pip",
+            //      "mamba") fold to canonical variants.
+            //   2. Unknown wire value that isn't an alias — fall back to
+            //      `default_python_env` and log; the wire layer is permissive
+            //      but the daemon must land on a real section.
+            //   3. No explicit manager — use `default_python_env`.
             use notebook_protocol::connection::PackageManager;
-            let effective_manager: PackageManager =
-                package_manager.unwrap_or(match default_python_env {
-                    crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
-                    crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
-                    _ => PackageManager::Uv,
-                });
+            let default_from_setting = || match default_python_env {
+                crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
+                crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
+                _ => PackageManager::Uv,
+            };
+            let effective_manager: PackageManager = match package_manager {
+                Some(pm) => match pm.resolve() {
+                    Ok(resolved) => resolved,
+                    Err(msg) => {
+                        tracing::warn!(
+                            "[runtimed] build_new_notebook_metadata: {msg}; falling back to default_python_env"
+                        );
+                        default_from_setting()
+                    }
+                },
+                None => default_from_setting(),
+            };
 
             let deps = dependencies.to_vec();
 
@@ -844,6 +860,12 @@ pub(crate) fn build_new_notebook_metadata(
                     }),
                     None,
                     None,
+                ),
+                // Resolved above — this branch is defensive; Unknown would
+                // already have been folded to a canonical variant or the
+                // default_python_env fallback.
+                PackageManager::Unknown(_) => unreachable!(
+                    "effective_manager was resolved above; Unknown shouldn't reach this match"
                 ),
             };
 

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -727,7 +727,7 @@ pub fn create_empty_notebook(
     runtime: &str,
     default_python_env: crate::settings_doc::PythonEnvType,
     env_id: Option<&str>,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: &[String],
 ) -> Result<String, String> {
     let env_id = env_id
@@ -771,7 +771,7 @@ pub(crate) fn build_new_notebook_metadata(
     runtime: &str,
     env_id: &str,
     default_python_env: crate::settings_doc::PythonEnvType,
-    package_manager: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: &[String],
 ) -> NotebookMetadataSnapshot {
     use crate::notebook_metadata::{
@@ -806,24 +806,18 @@ pub(crate) fn build_new_notebook_metadata(
             // Resolve which package manager section to create:
             //   1. Explicit package_manager from the request
             //   2. No explicit manager - use default_python_env
-            let effective_manager: &str = match package_manager {
-                Some(pm) => {
-                    // Normalize aliases (e.g. "pip" -> "uv", "mamba" -> "conda").
-                    // If the value is unrecognized, fall through to "uv" as a
-                    // safe default - callers should validate before reaching here.
-                    notebook_protocol::connection::normalize_package_manager(pm).unwrap_or("uv")
-                }
-                None => match default_python_env {
-                    crate::settings_doc::PythonEnvType::Conda => "conda",
-                    crate::settings_doc::PythonEnvType::Pixi => "pixi",
-                    _ => "uv",
-                },
-            };
+            use notebook_protocol::connection::PackageManager;
+            let effective_manager: PackageManager =
+                package_manager.unwrap_or_else(|| match default_python_env {
+                    crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
+                    crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
+                    _ => PackageManager::Uv,
+                });
 
             let deps = dependencies.to_vec();
 
             let (uv, conda, pixi) = match effective_manager {
-                "conda" => (
+                PackageManager::Conda => (
                     None,
                     Some(CondaInlineMetadata {
                         dependencies: deps,
@@ -832,7 +826,7 @@ pub(crate) fn build_new_notebook_metadata(
                     }),
                     None,
                 ),
-                "pixi" => (
+                PackageManager::Pixi => (
                     None,
                     None,
                     Some(notebook_doc::metadata::PixiInlineMetadata {
@@ -842,7 +836,7 @@ pub(crate) fn build_new_notebook_metadata(
                         python: None,
                     }),
                 ),
-                _ => (
+                PackageManager::Uv => (
                     Some(UvInlineMetadata {
                         dependencies: deps,
                         requires_python: None,

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -808,7 +808,7 @@ pub(crate) fn build_new_notebook_metadata(
             //   2. No explicit manager - use default_python_env
             use notebook_protocol::connection::PackageManager;
             let effective_manager: PackageManager =
-                package_manager.unwrap_or_else(|| match default_python_env {
+                package_manager.unwrap_or(match default_python_env {
                     crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
                     crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
                     _ => PackageManager::Uv,

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -53,13 +53,16 @@ pub(crate) fn check_inline_deps(snapshot: &NotebookMetadataSnapshot) -> Option<S
 /// Priority: pixi > conda > uv. Pixi is most specific (manages both conda
 /// and pypi deps). Matches detect_package_manager in runt-mcp and
 /// get_metadata_env_type in runtimed-py.
-fn detect_manager_from_metadata(snapshot: &NotebookMetadataSnapshot) -> Option<&'static str> {
+fn detect_manager_from_metadata(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::PackageManager> {
+    use notebook_protocol::connection::PackageManager;
     if snapshot.runt.pixi.is_some() {
-        Some("pixi")
+        Some(PackageManager::Pixi)
     } else if snapshot.runt.conda.is_some() {
-        Some("conda")
+        Some(PackageManager::Conda)
     } else if snapshot.runt.uv.is_some() {
-        Some("uv")
+        Some(PackageManager::Uv)
     } else {
         None
     }
@@ -2246,14 +2249,15 @@ pub(crate) async fn auto_launch_kernel(
                 // Check if the metadata has an explicit manager section
                 // (e.g. create_notebook(package_manager="conda") with empty deps).
                 // Use that to pick the pool type instead of default_python_env.
+                use notebook_protocol::connection::PackageManager;
                 let manager = metadata_snapshot
                     .as_ref()
                     .and_then(detect_manager_from_metadata);
                 let prewarmed = match manager {
-                    Some("conda") => "conda:prewarmed",
-                    Some("pixi") => "pixi:prewarmed",
-                    Some("uv") => "uv:prewarmed",
-                    _ => match default_python_env {
+                    Some(PackageManager::Conda) => "conda:prewarmed",
+                    Some(PackageManager::Pixi) => "pixi:prewarmed",
+                    Some(PackageManager::Uv) => "uv:prewarmed",
+                    None => match default_python_env {
                         crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
                         crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
                         _ => "uv:prewarmed",

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2253,15 +2253,21 @@ pub(crate) async fn auto_launch_kernel(
                 let manager = metadata_snapshot
                     .as_ref()
                     .and_then(detect_manager_from_metadata);
+                // Fallback pool for when the metadata didn't declare a section
+                // or the declared section is non-canonical. Non-canonical
+                // shouldn't happen from `detect_manager_from_metadata` (it
+                // only inspects the three typed sections), but the compiler
+                // needs an exhaustive match against `PackageManager`.
+                let fallback = match default_python_env {
+                    crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
+                    crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
+                    _ => "uv:prewarmed",
+                };
                 let prewarmed = match manager {
                     Some(PackageManager::Conda) => "conda:prewarmed",
                     Some(PackageManager::Pixi) => "pixi:prewarmed",
                     Some(PackageManager::Uv) => "uv:prewarmed",
-                    None => match default_python_env {
-                        crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                        crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
-                        _ => "uv:prewarmed",
-                    },
+                    Some(PackageManager::Unknown(_)) | None => fallback,
                 };
                 info!(
                     "[notebook-sync] Auto-launch: using prewarmed ({})",

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1954,7 +1954,7 @@ async fn test_create_notebook_with_deps() {
         None,
         "test",
         false,
-        Some("conda"),
+        Some(notebook_protocol::connection::PackageManager::Conda),
         vec!["pandas".to_string(), "numpy".to_string()],
     )
     .await
@@ -2027,7 +2027,7 @@ async fn test_create_notebook_with_explicit_manager_no_deps() {
         None,
         "test",
         false,
-        Some("pixi"),
+        Some(notebook_protocol::connection::PackageManager::Pixi),
         vec![],
     )
     .await

--- a/docs/superpowers/plans/2026-04-22-package-manager-enum.md
+++ b/docs/superpowers/plans/2026-04-22-package-manager-enum.md
@@ -1,0 +1,1144 @@
+# PackageManager Enum Refactor — Implementation Plan (PR 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace raw `"uv"`/`"conda"`/`"pixi"` strings with a typed `PackageManager` enum across ~10 function signatures in 6 crates. Delete `normalize_package_manager` once callers use the enum's `parse()` method.
+
+**Architecture:** Introduce `PackageManager` (Copy, 3 variants, wire-compatible via `#[serde(rename_all = "lowercase")]`) in `notebook-protocol::connection`. Migrate signatures layer by layer (protocol → sync → daemon → mcp → py → tauri/node) so every task produces a compiling, test-passing workspace. Internal code uses the enum; the MCP JSON output and the PyO3 Python boundary keep strings. The wire handshake is byte-identical before/after.
+
+**Tech Stack:** Rust, serde, PyO3, Automerge (indirect). No frontend changes. No wire or schema version bump — serialization is identical.
+
+**Scope:** This plan covers PR 1 only. PR 2 (`EnvSource` enum, `env_source.starts_with(...)` replacements, prewarmed fallback) is a separate plan tracked by the spec at `docs/superpowers/specs/2026-04-22-package-manager-enum-design.md`.
+
+---
+
+## File Structure
+
+| File | Role in this refactor |
+|------|----------------------|
+| `crates/notebook-protocol/src/connection.rs` | Define `PackageManager` enum, change `CreateNotebook.package_manager` field type, remove `normalize_package_manager` |
+| `crates/notebook-sync/src/connect.rs` | Thread `Option<PackageManager>` through `connect_create` and `connect_create_relay` |
+| `crates/runtimed/src/daemon.rs` | `handle_create_notebook` signature + `Handshake::CreateNotebook` destructuring |
+| `crates/runtimed/src/notebook_sync_server/load.rs` | `create_empty_notebook`, `build_new_notebook_metadata` signatures |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | `detect_manager_from_metadata` return type + auto-launch 3-way match |
+| `crates/runtimed/tests/integration.rs` | All `connect_create` call sites pass `Option<PackageManager>` |
+| `crates/runt-mcp/src/tools/session.rs` | `create_notebook` handler parses to enum, passes through |
+| `crates/runt-mcp/src/tools/deps.rs` | `detect_package_manager`, `add_dep_for_manager`, `remove_dep_for_manager`, `get_deps_for_manager*` signatures |
+| `crates/runt-mcp/src/project_file.rs` | `ProjectFile::manager()` returns `PackageManager` |
+| `crates/runtimed-py/src/async_client.rs` | Parse `Option<String>` → `Option<PackageManager>` at PyO3 boundary |
+| `crates/runtimed-py/src/async_session.rs` | `create_notebook_async` signature |
+| `crates/runtimed-py/src/session_core.rs` | `connect_create` signature, `get_metadata_env_type` return type |
+| `crates/notebook/src/lib.rs` | `connect_create_relay` call site (passes `None`) |
+| `crates/runtimed-node/src/session.rs` | `connect_create` call site (passes `None`) |
+
+---
+
+## Task 1: Define `PackageManager` enum in `notebook-protocol`
+
+**Files:**
+- Modify: `crates/notebook-protocol/src/connection.rs`
+
+**Goal:** Add the enum, `as_str`, `parse`, `FromStr`, `Display`, and unit tests. Additive — existing `normalize_package_manager` stays for now so dependent crates keep compiling.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the bottom of the existing `#[cfg(test)] mod tests` block in `crates/notebook-protocol/src/connection.rs` (immediately after the existing `normalize_package_manager_rejects_unknown` test on line 1016):
+
+```rust
+    #[test]
+    fn package_manager_as_str_round_trips() {
+        assert_eq!(PackageManager::Uv.as_str(), "uv");
+        assert_eq!(PackageManager::Conda.as_str(), "conda");
+        assert_eq!(PackageManager::Pixi.as_str(), "pixi");
+    }
+
+    #[test]
+    fn package_manager_parse_valid() {
+        assert_eq!(PackageManager::parse("uv").unwrap(), PackageManager::Uv);
+        assert_eq!(PackageManager::parse("conda").unwrap(), PackageManager::Conda);
+        assert_eq!(PackageManager::parse("pixi").unwrap(), PackageManager::Pixi);
+    }
+
+    #[test]
+    fn package_manager_parse_aliases() {
+        assert_eq!(PackageManager::parse("pip").unwrap(), PackageManager::Uv);
+        assert_eq!(PackageManager::parse("mamba").unwrap(), PackageManager::Conda);
+    }
+
+    #[test]
+    fn package_manager_parse_rejects_unknown() {
+        let err = PackageManager::parse("npm").unwrap_err();
+        assert!(err.contains("Unsupported package manager 'npm'"));
+        assert!(err.contains("Supported: uv, conda, pixi"));
+    }
+
+    #[test]
+    fn package_manager_fromstr_works() {
+        use std::str::FromStr;
+        let pm: PackageManager = PackageManager::from_str("conda").unwrap();
+        assert_eq!(pm, PackageManager::Conda);
+        assert!(PackageManager::from_str("bogus").is_err());
+    }
+
+    #[test]
+    fn package_manager_display_matches_as_str() {
+        assert_eq!(format!("{}", PackageManager::Uv), "uv");
+        assert_eq!(format!("{}", PackageManager::Conda), "conda");
+        assert_eq!(format!("{}", PackageManager::Pixi), "pixi");
+    }
+
+    #[test]
+    fn package_manager_serde_is_lowercase() {
+        let json = serde_json::to_string(&PackageManager::Conda).unwrap();
+        assert_eq!(json, "\"conda\"");
+        let pm: PackageManager = serde_json::from_str("\"pixi\"").unwrap();
+        assert_eq!(pm, PackageManager::Pixi);
+    }
+```
+
+- [ ] **Step 2: Run the tests — they should fail to compile (enum not defined)**
+
+Run: `cargo test -p notebook-protocol --lib package_manager 2>&1 | head -40`
+Expected: compile error: `cannot find type 'PackageManager' in this scope`.
+
+- [ ] **Step 3: Add the enum definition**
+
+At the top of `crates/notebook-protocol/src/connection.rs`, replace the imports block (line 30) to add `std::fmt` and `std::str::FromStr`:
+
+```rust
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+```
+
+Then, immediately after the module-level doc comments and imports (before the existing `MAX_FRAME_SIZE` constant at ~line 34, or any other natural location before the first type definition), insert the enum:
+
+```rust
+/// Supported package managers for Python notebooks.
+///
+/// The wire format is the lowercase variant name (`"uv"`, `"conda"`, `"pixi"`),
+/// matching the historical `normalize_package_manager` output. `parse()`
+/// additionally accepts `"pip"` (→ Uv) and `"mamba"` (→ Conda) aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageManager {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+impl PackageManager {
+    /// The canonical wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uv => "uv",
+            Self::Conda => "conda",
+            Self::Pixi => "pixi",
+        }
+    }
+
+    /// Parse a package manager name with alias support.
+    ///
+    /// Accepts `"uv"`, `"conda"`, `"pixi"` (canonical), plus `"pip"` (→ Uv)
+    /// and `"mamba"` (→ Conda).
+    pub fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "uv" => Ok(Self::Uv),
+            "conda" => Ok(Self::Conda),
+            "pixi" => Ok(Self::Pixi),
+            "pip" => Ok(Self::Uv),
+            "mamba" => Ok(Self::Conda),
+            _ => Err(format!(
+                "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
+                input
+            )),
+        }
+    }
+}
+
+impl fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PackageManager {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+```
+
+- [ ] **Step 4: Run the new tests — they should pass**
+
+Run: `cargo test -p notebook-protocol --lib package_manager`
+Expected: 7 tests pass (`package_manager_as_str_round_trips`, `..._parse_valid`, `..._parse_aliases`, `..._parse_rejects_unknown`, `..._fromstr_works`, `..._display_matches_as_str`, `..._serde_is_lowercase`).
+
+- [ ] **Step 5: Run the full protocol test suite — nothing regressed**
+
+Run: `cargo test -p notebook-protocol`
+Expected: all tests pass, including the pre-existing `normalize_package_manager_*` tests (unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-protocol/src/connection.rs
+git commit -m "feat(notebook-protocol): add PackageManager enum"
+```
+
+---
+
+## Task 2: Migrate the `CreateNotebook` handshake + `connect_create*` signatures
+
+**Files:**
+- Modify: `crates/notebook-protocol/src/connection.rs` (struct field + 3 serialization tests)
+- Modify: `crates/notebook-sync/src/connect.rs` (2 public functions + 1 private)
+- Modify: `crates/runtimed/src/daemon.rs` (`handle_create_notebook` signature + destructuring)
+- Modify: `crates/runtimed/src/notebook_sync_server/load.rs` (`create_empty_notebook`, `build_new_notebook_metadata`)
+- Modify: `crates/runtimed/src/notebook_sync_server/metadata.rs` (none yet — just a spot-check)
+- Modify: `crates/runtimed/tests/integration.rs` (all `connect_create` calls)
+- Modify: `crates/runtimed-py/src/session_core.rs` (`connect_create` helper)
+- Modify: `crates/runtimed-py/src/async_session.rs` (`create_notebook_async`)
+- Modify: `crates/runtimed-py/src/async_client.rs` (PyO3 boundary)
+- Modify: `crates/runt-mcp/src/tools/session.rs` (`create_notebook` tool handler)
+- Modify: `crates/notebook/src/lib.rs` (Tauri relay call site)
+- Modify: `crates/runtimed-node/src/session.rs` (Node binding call site)
+
+**Goal:** Change `Option<String>`/`Option<&str>` to `Option<PackageManager>` everywhere the handshake flows. Internal callers construct the enum at the boundary (PyO3 argument parsing, MCP JSON argument parsing). Wire format is unchanged (serde produces `"uv"`/`"conda"`/`"pixi"`). `normalize_package_manager` is still present — it's deleted in Task 7.
+
+This is a single atomic commit: compile goes green at the end. Steps walk through each file; do not commit in the middle.
+
+### Step 1: Change the handshake struct field type
+
+- [ ] **Edit `crates/notebook-protocol/src/connection.rs`**
+
+Change the `package_manager` field on `Handshake::CreateNotebook` (line 150-154):
+
+```rust
+        /// Package manager preference: uv, conda, or pixi.
+        /// When set, the daemon creates only this manager's metadata section.
+        /// When None, the daemon uses its default_python_env setting.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        package_manager: Option<PackageManager>,
+```
+
+Update the 3 handshake serialization tests (lines 741-780): the `package_manager: None` values still compile (the enum is the inner type of the Option). No changes needed there — but verify by reading the file.
+
+### Step 2: Change `connect_create` and `connect_create_relay` signatures
+
+- [ ] **Edit `crates/notebook-sync/src/connect.rs`**
+
+At line 272-292 (`connect_create`), change `package_manager: Option<&str>` to `package_manager: Option<PackageManager>`:
+
+```rust
+pub async fn connect_create(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    actor_label: &str,
+    ephemeral: bool,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+) -> Result<CreateResult, SyncError> {
+    connect_create_inner(
+        socket_path,
+        runtime,
+        working_dir,
+        None,
+        actor_label,
+        ephemeral,
+        package_manager,
+        dependencies,
+    )
+    .await
+}
+```
+
+At line 295-304 (`connect_create_inner`), same change:
+
+```rust
+async fn connect_create_inner(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    actor_label: &str,
+    ephemeral: bool,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+) -> Result<CreateResult, SyncError> {
+```
+
+And inside, change the handshake construction (was `package_manager: package_manager.map(String::from)` at line 321):
+
+```rust
+        package_manager,
+```
+
+At line 488-497 (`connect_create_relay`), same change:
+
+```rust
+pub async fn connect_create_relay(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    ephemeral: bool,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+) -> Result<RelayCreateResult, SyncError> {
+```
+
+And at line 514 (the handshake construction inside `connect_create_relay`), change:
+
+```rust
+        package_manager,
+```
+
+### Step 3: Update the runtimed daemon
+
+- [ ] **Edit `crates/runtimed/src/daemon.rs`**
+
+At line 1701-1720 (the `Handshake::CreateNotebook` arm), the destructuring `package_manager` now binds a `Option<PackageManager>` instead of `Option<String>`. The subsequent call to `self.handle_create_notebook(...)` is positional; no source change needed at the call site, but the callee's signature changes in the next substep.
+
+At line 2112-2123 (`handle_create_notebook` signature), change:
+
+```rust
+    async fn handle_create_notebook<S>(
+        self: Arc<Self>,
+        stream: S,
+        runtime: String,
+        working_dir: Option<String>,
+        notebook_id_hint: Option<String>,
+        ephemeral: Option<bool>,
+        package_manager: Option<notebook_protocol::connection::PackageManager>,
+        dependencies: Vec<String>,
+        client_protocol_version: u8,
+    ) -> anyhow::Result<()>
+```
+
+At line 2180 (the call into `create_empty_notebook`), change `package_manager.as_deref()` to `package_manager` (now we pass the enum through, not an `&str`):
+
+```rust
+                match crate::notebook_sync_server::create_empty_notebook(
+                    &mut doc,
+                    &runtime,
+                    default_python_env.clone(),
+                    Some(&notebook_id),
+                    package_manager,
+                    &dependencies,
+                ) {
+```
+
+At line 1875-1885 (`self.handle_create_notebook(...)` call from a different path; passes `None` for package_manager), no change needed — `None` is polymorphic.
+
+### Step 4: Update `create_empty_notebook` and `build_new_notebook_metadata`
+
+- [ ] **Edit `crates/runtimed/src/notebook_sync_server/load.rs`**
+
+At line 725-732 (`create_empty_notebook` signature), change `package_manager: Option<&str>` to `Option<PackageManager>`:
+
+```rust
+pub fn create_empty_notebook(
+    doc: &mut NotebookDoc,
+    runtime: &str,
+    default_python_env: crate::settings_doc::PythonEnvType,
+    env_id: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: &[String],
+) -> Result<String, String> {
+```
+
+At line 770-776 (`build_new_notebook_metadata` signature), same change:
+
+```rust
+pub(crate) fn build_new_notebook_metadata(
+    runtime: &str,
+    env_id: &str,
+    default_python_env: crate::settings_doc::PythonEnvType,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: &[String],
+) -> NotebookMetadataSnapshot {
+```
+
+Inside `build_new_notebook_metadata`, replace the `effective_manager: &str` block at lines 809-821 with an enum-based resolution. Keep the subsequent `match effective_manager { ... }` block working by matching on the enum:
+
+```rust
+        _ => {
+            // Resolve which package manager section to create:
+            //   1. Explicit package_manager from the request
+            //   2. No explicit manager - use default_python_env
+            use notebook_protocol::connection::PackageManager;
+            let effective_manager: PackageManager = package_manager.unwrap_or_else(|| {
+                match default_python_env {
+                    crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
+                    crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
+                    _ => PackageManager::Uv,
+                }
+            });
+
+            let deps = dependencies.to_vec();
+
+            let (uv, conda, pixi) = match effective_manager {
+                PackageManager::Conda => (
+                    None,
+                    Some(CondaInlineMetadata {
+                        dependencies: deps,
+                        channels: vec!["conda-forge".to_string()],
+                        python: None,
+                    }),
+                    None,
+                ),
+                PackageManager::Pixi => (
+                    None,
+                    None,
+                    Some(notebook_doc::metadata::PixiInlineMetadata {
+                        dependencies: deps,
+                        pypi_dependencies: vec![],
+                        channels: vec!["conda-forge".to_string()],
+                        python: None,
+                    }),
+                ),
+                PackageManager::Uv => (
+                    Some(UvInlineMetadata {
+                        dependencies: deps,
+                        requires_python: None,
+                        prerelease: None,
+```
+
+Continue through the existing `_ => ( Some(UvInlineMetadata { ... }), None, None)` trailing arm — rename the `_` arm to `PackageManager::Uv` so the match is exhaustive. (Read lines 845-870 in the file to see the full existing trailing arm; keep its body verbatim but change the arm label from `_` to `PackageManager::Uv`.)
+
+Remove the call to `normalize_package_manager` (line 814); the enum carries aliases internally via `PackageManager::parse` at the boundary.
+
+### Step 5: Update the runtimed integration tests
+
+- [ ] **Edit `crates/runtimed/tests/integration.rs`**
+
+Every `connect_create(...)` call in this file currently passes `None` for `package_manager` (or, in the case of the create_notebook-with-deps tests, parses a string). Grep the file to confirm, and change any `Some("uv")`-style calls to `Some(PackageManager::Uv)`:
+
+```bash
+rg 'connect_create\s*\(' crates/runtimed/tests/integration.rs -n -A 8
+```
+
+For every call site, if the `package_manager` argument (7th positional for `connect_create`, after `ephemeral`) is `None`, no change is required. If it's `Some("uv"|"conda"|"pixi")`, replace with the enum value and add:
+
+```rust
+use notebook_protocol::connection::PackageManager;
+```
+
+near the top of the test file (or the local `mod` if tests are grouped).
+
+### Step 6: Update runtimed-py
+
+- [ ] **Edit `crates/runtimed-py/src/session_core.rs`**
+
+At line 407-414 (`connect_create` helper signature):
+
+```rust
+pub(crate) async fn connect_create(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    actor_label: Option<&str>,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
+```
+
+Inside, the forwarded `notebook_sync::connect::connect_create(..., package_manager, dependencies)` call keeps working with the new type.
+
+- [ ] **Edit `crates/runtimed-py/src/async_session.rs`**
+
+At line 75-94 (`create_notebook_async`), change the parameter type and pass-through:
+
+```rust
+    pub(crate) async fn create_notebook_async(
+        socket_path: PathBuf,
+        runtime: String,
+        working_dir: Option<PathBuf>,
+        peer_label: Option<String>,
+        package_manager: Option<notebook_protocol::connection::PackageManager>,
+        dependencies: Vec<String>,
+    ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        let (notebook_id, mut state, _info) = session_core::connect_create(
+            socket_path,
+            &runtime,
+            working_dir,
+            actor_label.as_deref(),
+            package_manager,
+            dependencies,
+        )
+        .await?;
+```
+
+- [ ] **Edit `crates/runtimed-py/src/async_client.rs`**
+
+At lines 217-240 (the argument-parsing block inside `create_notebook`). The Python API keeps `Option<String>`; parse into the enum at the PyO3 boundary and forward the enum downstream:
+
+```rust
+        // Validate and normalize package_manager before entering the async block.
+        // Python API accepts "uv"/"conda"/"pixi" plus aliases ("pip", "mamba").
+        let parsed_pm: Option<notebook_protocol::connection::PackageManager> = match &package_manager {
+            Some(pm) => Some(
+                notebook_protocol::connection::PackageManager::parse(pm)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?,
+            ),
+            None => None,
+        };
+
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        let socket_path = self.socket_path.clone();
+        let runtime = runtime.to_string();
+        let working_dir_buf = working_dir.map(PathBuf::from);
+        let deps = dependencies.unwrap_or_default();
+        future_into_py(py, async move {
+            AsyncSession::create_notebook_async(
+                socket_path,
+                runtime,
+                working_dir_buf,
+                label,
+                parsed_pm,
+                deps,
+```
+
+The rest of `create_notebook_async` forwards `parsed_pm` verbatim; no changes to the trailing call lines.
+
+### Step 7: Update runt-mcp `create_notebook` tool
+
+- [ ] **Edit `crates/runt-mcp/src/tools/session.rs`**
+
+At lines 423-443 (the block that parses `package_manager` argument and calls `connect_create`), replace `normalize_package_manager` with `PackageManager::parse`, and thread the enum through:
+
+```rust
+    let deps: Vec<String> = arg_string_array(request, "dependencies").unwrap_or_default();
+    let explicit_pkg_manager = match arg_str(request, "package_manager") {
+        Some(pm) => {
+            let parsed = notebook_protocol::connection::PackageManager::parse(pm)
+                .map_err(|msg| McpError::invalid_params(msg, None))?;
+            Some(parsed)
+        }
+        None => None,
+    };
+
+    let prev = previous_notebook_id(server).await;
+
+    match notebook_sync::connect::connect_create(
+        server.socket_path.clone(),
+        runtime,
+        working_dir,
+        &server.get_peer_label().await,
+        ephemeral,
+        explicit_pkg_manager,
+        deps.clone(),
+    )
+    .await
+```
+
+Lines 456-458 (the `pkg_manager: String` local) currently fall back to `detect_package_manager`, which returns a `String` today. That function is migrated in **Task 4**. For this task, keep the existing behavior intact using `.as_str().to_string()` on the enum:
+
+```rust
+            let pkg_manager: String = explicit_pkg_manager
+                .map(|pm| pm.as_str().to_string())
+                .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
+```
+
+This preserves the JSON output shape (`"package_manager": "conda"`) without breaking `get_deps_for_manager_pub(&s.handle, &pkg_manager)` — which still takes `&str` at this point. Task 4 will migrate that together with `detect_package_manager`.
+
+### Step 8: Update the Tauri relay call site
+
+- [ ] **Edit `crates/notebook/src/lib.rs`**
+
+At line 730-740, the `connect_create_relay` call passes `None` for `package_manager`. With the new enum, `None` is polymorphic — no source change required:
+
+```rust
+    let result = notebook_sync::connect::connect_create_relay(
+        socket_path,
+        &runtime,
+        working_dir,
+        notebook_id_hint,
+        frame_tx,
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .map_err(|e| format!("sync connect (create): {}", e))?;
+```
+
+Build-check only. Do not modify.
+
+### Step 9: Update the Node binding call site
+
+- [ ] **Edit `crates/runtimed-node/src/session.rs`**
+
+At line 273-282, same situation — passes `None`. Build-check only.
+
+### Step 10: Build the workspace — no errors, warnings, or `clippy` diagnostics
+
+Run: `cargo xtask clippy 2>&1 | tail -40`
+Expected: no new warnings or errors. `clippy` excludes `runtimed-py`; that's fine — CI covers it.
+
+Run: `cargo build --workspace --all-targets 2>&1 | tail -40`
+Expected: clean build.
+
+- [ ] **Step 11: Run protocol + sync + daemon tests**
+
+Run:
+```bash
+cargo test -p notebook-protocol
+cargo test -p notebook-sync
+cargo test -p runtimed --lib
+```
+Expected: all green.
+
+- [ ] **Step 12: Run the runtimed daemon integration tests**
+
+Run: `cargo xtask integration create_notebook 2>&1 | tail -20`
+Expected: tests pass. This exercises the full handshake path.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add -u
+git commit -m "refactor: thread PackageManager through CreateNotebook handshake"
+```
+
+---
+
+## Task 3: Migrate `detect_manager_from_metadata` + auto-launch match
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/metadata.rs`
+
+**Goal:** Change `detect_manager_from_metadata` to return `Option<PackageManager>` and make the two auto-launch sites (lines ~2249-2261) exhaustive-match on the enum. Do not touch `env_source` strings — that is PR 2's job.
+
+- [ ] **Step 1: Change the helper**
+
+In `crates/runtimed/src/notebook_sync_server/metadata.rs`, replace `detect_manager_from_metadata` (lines 56-66):
+
+```rust
+fn detect_manager_from_metadata(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::PackageManager> {
+    use notebook_protocol::connection::PackageManager;
+    if snapshot.runt.pixi.is_some() {
+        Some(PackageManager::Pixi)
+    } else if snapshot.runt.conda.is_some() {
+        Some(PackageManager::Conda)
+    } else if snapshot.runt.uv.is_some() {
+        Some(PackageManager::Uv)
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Update the one caller at the auto-launch site**
+
+At lines 2246-2267 (inside the `Some("python")` kernel-type arm), change the `match manager { Some("conda") => ..., Some("pixi") => ..., Some("uv") => ..., _ => ... }` block to match on the enum option:
+
+```rust
+            } else {
+                // Check if the metadata has an explicit manager section
+                // (e.g. create_notebook(package_manager="conda") with empty deps).
+                // Use that to pick the pool type instead of default_python_env.
+                use notebook_protocol::connection::PackageManager;
+                let manager = metadata_snapshot
+                    .as_ref()
+                    .and_then(detect_manager_from_metadata);
+                let prewarmed = match manager {
+                    Some(PackageManager::Conda) => "conda:prewarmed",
+                    Some(PackageManager::Pixi) => "pixi:prewarmed",
+                    Some(PackageManager::Uv) => "uv:prewarmed",
+                    None => match default_python_env {
+                        crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
+                        crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
+                        _ => "uv:prewarmed",
+                    },
+                };
+                info!(
+                    "[notebook-sync] Auto-launch: using prewarmed ({})",
+                    prewarmed
+                );
+                prewarmed.to_string()
+            };
+```
+
+The match is now exhaustive over `Option<PackageManager>`; removing one variant would be a compile error.
+
+- [ ] **Step 3: Build**
+
+Run: `cargo build -p runtimed --all-targets 2>&1 | tail -20`
+Expected: clean.
+
+- [ ] **Step 4: Run the daemon tests**
+
+Run: `cargo test -p runtimed --lib`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/metadata.rs
+git commit -m "refactor(runtimed): use PackageManager in auto-launch metadata resolution"
+```
+
+---
+
+## Task 4: Migrate `runt-mcp` dependency helpers
+
+**Files:**
+- Modify: `crates/runt-mcp/src/tools/deps.rs` (5 functions)
+- Modify: `crates/runt-mcp/src/tools/session.rs` (follow-up to Task 2 Step 7)
+- Modify: `crates/runt-mcp/src/project_file.rs` (`ProjectFile::manager()`)
+
+**Goal:** `detect_package_manager` returns `PackageManager`; `add_dep_for_manager`, `remove_dep_for_manager`, and `get_deps_for_manager*` take `PackageManager`. The MCP JSON output still emits strings via `.as_str()`.
+
+- [ ] **Step 1: Migrate `detect_package_manager` in `deps.rs`**
+
+Replace lines 48-79 in `crates/runt-mcp/src/tools/deps.rs`:
+
+```rust
+pub(crate) fn detect_package_manager(
+    handle: &notebook_sync::handle::DocHandle,
+) -> notebook_protocol::connection::PackageManager {
+    use notebook_protocol::connection::PackageManager;
+    // Priority 1: metadata declares which package manager section exists.
+    if let Some(meta) = handle.get_notebook_metadata() {
+        if meta.runt.pixi.is_some() {
+            return PackageManager::Pixi;
+        }
+        if meta.runt.conda.is_some() {
+            return PackageManager::Conda;
+        }
+        if meta.runt.uv.is_some() {
+            return PackageManager::Uv;
+        }
+    }
+    // Priority 2: env_source from running kernel (fallback for notebooks
+    // with no runt metadata yet).
+    if let Ok(state) = handle.get_runtime_state() {
+        let src = &state.kernel.env_source;
+        if src.starts_with("conda:") {
+            return PackageManager::Conda;
+        }
+        if src.starts_with("pixi:") {
+            return PackageManager::Pixi;
+        }
+        if src.starts_with("uv:") {
+            return PackageManager::Uv;
+        }
+    }
+    PackageManager::Uv
+}
+```
+
+- [ ] **Step 2: Migrate `add_dep_for_manager`, `remove_dep_for_manager`, `get_deps_for_manager*`**
+
+Replace lines 82-97 (`add_dep_for_manager`):
+
+```rust
+pub(crate) fn add_dep_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    package: &str,
+    manager: notebook_protocol::connection::PackageManager,
+) -> Result<(), String> {
+    use notebook_protocol::connection::PackageManager;
+    match manager {
+        PackageManager::Conda => handle
+            .add_conda_dependency(package)
+            .map_err(|e| format!("Failed to add conda dependency: {e}")),
+        PackageManager::Pixi => handle
+            .add_pixi_dependency(package)
+            .map_err(|e| format!("Failed to add pixi dependency: {e}")),
+        PackageManager::Uv => handle
+            .add_uv_dependency(package)
+            .map_err(|e| format!("Failed to add uv dependency: {e}")),
+    }
+}
+```
+
+Replace lines 101-117 (`remove_dep_for_manager`):
+
+```rust
+fn remove_dep_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    package: &str,
+    manager: notebook_protocol::connection::PackageManager,
+) -> Result<bool, String> {
+    use notebook_protocol::connection::PackageManager;
+    match manager {
+        PackageManager::Conda => handle
+            .remove_conda_dependency(package)
+            .map_err(|e| format!("Failed to remove conda dependency: {e}")),
+        PackageManager::Pixi => handle
+            .remove_pixi_dependency(package)
+            .map_err(|e| format!("Failed to remove pixi dependency: {e}")),
+        PackageManager::Uv => handle
+            .remove_uv_dependency(package)
+            .map_err(|e| format!("Failed to remove uv dependency: {e}")),
+    }
+}
+```
+
+Replace lines 398-415 (`get_deps_for_manager_pub` + `get_deps_for_manager`):
+
+```rust
+pub(crate) fn get_deps_for_manager_pub(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: notebook_protocol::connection::PackageManager,
+) -> Vec<String> {
+    get_deps_for_manager(handle, manager)
+}
+
+fn get_deps_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    manager: notebook_protocol::connection::PackageManager,
+) -> Vec<String> {
+    use notebook_protocol::connection::PackageManager;
+    handle
+        .get_notebook_metadata()
+        .map(|m| match manager {
+            PackageManager::Conda => m.conda_dependencies().to_vec(),
+            PackageManager::Pixi => m.pixi_dependencies().to_vec(),
+            PackageManager::Uv => m.uv_dependencies().to_vec(),
+        })
+        .unwrap_or_default()
+}
+```
+
+- [ ] **Step 3: Fix the callers of these helpers in `deps.rs`**
+
+In `add_dependency` (lines 120-266), update these sites:
+- Line 139: `let manager = detect_package_manager(&handle);` — unchanged (type inference picks up the new return type).
+- Line 141: `add_dep_for_manager(&handle, package, &manager)` → `add_dep_for_manager(&handle, package, manager)` (`PackageManager: Copy`).
+- Line 150: `let deps = get_deps_for_manager(&handle, &manager);` → `let deps = get_deps_for_manager(&handle, manager);`
+- Line 155 (`"package_manager": manager`) → `"package_manager": manager.as_str()`.
+
+In `remove_dependency` (lines 269-297):
+- Line 278: same — unchanged local.
+- Line 280: `remove_dep_for_manager(&handle, package, &manager)` → `remove_dep_for_manager(&handle, package, manager)`.
+- Line 288: `get_deps_for_manager(&handle, &manager)` → `get_deps_for_manager(&handle, manager)`.
+- Line 294: `"package_manager": manager` → `"package_manager": manager.as_str()`.
+
+In `get_dependencies` (lines 300-338):
+- Line 306: `let manager = detect_package_manager(&handle);` — unchanged.
+- Line 307: `get_deps_for_manager(&handle, &manager)` → `get_deps_for_manager(&handle, manager)`.
+- Line 328: `"package_manager": manager` → `"package_manager": manager.as_str()`.
+
+- [ ] **Step 4: Fix the callers in `session.rs`**
+
+In `crates/runt-mcp/src/tools/session.rs`:
+
+Remove the `String` local from Task 2 Step 7 — with `detect_package_manager` now returning `PackageManager`, the local should be the enum. Replace lines 456-458:
+
+```rust
+            let pkg_manager: notebook_protocol::connection::PackageManager = explicit_pkg_manager
+                .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
+```
+
+At line 480-482 (`get_deps_for_manager_pub(&s.handle, &pkg_manager)` → by-value):
+
+```rust
+                    super::deps::get_deps_for_manager_pub(&s.handle, pkg_manager)
+```
+
+At line 489 (`"package_manager": pkg_manager`):
+
+```rust
+                "package_manager": pkg_manager.as_str(),
+```
+
+- [ ] **Step 5: Migrate `ProjectFile::manager()`**
+
+In `crates/runt-mcp/src/project_file.rs`, lines 24-30:
+
+```rust
+    pub fn manager(&self) -> notebook_protocol::connection::PackageManager {
+        use notebook_protocol::connection::PackageManager;
+        match self.kind {
+            ProjectFileKind::PyprojectToml => PackageManager::Uv,
+            ProjectFileKind::PixiToml => PackageManager::Pixi,
+        }
+    }
+```
+
+Grep for callers (`rg 'project_file.*\.manager\(\)' crates/runt-mcp/src -n`) and fix each to treat the return value as a `PackageManager`. Likely fixes: `.as_str()` before `format!`/JSON insertion, or direct comparison via `== PackageManager::Uv`.
+
+- [ ] **Step 6: Build + lint + test**
+
+Run:
+```bash
+cargo build -p runt-mcp --all-targets 2>&1 | tail -20
+cargo xtask clippy 2>&1 | tail -20
+cargo test -p runt-mcp
+```
+Expected: green across the board.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/runt-mcp/src/tools/deps.rs crates/runt-mcp/src/tools/session.rs crates/runt-mcp/src/project_file.rs
+git commit -m "refactor(runt-mcp): use PackageManager enum in dependency helpers"
+```
+
+---
+
+## Task 5: Migrate `get_metadata_env_type` in `runtimed-py`
+
+**Files:**
+- Modify: `crates/runtimed-py/src/session_core.rs`
+- Modify: `crates/runtimed-py/src/async_session.rs` (call site at line 1019)
+
+**Goal:** `get_metadata_env_type` returns `Option<PackageManager>` internally. The PyO3 boundary continues to expose `Option<str>` — Python sees the same API.
+
+- [ ] **Step 1: Change the helper**
+
+In `crates/runtimed-py/src/session_core.rs`, replace lines 143-154:
+
+```rust
+pub(crate) fn get_metadata_env_type(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::PackageManager> {
+    use notebook_protocol::connection::PackageManager;
+    if snapshot.runt.pixi.is_some() {
+        return Some(PackageManager::Pixi);
+    }
+    if snapshot.runt.conda.is_some() {
+        return Some(PackageManager::Conda);
+    }
+    if snapshot.runt.uv.is_some() {
+        return Some(PackageManager::Uv);
+    }
+    None
+}
+```
+
+- [ ] **Step 2: Update the caller at the PyO3 boundary**
+
+In `crates/runtimed-py/src/async_session.rs` at line 1019 (the body of the `get_metadata_env_type` Python method), convert the enum to a Python string before returning:
+
+```rust
+        Ok(session_core::get_metadata_env_type(&snapshot)
+            .map(|pm| pm.as_str().to_string())
+```
+
+Keep the surrounding PyO3 wrapping logic (`into_py`/`into_pyobject`) intact — only the inner `Option<String>` → `Option<PackageManager>` transformation changes, then `.map(|pm| pm.as_str().to_string())` restores the string for Python.
+
+- [ ] **Step 3: Check for any other callers of `get_metadata_env_type`**
+
+Run: `rg "get_metadata_env_type" crates/runtimed-py/src -n`
+
+Every caller should now call `.map(|pm| pm.as_str().to_string())` (for string output) or use the enum directly (internal Rust). Fix any remaining sites.
+
+- [ ] **Step 4: Build + test**
+
+Run:
+```bash
+cargo build -p runtimed-py 2>&1 | tail -20
+```
+Expected: clean.
+
+Rebuild the Python bindings and run the Python tests:
+```bash
+up rebuild=true
+```
+
+Then run the integration tests that exercise `get_metadata_env_type`:
+```bash
+cargo xtask integration async_session 2>&1 | tail -20
+```
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/runtimed-py/src/session_core.rs crates/runtimed-py/src/async_session.rs
+git commit -m "refactor(runtimed-py): return PackageManager from get_metadata_env_type"
+```
+
+---
+
+## Task 6: Update the Python docstring and .pyi stub
+
+**Files:**
+- Modify: `crates/runtimed-py/src/async_client.rs` (docstring on `create_notebook`)
+- Modify: `python/runtimed/src/runtimed/_internals.pyi` (the stub declares `package_manager: str | None = None` at one site)
+
+**Goal:** The Python-facing docstring already lists `"uv"/"conda"/"pixi"` correctly. Verify the `.pyi` stub matches. No source code change.
+
+- [ ] **Step 1: Verify the docstring**
+
+Read `crates/runtimed-py/src/async_client.rs` around line 189. Confirm the line:
+```
+package_manager: Package manager ("uv", "conda", "pixi"). When None, daemon uses default_python_env.
+```
+already matches the enum's accepted values. If aliases ("pip", "mamba") are worth documenting, append:
+```
+Also accepts "pip" (→ uv) and "mamba" (→ conda) aliases.
+```
+
+- [ ] **Step 2: Check the type stub**
+
+Run: `rg "package_manager" python/runtimed/src/runtimed/_internals.pyi`
+Expected: one match — `package_manager: str | None = None,`. No change required; the Python API is still `str | None`, backed by `PackageManager::parse` inside the PyO3 boundary.
+
+- [ ] **Step 3: Commit (if anything changed)**
+
+```bash
+git add -u
+git commit -m "docs(runtimed-py): document package_manager aliases"
+```
+
+If nothing changed, skip the commit.
+
+---
+
+## Task 7: Delete `normalize_package_manager` and its tests
+
+**Files:**
+- Modify: `crates/notebook-protocol/src/connection.rs`
+- Modify: `crates/runt-mcp/src/tools/session.rs` (delete the `normalize_package_manager` test block)
+
+**Goal:** Retire the band-aid now that every caller uses `PackageManager::parse`.
+
+- [ ] **Step 1: Delete the function**
+
+In `crates/notebook-protocol/src/connection.rs`, delete lines 161-182 (the doc comment, the `pub fn normalize_package_manager` body, and any surrounding blank lines).
+
+- [ ] **Step 2: Delete its tests**
+
+Delete the three tests (lines 999-1016):
+- `normalize_package_manager_valid`
+- `normalize_package_manager_aliases`
+- `normalize_package_manager_rejects_unknown`
+
+Coverage is fully carried by the `PackageManager::parse*` tests from Task 1.
+
+- [ ] **Step 3: Delete the mirrored test in runt-mcp**
+
+In `crates/runt-mcp/src/tools/session.rs`, grep for the `#[test]` block that uses `normalize_package_manager` (around lines 690-705):
+
+```bash
+rg -n "normalize_package_manager" crates/runt-mcp/src/tools/session.rs
+```
+
+Delete the whole test function (from its `#[test]` or `#[cfg(test)]` scope start to the closing brace). This test was redundant coverage of the shared `notebook_protocol::connection::normalize_package_manager` function.
+
+- [ ] **Step 4: Verify no lingering references**
+
+Run: `rg "normalize_package_manager" --type rust -n`
+Expected: zero matches.
+
+- [ ] **Step 5: Build workspace + lint + run tests**
+
+Run:
+```bash
+cargo build --workspace --all-targets 2>&1 | tail -10
+cargo xtask clippy 2>&1 | tail -10
+cargo test -p notebook-protocol
+cargo test -p runt-mcp
+cargo test -p runtimed --lib
+```
+Expected: all green.
+
+- [ ] **Step 6: Run the daemon integration tests**
+
+Run: `cargo xtask integration 2>&1 | tail -30`
+Expected: all green. Exercises the full create_notebook-with-deps + package-manager path.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -u
+git commit -m "refactor: delete normalize_package_manager in favor of PackageManager::parse"
+```
+
+---
+
+## Task 8: End-to-end verification
+
+**Goal:** Confirm the wire format is byte-identical to main and that a real dev-daemon session works.
+
+- [ ] **Step 1: Manually inspect wire format**
+
+Run the unit test that dumps a `CreateNotebook` handshake as JSON:
+
+```bash
+cargo test -p notebook-protocol test_handshake_serialization -- --nocapture 2>&1 | grep 'create_notebook'
+```
+
+Expected: lines like
+```
+{"channel":"create_notebook","runtime":"python"}
+```
+identical to before. (The enum's `rename_all = "lowercase"` produces `"uv"`/`"conda"`/`"pixi"` identical to the old `String` values.)
+
+- [ ] **Step 2: Rebuild Python bindings and run MCP create_notebook**
+
+```bash
+up rebuild=true
+```
+
+Then, via nteract-dev MCP, create a notebook with an explicit conda package manager and a dependency:
+
+```
+create_notebook(runtime="python", dependencies=["numpy"], package_manager="conda", ephemeral=true)
+```
+
+Expected response: includes `"package_manager": "conda"` and auto-launches a conda kernel. `get_dependencies()` on the same notebook returns `{"package_manager": "conda", "dependencies": ["numpy"], ...}`.
+
+Also test an alias:
+
+```
+create_notebook(runtime="python", dependencies=["pandas"], package_manager="mamba", ephemeral=true)
+```
+
+Expected: same as above but with `"package_manager": "conda"` (alias folded).
+
+And an unknown value:
+
+```
+create_notebook(runtime="python", package_manager="poetry", ephemeral=true)
+```
+
+Expected: tool error `Unsupported package manager 'poetry'. Supported: uv, conda, pixi.`
+
+- [ ] **Step 3: Final commit (if any doc or stray fix needed)**
+
+If Steps 1-2 surfaced a defect, fix it and commit. Otherwise skip.
+
+- [ ] **Step 4: Run `cargo xtask lint --fix`**
+
+Run: `cargo xtask lint --fix`
+Expected: no diffs produced (code is already formatted).
+
+If diffs appear, amend the appropriate commit (or create a small `chore: fmt` commit).
+
+---
+
+## Testing Summary
+
+| What | Why |
+|------|-----|
+| `cargo test -p notebook-protocol` | Enum definition, parse/FromStr/Display/serde roundtrip |
+| `cargo test -p notebook-sync` | Handshake serialization invariant |
+| `cargo test -p runtimed --lib` | Auto-launch metadata resolution, `build_new_notebook_metadata` |
+| `cargo test -p runt-mcp` | MCP tool handlers (create_notebook, add_dependency, etc.) |
+| `cargo xtask integration` | End-to-end daemon + create_notebook + deps |
+| `up rebuild=true` + MCP `create_notebook` | Real PyO3 boundary behaves as expected |
+| `cargo xtask clippy` | No new warnings, exhaustive-match coverage |
+
+## Deliverables
+
+At the end of PR 1:
+- New enum: `notebook_protocol::connection::PackageManager` (Copy, 3 variants, serde-lowercase).
+- All 10 call sites through the 6 crates carry the enum internally.
+- `normalize_package_manager` deleted; its tests retired.
+- Wire format identical; Python API identical; MCP JSON identical.
+- PR 2 (EnvSource enum) stays in `docs/superpowers/specs/2026-04-22-package-manager-enum-design.md` for a follow-up plan.

--- a/docs/superpowers/specs/2026-04-22-package-manager-enum-design.md
+++ b/docs/superpowers/specs/2026-04-22-package-manager-enum-design.md
@@ -1,0 +1,238 @@
+# Refactor: PackageManager and EnvSource enums
+
+## Problem
+
+Package manager identity flows as raw strings (`"uv"`, `"conda"`, `"pixi"`) through ~20 function signatures across 5 crates. Environment source labels (`"uv:inline"`, `"conda:prewarmed"`, `"pixi:toml"`) are similarly stringly-typed through auto-launch, RuntimeStateDoc, and kernel agent code.
+
+This causes:
+- Priority order mismatches between detection functions (we just fixed one today)
+- Silent fallthrough to `"uv"` for unknown values (we just added `normalize_package_manager` as a band-aid)
+- No exhaustive match - adding a new manager means grep, not the compiler
+- 64 string comparisons against manager values in production code
+
+## Fix
+
+Two enums in `notebook-protocol`, introduced in two sequential PRs.
+
+## PR 1: `PackageManager` enum
+
+### Definition
+
+```rust
+// crates/notebook-protocol/src/connection.rs
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageManager {
+    Uv,
+    Conda,
+    Pixi,
+}
+```
+
+### Traits and methods
+
+```rust
+impl PackageManager {
+    /// The canonical wire string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uv => "uv",
+            Self::Conda => "conda",
+            Self::Pixi => "pixi",
+        }
+    }
+
+    /// Parse with alias support. "pip" -> Uv, "mamba" -> Conda.
+    pub fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "uv" => Ok(Self::Uv),
+            "conda" => Ok(Self::Conda),
+            "pixi" => Ok(Self::Pixi),
+            "pip" => Ok(Self::Uv),
+            "mamba" => Ok(Self::Conda),
+            _ => Err(format!(
+                "Unsupported package manager '{}'. Supported: uv, conda, pixi.",
+                input
+            )),
+        }
+    }
+}
+
+impl fmt::Display for PackageManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PackageManager {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+```
+
+### Properties
+
+- `Copy` - three fieldless variants, no heap allocation
+- `#[serde(rename_all = "lowercase")]` - serializes as `"uv"`, `"conda"`, `"pixi"` (wire-compatible)
+- `parse()` absorbs `normalize_package_manager` (deleted)
+- `FromStr` enables `.parse::<PackageManager>()` at all call sites
+- `Display` enables `format!("{}", pm)` for logging
+
+### What changes
+
+| Location | Before | After |
+|----------|--------|-------|
+| `CreateNotebook` handshake | `package_manager: Option<String>` | `package_manager: Option<PackageManager>` |
+| `connect_create` / `connect_create_relay` | `package_manager: Option<&str>` | `package_manager: Option<PackageManager>` |
+| `handle_create_notebook` | `package_manager: Option<String>` | `package_manager: Option<PackageManager>` |
+| `create_empty_notebook` | `package_manager: Option<&str>` | `package_manager: Option<PackageManager>` |
+| `build_new_notebook_metadata` | `package_manager: Option<&str>` | `package_manager: Option<PackageManager>` |
+| `detect_package_manager` (runt-mcp) | returns `String` | returns `PackageManager` |
+| `detect_manager_from_metadata` | returns `Option<&'static str>` | returns `Option<PackageManager>` |
+| `get_metadata_env_type` (runtimed-py) | returns `Option<String>` | returns `Option<String>` (Python boundary, converts via `.as_str()`) |
+| `add_dep_for_manager` | `manager: &str` | `manager: PackageManager` |
+| MCP `create_notebook` | `explicit_pkg_manager: Option<&str>` | `explicit_pkg_manager: Option<PackageManager>` |
+| Python `async_client.rs` | `package_manager: Option<String>` | parses to `Option<PackageManager>` at the boundary |
+
+### What gets deleted
+
+- `normalize_package_manager` in `connection.rs` (absorbed by `PackageManager::parse`)
+- All `match manager { "conda" => ..., "pixi" => ..., _ => ... }` patterns become `match manager { PackageManager::Conda => ..., PackageManager::Pixi => ..., PackageManager::Uv => ... }` with exhaustive checking
+
+### Python boundary
+
+The PyO3 boundary in `async_client.rs` accepts `Option<String>` from Python and calls `PackageManager::parse()` to convert. Returns `PyValueError` on failure. The Python-side type stays `str | None` since Python doesn't benefit from a Rust enum.
+
+### Serde compatibility
+
+The `CreateNotebook` handshake currently sends `"package_manager": "conda"`. With `#[serde(rename_all = "lowercase")]`, the enum serializes identically. Old clients that don't send the field get `None` via `#[serde(default)]`. Wire-compatible.
+
+---
+
+## PR 2: `EnvSource` enum
+
+### Definition
+
+```rust
+// crates/notebook-protocol/src/connection.rs
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvSource {
+    Prewarmed(PackageManager),
+    Inline(PackageManager),
+    Pyproject,              // always uv
+    PixiToml,               // always pixi
+    EnvYml,                 // always conda
+    Pep723(PackageManager), // uv or pixi
+    Deno,
+}
+```
+
+### Methods
+
+```rust
+impl EnvSource {
+    /// The package manager for this env source, if applicable.
+    pub fn package_manager(&self) -> Option<PackageManager> {
+        match self {
+            Self::Prewarmed(pm) | Self::Inline(pm) | Self::Pep723(pm) => Some(*pm),
+            Self::Pyproject => Some(PackageManager::Uv),
+            Self::PixiToml => Some(PackageManager::Pixi),
+            Self::EnvYml => Some(PackageManager::Conda),
+            Self::Deno => None,
+        }
+    }
+
+    /// The canonical wire string (e.g. "uv:prewarmed", "conda:inline").
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Prewarmed(PackageManager::Uv) => "uv:prewarmed",
+            Self::Prewarmed(PackageManager::Conda) => "conda:prewarmed",
+            Self::Prewarmed(PackageManager::Pixi) => "pixi:prewarmed",
+            Self::Inline(PackageManager::Uv) => "uv:inline",
+            Self::Inline(PackageManager::Conda) => "conda:inline",
+            Self::Inline(PackageManager::Pixi) => "pixi:inline",
+            Self::Pyproject => "uv:pyproject",
+            Self::PixiToml => "pixi:toml",
+            Self::EnvYml => "conda:env_yml",
+            Self::Pep723(PackageManager::Uv) => "uv:pep723",
+            Self::Pep723(PackageManager::Conda) => "conda:pep723",
+            Self::Pep723(PackageManager::Pixi) => "pixi:pep723",
+            Self::Deno => "deno",
+        }
+    }
+
+    /// Parse from the wire string.
+    pub fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "uv:prewarmed" => Ok(Self::Prewarmed(PackageManager::Uv)),
+            "conda:prewarmed" => Ok(Self::Prewarmed(PackageManager::Conda)),
+            "pixi:prewarmed" => Ok(Self::Prewarmed(PackageManager::Pixi)),
+            "uv:inline" => Ok(Self::Inline(PackageManager::Uv)),
+            "conda:inline" => Ok(Self::Inline(PackageManager::Conda)),
+            "pixi:inline" => Ok(Self::Inline(PackageManager::Pixi)),
+            "uv:pyproject" => Ok(Self::Pyproject),
+            "pixi:toml" => Ok(Self::PixiToml),
+            "conda:env_yml" => Ok(Self::EnvYml),
+            "uv:pep723" => Ok(Self::Pep723(PackageManager::Uv)),
+            "pixi:pep723" => Ok(Self::Pep723(PackageManager::Pixi)),
+            "deno" => Ok(Self::Deno),
+            _ => Err(format!("Unknown env source: '{}'", input)),
+        }
+    }
+
+    /// Whether this source prepares its own env (no pool env needed).
+    pub fn prepares_own_env(&self) -> bool {
+        matches!(
+            self,
+            Self::Inline(_) | Self::Pyproject | Self::PixiToml | Self::Pep723(_)
+        )
+    }
+}
+```
+
+### What changes
+
+| Location | Before | After |
+|----------|--------|-------|
+| `check_inline_deps` | returns `Option<String>` | returns `Option<EnvSource>` |
+| `auto_launch_kernel` env_source variable | `String` | `EnvSource` |
+| `detect_manager_from_metadata` prewarmed construction | string match on `default_python_env` | `EnvSource::Prewarmed(pm)` |
+| `prepares_own_env` check in auto-launch | 7-way string `==` comparison | `env_source.prepares_own_env()` |
+| `KernelLaunched` response | `env_source: String` | `env_source: String` (wire format preserved, `.as_str()` at boundary) |
+| RuntimeStateDoc `kernel.env_source` | written as string | written via `.as_str()`, read via `EnvSource::parse()` |
+
+### Serde
+
+`EnvSource` uses custom `Serialize`/`Deserialize` that delegate to `as_str()`/`parse()` for string-format compatibility. The RuntimeStateDoc and `KernelLaunched` response continue to carry `env_source` as a string on the wire. Internal code uses the enum.
+
+### What gets deleted
+
+- All `env_source.starts_with("conda:")` / `.starts_with("uv:")` prefix checks
+- The 7-way `if env_source == "uv:pyproject" || env_source == "uv:inline" || ...` in auto-launch (replaced by `prepares_own_env()`)
+- String construction like `format!("{}:prewarmed", ...)` in the prewarmed fallback
+
+---
+
+## Crates affected
+
+| Crate | PR 1 (PackageManager) | PR 2 (EnvSource) |
+|-------|----------------------|------------------|
+| `notebook-protocol` | Enum definition, delete `normalize_package_manager` | Enum definition |
+| `notebook-sync` | `connect_create` signatures | - |
+| `runtimed` | `daemon.rs`, `load.rs`, `metadata.rs` | `metadata.rs` (auto-launch), `daemon.rs` (launch handler) |
+| `runt-mcp` | `session.rs`, `deps.rs` | - |
+| `runtimed-py` | `async_client.rs`, `session_core.rs`, `async_session.rs` | `session_core.rs` (env_type detection) |
+| `notebook` (Tauri) | `lib.rs` (relay signature) | - |
+| `runtimed-node` | `session.rs` (signature) | - |
+
+## Testing
+
+- Existing tests continue to pass (wire format unchanged)
+- Unit tests for `PackageManager::parse` (valid, aliases, rejection)
+- Unit tests for `EnvSource::parse` / `as_str` roundtrip
+- Unit tests for `EnvSource::prepares_own_env`
+- Exhaustive match warnings surface any missed call sites during compilation


### PR DESCRIPTION
## Summary

Replaces raw `"uv"` / `"conda"` / `"pixi"` strings with a typed `PackageManager` enum across ~10 function signatures in 6 crates. `normalize_package_manager` (added as a band-aid in #2043) is retired in favor of `PackageManager::parse`, which carries the same alias semantics (`"pip"` → Uv, `"mamba"` → Conda) via a single authoritative implementation.

- New enum lives in `notebook-protocol::connection`. Copy, fieldless, `#[serde(rename_all = "lowercase")]` — wire-identical to the previous `Option<String>` handshake field.
- All internal callers thread the enum through; exhaustive match gives the compiler a seat at the table. The Python boundary keeps `str | None` and parses to the enum once at the PyO3 edge. The MCP tool output continues to emit lowercase strings via `.as_str()`.
- Eight commits, one per natural refactor boundary. Task 2 is deliberately atomic (signatures and all call sites) so the workspace compiles at the commit boundary.

PR 2 (`EnvSource` enum for `"uv:inline"` / `"conda:prewarmed"` / etc.) is tracked by the spec at `docs/superpowers/specs/2026-04-22-package-manager-enum-design.md` and will follow.

## Test plan

- [x] `cargo test -p notebook-protocol` — 47 pass (3 removed, 7 new)
- [x] `cargo test -p notebook-sync` — doctests only, all green
- [x] `cargo test -p runtimed --lib` — 384 pass
- [x] `cargo test -p runt-mcp` — 86 pass (1 removed)
- [x] `cargo xtask clippy` — clean
- [x] `cargo xtask lint` — clean
- [x] MCP `create_notebook(package_manager="conda", dependencies=["numpy"])` — returns `"package_manager": "conda"`, deps land in the conda section
- [x] MCP `create_notebook(package_manager="mamba", ...)` — alias correctly normalizes to `"conda"`
- [x] MCP `create_notebook(package_manager="poetry", ...)` — rejected with `Unsupported package manager 'poetry'. Supported: uv, conda, pixi.`
- [x] Wire format verified identical — existing `test_handshake_serialization` passes unchanged