### PR TITLE
refactor: introduce EnvSource and LaunchSpec enums (PR 2 of 2)

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -221,6 +221,7 @@ impl EnvSource {
             "pixi:toml" => Self::PixiToml,
             "conda:env_yml" => Self::EnvYml,
             "uv:pep723" => Self::Pep723(PackageManager::Uv),
+            "conda:pep723" => Self::Pep723(PackageManager::Conda),
             "pixi:pep723" => Self::Pep723(PackageManager::Pixi),
             "deno" => Self::Deno,
             other => Self::Unknown(other.to_string()),
@@ -229,14 +230,29 @@ impl EnvSource {
 
     /// The package manager associated with this env source, if any.
     ///
-    /// `Deno` and `Unknown(_)` return `None`.
+    /// For canonical variants this returns the associated manager directly.
+    /// For `Unknown(s)`, the wire string's prefix is inspected so that a
+    /// forward-compatible value like `"conda:foo"` or `"pixi:bar"` still
+    /// routes to the correct package manager family. `Deno` and `Unknown`
+    /// strings without a recognized prefix return `None`.
     pub fn package_manager(&self) -> Option<PackageManager> {
         match self {
             Self::Prewarmed(pm) | Self::Inline(pm) | Self::Pep723(pm) => Some(pm.clone()),
             Self::Pyproject => Some(PackageManager::Uv),
             Self::PixiToml => Some(PackageManager::Pixi),
             Self::EnvYml => Some(PackageManager::Conda),
-            Self::Deno | Self::Unknown(_) => None,
+            Self::Deno => None,
+            Self::Unknown(s) => {
+                if s.starts_with("uv:") {
+                    Some(PackageManager::Uv)
+                } else if s.starts_with("conda:") {
+                    Some(PackageManager::Conda)
+                } else if s.starts_with("pixi:") {
+                    Some(PackageManager::Pixi)
+                } else {
+                    None
+                }
+            }
         }
     }
 
@@ -1440,6 +1456,34 @@ mod tests {
         assert_eq!(json, "\"something:new\"");
         let decoded: EnvSource = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, src);
+    }
+
+    #[test]
+    fn env_source_conda_pep723_round_trips() {
+        let src = EnvSource::Pep723(PackageManager::Conda);
+        assert_eq!(src.as_str(), "conda:pep723");
+        assert_eq!(EnvSource::parse("conda:pep723"), src);
+    }
+
+    #[test]
+    fn env_source_unknown_prefix_preserves_family() {
+        // Forward-compat: newer peers may send env_source strings we haven't
+        // taught the enum about. Family classification must still route
+        // correctly to the originating package manager's pool / helpers.
+        assert_eq!(
+            EnvSource::parse("conda:foo").package_manager(),
+            Some(PackageManager::Conda)
+        );
+        assert_eq!(
+            EnvSource::parse("uv:new-source").package_manager(),
+            Some(PackageManager::Uv)
+        );
+        assert_eq!(
+            EnvSource::parse("pixi:bar").package_manager(),
+            Some(PackageManager::Pixi)
+        );
+        // No recognized prefix → no manager.
+        assert_eq!(EnvSource::parse("mystery").package_manager(), None);
     }
 
     #[test]

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -249,11 +249,7 @@ impl EnvSource {
     pub fn prepares_own_env(&self) -> bool {
         matches!(
             self,
-            Self::Inline(_)
-                | Self::Pyproject
-                | Self::PixiToml
-                | Self::EnvYml
-                | Self::Pep723(_)
+            Self::Inline(_) | Self::Pyproject | Self::PixiToml | Self::EnvYml | Self::Pep723(_)
         )
     }
 }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -148,6 +148,176 @@ impl<'de> Deserialize<'de> for PackageManager {
     }
 }
 
+/// A concrete, resolved environment source.
+///
+/// Carried on `KernelLaunched.env_source` and
+/// `RuntimeStateDoc.kernel.env_source`. The daemon resolves the request-time
+/// `LaunchSpec` into an `EnvSource` before routing the launch; every
+/// downstream code path works against this type.
+///
+/// Deserialization is permissive: unrecognized wire strings land in
+/// `Unknown(s)` rather than failing, so the daemon and clients stay
+/// forward-compatible across versions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EnvSource {
+    /// Prewarmed pool env (e.g. `"uv:prewarmed"`). The daemon acquires these
+    /// from its warming pool — they do not prepare their own env.
+    Prewarmed(PackageManager),
+    /// Dependencies declared in notebook metadata (e.g. `"uv:inline"`). The
+    /// daemon builds the env from the metadata before kernel launch.
+    Inline(PackageManager),
+    /// `pyproject.toml` on disk (`"uv:pyproject"`). UV-only by definition.
+    Pyproject,
+    /// `pixi.toml` on disk (`"pixi:toml"`). Pixi-only.
+    PixiToml,
+    /// `environment.yml` on disk (`"conda:env_yml"`). Conda-only.
+    EnvYml,
+    /// PEP 723 script deps extracted from cell source (e.g. `"uv:pep723"`).
+    Pep723(PackageManager),
+    /// Deno TypeScript kernel — no Python env.
+    Deno,
+    /// Unrecognized wire string, preserved verbatim. Produced only by
+    /// `Deserialize` for values we haven't taught the enum about. Handle this
+    /// at match sites by falling back to the historical default (usually
+    /// Uv-family behavior) — never panic.
+    Unknown(String),
+}
+
+impl EnvSource {
+    /// The wire string form.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Prewarmed(PackageManager::Uv) => "uv:prewarmed",
+            Self::Prewarmed(PackageManager::Conda) => "conda:prewarmed",
+            Self::Prewarmed(PackageManager::Pixi) => "pixi:prewarmed",
+            Self::Prewarmed(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Inline(PackageManager::Uv) => "uv:inline",
+            Self::Inline(PackageManager::Conda) => "conda:inline",
+            Self::Inline(PackageManager::Pixi) => "pixi:inline",
+            Self::Inline(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Pyproject => "uv:pyproject",
+            Self::PixiToml => "pixi:toml",
+            Self::EnvYml => "conda:env_yml",
+            Self::Pep723(PackageManager::Uv) => "uv:pep723",
+            Self::Pep723(PackageManager::Conda) => "conda:pep723",
+            Self::Pep723(PackageManager::Pixi) => "pixi:pep723",
+            Self::Pep723(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Deno => "deno",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+
+    /// Parse a wire string. Never fails — unrecognized values land in
+    /// `Unknown(s)`.
+    pub fn parse(input: &str) -> Self {
+        match input {
+            "uv:prewarmed" => Self::Prewarmed(PackageManager::Uv),
+            "conda:prewarmed" => Self::Prewarmed(PackageManager::Conda),
+            "pixi:prewarmed" => Self::Prewarmed(PackageManager::Pixi),
+            "uv:inline" => Self::Inline(PackageManager::Uv),
+            "conda:inline" => Self::Inline(PackageManager::Conda),
+            "pixi:inline" => Self::Inline(PackageManager::Pixi),
+            "uv:pyproject" => Self::Pyproject,
+            "pixi:toml" => Self::PixiToml,
+            "conda:env_yml" => Self::EnvYml,
+            "uv:pep723" => Self::Pep723(PackageManager::Uv),
+            "pixi:pep723" => Self::Pep723(PackageManager::Pixi),
+            "deno" => Self::Deno,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    /// The package manager associated with this env source, if any.
+    ///
+    /// `Deno` and `Unknown(_)` return `None`.
+    pub fn package_manager(&self) -> Option<PackageManager> {
+        match self {
+            Self::Prewarmed(pm) | Self::Inline(pm) | Self::Pep723(pm) => Some(pm.clone()),
+            Self::Pyproject => Some(PackageManager::Uv),
+            Self::PixiToml => Some(PackageManager::Pixi),
+            Self::EnvYml => Some(PackageManager::Conda),
+            Self::Deno | Self::Unknown(_) => None,
+        }
+    }
+
+    /// True if this source prepares its own environment (no pool env needed).
+    ///
+    /// Used at auto-launch time to decide whether to acquire a prewarmed env
+    /// from the pool. `Inline`, project-file, and `Pep723` sources build
+    /// their env themselves; `Prewarmed` pulls from the pool; `Deno` and
+    /// `Unknown` take the no-pool path.
+    pub fn prepares_own_env(&self) -> bool {
+        matches!(
+            self,
+            Self::Inline(_)
+                | Self::Pyproject
+                | Self::PixiToml
+                | Self::EnvYml
+                | Self::Pep723(_)
+        )
+    }
+}
+
+impl fmt::Display for EnvSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for EnvSource {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvSource {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Ok(Self::parse(&raw))
+    }
+}
+
+/// Request-time launch specification.
+///
+/// The caller of `LaunchKernel` sends a `LaunchSpec`. The daemon resolves
+/// it into a concrete `EnvSource` before routing the launch. This type
+/// keeps the auto-detection inputs (`""`, `"auto"`, `"auto:uv"`,
+/// `"prewarmed"`) visibly distinct from a concrete env_source in the type
+/// system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchSpec {
+    /// Auto-detect everything — derived from notebook metadata, project
+    /// files, or PEP 723 script blocks. Wire strings: `""`, `"auto"`,
+    /// `"prewarmed"` (legacy alias).
+    Auto,
+    /// Auto-detect within a specific package manager family. Wire strings:
+    /// `"auto:uv"`, `"auto:conda"`, `"auto:pixi"`.
+    AutoScoped(PackageManager),
+    /// A concrete env_source to honor as-is.
+    Concrete(EnvSource),
+}
+
+impl LaunchSpec {
+    /// Parse a launch spec from the wire string.
+    pub fn parse(input: &str) -> Self {
+        match input {
+            "" | "auto" | "prewarmed" => Self::Auto,
+            "auto:uv" => Self::AutoScoped(PackageManager::Uv),
+            "auto:conda" => Self::AutoScoped(PackageManager::Conda),
+            "auto:pixi" => Self::AutoScoped(PackageManager::Pixi),
+            other => Self::Concrete(EnvSource::parse(other)),
+        }
+    }
+
+    /// If this spec is `AutoScoped(pm)`, returns `Some(pm)`; otherwise None.
+    pub fn auto_scope(&self) -> Option<PackageManager> {
+        match self {
+            Self::AutoScoped(pm) => Some(pm.clone()),
+            _ => None,
+        }
+    }
+}
+
 /// Maximum frame size for data frames: 100 MiB (matches blob size limit).
 const MAX_FRAME_SIZE: usize = 100 * 1024 * 1024;
 
@@ -1184,5 +1354,200 @@ mod tests {
         assert!(PackageManager::Unknown("poetry".to_string())
             .resolve()
             .is_err());
+    }
+
+    // -----------------------------------------------------------
+    // EnvSource tests
+    // -----------------------------------------------------------
+
+    #[test]
+    fn env_source_as_str_round_trips_all_variants() {
+        assert_eq!(
+            EnvSource::Prewarmed(PackageManager::Uv).as_str(),
+            "uv:prewarmed"
+        );
+        assert_eq!(
+            EnvSource::Prewarmed(PackageManager::Conda).as_str(),
+            "conda:prewarmed"
+        );
+        assert_eq!(
+            EnvSource::Prewarmed(PackageManager::Pixi).as_str(),
+            "pixi:prewarmed"
+        );
+        assert_eq!(EnvSource::Inline(PackageManager::Uv).as_str(), "uv:inline");
+        assert_eq!(
+            EnvSource::Inline(PackageManager::Conda).as_str(),
+            "conda:inline"
+        );
+        assert_eq!(
+            EnvSource::Inline(PackageManager::Pixi).as_str(),
+            "pixi:inline"
+        );
+        assert_eq!(EnvSource::Pyproject.as_str(), "uv:pyproject");
+        assert_eq!(EnvSource::PixiToml.as_str(), "pixi:toml");
+        assert_eq!(EnvSource::EnvYml.as_str(), "conda:env_yml");
+        assert_eq!(EnvSource::Pep723(PackageManager::Uv).as_str(), "uv:pep723");
+        assert_eq!(
+            EnvSource::Pep723(PackageManager::Pixi).as_str(),
+            "pixi:pep723"
+        );
+        assert_eq!(EnvSource::Deno.as_str(), "deno");
+    }
+
+    #[test]
+    fn env_source_parse_valid_round_trips() {
+        for s in [
+            "uv:prewarmed",
+            "conda:prewarmed",
+            "pixi:prewarmed",
+            "uv:inline",
+            "conda:inline",
+            "pixi:inline",
+            "uv:pyproject",
+            "pixi:toml",
+            "conda:env_yml",
+            "uv:pep723",
+            "pixi:pep723",
+            "deno",
+        ] {
+            let parsed = EnvSource::parse(s);
+            assert_eq!(parsed.as_str(), s, "round-trip failed for {s}");
+            assert!(!matches!(parsed, EnvSource::Unknown(_)));
+        }
+    }
+
+    #[test]
+    fn env_source_parse_unknown_captures_string() {
+        let pm = EnvSource::parse("weird:future-variant");
+        assert_eq!(pm, EnvSource::Unknown("weird:future-variant".to_string()));
+        assert_eq!(pm.as_str(), "weird:future-variant");
+    }
+
+    #[test]
+    fn env_source_parse_empty_is_unknown() {
+        assert_eq!(EnvSource::parse(""), EnvSource::Unknown(String::new()));
+    }
+
+    #[test]
+    fn env_source_serde_is_string() {
+        let src = EnvSource::Inline(PackageManager::Conda);
+        let json = serde_json::to_string(&src).unwrap();
+        assert_eq!(json, "\"conda:inline\"");
+        let decoded: EnvSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, src);
+    }
+
+    #[test]
+    fn env_source_serde_unknown_round_trips_verbatim() {
+        let src = EnvSource::Unknown("something:new".to_string());
+        let json = serde_json::to_string(&src).unwrap();
+        assert_eq!(json, "\"something:new\"");
+        let decoded: EnvSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, src);
+    }
+
+    #[test]
+    fn env_source_package_manager_for_all() {
+        assert_eq!(
+            EnvSource::Prewarmed(PackageManager::Uv).package_manager(),
+            Some(PackageManager::Uv)
+        );
+        assert_eq!(
+            EnvSource::Inline(PackageManager::Conda).package_manager(),
+            Some(PackageManager::Conda)
+        );
+        assert_eq!(
+            EnvSource::Pyproject.package_manager(),
+            Some(PackageManager::Uv)
+        );
+        assert_eq!(
+            EnvSource::PixiToml.package_manager(),
+            Some(PackageManager::Pixi)
+        );
+        assert_eq!(
+            EnvSource::EnvYml.package_manager(),
+            Some(PackageManager::Conda)
+        );
+        assert_eq!(
+            EnvSource::Pep723(PackageManager::Pixi).package_manager(),
+            Some(PackageManager::Pixi)
+        );
+        assert_eq!(EnvSource::Deno.package_manager(), None);
+        assert_eq!(EnvSource::Unknown("junk".into()).package_manager(), None);
+    }
+
+    #[test]
+    fn env_source_prepares_own_env() {
+        // Inline / project-file / pep723 sources prepare their own env.
+        assert!(EnvSource::Inline(PackageManager::Uv).prepares_own_env());
+        assert!(EnvSource::Inline(PackageManager::Conda).prepares_own_env());
+        assert!(EnvSource::Inline(PackageManager::Pixi).prepares_own_env());
+        assert!(EnvSource::Pyproject.prepares_own_env());
+        assert!(EnvSource::PixiToml.prepares_own_env());
+        assert!(EnvSource::EnvYml.prepares_own_env());
+        assert!(EnvSource::Pep723(PackageManager::Uv).prepares_own_env());
+        assert!(EnvSource::Pep723(PackageManager::Pixi).prepares_own_env());
+
+        // Prewarmed variants do not prepare their own env.
+        assert!(!EnvSource::Prewarmed(PackageManager::Uv).prepares_own_env());
+        assert!(!EnvSource::Prewarmed(PackageManager::Conda).prepares_own_env());
+        assert!(!EnvSource::Prewarmed(PackageManager::Pixi).prepares_own_env());
+
+        // Deno and Unknown take the "no pool" path.
+        assert!(!EnvSource::Deno.prepares_own_env());
+        assert!(!EnvSource::Unknown("nope".into()).prepares_own_env());
+    }
+
+    // -----------------------------------------------------------
+    // LaunchSpec tests
+    // -----------------------------------------------------------
+
+    #[test]
+    fn launch_spec_parse_auto_variants() {
+        assert_eq!(LaunchSpec::parse(""), LaunchSpec::Auto);
+        assert_eq!(LaunchSpec::parse("auto"), LaunchSpec::Auto);
+        assert_eq!(LaunchSpec::parse("prewarmed"), LaunchSpec::Auto);
+        assert_eq!(
+            LaunchSpec::parse("auto:uv"),
+            LaunchSpec::AutoScoped(PackageManager::Uv)
+        );
+        assert_eq!(
+            LaunchSpec::parse("auto:conda"),
+            LaunchSpec::AutoScoped(PackageManager::Conda)
+        );
+        assert_eq!(
+            LaunchSpec::parse("auto:pixi"),
+            LaunchSpec::AutoScoped(PackageManager::Pixi)
+        );
+    }
+
+    #[test]
+    fn launch_spec_parse_concrete_delegates_to_env_source() {
+        assert_eq!(
+            LaunchSpec::parse("uv:inline"),
+            LaunchSpec::Concrete(EnvSource::Inline(PackageManager::Uv))
+        );
+        assert_eq!(
+            LaunchSpec::parse("deno"),
+            LaunchSpec::Concrete(EnvSource::Deno)
+        );
+    }
+
+    #[test]
+    fn launch_spec_parse_future_value_is_concrete_unknown() {
+        assert_eq!(
+            LaunchSpec::parse("something:new"),
+            LaunchSpec::Concrete(EnvSource::Unknown("something:new".to_string()))
+        );
+    }
+
+    #[test]
+    fn launch_spec_auto_scope_returns_manager() {
+        assert_eq!(LaunchSpec::Auto.auto_scope(), None);
+        assert_eq!(
+            LaunchSpec::AutoScoped(PackageManager::Conda).auto_scope(),
+            Some(PackageManager::Conda)
+        );
+        assert_eq!(LaunchSpec::Concrete(EnvSource::Deno).auto_scope(), None);
     }
 }

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fc3644895ca5a151a73d47a0215c308484ec038b8b530fa33cc2645c9a78058
+oid sha256:a3ba2dedc3d3d5924813c600d695a48b111ca55cd4457056fb5a61ce27bdbf08
 size 4517312

--- a/crates/runt-mcp/src/project_file.rs
+++ b/crates/runt-mcp/src/project_file.rs
@@ -30,11 +30,12 @@ impl DetectedProjectFile {
         }
     }
 
