### PR TITLE
refactor(runtimed): extract RoomIdentity substruct

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2775,7 +2775,10 @@ impl Daemon {
                         kernel_type,
                         env_source,
                         kernel_status,
-                        ephemeral: room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed),
+                        ephemeral: room
+                            .identity
+                            .is_ephemeral
+                            .load(std::sync::atomic::Ordering::Relaxed),
                     });
                 }
                 Response::RoomsList { rooms: room_infos }
@@ -2798,7 +2801,7 @@ impl Daemon {
                 };
                 // Clean up path_index if the room had a path.
                 if let Some(ref room) = maybe_room {
-                    let path = room.path.read().await.clone();
+                    let path = room.identity.path.read().await.clone();
                     if let Some(p) = path {
                         self.path_index.lock().await.remove(&p);
                     }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -936,7 +936,7 @@ pub(crate) async fn apply_ipynb_changes(
         }
         map
     };
-    let notebook_path_for_assets = room.path.read().await.clone();
+    let notebook_path_for_assets = room.identity.path.read().await.clone();
     let converted_assets: HashMap<String, ResolvedAssets> = {
         let mut map = HashMap::new();
         for cell in external_cells {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -576,7 +576,13 @@ pub(crate) fn compute_env_sync_diff(
 /// blob-store hashes, then updates the cell-local `resolved_assets` maps so
 /// isolated markdown rendering can rewrite those refs to blob URLs.
 pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
-    let notebook_path = room.path.read().await.clone().filter(|p| p.exists());
+    let notebook_path = room
+        .identity
+        .path
+        .read()
+        .await
+        .clone()
+        .filter(|p| p.exists());
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
 
     // Fork BEFORE async resolution so the fork's baseline predates
@@ -2057,7 +2063,7 @@ pub(crate) async fn auto_launch_kernel(
     let notebook_path_opt = if notebook_path.exists() {
         Some(notebook_path.clone())
     } else if is_untitled_notebook(notebook_id) {
-        let working_dir = room.working_dir.read().await;
+        let working_dir = room.identity.working_dir.read().await;
         working_dir.clone().inspect(|p| {
             info!(
                 "[notebook-sync] Using working_dir for untitled notebook: {}",

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -350,7 +350,7 @@ where
 {
     // Set working_dir on the room if provided (for untitled notebook project detection)
     if let Some(wd) = working_dir {
-        let mut room_wd = room.working_dir.write().await;
+        let mut room_wd = room.identity.working_dir.write().await;
         *room_wd = Some(wd);
     }
 
@@ -427,7 +427,7 @@ where
     // Auto-launch kernel if this is the first peer and notebook is trusted
     if peers == 1 {
         // Check if notebook_id is a UUID (new unsaved notebook) vs a file path
-        let path_snapshot = room.path.read().await.clone();
+        let path_snapshot = room.identity.path.read().await.clone();
         let is_new_notebook = path_snapshot.as_ref().is_none_or(|p| !p.exists())
             && uuid::Uuid::parse_str(&notebook_id).is_ok();
 
@@ -704,8 +704,8 @@ where
             }; // rooms lock dropped here
 
             // Clean up path_index entry (separate lock, after rooms lock is dropped).
-            // Use remove_by_uuid rather than reading room.path — a concurrent writer
-            // A concurrent save-path-update could hold room.path.write() and a
+            // Use remove_by_uuid rather than reading room.identity.path — a concurrent writer
+            // A concurrent save-path-update could hold room.identity.path.write() and a
             // try_read() would silently return None, leaking the path_index entry.
             if should_teardown {
                 if let Some(uuid) = evicted_uuid {
@@ -788,7 +788,7 @@ where
                 let mut flushed_runtime: Option<CapturedEnvRuntime> = None;
                 let mut save_succeeded = false;
                 if let Some(ref launched) = launched_snapshot {
-                    let has_saved_path = room_for_eviction.path.read().await.is_some();
+                    let has_saved_path = room_for_eviction.identity.path.read().await.is_some();
                     if has_saved_path {
                         for runtime in [CapturedEnvRuntime::Uv, CapturedEnvRuntime::Conda] {
                             if flush_launched_deps_to_metadata(
@@ -880,7 +880,7 @@ where
                         .await
                         .clone();
                     if let Some(ref path) = env_path {
-                        let has_saved_path = room_for_eviction.path.read().await.is_some();
+                        let has_saved_path = room_for_eviction.identity.path.read().await.is_some();
                         let metadata = {
                             let doc = room_for_eviction.doc.read().await;
                             doc.get_metadata_snapshot()

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -25,10 +25,10 @@ pub(crate) async fn save_notebook_to_disk(
     // room currently has as its path. Triangulates stray-file bugs by letting
     // us correlate saves against whoever fired them.
     debug!(
-        "[save] save_notebook_to_disk entered: target_path={:?}, room.id={}, room.path={:?}",
+        "[save] save_notebook_to_disk entered: target_path={:?}, room.id={}, room.identity.path={:?}",
         target_path,
         room.id,
-        room.path.read().await.as_deref()
+        room.identity.path.read().await.as_deref()
     );
     // Determine the actual save path
     let notebook_path = match target_path {
@@ -51,7 +51,7 @@ pub(crate) async fn save_notebook_to_disk(
                 PathBuf::from(format!("{}.ipynb", p))
             }
         }
-        None => match room.path.read().await.clone() {
+        None => match room.identity.path.read().await.clone() {
             Some(p) => p,
             None => {
                 return Err(SaveError::Unrecoverable(
@@ -252,8 +252,8 @@ pub(crate) async fn save_notebook_to_disk(
     // our own writes from genuine external changes. Only update when saving
     // to the primary path — saving to an alternate path (Save As) must not
     // corrupt the baseline for the file watcher.
-    let is_primary_path =
-        target_path.is_none() || room.path.read().await.as_deref() == Some(notebook_path.as_path());
+    let is_primary_path = target_path.is_none()
+        || room.identity.path.read().await.as_deref() == Some(notebook_path.as_path());
     if is_primary_path {
         let mut saved = HashMap::with_capacity(cells.len());
         for cell in &cells {
@@ -271,7 +271,7 @@ pub(crate) async fn save_notebook_to_disk(
 }
 
 /// Transitions an untitled room to file-backed: claims path in path_index,
-/// updates room.path, cleans up the stale `.automerge` persist file, spawns
+/// updates room.identity.path, cleans up the stale `.automerge` persist file, spawns
 /// the `.ipynb` file watcher and autosave debouncer, clears ephemeral markers,
 /// and broadcasts `PathChanged`.
 ///
@@ -320,7 +320,7 @@ pub(crate) async fn try_claim_path(
 /// autosave debouncer spawn, ephemeral marker clear, and PathChanged broadcast.
 pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canonical: PathBuf) {
     // Update room's path now that path_index owns it.
-    *room.path.write().await = Some(canonical.clone());
+    *room.identity.path.write().await = Some(canonical.clone());
 
     // NOTE: We don't actually stop the .automerge persist debouncer here —
     // stopping it would require taking ownership of room.persist_tx, which
@@ -334,11 +334,11 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     //   - The debouncer task dies when NotebookRoom is dropped on eviction.
     // TODO(followup): make persist_tx: Mutex<Option<...>> so .take() can
     // properly drop the sender and close the channel.
-    if room.persist_path.exists() {
-        if let Err(e) = tokio::fs::remove_file(&room.persist_path).await {
+    if room.identity.persist_path.exists() {
+        if let Err(e) = tokio::fs::remove_file(&room.identity.persist_path).await {
             warn!(
                 "[notebook-sync] Failed to remove stale persist file {:?}: {}",
-                room.persist_path, e
+                room.identity.persist_path, e
             );
         }
     }
@@ -353,7 +353,7 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     spawn_autosave_debouncer(canonical.to_string_lossy().into_owned(), Arc::clone(room));
 
     // Clear ephemeral markers.
-    room.is_ephemeral.store(false, Ordering::Relaxed);
+    room.identity.is_ephemeral.store(false, Ordering::Relaxed);
     {
         let mut doc = room.doc.write().await;
         let _ = doc.delete_metadata("ephemeral");
@@ -372,7 +372,7 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
     );
 }
 
-/// Updates path_index and room.path when a file-backed room is saved to a
+/// Updates path_index and room.identity.path when a file-backed room is saved to a
 /// Clone the notebook to a new path with a fresh env_id and cleared outputs.
 ///
 /// This is used for "Save As Copy" functionality - creates a new independent notebook
@@ -411,7 +411,7 @@ pub(crate) async fn clone_notebook_to_disk(
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
 
     // Read existing source notebook to preserve unknown top-level metadata keys.
-    let source_notebook_path = room.path.read().await.clone();
+    let source_notebook_path = room.identity.path.read().await.clone();
     let existing: Option<serde_json::Value> = match source_notebook_path {
         Some(ref p) => match tokio::fs::read_to_string(p).await {
             Ok(content) => serde_json::from_str(&content).ok(),

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+/// Per-room identity and filesystem bindings.
+///
+/// Groups the four fields that describe *which* notebook this room represents,
+/// separate from its document state, broadcasts, or kernel lifecycle. These
+/// fields are read from most code paths but mutated rarely (path changes when
+/// an untitled notebook is saved; working_dir is set once at create time).
+pub struct RoomIdentity {
+    /// Persistence path for this room's Automerge document (not the .ipynb).
+    pub persist_path: PathBuf,
+    /// Whether this notebook is ephemeral (in-memory only, no .ipynb on disk).
+    pub is_ephemeral: AtomicBool,
+    /// The `.ipynb` path, when this room is file-backed. `None` for untitled
+    /// and ephemeral rooms. Mutated when an untitled room is saved to disk
+    /// (see `handle_save_notebook`).
+    pub path: RwLock<Option<PathBuf>>,
+    /// Working directory for untitled notebooks (used for project file detection).
+    /// When the notebook_id is a UUID (untitled), this provides the directory
+    /// context for finding pyproject.toml, pixi.toml, or environment.yaml.
+    pub working_dir: RwLock<Option<PathBuf>>,
+}
+
+impl RoomIdentity {
+    pub fn new(persist_path: PathBuf, path: Option<PathBuf>, ephemeral: bool) -> Self {
+        Self {
+            persist_path,
+            is_ephemeral: AtomicBool::new(ephemeral),
+            path: RwLock::new(path),
+            working_dir: RwLock::new(None),
+        }
+    }
+}
+
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room. Used as the map key once
     /// Phase 5 lands; for now coexists with the string-keyed map.
@@ -27,29 +59,19 @@ pub struct NotebookRoom {
     ///
     /// `None` for ephemeral rooms (persistence skipped) and matches `persist_tx`.
     pub flush_request_tx: Option<mpsc::UnboundedSender<FlushRequest>>,
-    /// Persistence path for this room's document.
-    pub persist_path: PathBuf,
+    /// Notebook identity: persist_path, is_ephemeral, .ipynb path, working_dir.
+    pub identity: RoomIdentity,
     /// Number of active peer connections in this room.
     pub active_peers: AtomicUsize,
     /// Whether at least one peer has ever connected to this room.
     pub had_peers: AtomicBool,
-    /// Whether this notebook is ephemeral (in-memory only, no persistence).
-    pub is_ephemeral: AtomicBool,
     /// Blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
     /// Trust state for this notebook (for auto-launch decisions).
     pub trust_state: Arc<RwLock<TrustState>>,
-    /// The `.ipynb` path, when this room is file-backed. `None` for untitled and
-    /// ephemeral rooms. Mutated when an untitled room is saved to disk (see
-    /// `handle_save_notebook`).
-    pub path: RwLock<Option<PathBuf>>,
     /// Raw nbformat attachments preserved from disk, keyed by cell ID.
     /// These are not user-editable in the current UI, so the file remains the source of truth.
     pub nbformat_attachments: Arc<RwLock<HashMap<String, serde_json::Value>>>,
-    /// Working directory for untitled notebooks (used for project file detection).
-    /// When the notebook_id is a UUID (untitled), this provides the directory context
-    /// for finding pyproject.toml, pixi.toml, or environment.yaml.
-    pub working_dir: Arc<RwLock<Option<PathBuf>>>,
     /// Comm channel state for widgets.
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
@@ -221,15 +243,12 @@ impl NotebookRoom {
             presence: Arc::new(RwLock::new(PresenceState::new())),
             persist_tx,
             flush_request_tx,
-            persist_path,
+            identity: RoomIdentity::new(persist_path, path, ephemeral),
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
-            is_ephemeral: AtomicBool::new(ephemeral),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
-            path: RwLock::new(path),
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-            working_dir: Arc::new(RwLock::new(None)),
 
             is_loading: AtomicBool::new(false),
             last_self_write: AtomicU64::new(0),
@@ -313,15 +332,12 @@ impl NotebookRoom {
             presence: Arc::new(RwLock::new(PresenceState::new())),
             persist_tx: Some(persist_tx),
             flush_request_tx: Some(flush_request_tx),
-            persist_path,
+            identity: RoomIdentity::new(persist_path, path, false),
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
-            is_ephemeral: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
-            path: RwLock::new(path),
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-            working_dir: Arc::new(RwLock::new(None)),
 
             is_loading: AtomicBool::new(false),
             last_self_write: AtomicU64::new(0),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -132,7 +132,7 @@ async fn untitled_room_has_path_none() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
     let room = NotebookRoom::new_fresh(Uuid::new_v4(), None, tmp.path(), blob_store, false);
-    assert!(room.path.read().await.is_none());
+    assert!(room.identity.path.read().await.is_none());
 }
 
 #[tokio::test]
@@ -147,7 +147,7 @@ async fn file_backed_room_has_path_some() {
         blob_store,
         false,
     );
-    let guard = room.path.read().await;
+    let guard = room.identity.path.read().await;
     assert_eq!(guard.as_deref(), Some(fake_path.as_path()));
 }
 
@@ -175,7 +175,7 @@ async fn test_room_persists_and_reloads() {
         doc.add_cell(0, "c1", "code").unwrap();
         doc.update_source("c1", "hello").unwrap();
         let bytes = doc.save();
-        persist_notebook_bytes(&bytes, &room.persist_path);
+        persist_notebook_bytes(&bytes, &room.identity.persist_path);
     }
 
     // Load again — should have the cell
@@ -302,7 +302,7 @@ async fn test_new_fresh_deletes_stale_persisted_doc_for_file_path() {
         doc.add_cell(0, "c1", "code").unwrap();
         doc.update_source("c1", "old content").unwrap();
         let bytes = doc.save();
-        persist_notebook_bytes(&bytes, &room.persist_path);
+        persist_notebook_bytes(&bytes, &room.identity.persist_path);
     }
 
     // Verify persisted file exists
@@ -341,7 +341,7 @@ async fn test_new_fresh_loads_persisted_doc_for_untitled_notebook() {
         doc.add_cell(0, "c1", "code").unwrap();
         doc.update_source("c1", "restored content").unwrap();
         let bytes = doc.save();
-        persist_notebook_bytes(&bytes, &room.persist_path);
+        persist_notebook_bytes(&bytes, &room.identity.persist_path);
     }
 
     // Verify persisted file exists
@@ -399,7 +399,7 @@ async fn test_new_fresh_untitled_trust_from_doc() {
             let mut doc = room.doc.try_write().unwrap();
             doc.set_metadata_snapshot(&snapshot).unwrap();
             let bytes = doc.save();
-            persist_notebook_bytes(&bytes, &room.persist_path);
+            persist_notebook_bytes(&bytes, &room.identity.persist_path);
         }
     }
 
@@ -426,7 +426,10 @@ async fn test_ephemeral_room_skips_persistence() {
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, true);
 
     assert!(room.persist_tx.is_none());
-    assert!(room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed));
+    assert!(room
+        .identity
+        .is_ephemeral
+        .load(std::sync::atomic::Ordering::Relaxed));
 
     // No .automerge file should exist
     let filename = notebook_doc_filename(&notebook_uuid.to_string());
@@ -441,7 +444,10 @@ async fn test_session_room_persists() {
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, false);
 
     assert!(room.persist_tx.is_some());
-    assert!(!room.is_ephemeral.load(std::sync::atomic::Ordering::Relaxed));
+    assert!(!room
+        .identity
+        .is_ephemeral
+        .load(std::sync::atomic::Ordering::Relaxed));
 }
 
 #[tokio::test(start_paused = true)]
@@ -652,10 +658,9 @@ fn test_room_with_path(
         presence: Arc::new(RwLock::new(PresenceState::new())),
         persist_tx: Some(persist_tx),
         flush_request_tx: Some(flush_request_tx),
-        persist_path,
+        identity: RoomIdentity::new(persist_path, Some(notebook_path.clone()), false),
         active_peers: AtomicUsize::new(0),
         had_peers: AtomicBool::new(false),
-        is_ephemeral: AtomicBool::new(false),
         blob_store,
         trust_state: Arc::new(RwLock::new(TrustState {
             status: runt_trust::TrustStatus::Untrusted,
@@ -667,9 +672,7 @@ fn test_room_with_path(
             },
             pending_launch: false,
         })),
-        path: RwLock::new(Some(notebook_path.clone())),
         nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-        working_dir: Arc::new(RwLock::new(None)),
 
         is_loading: AtomicBool::new(false),
         last_self_write: AtomicU64::new(0),
@@ -2333,7 +2336,7 @@ async fn test_update_kernel_presence_publishes_state_and_relays() {
 // ── Regression test: autosave after save_notebook path update ──────
 
 /// Verify that saving an untitled (UUID-keyed) room updates path_index and
-/// room.path, while keeping the UUID stable in the rooms map.
+/// room.identity.path, while keeping the UUID stable in the rooms map.
 #[tokio::test]
 async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -2368,12 +2371,15 @@ async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
         .await
         .insert(canonical.clone(), room.id)
         .unwrap();
-    *room.path.write().await = Some(canonical.clone());
+    *room.identity.path.write().await = Some(canonical.clone());
 
-    // UUID key unchanged, path_index populated, room.path set.
+    // UUID key unchanged, path_index populated, room.identity.path set.
     assert!(rooms.lock().await.contains_key(&uuid));
     assert_eq!(path_index.lock().await.lookup(&canonical), Some(uuid));
-    assert_eq!(room.path.read().await.as_deref(), Some(canonical.as_path()));
+    assert_eq!(
+        room.identity.path.read().await.as_deref(),
+        Some(canonical.as_path())
+    );
 }
 
 /// Verify that `promote_untitled_to_file_backed` returns
@@ -2415,10 +2421,10 @@ async fn saving_to_already_open_path_returns_path_already_open_error() {
         other => panic!("expected PathAlreadyOpen, got {:?}", other),
     }
 
-    // room.path must NOT have been mutated on error.
+    // room.identity.path must NOT have been mutated on error.
     assert!(
-        room.path.read().await.is_none(),
-        "room.path should still be None after a failed claim"
+        room.identity.path.read().await.is_none(),
+        "room.identity.path should still be None after a failed claim"
     );
 }
 
@@ -2527,9 +2533,9 @@ async fn test_promote_untitled_starts_autosave() {
         "UUID key should still be present after promotion"
     );
     assert_eq!(
-        room.path.read().await.as_deref(),
+        room.identity.path.read().await.as_deref(),
         Some(canonical.as_path()),
-        "room.path should be set after promotion"
+        "room.identity.path should be set after promotion"
     );
     assert_eq!(
         path_index.lock().await.lookup(&canonical),
@@ -2537,7 +2543,7 @@ async fn test_promote_untitled_starts_autosave() {
         "path_index should contain the room's UUID"
     );
     assert!(
-        !room.is_ephemeral.load(Ordering::Relaxed),
+        !room.identity.is_ephemeral.load(Ordering::Relaxed),
         "is_ephemeral should be cleared after promotion"
     );
 

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -40,6 +40,7 @@ pub(crate) async fn handle(
     let notebook_path = match notebook_path {
         Some(p) => Some(p),
         None => room
+            .identity
             .path
             .read()
             .await
@@ -114,13 +115,13 @@ pub(crate) async fn handle(
     }
 
     let notebook_path = notebook_path.map(std::path::PathBuf::from);
-    // Fall back to room.working_dir for untitled notebooks (mirrors auto-launch path).
+    // Fall back to room.identity.working_dir for untitled notebooks (mirrors auto-launch path).
     // Enables project file detection (environment.yaml, pyproject.toml, pixi.toml)
     // when MCP callers send notebook_path: None for UUID-based notebooks.
     let notebook_path = match notebook_path {
         some @ Some(_) => some,
         None => {
-            let wd = room.working_dir.read().await;
+            let wd = room.identity.working_dir.read().await;
             wd.clone().inspect(|p| {
                 info!(
                     "[notebook-sync] LaunchKernel: using room working_dir for project file detection: {}",

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle(
     // Capture was_untitled and old_path in a single critical section to
     // avoid a TOCTOU race between the two reads.
     let (was_untitled, old_path) = {
-        let p = room.path.read().await;
+        let p = room.identity.path.read().await;
         (p.is_none(), p.clone())
     };
 
@@ -41,7 +41,7 @@ pub(crate) async fn handle(
     //
     // Compute the pre-write canonical target. For untitled rooms a path
     // is required; for file-backed rooms we only need a pre-write claim
-    // if the caller specified a path different from room.path.
+    // if the caller specified a path different from room.identity.path.
     let target_for_claim: Option<PathBuf> = match (&path, was_untitled) {
         (Some(p), _) => match crate::paths::normalize_save_target(p) {
             Ok(normalized) => Some(canonical_target_path(&normalized).await),
@@ -85,12 +85,12 @@ pub(crate) async fn handle(
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
-            if room.is_ephemeral.load(Ordering::Relaxed) && room.persist_tx.is_none() {
+            if room.identity.is_ephemeral.load(Ordering::Relaxed) && room.persist_tx.is_none() {
                 let bytes = room.doc.write().await.save();
-                persist_notebook_bytes(&bytes, &room.persist_path);
+                persist_notebook_bytes(&bytes, &room.identity.persist_path);
                 warn!(
                     "[notebook-sync] Save failed for ephemeral room — emergency persist to {:?}",
-                    room.persist_path
+                    room.identity.persist_path
                 );
             }
             let kind = match e {
@@ -138,12 +138,12 @@ pub(crate) async fn handle(
         let path_changed = old != &canonical;
         if path_changed {
             // Save-as rename: new path already claimed above; remove
-            // the old path_index entry and update room.path.
+            // the old path_index entry and update room.identity.path.
             {
                 let mut idx = daemon.path_index.lock().await;
                 idx.remove(old);
             }
-            *room.path.write().await = Some(canonical.clone());
+            *room.identity.path.write().await = Some(canonical.clone());
             let _ = room
                 .kernel_broadcast_tx
                 .send(NotebookBroadcast::PathChanged {


### PR DESCRIPTION
## Summary

First of four substruct extractions to break up the 23-field `NotebookRoom` god struct. Groups the four notebook-identity fields — `persist_path`, `is_ephemeral`, `path`, `working_dir` — into a focused `RoomIdentity` struct accessed via `room.identity.X`.

**Why these four together:** they describe *which* notebook this room represents, independent of document state, broadcasts, kernel, or connection accounting. `path` changes once (untitled → saved); `working_dir` is set at create time; the other two are read-mostly.

## Details

- New `RoomIdentity` struct in `crates/runtimed/src/notebook_sync_server/room.rs` with a `RoomIdentity::new(persist_path, path, ephemeral)` constructor.
- Removed four fields from `NotebookRoom`, added `pub identity: RoomIdentity`.
- Updated `new_fresh`, `load_or_create`, and the test helper to construct through `RoomIdentity::new`.
- Migrated ~48 callsites from `room.X` to `room.identity.X` across `daemon.rs`, `notebook_sync_server/{peer,load,metadata,persist,tests}.rs`, `requests/{launch_kernel,save_notebook}.rs`.
- Dropped the redundant `Arc<_>` wrapper on `working_dir` — the room is already behind `Arc<NotebookRoom>`, so nested `Arc<RwLock<_>>` was dead weight.

## Scope

PR 1 of 4 per `docs/superpowers/specs/2026-04-22-notebook-room-substructs.md`. Remaining substructs (`RoomBroadcasts`, `RoomPersistence`, `RoomConnections`) land as separate PRs. `doc`, `state`, `trust_state`, `blob_store`, and the 8 runtime-agent fields stay top-level per the spec's design decisions.

## Test plan

- [x] `cargo test -p runtimed --lib` — 389 passing
- [x] `cargo build --workspace --exclude runtimed-py --all-targets` — clean
- [x] `cargo xtask clippy` — clean
- [x] `cargo xtask lint` — clean
- [x] No behavior change — wire format, broadcasts, and locking discipline all preserved