### PR TITLE
feat(runtimed): prefer stable blob server port per channel

### DIFF
--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -886,6 +886,32 @@ pub fn vite_port_for_workspace(path: &Path) -> u16 {
     5100 + offset
 }
 
+/// Preferred port for the blob HTTP server.
+///
+/// Keeping this stable across daemon restarts lets the MCP App's baked-in
+/// CSP (`http://127.0.0.1:<port>`) keep working between sessions. We still
+/// probe for conflicts and fall back — this is a hint, not a guarantee.
+///
+/// Port assignments (IANA unassigned range):
+/// - Stable channel: 47820
+/// - Nightly channel: 47821
+/// - Dev worktree: 48000 + hash(worktree) % 1000 (stable per-worktree, no
+///   cross-worktree collisions)
+pub fn preferred_blob_port() -> u16 {
+    if is_dev_mode() {
+        if let Some(worktree) = get_workspace_path() {
+            let hash = worktree_hash(&worktree);
+            let prefix = hash.get(..4).unwrap_or("0000");
+            let offset = u16::from_str_radix(prefix, 16).unwrap_or(0) % 1000;
+            return 48000 + offset;
+        }
+    }
+    match build_channel() {
+        BuildChannel::Stable => 47820,
+        BuildChannel::Nightly => 47821,
+    }
+}
+
 // ============================================================================
 // Directory Paths
 // ============================================================================
@@ -1247,6 +1273,16 @@ mod tests {
             Some(v) => std::env::set_var("RUNTIMED_WORKSPACE_PATH", v),
             None => std::env::remove_var("RUNTIMED_WORKSPACE_PATH"),
         }
