### PR TITLE
chore(claude): allowlist common dev commands to reduce prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,21 @@
       }
     }
   },
+  "permissions": {
+    "allow": [
+      "Bash(cargo xtask *)",
+      "Bash(cargo build *)",
+      "Bash(cargo check *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo fmt *)",
+      "Bash(cargo test *)",
+      "Bash(voice *)",
+      "Bash(git fetch *)",
+      "Bash(mkdir *)",
+      "Bash(wasm-pack *)",
+      "mcp__nteract-dev"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

Adds prefix rules to project `.claude/settings.json` for the read-only / safe-mutation commands agents run most often in this repo. Pulled from transcript frequency analysis across recent sessions, with auto-allowed commands (cat, ls, git status/log/diff/show, gh pr view/list/diff/checks, etc.) dropped since they already don't prompt.

## What's allowlisted

| Pattern | Why |
|---|---|
| `Bash(cargo xtask *)` | repo build orchestrator (lint, clippy, wasm, renderer-plugins, sync-tool-cache...) |
| `Bash(cargo build *)` | compile |
| `Bash(cargo check *)` | type-check |
| `Bash(cargo clippy *)` | lint |
| `Bash(cargo fmt *)` | formatter (manual runs; automated via PostToolUse hook) |
| `Bash(cargo test *)` | unit/integration tests |
| `Bash(voice *)` | local TTS CLI |
| `Bash(git fetch *)` | network-read only |
| `Bash(mkdir *)` | non-destructive |
| `Bash(wasm-pack *)` | wasm build |
| `mcp__nteract-dev` | entire dev MCP surface — repo-scoped, local daemon only |

## What's NOT allowlisted (on purpose)

Commands that mutate shared state keep prompting so the human stays in the loop:

- `git push`, `git checkout`, `git add`, `git commit`, `git rebase`, `git pull`
- `gh pr create`, `gh pr merge`, `gh pr edit`, `gh issue create`, `gh issue edit`
- `rm`, `pkill`, `chmod`, `scp`
- Arbitrary-execution surfaces: `ssh`, `curl`, `python3`, `node`, `npx`, `codex`

## Test plan

- [x] `jq -e .permissions.allow` on the settings file parses and returns the array.
- [ ] CI green.