### PR TITLE
chore(claude): auto-format Rust and Python files after Edit/Write

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,19 @@
         "path": "./.claude/plugins"
       }
     }
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f || exit 0; case \"$f\" in *.rs) rustfmt --edition 2021 \"$f\" ;; esac; } 2>/dev/null || true",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f || exit 0; case \"$f\" in *.rs) rustfmt --edition 2021 \"$f\" ;; esac; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f || exit 0; case \"$f\" in *.rs) rustfmt --edition 2021 \"$f\" ;; *.py) ruff format \"$f\" && ruff check --fix \"$f\" ;; esac; } 2>/dev/null || true",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

Adds a `PostToolUse` hook on `Write|Edit` in `.claude/settings.json` that auto-formats files Claude modifies, matched by extension:

- **`.rs`** → `rustfmt --edition 2021 <file>`
- **`.py`** → `ruff format <file>` then `ruff check --fix <file>`

Non-matching extensions fall through untouched. The whole chain runs with `2>/dev/null || true` so a formatter failing (missing binary, malformed file) never blocks the agent turn.

## Why

Small formatter violations introduced via Edit would pass `cargo check` and only trip the clippy/CI formatting gates after the commit was already up. With this hook the file is reformatted in place before the agent can move on — the same safety net `rust-analyzer`/editor-on-save gives humans.

Observed this loop directly this week: the clippy `int_plus_one` fix for PR #2054 needed a follow-up commit purely because the reformatted assertion didn't land in the file until I re-ran `cargo fmt` manually.

Matches the commands `cargo xtask lint --fix` already runs, just scoped to one file per Edit instead of the whole workspace.

## What's NOT in this PR

TS/JS auto-format. `vp check --fix` is a heavier tool (warms a worker per call) and agents already run `cargo xtask lint --fix` before committing, which covers it. Can revisit if drift shows up there too.

## Test plan

- [x] Hook pipe-test (Rust): JSON-on-stdin → extracts `file_path` → runs rustfmt → exits 0.
- [x] Hook pipe-test (Python): same path through `ruff format` + `ruff check --fix`.
- [x] End-to-end: introduced a formatting violation via Edit, confirmed the file was already reformatted before I could Read it again (Claude Code UI surfaced "PostToolUse hook modified the file").
- [x] `jq -e` on the settings.json round-trips the exact command (schema valid).
- [x] CI green.