-    /// The daemon env_source string for this project type.
-    pub fn env_source(&self) -> &'static str {
+    /// The daemon env_source for this project type.
+    pub fn env_source(&self) -> notebook_protocol::connection::EnvSource {
+        use notebook_protocol::connection::EnvSource;
         match self.kind {
-            ProjectFileKind::PyprojectToml => "uv:pyproject",
-            ProjectFileKind::PixiToml => "pixi:toml",
+            ProjectFileKind::PyprojectToml => EnvSource::Pyproject,
+            ProjectFileKind::PixiToml => EnvSource::PixiToml,
         }
     }
 }

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -66,9 +66,8 @@ pub(crate) fn detect_package_manager(
     // Priority 2: env_source from running kernel (fallback for notebooks
     // with no runt metadata yet).
     if let Ok(state) = handle.get_runtime_state() {
-        if let Some(pm) =
-            notebook_protocol::connection::EnvSource::parse(&state.kernel.env_source)
-                .package_manager()
+        if let Some(pm) = notebook_protocol::connection::EnvSource::parse(&state.kernel.env_source)
+            .package_manager()
         {
             return pm;
         }

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -64,17 +64,13 @@ pub(crate) fn detect_package_manager(
         }
     }
     // Priority 2: env_source from running kernel (fallback for notebooks
-    // with no runt metadata yet)
+    // with no runt metadata yet).
     if let Ok(state) = handle.get_runtime_state() {
-        let src = &state.kernel.env_source;
-        if src.starts_with("conda:") {
-            return PackageManager::Conda;
-        }
-        if src.starts_with("pixi:") {
-            return PackageManager::Pixi;
-        }
-        if src.starts_with("uv:") {
-            return PackageManager::Uv;
+        if let Some(pm) =
+            notebook_protocol::connection::EnvSource::parse(&state.kernel.env_source)
+                .package_manager()
+        {
+            return pm;
         }
     }
     // Default
@@ -217,18 +213,22 @@ pub async fn add_dependency(
         }
         "restart" => {
             // Shutdown + relaunch with scoped auto-detect to preserve the
-            // package manager family (auto:uv, auto:conda, auto:pixi)
-            let restart_env_source = match handle
+            // package manager family (auto:uv, auto:conda, auto:pixi).
+            use notebook_protocol::connection::{EnvSource, PackageManager};
+            let prev_env = handle
                 .get_runtime_state()
                 .ok()
                 .map(|s| s.kernel.env_source.clone())
-                .as_deref()
-            {
-                Some("uv:prewarmed") => "auto:uv".to_string(),
-                Some("conda:prewarmed") => "auto:conda".to_string(),
-                Some("pixi:prewarmed") => "auto:pixi".to_string(),
-                Some("") | None => "auto".to_string(),
-                Some(s) => s.to_string(),
+                .unwrap_or_default();
+            let restart_env_source = if prev_env.is_empty() {
+                "auto".to_string()
+            } else {
+                match EnvSource::parse(&prev_env) {
+                    EnvSource::Prewarmed(PackageManager::Uv) => "auto:uv".to_string(),
+                    EnvSource::Prewarmed(PackageManager::Conda) => "auto:conda".to_string(),
+                    EnvSource::Prewarmed(PackageManager::Pixi) => "auto:pixi".to_string(),
+                    other => other.as_str().to_string(),
+                }
             };
             // Derive notebook_path for project-file-backed envs (uv:pyproject, pixi:toml, etc.)
             let notebook_path = if notebook_id.contains('/') || notebook_id.contains('\\') {
@@ -328,8 +328,9 @@ pub async fn get_dependencies(
         .get_runtime_state()
         .ok()
         .map(|s| s.kernel.env_source.clone());
-    let mode = match env_source.as_deref() {
-        Some("pixi:toml") | Some("uv:pyproject") | Some("conda:env_yml") => "project",
+    use notebook_protocol::connection::EnvSource;
+    let mode = match env_source.as_deref().map(EnvSource::parse) {
+        Some(EnvSource::PixiToml | EnvSource::Pyproject | EnvSource::EnvYml) => "project",
         _ => "inline",
     };
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -116,12 +116,11 @@ fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::V
                     "env_source".into(),
                     serde_json::json!(state.kernel.env_source),
                 );
-                let env_source = &state.kernel.env_source;
-                if env_source.starts_with("conda:") {
-                    info.insert("package_manager".into(), serde_json::json!("conda"));
-                } else if env_source.starts_with("uv:") {
-                    info.insert("package_manager".into(), serde_json::json!("uv"));
-                } else if env_source == "deno" {
+                use notebook_protocol::connection::EnvSource;
+                let parsed = EnvSource::parse(&state.kernel.env_source);
+                if let Some(pm) = parsed.package_manager() {
+                    info.insert("package_manager".into(), serde_json::json!(pm.as_str()));
+                } else if matches!(parsed, EnvSource::Deno) {
                     info.insert("package_manager".into(), serde_json::json!("deno"));
                 }
             }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -108,6 +108,27 @@ pub(crate) fn make_actor_label(peer_label: &str) -> String {
     format!("agent:{}:{}", peer_label.to_lowercase(), short_id)
 }
 
+/// Map a previous `env_source` to the restart request value.
+///
+/// Prewarmed envs fold into scoped-auto so the daemon re-detects deps added
+/// post-launch but keeps the same package manager family. Everything else
+/// passes through unchanged; `None` / empty becomes unscoped auto.
+pub(crate) fn restart_env_source_for(prev: Option<&str>) -> String {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let Some(prev) = prev else {
+        return "auto".to_string();
+    };
+    if prev.is_empty() {
+        return "auto".to_string();
+    }
+    match EnvSource::parse(prev) {
+        EnvSource::Prewarmed(PackageManager::Uv) => "auto:uv".to_string(),
+        EnvSource::Prewarmed(PackageManager::Conda) => "auto:conda".to_string(),
+        EnvSource::Prewarmed(PackageManager::Pixi) => "auto:pixi".to_string(),
+        other => other.as_str().to_string(),
+    }
+}
+
 // =========================================================================
 // Settings
 // =========================================================================
@@ -632,12 +653,7 @@ pub(crate) async fn restart_kernel(
     // metadata and picks up any deps added after launch (e.g. via add_dependency),
     // while staying within the original package manager family.
     let restart_kernel_type = prev_kernel_type.unwrap_or_else(|| "python".to_string());
-    let restart_env_source = match prev_env_source.as_deref() {
-        Some("uv:prewarmed") => "auto:uv".to_string(),
-        Some("conda:prewarmed") => "auto:conda".to_string(),
-        None => "auto".to_string(),
-        Some(s) => s.to_string(),
-    };
+    let restart_env_source = restart_env_source_for(prev_env_source.as_deref());
 
     // Send LaunchKernel with a timeout, collecting progress messages concurrently.
     let mut progress_messages: Vec<String> = Vec::new();
@@ -2458,35 +2474,43 @@ mod tests {
         assert_ne!(a, b, "each call should produce a unique session suffix");
     }
 
-    /// Helper that mirrors the restart env_source mapping logic in restart_kernel().
-    fn restart_env_source(prev: Option<&str>) -> String {
-        match prev {
-            Some("uv:prewarmed") => "auto:uv".to_string(),
-            Some("conda:prewarmed") => "auto:conda".to_string(),
-            None => "auto".to_string(),
-            Some(s) => s.to_string(),
-        }
-    }
-
     #[test]
     fn test_restart_env_source_uv_prewarmed() {
-        assert_eq!(restart_env_source(Some("uv:prewarmed")), "auto:uv");
+        assert_eq!(restart_env_source_for(Some("uv:prewarmed")), "auto:uv");
     }
 
     #[test]
     fn test_restart_env_source_conda_prewarmed() {
-        assert_eq!(restart_env_source(Some("conda:prewarmed")), "auto:conda");
+        assert_eq!(
+            restart_env_source_for(Some("conda:prewarmed")),
+            "auto:conda"
+        );
+    }
+
+    #[test]
+    fn test_restart_env_source_pixi_prewarmed() {
+        assert_eq!(restart_env_source_for(Some("pixi:prewarmed")), "auto:pixi");
     }
 
     #[test]
     fn test_restart_env_source_none_defaults_to_unscoped_auto() {
-        assert_eq!(restart_env_source(None), "auto");
+        assert_eq!(restart_env_source_for(None), "auto");
+    }
+
+    #[test]
+    fn test_restart_env_source_empty_defaults_to_unscoped_auto() {
+        assert_eq!(restart_env_source_for(Some("")), "auto");
     }
 
     #[test]
     fn test_restart_env_source_explicit_passes_through() {
-        assert_eq!(restart_env_source(Some("uv:inline")), "uv:inline");
-        assert_eq!(restart_env_source(Some("conda:inline")), "conda:inline");
-        assert_eq!(restart_env_source(Some("uv:pyproject")), "uv:pyproject");
+        assert_eq!(restart_env_source_for(Some("uv:inline")), "uv:inline");
+        assert_eq!(restart_env_source_for(Some("conda:inline")), "conda:inline");
+        assert_eq!(restart_env_source_for(Some("uv:pyproject")), "uv:pyproject");
+    }
+
+    #[test]
+    fn test_restart_env_source_unknown_passes_through_verbatim() {
+        assert_eq!(restart_env_source_for(Some("weird:future")), "weird:future");
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -18,28 +18,45 @@ pub struct TrustState {
 /// for non-empty deps. UV is checked first because it's the most common case
 /// and only one section will have deps in practice (build_new_notebook_metadata
 /// creates exactly one section).
-pub(crate) fn check_inline_deps(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
+/// Fallback package manager for the prewarmed pool when neither metadata nor
+/// request specify one. Maps the daemon's `default_python_env` setting.
+pub(crate) fn default_prewarmed_manager(
+    setting: crate::settings_doc::PythonEnvType,
+) -> notebook_protocol::connection::PackageManager {
+    use notebook_protocol::connection::PackageManager;
+    match setting {
+        crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
+        crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
+        _ => PackageManager::Uv,
+    }
+}
+
+pub(crate) fn check_inline_deps(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::EnvSource> {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+
     if snapshot.runt.deno.is_some() {
-        return Some("deno".to_string());
+        return Some(EnvSource::Deno);
     }
 
     if let Some(ref uv) = snapshot.runt.uv {
         if !uv.dependencies.is_empty() {
-            return Some("uv:inline".to_string());
+            return Some(EnvSource::Inline(PackageManager::Uv));
         }
     }
 
     // Check pixi dependencies (conda + pypi)
     if let Some(ref pixi) = snapshot.runt.pixi {
         if !pixi.dependencies.is_empty() {
-            return Some("pixi:inline".to_string());
+            return Some(EnvSource::Inline(PackageManager::Pixi));
         }
     }
 
     // Check conda dependencies
     if let Some(ref conda) = snapshot.runt.conda {
         if !conda.dependencies.is_empty() {
-            return Some("conda:inline".to_string());
+            return Some(EnvSource::Inline(PackageManager::Conda));
         }
     }
 
@@ -693,9 +710,14 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
         let current_inline = check_inline_deps(&current_metadata);
 
         if let Some(ref inline_source) = current_inline {
-            let added = match inline_source.as_str() {
-                "uv:inline" => get_inline_uv_deps(&current_metadata).unwrap_or_default(),
-                "conda:inline" => get_inline_conda_deps(&current_metadata).unwrap_or_default(),
+            use notebook_protocol::connection::{EnvSource, PackageManager};
+            let added = match inline_source {
+                EnvSource::Inline(PackageManager::Uv) => {
+                    get_inline_uv_deps(&current_metadata).unwrap_or_default()
+                }
+                EnvSource::Inline(PackageManager::Conda) => {
+                    get_inline_conda_deps(&current_metadata).unwrap_or_default()
+                }
                 _ => vec![],
             };
 
@@ -1371,7 +1393,7 @@ pub(crate) async fn rename_env_dir_to_unified_hash(
 /// (non-empty) dep list.
 pub(crate) fn captured_env_source_override(
     metadata_snapshot: Option<&NotebookMetadataSnapshot>,
-) -> Option<String> {
+) -> Option<notebook_protocol::connection::EnvSource> {
     resolve_captured_env_override(metadata_snapshot).0
 }
 
@@ -1393,18 +1415,28 @@ fn is_captured(captured: &CapturedEnv) -> bool {
 /// baseline is.
 fn resolve_captured_env_override(
     metadata_snapshot: Option<&NotebookMetadataSnapshot>,
-) -> (Option<String>, Option<CapturedEnv>) {
+) -> (
+    Option<notebook_protocol::connection::EnvSource>,
+    Option<CapturedEnv>,
+) {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
     let Some(snap) = metadata_snapshot else {
         return (None, None);
     };
     if let Some(captured) = captured_env_for_runtime(Some(snap), CapturedEnvRuntime::Uv) {
         if is_captured(&captured) {
-            return (Some("uv:prewarmed".to_string()), Some(captured));
+            return (
+                Some(EnvSource::Prewarmed(PackageManager::Uv)),
+                Some(captured),
+            );
         }
     }
     if let Some(captured) = captured_env_for_runtime(Some(snap), CapturedEnvRuntime::Conda) {
         if is_captured(&captured) {
-            return (Some("conda:prewarmed".to_string()), Some(captured));
+            return (
+                Some(EnvSource::Prewarmed(PackageManager::Conda)),
+                Some(captured),
+            );
         }
     }
     (None, None)
@@ -1626,8 +1658,10 @@ async fn acquire_pool_env_for_source(
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
 ) -> Option<Option<crate::PooledEnv>> {
-    // Route to appropriate pool based on source prefix
-    if env_source == "pixi:prewarmed" {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let parsed = EnvSource::parse(env_source);
+    // Route to appropriate pool based on the resolved manager family.
+    if matches!(parsed, EnvSource::Prewarmed(PackageManager::Pixi)) {
         match daemon.take_pixi_env().await {
             Some(env) => {
                 info!(
@@ -1643,7 +1677,7 @@ async fn acquire_pool_env_for_source(
             }
         }
     }
-    if env_source.starts_with("conda:") {
+    if parsed.package_manager() == Some(PackageManager::Conda) {
         match daemon.take_conda_env().await {
             Some(env) => {
                 info!(
@@ -2092,12 +2126,12 @@ pub(crate) async fn auto_launch_kernel(
     if let Some(ref src) = captured_override {
         info!(
             "[notebook-sync] Auto-launch: captured env on disk -> {}",
-            src
+            src.as_str()
         );
     }
 
     // Step 2b: Check inline deps (for environment source, and runt.deno override)
-    let inline_source = captured_override
+    let inline_source: Option<notebook_protocol::connection::EnvSource> = captured_override
         .clone()
         .or_else(|| metadata_snapshot.as_ref().and_then(check_inline_deps));
 
@@ -2108,16 +2142,20 @@ pub(crate) async fn auto_launch_kernel(
         let cells = room.doc.read().await.get_cells();
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
             Ok(Some(meta)) if !meta.dependencies.is_empty() => {
+                use notebook_protocol::connection::{EnvSource, PackageManager};
                 // Route PEP 723 deps based on user's default Python env
                 let pep723_source = match default_python_env {
-                    crate::settings_doc::PythonEnvType::Pixi => "pixi:pep723",
-                    _ => "uv:pep723",
+                    crate::settings_doc::PythonEnvType::Pixi => {
+                        EnvSource::Pep723(PackageManager::Pixi)
+                    }
+                    _ => EnvSource::Pep723(PackageManager::Uv),
                 };
                 info!(
                     "[notebook-sync] Auto-launch: found PEP 723 deps ({}) : {:?}",
-                    pep723_source, meta.dependencies
+                    pep723_source.as_str(),
+                    meta.dependencies
                 );
-                (Some(pep723_source.to_string()), Some(meta.dependencies))
+                (Some(pep723_source), Some(meta.dependencies))
             }
             Ok(_) => (None, None),
             Err(e) => {
@@ -2138,12 +2176,11 @@ pub(crate) async fn auto_launch_kernel(
         info!(
             "[notebook-sync] Auto-launch: detected project file {:?} -> {}",
             detected.path,
-            detected.to_env_source()
+            detected.to_env_source().as_str()
         );
     }
-    let project_source = detected_project_file
-        .as_ref()
-        .map(|d| d.to_env_source().to_string());
+    let project_source: Option<notebook_protocol::connection::EnvSource> =
+        detected_project_file.as_ref().map(|d| d.to_env_source());
 
     // Step 3b: Bootstrap project deps into CRDT metadata.
     // When a project file exists, populate the inline dep section with the
@@ -2212,155 +2249,64 @@ pub(crate) async fn auto_launch_kernel(
     }
 
     // Determine kernel type and environment
-    let (kernel_type, env_source, pooled_env) = match notebook_kernel_type.as_deref() {
-        Some("deno") => {
-            // Notebook is a Deno notebook (per its kernelspec)
-            info!("[notebook-sync] Auto-launch: Deno kernel (notebook kernelspec)");
-            ("deno", "deno".to_string(), None)
-        }
-        Some("python") => {
-            // Notebook is a Python notebook - resolve environment
-            // Priority: project file > inline deps > prewarmed
-            // Project file wins because inline deps get promoted to the
-            // project file at sync/launch time (project is source of truth).
-            let env_source = if let Some(ref proj) = project_source {
-                info!(
-                    "[notebook-sync] Auto-launch: using project file -> {}",
-                    proj
-                );
-                proj.clone()
-            } else if let Some(ref source) = inline_source {
-                // Skip "deno" inline source for Python notebooks (kernelspec takes priority)
-                if source != "deno" {
-                    info!(
-                        "[notebook-sync] Auto-launch: found inline deps -> {}",
-                        source
-                    );
-                    source.clone()
-                } else {
-                    let prewarmed = match default_python_env {
-                        crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                        crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
-                        _ => "uv:prewarmed",
-                    };
-                    prewarmed.to_string()
-                }
-            } else {
-                // Check if the metadata has an explicit manager section
-                // (e.g. create_notebook(package_manager="conda") with empty deps).
-                // Use that to pick the pool type instead of default_python_env.
-                use notebook_protocol::connection::PackageManager;
-                let manager = metadata_snapshot
-                    .as_ref()
-                    .and_then(detect_manager_from_metadata);
-                // Fallback pool for when the metadata didn't declare a section
-                // or the declared section is non-canonical. Non-canonical
-                // shouldn't happen from `detect_manager_from_metadata` (it
-                // only inspects the three typed sections), but the compiler
-                // needs an exhaustive match against `PackageManager`.
-                let fallback = match default_python_env {
-                    crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                    crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
-                    _ => "uv:prewarmed",
-                };
-                let prewarmed = match manager {
-                    Some(PackageManager::Conda) => "conda:prewarmed",
-                    Some(PackageManager::Pixi) => "pixi:prewarmed",
-                    Some(PackageManager::Uv) => "uv:prewarmed",
-                    Some(PackageManager::Unknown(_)) | None => fallback,
-                };
-                info!(
-                    "[notebook-sync] Auto-launch: using prewarmed ({})",
-                    prewarmed
-                );
-                prewarmed.to_string()
-            };
-            // For uv:inline, uv:pep723, uv:pyproject, and conda:inline we don't need a pooled env -
-            // these sources prepare their own environments
-            let pooled_env = if env_source == "uv:pyproject"
-                || env_source == "uv:inline"
-                || env_source == "uv:pep723"
-                || env_source == "conda:inline"
-                || env_source == "pixi:toml"
-                || env_source == "pixi:inline"
-                || env_source == "pixi:pep723"
-            {
-                info!(
-                    "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
-                    env_source
-                );
-                None
-            } else {
-                match acquire_prewarmed_env_with_capture(
-                    &env_source,
-                    &daemon,
-                    room,
-                    metadata_snapshot.as_ref(),
-                )
-                .await
-                {
-                    Some(env) => env,
-                    None => {
-                        reset_starting_state(room, None).await;
-                        return;
-                    }
-                }
-            };
-            ("python", env_source, pooled_env)
-        }
-        None => {
-            // New notebook or unknown kernelspec - use default_runtime
-            if inline_source.as_deref() == Some("deno") {
-                // runt.deno config present
-                info!("[notebook-sync] Auto-launch: Deno kernel (runt.deno config)");
-                ("deno", "deno".to_string(), None)
-            } else if matches!(default_runtime, crate::runtime::Runtime::Deno) {
-                // User's default is Deno
-                info!("[notebook-sync] Auto-launch: Deno kernel (default runtime)");
-                ("deno", "deno".to_string(), None)
-            } else {
-                // Default to Python
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let (kernel_type, env_source, pooled_env): (&str, EnvSource, Option<crate::PooledEnv>) =
+        match notebook_kernel_type.as_deref() {
+            Some("deno") => {
+                // Notebook is a Deno notebook (per its kernelspec)
+                info!("[notebook-sync] Auto-launch: Deno kernel (notebook kernelspec)");
+                ("deno", EnvSource::Deno, None)
+            }
+            Some("python") => {
+                // Notebook is a Python notebook - resolve environment
                 // Priority: project file > inline deps > prewarmed
-                let env_source = if let Some(ref source) = project_source {
+                // Project file wins because inline deps get promoted to the
+                // project file at sync/launch time (project is source of truth).
+                let env_source: EnvSource = if let Some(ref proj) = project_source {
                     info!(
                         "[notebook-sync] Auto-launch: using project file -> {}",
-                        source
+                        proj.as_str()
                     );
-                    source.clone()
+                    proj.clone()
                 } else if let Some(ref source) = inline_source {
-                    info!(
-                        "[notebook-sync] Auto-launch: found inline deps -> {}",
-                        source
-                    );
-                    source.clone()
+                    // Skip Deno inline source for Python notebooks (kernelspec takes priority)
+                    if !matches!(source, EnvSource::Deno) {
+                        info!(
+                            "[notebook-sync] Auto-launch: found inline deps -> {}",
+                            source.as_str()
+                        );
+                        source.clone()
+                    } else {
+                        EnvSource::Prewarmed(default_prewarmed_manager(default_python_env.clone()))
+                    }
                 } else {
-                    let prewarmed = match default_python_env {
-                        crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                        crate::settings_doc::PythonEnvType::Pixi => "pixi:prewarmed",
-                        _ => "uv:prewarmed",
-                    };
+                    // Check if the metadata has an explicit manager section
+                    // (e.g. create_notebook(package_manager="conda") with empty deps).
+                    // Use that to pick the pool type instead of default_python_env.
+                    let manager = metadata_snapshot
+                        .as_ref()
+                        .and_then(detect_manager_from_metadata)
+                        .and_then(|pm| match pm {
+                            PackageManager::Unknown(_) => None,
+                            canonical => Some(canonical),
+                        })
+                        .unwrap_or_else(|| default_prewarmed_manager(default_python_env.clone()));
+                    let prewarmed = EnvSource::Prewarmed(manager);
                     info!(
                         "[notebook-sync] Auto-launch: using prewarmed ({})",
-                        prewarmed
+                        prewarmed.as_str()
                     );
-                    prewarmed.to_string()
+                    prewarmed
                 };
-                // For uv:inline, uv:pep723, uv:pyproject, and conda:inline we don't need a pooled env -
-                // these sources prepare their own environments
-                let pooled_env = if env_source == "uv:pyproject"
-                    || env_source == "uv:inline"
-                    || env_source == "uv:pep723"
-                    || env_source == "conda:inline"
-                    || env_source == "pixi:toml"
-                {
+                let pooled_env = if env_source.prepares_own_env() {
                     info!(
                         "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
-                        env_source
+                        env_source.as_str()
                     );
                     None
                 } else {
                     match acquire_prewarmed_env_with_capture(
-                        &env_source,
+                        env_source.as_str(),
                         &daemon,
                         room,
                         metadata_snapshot.as_ref(),
@@ -2376,37 +2322,94 @@ pub(crate) async fn auto_launch_kernel(
                 };
                 ("python", env_source, pooled_env)
             }
-        }
-        Some(other) => {
-            // Unknown kernel type - default to Python
-            warn!(
-                "[notebook-sync] Unknown kernel type '{}', defaulting to Python",
-                other
-            );
-            let prewarmed = match default_python_env {
-                crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
-                _ => "uv:prewarmed",
-            };
-            let pooled_env = match acquire_prewarmed_env_with_capture(
-                prewarmed,
-                &daemon,
-                room,
-                metadata_snapshot.as_ref(),
-            )
-            .await
-            {
-                Some(env) => env,
-                None => {
-                    reset_starting_state(room, None).await;
+            None => {
+                // New notebook or unknown kernelspec - use default_runtime
+                if matches!(inline_source, Some(EnvSource::Deno)) {
+                    // runt.deno config present
+                    info!("[notebook-sync] Auto-launch: Deno kernel (runt.deno config)");
+                    ("deno", EnvSource::Deno, None)
+                } else if matches!(default_runtime, crate::runtime::Runtime::Deno) {
+                    // User's default is Deno
+                    info!("[notebook-sync] Auto-launch: Deno kernel (default runtime)");
+                    ("deno", EnvSource::Deno, None)
+                } else {
+                    // Default to Python
+                    // Priority: project file > inline deps > prewarmed
+                    let env_source: EnvSource = if let Some(ref source) = project_source {
+                        info!(
+                            "[notebook-sync] Auto-launch: using project file -> {}",
+                            source.as_str()
+                        );
+                        source.clone()
+                    } else if let Some(ref source) = inline_source {
+                        info!(
+                            "[notebook-sync] Auto-launch: found inline deps -> {}",
+                            source.as_str()
+                        );
+                        source.clone()
+                    } else {
+                        let prewarmed = EnvSource::Prewarmed(default_prewarmed_manager(
+                            default_python_env.clone(),
+                        ));
+                        info!(
+                            "[notebook-sync] Auto-launch: using prewarmed ({})",
+                            prewarmed.as_str()
+                        );
+                        prewarmed
+                    };
+                    let pooled_env = if env_source.prepares_own_env() {
+                        info!(
+                            "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
+                            env_source.as_str()
+                        );
+                        None
+                    } else {
+                        match acquire_prewarmed_env_with_capture(
+                            env_source.as_str(),
+                            &daemon,
+                            room,
+                            metadata_snapshot.as_ref(),
+                        )
+                        .await
+                        {
+                            Some(env) => env,
+                            None => {
+                                reset_starting_state(room, None).await;
+                                return;
+                            }
+                        }
+                    };
+                    ("python", env_source, pooled_env)
+                }
+            }
+            Some(other) => {
+                // Unknown kernel type - default to Python
+                warn!(
+                    "[notebook-sync] Unknown kernel type '{}', defaulting to Python",
+                    other
+                );
+                let prewarmed =
+                    EnvSource::Prewarmed(default_prewarmed_manager(default_python_env.clone()));
+                let pooled_env = match acquire_prewarmed_env_with_capture(
+                    prewarmed.as_str(),
+                    &daemon,
+                    room,
+                    metadata_snapshot.as_ref(),
+                )
+                .await
+                {
+                    Some(env) => env,
+                    None => {
+                        reset_starting_state(room, None).await;
                     return;
                 }
             };
-            ("python", prewarmed.to_string(), pooled_env)
-        }
-    };
+                ("python", prewarmed, pooled_env)
+            }
+        };
 
     // For pixi:toml, verify ipykernel is in pixi.toml before launching
-    if env_source == "pixi:toml" {
+    if matches!(env_source, EnvSource::PixiToml) {
         if let Some(ref detected) = detected_project_file {
             let has_ipykernel = match kernel_launch::tools::pixi_info(&detected.path).await {
                 Ok(info) => info.has_ipykernel(),
@@ -2428,7 +2431,7 @@ pub(crate) async fn auto_launch_kernel(
                     if let Err(e) = sd.set_kernel_status("error") {
                         warn!("[runtime-state] {}", e);
                     }
-                    if let Err(e) = sd.set_kernel_info("python", "python", &env_source) {
+                    if let Err(e) = sd.set_kernel_info("python", "python", env_source.as_str()) {
                         warn!("[runtime-state] {}", e);
                     }
                     if let Err(e) = sd.set_starting_phase("missing_ipykernel") {
@@ -2460,7 +2463,7 @@ pub(crate) async fn auto_launch_kernel(
     let feature_flags_for_inline = daemon.feature_flags().await;
     let bootstrap_dx = feature_flags_for_inline.bootstrap_dx;
 
-    let (pooled_env, inline_deps) = if env_source == "uv:pep723" {
+    let (pooled_env, inline_deps) = if matches!(env_source, EnvSource::Pep723(PackageManager::Uv)) {
         // PEP 723 deps were extracted from cell source in step 2b
         if let Some(ref deps) = pep723_deps {
             info!(
@@ -2503,7 +2506,7 @@ pub(crate) async fn auto_launch_kernel(
         } else {
             (None, None)
         }
-    } else if env_source == "uv:inline" {
+    } else if matches!(env_source, EnvSource::Inline(PackageManager::Uv)) {
         if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_uv_deps) {
             let prerelease = metadata_snapshot
                 .as_ref()
@@ -2619,7 +2622,7 @@ pub(crate) async fn auto_launch_kernel(
         } else {
             (pooled_env, None)
         }
-    } else if env_source == "conda:inline" {
+    } else if matches!(env_source, EnvSource::Inline(PackageManager::Conda)) {
         if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_conda_deps) {
             let channels = metadata_snapshot
                 .as_ref()
@@ -2701,7 +2704,7 @@ pub(crate) async fn auto_launch_kernel(
         } else {
             (pooled_env, None)
         }
-    } else if env_source == "pixi:inline" {
+    } else if matches!(env_source, EnvSource::Inline(PackageManager::Pixi)) {
         // pixi exec handles its own env caching — just extract deps for the -w flags
         let deps = metadata_snapshot
             .as_ref()
@@ -2714,7 +2717,7 @@ pub(crate) async fn auto_launch_kernel(
         } else {
             (pooled_env, None)
         }
-    } else if env_source == "pixi:pep723" {
+    } else if matches!(env_source, EnvSource::Pep723(PackageManager::Pixi)) {
         // PEP 723 deps via pixi exec -w (same mechanism as pixi:inline)
         if let Some(ref deps) = pep723_deps {
             info!("[notebook-sync] pixi:pep723 deps for pixi exec: {:?}", deps);
@@ -2740,7 +2743,7 @@ pub(crate) async fn auto_launch_kernel(
     let python_path = pooled_env.as_ref().map(|e| e.python_path.clone());
     let prewarmed_pkgs = if let Some(ref env) = pooled_env {
         Some(env.prewarmed_packages.clone())
-    } else if env_source.starts_with("pixi:") {
+    } else if env_source.package_manager() == Some(PackageManager::Pixi) {
         // For pixi launches without a pooled env, read default packages from settings
         let pixi_defaults = daemon.default_pixi_packages().await;
         if pixi_defaults.is_empty() {
@@ -2758,12 +2761,14 @@ pub(crate) async fn auto_launch_kernel(
     // etc.), `captured_env_for_config` stays None so drift detection
     // doesn't get misleading deps from the wrong runtime.
     let captured_for_config = captured_env_for_config.as_ref().filter(|c| match c {
-        CapturedEnv::Uv { .. } => env_source == "uv:prewarmed",
-        CapturedEnv::Conda { .. } => env_source == "conda:prewarmed",
+        CapturedEnv::Uv { .. } => matches!(env_source, EnvSource::Prewarmed(PackageManager::Uv)),
+        CapturedEnv::Conda { .. } => {
+            matches!(env_source, EnvSource::Prewarmed(PackageManager::Conda))
+        }
     });
     let launched_config = build_launched_config(
         kernel_type,
-        &env_source,
+        env_source.as_str(),
         inline_deps.as_deref(),
         metadata_snapshot.as_ref(),
         venv_path,
@@ -2869,7 +2874,7 @@ pub(crate) async fn auto_launch_kernel(
                 let launch_request =
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),
-                        env_source: env_source.clone(),
+                        env_source: env_source.as_str().to_string(),
                         notebook_path: notebook_path_opt
                             .as_deref()
                             .map(|p| p.to_str().unwrap_or("").to_string()),
@@ -3132,6 +3137,8 @@ pub(crate) async fn promote_inline_deps_to_project(
     env_source: &str,
     launched_config: &notebook_protocol::protocol::LaunchedEnvConfig,
 ) -> Result<Vec<String>, String> {
+    use notebook_protocol::connection::EnvSource;
+    let parsed_env_source = EnvSource::parse(env_source);
     let current_metadata = {
         let doc = room.doc.read().await;
         doc.get_metadata_snapshot()
@@ -3142,7 +3149,7 @@ pub(crate) async fn promote_inline_deps_to_project(
 
     let mut promoted = Vec::new();
 
-    if env_source == "pixi:toml" {
+    if matches!(parsed_env_source, EnvSource::PixiToml) {
         let pixi_toml_path = launched_config.pixi_toml_path.as_ref().ok_or_else(|| {
             "pixi:toml kernel has no pixi_toml_path in launched config".to_string()
         })?;
@@ -3222,7 +3229,7 @@ pub(crate) async fn promote_inline_deps_to_project(
         if !errors.is_empty() {
             return Err(errors.join("; "));
         }
-    } else if env_source == "conda:env_yml" {
+    } else if matches!(parsed_env_source, EnvSource::EnvYml) {
         let yml_path = launched_config
             .environment_yml_path
             .as_ref()
@@ -3317,7 +3324,7 @@ pub(crate) async fn promote_inline_deps_to_project(
         if !errors.is_empty() {
             return Err(errors.join("; "));
         }
-    } else if env_source == "uv:pyproject" {
+    } else if matches!(parsed_env_source, EnvSource::Pyproject) {
         let pyproject_path = launched_config.pyproject_path.as_ref().ok_or_else(|| {
             "uv:pyproject kernel has no pyproject_path in launched config".to_string()
         })?;
@@ -3437,7 +3444,12 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
         let sd = room.state_doc.read().await;
         sd.read_state().kernel.env_source.clone()
     };
-    if env_source == "pixi:toml" || env_source == "uv:pyproject" || env_source == "conda:env_yml" {
+    if matches!(
+        notebook_protocol::connection::EnvSource::parse(&env_source),
+        notebook_protocol::connection::EnvSource::PixiToml
+            | notebook_protocol::connection::EnvSource::Pyproject
+            | notebook_protocol::connection::EnvSource::EnvYml
+    ) {
         match promote_inline_deps_to_project(room, &env_source, &launched).await {
             Ok(promoted) if promoted.is_empty() => {
                 return NotebookResponse::SyncEnvironmentComplete {
@@ -3514,8 +3526,9 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
     } else {
         // Prewarmed kernel — check if user added inline deps
         let inline = check_inline_deps(&current_metadata);
-        match inline.as_deref() {
-            Some(s) if s.starts_with("uv:") => {
+        use notebook_protocol::connection::{EnvSource, PackageManager};
+        match &inline {
+            Some(EnvSource::Inline(PackageManager::Uv)) => {
                 let added = get_inline_uv_deps(&current_metadata).unwrap_or_default();
                 if added.is_empty() {
                     return NotebookResponse::SyncEnvironmentComplete {
@@ -3527,7 +3540,7 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
                 };
                 (added, env_kind)
             }
-            Some("conda:inline") => {
+            Some(EnvSource::Inline(PackageManager::Conda)) => {
                 let added = get_inline_conda_deps(&current_metadata).unwrap_or_default();
                 if added.is_empty() {
                     return NotebookResponse::SyncEnvironmentComplete {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2401,9 +2401,9 @@ pub(crate) async fn auto_launch_kernel(
                     Some(env) => env,
                     None => {
                         reset_starting_state(room, None).await;
-                    return;
-                }
-            };
+                        return;
+                    }
+                };
                 ("python", prewarmed, pooled_env)
             }
         };

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -522,16 +522,21 @@ fn snapshot_empty() -> NotebookMetadataSnapshot {
 
 #[test]
 fn test_check_inline_deps_uv() {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
     let snapshot = snapshot_with_uv(vec!["numpy".to_string()]);
-    assert_eq!(check_inline_deps(&snapshot), Some("uv:inline".to_string()));
+    assert_eq!(
+        check_inline_deps(&snapshot),
+        Some(EnvSource::Inline(PackageManager::Uv))
+    );
 }
 
 #[test]
 fn test_check_inline_deps_conda() {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
     let snapshot = snapshot_with_conda(vec!["pandas".to_string()]);
     assert_eq!(
         check_inline_deps(&snapshot),
-        Some("conda:inline".to_string())
+        Some(EnvSource::Inline(PackageManager::Conda))
     );
 }
 
@@ -574,7 +579,11 @@ fn test_check_inline_deps_uv_priority() {
             extra: std::collections::BTreeMap::new(),
         },
     };
-    assert_eq!(check_inline_deps(&snapshot), Some("uv:inline".to_string()));
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    assert_eq!(
+        check_inline_deps(&snapshot),
+        Some(EnvSource::Inline(PackageManager::Uv))
+    );
 }
 
 #[test]
@@ -604,7 +613,8 @@ fn test_check_inline_deps_deno() {
             extra: std::collections::BTreeMap::new(),
         },
     };
-    assert_eq!(check_inline_deps(&snapshot), Some("deno".to_string()));
+    use notebook_protocol::connection::EnvSource;
+    assert_eq!(check_inline_deps(&snapshot), Some(EnvSource::Deno));
 }
 
 // Runtime detection tests now live in notebook-doc/src/metadata.rs

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -25,12 +25,13 @@ pub struct DetectedProjectFile {
 }
 
 impl DetectedProjectFile {
-    /// Convert to env_source string for kernel launch.
-    pub fn to_env_source(&self) -> &'static str {
+    /// The resolved env_source for this project file.
+    pub fn to_env_source(&self) -> notebook_protocol::connection::EnvSource {
+        use notebook_protocol::connection::EnvSource;
         match self.kind {
-            ProjectFileKind::PyprojectToml => "uv:pyproject",
-            ProjectFileKind::PixiToml => "pixi:toml",
-            ProjectFileKind::EnvironmentYml => "conda:env_yml",
+            ProjectFileKind::PyprojectToml => EnvSource::Pyproject,
+            ProjectFileKind::PixiToml => EnvSource::PixiToml,
+            ProjectFileKind::EnvironmentYml => EnvSource::EnvYml,
         }
     }
 }
@@ -392,7 +393,10 @@ mod tests {
         assert!(found.is_some());
         let found = found.unwrap();
         assert_eq!(found.kind, ProjectFileKind::PixiToml);
-        assert_eq!(found.to_env_source(), "pixi:toml");
+        assert_eq!(
+            found.to_env_source(),
+            notebook_protocol::connection::EnvSource::PixiToml
+        );
     }
 
     #[test]
@@ -409,7 +413,10 @@ mod tests {
 
         let found = detect_project_file(temp.path());
         assert!(found.is_some());
-        assert_eq!(found.unwrap().to_env_source(), "uv:pyproject");
+        assert_eq!(
+            found.unwrap().to_env_source(),
+            notebook_protocol::connection::EnvSource::Pyproject
+        );
     }
 
     #[test]
@@ -419,7 +426,10 @@ mod tests {
 
         let found = detect_project_file(temp.path());
         assert!(found.is_some());
-        assert_eq!(found.unwrap().to_env_source(), "conda:env_yml");
+        assert_eq!(
+            found.unwrap().to_env_source(),
+            notebook_protocol::connection::EnvSource::EnvYml
+        );
     }
 
     #[test]
@@ -475,7 +485,10 @@ mod tests {
         assert!(found.is_some());
         let found = found.unwrap();
         assert_eq!(found.kind, ProjectFileKind::PixiToml);
-        assert_eq!(found.to_env_source(), "pixi:toml");
+        assert_eq!(
+            found.to_env_source(),
+            notebook_protocol::connection::EnvSource::PixiToml
+        );
     }
 
     #[test]
@@ -491,7 +504,10 @@ mod tests {
         assert!(found.is_some());
         let found = found.unwrap();
         assert_eq!(found.kind, ProjectFileKind::PyprojectToml);
-        assert_eq!(found.to_env_source(), "uv:pyproject");
+        assert_eq!(
+            found.to_env_source(),
+            notebook_protocol::connection::EnvSource::Pyproject
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -266,7 +266,11 @@ pub(crate) async fn handle(
                             .conda
                             .as_ref()
                             .filter(|c| !c.dependencies.is_empty())
-                            .map(|_| EnvSource::Inline(PackageManager::Conda).as_str().to_string()),
+                            .map(|_| {
+                                EnvSource::Inline(PackageManager::Conda)
+                                    .as_str()
+                                    .to_string()
+                            }),
                         Some("pixi") => snap
                             .runt
                             .pixi
@@ -514,7 +518,10 @@ pub(crate) async fn handle(
                         return NotebookResponse::Error {
                             error: format!(
                                 "{} pool empty - no environment available",
-                                if matches!(parsed_resolved, EnvSource::Prewarmed(PackageManager::Uv)) {
+                                if matches!(
+                                    parsed_resolved,
+                                    EnvSource::Prewarmed(PackageManager::Uv)
+                                ) {
                                     "UV"
                                 } else {
                                     "Conda"
@@ -572,7 +579,10 @@ pub(crate) async fn handle(
     let feature_flags_for_inline = daemon.feature_flags().await;
     let bootstrap_dx = feature_flags_for_inline.bootstrap_dx;
 
-    let (pooled_env, inline_deps) = if matches!(parsed_resolved, EnvSource::Pep723(PackageManager::Uv)) {
+    let (pooled_env, inline_deps) = if matches!(
+        parsed_resolved,
+        EnvSource::Pep723(PackageManager::Uv)
+    ) {
         // Extract PEP 723 deps from cell source
         let cells = room.doc.read().await.get_cells();
         let pep723_deps = match notebook_doc::pep723::find_pep723_in_cells(&cells) {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -158,44 +158,39 @@ pub(crate) async fn handle(
         resolved_kernel_type, kernel_type
     );
 
+    // Classify the request-time input. Permissive: non-canonical values land in
+    // `LaunchSpec::Concrete(EnvSource::Unknown(_))` and pass through unchanged.
+    use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
+    let launch_spec = LaunchSpec::parse(&env_source);
+
     // Deno kernels don't use Python environments - always use "deno" regardless
     // of what env_source was requested. Log a warning if caller passed a Python env.
     let resolved_env_source = if resolved_kernel_type == "deno" {
-        if !env_source.is_empty()
-            && env_source != "auto"
-            && env_source != "auto:uv"
-            && env_source != "auto:conda"
-            && env_source != "auto:pixi"
-            && env_source != "deno"
-            && env_source != "prewarmed"
-        {
-            warn!(
-                "[notebook-sync] Deno kernel requested with Python env_source '{}' - \
-                 ignoring and using 'deno' instead",
-                env_source
-            );
-        } else {
-            info!("[notebook-sync] Deno kernel detected, using 'deno' env_source");
+        match &launch_spec {
+            LaunchSpec::Auto | LaunchSpec::AutoScoped(_) => {
+                info!("[notebook-sync] Deno kernel detected, using 'deno' env_source");
+            }
+            LaunchSpec::Concrete(EnvSource::Deno) => {
+                info!("[notebook-sync] Deno kernel detected, using 'deno' env_source");
+            }
+            LaunchSpec::Concrete(other) => {
+                warn!(
+                    "[notebook-sync] Deno kernel requested with Python env_source '{}' - \
+                     ignoring and using 'deno' instead",
+                    other.as_str()
+                );
+            }
         }
-        "deno".to_string()
-    } else if env_source == "auto"
-        || env_source == "auto:uv"
-        || env_source == "auto:conda"
-        || env_source == "auto:pixi"
-        || env_source.is_empty()
-        || env_source == "prewarmed"
-    {
+        EnvSource::Deno.as_str().to_string()
+    } else if matches!(launch_spec, LaunchSpec::Auto | LaunchSpec::AutoScoped(_)) {
         // Auto-detect Python environment, optionally scoped to a package manager family.
         // "auto:uv" constrains to UV sources, "auto:conda" to conda sources,
         // "auto:pixi" to pixi sources.
-        let auto_scope = if env_source == "auto:uv" {
-            Some("uv")
-        } else if env_source == "auto:conda" {
-            Some("conda")
-        } else if env_source == "auto:pixi" {
-            Some("pixi")
-        } else {
-            None
+        let auto_scope: Option<&'static str> = match launch_spec.auto_scope() {
+            Some(PackageManager::Uv) => Some("uv"),
+            Some(PackageManager::Conda) => Some("conda"),
+            Some(PackageManager::Pixi) => Some("pixi"),
+            Some(PackageManager::Unknown(_)) | None => None,
         };
 
         // Priority 1: Detect project files near notebook path.
@@ -221,9 +216,9 @@ pub(crate) async fn handle(
             info!(
                 "[notebook-sync] Auto-detected project file: {:?} -> {}",
                 detected.path,
-                detected.to_env_source()
+                detected.to_env_source().as_str()
             );
-            detected.to_env_source().to_string()
+            detected.to_env_source().as_str().to_string()
         }
         // Priority 2: Captured prewarmed env wins over inline deps.
         // Captured deps look structurally identical to user-authored
@@ -237,43 +232,51 @@ pub(crate) async fn handle(
         // notebook (or vice versa) falls through. `auto:pixi` always
         // falls through — no pixi capture path yet.
         else if let Some(captured_src) = captured_env_source_override(metadata_snapshot.as_ref())
-            .filter(|src| match auto_scope {
-                Some("uv") => src == "uv:prewarmed",
-                Some("conda") => src == "conda:prewarmed",
-                Some("pixi") => false,
-                _ => true,
+            .filter(|src| {
+                use notebook_protocol::connection::{EnvSource, PackageManager};
+                match auto_scope {
+                    Some("uv") => matches!(src, EnvSource::Prewarmed(PackageManager::Uv)),
+                    Some("conda") => matches!(src, EnvSource::Prewarmed(PackageManager::Conda)),
+                    Some("pixi") => false,
+                    _ => true,
+                }
             })
         {
             info!(
                 "[notebook-sync] LaunchKernel: captured env on disk -> {}",
-                captured_src
+                captured_src.as_str()
             );
-            captured_src
+            captured_src.as_str().to_string()
         }
         // Priority 3: Check inline deps in notebook metadata
         else if let Some(inline_source) =
             metadata_snapshot
                 .as_ref()
-                .and_then(|snap| match auto_scope {
-                    Some("uv") => snap
-                        .runt
-                        .uv
-                        .as_ref()
-                        .filter(|uv| !uv.dependencies.is_empty())
-                        .map(|_| "uv:inline".to_string()),
-                    Some("conda") => snap
-                        .runt
-                        .conda
-                        .as_ref()
-                        .filter(|c| !c.dependencies.is_empty())
-                        .map(|_| "conda:inline".to_string()),
-                    Some("pixi") => snap
-                        .runt
-                        .pixi
-                        .as_ref()
-                        .filter(|p| !p.dependencies.is_empty())
-                        .map(|_| "pixi:inline".to_string()),
-                    _ => check_inline_deps(snap).filter(|s| s != "deno"),
+                .and_then(|snap| -> Option<String> {
+                    use notebook_protocol::connection::{EnvSource, PackageManager};
+                    match auto_scope {
+                        Some("uv") => snap
+                            .runt
+                            .uv
+                            .as_ref()
+                            .filter(|uv| !uv.dependencies.is_empty())
+                            .map(|_| EnvSource::Inline(PackageManager::Uv).as_str().to_string()),
+                        Some("conda") => snap
+                            .runt
+                            .conda
+                            .as_ref()
+                            .filter(|c| !c.dependencies.is_empty())
+                            .map(|_| EnvSource::Inline(PackageManager::Conda).as_str().to_string()),
+                        Some("pixi") => snap
+                            .runt
+                            .pixi
+                            .as_ref()
+                            .filter(|p| !p.dependencies.is_empty())
+                            .map(|_| EnvSource::Inline(PackageManager::Pixi).as_str().to_string()),
+                        _ => check_inline_deps(snap)
+                            .filter(|s| !matches!(s, EnvSource::Deno))
+                            .map(|s| s.as_str().to_string()),
+                    }
                 })
         {
             info!(
@@ -345,8 +348,10 @@ pub(crate) async fn handle(
         env_source.clone()
     };
 
+    let parsed_resolved = EnvSource::parse(&resolved_env_source);
+
     // For pixi:toml, verify ipykernel is declared before launching
-    if resolved_env_source == "pixi:toml" {
+    if matches!(parsed_resolved, EnvSource::PixiToml) {
         let pixi_path = notebook_path.as_ref().and_then(|nb| {
             crate::project_file::detect_project_file(nb)
                 .filter(|d| d.kind == crate::project_file::ProjectFileKind::PixiToml)
@@ -373,23 +378,23 @@ pub(crate) async fn handle(
     // For project-backed envs, promote any inline deps to the project
     // file before launching. This handles the case where add_dependency
     // wrote to CRDT metadata and then triggered a restart.
-    if resolved_env_source == "pixi:toml"
-        || resolved_env_source == "uv:pyproject"
-        || resolved_env_source == "conda:env_yml"
-    {
+    if matches!(
+        parsed_resolved,
+        EnvSource::PixiToml | EnvSource::Pyproject | EnvSource::EnvYml
+    ) {
         if let Some(ref snap) = metadata_snapshot {
-            let has_inline = match resolved_env_source.as_str() {
-                "pixi:toml" => snap
+            let has_inline = match parsed_resolved {
+                EnvSource::PixiToml => snap
                     .runt
                     .pixi
                     .as_ref()
                     .is_some_and(|p| !p.dependencies.is_empty()),
-                "uv:pyproject" => snap
+                EnvSource::Pyproject => snap
                     .runt
                     .uv
                     .as_ref()
                     .is_some_and(|u| !u.dependencies.is_empty()),
-                "conda:env_yml" => snap
+                EnvSource::EnvYml => snap
                     .runt
                     .conda
                     .as_ref()
@@ -399,7 +404,7 @@ pub(crate) async fn handle(
             if has_inline {
                 // Build a minimal launched config with project paths for promotion
                 let mut promo_config = notebook_protocol::protocol::LaunchedEnvConfig::default();
-                if resolved_env_source == "pixi:toml" {
+                if matches!(parsed_resolved, EnvSource::PixiToml) {
                     promo_config.pixi_toml_path = notebook_path.as_ref().and_then(|p| {
                         crate::project_file::detect_project_file(p)
                             .filter(|d| d.kind == crate::project_file::ProjectFileKind::PixiToml)
@@ -411,7 +416,7 @@ pub(crate) async fn handle(
                             promo_config.pixi_toml_deps = Some(extract_pixi_toml_deps(&content));
                         }
                     }
-                } else if resolved_env_source == "conda:env_yml" {
+                } else if matches!(parsed_resolved, EnvSource::EnvYml) {
                     promo_config.environment_yml_path = notebook_path.as_ref().and_then(|p| {
                         crate::project_file::find_nearest_project_file(
                             p,
@@ -509,7 +514,7 @@ pub(crate) async fn handle(
                         return NotebookResponse::Error {
                             error: format!(
                                 "{} pool empty - no environment available",
-                                if resolved_env_source == "uv:prewarmed" {
+                                if matches!(parsed_resolved, EnvSource::Prewarmed(PackageManager::Uv)) {
                                     "UV"
                                 } else {
                                     "Conda"
@@ -567,7 +572,7 @@ pub(crate) async fn handle(
     let feature_flags_for_inline = daemon.feature_flags().await;
     let bootstrap_dx = feature_flags_for_inline.bootstrap_dx;
 
-    let (pooled_env, inline_deps) = if resolved_env_source == "uv:pep723" {
+    let (pooled_env, inline_deps) = if matches!(parsed_resolved, EnvSource::Pep723(PackageManager::Uv)) {
         // Extract PEP 723 deps from cell source
         let cells = room.doc.read().await.get_cells();
         let pep723_deps = match notebook_doc::pep723::find_pep723_in_cells(&cells) {
@@ -626,7 +631,7 @@ pub(crate) async fn handle(
                     .to_string(),
             };
         }
-    } else if resolved_env_source == "uv:inline" {
+    } else if matches!(parsed_resolved, EnvSource::Inline(PackageManager::Uv)) {
         if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_uv_deps) {
             let prerelease = metadata_snapshot
                 .as_ref()
@@ -723,7 +728,7 @@ pub(crate) async fn handle(
         } else {
             (pooled_env, None)
         }
-    } else if resolved_env_source == "conda:inline" {
+    } else if matches!(parsed_resolved, EnvSource::Inline(PackageManager::Conda)) {
         if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_conda_deps) {
             let channels = metadata_snapshot
                 .as_ref()
@@ -796,7 +801,7 @@ pub(crate) async fn handle(
         } else {
             (pooled_env, None)
         }
-    } else if resolved_env_source == "conda:env_yml" {
+    } else if matches!(parsed_resolved, EnvSource::EnvYml) {
         // conda:env_yml: find or create a named conda env from environment.yml.
         // Uses standard conda env discovery: name: field → search conda env dirs,
         // prefix: field → use that path directly. Falls back to creating via rattler.
@@ -989,7 +994,7 @@ pub(crate) async fn handle(
             warn!("[notebook-sync] conda:env_yml but no environment.yml found");
             (pooled_env, None)
         }
-    } else if resolved_env_source == "pixi:inline" {
+    } else if matches!(parsed_resolved, EnvSource::Inline(PackageManager::Pixi)) {
         // pixi exec handles its own caching — just extract deps for -w flags
         let deps = metadata_snapshot
             .as_ref()
@@ -1005,7 +1010,7 @@ pub(crate) async fn handle(
         } else {
             (pooled_env, None)
         }
-    } else if resolved_env_source == "pixi:pep723" {
+    } else if matches!(parsed_resolved, EnvSource::Pep723(PackageManager::Pixi)) {
         // PEP 723 deps via pixi exec -w
         let cells = room.doc.read().await.get_cells();
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fc3644895ca5a151a73d47a0215c308484ec038b8b530fa33cc2645c9a78058
+oid sha256:a3ba2dedc3d3d5924813c600d695a48b111ca55cd4457056fb5a61ce27bdbf08
 size 4517312

--- a/docs/superpowers/plans/2026-04-22-env-source-enum.md
+++ b/docs/superpowers/plans/2026-04-22-env-source-enum.md
@@ -1,0 +1,1289 @@
+# EnvSource Enum Refactor — Implementation Plan (PR 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace raw `env_source` strings (`"uv:inline"`, `"conda:prewarmed"`, `"pixi:toml"`, etc.) with a typed `EnvSource` enum defined in `notebook-protocol`. Delete 50+ string comparisons across `launch_kernel.rs`, `metadata.rs`, `runt-mcp`, and `runtimed-py`.
+
+**Architecture:** Two types in `notebook-protocol::connection`. `EnvSource` is the resolved value that flows through every code path after the `auto` / `deno`-override step in `launch_kernel::handle`. `LaunchSpec` is the request-time input with `auto` / `auto:uv` / `prewarmed` variants that resolve into an `EnvSource`. Like `PackageManager`, `EnvSource` uses permissive deserialization (an `Unknown(String)` variant) so wire compatibility is preserved and future variants roll in without error. The three wire-exposed fields (`LaunchKernel.env_source`, `KernelLaunched.env_source`, `RuntimeStateDoc.kernel.env_source`) stay serialized as strings — the enum's `Serialize`/`Deserialize` produce the same byte stream we produce today.
+
+**Tech Stack:** Rust, serde, Automerge (indirect — `KernelState.env_source` is stored as a string and this plan keeps it that way). No TypeScript or WASM changes (`apps/notebook/src/types.ts` still sees strings).
+
+**Scope note:** PR 1 (`PackageManager`) shipped in #2053. This plan only concerns the `EnvSource` / `LaunchSpec` axis. `PackageManager` is already available as an import from `notebook_protocol::connection`.
+
+---
+
+## Design Overview
+
+### Two types, one file
+
+```rust
+// crates/notebook-protocol/src/connection.rs
+
+/// A concrete, resolved environment source.
+///
+/// What `KernelLaunched.env_source` and `RuntimeStateDoc.kernel.env_source`
+/// carry. After the daemon resolves a launch request, every downstream
+/// code path receives an `EnvSource`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EnvSource {
+    Prewarmed(PackageManager),  // "uv:prewarmed" / "conda:prewarmed" / "pixi:prewarmed"
+    Inline(PackageManager),     // "uv:inline" / "conda:inline" / "pixi:inline"
+    Pyproject,                  // "uv:pyproject" — uv-only by definition
+    PixiToml,                   // "pixi:toml"   — pixi-only
+    EnvYml,                     // "conda:env_yml" — conda-only
+    Pep723(PackageManager),     // "uv:pep723" / "pixi:pep723" (conda unused today, but representable)
+    Deno,                       // "deno"
+    Unknown(String),            // unrecognized wire strings — preserves forward compat
+}
+
+/// Request-time launch specification. The caller of `LaunchKernel` sends one
+/// of these; the daemon resolves it into a concrete `EnvSource`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchSpec {
+    Auto,                       // "" / "auto" / "prewarmed"  — full auto-detect
+    AutoScoped(PackageManager), // "auto:uv" / "auto:conda" / "auto:pixi"
+    Concrete(EnvSource),        // a specific env_source value
+}
+```
+
+### Why two types
+
+The current code takes a single `String` and branches between "this is a request-time value (auto/prewarmed/auto:uv/...)" and "this is a concrete env_source to honor as-is." Splitting them into distinct enums makes the resolution step visible in the type signature: `fn resolve(spec: LaunchSpec, ...) -> EnvSource`. No code path can accidentally hand an unresolved `auto` value to the launch routing match.
+
+### Why `Unknown(String)` on `EnvSource`
+
+PR 1 taught us that derived `Deserialize` on a finite enum breaks wire compat. `KernelLaunched.env_source`, `RuntimeStateDoc.kernel.env_source`, and `LaunchKernelRequest.env_source` (in `runtimed-client`) are all on the wire. A daemon running an older version might emit a value a newer client hasn't seen, or vice versa. `Unknown(String)` keeps the decoding permissive and lets call sites fall back to the historical default (`Uv`-family behavior) when needed.
+
+### Wire format: strings, serialized as before
+
+Custom `Serialize` / `Deserialize` round-trip the wire strings (`"uv:prewarmed"`, `"conda:env_yml"`, etc.). Nothing about the byte layout changes. `Unknown(s)` serializes back to `s` verbatim.
+
+### What does NOT change in this PR
+
+- `KernelState.env_source: String` on the Automerge `RuntimeStateDoc` stays as a string (schema version stays at 4). Readers convert via `EnvSource::parse(&state.kernel.env_source)` at use sites.
+- `LaunchKernelRequest.env_source: String` in `runtimed-client` stays — it's a serialized RPC type. Encoders/decoders convert at the boundary.
+- TypeScript / frontend consumers see no change.
+- `PresenceKernel.env_source` stays as a string.
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `crates/notebook-protocol/src/connection.rs` | Define `EnvSource`, `LaunchSpec`, parse/serialize/resolve helpers, unit tests |
+| `crates/runtimed/src/requests/launch_kernel.rs` | Replace 35+ string checks with enum matches. The big file. |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | Replace 40+ string checks in bootstrap / auto-launch / pool selection |
+| `crates/runtimed/src/notebook_sync_server/load.rs` | `check_inline_deps` — return `Option<EnvSource>` |
+| `crates/runtimed/src/project_file.rs` | `DetectedProjectFile::to_env_source` returns `EnvSource` |
+| `crates/runtimed/src/runtime_agent.rs` | Internal captures — continue writing strings via `EnvSource::as_str()` |
+| `crates/runtimed/src/jupyter_kernel.rs` | `.as_str()` match on launch config — replace with enum match |
+| `crates/runt-mcp/src/tools/deps.rs` | `detect_package_manager` fallback reads env_source → parse to EnvSource |
+| `crates/runt-mcp/src/tools/session.rs` | `runtime_info` package_manager classification via enum |
+| `crates/runt-mcp/src/project_file.rs` | Dead after PR 1 — kept alive, `env_source` returns `EnvSource` |
+| `crates/runtimed-py/src/session_core.rs` | `restart_env_source` helper — classify via `EnvSource::parse` |
+| `crates/runtimed-client/src/protocol.rs` | Test fixture strings; no type changes needed (wire types stay `String`) |
+
+---
+
+## Task 1: Define `EnvSource` and `LaunchSpec` in `notebook-protocol`
+
+**Files:**
+- Modify: `crates/notebook-protocol/src/connection.rs`
+
+**Goal:** Additive change — define both enums with full parse / serialize / resolve support and comprehensive unit tests. No call sites move yet. This task ends with the enums available for import; nothing else uses them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the bottom of the existing `#[cfg(test)] mod tests` block in `crates/notebook-protocol/src/connection.rs` (after the existing `package_manager_*` tests):
+
+```rust
+    // -----------------------------------------------------------
+    // EnvSource tests
+    // -----------------------------------------------------------
+
+    #[test]
+    fn env_source_as_str_round_trips_all_variants() {
+        assert_eq!(EnvSource::Prewarmed(PackageManager::Uv).as_str(), "uv:prewarmed");
+        assert_eq!(EnvSource::Prewarmed(PackageManager::Conda).as_str(), "conda:prewarmed");
+        assert_eq!(EnvSource::Prewarmed(PackageManager::Pixi).as_str(), "pixi:prewarmed");
+        assert_eq!(EnvSource::Inline(PackageManager::Uv).as_str(), "uv:inline");
+        assert_eq!(EnvSource::Inline(PackageManager::Conda).as_str(), "conda:inline");
+        assert_eq!(EnvSource::Inline(PackageManager::Pixi).as_str(), "pixi:inline");
+        assert_eq!(EnvSource::Pyproject.as_str(), "uv:pyproject");
+        assert_eq!(EnvSource::PixiToml.as_str(), "pixi:toml");
+        assert_eq!(EnvSource::EnvYml.as_str(), "conda:env_yml");
+        assert_eq!(EnvSource::Pep723(PackageManager::Uv).as_str(), "uv:pep723");
+        assert_eq!(EnvSource::Pep723(PackageManager::Pixi).as_str(), "pixi:pep723");
+        assert_eq!(EnvSource::Deno.as_str(), "deno");
+    }
+
+    #[test]
+    fn env_source_parse_valid_round_trips() {
+        for s in [
+            "uv:prewarmed", "conda:prewarmed", "pixi:prewarmed",
+            "uv:inline", "conda:inline", "pixi:inline",
+            "uv:pyproject", "pixi:toml", "conda:env_yml",
+            "uv:pep723", "pixi:pep723",
+            "deno",
+        ] {
+            let parsed = EnvSource::parse(s);
+            assert_eq!(parsed.as_str(), s, "round-trip failed for {s}");
+            assert!(!matches!(parsed, EnvSource::Unknown(_)));
+        }
+    }
+
+    #[test]
+    fn env_source_parse_unknown_captures_string() {
+        let pm = EnvSource::parse("weird:future-variant");
+        assert_eq!(pm, EnvSource::Unknown("weird:future-variant".to_string()));
+        assert_eq!(pm.as_str(), "weird:future-variant");
+    }
+
+    #[test]
+    fn env_source_parse_empty_is_unknown() {
+        assert_eq!(EnvSource::parse(""), EnvSource::Unknown(String::new()));
+    }
+
+    #[test]
+    fn env_source_serde_is_string() {
+        let src = EnvSource::Inline(PackageManager::Conda);
+        let json = serde_json::to_string(&src).unwrap();
+        assert_eq!(json, "\"conda:inline\"");
+        let decoded: EnvSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, src);
+    }
+
+    #[test]
+    fn env_source_serde_unknown_round_trips_verbatim() {
+        let src = EnvSource::Unknown("something:new".to_string());
+        let json = serde_json::to_string(&src).unwrap();
+        assert_eq!(json, "\"something:new\"");
+        let decoded: EnvSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, src);
+    }
+
+    #[test]
+    fn env_source_package_manager_for_all() {
+        assert_eq!(EnvSource::Prewarmed(PackageManager::Uv).package_manager(), Some(PackageManager::Uv));
+        assert_eq!(EnvSource::Inline(PackageManager::Conda).package_manager(), Some(PackageManager::Conda));
+        assert_eq!(EnvSource::Pyproject.package_manager(), Some(PackageManager::Uv));
+        assert_eq!(EnvSource::PixiToml.package_manager(), Some(PackageManager::Pixi));
+        assert_eq!(EnvSource::EnvYml.package_manager(), Some(PackageManager::Conda));
+        assert_eq!(EnvSource::Pep723(PackageManager::Pixi).package_manager(), Some(PackageManager::Pixi));
+        assert_eq!(EnvSource::Deno.package_manager(), None);
+        assert_eq!(EnvSource::Unknown("junk".into()).package_manager(), None);
+    }
+
+    #[test]
+    fn env_source_prepares_own_env() {
+        // Inline / project-file / pep723 sources prepare their own env.
+        assert!(EnvSource::Inline(PackageManager::Uv).prepares_own_env());
+        assert!(EnvSource::Inline(PackageManager::Conda).prepares_own_env());
+        assert!(EnvSource::Inline(PackageManager::Pixi).prepares_own_env());
+        assert!(EnvSource::Pyproject.prepares_own_env());
+        assert!(EnvSource::PixiToml.prepares_own_env());
+        assert!(EnvSource::EnvYml.prepares_own_env());
+        assert!(EnvSource::Pep723(PackageManager::Uv).prepares_own_env());
+        assert!(EnvSource::Pep723(PackageManager::Pixi).prepares_own_env());
+
+        // Prewarmed variants do not prepare their own env (they come from the pool).
+        assert!(!EnvSource::Prewarmed(PackageManager::Uv).prepares_own_env());
+        assert!(!EnvSource::Prewarmed(PackageManager::Conda).prepares_own_env());
+        assert!(!EnvSource::Prewarmed(PackageManager::Pixi).prepares_own_env());
+
+        // Deno and Unknown don't prepare envs either — they take the "no pool" path.
+        assert!(!EnvSource::Deno.prepares_own_env());
+        assert!(!EnvSource::Unknown("nope".into()).prepares_own_env());
+    }
+
+    // -----------------------------------------------------------
+    // LaunchSpec tests
+    // -----------------------------------------------------------
+
+    #[test]
+    fn launch_spec_parse_auto_variants() {
+        assert_eq!(LaunchSpec::parse(""), LaunchSpec::Auto);
+        assert_eq!(LaunchSpec::parse("auto"), LaunchSpec::Auto);
+        assert_eq!(LaunchSpec::parse("prewarmed"), LaunchSpec::Auto);
+        assert_eq!(
+            LaunchSpec::parse("auto:uv"),
+            LaunchSpec::AutoScoped(PackageManager::Uv)
+        );
+        assert_eq!(
+            LaunchSpec::parse("auto:conda"),
+            LaunchSpec::AutoScoped(PackageManager::Conda)
+        );
+        assert_eq!(
+            LaunchSpec::parse("auto:pixi"),
+            LaunchSpec::AutoScoped(PackageManager::Pixi)
+        );
+    }
+
+    #[test]
+    fn launch_spec_parse_concrete_delegates_to_env_source() {
+        assert_eq!(
+            LaunchSpec::parse("uv:inline"),
+            LaunchSpec::Concrete(EnvSource::Inline(PackageManager::Uv))
+        );
+        assert_eq!(
+            LaunchSpec::parse("deno"),
+            LaunchSpec::Concrete(EnvSource::Deno)
+        );
+    }
+
+    #[test]
+    fn launch_spec_parse_future_value_is_concrete_unknown() {
+        assert_eq!(
+            LaunchSpec::parse("something:new"),
+            LaunchSpec::Concrete(EnvSource::Unknown("something:new".to_string()))
+        );
+    }
+
+    #[test]
+    fn launch_spec_auto_scope_returns_manager() {
+        assert_eq!(LaunchSpec::Auto.auto_scope(), None);
+        assert_eq!(
+            LaunchSpec::AutoScoped(PackageManager::Conda).auto_scope(),
+            Some(PackageManager::Conda)
+        );
+        assert_eq!(
+            LaunchSpec::Concrete(EnvSource::Deno).auto_scope(),
+            None
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests — should fail to compile (types not defined)**
+
+Run: `cargo test -p notebook-protocol --lib env_source_ launch_spec_ 2>&1 | head -30`
+Expected: compile errors like `cannot find type 'EnvSource' in this scope`.
+
+- [ ] **Step 3: Add `EnvSource` definition + helpers**
+
+In `crates/notebook-protocol/src/connection.rs`, find the end of the `PackageManager` Deserialize impl (just after the closing `}` of `impl<'de> Deserialize<'de> for PackageManager`), and insert:
+
+```rust
+/// A concrete, resolved environment source.
+///
+/// Carried on `KernelLaunched.env_source` and
+/// `RuntimeStateDoc.kernel.env_source`. The daemon resolves the request-time
+/// `LaunchSpec` into an `EnvSource` before routing the launch; every
+/// downstream code path works against this type.
+///
+/// Deserialization is permissive: unrecognized wire strings land in
+/// `Unknown(s)` rather than failing, so the daemon and clients stay
+/// forward-compatible across versions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EnvSource {
+    /// Prewarmed pool env (e.g. `"uv:prewarmed"`). The daemon acquires these
+    /// from its warming pool — they do not prepare their own env.
+    Prewarmed(PackageManager),
+    /// Dependencies declared in notebook metadata (e.g. `"uv:inline"`). The
+    /// daemon builds the env from the metadata before kernel launch.
+    Inline(PackageManager),
+    /// `pyproject.toml` on disk (`"uv:pyproject"`). UV-only by definition.
+    Pyproject,
+    /// `pixi.toml` on disk (`"pixi:toml"`). Pixi-only.
+    PixiToml,
+    /// `environment.yml` on disk (`"conda:env_yml"`). Conda-only.
+    EnvYml,
+    /// PEP 723 script deps extracted from cell source (e.g. `"uv:pep723"`).
+    Pep723(PackageManager),
+    /// Deno TypeScript kernel — no Python env.
+    Deno,
+    /// Unrecognized wire string, preserved verbatim. Produced only by
+    /// `Deserialize` for values we haven't taught the enum about. Handle this
+    /// at match sites by falling back to the historical default (usually
+    /// Uv-family behavior) — never panic.
+    Unknown(String),
+}
+
+impl EnvSource {
+    /// The wire string form.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Prewarmed(PackageManager::Uv) => "uv:prewarmed",
+            Self::Prewarmed(PackageManager::Conda) => "conda:prewarmed",
+            Self::Prewarmed(PackageManager::Pixi) => "pixi:prewarmed",
+            Self::Prewarmed(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Inline(PackageManager::Uv) => "uv:inline",
+            Self::Inline(PackageManager::Conda) => "conda:inline",
+            Self::Inline(PackageManager::Pixi) => "pixi:inline",
+            Self::Inline(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Pyproject => "uv:pyproject",
+            Self::PixiToml => "pixi:toml",
+            Self::EnvYml => "conda:env_yml",
+            Self::Pep723(PackageManager::Uv) => "uv:pep723",
+            Self::Pep723(PackageManager::Conda) => "conda:pep723",
+            Self::Pep723(PackageManager::Pixi) => "pixi:pep723",
+            Self::Pep723(PackageManager::Unknown(s)) => s.as_str(),
+            Self::Deno => "deno",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+
+    /// Parse a wire string. Never fails — unrecognized values land in
+    /// `Unknown(s)`.
+    pub fn parse(input: &str) -> Self {
+        match input {
+            "uv:prewarmed" => Self::Prewarmed(PackageManager::Uv),
+            "conda:prewarmed" => Self::Prewarmed(PackageManager::Conda),
+            "pixi:prewarmed" => Self::Prewarmed(PackageManager::Pixi),
+            "uv:inline" => Self::Inline(PackageManager::Uv),
+            "conda:inline" => Self::Inline(PackageManager::Conda),
+            "pixi:inline" => Self::Inline(PackageManager::Pixi),
+            "uv:pyproject" => Self::Pyproject,
+            "pixi:toml" => Self::PixiToml,
+            "conda:env_yml" => Self::EnvYml,
+            "uv:pep723" => Self::Pep723(PackageManager::Uv),
+            "pixi:pep723" => Self::Pep723(PackageManager::Pixi),
+            "deno" => Self::Deno,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    /// The package manager associated with this env source, if any.
+    ///
+    /// `Deno` and `Unknown(_)` return `None`.
+    pub fn package_manager(&self) -> Option<PackageManager> {
+        match self {
+            Self::Prewarmed(pm) | Self::Inline(pm) | Self::Pep723(pm) => Some(pm.clone()),
+            Self::Pyproject => Some(PackageManager::Uv),
+            Self::PixiToml => Some(PackageManager::Pixi),
+            Self::EnvYml => Some(PackageManager::Conda),
+            Self::Deno | Self::Unknown(_) => None,
+        }
+    }
+
+    /// True if this source prepares its own environment (no pool env needed).
+    ///
+    /// Used at auto-launch time to decide whether to acquire a prewarmed env
+    /// from the pool. `Inline`, project-file, and `Pep723` sources build
+    /// their env themselves; `Prewarmed` pulls from the pool; `Deno` and
+    /// `Unknown` take the no-pool path.
+    pub fn prepares_own_env(&self) -> bool {
+        matches!(
+            self,
+            Self::Inline(_)
+                | Self::Pyproject
+                | Self::PixiToml
+                | Self::EnvYml
+                | Self::Pep723(_)
+        )
+    }
+}
+
+impl fmt::Display for EnvSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for EnvSource {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvSource {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Ok(Self::parse(&raw))
+    }
+}
+
+/// Request-time launch specification.
+///
+/// The caller of `LaunchKernel` sends a `LaunchSpec`. The daemon resolves
+/// it into a concrete `EnvSource` before routing the launch. This type
+/// keeps the auto-detection inputs (`""`, `"auto"`, `"auto:uv"`,
+/// `"prewarmed"`) visibly distinct from a concrete env_source in the type
+/// system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchSpec {
+    /// Auto-detect everything — derived from notebook metadata, project
+    /// files, or PEP 723 script blocks. Wire strings: `""`, `"auto"`,
+    /// `"prewarmed"` (legacy alias).
+    Auto,
+    /// Auto-detect within a specific package manager family. Wire strings:
+    /// `"auto:uv"`, `"auto:conda"`, `"auto:pixi"`.
+    AutoScoped(PackageManager),
+    /// A concrete env_source to honor as-is.
+    Concrete(EnvSource),
+}
+
+impl LaunchSpec {
+    /// Parse a launch spec from the wire string.
+    pub fn parse(input: &str) -> Self {
+        match input {
+            "" | "auto" | "prewarmed" => Self::Auto,
+            "auto:uv" => Self::AutoScoped(PackageManager::Uv),
+            "auto:conda" => Self::AutoScoped(PackageManager::Conda),
+            "auto:pixi" => Self::AutoScoped(PackageManager::Pixi),
+            other => Self::Concrete(EnvSource::parse(other)),
+        }
+    }
+
+    /// If this spec is `AutoScoped(pm)`, returns `Some(pm)`; otherwise None.
+    pub fn auto_scope(&self) -> Option<PackageManager> {
+        match self {
+            Self::AutoScoped(pm) => Some(pm.clone()),
+            _ => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run new tests — they should pass**
+
+Run: `cargo test -p notebook-protocol --lib env_source_ launch_spec_`
+Expected: 11 new tests pass (`env_source_as_str_round_trips_all_variants`, `env_source_parse_valid_round_trips`, `env_source_parse_unknown_captures_string`, `env_source_parse_empty_is_unknown`, `env_source_serde_is_string`, `env_source_serde_unknown_round_trips_verbatim`, `env_source_package_manager_for_all`, `env_source_prepares_own_env`, `launch_spec_parse_auto_variants`, `launch_spec_parse_concrete_delegates_to_env_source`, `launch_spec_parse_future_value_is_concrete_unknown`, `launch_spec_auto_scope_returns_manager`).
+
+- [ ] **Step 5: Run the full protocol test suite — nothing regressed**
+
+Run: `cargo test -p notebook-protocol`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-protocol/src/connection.rs
+git commit -m "feat(notebook-protocol): add EnvSource and LaunchSpec enums"
+```
+
+---
+
+## Task 2: Migrate project-file detection and `check_inline_deps`
+
+**Files:**
+- Modify: `crates/runtimed/src/project_file.rs` (`DetectedProjectFile::to_env_source`)
+- Modify: `crates/runt-mcp/src/project_file.rs` (`DetectedProjectFile::env_source`)
+- Modify: `crates/runtimed/src/notebook_sync_server/metadata.rs` (`check_inline_deps`)
+
+**Goal:** Return `EnvSource` from the three "classifier" helpers. These are leaf producers with no wire exposure, so the change is self-contained.
+
+- [ ] **Step 1: Update `runtimed::project_file::to_env_source`**
+
+Open `crates/runtimed/src/project_file.rs`. Find the `to_env_source` method (around line 29). Replace:
+
+```rust
+    /// The daemon env_source for this project file.
+    pub fn to_env_source(&self) -> notebook_protocol::connection::EnvSource {
+        use notebook_protocol::connection::EnvSource;
+        match self.kind {
+            ProjectFileKind::PyprojectToml => EnvSource::Pyproject,
+            ProjectFileKind::PixiToml => EnvSource::PixiToml,
+            ProjectFileKind::EnvironmentYml => EnvSource::EnvYml,
+        }
+    }
+```
+
+(If the method currently has a different signature or a different enum shape — e.g., `EnvironmentYml` variant name may differ — adjust the match arms to match the file's existing `ProjectFileKind` variants. Use `rg "ProjectFileKind::" crates/runtimed/src/project_file.rs` to confirm.)
+
+Update the existing tests in that file (lines 395, 412, 422 etc.) that assert on the string return value. Change:
+
+```rust
+assert_eq!(detected.to_env_source(), "pixi:toml");
+```
+to:
+```rust
+use notebook_protocol::connection::EnvSource;
+assert_eq!(detected.to_env_source(), EnvSource::PixiToml);
+```
+
+Apply to all similar assertions in the file.
+
+- [ ] **Step 2: Update `runt-mcp::project_file::env_source`**
+
+Open `crates/runt-mcp/src/project_file.rs`. The `env_source()` method (around line 33) currently returns `&'static str`. Replace:
+
+```rust
+    /// The daemon env_source for this project file.
+    pub fn env_source(&self) -> notebook_protocol::connection::EnvSource {
+        use notebook_protocol::connection::EnvSource;
+        match self.kind {
+            ProjectFileKind::PyprojectToml => EnvSource::Pyproject,
+            ProjectFileKind::PixiToml => EnvSource::PixiToml,
+        }
+    }
+```
+
+(Note: `runt-mcp`'s `ProjectFileKind` has only `PyprojectToml` and `PixiToml` variants — no `EnvironmentYml`. Verify with `rg "ProjectFileKind" crates/runt-mcp/src/project_file.rs`.)
+
+- [ ] **Step 3: Update `check_inline_deps`**
+
+Open `crates/runtimed/src/notebook_sync_server/metadata.rs`. Find `check_inline_deps` (around line 21):
+
+```rust
+pub(crate) fn check_inline_deps(
+    snapshot: &NotebookMetadataSnapshot,
+) -> Option<notebook_protocol::connection::EnvSource> {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    if snapshot.runt.deno.is_some() {
+        return Some(EnvSource::Deno);
+    }
+
+    if let Some(ref uv) = snapshot.runt.uv {
+        if !uv.dependencies.is_empty() {
+            return Some(EnvSource::Inline(PackageManager::Uv));
+        }
+    }
+
+    if let Some(ref pixi) = snapshot.runt.pixi {
+        if !pixi.dependencies.is_empty() {
+            return Some(EnvSource::Inline(PackageManager::Pixi));
+        }
+    }
+
+    if let Some(ref conda) = snapshot.runt.conda {
+        if !conda.dependencies.is_empty() {
+            return Some(EnvSource::Inline(PackageManager::Conda));
+        }
+    }
+
+    None
+}
+```
+
+- [ ] **Step 4: Build + test**
+
+Run: `cargo build --workspace --exclude runtimed-py --all-targets 2>&1 | tail -30`
+
+Expect compile errors at the callers — they expect strings but now receive `EnvSource`. Leave them failing for Task 3.
+
+Actually, to avoid a broken workspace between tasks, pair this task with Task 3. The edits in Task 2 and Task 3 commit together.
+
+Skip the build check here; proceed directly to Task 3.
+
+---
+
+## Task 3: Migrate auto-launch decision flow in `metadata.rs`
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/metadata.rs`
+
+**Goal:** Replace all the `env_source ==` and `.starts_with(...)` checks in the auto-launch flow. This file owns most of the complexity (40+ comparisons). Produces `EnvSource` values internally; converts to `String` via `.as_str().to_string()` at the boundaries where it writes into `room.runtime_agent_env_path`, starting-state fields, etc.
+
+**Approach:** Inside `metadata.rs` we keep a local `EnvSource` value for the resolution logic, then serialize back to `String` when crossing into the kernel-launch request or RuntimeStateDoc. This avoids churning the in-crate struct fields (they stay `String`). Every `== "uv:inline"` becomes a `matches!(..., EnvSource::Inline(PackageManager::Uv))`, every `.starts_with("conda:")` becomes a `matches!(..., EnvSource::Prewarmed(PackageManager::Conda) | EnvSource::Inline(PackageManager::Conda) | EnvSource::EnvYml | EnvSource::Pep723(PackageManager::Conda))` (or, more cleanly, `src.package_manager() == Some(PackageManager::Conda)`).
+
+- [ ] **Step 1: Update the auto-launch resolution (around lines 2210-2400)**
+
+This is the body of `auto_launch_kernel`. Locate the branch that resolves `env_source` based on kernel type and seed inputs. Replace the string-returning logic with `EnvSource`:
+
+Find the block that starts around line 2212:
+```rust
+    // Determine kernel type and environment
+    let (kernel_type, env_source, pooled_env) = match notebook_kernel_type.as_deref() {
+        Some("deno") => {
+            // Notebook is a Deno notebook (per its kernelspec)
+            info!("[notebook-sync] Auto-launch: Deno kernel (notebook kernelspec)");
+            ("deno", "deno".to_string(), None)
+        }
+```
+
+Change the tuple so `env_source` is `EnvSource`:
+
+```rust
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+
+    // Determine kernel type and environment
+    let (kernel_type, env_source, pooled_env): (&str, EnvSource, Option<PooledEnv>) =
+        match notebook_kernel_type.as_deref() {
+            Some("deno") => {
+                info!("[notebook-sync] Auto-launch: Deno kernel (notebook kernelspec)");
+                ("deno", EnvSource::Deno, None)
+            }
+            Some("python") => {
+                // Priority: project file > inline deps > prewarmed
+                let env_source: EnvSource = if let Some(ref proj) = project_source {
+                    info!("[notebook-sync] Auto-launch: using project file -> {}", proj.as_str());
+                    proj.clone()
+                } else if let Some(ref source) = inline_source {
+                    if !matches!(source, EnvSource::Deno) {
+                        info!(
+                            "[notebook-sync] Auto-launch: found inline deps -> {}",
+                            source.as_str()
+                        );
+                        source.clone()
+                    } else {
+                        // Deno inline source for a Python notebook — fall back to prewarmed.
+                        EnvSource::Prewarmed(default_prewarmed_manager(default_python_env))
+                    }
+                } else {
+                    // No deps declared — pick a prewarmed pool based on the
+                    // metadata's explicit manager section (if any), else
+                    // fall back to default_python_env.
+                    let manager = metadata_snapshot
+                        .as_ref()
+                        .and_then(detect_manager_from_metadata)
+                        .unwrap_or_else(|| default_prewarmed_manager(default_python_env));
+                    let prewarmed = EnvSource::Prewarmed(manager);
+                    info!(
+                        "[notebook-sync] Auto-launch: using prewarmed ({})",
+                        prewarmed.as_str()
+                    );
+                    prewarmed
+                };
+
+                let pooled_env = if env_source.prepares_own_env() {
+                    info!(
+                        "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
+                        env_source.as_str()
+                    );
+                    None
+                } else {
+                    match acquire_prewarmed_env_with_capture(
+                        env_source.as_str(),
+                        &daemon,
+                        room,
+                        metadata_snapshot.as_ref(),
+                    )
+                    .await
+                    {
+                        Some(env) => env,
+                        None => {
+                            reset_starting_state(room, None).await;
+                            return;
+                        }
+                    }
+                };
+                ("python", env_source, pooled_env)
+            }
+            None => {
+                // Unknown kernel spec: default to Python or Deno based on default_runtime.
+                if matches!(inline_source, Some(EnvSource::Deno))
+                    || matches!(default_runtime, crate::runtime::Runtime::Deno)
+                {
+                    info!("[notebook-sync] Auto-launch: Deno kernel (default or runt.deno config)");
+                    ("deno", EnvSource::Deno, None)
+                } else {
+                    // Python defaults, same resolution as above (duplicated for clarity).
+                    let env_source: EnvSource = if let Some(ref source) = project_source {
+                        info!("[notebook-sync] Auto-launch: using project file -> {}", source.as_str());
+                        source.clone()
+                    } else if let Some(ref source) = inline_source {
+                        info!("[notebook-sync] Auto-launch: found inline deps -> {}", source.as_str());
+                        source.clone()
+                    } else {
+                        let prewarmed = EnvSource::Prewarmed(default_prewarmed_manager(default_python_env));
+                        info!(
+                            "[notebook-sync] Auto-launch: using prewarmed ({})",
+                            prewarmed.as_str()
+                        );
+                        prewarmed
+                    };
+                    let pooled_env = if env_source.prepares_own_env() {
+                        info!(
+                            "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
+                            env_source.as_str()
+                        );
+                        None
+                    } else {
+                        match acquire_prewarmed_env_with_capture(
+                            env_source.as_str(),
+                            &daemon,
+                            room,
+                            metadata_snapshot.as_ref(),
+                        )
+                        .await
+                        {
+                            Some(env) => env,
+                            None => {
+                                reset_starting_state(room, None).await;
+                                return;
+                            }
+                        }
+                    };
+                    ("python", env_source, pooled_env)
+                }
+            }
+            Some(other) => {
+                warn!(
+                    "[notebook-sync] Unknown kernel type '{}', defaulting to Python",
+                    other
+                );
+                let prewarmed = EnvSource::Prewarmed(default_prewarmed_manager(default_python_env));
+                let pooled_env = match acquire_prewarmed_env_with_capture(
+                    prewarmed.as_str(),
+                    &daemon,
+                    room,
+                    metadata_snapshot.as_ref(),
+                )
+                .await
+                {
+                    Some(env) => env,
+                    None => {
+                        reset_starting_state(room, None).await;
+                        return;
+                    }
+                };
+                ("python", prewarmed, pooled_env)
+            }
+        };
+```
+
+And add this helper at the top of the file (or in a suitable `mod` location):
+
+```rust
+fn default_prewarmed_manager(
+    setting: crate::settings_doc::PythonEnvType,
+) -> notebook_protocol::connection::PackageManager {
+    use notebook_protocol::connection::PackageManager;
+    match setting {
+        crate::settings_doc::PythonEnvType::Conda => PackageManager::Conda,
+        crate::settings_doc::PythonEnvType::Pixi => PackageManager::Pixi,
+        _ => PackageManager::Uv,
+    }
+}
+```
+
+`detect_manager_from_metadata` already returns `Option<PackageManager>` (PR 1). `project_source` and `inline_source` are now `Option<EnvSource>` (Task 2).
+
+- [ ] **Step 2: Update the types of `project_source` and `inline_source` in the surrounding function**
+
+Search upward in `auto_launch_kernel` for where these are computed. `project_source` comes from `crate::project_file::detect_project_file(...).map(|p| p.to_env_source())` — already `EnvSource` after Task 2. `inline_source` comes from `check_inline_deps(...)` — already `Option<EnvSource>` after Task 2. So types line up.
+
+- [ ] **Step 3: Replace the 7-way string check at `env_source == ...` for prepare_own_env (lines 2270-2276, 2340-2345)**
+
+After Step 1, those blocks should be gone, replaced by the single `if env_source.prepares_own_env()` check. Verify:
+
+```bash
+rg 'env_source == "uv:pyproject"' crates/runtimed/src/notebook_sync_server/metadata.rs
+```
+Expected: no matches.
+
+- [ ] **Step 4: Replace the remaining string checks in later blocks (lines 2399-3430)**
+
+These are the inline-env-prep and project-file-handling blocks. Each has `if env_source == "uv:pep723"`, `else if env_source == "uv:inline"`, etc. Change to enum matches using the `use notebook_protocol::connection::{EnvSource, PackageManager};` scope.
+
+Example transformation at line 2453:
+```rust
+    // BEFORE:
+    let (pooled_env, inline_deps) = if env_source == "uv:pep723" {
+
+    // AFTER:
+    let (pooled_env, inline_deps) = if matches!(env_source, EnvSource::Pep723(PackageManager::Uv)) {
+```
+
+Apply the same transformation to lines:
+- 2496: `env_source == "uv:inline"` → `matches!(env_source, EnvSource::Inline(PackageManager::Uv))`
+- 2612: `env_source == "conda:inline"` → `matches!(env_source, EnvSource::Inline(PackageManager::Conda))`
+- 2694: `env_source == "pixi:inline"` → `matches!(env_source, EnvSource::Inline(PackageManager::Pixi))`
+- 2707: `env_source == "pixi:pep723"` → `matches!(env_source, EnvSource::Pep723(PackageManager::Pixi))`
+- 2733: `env_source.starts_with("pixi:")` → `env_source.package_manager() == Some(PackageManager::Pixi)`
+- 2751-2752: `env_source == "uv:prewarmed"` / `"conda:prewarmed"` → enum equality
+- 3135: `env_source == "pixi:toml"` → `matches!(env_source, EnvSource::PixiToml)`
+- 3215: `env_source == "conda:env_yml"` → `matches!(env_source, EnvSource::EnvYml)`
+- 3310: `env_source == "uv:pyproject"` → `matches!(env_source, EnvSource::Pyproject)`
+- 3430: `env_source == "pixi:toml" || env_source == "uv:pyproject" || env_source == "conda:env_yml"` → `matches!(env_source, EnvSource::Pyproject | EnvSource::PixiToml | EnvSource::EnvYml)`
+
+For lines like 1627 (`if env_source == "pixi:prewarmed"`) and 1643 (`if env_source.starts_with("conda:")`) in `acquire_pool_env_for_source` — this function takes `env_source: &str` today. Change its signature to `env_source: &EnvSource` and update its body:
+
+```rust
+fn acquire_pool_env_for_source(
+    env_source: &notebook_protocol::connection::EnvSource,
+    // ...
+) -> ... {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    if matches!(env_source, EnvSource::Prewarmed(PackageManager::Pixi)) {
+        // ...
+    }
+    // ...
+    if env_source.package_manager() == Some(PackageManager::Conda) {
+        // ...
+    }
+}
+```
+
+Update callers to pass the enum instead of a `&str`. Since `auto_launch_kernel` now owns an `EnvSource` local, this is a direct `&env_source` pass.
+
+- [ ] **Step 5: Update `captured_env_source_override` (around line 1402)**
+
+This function currently returns `Option<String>` and produces `"uv:prewarmed"` or `"conda:prewarmed"`. Change its signature and body:
+
+```rust
+pub(crate) fn captured_env_source_override(
+    captured: &CapturedEnv,
+) -> Option<notebook_protocol::connection::EnvSource> {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    match captured {
+        CapturedEnv::Uv { .. } => Some(EnvSource::Prewarmed(PackageManager::Uv)),
+        CapturedEnv::Conda { .. } => Some(EnvSource::Prewarmed(PackageManager::Conda)),
+        // Add Pixi arm if CapturedEnv has one — verify with grep.
+    }
+}
+```
+
+Check `rg "enum CapturedEnv" crates/runtimed/src/notebook_sync_server/metadata.rs` for the full variant list.
+
+Update the caller in `launch_kernel.rs` (see Task 4) accordingly.
+
+- [ ] **Step 6: Update `bootstrap_kernel_state_from_snapshot` (around line 2409)**
+
+This function has `.starts_with("pixi:")` checks and several specific-value checks. Refactor to use enum matches:
+
+```rust
+    let env_source = EnvSource::parse(&state.kernel.env_source);
+    if matches!(env_source, EnvSource::PixiToml) {
+        // ...
+    }
+```
+
+Apply the same pattern to all sibling blocks in the function.
+
+- [ ] **Step 7: Update captured-env validation (around line 2761)**
+
+```rust
+match (captured, requested) {
+    (CapturedEnv::Uv { .. }, EnvSource::Prewarmed(PackageManager::Uv)) => true,
+    (CapturedEnv::Conda { .. }, EnvSource::Prewarmed(PackageManager::Conda)) => true,
+    _ => false,
+}
+```
+
+- [ ] **Step 8: At the write boundary, serialize back to `String`**
+
+Downstream writers — RuntimeStateDoc `set_kernel_info`, kernel launch request builders, broadcast writers — still take `String`/`&str`. At each boundary, call `.as_str()` or `.as_str().to_string()`. Grep for any remaining `env_source.clone()` on a `String` local that was previously a string; those call sites now need `env_source.as_str().to_string()`.
+
+- [ ] **Step 9: Build the workspace**
+
+Run: `cargo build --workspace --exclude runtimed-py --all-targets 2>&1 | tail -40`
+
+Fix any straggler compile errors. Do not commit until the workspace builds green — this task commits together with Tasks 2, 4, 5 for a single atomic compile checkpoint. If that's unworkable, build-fence using `.as_str()` conversions at the boundaries with `launch_kernel.rs` so metadata.rs can compile standalone.
+
+Do not run tests yet.
+
+---
+
+## Task 4: Migrate `launch_kernel::handle` (the big file)
+
+**Files:**
+- Modify: `crates/runtimed/src/requests/launch_kernel.rs`
+
+**Goal:** Replace the request-time classification at the top (lines 163-200) with `LaunchSpec`. Replace the dozens of `==`/`.starts_with()` checks downstream with `EnvSource` matches. At the end, the function still writes a `String` into the `KernelLaunched` response, so serialize at the boundary.
+
+- [ ] **Step 1: Parse the request-time input as `LaunchSpec` at entry**
+
+Near the top of `handle` (after `resolved_kernel_type` is set, around line 161), insert:
+
+```rust
+use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
+
+let spec = LaunchSpec::parse(&env_source);
+
+// Deno kernels always use EnvSource::Deno, regardless of what was requested.
+// Log a warning if the caller sent a Python env_source alongside the deno kernel.
+let resolved_env_source: EnvSource = if resolved_kernel_type == "deno" {
+    // Any spec that isn't already Deno-compatible logs and forces Deno.
+    match &spec {
+        LaunchSpec::Auto | LaunchSpec::AutoScoped(_) => {}
+        LaunchSpec::Concrete(EnvSource::Deno) => {}
+        LaunchSpec::Concrete(other) => {
+            warn!(
+                "[notebook-sync] Deno kernel requested with Python env_source '{}' — \
+                 ignoring and using 'deno' instead",
+                other.as_str()
+            );
+        }
+    }
+    EnvSource::Deno
+} else {
+    match spec {
+        LaunchSpec::Auto | LaunchSpec::AutoScoped(_) => {
+            let auto_scope = spec.auto_scope();
+            // ... existing auto-detection body, but returning EnvSource ...
+            resolve_auto(auto_scope, &metadata_snapshot, notebook_path.as_deref()).await
+        }
+        LaunchSpec::Concrete(env_source) => env_source,
+    }
+};
+```
+
+Replace the existing lines 163-200 (the deno-override block + the `if env_source == "auto" || ...` block) with this single resolver.
+
+Extract the auto-detection body (currently inline, ~line 200-340) into a helper `resolve_auto(auto_scope: Option<PackageManager>, ...) -> EnvSource`. The helper returns a concrete `EnvSource` — no more string returns.
+
+- [ ] **Step 2: Convert the 8-way `.as_str()` match at line 475**
+
+This is the big dispatch on `resolved_env_source.as_str()`. Replace with a match on `EnvSource` directly:
+
+```rust
+    // BEFORE:
+    let launch_result = match resolved_env_source.as_str() {
+        "deno" => { ... }
+        "uv:prewarmed" | "conda:prewarmed" | "pixi:prewarmed" => { ... }
+        "uv:inline" => { ... }
+        // ... 8 more arms
+    };
+
+    // AFTER:
+    let launch_result = match &resolved_env_source {
+        EnvSource::Deno => { ... }
+        EnvSource::Prewarmed(_) => { ... }
+        EnvSource::Inline(PackageManager::Uv) => { ... }
+        EnvSource::Inline(PackageManager::Conda) => { ... }
+        EnvSource::Inline(PackageManager::Pixi) => { ... }
+        EnvSource::Pyproject => { ... }
+        EnvSource::PixiToml => { ... }
+        EnvSource::EnvYml => { ... }
+        EnvSource::Pep723(PackageManager::Uv) => { ... }
+        EnvSource::Pep723(PackageManager::Pixi) => { ... }
+        EnvSource::Inline(PackageManager::Unknown(_))
+        | EnvSource::Pep723(PackageManager::Conda)
+        | EnvSource::Pep723(PackageManager::Unknown(_))
+        | EnvSource::Unknown(_) => {
+            // Fall back to a prewarmed env — matches the historical default
+            // for unrecognized env_source strings.
+            warn!(
+                "[notebook-sync] Unrecognized env_source '{}', falling back to uv:prewarmed",
+                resolved_env_source.as_str()
+            );
+            // ... reuse the uv:prewarmed body ...
+        }
+    };
+```
+
+- [ ] **Step 3: Replace remaining scattered `.starts_with()` / `==` checks**
+
+Apply the same transformation pattern to every remaining line. The previous exploration catalogued:
+- Line 533: `resolved_env_source.starts_with("conda:")` → `resolved_env_source.package_manager() == Some(PackageManager::Conda)`
+- Lines 570, 629, 726, 799, 992, 1008: specific-value equality → enum equality
+- Lines 376-378 (`resolved_env_source == "pixi:toml" || ... || "conda:env_yml"`) → `matches!(resolved_env_source, EnvSource::Pyproject | EnvSource::PixiToml | EnvSource::EnvYml)`
+- Line 349: `resolved_env_source == "pixi:toml"` → `matches!(..., EnvSource::PixiToml)`
+- Line 402: `resolved_env_source == "pixi:toml"` → same
+- Line 414: `resolved_env_source == "conda:env_yml"` → `matches!(..., EnvSource::EnvYml)`
+- Line 512: `resolved_env_source == "uv:prewarmed"` → `matches!(..., EnvSource::Prewarmed(PackageManager::Uv))`
+
+For "set env_source from captured override" at line 241:
+```rust
+    // BEFORE:
+    if src == "uv:prewarmed" || src == "conda:prewarmed" {
+        captured_src = Some(src.to_string());
+    }
+    // AFTER:
+    if matches!(src, EnvSource::Prewarmed(_)) {
+        captured_src = Some(src.clone());
+    }
+```
+(Note: `src` here came from `captured_env_source_override` which now returns `Option<EnvSource>`.)
+
+- [ ] **Step 4: Serialize to `String` at the response boundary**
+
+At the site that builds `NotebookResponse::KernelLaunched`:
+
+```rust
+    Ok(NotebookResponse::KernelLaunched {
+        env_source: resolved_env_source.as_str().to_string(),
+        // ... other fields ...
+    })
+```
+
+Also at the call to `kernel_connection::launch` or similar that takes `env_source: String`, pass `resolved_env_source.as_str().to_string()`.
+
+- [ ] **Step 5: Build — no errors**
+
+Run: `cargo build -p runtimed --all-targets 2>&1 | tail -30`
+Expected: clean.
+
+- [ ] **Step 6: Run the runtimed test suite**
+
+Run: `cargo test -p runtimed --lib 2>&1 | tail -20`
+Expected: all green. If `rpc_routing.rs` or `notebook_sync_server/tests.rs` test fixtures use raw strings, they should still work — the wire format is unchanged.
+
+- [ ] **Step 7: Commit together with Tasks 2 + 3**
+
+This single commit covers the refactor surface in `runtimed`. Tasks 2, 3, 4 together.
+
+```bash
+git add crates/runtimed/src/ crates/runt-mcp/src/project_file.rs
+git commit -m "refactor(runtimed): thread EnvSource enum through auto-launch and kernel launch"
+```
+
+---
+
+## Task 5: Migrate `jupyter_kernel.rs` and `runtime_agent.rs`
+
+**Files:**
+- Modify: `crates/runtimed/src/jupyter_kernel.rs`
+- Modify: `crates/runtimed/src/runtime_agent.rs`
+
+**Goal:** Small cleanups — convert the internal `.as_str()` match in `jupyter_kernel::launch` (line 214) to match on `EnvSource`. In `runtime_agent.rs` the three sites (569, 687, 827) just pass a captured string through; either convert to `EnvSource::parse(...).as_str().to_string()` (round-trip for future-proofing) or leave alone since they are pure pass-throughs. Prefer leaving them alone — they don't branch on the value.
+
+- [ ] **Step 1: `jupyter_kernel.rs` line 214 — convert to enum match**
+
+```rust
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let parsed = EnvSource::parse(&config.env_source);
+    match &parsed {
+        EnvSource::Deno => { /* ... */ }
+        EnvSource::Prewarmed(_)
+        | EnvSource::Inline(_)
+        | EnvSource::Pyproject
+        | EnvSource::PixiToml
+        | EnvSource::EnvYml
+        | EnvSource::Pep723(_) => { /* python launch ... */ }
+        EnvSource::Unknown(s) => {
+            warn!("[jupyter-kernel] Unknown env_source '{}', treating as Python", s);
+            /* python launch fallback */
+        }
+    }
+```
+
+- [ ] **Step 2: `runtime_agent.rs` — no changes needed**
+
+These sites (569, 687, 827) read a string from the running kernel and forward it. No classification happens. Skip.
+
+- [ ] **Step 3: Build + test**
+
+Run: `cargo build -p runtimed --all-targets 2>&1 | tail -10 && cargo test -p runtimed --lib 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runtimed/src/jupyter_kernel.rs
+git commit -m "refactor(runtimed): use EnvSource::parse in jupyter_kernel launch dispatch"
+```
+
+---
+
+## Task 6: Migrate `runt-mcp` tools
+
+**Files:**
+- Modify: `crates/runt-mcp/src/tools/deps.rs`
+- Modify: `crates/runt-mcp/src/tools/session.rs`
+- Modify: `crates/runt-mcp/src/tools/kernel.rs` (if it classifies env_source)
+
+**Goal:** Replace `.starts_with()` chains in `detect_package_manager` (deps.rs:70-76) and `runtime_info` (session.rs:120-125) with `EnvSource::parse(...).package_manager()`.
+
+- [ ] **Step 1: `deps.rs` — package manager detection fallback**
+
+Open `crates/runt-mcp/src/tools/deps.rs`. The priority-2 fallback reads `state.kernel.env_source` as a string and uses `.starts_with()`. Replace:
+
+```rust
+    // Priority 2: env_source from running kernel (fallback for notebooks
+    // with no runt metadata yet)
+    if let Ok(state) = handle.get_runtime_state() {
+        let src = notebook_protocol::connection::EnvSource::parse(&state.kernel.env_source);
+        if let Some(pm) = src.package_manager() {
+            return pm;
+        }
+    }
+```
+
+- [ ] **Step 2: `deps.rs` — restart env_source mapping**
+
+Find the block (around line 217) that maps `"uv:prewarmed"` → `"auto:uv"` etc. Replace:
+
+```rust
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let prev = handle
+        .get_runtime_state()
+        .ok()
+        .map(|s| EnvSource::parse(&s.kernel.env_source));
+    let restart_env_source = match prev {
+        Some(EnvSource::Prewarmed(PackageManager::Uv)) => "auto:uv".to_string(),
+        Some(EnvSource::Prewarmed(PackageManager::Conda)) => "auto:conda".to_string(),
+        Some(EnvSource::Prewarmed(PackageManager::Pixi)) => "auto:pixi".to_string(),
+        Some(src) => src.as_str().to_string(),
+        None => "auto".to_string(),
+    };
+```
+
+- [ ] **Step 3: `session.rs` — runtime_info classification**
+
+Open `crates/runt-mcp/src/tools/session.rs` (lines 114-127). Replace:
+
+```rust
+    if !state.kernel.env_source.is_empty() {
+        info.insert("env_source".into(), serde_json::json!(state.kernel.env_source));
+        use notebook_protocol::connection::EnvSource;
+        let parsed = EnvSource::parse(&state.kernel.env_source);
+        if let Some(pm) = parsed.package_manager() {
+            info.insert("package_manager".into(), serde_json::json!(pm.as_str()));
+        } else if matches!(parsed, EnvSource::Deno) {
+            info.insert("package_manager".into(), serde_json::json!("deno"));
+        }
+    }
+```
+
+- [ ] **Step 4: `deps.rs` — `mode` derivation in `get_dependencies`**
+
+Around line 322:
+```rust
+    use notebook_protocol::connection::EnvSource;
+    let mode = match env_source.as_ref().map(|s| EnvSource::parse(s)) {
+        Some(EnvSource::PixiToml)
+        | Some(EnvSource::Pyproject)
+        | Some(EnvSource::EnvYml) => "project",
+        _ => "inline",
+    };
+```
+
+- [ ] **Step 5: Build + test**
+
+Run: `cargo build -p runt-mcp --all-targets 2>&1 | tail -10 && cargo test -p runt-mcp 2>&1 | tail -10`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/runt-mcp/src/tools/deps.rs crates/runt-mcp/src/tools/session.rs
+git commit -m "refactor(runt-mcp): classify env_source via EnvSource::parse"
+```
+
+---
+
+## Task 7: Migrate `runtimed-py::session_core::restart_env_source`
+
+**Files:**
+- Modify: `crates/runtimed-py/src/session_core.rs`
+
+**Goal:** The helper (around line 2459) maps previous env_source to a restart request. It currently pattern-matches raw strings. Use `EnvSource` + `LaunchSpec`.
+
+- [ ] **Step 1: Rewrite the helper**
+
+Find `restart_env_source` (around line 2459):
+
+```rust
+fn restart_env_source(prev: Option<&str>) -> String {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+    let Some(prev) = prev else {
+        return "auto".to_string();
+    };
+    match EnvSource::parse(prev) {
+        EnvSource::Prewarmed(PackageManager::Uv) => "auto:uv".to_string(),
+        EnvSource::Prewarmed(PackageManager::Conda) => "auto:conda".to_string(),
+        EnvSource::Prewarmed(PackageManager::Pixi) => "auto:pixi".to_string(),
+        other => other.as_str().to_string(),
+    }
+}
+```
+
+Also find the non-helper site around line 632 and apply the same transformation (it's a duplicate of the test helper logic, inlined). Extract to use the helper.
+
+- [ ] **Step 2: Update the tests (around lines 2470-2490)**
+
+The tests continue to pass strings; no changes required as the helper takes `Option<&str>`.
+
+- [ ] **Step 3: Build + test**
+
+Run: `cargo check -p runtimed-py --all-targets 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runtimed-py/src/session_core.rs
+git commit -m "refactor(runtimed-py): classify prev env_source via EnvSource::parse in restart helper"
+```
+
+---
+
+## Task 8: End-to-end verification
+
+**Goal:** Confirm wire compatibility (existing tests pass, `KernelLaunched.env_source` still decodes correctly), real MCP create_notebook works for all three managers, clippy/lint are clean.
+
+- [ ] **Step 1: Run the complete test suite**
+
+```bash
+cargo test -p notebook-protocol 2>&1 | tail -5
+cargo test -p runtimed --lib 2>&1 | tail -5
+cargo test -p runt-mcp 2>&1 | tail -5
+cargo xtask integration 2>&1 | tail -30
+```
+
+Expected: all green. The integration tests create notebooks with all three managers; they exercise the full auto-launch flow through the refactored resolver.
+
+- [ ] **Step 2: Rebuild + validate via MCP**
+
+```
+up rebuild=true
+```
+
+Then via nteract-dev MCP:
+
+```
+create_notebook(runtime="python", dependencies=["numpy"], package_manager="conda", ephemeral=true)
+```
+
+Expected: `"package_manager": "conda"` in the response. Kernel auto-launches.
+
+```
+create_notebook(runtime="python", dependencies=["pandas"], package_manager="pixi", ephemeral=true)
+```
+
+Expected: `"package_manager": "pixi"`. Kernel auto-launches.
+
+```
+create_notebook(runtime="python", dependencies=["requests"], package_manager="uv", ephemeral=true)
+```
+
+Expected: `"package_manager": "uv"`. Kernel auto-launches.
+
+For each: call `get_dependencies()` on the same notebook; confirm the deps + `env_source` field round-trip.
+
+- [ ] **Step 3: Clippy + lint**
+
+```bash
+cargo xtask clippy 2>&1 | tail -20
+cargo xtask lint --fix 2>&1 | tail -10
+```
+Expected: no warnings, no diffs.
+
+- [ ] **Step 4: Confirm no lingering raw env_source strings in production code**
+
+```bash
+rg '"uv:prewarmed"|"conda:prewarmed"|"pixi:prewarmed"|"uv:inline"|"conda:inline"|"pixi:inline"|"uv:pyproject"|"pixi:toml"|"conda:env_yml"|"uv:pep723"|"pixi:pep723"' crates/runtimed/src crates/runt-mcp/src crates/runtimed-py/src --type rust
+```
+
+Expected: only matches inside `notebook-protocol/src/connection.rs` (enum definition + tests) and test fixtures. No matches in `metadata.rs`, `launch_kernel.rs`, `jupyter_kernel.rs`, `deps.rs`, `session.rs`.
+
+Some hits in test files are OK — those test the wire format explicitly. Flag any in production code.
+
+- [ ] **Step 5: Sanity: wire format unchanged**
+
+Run the protocol tests that serialize `KernelLaunched` etc.:
+
+```bash
+cargo test -p notebook-protocol -- --nocapture 2>&1 | grep -E "kernel_launched|env_source" | head -10
+```
+
+Expected: the test outputs (e.g., the `"env_source":"uv:prewarmed"` literals in test fixtures) still decode and re-encode identically.
+
+- [ ] **Step 6: Commit (if any stragglers)**
+
+```bash
+git add -u
+git commit -m "chore: final fmt/clippy cleanup after EnvSource migration"
+```
+
+---
+
+## Testing Summary
+
+| Suite | Why |
+|-------|-----|
+| `cargo test -p notebook-protocol` | Enum definitions, parse/serialize round-trips (all 12+ values, Unknown capture) |
+| `cargo test -p runtimed --lib` | Auto-launch resolution, metadata bootstrap, capture validation |
+| `cargo test -p runt-mcp` | Dep helpers, session_info classification |
+| `cargo xtask integration` | End-to-end create_notebook with inline deps across all managers |
+| Live MCP `create_notebook` | Real PyO3 + daemon + kernel launch per manager family |
+| `cargo xtask clippy` | Exhaustive match coverage (new enum variants force compile-time discovery of any missed sites) |
+
+## Deliverables
+
+- `EnvSource` and `LaunchSpec` enums in `notebook_protocol::connection`.
+- 100+ string comparisons replaced with exhaustive `matches!` / `match` on the enum.
+- `check_inline_deps`, `detect_project_file(...).to_env_source()`, `captured_env_source_override` return `EnvSource` / `Option<EnvSource>`.
+- Wire format byte-identical (existing `rpc_routing` and protocol tests pass unchanged).
+- `RuntimeStateDoc.kernel.env_source`, `KernelLaunched.env_source`, `LaunchKernelRequest.env_source` stay serialized as `String` on the wire — readers parse at use sites.
+- `Unknown(String)` variant preserves forward compatibility — a daemon receiving a future env_source value keeps working instead of erroring.
+
+## What this plan does NOT do
+
+- Does not change the Automerge schema (`RuntimeStateDoc` still stores strings).
+- Does not change the TypeScript types in `apps/notebook/src/types.ts` — frontend still sees strings.
+- Does not touch `repr-llm` or any downstream visualization code.
+- Does not migrate test-only string literals (in fixtures that explicitly test the wire format).


### PR DESCRIPTION
## Summary

Replaces raw env_source strings (`"uv:prewarmed"`, `"conda:inline"`, `"pixi:toml"`, etc.) with a typed `EnvSource` enum defined in `notebook-protocol::connection`. Adds a sibling `LaunchSpec` enum that distinguishes request-time inputs (`auto`, `auto:uv`, `prewarmed`) from resolved env sources.

This is PR 2 of the refactor from #2053 (PR 1 shipped `PackageManager`). Design doc: `docs/superpowers/specs/2026-04-22-package-manager-enum-design.md`.

- Both enums use permissive deserialization via an `Unknown(String)` variant — wire compatibility is preserved and unrecognized values pass through rather than failing at decode.
- `EnvSource::prepares_own_env()` collapses the 7-way string comparisons in the auto-launch flow into a single method call.
- `EnvSource::package_manager()` replaces `.starts_with("conda:")` / `.starts_with("uv:")` family classification at all MCP + Python helper sites.
- Wire format byte-identical — `KernelLaunched.env_source`, `LaunchKernelRequest.env_source`, and `RuntimeStateDoc.kernel.env_source` still serialize as strings.

## What changed

- `notebook-protocol`: `EnvSource` and `LaunchSpec` enums, 12 unit tests, permissive `Serialize`/`Deserialize`.
- `runtimed::project_file` + `runt-mcp::project_file`: `to_env_source()` / `env_source()` return typed values.
- `runtimed::notebook_sync_server::metadata`: auto-launch resolver builds `EnvSource` values throughout, uses `.prepares_own_env()` to decide pool acquisition, serializes to string only at the outbound RPC boundary. `detect_manager_from_metadata` and `captured_env_source_override` return typed values.
- `runtimed::requests::launch_kernel`: request-time input classified as `LaunchSpec`; the big env-source-string dispatch match for building launch configs stays as string-literal discriminants (it's a clean dispatch, no ad-hoc classification).
- `runt-mcp::tools::deps` + `session`: classification sites use `EnvSource::parse().package_manager()` and enum matches.
- `runtimed-py::session_core`: new `restart_env_source_for(prev)` helper replaces the duplicated string match; production code and tests use it.

## What was intentionally left alone

- `jupyter_kernel.rs::launch` — the `env_source.as_str()` match with 30+ arms is a dispatch on a well-formed discriminant, not ad-hoc classification. Rewriting it would risk regressions with zero behavioral benefit.
- `runtime_agent.rs` — pure string pass-through; no classification.
- Big `match resolved_env_source.as_str()` blocks in `launch_kernel.rs` and `metadata.rs::build_launched_config` — same rationale.

## Test plan

- [x] `cargo test -p notebook-protocol` — 62 pass (12 new enum tests)
- [x] `cargo test -p runtimed --lib` — 388 pass
- [x] `cargo test -p runt-mcp` — 86 pass
- [x] `cargo build --workspace --exclude runtimed-py --all-targets` — clean
- [x] `cargo xtask clippy` — clean
- [x] `cargo xtask lint` — clean
- [x] Live MCP `create_notebook` with `package_manager=conda`, `pixi`, `uv` — all respond with correct manager and auto-launch