+    }
+
+    #[test]
+    fn test_preferred_blob_port_channel_defaults() {
+        // We can't toggle channel or dev mode from a test (they're read at
+        // compile time and from process-wide env vars), so just sanity-check
+        // that the returned port is in one of the expected ranges.
+        let port = preferred_blob_port();
+        let ok = port == 47820 || port == 47821 || (48000..49000).contains(&port);
+        assert!(ok, "unexpected preferred_blob_port: {port}");
     }
 
     #[test]

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -893,10 +893,14 @@ pub fn vite_port_for_workspace(path: &Path) -> u16 {
 /// probe for conflicts and fall back — this is a hint, not a guarantee.
 ///
 /// Port assignments (IANA unassigned range):
-/// - Stable channel: 47820
-/// - Nightly channel: 47821
-/// - Dev worktree: 48000 + hash(worktree) % 1000 (stable per-worktree, no
-///   cross-worktree collisions)
+/// - Stable channel:  47820 (bumps 47820..=47829)
+/// - Nightly channel: 47830 (bumps 47830..=47839)
+/// - Dev worktree:    48000 + hash(worktree) % 1000 (stable per-worktree,
+///   no cross-worktree collisions)
+///
+/// Stable and nightly get disjoint 10-port ranges so they never bump into
+/// each other's preferred port when both are running on the same machine.
+/// See `PREFERRED_BLOB_PORT_RANGE` for the bump budget.
 pub fn preferred_blob_port() -> u16 {
     if is_dev_mode() {
         if let Some(worktree) = get_workspace_path() {
@@ -908,9 +912,17 @@ pub fn preferred_blob_port() -> u16 {
     }
     match build_channel() {
         BuildChannel::Stable => 47820,
-        BuildChannel::Nightly => 47821,
+        BuildChannel::Nightly => 47830,
     }
 }
+
+/// How many consecutive ports past `preferred_blob_port()` the blob server
+/// is allowed to bump through before falling back to an OS-assigned port.
+///
+/// The value (10) matches the per-channel port range carved out in
+/// `preferred_blob_port()` — going higher would let stable drift into
+/// nightly's range or vice versa.
+pub const PREFERRED_BLOB_PORT_RANGE: u16 = 10;
 
 // ============================================================================
 // Directory Paths
@@ -1281,8 +1293,20 @@ mod tests {
         // compile time and from process-wide env vars), so just sanity-check
         // that the returned port is in one of the expected ranges.
         let port = preferred_blob_port();
-        let ok = port == 47820 || port == 47821 || (48000..49000).contains(&port);
+        let ok = port == 47820 || port == 47830 || (48000..49000).contains(&port);
         assert!(ok, "unexpected preferred_blob_port: {port}");
+    }
+
+    #[test]
+    fn test_blob_port_ranges_are_disjoint() {
+        // Stable's bump range and nightly's preferred port must not overlap.
+        let stable_max = 47820 + PREFERRED_BLOB_PORT_RANGE - 1;
+        assert!(
+            stable_max < 47830,
+            "stable range {}..={} overlaps nightly preferred 47830 — shrink PREFERRED_BLOB_PORT_RANGE or move a channel",
+            47820,
+            stable_max,
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -34,9 +34,10 @@ use crate::daemon::Daemon;
 use crate::embedded_plugins;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 
-/// Number of consecutive ports to try starting at the preferred port before
-/// falling back to an OS-assigned port.
-const PREFERRED_PORT_ATTEMPTS: u16 = 10;
+/// How many consecutive ports past the preferred port we'll try before
+/// falling back to an OS-assigned port. Sourced from `runt_workspace` so the
+/// bump budget stays in sync with the per-channel range carve-out.
+const PREFERRED_PORT_ATTEMPTS: u16 = runt_workspace::PREFERRED_BLOB_PORT_RANGE;
 
 /// Start the blob HTTP server on a random localhost port.
 ///

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -356,14 +356,10 @@ mod tests {
             .local_addr()
             .unwrap()
             .port();
-        assert_ne!(port, preferred, "should have bumped past held port");
+        let bump_range = (preferred + 1)..=(preferred + PREFERRED_PORT_ATTEMPTS - 1);
         assert!(
-            port == preferred + 1
-                || port >= preferred + 1 && port <= preferred + PREFERRED_PORT_ATTEMPTS,
-            "port {} should be in the bump range [{}..{}]",
-            port,
-            preferred + 1,
-            preferred + PREFERRED_PORT_ATTEMPTS - 1,
+            bump_range.contains(&port),
+            "port {port} should be in the bump range {bump_range:?}",
         );
         drop(blocker);
     }

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -10,9 +10,12 @@
 //! - `GET /plugins/{name}` — embedded renderer plugin assets (JS/CSS)
 //! - `GET /health` — 200 OK
 //!
-//! The server binds `127.0.0.1:0` (OS-assigned random port) and runs on
-//! the caller's tokio runtime. It shuts down when the process exits; no
-//! explicit cancellation is implemented yet.
+//! The server tries to bind a stable per-channel preferred port first
+//! (see `runt_workspace::preferred_blob_port`), bumping to the next port on
+//! collision (up to 10 attempts) before falling back to `127.0.0.1:0`. A
+//! stable port keeps frozen MCP App CSPs pointing at a working origin across
+//! daemon restarts. The server runs on the caller's tokio runtime and shuts
+//! down when the process exits; no explicit cancellation is implemented yet.
 
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -24,12 +27,16 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::blob_store::BlobStore;
 use crate::daemon::Daemon;
 use crate::embedded_plugins;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
+
+/// Number of consecutive ports to try starting at the preferred port before
+/// falling back to an OS-assigned port.
+const PREFERRED_PORT_ATTEMPTS: u16 = 10;
 
 /// Start the blob HTTP server on a random localhost port.
 ///
@@ -42,7 +49,16 @@ pub async fn start_blob_server(
     store: Arc<BlobStore>,
     daemon: Option<Arc<Daemon>>,
 ) -> std::io::Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    start_blob_server_with_listener(bind_preferred_or_random().await?, store, daemon).await
+}
+
+/// Start the blob HTTP server on an already-bound listener. Exposed for tests
+/// that want to pin the server to a random OS-assigned port.
+async fn start_blob_server_with_listener(
+    listener: TcpListener,
+    store: Arc<BlobStore>,
+    daemon: Option<Arc<Daemon>>,
+) -> std::io::Result<u16> {
     let port = listener.local_addr()?.port();
 
     info!("[blob-server] Listening on http://127.0.0.1:{}", port);
@@ -80,6 +96,29 @@ pub async fn start_blob_server(
     );
 
     Ok(port)
+}
+
+/// Bind the blob server port.
+///
+/// Tries the channel's preferred port first, bumps to the next port on
+/// `EADDRINUSE`, and falls back to an OS-assigned port after
+/// `PREFERRED_PORT_ATTEMPTS` consecutive collisions.
+async fn bind_preferred_or_random() -> std::io::Result<TcpListener> {
+    let preferred = runt_workspace::preferred_blob_port();
+    for offset in 0..PREFERRED_PORT_ATTEMPTS {
+        let port = preferred.saturating_add(offset);
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    warn!(
+        "[blob-server] preferred ports {}..{} all in use, falling back to OS-assigned port",
+        preferred,
+        preferred.saturating_add(PREFERRED_PORT_ATTEMPTS - 1)
+    );
+    TcpListener::bind("127.0.0.1:0").await
 }
 
 /// Handle a single HTTP request.
@@ -177,7 +216,12 @@ mod tests {
     async fn setup() -> (TempDir, Arc<BlobStore>, u16) {
         let dir = TempDir::new().unwrap();
         let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
-        let port = start_blob_server(store.clone(), None).await.unwrap();
+        // Tests bind :0 explicitly to avoid fighting a locally-running dev
+        // daemon for the channel's preferred port.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = start_blob_server_with_listener(listener, store.clone(), None)
+            .await
+            .unwrap();
         // Give the server a moment to start accepting
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         (dir, store, port)
@@ -283,9 +327,44 @@ mod tests {
     async fn test_two_servers_get_different_ports() {
         let dir = TempDir::new().unwrap();
         let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
-        let port1 = start_blob_server(store.clone(), None).await.unwrap();
-        let port2 = start_blob_server(store.clone(), None).await.unwrap();
+        let listener1 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listener2 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port1 = start_blob_server_with_listener(listener1, store.clone(), None)
+            .await
+            .unwrap();
+        let port2 = start_blob_server_with_listener(listener2, store.clone(), None)
+            .await
+            .unwrap();
         assert_ne!(port1, port2);
+    }
+
+    #[tokio::test]
+    async fn test_bind_bumps_on_collision() {
+        // Hold the preferred port so the first attempt hits AddrInUse.
+        let preferred = runt_workspace::preferred_blob_port();
+        let Ok(blocker) = TcpListener::bind(("127.0.0.1", preferred)).await else {
+            // Preferred port already in use by something else (a running
+            // daemon, parallel test). The bump path will still be exercised —
+            // just skip the explicit assertion about which port we got.
+            return;
+        };
+
+        let port = bind_preferred_or_random()
+            .await
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        assert_ne!(port, preferred, "should have bumped past held port");
+        assert!(
+            port == preferred + 1
+                || port >= preferred + 1 && port <= preferred + PREFERRED_PORT_ATTEMPTS,
+            "port {} should be in the bump range [{}..{}]",
+            port,
+            preferred + 1,
+            preferred + PREFERRED_PORT_ATTEMPTS - 1,
+        );
+        drop(blocker);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The blob server used to bind `127.0.0.1:0` on every daemon start, so the port changed on every restart. That invalidated the `resourceDomains` / `connectDomains` CSP snapshot the MCP App embedded on the prior session — old claude.ai sessions reopened against a running daemon saw `net::ERR_ABORTED 404` on plugin and blob fetches because their CSP pointed at a dead port.

This is the "mostly fixed" route: prefer a stable per-channel port, bump on collision (within a carved-out range so channels can't stomp each other), still fall back to OS-assigned as a safety net.

### Port assignments (IANA unassigned range)

| Channel | Preferred | Bump range |
|---|---|---|
| **Stable** | 47820 | 47820–47829 |
| **Nightly** | 47830 | 47830–47839 |
| **Dev worktree** | `48000 + hash(path) % 1000` | +0..+9 |

Stable and nightly get disjoint 10-port ranges so stable's bump path can't drift into nightly's preferred port when both are running on the same machine. A `test_blob_port_ranges_are_disjoint` test enforces this.

### Collision handling

Tries preferred, preferred+1, …, preferred+9 on `EADDRINUSE`. After 10 consecutive collisions falls back to `127.0.0.1:0` with a warning. Behavior-preserving safety net: if everything fails, we're back to today's random-port model.

### What this doesn't fix

Same-machine, daemon-restarted-since sessions are fixed. Cross-machine sessions still break — the baked URL (`http://127.0.0.1:47830`) points nowhere on a different host. That's a separate problem (server-side URL rewriting, or non-localhost origin), left for a follow-up.

## Design notes

- `preferred_blob_port()` and the shared bump budget `PREFERRED_BLOB_PORT_RANGE` live in `runt-workspace` alongside existing `vite_port_for_workspace` logic.
- `start_blob_server` now factors its listener setup through `bind_preferred_or_random`, with a private `start_blob_server_with_listener` so tests can explicitly request `:0` and avoid stomping on running daemons.

## Test plan

- [x] `cargo test -p runtimed --lib blob_server` — 9 tests pass, including new `test_bind_bumps_on_collision` that holds the preferred port and asserts the next bind lands in the bump range.
- [x] `cargo test -p runt-workspace` — 20 tests pass, including `test_preferred_blob_port_channel_defaults` and the new `test_blob_port_ranges_are_disjoint`.
- [x] `cargo fmt` clean.
- [ ] CI green.
- [ ] Smoke test on nightly: start daemon, check blob port is 47830 (or bumped to 47831 on contention), restart, confirm same port.