### PR TITLE
refactor(runtimed): migrate to RuntimeStateHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7059,6 +7059,7 @@ dependencies = [
  "reqwest-middleware",
  "runt-trust",
  "runt-workspace",
+ "runtime-doc",
  "runtimed-client",
  "runtimelib",
  "schemars 1.2.1",

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -436,6 +436,11 @@ impl RuntimeStateDoc {
         &mut self.doc
     }
 
+    /// Current document heads (for change detection).
+    pub fn get_heads(&mut self) -> Vec<automerge::ChangeHash> {
+        self.doc.get_heads()
+    }
+
     // ── Fork + Merge ────────────────────────────────────────────────
 
     /// Fork the document at its current state.

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -29,7 +29,10 @@ impl RuntimeStateHandle {
     where
         F: FnOnce(&mut RuntimeStateDoc) -> Result<T, RuntimeStateError>,
     {
-        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
         let heads_before = sd.get_heads();
         let result = f(&mut sd)?;
         if sd.get_heads() != heads_before {
@@ -40,13 +43,19 @@ impl RuntimeStateHandle {
 
     /// Fork at current heads for async work. Never uses fork_at (automerge#1327).
     pub fn fork(&self, actor_label: &str) -> Result<RuntimeStateDoc, RuntimeStateError> {
-        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
         Ok(sd.fork_with_actor(actor_label))
     }
 
     /// Merge a fork back. Notifies if heads changed.
     pub fn merge(&self, fork: &mut RuntimeStateDoc) -> Result<(), RuntimeStateError> {
-        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
         let heads_before = sd.get_heads();
         sd.merge(fork)?;
         if sd.get_heads() != heads_before {
@@ -60,7 +69,10 @@ impl RuntimeStateHandle {
     where
         F: FnOnce(&RuntimeStateDoc) -> T,
     {
-        let sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
         Ok(f(&sd))
     }
 
@@ -84,22 +96,16 @@ mod tests {
     fn with_doc_notifies_on_change() {
         let handle = make_handle();
         let mut rx = handle.subscribe();
-        handle
-            .with_doc(|sd| sd.set_kernel_status("busy"))
-            .unwrap();
+        handle.with_doc(|sd| sd.set_kernel_status("busy")).unwrap();
         assert!(rx.try_recv().is_ok());
     }
 
     #[test]
     fn with_doc_skips_notification_when_unchanged() {
         let handle = make_handle();
-        handle
-            .with_doc(|sd| sd.set_kernel_status("busy"))
-            .unwrap();
+        handle.with_doc(|sd| sd.set_kernel_status("busy")).unwrap();
         let mut rx = handle.subscribe();
-        handle
-            .with_doc(|sd| sd.set_kernel_status("busy"))
-            .unwrap();
+        handle.with_doc(|sd| sd.set_kernel_status("busy")).unwrap();
         assert!(rx.try_recv().is_err());
     }
 
@@ -131,9 +137,7 @@ mod tests {
     #[test]
     fn read_does_not_notify() {
         let handle = make_handle();
-        handle
-            .with_doc(|sd| sd.set_kernel_status("busy"))
-            .unwrap();
+        handle.with_doc(|sd| sd.set_kernel_status("busy")).unwrap();
         let mut rx = handle.subscribe();
         let status = handle
             .read(|sd| sd.read_state().kernel.status.clone())

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -25,6 +25,10 @@ impl RuntimeStateHandle {
     }
 
     /// Synchronous mutation. Acquires mutex, runs closure, notifies if heads changed.
+    ///
+    /// Notification fires even if the closure returns `Err`, because earlier
+    /// mutations in a batched closure may have already changed the doc before
+    /// a later write failed.
     pub fn with_doc<F, T>(&self, f: F) -> Result<T, RuntimeStateError>
     where
         F: FnOnce(&mut RuntimeStateDoc) -> Result<T, RuntimeStateError>,
@@ -34,11 +38,11 @@ impl RuntimeStateHandle {
             .lock()
             .map_err(|_| RuntimeStateError::LockPoisoned)?;
         let heads_before = sd.get_heads();
-        let result = f(&mut sd)?;
+        let result = f(&mut sd);
         if sd.get_heads() != heads_before {
             let _ = self.changed_tx.send(());
         }
-        Ok(result)
+        result
     }
 
     /// Fork at current heads for async work. Never uses fork_at (automerge#1327).
@@ -51,13 +55,34 @@ impl RuntimeStateHandle {
     }
 
     /// Merge a fork back. Notifies if heads changed.
+    ///
+    /// If merge panics (Automerge's apply path is not transactional),
+    /// catches the unwind and rebuilds the doc via save/load to restore
+    /// a consistent state. The fork's writes are lost but the session
+    /// continues.
     pub fn merge(&self, fork: &mut RuntimeStateDoc) -> Result<(), RuntimeStateError> {
         let mut sd = self
             .doc
             .lock()
             .map_err(|_| RuntimeStateError::LockPoisoned)?;
         let heads_before = sd.get_heads();
-        sd.merge(fork)?;
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sd.merge(fork))) {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => {
+                // Normal error: doc is unchanged (error fires before mutation).
+                return Err(e.into());
+            }
+            Err(_panic) => {
+                // Panic during apply: doc may be half-merged. Rebuild from save.
+                tracing::warn!(
+                    "[runtime-state] merge panicked, rebuilding from save to restore consistency"
+                );
+                sd.rebuild_from_save();
+                return Err(RuntimeStateError::MissingScaffold(
+                    "merge panicked, rebuilt from save",
+                ));
+            }
+        }
         if sd.get_heads() != heads_before {
             let _ = self.changed_tx.send(());
         }

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -1,1 +1,144 @@
-// Populated in Phase B
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+
+use crate::{RuntimeStateDoc, RuntimeStateError};
+
+/// Handle to a per-notebook RuntimeStateDoc.
+///
+/// All mutations go through `with_doc` (sync) or `fork`/`merge` (async).
+/// Notification is automatic via heads comparison. Clone is cheap.
+///
+/// Uses `std::sync::Mutex`, not `tokio::sync::RwLock`. Automerge writes are
+/// microsecond-fast. The `!Send` guard prevents holding across `.await`.
+#[derive(Clone)]
+pub struct RuntimeStateHandle {
+    doc: Arc<Mutex<RuntimeStateDoc>>,
+    changed_tx: broadcast::Sender<()>,
+}
+
+impl RuntimeStateHandle {
+    pub fn new(doc: RuntimeStateDoc, changed_tx: broadcast::Sender<()>) -> Self {
+        Self {
+            doc: Arc::new(Mutex::new(doc)),
+            changed_tx,
+        }
+    }
+
+    /// Synchronous mutation. Acquires mutex, runs closure, notifies if heads changed.
+    pub fn with_doc<F, T>(&self, f: F) -> Result<T, RuntimeStateError>
+    where
+        F: FnOnce(&mut RuntimeStateDoc) -> Result<T, RuntimeStateError>,
+    {
+        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let heads_before = sd.get_heads();
+        let result = f(&mut sd)?;
+        if sd.get_heads() != heads_before {
+            let _ = self.changed_tx.send(());
+        }
+        Ok(result)
+    }
+
+    /// Fork at current heads for async work. Never uses fork_at (automerge#1327).
+    pub fn fork(&self, actor_label: &str) -> Result<RuntimeStateDoc, RuntimeStateError> {
+        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        Ok(sd.fork_with_actor(actor_label))
+    }
+
+    /// Merge a fork back. Notifies if heads changed.
+    pub fn merge(&self, fork: &mut RuntimeStateDoc) -> Result<(), RuntimeStateError> {
+        let mut sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let heads_before = sd.get_heads();
+        sd.merge(fork)?;
+        if sd.get_heads() != heads_before {
+            let _ = self.changed_tx.send(());
+        }
+        Ok(())
+    }
+
+    /// Read-only access. No notification.
+    pub fn read<F, T>(&self, f: F) -> Result<T, RuntimeStateError>
+    where
+        F: FnOnce(&RuntimeStateDoc) -> T,
+    {
+        let sd = self.doc.lock().map_err(|_| RuntimeStateError::LockPoisoned)?;
+        Ok(f(&sd))
+    }
+
+    /// Subscribe to change notifications.
+    pub fn subscribe(&self) -> broadcast::Receiver<()> {
+        self.changed_tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_handle() -> RuntimeStateHandle {
+        let doc = RuntimeStateDoc::new();
+        let (tx, _) = broadcast::channel(16);
+        RuntimeStateHandle::new(doc, tx)
+    }
+
+    #[test]
+    fn with_doc_notifies_on_change() {
+        let handle = make_handle();
+        let mut rx = handle.subscribe();
+        handle
+            .with_doc(|sd| sd.set_kernel_status("busy"))
+            .unwrap();
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn with_doc_skips_notification_when_unchanged() {
+        let handle = make_handle();
+        handle
+            .with_doc(|sd| sd.set_kernel_status("busy"))
+            .unwrap();
+        let mut rx = handle.subscribe();
+        handle
+            .with_doc(|sd| sd.set_kernel_status("busy"))
+            .unwrap();
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn batched_writes_single_notification() {
+        let handle = make_handle();
+        let mut rx = handle.subscribe();
+        handle
+            .with_doc(|sd| {
+                sd.set_kernel_status("busy")?;
+                sd.set_starting_phase("resolving")?;
+                Ok(())
+            })
+            .unwrap();
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn fork_and_merge_notifies() {
+        let handle = make_handle();
+        let mut rx = handle.subscribe();
+        let mut fork = handle.fork("test-fork").unwrap();
+        fork.set_kernel_status("idle").unwrap();
+        handle.merge(&mut fork).unwrap();
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn read_does_not_notify() {
+        let handle = make_handle();
+        handle
+            .with_doc(|sd| sd.set_kernel_status("busy"))
+            .unwrap();
+        let mut rx = handle.subscribe();
+        let status = handle
+            .read(|sd| sd.read_state().kernel.status.clone())
+            .unwrap();
+        assert_eq!(status, "busy");
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/runtime-doc/src/lib.rs
+++ b/crates/runtime-doc/src/lib.rs
@@ -5,4 +5,5 @@ mod types;
 
 pub use doc::*;
 pub use error::RuntimeStateError;
+pub use handle::RuntimeStateHandle;
 pub use types::*;

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -75,6 +75,9 @@ automerge = "0.8"
 # Shared notebook document types (cell CRUD, metadata, sync)
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 
+# RuntimeStateHandle — typed handle for per-notebook RuntimeStateDoc
+runtime-doc = { path = "../runtime-doc" }
+
 # Trust verification (shared with notebook crate)
 runt-trust = { path = "../runt-trust" }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2680,16 +2680,18 @@ impl Daemon {
                             .collect();
                         (cells, eids)
                     };
-                    let outputs_by_cell: std::collections::HashMap<String, Vec<serde_json::Value>> = {
-                        let state_doc = room.state_doc.read().await;
-                        eids_by_cell
-                            .into_iter()
-                            .filter_map(|(cell_id, eid)| {
-                                let outputs = state_doc.get_outputs(&eid);
-                                (!outputs.is_empty()).then_some((cell_id, outputs))
+                    let outputs_by_cell: std::collections::HashMap<String, Vec<serde_json::Value>> =
+                        room.state
+                            .read(|state_doc| {
+                                eids_by_cell
+                                    .into_iter()
+                                    .filter_map(|(cell_id, eid)| {
+                                        let outputs = state_doc.get_outputs(&eid);
+                                        (!outputs.is_empty()).then_some((cell_id, outputs))
+                                    })
+                                    .collect()
                             })
-                            .collect()
-                    };
+                            .unwrap_or_default();
                     let kernel_info = room.kernel_info().await.map(|(kt, es, status)| {
                         crate::protocol::NotebookKernelInfo {
                             kernel_type: kt,
@@ -3285,8 +3287,7 @@ impl Daemon {
         // 1. In-memory: active rooms (RuntimeStateDoc + notebook doc).
         for batch in rooms.chunks(ROOM_BATCH_SIZE) {
             for (_id, room) in batch {
-                {
-                    let sd = room.state_doc.read().await;
+                let _ = room.state.read(|sd| {
                     let state = sd.read_state();
                     for exec in state.executions.values() {
                         for output in &exec.outputs {
@@ -3299,7 +3300,7 @@ impl Daemon {
                         }
                         collect_blob_hashes_recursive(&comm.state, &mut referenced_hashes);
                     }
-                }
+                });
                 {
                     let doc = room.doc.read().await;
                     for cell in doc.get_cells() {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -682,8 +682,7 @@ impl KernelConnection for JupyterKernel {
         let blob_store = shared.blob_store.clone();
         let iopub_comm_seq = comm_seq.clone();
         let iopub_stream_terminals = stream_terminals.clone();
-        let state_doc_for_iopub = shared.state_doc.clone();
-        let state_changed_for_iopub = shared.state_changed_tx.clone();
+        let state_for_iopub = shared.state.clone();
         // Stable per-task actor IDs. Each long-running task (iopub, shell,
         // coalesce) processes messages sequentially within its own loop, so
         // one actor per task is sufficient — Automerge's `(actor, seq)`
@@ -759,11 +758,11 @@ impl KernelConnection for JupyterKernel {
                                             && (status_str == "busy" || status_str == "idle");
 
                                         if !is_transient {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            if let Err(e) = sd.set_kernel_status(status_str) {
+                                            if let Err(e) = state_for_iopub
+                                                .with_doc(|sd| sd.set_kernel_status(status_str))
+                                            {
                                                 warn!("[runtime-state] {}", e);
                                             }
-                                            let _ = state_changed_for_iopub.send(());
                                         }
                                     }
 
@@ -786,13 +785,11 @@ impl KernelConnection for JupyterKernel {
                                         let execution_count = input.execution_count.0 as i64;
 
                                         if let Some(ref eid) = execution_id {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            if let Err(e) =
+                                            if let Err(e) = state_for_iopub.with_doc(|sd| {
                                                 sd.set_execution_count(eid, execution_count)
-                                            {
+                                            }) {
                                                 warn!("[runtime-state] {}", e);
                                             }
-                                            let _ = state_changed_for_iopub.send(());
                                         }
 
                                         let _ = broadcast_tx.send(
@@ -835,39 +832,49 @@ impl KernelConnection for JupyterKernel {
                                         .await
                                         {
                                             let manifest_json = manifest.to_json();
-                                            let output_manifests = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if pending_clear_widgets.remove(&widget_comm_id) {
-                                                    if let Err(e) =
-                                                        sd.clear_comm_outputs(&widget_comm_id)
-                                                    {
-                                                        warn!("[runtime-state] {}", e);
+                                            let need_clear =
+                                                pending_clear_widgets.remove(&widget_comm_id);
+                                            let output_manifests = state_for_iopub
+                                                .with_doc(|sd| {
+                                                    if need_clear {
+                                                        if let Err(e) =
+                                                            sd.clear_comm_outputs(&widget_comm_id)
+                                                        {
+                                                            warn!("[runtime-state] {}", e);
+                                                        }
                                                     }
-                                                }
-                                                if let Err(e) = sd.append_comm_output(
-                                                    &widget_comm_id,
-                                                    &manifest_json,
-                                                ) {
-                                                    warn!("[runtime-state] {}", e);
-                                                }
-                                                let _ = state_changed_for_iopub.send(());
-
-                                                if let Some(entry) = sd.get_comm(&widget_comm_id) {
-                                                    let manifests = entry.outputs.clone();
-                                                    let manifests_json =
-                                                        serde_json::Value::Array(manifests.clone());
-                                                    if let Err(e) = sd.set_comm_state_property(
+                                                    if let Err(e) = sd.append_comm_output(
                                                         &widget_comm_id,
-                                                        "outputs",
-                                                        &manifests_json,
+                                                        &manifest_json,
                                                     ) {
                                                         warn!("[runtime-state] {}", e);
                                                     }
-                                                    Some(manifests)
-                                                } else {
-                                                    None
-                                                }
-                                            };
+                                                    Ok(
+                                                        if let Some(entry) =
+                                                            sd.get_comm(&widget_comm_id)
+                                                        {
+                                                            let manifests = entry.outputs.clone();
+                                                            let manifests_json =
+                                                                serde_json::Value::Array(
+                                                                    manifests.clone(),
+                                                                );
+                                                            if let Err(e) = sd
+                                                                .set_comm_state_property(
+                                                                    &widget_comm_id,
+                                                                    "outputs",
+                                                                    &manifests_json,
+                                                                )
+                                                            {
+                                                                warn!("[runtime-state] {}", e);
+                                                            }
+                                                            Some(manifests)
+                                                        } else {
+                                                            None
+                                                        },
+                                                    )
+                                                })
+                                                .ok()
+                                                .flatten();
                                             if let Some(output_manifests) = output_manifests {
                                                 let mut resolved_outputs = Vec::new();
                                                 for m in &output_manifests {
@@ -953,9 +960,12 @@ impl KernelConnection for JupyterKernel {
                                                 String::new()
                                             };
 
-                                        let mut fork = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            sd.fork_with_actor(&iopub_actor_id)
+                                        let mut fork = match state_for_iopub.fork(&iopub_actor_id) {
+                                            Ok(f) => f,
+                                            Err(e) => {
+                                                warn!("[runtime-state] fork: {}", e);
+                                                continue;
+                                            }
                                         };
 
                                         let upsert_result = fork.upsert_stream_output(
@@ -965,19 +975,11 @@ impl KernelConnection for JupyterKernel {
                                             known_state.as_ref(),
                                         );
 
-                                        let merge_ok = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            if let Err(e) =
-                                                crate::notebook_sync_server::catch_automerge_panic(
-                                                    "iopub-stream-output-merge",
-                                                    || sd.merge(&mut fork),
-                                                )
-                                            {
-                                                warn!("{}", e);
-                                                sd.rebuild_from_save();
+                                        let merge_ok = match state_for_iopub.merge(&mut fork) {
+                                            Ok(()) => true,
+                                            Err(e) => {
+                                                warn!("[runtime-state] merge: {}", e);
                                                 false
-                                            } else {
-                                                true
                                             }
                                         };
 
@@ -1009,7 +1011,7 @@ impl KernelConnection for JupyterKernel {
                                                 }
                                             };
 
-                                            let _ = state_changed_for_iopub.send(());
+                                            // merge() already notified via heads check
                                             let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                                 cell_id: cid.clone(),
                                                 execution_id: eid,
@@ -1058,44 +1060,50 @@ impl KernelConnection for JupyterKernel {
                                                 .await
                                             {
                                                 let manifest_json = manifest.to_json();
-                                                let output_manifests = {
-                                                    let mut sd = state_doc_for_iopub.write().await;
-                                                    if pending_clear_widgets.remove(&widget_comm_id)
-                                                    {
-                                                        if let Err(e) =
-                                                            sd.clear_comm_outputs(&widget_comm_id)
-                                                        {
-                                                            warn!("[runtime-state] {}", e);
+                                                let need_clear =
+                                                    pending_clear_widgets.remove(&widget_comm_id);
+                                                let output_manifests = state_for_iopub
+                                                    .with_doc(|sd| {
+                                                        if need_clear {
+                                                            if let Err(e) = sd
+                                                                .clear_comm_outputs(&widget_comm_id)
+                                                            {
+                                                                warn!("[runtime-state] {}", e);
+                                                            }
                                                         }
-                                                    }
-                                                    if let Err(e) = sd.append_comm_output(
-                                                        &widget_comm_id,
-                                                        &manifest_json,
-                                                    ) {
-                                                        warn!("[runtime-state] {}", e);
-                                                    }
-                                                    let _ = state_changed_for_iopub.send(());
-
-                                                    if let Some(entry) =
-                                                        sd.get_comm(&widget_comm_id)
-                                                    {
-                                                        let manifests = entry.outputs.clone();
-                                                        let manifests_json =
-                                                            serde_json::Value::Array(
-                                                                manifests.clone(),
-                                                            );
-                                                        if let Err(e) = sd.set_comm_state_property(
+                                                        if let Err(e) = sd.append_comm_output(
                                                             &widget_comm_id,
-                                                            "outputs",
-                                                            &manifests_json,
+                                                            &manifest_json,
                                                         ) {
                                                             warn!("[runtime-state] {}", e);
                                                         }
-                                                        Some(manifests)
-                                                    } else {
-                                                        None
-                                                    }
-                                                };
+                                                        Ok(
+                                                            if let Some(entry) =
+                                                                sd.get_comm(&widget_comm_id)
+                                                            {
+                                                                let manifests =
+                                                                    entry.outputs.clone();
+                                                                let manifests_json =
+                                                                    serde_json::Value::Array(
+                                                                        manifests.clone(),
+                                                                    );
+                                                                if let Err(e) = sd
+                                                                    .set_comm_state_property(
+                                                                        &widget_comm_id,
+                                                                        "outputs",
+                                                                        &manifests_json,
+                                                                    )
+                                                                {
+                                                                    warn!("[runtime-state] {}", e);
+                                                                }
+                                                                Some(manifests)
+                                                            } else {
+                                                                None
+                                                            },
+                                                        )
+                                                    })
+                                                    .ok()
+                                                    .flatten();
                                                 if let Some(output_manifests) = output_manifests {
                                                     let mut resolved_outputs = Vec::new();
                                                     for m in &output_manifests {
@@ -1170,10 +1178,14 @@ impl KernelConnection for JupyterKernel {
                                                 }
                                             };
 
-                                            let mut fork = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                sd.fork_with_actor(&iopub_actor_id)
-                                            };
+                                            let mut fork =
+                                                match state_for_iopub.fork(&iopub_actor_id) {
+                                                    Ok(f) => f,
+                                                    Err(e) => {
+                                                        warn!("[runtime-state] fork: {}", e);
+                                                        continue;
+                                                    }
+                                                };
 
                                             if let Err(e) = fork.append_output(&eid, &manifest_json)
                                             {
@@ -1183,21 +1195,12 @@ impl KernelConnection for JupyterKernel {
                                             );
                                             }
 
-                                            let merge_ok = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if let Err(e) =
-                                                crate::notebook_sync_server::catch_automerge_panic(
-                                                    "iopub-output-merge",
-                                                    || sd.merge(&mut fork),
-                                                )
-                                            {
-                                                warn!("{}", e);
-                                                sd.rebuild_from_save();
-                                                false
-                                            } else {
-                                                let _ = state_changed_for_iopub.send(());
-                                                true
-                                            }
+                                            let merge_ok = match state_for_iopub.merge(&mut fork) {
+                                                Ok(()) => true,
+                                                Err(e) => {
+                                                    warn!("[runtime-state] merge: {}", e);
+                                                    false
+                                                }
                                             };
 
                                             if merge_ok {
@@ -1216,9 +1219,12 @@ impl KernelConnection for JupyterKernel {
 
                                 JupyterMessageContent::UpdateDisplayData(update) => {
                                     if let Some(ref display_id) = update.transient.display_id {
-                                        let mut fork = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            sd.fork_with_actor(&iopub_actor_id)
+                                        let mut fork = match state_for_iopub.fork(&iopub_actor_id) {
+                                            Ok(f) => f,
+                                            Err(e) => {
+                                                warn!("[runtime-state] fork: {}", e);
+                                                continue;
+                                            }
                                         };
 
                                         let updated = update_output_by_display_id_with_manifests(
@@ -1230,25 +1236,20 @@ impl KernelConnection for JupyterKernel {
                                         )
                                         .await;
 
-                                        let merge_ok = {
-                                            let mut sd = state_doc_for_iopub.write().await;
-                                            match updated {
-                                            Ok(true) => {
-                                                if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
-                                                    "iopub-display-update-merge",
-                                                    || sd.merge(&mut fork),
-                                                ) {
-                                                    warn!("{}", e);
-                                                    sd.rebuild_from_save();
-                                                    false
-                                                } else {
+                                        let merge_ok = match updated {
+                                            Ok(true) => match state_for_iopub.merge(&mut fork) {
+                                                Ok(()) => {
                                                     debug!(
                                                         "[jupyter-kernel] Updated display_id={}",
                                                         display_id
                                                     );
                                                     true
                                                 }
-                                            }
+                                                Err(e) => {
+                                                    warn!("[runtime-state] merge: {}", e);
+                                                    false
+                                                }
+                                            },
                                             Ok(false) => {
                                                 error!(
                                                     "[jupyter-kernel] No output found for display_id={}",
@@ -1263,11 +1264,9 @@ impl KernelConnection for JupyterKernel {
                                                 );
                                                 false
                                             }
-                                        }
                                         };
 
                                         if merge_ok {
-                                            let _ = state_changed_for_iopub.send(());
                                             let _ = broadcast_tx.send(
                                                 NotebookBroadcast::DisplayUpdate {
                                                     display_id: display_id.clone(),
@@ -1301,44 +1300,50 @@ impl KernelConnection for JupyterKernel {
                                                 .await
                                             {
                                                 let manifest_json = manifest.to_json();
-                                                let output_manifests = {
-                                                    let mut sd = state_doc_for_iopub.write().await;
-                                                    if pending_clear_widgets.remove(&widget_comm_id)
-                                                    {
-                                                        if let Err(e) =
-                                                            sd.clear_comm_outputs(&widget_comm_id)
-                                                        {
-                                                            warn!("[runtime-state] {}", e);
+                                                let need_clear =
+                                                    pending_clear_widgets.remove(&widget_comm_id);
+                                                let output_manifests = state_for_iopub
+                                                    .with_doc(|sd| {
+                                                        if need_clear {
+                                                            if let Err(e) = sd
+                                                                .clear_comm_outputs(&widget_comm_id)
+                                                            {
+                                                                warn!("[runtime-state] {}", e);
+                                                            }
                                                         }
-                                                    }
-                                                    if let Err(e) = sd.append_comm_output(
-                                                        &widget_comm_id,
-                                                        &manifest_json,
-                                                    ) {
-                                                        warn!("[runtime-state] {}", e);
-                                                    }
-                                                    let _ = state_changed_for_iopub.send(());
-
-                                                    if let Some(entry) =
-                                                        sd.get_comm(&widget_comm_id)
-                                                    {
-                                                        let manifests = entry.outputs.clone();
-                                                        let manifests_json =
-                                                            serde_json::Value::Array(
-                                                                manifests.clone(),
-                                                            );
-                                                        if let Err(e) = sd.set_comm_state_property(
+                                                        if let Err(e) = sd.append_comm_output(
                                                             &widget_comm_id,
-                                                            "outputs",
-                                                            &manifests_json,
+                                                            &manifest_json,
                                                         ) {
                                                             warn!("[runtime-state] {}", e);
                                                         }
-                                                        Some(manifests)
-                                                    } else {
-                                                        None
-                                                    }
-                                                };
+                                                        Ok(
+                                                            if let Some(entry) =
+                                                                sd.get_comm(&widget_comm_id)
+                                                            {
+                                                                let manifests =
+                                                                    entry.outputs.clone();
+                                                                let manifests_json =
+                                                                    serde_json::Value::Array(
+                                                                        manifests.clone(),
+                                                                    );
+                                                                if let Err(e) = sd
+                                                                    .set_comm_state_property(
+                                                                        &widget_comm_id,
+                                                                        "outputs",
+                                                                        &manifests_json,
+                                                                    )
+                                                                {
+                                                                    warn!("[runtime-state] {}", e);
+                                                                }
+                                                                Some(manifests)
+                                                            } else {
+                                                                None
+                                                            },
+                                                        )
+                                                    })
+                                                    .ok()
+                                                    .flatten();
                                                 if let Some(output_manifests) = output_manifests {
                                                     let mut resolved_outputs = Vec::new();
                                                     for m in &output_manifests {
@@ -1400,10 +1405,14 @@ impl KernelConnection for JupyterKernel {
                                                 }
                                             };
 
-                                            let mut fork = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                sd.fork_with_actor(&iopub_actor_id)
-                                            };
+                                            let mut fork =
+                                                match state_for_iopub.fork(&iopub_actor_id) {
+                                                    Ok(f) => f,
+                                                    Err(e) => {
+                                                        warn!("[runtime-state] fork: {}", e);
+                                                        continue;
+                                                    }
+                                                };
 
                                             if let Err(e) = fork.append_output(&eid, &manifest_json)
                                             {
@@ -1413,21 +1422,12 @@ impl KernelConnection for JupyterKernel {
                                             );
                                             }
 
-                                            let merge_ok = {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if let Err(e) =
-                                                crate::notebook_sync_server::catch_automerge_panic(
-                                                    "iopub-error-output-merge",
-                                                    || sd.merge(&mut fork),
-                                                )
-                                            {
-                                                warn!("{}", e);
-                                                sd.rebuild_from_save();
-                                                false
-                                            } else {
-                                                let _ = state_changed_for_iopub.send(());
-                                                true
-                                            }
+                                            let merge_ok = match state_for_iopub.merge(&mut fork) {
+                                                Ok(()) => true,
+                                                Err(e) => {
+                                                    warn!("[runtime-state] merge: {}", e);
+                                                    false
+                                                }
                                             };
 
                                             if merge_ok {
@@ -1462,21 +1462,16 @@ impl KernelConnection for JupyterKernel {
                                             pending_clear_widgets.insert(widget_comm_id.clone());
                                         } else {
                                             pending_clear_widgets.remove(&widget_comm_id);
-                                            {
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if let Err(e) =
-                                                    sd.clear_comm_outputs(&widget_comm_id)
-                                                {
-                                                    warn!("[runtime-state] {}", e);
-                                                }
-                                                let _ = state_changed_for_iopub.send(());
-                                                if let Err(e) = sd.set_comm_state_property(
+                                            if let Err(e) = state_for_iopub.with_doc(|sd| {
+                                                sd.clear_comm_outputs(&widget_comm_id)?;
+                                                sd.set_comm_state_property(
                                                     &widget_comm_id,
                                                     "outputs",
                                                     &serde_json::json!([]),
-                                                ) {
-                                                    warn!("[runtime-state] {}", e);
-                                                }
+                                                )?;
+                                                Ok(())
+                                            }) {
+                                                warn!("[runtime-state] {}", e);
                                             }
                                             let _ = iopub_cmd_tx
                                                 .send(QueueCommand::SendCommUpdate {
@@ -1557,23 +1552,42 @@ impl KernelConnection for JupyterKernel {
                                             .and_then(|v| v.as_str())
                                             .unwrap_or("");
                                         let seq = iopub_comm_seq.fetch_add(1, Ordering::Relaxed);
-                                        let mut sd = state_doc_for_iopub.write().await;
                                         let lock_wait = lock_start.elapsed();
                                         if lock_wait > std::time::Duration::from_millis(5) {
                                             warn!(
-                                            "[iopub-timing] comm_open state_doc write lock waited {:?} for comm_id={}",
+                                            "[iopub-timing] comm_open state handle lock waited {:?} for comm_id={}",
                                             lock_wait, open.comm_id.0
                                         );
                                         }
                                         let crdt_start = std::time::Instant::now();
-                                        if let Err(e) = sd.put_comm(
-                                            &open.comm_id.0,
-                                            &open.target_name,
-                                            model_module,
-                                            model_name,
-                                            &state_with_blobs,
-                                            seq,
-                                        ) {
+                                        // Extract capture msg_id before with_doc so we can
+                                        // update the local cache outside the lock.
+                                        let capture_msg = if model_name == "OutputModel" {
+                                            state_with_blobs
+                                                .get("msg_id")
+                                                .and_then(|v| v.as_str())
+                                                .filter(|s| !s.is_empty())
+                                                .map(|s| s.to_string())
+                                        } else {
+                                            None
+                                        };
+                                        if let Err(e) = state_for_iopub.with_doc(|sd| {
+                                            sd.put_comm(
+                                                &open.comm_id.0,
+                                                &open.target_name,
+                                                model_module,
+                                                model_name,
+                                                &state_with_blobs,
+                                                seq,
+                                            )?;
+                                            if let Some(ref msg_id) = capture_msg {
+                                                sd.set_comm_capture_msg_id(
+                                                    &open.comm_id.0,
+                                                    msg_id,
+                                                )?;
+                                            }
+                                            Ok(())
+                                        }) {
                                             warn!("[runtime-state] {}", e);
                                         }
                                         let crdt_elapsed = crdt_start.elapsed();
@@ -1583,27 +1597,9 @@ impl KernelConnection for JupyterKernel {
                                             crdt_elapsed, open.comm_id.0, state_json_size
                                         );
                                         }
-
-                                        if model_name == "OutputModel" {
-                                            if let Some(msg_id) = state_with_blobs
-                                                .get("msg_id")
-                                                .and_then(|v| v.as_str())
-                                                .filter(|s| !s.is_empty())
-                                            {
-                                                if let Err(e) = sd.set_comm_capture_msg_id(
-                                                    &open.comm_id.0,
-                                                    msg_id,
-                                                ) {
-                                                    warn!("[runtime-state] {}", e);
-                                                }
-                                                capture_cache.insert(
-                                                    msg_id.to_string(),
-                                                    open.comm_id.0.clone(),
-                                                );
-                                            }
+                                        if let Some(msg_id) = capture_msg {
+                                            capture_cache.insert(msg_id, open.comm_id.0.clone());
                                         }
-
-                                        let _ = state_changed_for_iopub.send(());
                                     }
 
                                     let total = comm_open_start.elapsed();
@@ -1669,14 +1665,14 @@ impl KernelConnection for JupyterKernel {
                                                     );
                                                 }
 
-                                                let mut sd = state_doc_for_iopub.write().await;
-                                                if let Err(e) = sd.set_comm_capture_msg_id(
-                                                    &msg.comm_id.0,
-                                                    new_msg_id,
-                                                ) {
+                                                if let Err(e) = state_for_iopub.with_doc(|sd| {
+                                                    sd.set_comm_capture_msg_id(
+                                                        &msg.comm_id.0,
+                                                        new_msg_id,
+                                                    )
+                                                }) {
                                                     warn!("[runtime-state] {}", e);
                                                 }
-                                                let _ = state_changed_for_iopub.send(());
                                             }
 
                                             let coalesce_delta = if !buffers.is_empty() {
@@ -1742,12 +1738,10 @@ impl KernelConnection for JupyterKernel {
 
                                     capture_cache.retain(|_, cid| cid != &close.comm_id.0);
 
+                                    if let Err(e) = state_for_iopub
+                                        .with_doc(|sd| sd.remove_comm(&close.comm_id.0))
                                     {
-                                        let mut sd = state_doc_for_iopub.write().await;
-                                        if let Err(e) = sd.remove_comm(&close.comm_id.0) {
-                                            warn!("[runtime-state] {}", e);
-                                        }
-                                        let _ = state_changed_for_iopub.send(());
+                                        warn!("[runtime-state] {}", e);
                                     }
                                 }
 
@@ -1825,8 +1819,7 @@ impl KernelConnection for JupyterKernel {
         let shell_cell_id_map = cell_id_map.clone();
         let shell_pending_history = pending_history.clone();
         let shell_pending_completions = pending_completions.clone();
-        let shell_state_doc = shared.state_doc.clone();
-        let shell_state_changed_tx = shared.state_changed_tx.clone();
+        let shell_state = shared.state.clone();
         let shell_blob_store = shared.blob_store.clone();
         let shell_actor_id = format!("{kernel_actor_id}:shell");
 
@@ -1878,10 +1871,14 @@ impl KernelConnection for JupyterKernel {
                                                     };
 
                                                 let eid = execution_id.clone().unwrap_or_default();
-                                                let mut fork = {
-                                                    let mut sd = shell_state_doc.write().await;
-                                                    sd.fork_with_actor(&shell_actor_id)
-                                                };
+                                                let mut fork =
+                                                    match shell_state.fork(&shell_actor_id) {
+                                                        Ok(f) => f,
+                                                        Err(e) => {
+                                                            warn!("[runtime-state] fork: {}", e);
+                                                            continue;
+                                                        }
+                                                    };
 
                                                 if let Err(e) =
                                                     fork.append_output(&eid, &manifest_json)
@@ -1892,20 +1889,12 @@ impl KernelConnection for JupyterKernel {
                                                 );
                                                 }
 
-                                                let merge_ok = {
-                                                    let mut sd = shell_state_doc.write().await;
-                                                    if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
-                                                    "shell-output-merge",
-                                                    || sd.merge(&mut fork),
-                                                ) {
-                                                    warn!("{}", e);
-                                                    sd.rebuild_from_save();
-                                                    false
-                                                } else {
-                                                    let _ =
-                                                        shell_state_changed_tx.send(());
-                                                    true
-                                                }
+                                                let merge_ok = match shell_state.merge(&mut fork) {
+                                                    Ok(()) => true,
+                                                    Err(e) => {
+                                                        warn!("[runtime-state] merge: {}", e);
+                                                        false
+                                                    }
                                                 };
 
                                                 if merge_ok {
@@ -2072,8 +2061,7 @@ impl KernelConnection for JupyterKernel {
         // ── Coalesced comm state writer ──────────────────────────────────
 
         let mut coalesce_rx = coalesce_rx;
-        let coalesce_state_doc = shared.state_doc.clone();
-        let coalesce_state_changed = shared.state_changed_tx.clone();
+        let coalesce_state = shared.state.clone();
         let coalesce_blob_store = shared.blob_store.clone();
         // Coalesced comm writes must carry the kernel actor ID so the
         // runtime agent's actor filter in `receive_sync_and_foreign_comms`
@@ -2116,16 +2104,19 @@ impl KernelConnection for JupyterKernel {
                             for delta in batch.values_mut() {
                                 *delta = blob_store_large_state_values(delta, &coalesce_blob_store).await;
                             }
-                            let mut sd = coalesce_state_doc.write().await;
-                            sd.fork_and_merge(|f| {
-                                f.set_actor(&coalesce_actor_id);
-                                for (comm_id, delta) in &batch {
-                                    if let Err(e) = f.merge_comm_state_delta(comm_id, delta) {
-                                        warn!("[runtime-state] {}", e);
+                            if let Err(e) = coalesce_state.with_doc(|sd| {
+                                sd.fork_and_merge(|f| {
+                                    f.set_actor(&coalesce_actor_id);
+                                    for (comm_id, delta) in &batch {
+                                        if let Err(e) = f.merge_comm_state_delta(comm_id, delta) {
+                                            warn!("[runtime-state] {}", e);
+                                        }
                                     }
-                                }
-                            });
-                            let _ = coalesce_state_changed.send(());
+                                });
+                                Ok(())
+                            }) {
+                                warn!("[runtime-state] {}", e);
+                            }
                         }
                     }
                 }

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use notebook_doc::presence::PresenceState;
-use notebook_doc::runtime_state::RuntimeStateDoc;
+use runtime_doc::RuntimeStateHandle;
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 use crate::blob_store::BlobStore;
@@ -50,10 +50,8 @@ pub struct KernelLaunchConfig {
 /// into the kernel at launch time. Grouped here so `launch()` takes two
 /// structs instead of a dozen parameters.
 pub struct KernelSharedRefs {
-    /// Per-notebook runtime state document (daemon-authoritative).
-    pub state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    /// Notification channel for RuntimeStateDoc changes.
-    pub state_changed_tx: broadcast::Sender<()>,
+    /// Per-notebook runtime state handle (daemon-authoritative).
+    pub state: RuntimeStateHandle,
     /// Content-addressed blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
     /// Broadcast channel for notebook events to connected peers.

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -9,16 +9,16 @@
 //! owning the connection.
 
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::sync::{broadcast, RwLock};
+use runtime_doc::RuntimeStateHandle;
+use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
 use crate::kernel_connection::KernelConnection;
 use crate::output_prep::{KernelStatus, QueuedCell};
 use crate::protocol::{NotebookBroadcast, QueueEntry};
-use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
+use notebook_doc::runtime_state::QueueEntry as DocQueueEntry;
 
 /// Maximum execution entries retained in the RuntimeStateDoc.
 ///
@@ -60,10 +60,8 @@ pub struct KernelState {
     status: KernelStatus,
 
     // ── Shared references (not owned, just held) ───────────────────────
-    /// Per-notebook runtime state document (daemon-authoritative).
-    state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    /// Notification channel for RuntimeStateDoc changes.
-    state_changed_tx: broadcast::Sender<()>,
+    /// Per-notebook runtime state handle (daemon-authoritative).
+    state: RuntimeStateHandle,
     /// Broadcast channel for execution events to connected peers.
     broadcast_tx: broadcast::Sender<NotebookBroadcast>,
 }
@@ -71,8 +69,7 @@ pub struct KernelState {
 impl KernelState {
     /// Create a new `KernelState` with initial status `Starting`.
     pub fn new(
-        state_doc: Arc<RwLock<RuntimeStateDoc>>,
-        state_changed_tx: broadcast::Sender<()>,
+        state: RuntimeStateHandle,
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     ) -> Self {
         Self {
@@ -80,8 +77,7 @@ impl KernelState {
             executing: None,
             execution_had_error: false,
             status: KernelStatus::Starting,
-            state_doc,
-            state_changed_tx,
+            state,
             broadcast_tx,
         }
     }
@@ -158,14 +154,13 @@ impl KernelState {
         {
             let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
             let doc_queued = to_doc_entries(&self.queued_entries());
-            let mut sd = self.state_doc.write().await;
-            if let Err(e) = sd.create_execution(&execution_id, &cell_id_ref) {
+            if let Err(e) = self.state.with_doc(|sd| {
+                sd.create_execution(&execution_id, &cell_id_ref)?;
+                sd.set_queue(doc_exec.as_ref(), &doc_queued)?;
+                Ok(())
+            }) {
                 warn!("[runtime-state] {}", e);
             }
-            if let Err(e) = sd.set_queue(doc_exec.as_ref(), &doc_queued) {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = self.state_changed_tx.send(());
         }
 
         // Try to process if nothing executing
@@ -207,27 +202,26 @@ impl KernelState {
             // Write to state doc
             {
                 let doc_queued = to_doc_entries(&self.queued_entries());
-                let mut sd = self.state_doc.write().await;
-                if let Err(e) = sd.set_execution_done(execution_id, success) {
+                if let Err(e) = self.state.with_doc(|sd| {
+                    sd.set_execution_done(execution_id, success)?;
+                    sd.set_queue(None, &doc_queued)?;
+                    match sd.trim_executions(MAX_EXECUTION_ENTRIES) {
+                        Ok(trimmed) if trimmed > 0 => {
+                            sd.rebuild_from_save();
+                            debug!(
+                                "[kernel-state] Compacted RuntimeStateDoc after trimming {} executions",
+                                trimmed
+                            );
+                        }
+                        Err(e) => {
+                            warn!("[runtime-state] {}", e);
+                        }
+                        _ => {}
+                    }
+                    Ok(())
+                }) {
                     warn!("[runtime-state] {}", e);
                 }
-                if let Err(e) = sd.set_queue(None, &doc_queued) {
-                    warn!("[runtime-state] {}", e);
-                }
-                match sd.trim_executions(MAX_EXECUTION_ENTRIES) {
-                    Ok(trimmed) if trimmed > 0 => {
-                        sd.rebuild_from_save();
-                        debug!(
-                            "[kernel-state] Compacted RuntimeStateDoc after trimming {} executions",
-                            trimmed
-                        );
-                    }
-                    Err(e) => {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    _ => {}
-                }
-                let _ = self.state_changed_tx.send(());
             }
 
             // Process next
@@ -350,14 +344,13 @@ impl KernelState {
         {
             let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
             let doc_queued = to_doc_entries(&self.queued_entries());
-            let mut sd = self.state_doc.write().await;
-            if let Err(e) = sd.set_execution_running(&cell.execution_id) {
+            if let Err(e) = self.state.with_doc(|sd| {
+                sd.set_execution_running(&cell.execution_id)?;
+                sd.set_queue(doc_exec.as_ref(), &doc_queued)?;
+                Ok(())
+            }) {
                 warn!("[runtime-state] {}", e);
             }
-            if let Err(e) = sd.set_queue(doc_exec.as_ref(), &doc_queued) {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = self.state_changed_tx.send(());
         }
 
         // Send execute request via the connection
@@ -412,14 +405,15 @@ impl KernelState {
     ///
     /// Used by callers that need to sync state doc after modifying the queue
     /// externally (e.g., interrupt handler).
-    pub async fn write_queue_to_state_doc(&self) {
+    pub fn write_queue_to_state_doc(&self) {
         let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
         let doc_queued = to_doc_entries(&self.queued_entries());
-        let mut sd = self.state_doc.write().await;
-        if let Err(e) = sd.set_queue(doc_exec.as_ref(), &doc_queued) {
+        if let Err(e) = self.state.with_doc(|sd| {
+            sd.set_queue(doc_exec.as_ref(), &doc_queued)?;
+            Ok(())
+        }) {
             warn!("[runtime-state] {}", e);
         }
-        let _ = self.state_changed_tx.send(());
     }
 }
 
@@ -511,22 +505,27 @@ mod tests {
         fn update_launched_uv_deps(&mut self, _: Vec<String>) {}
     }
 
-    /// Build a `KernelState` wired to the given `RuntimeStateDoc`.
-    fn test_state(
-        state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    ) -> (KernelState, broadcast::Receiver<NotebookBroadcast>) {
+    /// Build a `KernelState` wired to a fresh `RuntimeStateHandle`.
+    fn test_state() -> (
+        KernelState,
+        RuntimeStateHandle,
+        broadcast::Receiver<NotebookBroadcast>,
+    ) {
         let (state_changed_tx, _) = broadcast::channel(64);
+        let handle = RuntimeStateHandle::new(
+            notebook_doc::runtime_state::RuntimeStateDoc::new(),
+            state_changed_tx,
+        );
         let (broadcast_tx, broadcast_rx) = broadcast::channel(64);
-        let state = KernelState::new(state_doc, state_changed_tx, broadcast_tx);
-        (state, broadcast_rx)
+        let state = KernelState::new(handle.clone(), broadcast_tx);
+        (state, handle, broadcast_rx)
     }
 
     // ── kernel_died tests ────────────────────────────────────────────────
 
     #[tokio::test]
     async fn kernel_died_returns_interrupted_execution_and_cleared_queue() {
-        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
-        let (mut state, _rx) = test_state(sd.clone());
+        let (mut state, _handle, _rx) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 
@@ -562,8 +561,7 @@ mod tests {
 
     #[tokio::test]
     async fn kernel_died_idempotent_when_already_dead() {
-        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
-        let (mut state, _rx) = test_state(sd.clone());
+        let (mut state, _handle, _rx) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 
@@ -584,8 +582,7 @@ mod tests {
 
     #[tokio::test]
     async fn kernel_died_with_empty_queue() {
-        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
-        let (mut state, _rx) = test_state(sd.clone());
+        let (mut state, _handle, _rx) = test_state();
         state.set_idle();
 
         let (interrupted, cleared) = state.kernel_died();
@@ -597,8 +594,7 @@ mod tests {
 
     #[tokio::test]
     async fn reset_clears_executing_and_queue() {
-        let sd = Arc::new(RwLock::new(RuntimeStateDoc::new()));
-        let (mut state, _rx) = test_state(sd.clone());
+        let (mut state, _handle, _rx) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -509,8 +509,7 @@ where
         // Store outputs in RuntimeStateDoc with synthetic execution_ids.
         // Collect (cell_id, synthetic_eid) pairs for linking below.
         let mut cell_eids: HashMap<String, String> = HashMap::new();
-        {
-            let mut sd = room.state_doc.write().await;
+        let _ = room.state.with_doc(|sd| {
             for (_idx, cell, output_refs, _resolved_assets) in &batch {
                 if !output_refs.is_empty() {
                     let synthetic_eid = uuid::Uuid::new_v4().to_string();
@@ -520,7 +519,8 @@ where
                     cell_eids.insert(cell.id.clone(), synthetic_eid);
                 }
             }
-        }
+            Ok(())
+        });
 
         // Add batch to Automerge doc and generate sync message (inside lock)
         let encoded = {
@@ -564,9 +564,7 @@ where
 
         // Notify other peers in the room
         let _ = room.changed_tx.send(());
-        if !cell_eids.is_empty() {
-            let _ = room.state_changed_tx.send(());
-        }
+        // RuntimeStateDoc notification is automatic via with_doc heads check
 
         // Drain incoming sync replies to prevent deadlock
         drain_incoming_frames(reader, room, peer_state).await;
@@ -1111,18 +1109,19 @@ pub(crate) async fn apply_ipynb_changes(
 
         // Apply deferred state_doc writes
         if !deferred_executions.is_empty() {
-            let mut sd = room.state_doc.write().await;
-            for de in &deferred_executions {
-                let _ = sd.create_execution(&de.synthetic_eid, &de.cell_id);
-                if !de.outputs.is_empty() {
-                    let _ = sd.set_outputs(&de.synthetic_eid, de.outputs);
+            let _ = room.state.with_doc(|sd| {
+                for de in &deferred_executions {
+                    let _ = sd.create_execution(&de.synthetic_eid, &de.cell_id);
+                    if !de.outputs.is_empty() {
+                        let _ = sd.set_outputs(&de.synthetic_eid, de.outputs);
+                    }
+                    if let Some(ec) = de.execution_count {
+                        let _ = sd.set_execution_count(&de.synthetic_eid, ec);
+                    }
+                    let _ = sd.set_execution_done(&de.synthetic_eid, true);
                 }
-                if let Some(ec) = de.execution_count {
-                    let _ = sd.set_execution_count(&de.synthetic_eid, ec);
-                }
-                let _ = sd.set_execution_done(&de.synthetic_eid, true);
-            }
-            let _ = room.state_changed_tx.send(());
+                Ok(())
+            });
         }
 
         // Update saved_sources baseline so subsequent external edits are
@@ -1191,14 +1190,17 @@ pub(crate) async fn apply_ipynb_changes(
                 }
                 map
             };
-            let sd = room.state_doc.read().await;
-            let mut state_map = HashMap::new();
-            for (cell_id, eid) in &eid_map {
-                let outputs = sd.get_outputs(eid);
-                let ec = sd.get_execution(eid).and_then(|e| e.execution_count);
-                state_map.insert(cell_id.clone(), (outputs, ec));
-            }
-            state_map
+            room.state
+                .read(|sd| {
+                    let mut state_map = HashMap::new();
+                    for (cell_id, eid) in &eid_map {
+                        let outputs = sd.get_outputs(eid);
+                        let ec = sd.get_execution(eid).and_then(|e| e.execution_count);
+                        state_map.insert(cell_id.clone(), (outputs, ec));
+                    }
+                    state_map
+                })
+                .unwrap_or_default()
         } else {
             HashMap::new()
         };
@@ -1376,18 +1378,19 @@ pub(crate) async fn apply_ipynb_changes(
 
     // Apply deferred state_doc writes
     if !deferred_execs.is_empty() {
-        let mut sd = room.state_doc.write().await;
-        for de in &deferred_execs {
-            let _ = sd.create_execution(&de.synthetic_eid, &de.cell_id);
-            if !de.outputs.is_empty() {
-                let _ = sd.set_outputs(&de.synthetic_eid, de.outputs);
+        let _ = room.state.with_doc(|sd| {
+            for de in &deferred_execs {
+                let _ = sd.create_execution(&de.synthetic_eid, &de.cell_id);
+                if !de.outputs.is_empty() {
+                    let _ = sd.set_outputs(&de.synthetic_eid, de.outputs);
+                }
+                if let Some(ec) = de.execution_count {
+                    let _ = sd.set_execution_count(&de.synthetic_eid, ec);
+                }
+                let _ = sd.set_execution_done(&de.synthetic_eid, true);
             }
-            if let Some(ec) = de.execution_count {
-                let _ = sd.set_execution_count(&de.synthetic_eid, ec);
-            }
-            let _ = sd.set_execution_done(&de.synthetic_eid, true);
-        }
-        let _ = room.state_changed_tx.send(());
+            Ok(())
+        });
     }
 
     // Update saved_sources baseline after applying external changes so

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -664,8 +664,10 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
 
     // Check kernel is actually running via RuntimeStateDoc
     {
-        let sd = room.state_doc.read().await;
-        let status = sd.read_state().kernel.status;
+        let status = room
+            .state
+            .read(|sd| sd.read_state().kernel.status.clone())
+            .unwrap_or_default();
         if status != "idle" && status != "busy" {
             return;
         }
@@ -684,22 +686,17 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
         let in_sync = diff.is_none();
 
         // Write to RuntimeStateDoc
-        {
-            let mut sd = room.state_doc.write().await;
-            let result = match &diff {
-                Some(d) => sd.set_env_sync(
-                    false,
-                    &d.added,
-                    &d.removed,
-                    d.channels_changed,
-                    d.deno_changed,
-                ),
-                None => sd.set_env_sync(true, &[], &[], false, false),
-            };
-            if let Err(e) = result {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = room.state_changed_tx.send(());
+        if let Err(e) = room.state.with_doc(|sd| match &diff {
+            Some(d) => sd.set_env_sync(
+                false,
+                &d.added,
+                &d.removed,
+                d.channels_changed,
+                d.deno_changed,
+            ),
+            None => sd.set_env_sync(true, &[], &[], false, false),
+        }) {
+            warn!("[runtime-state] {}", e);
         }
 
         let _ = room
@@ -722,12 +719,11 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
             };
 
             if !added.is_empty() {
+                if let Err(e) = room
+                    .state
+                    .with_doc(|sd| sd.set_env_sync(false, &added, &[], false, false))
                 {
-                    let mut sd = room.state_doc.write().await;
-                    if let Err(e) = sd.set_env_sync(false, &added, &[], false, false) {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    let _ = room.state_changed_tx.send(());
+                    warn!("[runtime-state] {}", e);
                 }
                 let _ = room
                     .kernel_broadcast_tx
@@ -807,11 +803,12 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
         }
 
         // Update RuntimeStateDoc so the frontend banner reacts immediately
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_trust(status_str, needs_approval) {
+        if let Err(e) = room
+            .state
+            .with_doc(|sd| sd.set_trust(status_str, needs_approval))
+        {
             warn!("[runtime-state] {}", e);
         }
-        let _ = room.state_changed_tx.send(());
     }
 }
 
@@ -1763,17 +1760,14 @@ pub(crate) async fn reset_starting_state(
         None
     };
 
-    // Scope the state_doc write guard so it drops before acquiring
-    // runtime_agent_handle lock (deadlock prevention).
-    {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_kernel_status("not_started") {
-            warn!("[runtime-state] {}", e);
-        }
-        if let Err(e) = sd.set_prewarmed_packages(&[]) {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+    // state handle uses std::sync::Mutex - no lock ordering concern
+    // with runtime_agent_handle (tokio::sync::Mutex).
+    if let Err(e) = room.state.with_doc(|sd| {
+        sd.set_kernel_status("not_started")?;
+        sd.set_prewarmed_packages(&[])?;
+        Ok(())
+    }) {
+        warn!("[runtime-state] {}", e);
     }
 
     // Clear stale runtime agent handle so auto-launch can retry.
@@ -2099,13 +2093,11 @@ pub(crate) async fn auto_launch_kernel(
     }
 
     // Clear any stale comm state from a previous kernel (in case it crashed)
-
-    {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.clear_comms() {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+    if let Err(e) = room.state.with_doc(|sd| {
+        sd.clear_comms()?;
+        Ok(())
+    }) {
+        warn!("[runtime-state] {}", e);
     }
 
     // Detection priority:
@@ -2426,18 +2418,13 @@ pub(crate) async fn auto_launch_kernel(
                     "[notebook-sync] pixi.toml at {:?} does not declare ipykernel — cannot launch kernel",
                     detected.path
                 );
-                {
-                    let mut sd = room.state_doc.write().await;
-                    if let Err(e) = sd.set_kernel_status("error") {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    if let Err(e) = sd.set_kernel_info("python", "python", env_source.as_str()) {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    if let Err(e) = sd.set_starting_phase("missing_ipykernel") {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    let _ = room.state_changed_tx.send(());
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_kernel_status("error")?;
+                    sd.set_kernel_info("python", "python", env_source.as_str())?;
+                    sd.set_starting_phase("missing_ipykernel")?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
                 }
                 return;
             }
@@ -2445,12 +2432,11 @@ pub(crate) async fn auto_launch_kernel(
     }
 
     // Transition to "preparing_env" phase now that runtime/env has been resolved
+    if let Err(e) = room
+        .state
+        .with_doc(|sd| sd.set_starting_phase("preparing_env"))
     {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_starting_phase("preparing_env") {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+        warn!("[runtime-state] {}", e);
     }
 
     // For inline deps, prepare a cached environment with rich progress
@@ -2780,12 +2766,8 @@ pub(crate) async fn auto_launch_kernel(
     );
 
     // Transition to "launching" phase before starting the kernel process
-    {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_starting_phase("launching") {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+    if let Err(e) = room.state.with_doc(|sd| sd.set_starting_phase("launching")) {
+        warn!("[runtime-state] {}", e);
     }
 
     // (prewarmed_packages no longer needed — runtime agent handles its own launch config)
@@ -2836,12 +2818,11 @@ pub(crate) async fn auto_launch_kernel(
                 }
 
                 // Write "connecting" phase — fills the gap between spawn and connect
+                if let Err(e) = room
+                    .state
+                    .with_doc(|sd| sd.set_starting_phase("connecting"))
                 {
-                    let mut sd = room.state_doc.write().await;
-                    if let Err(e) = sd.set_starting_phase("connecting") {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    let _ = room.state_changed_tx.send(());
+                    warn!("[runtime-state] {}", e);
                 }
 
                 // Wait for THIS runtime agent to establish its sync connection
@@ -2899,27 +2880,15 @@ pub(crate) async fn auto_launch_kernel(
 
                         // Write kernel status + info to RuntimeStateDoc so
                         // frontends see "idle" via CRDT sync.
-                        {
-                            let mut sd = room.state_doc.write().await;
-                            if let Err(e) = sd.set_kernel_status("idle") {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            if let Err(e) = sd.set_kernel_info(kernel_type, kernel_type, &es) {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            if let Err(e) = sd.set_runtime_agent_id(&runtime_agent_id) {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            let _ = room.state_changed_tx.send(());
-                        }
-
-                        // Fresh kernel is in sync with its launched config
-                        {
-                            let mut sd = room.state_doc.write().await;
-                            if let Err(e) = sd.set_env_sync(true, &[], &[], false, false) {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            let _ = room.state_changed_tx.send(());
+                        if let Err(e) = room.state.with_doc(|sd| {
+                            sd.set_kernel_status("idle")?;
+                            sd.set_kernel_info(kernel_type, kernel_type, &es)?;
+                            sd.set_runtime_agent_id(&runtime_agent_id)?;
+                            // Fresh kernel is in sync with its launched config
+                            sd.set_env_sync(true, &[], &[], false, false)?;
+                            Ok(())
+                        }) {
+                            warn!("[runtime-state] {}", e);
                         }
 
                         info!(
@@ -3440,16 +3409,11 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
 
     // For project-backed environments, promote inline deps to the project file.
     // Project envs can't hot-install — they need a kernel restart.
-    let env_source = {
-        let sd = room.state_doc.read().await;
-        sd.read_state().kernel.env_source.clone()
-    };
-    if matches!(
-        notebook_protocol::connection::EnvSource::parse(&env_source),
-        notebook_protocol::connection::EnvSource::PixiToml
-            | notebook_protocol::connection::EnvSource::Pyproject
-            | notebook_protocol::connection::EnvSource::EnvYml
-    ) {
+    let env_source = room
+        .state
+        .read(|sd| sd.read_state().kernel.env_source.clone())
+        .unwrap_or_default();
+    if env_source == "pixi:toml" || env_source == "uv:pyproject" || env_source == "conda:env_yml" {
         match promote_inline_deps_to_project(room, &env_source, &launched).await {
             Ok(promoted) if promoted.is_empty() => {
                 return NotebookResponse::SyncEnvironmentComplete {
@@ -3625,12 +3589,11 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
             }
 
             // Mark as in sync in RuntimeStateDoc
+            if let Err(e) = room
+                .state
+                .with_doc(|sd| sd.set_env_sync(true, &[], &[], false, false))
             {
-                let mut sd = room.state_doc.write().await;
-                if let Err(e) = sd.set_env_sync(true, &[], &[], false, false) {
-                    warn!("[runtime-state] {}", e);
-                }
-                let _ = room.state_changed_tx.send(());
+                warn!("[runtime-state] {}", e);
             }
 
             let _ = room

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -81,16 +81,18 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     }
 
     // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
-    // Scope the state_doc write guard so it drops before the async send.
     // Uses bounded generation to compact if oversized (same 80 MiB threshold).
     let mut state_sync_state = automerge::sync::State::new();
-    let state_sync_msg = {
-        let mut sd = room.state_doc.write().await;
-        sd.generate_sync_message_bounded_encoded(
-            &mut state_sync_state,
-            STATE_SYNC_COMPACT_THRESHOLD,
-        )
-    };
+    let state_sync_msg = room
+        .state
+        .with_doc(|sd| {
+            Ok(sd.generate_sync_message_bounded_encoded(
+                &mut state_sync_state,
+                STATE_SYNC_COMPACT_THRESHOLD,
+            ))
+        })
+        .ok()
+        .flatten();
     if let Some(encoded) = state_sync_msg {
         if let Err(e) =
             send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await
@@ -128,7 +130,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
 
     // ── 5. Sync loop ─────────────────────────────────────────────────
     let mut changed_rx = room.changed_tx.subscribe();
-    let mut state_changed_rx = room.state_changed_tx.subscribe();
+    let mut state_changed_rx = room.state.subscribe();
     let mut pending_replies: std::collections::HashMap<
         String,
         tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
@@ -160,17 +162,18 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                             }
                             NotebookFrameType::RuntimeStateSync => {
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
-                                    let mut sd = room.state_doc.write().await;
-                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                        &mut state_sync_state, msg,
-                                    ) {
-                                        if changed {
-                                            let _ = room.state_changed_tx.send(());
+                                    let reply_encoded = room.state.with_doc(|sd| {
+                                        if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                            &mut state_sync_state, msg,
+                                        ) {
+                                            if changed {
+                                                // Notification handled by with_doc heads check
+                                            }
                                         }
-                                    }
-                                    // Send sync reply
-                                    if let Some(reply) = sd.generate_sync_message(&mut state_sync_state) {
-                                        let encoded = reply.encode();
+                                        Ok(sd.generate_sync_message(&mut state_sync_state)
+                                            .map(|reply| reply.encode()))
+                                    }).ok().flatten();
+                                    if let Some(encoded) = reply_encoded {
                                         let _ = send_typed_frame(
                                             &mut writer,
                                             NotebookFrameType::RuntimeStateSync,
@@ -226,9 +229,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             // RuntimeStateDoc changes → sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
-                let mut sd = room.state_doc.write().await;
-                if let Some(msg) = sd.generate_sync_message(&mut state_sync_state) {
-                    let encoded = msg.encode();
+                let encoded = room.state.with_doc(|sd| {
+                    Ok(sd.generate_sync_message(&mut state_sync_state)
+                        .map(|msg| msg.encode()))
+                }).ok().flatten();
+                if let Some(encoded) = encoded {
                     if let Err(e) = send_typed_frame(
                         &mut writer,
                         NotebookFrameType::RuntimeStateSync,
@@ -398,12 +403,11 @@ where
         };
         (status_str, needs_approval)
     };
+    if let Err(e) = room
+        .state
+        .with_doc(|sd| sd.set_trust(status_str, needs_approval))
     {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_trust(status_str, needs_approval) {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+        warn!("[runtime-state] {}", e);
     }
     // Re-verify trust from doc metadata — picks up trust signatures that were
     // written to the Automerge doc (e.g., from a previous approval or from
@@ -455,15 +459,12 @@ where
                 *auto_launch_at = Some(std::time::Instant::now());
             }
             // Write "starting" immediately so clients never see stale "not_started"
-            {
-                let mut sd = room.state_doc.write().await;
-                if let Err(e) = sd.set_kernel_status("starting") {
-                    warn!("[runtime-state] {}", e);
-                }
-                if let Err(e) = sd.set_starting_phase("resolving") {
-                    warn!("[runtime-state] {}", e);
-                }
-                let _ = room.state_changed_tx.send(());
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_kernel_status("starting")?;
+                sd.set_starting_phase("resolving")?;
+                Ok(())
+            }) {
+                warn!("[runtime-state] {}", e);
             }
             // Spawn auto-launch in background so we don't block sync
             let room_clone = room.clone();
@@ -484,15 +485,17 @@ where
                 },
                 move |_| {
                     let r = panic_room;
+                    // with_doc is sync (std::sync::Mutex), so no need for tokio::spawn
+                    // to acquire the lock. But spawn_supervised's panic handler runs
+                    // outside async context, so we still need spawn for the closure.
                     tokio::spawn(async move {
-                        let mut sd = r.state_doc.write().await;
-                        if let Err(e) = sd.set_kernel_status("error") {
+                        if let Err(e) = r.state.with_doc(|sd| {
+                            sd.set_kernel_status("error")?;
+                            sd.set_starting_phase("")?;
+                            Ok(())
+                        }) {
                             tracing::warn!("[runtime-state] {}", e);
                         }
-                        if let Err(e) = sd.set_starting_phase("") {
-                            tracing::warn!("[runtime-state] {}", e);
-                        }
-                        let _ = r.state_changed_tx.send(());
                     });
                 },
             );
@@ -508,14 +511,13 @@ where
                 "[notebook-sync] Kernel blocked on trust approval for {} (trust: {:?})",
                 notebook_id, trust_status
             );
-            let mut sd = room.state_doc.write().await;
-            if let Err(e) = sd.set_kernel_status("awaiting_trust") {
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_kernel_status("awaiting_trust")?;
+                sd.set_starting_phase("")?;
+                Ok(())
+            }) {
                 warn!("[runtime-state] {}", e);
             }
-            if let Err(e) = sd.set_starting_phase("") {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = room.state_changed_tx.send(());
         } else {
             info!(
                 "[notebook-sync] Auto-launch skipped for {} (trust: {:?}, has_kernel: {}, path_exists: {}, is_new: {}, created_at_path: {})",
@@ -1108,7 +1110,7 @@ where
     let mut changed_rx = room.changed_tx.subscribe();
     let mut kernel_broadcast_rx = room.kernel_broadcast_tx.subscribe();
     let mut presence_rx = room.presence_tx.subscribe();
-    let mut state_changed_rx = room.state_changed_tx.subscribe();
+    let mut state_changed_rx = room.state.subscribe();
 
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
     let mut pool_changed_rx = daemon.pool_doc_changed.subscribe();
@@ -1149,31 +1151,34 @@ where
     // Initial RuntimeStateDoc sync — encode inside lock, send outside.
     // Uses bounded generation to compact atomically if the message would exceed
     // the 100 MiB frame limit.
-    let initial_state_encoded = {
-        let mut state_doc = room.state_doc.write().await;
-        // Safety net: compact before initial sync if the doc grew too large.
-        // 80 MiB leaves headroom under the 100 MiB frame limit.
-        const COMPACTION_THRESHOLD: usize = 80 * 1024 * 1024;
-        if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
-            info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
-        }
-        match catch_automerge_panic("initial-state-sync", || {
-            state_doc.generate_sync_message_bounded_encoded(
-                &mut state_peer_state,
-                STATE_SYNC_COMPACT_THRESHOLD,
-            )
-        }) {
-            Ok(encoded) => encoded,
-            Err(e) => {
-                warn!("{}", e);
-                state_doc.rebuild_from_save();
-                state_peer_state = sync::State::new();
-                state_doc
-                    .generate_sync_message(&mut state_peer_state)
-                    .map(|msg| msg.encode())
+    let initial_state_encoded = room
+        .state
+        .with_doc(|state_doc| {
+            // Safety net: compact before initial sync if the doc grew too large.
+            // 80 MiB leaves headroom under the 100 MiB frame limit.
+            const COMPACTION_THRESHOLD: usize = 80 * 1024 * 1024;
+            if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
+                info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
             }
-        }
-    };
+            match catch_automerge_panic("initial-state-sync", || {
+                state_doc.generate_sync_message_bounded_encoded(
+                    &mut state_peer_state,
+                    STATE_SYNC_COMPACT_THRESHOLD,
+                )
+            }) {
+                Ok(encoded) => Ok(encoded),
+                Err(e) => {
+                    warn!("{}", e);
+                    state_doc.rebuild_from_save();
+                    state_peer_state = sync::State::new();
+                    Ok(state_doc
+                        .generate_sync_message(&mut state_peer_state)
+                        .map(|msg| msg.encode()))
+                }
+            }
+        })
+        .ok()
+        .flatten();
     if let Some(encoded) = initial_state_encoded {
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
     }
@@ -1581,9 +1586,8 @@ where
                                 // to comms/*/state/* for widget state updates).
                                 let message = sync::Message::decode(&frame.payload)
                                     .map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
-                                let reply_encoded = {
-                                    let mut state_doc = room.state_doc.write().await;
-
+                                // None signals "continue" (receive failed, skip reply)
+                                let reply_encoded: Option<Option<Vec<u8>>> = room.state.with_doc(|state_doc| {
                                     let recv_result = catch_automerge_panic("state-receive-sync", || {
                                         state_doc.receive_sync_message_with_changes(
                                             &mut state_peer_state,
@@ -1594,25 +1598,23 @@ where
                                         Ok(Ok(changed)) => changed,
                                         Ok(Err(e)) => {
                                             warn!("[notebook-sync] state receive_sync_message error: {}", e);
-                                            continue;
+                                            return Ok(None); // signal continue
                                         }
                                         Err(e) => {
                                             warn!("{}", e);
                                             state_doc.rebuild_from_save();
                                             state_peer_state = sync::State::new();
-                                            continue;
+                                            return Ok(None); // signal continue
                                         }
                                     };
 
-                                    // If client sent changes, notify all peers.
-                                    // Comm state forwarding to kernel: the runtime agent diffs
-                                    // comm state before/after each RuntimeStateSync and
-                                    // sends changed properties to the kernel via send_comm_update.
-                                    if had_changes {
-                                        let _ = room.state_changed_tx.send(());
-                                    }
+                                    // If client sent changes, notification is automatic
+                                    // via heads comparison in with_doc.
+                                    // But if had_changes is true from receive, heads
+                                    // will differ and with_doc notifies automatically.
+                                    let _ = had_changes; // heads-based notification handles this
 
-                                    match catch_automerge_panic("state-sync-reply", || {
+                                    let encoded = match catch_automerge_panic("state-sync-reply", || {
                                         state_doc
                                             .generate_sync_message(&mut state_peer_state)
                                             .map(|msg| msg.encode())
@@ -1626,7 +1628,12 @@ where
                                                 .generate_sync_message(&mut state_peer_state)
                                                 .map(|msg| msg.encode())
                                         }
-                                    }
+                                    };
+                                    Ok(Some(encoded))
+                                }).ok().flatten();
+                                let reply_encoded = match reply_encoded {
+                                    Some(encoded) => encoded,
+                                    None => continue, // receive failed
                                 };
                                 if let Some(encoded) = reply_encoded {
                                     connection::send_typed_frame(
@@ -1782,24 +1789,23 @@ where
             result = state_changed_rx.recv() => {
                 match result {
                     Ok(()) => {
-                        let encoded = {
-                            let mut state_doc = room.state_doc.write().await;
+                        let encoded = room.state.with_doc(|state_doc| {
                             match catch_automerge_panic("state-broadcast", || {
                                 state_doc
                                     .generate_sync_message(&mut state_peer_state)
                                     .map(|msg| msg.encode())
                             }) {
-                                Ok(encoded) => encoded,
+                                Ok(encoded) => Ok(encoded),
                                 Err(e) => {
                                     warn!("{}", e);
                                     state_doc.rebuild_from_save();
                                     state_peer_state = sync::State::new();
-                                    state_doc
+                                    Ok(state_doc
                                         .generate_sync_message(&mut state_peer_state)
-                                        .map(|msg| msg.encode())
+                                        .map(|msg| msg.encode()))
                                 }
                             }
-                        };
+                        }).ok().flatten();
                         if let Some(encoded) = encoded {
                             connection::send_typed_frame(
                                 writer,
@@ -1815,24 +1821,23 @@ where
                             peer_id, n
                         );
                         // Send a full sync to catch up
-                        let encoded = {
-                            let mut state_doc = room.state_doc.write().await;
+                        let encoded = room.state.with_doc(|state_doc| {
                             match catch_automerge_panic("state-broadcast-lagged", || {
                                 state_doc
                                     .generate_sync_message(&mut state_peer_state)
                                     .map(|msg| msg.encode())
                             }) {
-                                Ok(encoded) => encoded,
+                                Ok(encoded) => Ok(encoded),
                                 Err(e) => {
                                     warn!("{}", e);
                                     state_doc.rebuild_from_save();
                                     state_peer_state = sync::State::new();
-                                    state_doc
+                                    Ok(state_doc
                                         .generate_sync_message(&mut state_peer_state)
-                                        .map(|msg| msg.encode())
+                                        .map(|msg| msg.encode()))
                                 }
                             }
-                        };
+                        }).ok().flatten();
                         if let Some(encoded) = encoded {
                             connection::send_typed_frame(
                                 writer,

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -107,27 +107,28 @@ pub(crate) async fn save_notebook_to_disk(
     };
 
     // Read outputs and execution_count from RuntimeStateDoc keyed by execution_id.
-    // Lock ordering: doc first (released above), then state_doc.
     let (cell_outputs, cell_execution_counts): (
         HashMap<String, Vec<serde_json::Value>>,
         HashMap<String, Option<i64>>,
-    ) = {
-        let sd = room.state_doc.read().await;
-        let mut outputs_map = HashMap::new();
-        let mut ec_map = HashMap::new();
-        for (cell_id, eid) in &cell_execution_ids {
-            if let Some(eid) = eid.as_ref() {
-                let outputs = sd.get_outputs(eid);
-                if !outputs.is_empty() {
-                    outputs_map.insert(cell_id.clone(), outputs);
-                }
-                if let Some(exec) = sd.get_execution(eid) {
-                    ec_map.insert(cell_id.clone(), exec.execution_count);
+    ) = room
+        .state
+        .read(|sd| {
+            let mut outputs_map = HashMap::new();
+            let mut ec_map = HashMap::new();
+            for (cell_id, eid) in &cell_execution_ids {
+                if let Some(eid) = eid.as_ref() {
+                    let outputs = sd.get_outputs(eid);
+                    if !outputs.is_empty() {
+                        outputs_map.insert(cell_id.clone(), outputs);
+                    }
+                    if let Some(exec) = sd.get_execution(eid) {
+                        ec_map.insert(cell_id.clone(), exec.execution_count);
+                    }
                 }
             }
-        }
-        (outputs_map, ec_map)
-    };
+            (outputs_map, ec_map)
+        })
+        .unwrap_or_default();
 
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
 

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -83,12 +83,10 @@ pub struct NotebookRoom {
     /// Wrapped in Mutex to allow setting after Arc creation.
     /// Sent when the room is evicted to stop the watcher.
     pub(crate) watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
-    /// Per-notebook RuntimeStateDoc — daemon-authoritative ephemeral state
+    /// Per-notebook RuntimeStateDoc handle — daemon-authoritative ephemeral state
     /// (kernel status, queue, env sync). Clients sync read-only.
-    pub state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    /// Notification channel for RuntimeStateDoc changes.
-    /// Peer sync loops subscribe to push RuntimeStateSync frames.
-    pub state_changed_tx: broadcast::Sender<()>,
+    /// Uses `std::sync::Mutex` internally (no `.await` needed).
+    pub state: runtime_doc::RuntimeStateHandle,
     /// Handle to the runtime agent subprocess that owns this notebook's kernel.
     /// Set by `LaunchKernel` or `auto_launch_kernel` when spawned.
     pub runtime_agent_handle: Arc<Mutex<Option<crate::runtime_agent_handle::RuntimeAgentHandle>>>,
@@ -220,9 +218,8 @@ impl NotebookRoom {
 
         let (presence_tx, _) = broadcast::channel(64);
 
-        let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
-
         let (state_changed_tx, _) = broadcast::channel(16);
+        let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
 
         Self {
             id,
@@ -249,8 +246,7 @@ impl NotebookRoom {
             last_save_heads: Arc::new(RwLock::new(Vec::new())),
             last_save_sources: Arc::new(RwLock::new(HashMap::new())),
             watcher_shutdown_tx: Mutex::new(None),
-            state_doc,
-            state_changed_tx,
+            state,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
@@ -317,8 +313,8 @@ impl NotebookRoom {
             },
             Some(p) => verify_trust_from_file(p),
         };
-        let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
         let (state_changed_tx, _) = broadcast::channel(16);
+        let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
@@ -344,8 +340,7 @@ impl NotebookRoom {
             last_save_heads: Arc::new(RwLock::new(Vec::new())),
             last_save_sources: Arc::new(RwLock::new(HashMap::new())),
             watcher_shutdown_tx: Mutex::new(None),
-            state_doc,
-            state_changed_tx,
+            state,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
@@ -375,14 +370,20 @@ impl NotebookRoom {
             ra.as_ref().is_some_and(|a| a.is_alive())
         };
         if is_alive {
-            let sd = self.state_doc.read().await;
-            let state = sd.read_state();
-            if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
-                return Some((
-                    state.kernel.name.clone(),
-                    state.kernel.env_source.clone(),
-                    state.kernel.status.clone(),
-                ));
+            let info = self.state.read(|sd| {
+                let state = sd.read_state();
+                if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
+                    Some((
+                        state.kernel.name.clone(),
+                        state.kernel.env_source.clone(),
+                        state.kernel.status.clone(),
+                    ))
+                } else {
+                    None
+                }
+            });
+            if let Ok(Some(info)) = info {
+                return Some(info);
             }
         }
         None

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -641,8 +641,8 @@ fn test_room_with_path(
 
     let (presence_tx, _) = broadcast::channel(64);
 
-    let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
     let (state_changed_tx, _) = broadcast::channel(16);
+    let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
     let room = NotebookRoom {
         id: uuid::Uuid::new_v4(),
         doc: Arc::new(RwLock::new(doc)),
@@ -677,8 +677,7 @@ fn test_room_with_path(
         last_save_heads: Arc::new(RwLock::new(Vec::new())),
         last_save_sources: Arc::new(RwLock::new(HashMap::new())),
         watcher_shutdown_tx: Mutex::new(None),
-        state_doc,
-        state_changed_tx,
+        state,
         runtime_agent_handle: Arc::new(Mutex::new(None)),
         runtime_agent_env_path: Arc::new(RwLock::new(None)),
         runtime_agent_launched_config: Arc::new(RwLock::new(None)),
@@ -839,15 +838,17 @@ async fn test_save_notebook_to_disk_with_outputs() {
         doc.update_source("cell1", "print('hello')").unwrap();
         doc.set_execution_id("cell1", Some(eid)).unwrap();
     }
-    {
-        let mut sd = room.state_doc.write().await;
-        let output: serde_json::Value =
-            serde_json::json!({"output_type": "stream", "name": "stdout", "text": ["hello\n"]});
-        sd.create_execution(eid, "cell1").unwrap();
-        sd.set_execution_count(eid, 1).unwrap();
-        sd.set_outputs(eid, &[output]).unwrap();
-        sd.set_execution_done(eid, true).unwrap();
-    }
+    room.state
+        .with_doc(|sd| {
+            let output: serde_json::Value =
+                serde_json::json!({"output_type": "stream", "name": "stdout", "text": ["hello\n"]});
+            sd.create_execution(eid, "cell1")?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_outputs(eid, &[output])?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
 
     save_notebook_to_disk(&room, None).await.unwrap();
 
@@ -1192,9 +1193,15 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
     let eid = doc.get_execution_id("cell-1");
     drop(doc);
     assert!(eid.is_some(), "Should have execution_id set");
-    let sd = room.state_doc.read().await;
-    let exec = sd.get_execution(eid.as_ref().unwrap());
-    assert_eq!(exec.unwrap().execution_count, Some(42));
+    let ec = room
+        .state
+        .read(|sd| {
+            sd.get_execution(eid.as_ref().unwrap())
+                .unwrap()
+                .execution_count
+        })
+        .unwrap();
+    assert_eq!(ec, Some(42));
 }
 
 #[tokio::test]
@@ -1209,12 +1216,14 @@ async fn test_apply_ipynb_changes_preserves_execution_count_when_kernel_running(
         doc.add_cell(0, "cell-1", "code").unwrap();
         doc.set_execution_id("cell-1", Some(eid)).unwrap();
     }
-    {
-        let mut sd = room.state_doc.write().await;
-        sd.create_execution(eid, "cell-1").unwrap();
-        sd.set_execution_count(eid, 10).unwrap();
-        sd.set_execution_done(eid, true).unwrap();
-    }
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution(eid, "cell-1")?;
+            sd.set_execution_count(eid, 10)?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
 
     // Apply external changes while kernel is "running"
     let external_cells = vec![CellSnapshot {
@@ -1244,8 +1253,7 @@ async fn test_apply_ipynb_changes_preserves_execution_count_when_kernel_running(
     // Source should be updated
     assert_eq!(cells[0].source, "new source");
     // execution_count should be preserved in RuntimeStateDoc (kernel running)
-    let sd = room.state_doc.read().await;
-    let exec = sd.get_execution(eid);
+    let exec = room.state.read(|sd| sd.get_execution(eid)).unwrap();
     assert_eq!(exec.unwrap().execution_count, Some(10));
 }
 
@@ -1315,11 +1323,9 @@ async fn test_apply_ipynb_changes_new_cell_with_outputs_while_kernel_running() {
         doc.get_execution_id("new-cell")
             .expect("new-cell should have execution_id")
     };
-    let sd = room.state_doc.read().await;
-    let exec = sd.get_execution(&eid);
+    let exec = room.state.read(|sd| sd.get_execution(&eid)).unwrap();
     assert_eq!(exec.unwrap().execution_count, Some(42));
-    let outputs = sd.get_outputs(&eid);
-    drop(sd);
+    let outputs = room.state.read(|sd| sd.get_outputs(&eid)).unwrap();
     assert_eq!(outputs.len(), 1);
     let manifest = &outputs[0];
     assert!(
@@ -2992,18 +2998,15 @@ async fn test_check_and_broadcast_sync_state_no_kernel() {
     }
 
     // Pre-set RuntimeStateDoc env to dirty so we can verify it's NOT changed
-    {
-        let mut sd = room.state_doc.write().await;
-        sd.set_env_sync(false, &["numpy".to_string()], &[], false, false)
-            .unwrap();
-    }
+    room.state
+        .with_doc(|sd| sd.set_env_sync(false, &["numpy".to_string()], &[], false, false))
+        .unwrap();
 
     // No kernel in the room — should be a no-op
     check_and_broadcast_sync_state(&room).await;
 
     // Verify env state was NOT touched (still dirty from pre-set)
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert!(
         !state.env.in_sync,
         "env should remain dirty when no kernel is present"
@@ -3044,17 +3047,19 @@ async fn test_check_and_broadcast_sync_state_captured_uv_prewarmed_in_sync() {
 
     // Kernel is idle (otherwise the function returns early).
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_kernel_status("idle").unwrap();
-        // Pre-set to dirty so we can verify it flips to in_sync.
-        sd.set_env_sync(false, &["pandas".to_string()], &[], false, false)
+        room.state
+            .with_doc(|sd| {
+                sd.set_kernel_status("idle")?;
+                // Pre-set to dirty so we can verify it flips to in_sync.
+                sd.set_env_sync(false, &["pandas".to_string()], &[], false, false)?;
+                Ok(())
+            })
             .unwrap();
     }
 
     check_and_broadcast_sync_state(&room).await;
 
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert!(
         state.env.in_sync,
         "captured-prewarmed launch with matching metadata must be in_sync"
@@ -3095,14 +3100,14 @@ async fn test_check_and_broadcast_sync_state_captured_uv_prewarmed_reports_addit
     }
 
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_kernel_status("idle").unwrap();
+        room.state
+            .with_doc(|sd| sd.set_kernel_status("idle"))
+            .unwrap();
     }
 
     check_and_broadcast_sync_state(&room).await;
 
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert!(
         !state.env.in_sync,
         "added dep post-capture must surface as drift"
@@ -3119,8 +3124,8 @@ async fn test_check_and_broadcast_sync_state_no_metadata() {
 
     // Pre-set RuntimeStateDoc env to dirty
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_env_sync(false, &["pandas".to_string()], &[], false, false)
+        room.state
+            .with_doc(|sd| sd.set_env_sync(false, &["pandas".to_string()], &[], false, false))
             .unwrap();
     }
 
@@ -3128,8 +3133,7 @@ async fn test_check_and_broadcast_sync_state_no_metadata() {
     check_and_broadcast_sync_state(&room).await;
 
     // Verify env state was NOT touched
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert!(
         !state.env.in_sync,
         "env should remain dirty when no metadata is present"
@@ -3248,8 +3252,9 @@ async fn test_check_and_update_trust_state_no_deps() {
     // Align RuntimeStateDoc with the room's initial Untrusted state so we
     // can verify the function actually writes the new value.
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_trust("untrusted", true).unwrap();
+        room.state
+            .with_doc(|sd| sd.set_trust("untrusted", true))
+            .unwrap();
     }
 
     // Write an empty metadata snapshot (no dependencies).
@@ -3267,8 +3272,7 @@ async fn test_check_and_update_trust_state_no_deps() {
     drop(ts);
 
     // RuntimeStateDoc should reflect "no_dependencies" with needs_approval=false.
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert_eq!(state.trust.status, "no_dependencies");
     assert!(!state.trust.needs_approval);
 }
@@ -3285,8 +3289,9 @@ async fn test_check_and_update_trust_state_approval_updates_room() {
 
     // Align RuntimeStateDoc with the room's initial Untrusted state.
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_trust("untrusted", true).unwrap();
+        room.state
+            .with_doc(|sd| sd.set_trust("untrusted", true))
+            .unwrap();
     }
 
     // Build a snapshot with UV deps and a valid trust signature.
@@ -3311,8 +3316,7 @@ async fn test_check_and_update_trust_state_approval_updates_room() {
     drop(ts);
 
     // RuntimeStateDoc should have "trusted" with needs_approval=false.
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
     assert_eq!(state.trust.status, "trusted");
     assert!(!state.trust.needs_approval);
 
@@ -3328,8 +3332,9 @@ async fn test_check_and_update_trust_state_idempotent() {
     // first transition to NoDependencies actually mutates the doc and fires
     // a notification.
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_trust("untrusted", true).unwrap();
+        room.state
+            .with_doc(|sd| sd.set_trust("untrusted", true))
+            .unwrap();
     }
 
     // Write an empty metadata snapshot to trigger Untrusted → NoDependencies.
@@ -3340,7 +3345,7 @@ async fn test_check_and_update_trust_state_idempotent() {
     }
 
     // Subscribe before either call so we capture all notifications.
-    let mut rx = room.state_changed_tx.subscribe();
+    let mut rx = room.state.subscribe();
 
     // First call: state changes from Untrusted → NoDependencies → notification sent.
     check_and_update_trust_state(&room).await;
@@ -3398,8 +3403,9 @@ async fn test_check_and_update_trust_state_external_dep_add_invalidates() {
         *ts = verify_trust_from_snapshot(&signed);
     }
     {
-        let mut sd = room.state_doc.write().await;
-        sd.set_trust("trusted", false).unwrap();
+        room.state
+            .with_doc(|sd| sd.set_trust("trusted", false))
+            .unwrap();
     }
 
     // Sanity check: starting state is Trusted.
@@ -3419,7 +3425,7 @@ async fn test_check_and_update_trust_state_external_dep_add_invalidates() {
     }
 
     // Subscribe before the re-verification so we can observe the flip.
-    let mut rx = room.state_changed_tx.subscribe();
+    let mut rx = room.state.subscribe();
 
     check_and_update_trust_state(&room).await;
 
@@ -3436,8 +3442,7 @@ async fn test_check_and_update_trust_state_external_dep_add_invalidates() {
 
     // RuntimeStateDoc should reflect the flip for the frontend banner.
     {
-        let sd = room.state_doc.read().await;
-        let state = sd.read_state();
+        let state = room.state.read(|sd| sd.read_state()).unwrap();
         assert_eq!(state.trust.status, "signature_invalid");
         assert!(state.trust.needs_approval);
     }
@@ -3525,20 +3530,21 @@ async fn test_reset_starting_state_guard() {
     }
 
     // Set kernel status to "starting" (simulates in-progress launch)
-    {
-        let mut sd = room.state_doc.write().await;
-        sd.set_kernel_status("starting").unwrap();
-    }
+    room.state
+        .with_doc(|sd| sd.set_kernel_status("starting"))
+        .unwrap();
 
     // Call reset with expected="agent-A" (stale handler) — should skip
     reset_starting_state(&room, Some("agent-A")).await;
 
     // Verify: kernel_status should still be "starting" (NOT reset)
     {
-        let sd = room.state_doc.read().await;
+        let status = room
+            .state
+            .read(|sd| sd.read_state().kernel.status.clone())
+            .unwrap();
         assert_eq!(
-            sd.read_state().kernel.status,
-            "starting",
+            status, "starting",
             "Guard should have prevented reset (agent-A != agent-B)"
         );
     }
@@ -3554,10 +3560,12 @@ async fn test_reset_starting_state_guard() {
 
     // Verify: kernel_status should be "not_started"
     {
-        let sd = room.state_doc.read().await;
+        let status = room
+            .state
+            .read(|sd| sd.read_state().kernel.status.clone())
+            .unwrap();
         assert_eq!(
-            sd.read_state().kernel.status,
-            "not_started",
+            status, "not_started",
             "Reset should proceed when expected matches current"
         );
     }
@@ -3572,16 +3580,17 @@ async fn test_reset_starting_state_guard() {
     }
 
     // Call with None (pre-spawn) — should always reset
-    {
-        let mut sd = room.state_doc.write().await;
-        sd.set_kernel_status("starting").unwrap();
-    }
+    room.state
+        .with_doc(|sd| sd.set_kernel_status("starting"))
+        .unwrap();
     reset_starting_state(&room, None).await;
     {
-        let sd = room.state_doc.read().await;
+        let status = room
+            .state
+            .read(|sd| sd.read_state().kernel.status.clone())
+            .unwrap();
         assert_eq!(
-            sd.read_state().kernel.status,
-            "not_started",
+            status, "not_started",
             "None (pre-spawn) should always reset"
         );
     }

--- a/crates/runtimed/src/requests/clear_outputs.rs
+++ b/crates/runtimed/src/requests/clear_outputs.rs
@@ -23,9 +23,12 @@ pub(crate) async fn handle(room: &NotebookRoom, cell_id: String) -> NotebookResp
 
     // Optionally clean up the old execution's outputs in RuntimeStateDoc
     if let Some(ref eid) = old_eid {
-        let mut sd = room.state_doc.write().await;
-        let _ = sd.clear_execution_outputs(eid);
-        let _ = room.state_changed_tx.send(());
+        if let Err(e) = room.state.with_doc(|sd| {
+            sd.clear_execution_outputs(eid)?;
+            Ok(())
+        }) {
+            tracing::warn!("[runtime-state] {}", e);
+        }
     }
 
     // Send to debounced persistence task

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -55,8 +55,10 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
             // Check if kernel is shut down — return NoKernel instead
             // of silently queuing into a dead kernel
             {
-                let sd = room.state_doc.read().await;
-                let status = sd.read_state().kernel.status;
+                let status = room
+                    .state
+                    .read(|sd| sd.read_state().kernel.status.clone())
+                    .unwrap_or_default();
                 if status == "shutdown" || status == "error" {
                     return NotebookResponse::NoKernel {};
                 }
@@ -73,14 +75,19 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
                     doc.get_execution_id(&cell_id)
                 };
                 if let Some(eid) = eid {
-                    let sd = room.state_doc.read().await;
-                    if let Some(exec) = sd.get_execution(&eid) {
-                        if exec.status == "queued" || exec.status == "running" {
-                            return NotebookResponse::CellQueued {
-                                cell_id,
-                                execution_id: eid,
-                            };
-                        }
+                    let is_active = room
+                        .state
+                        .read(|sd| {
+                            sd.get_execution(&eid).is_some_and(|exec| {
+                                exec.status == "queued" || exec.status == "running"
+                            })
+                        })
+                        .unwrap_or(false);
+                    if is_active {
+                        return NotebookResponse::CellQueued {
+                            cell_id,
+                            execution_id: eid,
+                        };
                     }
                 }
             }
@@ -93,20 +100,16 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
             // Write execution entry with source to RuntimeStateDoc first
             // so that NotebookDoc's cell→execution_id pointer never
             // dangles. If this fails we bail before stamping the cell.
-            {
-                let mut sd = room.state_doc.write().await;
-                if let Err(e) =
-                    sd.create_execution_with_source(&execution_id, &cell_id, &source, seq)
-                {
-                    warn!(
-                        "[notebook-sync] Failed to create_execution_with_source for {}: {}",
-                        execution_id, e
-                    );
-                    return NotebookResponse::Error {
-                        error: format!("failed to queue execution: {e}"),
-                    };
-                }
-                let _ = room.state_changed_tx.send(());
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.create_execution_with_source(&execution_id, &cell_id, &source, seq)
+            }) {
+                warn!(
+                    "[notebook-sync] Failed to create_execution_with_source for {}: {}",
+                    execution_id, e
+                );
+                return NotebookResponse::Error {
+                    error: format!("failed to queue execution: {e}"),
+                };
             }
 
             // Stamp execution_id on the cell in NotebookDoc

--- a/crates/runtimed/src/requests/get_kernel_info.rs
+++ b/crates/runtimed/src/requests/get_kernel_info.rs
@@ -5,27 +5,27 @@ use crate::protocol::NotebookResponse;
 
 pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
     // Read from RuntimeStateDoc (source of truth for runtime agent)
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
-    if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
-        NotebookResponse::KernelInfo {
-            kernel_type: if state.kernel.name.is_empty() {
-                None
-            } else {
-                Some(state.kernel.name)
-            },
-            env_source: if state.kernel.env_source.is_empty() {
-                None
-            } else {
-                Some(state.kernel.env_source)
-            },
-            status: state.kernel.status,
+    let state = room.state.read(|sd| sd.read_state());
+    match state {
+        Ok(state) if state.kernel.status != "not_started" && !state.kernel.status.is_empty() => {
+            NotebookResponse::KernelInfo {
+                kernel_type: if state.kernel.name.is_empty() {
+                    None
+                } else {
+                    Some(state.kernel.name)
+                },
+                env_source: if state.kernel.env_source.is_empty() {
+                    None
+                } else {
+                    Some(state.kernel.env_source)
+                },
+                status: state.kernel.status,
+            }
         }
-    } else {
-        NotebookResponse::KernelInfo {
+        _ => NotebookResponse::KernelInfo {
             kernel_type: None,
             env_source: None,
             status: "not_started".to_string(),
-        }
+        },
     }
 }

--- a/crates/runtimed/src/requests/get_queue_state.rs
+++ b/crates/runtimed/src/requests/get_queue_state.rs
@@ -5,8 +5,7 @@ use crate::protocol::{NotebookResponse, QueueEntry};
 
 pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
     // Read from RuntimeStateDoc (source of truth for runtime agent)
-    let sd = room.state_doc.read().await;
-    let state = sd.read_state();
+    let state = room.state.read(|sd| sd.read_state()).unwrap_or_default();
     NotebookResponse::QueueState {
         executing: state.queue.executing.map(|e| QueueEntry {
             cell_id: e.cell_id,

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -53,29 +53,25 @@ pub(crate) async fn handle(
     //
     // Scope the write guard so it drops before any async work
     // (deadlock prevention: no lock held across `.await`).
-    let kernel_status = {
-        let mut sd = room.state_doc.write().await;
-        let status = sd.read_state().kernel.status.clone();
-        if status != "idle" && status != "busy" && status != "starting" {
-            // not_started, error, shutdown — atomically claim the
-            // launch by writing "starting" while we hold the write lock.
-            // This prevents a concurrent LaunchKernel from also proceeding.
-            if let Err(e) = sd.clear_comms() {
-                warn!("[runtime-state] {}", e);
+    let kernel_status = room
+        .state
+        .with_doc(|sd| {
+            let status = sd.read_state().kernel.status.clone();
+            if status != "idle" && status != "busy" && status != "starting" {
+                // not_started, error, shutdown — atomically claim the
+                // launch by writing "starting" while we hold the mutex.
+                // This prevents a concurrent LaunchKernel from also proceeding.
+                sd.clear_comms().ok();
+                sd.set_trust("trusted", false).ok();
+                sd.set_kernel_status("starting").ok();
+                sd.set_starting_phase("resolving").ok();
             }
-            if let Err(e) = sd.set_trust("trusted", false) {
-                warn!("[runtime-state] {}", e);
-            }
-            if let Err(e) = sd.set_kernel_status("starting") {
-                warn!("[runtime-state] {}", e);
-            }
-            if let Err(e) = sd.set_starting_phase("resolving") {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = room.state_changed_tx.send(());
-        }
-        status
-    };
+            Ok(status)
+        })
+        .unwrap_or_else(|e| {
+            warn!("[runtime-state] {}", e);
+            "not_started".to_string()
+        });
     match kernel_status.as_str() {
         "idle" | "busy" => {
             // Agent already has a running kernel — check for restart path below
@@ -85,13 +81,9 @@ pub(crate) async fn handle(
             let wait_result = tokio::time::timeout(std::time::Duration::from_secs(60), async {
                 loop {
                     let s = room
-                        .state_doc
-                        .read()
-                        .await
-                        .read_state()
-                        .kernel
-                        .status
-                        .clone();
+                        .state
+                        .read(|sd| sd.read_state().kernel.status.clone())
+                        .unwrap_or_default();
                     if s == "idle"
                         || s == "busy"
                         || s == "error"
@@ -467,12 +459,11 @@ pub(crate) async fn handle(
     }
 
     // Transition to "preparing_env" phase
+    if let Err(e) = room
+        .state
+        .with_doc(|sd| sd.set_starting_phase("preparing_env"))
     {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_starting_phase("preparing_env") {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+        warn!("[runtime-state] {}", e);
     }
 
     // Deno kernels don't need pooled environments
@@ -1085,12 +1076,8 @@ pub(crate) async fn handle(
     );
 
     // Transition to "launching" phase before starting the kernel process
-    {
-        let mut sd = room.state_doc.write().await;
-        if let Err(e) = sd.set_starting_phase("launching") {
-            warn!("[runtime-state] {}", e);
-        }
-        let _ = room.state_changed_tx.send(());
+    if let Err(e) = room.state.with_doc(|sd| sd.set_starting_phase("launching")) {
+        warn!("[runtime-state] {}", e);
     }
 
     // If runtime agent is already connected, restart kernel in-place
@@ -1119,23 +1106,14 @@ pub(crate) async fn handle(
                     }
 
                     publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es).await;
-                    {
-                        let mut sd = room.state_doc.write().await;
-                        if let Err(e) = sd.set_kernel_status("idle") {
-                            warn!("[runtime-state] {}", e);
-                        }
-                        if let Err(e) =
-                            sd.set_kernel_info(&resolved_kernel_type, &resolved_kernel_type, &es)
-                        {
-                            warn!("[runtime-state] {}", e);
-                        }
-                        if let Err(e) =
-                            sd.set_prewarmed_packages(&launched_config.prewarmed_packages)
-                        {
-                            warn!("[runtime-state] {}", e);
-                        }
+                    if let Err(e) = room.state.with_doc(|sd| {
+                        sd.set_kernel_status("idle")?;
+                        sd.set_kernel_info(&resolved_kernel_type, &resolved_kernel_type, &es)?;
+                        sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
                         // runtime_agent_id doesn't change on restart — same runtime agent
-                        let _ = room.state_changed_tx.send(());
+                        Ok(())
+                    }) {
+                        warn!("[runtime-state] {}", e);
                     }
 
                     // Compute env sync state against the freshly
@@ -1213,12 +1191,11 @@ pub(crate) async fn handle(
                 }
 
                 // Write "connecting" phase — fills the gap between spawn and connect
+                if let Err(e) = room
+                    .state
+                    .with_doc(|sd| sd.set_starting_phase("connecting"))
                 {
-                    let mut sd = room.state_doc.write().await;
-                    if let Err(e) = sd.set_starting_phase("connecting") {
-                        warn!("[runtime-state] {}", e);
-                    }
-                    let _ = room.state_changed_tx.send(());
+                    warn!("[runtime-state] {}", e);
                 }
 
                 // Wait for THIS runtime agent to connect back via socket
@@ -1272,31 +1249,24 @@ pub(crate) async fn handle(
                         // Write kernel status + info + prewarmed packages
                         // to RuntimeStateDoc
                         {
-                            // Read agent ID before taking the write lock to
-                            // avoid holding state_doc across an .await.
+                            // Read agent ID before the sync mutex to
+                            // avoid holding two locks.
                             let agent_id = room.current_runtime_agent_id.read().await.clone();
-                            let mut sd = room.state_doc.write().await;
-                            if let Err(e) = sd.set_kernel_status("idle") {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            if let Err(e) = sd.set_kernel_info(
-                                &resolved_kernel_type,
-                                &resolved_kernel_type,
-                                &es,
-                            ) {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            if let Err(e) =
-                                sd.set_prewarmed_packages(&launched_config.prewarmed_packages)
-                            {
-                                warn!("[runtime-state] {}", e);
-                            }
-                            if let Some(ref aid) = agent_id {
-                                if let Err(e) = sd.set_runtime_agent_id(aid) {
-                                    warn!("[runtime-state] {}", e);
+                            if let Err(e) = room.state.with_doc(|sd| {
+                                sd.set_kernel_status("idle")?;
+                                sd.set_kernel_info(
+                                    &resolved_kernel_type,
+                                    &resolved_kernel_type,
+                                    &es,
+                                )?;
+                                sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
+                                if let Some(ref aid) = agent_id {
+                                    sd.set_runtime_agent_id(aid)?;
                                 }
+                                Ok(())
+                            }) {
+                                warn!("[runtime-state] {}", e);
                             }
-                            let _ = room.state_changed_tx.send(());
                         }
 
                         // Compute env sync state against the freshly

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -12,8 +12,10 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         if has_runtime_agent {
             // Check if kernel is shut down
             {
-                let sd = room.state_doc.read().await;
-                let status = sd.read_state().kernel.status;
+                let status = room
+                    .state
+                    .read(|sd| sd.read_state().kernel.status.clone())
+                    .unwrap_or_default();
                 if status == "shutdown" || status == "error" {
                     return NotebookResponse::NoKernel {};
                 }
@@ -51,22 +53,19 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
             // Write RuntimeStateDoc entries first; on failure bail
             // before stamping NotebookDoc so cell→execution_id pointers
             // cannot dangle. Any single failure aborts the whole batch.
-            {
-                let mut sd = room.state_doc.write().await;
+            if let Err(e) = room.state.with_doc(|sd| {
                 for (execution_id, cell_id, source, seq) in &entries {
-                    if let Err(e) =
-                        sd.create_execution_with_source(execution_id, cell_id, source, *seq)
-                    {
-                        warn!(
-                            "[notebook-sync] Failed to create_execution_with_source for {}: {}",
-                            execution_id, e
-                        );
-                        return NotebookResponse::Error {
-                            error: format!("failed to queue execution: {e}"),
-                        };
-                    }
+                    sd.create_execution_with_source(execution_id, cell_id, source, *seq)?;
                 }
-                let _ = room.state_changed_tx.send(());
+                Ok(())
+            }) {
+                warn!(
+                    "[notebook-sync] Failed to create_execution_with_source: {}",
+                    e
+                );
+                return NotebookResponse::Error {
+                    error: format!("failed to queue execution: {e}"),
+                };
             }
             {
                 let mut doc = room.doc.write().await;

--- a/crates/runtimed/src/requests/shutdown_kernel.rs
+++ b/crates/runtimed/src/requests/shutdown_kernel.rs
@@ -20,15 +20,12 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         // when status is "shutdown".
         //
         // Update RuntimeStateDoc to reflect shutdown
-        {
-            let mut sd = room.state_doc.write().await;
-            if let Err(e) = sd.set_kernel_status("shutdown") {
-                tracing::warn!("[runtime-state] {}", e);
-            }
-            if let Err(e) = sd.set_queue(None, &[]) {
-                tracing::warn!("[runtime-state] {}", e);
-            }
-            let _ = room.state_changed_tx.send(());
+        if let Err(e) = room.state.with_doc(|sd| {
+            sd.set_kernel_status("shutdown")?;
+            sd.set_queue(None, &[])?;
+            Ok(())
+        }) {
+            tracing::warn!("[runtime-state] {}", e);
         }
         NotebookResponse::KernelShuttingDown {}
     } else {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -40,6 +40,7 @@ use notebook_protocol::connection::{
     NotebookFrameType,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
+use runtime_doc::RuntimeStateHandle;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{debug, error, info, warn};
 
@@ -51,8 +52,7 @@ use crate::output_prep::QueueCommand;
 
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
-    state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    state_changed_tx: broadcast::Sender<()>,
+    state: RuntimeStateHandle,
     blob_store: Arc<BlobStore>,
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
@@ -84,8 +84,11 @@ pub async fn run_runtime_agent(
 
     let state_doc = RuntimeStateDoc::new_with_actor(&runtime_agent_id);
     let mut coordinator_sync_state = automerge::sync::State::new();
-    let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
+    // Keep a clone of the sender for the reconnect "kick" path that needs
+    // to force a sync round even when heads haven't changed.
+    let state_kick_tx = state_changed_tx.clone();
+    let state = RuntimeStateHandle::new(state_doc, state_changed_tx);
 
     // -- 3. Create local infrastructure -------------------------------------
 
@@ -96,8 +99,7 @@ pub async fn run_runtime_agent(
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
 
     let ctx = RuntimeAgentContext {
-        state_doc: state_doc.clone(),
-        state_changed_tx: state_changed_tx.clone(),
+        state: state.clone(),
         blob_store,
         broadcast_tx: broadcast_tx.clone(),
         presence,
@@ -108,11 +110,7 @@ pub async fn run_runtime_agent(
 
     let mut kernel: Option<JupyterKernel> = None;
     let mut interrupt_handle: Option<crate::jupyter_kernel::InterruptHandle> = None;
-    let mut kernel_state = KernelState::new(
-        state_doc.clone(),
-        state_changed_tx.clone(),
-        broadcast_tx.clone(),
-    );
+    let mut kernel_state = KernelState::new(state.clone(), broadcast_tx.clone());
     let mut seen_execution_ids = HashSet::new();
     let mut cmd_rx: Option<mpsc::Receiver<QueueCommand>> = None;
 
@@ -140,15 +138,15 @@ pub async fn run_runtime_agent(
                                             let handle = handle.clone();
                                             let cleared = kernel_state.clear_queue();
                                             // Write cleared entries to state doc
-                                            {
-                                                let mut sd = state_doc.write().await;
+                                            if let Err(e) = state.with_doc(|sd| {
                                                 for entry in &cleared {
-                                                    if let Err(e) = sd.set_execution_done(&entry.execution_id, false) {
-                                                        warn!("[runtime-state] {}", e);
-                                                    }
+                                                    sd.set_execution_done(&entry.execution_id, false)?;
                                                 }
+                                                Ok(())
+                                            }) {
+                                                warn!("[runtime-state] {}", e);
                                             }
-                                            kernel_state.write_queue_to_state_doc().await;
+                                            kernel_state.write_queue_to_state_doc();
                                             // Interrupt kernel in background — don't block the loop
                                             tokio::spawn(async move {
                                                 if let Err(e) = handle.interrupt().await {
@@ -194,101 +192,95 @@ pub async fn run_runtime_agent(
                             // and forward frontend-originated comm state changes to kernel
                             NotebookFrameType::RuntimeStateSync => {
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
-                                    let mut sd = ctx.state_doc.write().await;
+                                    // Apply sync and extract data we need for async
+                                    // work, all in one lock acquisition.
+                                    let sync_result = ctx.state.with_doc(|sd| {
+                                        // Snapshot comm state before applying sync so we can
+                                        // detect frontend-originated widget state changes.
+                                        let comms_before = sd.read_state().comms;
 
-                                    // Snapshot comm state before applying sync so we can
-                                    // detect frontend-originated widget state changes.
-                                    let comms_before = sd.read_state().comms;
+                                        // Per-change actor filter: diff comm state against a
+                                        // foreign-only view of the post-sync doc.
+                                        match sd.receive_sync_and_foreign_comms(
+                                            &mut coordinator_sync_state,
+                                            msg,
+                                            |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                                        ) {
+                                            Ok(view) if !view.applied_actors.is_empty() => {
+                                                let queued = sd.get_queued_executions();
+                                                let comm_updates = match view.foreign_comms {
+                                                    Some(foreign_comms) => {
+                                                        diff_comm_state(&comms_before, &foreign_comms)
+                                                    }
+                                                    None => {
+                                                        debug!(
+                                                            "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
+                                                            view.applied_actors.len()
+                                                        );
+                                                        Vec::new()
+                                                    }
+                                                };
+                                                Ok(Some((queued, comm_updates)))
+                                            }
+                                            Ok(_) => Ok(None),
+                                            Err(e) => {
+                                                warn!(
+                                                    "[runtime-agent] Failed to apply RuntimeStateSync: {}",
+                                                    e
+                                                );
+                                                Ok(None)
+                                            }
+                                        }
+                                    });
 
-                                    // Per-change actor filter: diff comm state against a
-                                    // foreign-only view of the post-sync doc. If the
-                                    // coordinator coalesces a kernel-authored echo with a
-                                    // frontend widget write into one RuntimeStateSync frame,
-                                    // the foreign view omits the echo so we don't re-forward
-                                    // it back to the kernel and trigger amplification.
-                                    // Actors are opaque byte strings; the kernel-side writer
-                                    // uses a UTF-8 `rt:kernel:<session>` prefix (see
-                                    // `jupyter_kernel.rs`), so `starts_with` on the raw
-                                    // bytes is sufficient.
-                                    match sd.receive_sync_and_foreign_comms(
-                                        &mut coordinator_sync_state,
-                                        msg,
-                                        |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
-                                    ) {
-                                        Ok(view) if !view.applied_actors.is_empty() => {
-                                            let _ = state_changed_tx.send(());
-
-                                            let queued = sd.get_queued_executions();
-                                            drop(sd); // release write lock before kernel interaction
-
-                                            let comm_updates = match view.foreign_comms {
-                                                Some(foreign_comms) => {
-                                                    diff_comm_state(&comms_before, &foreign_comms)
-                                                }
-                                                None => {
-                                                    debug!(
-                                                        "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
-                                                        view.applied_actors.len()
-                                                    );
-                                                    Vec::new()
-                                                }
-                                            };
-                                            if !comm_updates.is_empty() {
-                                                if let Some(ref mut k) = kernel {
-                                                    for (comm_id, delta) in &comm_updates {
-                                                        if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
-                                                            warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
-                                                        }
+                                    // Async work outside the lock
+                                    if let Ok(Some((queued, comm_updates))) = sync_result {
+                                        if !comm_updates.is_empty() {
+                                            if let Some(ref mut k) = kernel {
+                                                for (comm_id, delta) in &comm_updates {
+                                                    if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
+                                                        warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
                                                     }
                                                 }
                                             }
+                                        }
 
-                                            // Check for new queued executions
-                                            for (eid, exec) in queued {
-                                                if seen_execution_ids.insert(eid.clone()) {
-                                                    if let Some(ref source) = exec.source {
-                                                        if let Some(ref mut k) = kernel {
-                                                            match kernel_state.queue_cell(
-                                                                exec.cell_id.clone(),
-                                                                eid.clone(),
-                                                                source.clone(),
-                                                                k,
-                                                            ).await {
-                                                                Ok(_) => {
-                                                                    info!(
-                                                                        "[runtime-agent] Queued cell {} (execution {})",
-                                                                        exec.cell_id, eid
-                                                                    );
-                                                                }
-                                                                Err(e) => {
-                                                                    warn!(
-                                                                        "[runtime-agent] Failed to queue cell {}: {}",
-                                                                        exec.cell_id, e
-                                                                    );
-                                                                }
+                                        // Check for new queued executions
+                                        for (eid, exec) in queued {
+                                            if seen_execution_ids.insert(eid.clone()) {
+                                                if let Some(ref source) = exec.source {
+                                                    if let Some(ref mut k) = kernel {
+                                                        match kernel_state.queue_cell(
+                                                            exec.cell_id.clone(),
+                                                            eid.clone(),
+                                                            source.clone(),
+                                                            k,
+                                                        ).await {
+                                                            Ok(_) => {
+                                                                info!(
+                                                                    "[runtime-agent] Queued cell {} (execution {})",
+                                                                    exec.cell_id, eid
+                                                                );
+                                                            }
+                                                            Err(e) => {
+                                                                warn!(
+                                                                    "[runtime-agent] Failed to queue cell {}: {}",
+                                                                    exec.cell_id, e
+                                                                );
                                                             }
                                                         }
                                                     }
                                                 }
                                             }
                                         }
-                                        Ok(_) => {
-                                            // No changes applied (handshake/ack).
-                                            drop(sd);
-                                        }
-                                        Err(e) => {
-                                            warn!(
-                                                "[runtime-agent] Failed to apply RuntimeStateSync: {}",
-                                                e
-                                            );
-                                            drop(sd);
-                                        }
                                     }
 
                                     // Send sync reply
-                                    let mut sd = ctx.state_doc.write().await;
-                                    if let Some(reply) = sd.generate_sync_message(&mut coordinator_sync_state) {
-                                        let encoded = reply.encode();
+                                    let reply_encoded = ctx.state.with_doc(|sd| {
+                                        Ok(sd.generate_sync_message(&mut coordinator_sync_state)
+                                            .map(|reply| reply.encode()))
+                                    }).ok().flatten();
+                                    if let Some(encoded) = reply_encoded {
                                         let _ = send_typed_frame(
                                             &mut writer,
                                             NotebookFrameType::RuntimeStateSync,
@@ -351,7 +343,7 @@ pub async fn run_runtime_agent(
                                 // Kick off a full resync so the daemon gets
                                 // everything the kernel produced while we
                                 // were disconnected.
-                                let _ = state_changed_tx.send(());
+                                let _ = state_kick_tx.send(());
                                 info!("[runtime-agent] Reconnected to daemon");
                                 continue;
                             }
@@ -388,9 +380,11 @@ pub async fn run_runtime_agent(
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
 
-                let mut sd = ctx.state_doc.write().await;
-                if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
-                    let encoded = msg.encode();
+                let encoded = ctx.state.with_doc(|sd| {
+                    Ok(sd.generate_sync_message(&mut coordinator_sync_state)
+                        .map(|msg| msg.encode()))
+                }).ok().flatten();
+                if let Some(encoded) = encoded {
                     if let Err(e) = send_typed_frame(
                         &mut writer,
                         NotebookFrameType::RuntimeStateSync,
@@ -548,8 +542,7 @@ async fn handle_runtime_agent_request(
             });
 
             let shared = KernelSharedRefs {
-                state_doc: ctx.state_doc.clone(),
-                state_changed_tx: ctx.state_changed_tx.clone(),
+                state: ctx.state.clone(),
                 blob_store: ctx.blob_store.clone(),
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
@@ -631,8 +624,7 @@ async fn handle_runtime_agent_request(
             });
 
             let shared = KernelSharedRefs {
-                state_doc: ctx.state_doc.clone(),
-                state_changed_tx: ctx.state_changed_tx.clone(),
+                state: ctx.state.clone(),
                 blob_store: ctx.blob_store.clone(),
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
@@ -650,17 +642,12 @@ async fn handle_runtime_agent_request(
             // Mark stale executions as failed in RuntimeStateDoc.
             // The old kernel is gone after shutdown, so these executions
             // can never complete — do this before launching the new kernel.
-            {
-                let mut sd = ctx.state_doc.write().await;
+            if let Err(e) = ctx.state.with_doc(|sd| {
                 if let Some(ref eid) = interrupted_eid {
-                    if let Err(e) = sd.set_execution_done(eid, false) {
-                        warn!("[runtime-state] {}", e);
-                    }
+                    sd.set_execution_done(eid, false)?;
                 }
                 for eid in &stale_queue {
-                    if let Err(e) = sd.set_execution_done(eid, false) {
-                        warn!("[runtime-state] {}", e);
-                    }
+                    sd.set_execution_done(eid, false)?;
                 }
                 // Defensive sweep: mark any execution entries stuck in
                 // "running" or "queued" that the local KernelState missed
@@ -676,10 +663,10 @@ async fn handle_runtime_agent_request(
                     }
                     _ => {}
                 }
-                if let Err(e) = sd.set_queue(None, &[]) {
-                    warn!("[runtime-state] {}", e);
-                }
-                let _ = ctx.state_changed_tx.send(());
+                sd.set_queue(None, &[])?;
+                Ok(())
+            }) {
+                warn!("[runtime-state] {}", e);
             }
 
             match JupyterKernel::launch(config, shared).await {
@@ -708,15 +695,15 @@ async fn handle_runtime_agent_request(
                     Ok(()) => {
                         let cleared = state.clear_queue();
                         // Write cleared entries to state doc
-                        {
-                            let mut sd = ctx.state_doc.write().await;
+                        if let Err(e) = ctx.state.with_doc(|sd| {
                             for entry in &cleared {
-                                if let Err(e) = sd.set_execution_done(&entry.execution_id, false) {
-                                    warn!("[runtime-state] {}", e);
-                                }
+                                sd.set_execution_done(&entry.execution_id, false)?;
                             }
+                            Ok(())
+                        }) {
+                            warn!("[runtime-state] {}", e);
                         }
-                        state.write_queue_to_state_doc().await;
+                        state.write_queue_to_state_doc();
                         (
                             RuntimeAgentResponse::InterruptAcknowledged { cleared },
                             None,
@@ -973,16 +960,15 @@ async fn handle_queue_command(
             );
             state.mark_execution_error();
             let cleared = state.clear_queue();
-            let mut sd = ctx.state_doc.write().await;
-            for entry in &cleared {
-                if let Err(e) = sd.set_execution_done(&entry.execution_id, false) {
-                    warn!("[runtime-state] {}", e);
+            if let Err(e) = ctx.state.with_doc(|sd| {
+                for entry in &cleared {
+                    sd.set_execution_done(&entry.execution_id, false)?;
                 }
-            }
-            if let Err(e) = sd.set_queue(None, &[]) {
+                sd.set_queue(None, &[])?;
+                Ok(())
+            }) {
                 warn!("[runtime-state] {}", e);
             }
-            let _ = ctx.state_changed_tx.send(());
         }
 
         QueueCommand::KernelDied => {
@@ -992,24 +978,19 @@ async fn handle_queue_command(
             }
             *kernel = None;
             let (interrupted, cleared) = state.kernel_died();
-            let mut sd = ctx.state_doc.write().await;
-            if let Some((_, ref eid)) = interrupted {
-                if let Err(e) = sd.set_execution_done(eid, false) {
-                    warn!("[runtime-state] {}", e);
+            if let Err(e) = ctx.state.with_doc(|sd| {
+                if let Some((_, ref eid)) = interrupted {
+                    sd.set_execution_done(eid, false)?;
                 }
-            }
-            for entry in &cleared {
-                if let Err(e) = sd.set_execution_done(&entry.execution_id, false) {
-                    warn!("[runtime-state] {}", e);
+                for entry in &cleared {
+                    sd.set_execution_done(&entry.execution_id, false)?;
                 }
-            }
-            if let Err(e) = sd.set_kernel_status("error") {
+                sd.set_kernel_status("error")?;
+                sd.set_queue(None, &[])?;
+                Ok(())
+            }) {
                 warn!("[runtime-state] {}", e);
             }
-            if let Err(e) = sd.set_queue(None, &[]) {
-                warn!("[runtime-state] {}", e);
-            }
-            let _ = ctx.state_changed_tx.send(());
         }
 
         QueueCommand::SendCommUpdate {
@@ -1129,33 +1110,28 @@ mod tests {
     }
 
     /// Build test fixtures: RuntimeAgentContext + KernelState wired to the same doc.
-    fn test_fixtures() -> (
-        RuntimeAgentContext,
-        KernelState,
-        Arc<RwLock<RuntimeStateDoc>>,
-    ) {
-        let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
+    fn test_fixtures() -> (RuntimeAgentContext, KernelState, RuntimeStateHandle) {
         let (state_changed_tx, _) = broadcast::channel(64);
+        let handle = RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
         let (broadcast_tx, _) = broadcast::channel(64);
         let (presence_tx, _) = broadcast::channel(16);
         let blob_store = Arc::new(BlobStore::new(std::env::temp_dir().join("test-blobs")));
         let presence = Arc::new(RwLock::new(PresenceState::new()));
 
         let ctx = RuntimeAgentContext {
-            state_doc: state_doc.clone(),
-            state_changed_tx: state_changed_tx.clone(),
+            state: handle.clone(),
             blob_store,
             broadcast_tx: broadcast_tx.clone(),
             presence,
             presence_tx,
         };
-        let state = KernelState::new(state_doc.clone(), state_changed_tx, broadcast_tx);
-        (ctx, state, state_doc)
+        let state = KernelState::new(handle.clone(), broadcast_tx);
+        (ctx, state, handle)
     }
 
     #[tokio::test]
     async fn kernel_died_marks_inflight_executions_as_failed_in_state_doc() {
-        let (ctx, mut state, state_doc) = test_fixtures();
+        let (ctx, mut state, handle) = test_fixtures();
         let mut mock = MockKernel;
         state.set_idle();
 
@@ -1171,10 +1147,9 @@ mod tests {
 
         // Verify initial state in doc
         {
-            let sd = state_doc.read().await;
-            let e1 = sd.get_execution("e1").unwrap();
+            let e1 = handle.read(|sd| sd.get_execution("e1").unwrap()).unwrap();
             assert_eq!(e1.status, "running");
-            let e2 = sd.get_execution("e2").unwrap();
+            let e2 = handle.read(|sd| sd.get_execution("e2").unwrap()).unwrap();
             assert_eq!(e2.status, "queued");
         }
 
@@ -1189,17 +1164,16 @@ mod tests {
         .unwrap();
 
         // Both executions should now be marked as error in RuntimeStateDoc
-        let sd = state_doc.read().await;
-        let e1 = sd.get_execution("e1").unwrap();
+        let e1 = handle.read(|sd| sd.get_execution("e1").unwrap()).unwrap();
         assert_eq!(e1.status, "error");
         assert_eq!(e1.success, Some(false));
 
-        let e2 = sd.get_execution("e2").unwrap();
+        let e2 = handle.read(|sd| sd.get_execution("e2").unwrap()).unwrap();
         assert_eq!(e2.status, "error");
         assert_eq!(e2.success, Some(false));
 
         // Queue should be cleared
-        let queue = sd.read_state();
+        let queue = handle.read(|sd| sd.read_state()).unwrap();
         assert!(queue.queue.executing.is_none());
         assert!(queue.queue.queued.is_empty());
 
@@ -1209,7 +1183,7 @@ mod tests {
 
     #[tokio::test]
     async fn kernel_died_with_no_inflight_executions_clears_state() {
-        let (ctx, mut state, state_doc) = test_fixtures();
+        let (ctx, mut state, handle) = test_fixtures();
         state.set_idle();
 
         // No cells queued — just fire KernelDied
@@ -1222,8 +1196,7 @@ mod tests {
         .await
         .unwrap();
 
-        let sd = state_doc.read().await;
-        let rs = sd.read_state();
+        let rs = handle.read(|sd| sd.read_state()).unwrap();
         assert_eq!(rs.kernel.status, "error");
         assert!(rs.queue.executing.is_none());
         assert!(rs.queue.queued.is_empty());

--- a/docs/superpowers/specs/2026-04-22-runtime-state-handle-design.md
+++ b/docs/superpowers/specs/2026-04-22-runtime-state-handle-design.md
@@ -1,0 +1,172 @@
+# RuntimeStateHandle Design
+
+## Status
+
+- **Phase A**: Shipped (#2056). `runtime-doc` and `automunge` crates extracted.
+- **Phase B**: Next. `RuntimeStateHandle` implementation + caller migration.
+- **Phase C**: Future. Remove re-export shim from `notebook-doc`.
+
+## Current State (post Phase A)
+
+```
+automunge (leaf, ~300 lines)
+  └── automerge, serde_json
+
+runtime-doc
+  ├── automunge
+  ├── automerge, serde, serde_json, tokio, tracing
+  └── Owns: RuntimeStateDoc, RuntimeStateError, StreamOutputState, snapshot types
+
+notebook-doc
+  ├── automunge (for NotebookDoc's JSON operations)
+  ├── runtime-doc (re-export shim only)
+  └── Owns: NotebookDoc, cell operations, metadata, diff
+```
+
+`runtime-doc/src/handle.rs` is a placeholder. RuntimeStateDoc is still accessed via `Arc<tokio::sync::RwLock<RuntimeStateDoc>>` + manual `state_changed_tx.send(())` in the daemon.
+
+## Phase B: RuntimeStateHandle
+
+### The handle
+
+```rust
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+
+#[derive(Clone)]
+pub struct RuntimeStateHandle {
+    doc: Arc<Mutex<RuntimeStateDoc>>,
+    changed_tx: broadcast::Sender<()>,
+}
+```
+
+`std::sync::Mutex`, not `tokio::sync::RwLock`. Automerge writes are microsecond-fast, pure in-memory. The `!Send` guard on `MutexGuard` makes holding it across `.await` a compile error.
+
+### API
+
+**`with_doc`** - synchronous mutation, auto-notification via heads comparison:
+
+```rust
+pub fn with_doc<F, T>(&self, f: F) -> Result<T, RuntimeStateError>
+where
+    F: FnOnce(&mut RuntimeStateDoc) -> Result<T, RuntimeStateError>,
+```
+
+**`fork`** - start async work (current heads only, never `fork_at`):
+
+```rust
+pub fn fork(&self, actor_label: &str) -> Result<RuntimeStateDoc, RuntimeStateError>
+```
+
+**`merge`** - complete async work, auto-notification:
+
+```rust
+pub fn merge(&self, fork: &mut RuntimeStateDoc) -> Result<(), RuntimeStateError>
+```
+
+**`read`** - read-only access (same mutex, no notification):
+
+```rust
+pub fn read<F, T>(&self, f: F) -> Result<T, RuntimeStateError>
+where
+    F: FnOnce(&RuntimeStateDoc) -> T,
+```
+
+**`subscribe`** - change notifications for peer sync loops:
+
+```rust
+pub fn subscribe(&self) -> broadcast::Receiver<()>
+```
+
+### Merge failure semantics
+
+- `merge() -> Err`: document unchanged, no recovery needed (error fires before mutation in Automerge).
+- Panic during merge apply: `std::sync::Mutex` poisons automatically. All subsequent calls return `Err(LockPoisoned)`. Room reconstructs via fresh doc + re-sync.
+- No `rebuild_from_save()` in the handle. Save/load on a half-merged doc could persist bad state.
+
+### fork_at avoidance
+
+The handle exposes `fork()` only. `fork_at(historical_heads)` triggers `MissingOps` panics (automerge/automerge#1327). Whether this is an Automerge bug or a violated invariant is an open investigation.
+
+### Caller migration
+
+**NotebookRoom** replaces two fields with one:
+
+```rust
+// Before
+pub state_doc: Arc<RwLock<RuntimeStateDoc>>,
+pub state_changed_tx: broadcast::Sender<()>,
+
+// After
+pub state: RuntimeStateHandle,
+```
+
+**Sync writes** (95% of call sites):
+
+```rust
+// Before (4 steps)
+let mut sd = room.state_doc.write().await;
+if let Err(e) = sd.set_kernel_status("idle") {
+    warn!("[runtime-state] {}", e);
+}
+let _ = state_changed_tx.send(());
+
+// After (1 step)
+if let Err(e) = room.state.with_doc(|sd| sd.set_kernel_status("idle")) {
+    warn!("[runtime-state] {}", e);
+}
+```
+
+**Batched writes** (atomic, single notification):
+
+```rust
+if let Err(e) = self.state.with_doc(|sd| {
+    sd.create_execution(&eid, &cell_id)?;
+    sd.set_queue(exec, &queued)?;
+    Ok(())
+}) {
+    warn!("[runtime-state] {}", e);
+}
+```
+
+**Fork/merge** (IOPub outputs):
+
+```rust
+let mut fork = state.fork(&actor_id)?;
+// ... async blob work ...
+state.merge(&mut fork)?;
+```
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `crates/runtime-doc/src/handle.rs` | Implement RuntimeStateHandle |
+| `crates/runtime-doc/src/lib.rs` | Export RuntimeStateHandle |
+| `crates/runtimed/Cargo.toml` | Add runtime-doc dependency |
+| `crates/runtimed/src/notebook_sync_server/room.rs` | Replace two fields with handle |
+| `crates/runtimed/src/kernel_state.rs` | Use handle |
+| `crates/runtimed/src/jupyter_kernel.rs` | Use handle for writes + fork/merge |
+| `crates/runtimed/src/runtime_agent.rs` | Use handle |
+| `crates/runtimed/src/requests/*.rs` | Use handle |
+| `crates/runtimed/src/notebook_sync_server/peer.rs` | Use handle |
+| `crates/runtimed/src/notebook_sync_server/metadata.rs` | Use handle |
+| `crates/runtimed/src/notebook_sync_server/mod.rs` | Use handle |
+
+### Checkpoints
+
+1. Handle implemented + unit tests pass (`cargo test -p runtime-doc`)
+2. NotebookRoom switched, all callers migrated, `cargo build` clean
+3. Full test suite + clippy + lint pass
+4. `codex review`
+
+## Phase C: Remove re-export shim (future)
+
+Update downstream crates (`runtimed-wasm`, `notebook-sync`, `runt-mcp`, `runtimed-client`, `runtimed-py`) to import from `runtime-doc` directly. Delete `notebook-doc/src/runtime_state.rs`. Remove `runtime-doc` dep from `notebook-doc`.
+
+## References
+
+- **samod** (`alexjg/samod`): `DocHandle::with_document` uses `Arc<Mutex<>>` + closure API. `begin_modification()` checks readiness.
+- **notebook-sync** (`crates/notebook-sync/src/handle.rs:199`): Our existing `DocHandle::with_doc` for NotebookDoc. Same pattern.
+- **automerge core**: Merge is not transactional (`TODO: Make this fallible`). `Err` path is pre-mutation. Panic path has no rollback.
+- **automorph** (`codeberg.org/dpp/automorph`): Read-before-write pattern. Future replacement for automunge when 0.8 ships.


### PR DESCRIPTION
## Summary

Introduces `RuntimeStateHandle` and migrates the entire daemon from `Arc<tokio::sync::RwLock<RuntimeStateDoc>>` + manual `state_changed_tx` notification to the new handle.

**RuntimeStateHandle** wraps `Arc<std::sync::Mutex<RuntimeStateDoc>>` + `broadcast::Sender<()>` with three write APIs:
- `with_doc(closure)` - sync mutation, auto-notification via heads comparison
- `fork(actor_label)` - start async work (current heads only, never fork_at)
- `merge(fork)` - complete async work, auto-notification

Plus `read(closure)` and `subscribe()`.

**Key properties:**
- `std::sync::Mutex` instead of `tokio::sync::RwLock`. Automerge writes are microsecond-fast. The `!Send` guard on `MutexGuard` makes holding across `.await` a compile error.
- Notification is automatic. No manual `state_changed_tx.send(())`.
- Batched writes in `with_doc` are atomic (one lock, one heads check, one notification).

**NotebookRoom** collapses two fields into one:
```rust
// Before
pub state_doc: Arc<RwLock<RuntimeStateDoc>>,
pub state_changed_tx: broadcast::Sender<()>,
// After
pub state: RuntimeStateHandle,
```

21 files changed across kernel_state.rs, jupyter_kernel.rs, runtime_agent.rs, all request handlers, peer sync, and metadata handler.

## Context

Phase B of the RuntimeStateHandle design. Phase A shipped in #2056 (runtime-doc + automunge crate extraction). Mirrors the existing `DocHandle::with_doc` pattern from notebook-sync and samod's `with_document`.

## Test plan

- [x] `cargo test -p runtime-doc` - 93 tests (5 new handle tests)
- [x] `cargo test -p runtimed` - 389 tests pass
- [x] `cargo build` - full workspace clean
- [x] `cargo xtask clippy` - clean
- [x] `cargo xtask lint` - clean