### PR TITLE
refactor(runtimed): remove dead broadcast emissions

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -749,11 +749,6 @@ impl KernelConnection for JupyterKernel {
                                         _ => "unknown",
                                     };
 
-                                    let _ = broadcast_tx.send(NotebookBroadcast::KernelStatus {
-                                        status: status_str.to_string(),
-                                        cell_id: cell_id.clone(),
-                                    });
-
                                     if status_str != "unknown" {
                                         // Non-execute messages (kernel_info, completions) have a
                                         // parent_header.msg_id that isn't in our execute map.
@@ -787,7 +782,7 @@ impl KernelConnection for JupyterKernel {
                                 }
 
                                 JupyterMessageContent::ExecuteInput(input) => {
-                                    if let Some(ref cid) = cell_id {
+                                    if let Some(_cid) = cell_id {
                                         let execution_count = input.execution_count.0 as i64;
 
                                         if let Some(ref eid) = execution_id {
@@ -797,16 +792,6 @@ impl KernelConnection for JupyterKernel {
                                                 warn!("[runtime-state] {}", e);
                                             }
                                         }
-
-                                        let _ = broadcast_tx.send(
-                                            NotebookBroadcast::ExecutionStarted {
-                                                cell_id: cid.clone(),
-                                                execution_id: execution_id
-                                                    .clone()
-                                                    .unwrap_or_default(),
-                                                execution_count,
-                                            },
-                                        );
                                     }
                                 }
 
@@ -913,7 +898,7 @@ impl KernelConnection for JupyterKernel {
                                         continue;
                                     }
 
-                                    if let Some(ref cid) = cell_id {
+                                    if let Some(_cid) = cell_id {
                                         let stream_name = match stream.name {
                                             jupyter_protocol::Stdio::Stdout => "stdout",
                                             jupyter_protocol::Stdio::Stderr => "stderr",
@@ -990,8 +975,8 @@ impl KernelConnection for JupyterKernel {
                                         };
 
                                         if merge_ok {
-                                            let broadcast_output_index = match &upsert_result {
-                                                Ok((updated, output_index)) => {
+                                            match &upsert_result {
+                                                Ok((_updated, output_index)) => {
                                                     let mut terminals =
                                                         iopub_stream_terminals.lock().await;
                                                     terminals.set_output_state(
@@ -1002,29 +987,14 @@ impl KernelConnection for JupyterKernel {
                                                             blob_hash: blob_hash.clone(),
                                                         },
                                                     );
-                                                    if *updated {
-                                                        Some(*output_index)
-                                                    } else {
-                                                        None
-                                                    }
                                                 }
                                                 Err(e) => {
                                                     warn!(
                                                     "[jupyter-kernel] Failed to upsert stream output: {}",
                                                     e
                                                 );
-                                                    None
                                                 }
-                                            };
-
-                                            // merge() already notified via heads check
-                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                                cell_id: cid.clone(),
-                                                execution_id: eid,
-                                                output_type: "stream".to_string(),
-                                                output_json: manifest_json.to_string(),
-                                                output_index: broadcast_output_index,
-                                            });
+                                            }
                                         }
                                     }
                                 }
@@ -1143,8 +1113,8 @@ impl KernelConnection for JupyterKernel {
                                         continue;
                                     }
 
-                                    if let Some(ref cid) = cell_id {
-                                        let output_type = match &message.content {
+                                    if let Some(_cid) = cell_id {
+                                        let _output_type = match &message.content {
                                             JupyterMessageContent::DisplayData(_) => "display_data",
                                             JupyterMessageContent::ExecuteResult(_) => {
                                                 "execute_result"
@@ -1201,23 +1171,8 @@ impl KernelConnection for JupyterKernel {
                                             );
                                             }
 
-                                            let merge_ok = match state_for_iopub.merge(&mut fork) {
-                                                Ok(()) => true,
-                                                Err(e) => {
-                                                    warn!("[runtime-state] merge: {}", e);
-                                                    false
-                                                }
-                                            };
-
-                                            if merge_ok {
-                                                let _ =
-                                                    broadcast_tx.send(NotebookBroadcast::Output {
-                                                        cell_id: cid.clone(),
-                                                        execution_id: eid,
-                                                        output_type: output_type.to_string(),
-                                                        output_json: manifest_json.to_string(),
-                                                        output_index: None,
-                                                    });
+                                            if let Err(e) = state_for_iopub.merge(&mut fork) {
+                                                warn!("[runtime-state] merge: {}", e);
                                             }
                                         }
                                     }
@@ -1242,45 +1197,29 @@ impl KernelConnection for JupyterKernel {
                                         )
                                         .await;
 
-                                        let merge_ok = match updated {
-                                            Ok(true) => match state_for_iopub.merge(&mut fork) {
-                                                Ok(()) => {
+                                        match updated {
+                                            Ok(true) => {
+                                                if let Err(e) = state_for_iopub.merge(&mut fork) {
+                                                    warn!("[runtime-state] merge: {}", e);
+                                                } else {
                                                     debug!(
                                                         "[jupyter-kernel] Updated display_id={}",
                                                         display_id
                                                     );
-                                                    true
                                                 }
-                                                Err(e) => {
-                                                    warn!("[runtime-state] merge: {}", e);
-                                                    false
-                                                }
-                                            },
+                                            }
                                             Ok(false) => {
                                                 error!(
                                                     "[jupyter-kernel] No output found for display_id={}",
                                                     display_id
                                                 );
-                                                false
                                             }
                                             Err(e) => {
                                                 error!(
                                                     "[jupyter-kernel] Failed to update display: {}",
                                                     e
                                                 );
-                                                false
                                             }
-                                        };
-
-                                        if merge_ok {
-                                            let _ = broadcast_tx.send(
-                                                NotebookBroadcast::DisplayUpdate {
-                                                    display_id: display_id.clone(),
-                                                    data: serde_json::to_value(&update.data)
-                                                        .unwrap_or_default(),
-                                                    metadata: update.metadata.clone(),
-                                                },
-                                            );
                                         }
                                     }
                                 }
@@ -1428,23 +1367,8 @@ impl KernelConnection for JupyterKernel {
                                             );
                                             }
 
-                                            let merge_ok = match state_for_iopub.merge(&mut fork) {
-                                                Ok(()) => true,
-                                                Err(e) => {
-                                                    warn!("[runtime-state] merge: {}", e);
-                                                    false
-                                                }
-                                            };
-
-                                            if merge_ok {
-                                                let _ =
-                                                    broadcast_tx.send(NotebookBroadcast::Output {
-                                                        cell_id: cid.clone(),
-                                                        execution_id: eid.clone(),
-                                                        output_type: "error".to_string(),
-                                                        output_json: manifest_json.to_string(),
-                                                        output_index: None,
-                                                    });
+                                            if let Err(e) = state_for_iopub.merge(&mut fork) {
+                                                warn!("[runtime-state] merge: {}", e);
                                             }
                                         }
 
@@ -1821,7 +1745,7 @@ impl KernelConnection for JupyterKernel {
 
         // ── Shell reader task ────────────────────────────────────────────
 
-        let shell_broadcast_tx = shared.broadcast_tx.clone();
+        let _shell_broadcast_tx = shared.broadcast_tx.clone();
         let shell_cell_id_map = cell_id_map.clone();
         let shell_pending_history = pending_history.clone();
         let shell_pending_completions = pending_completions.clone();
@@ -1848,7 +1772,7 @@ impl KernelConnection for JupyterKernel {
                                     });
 
                                     // Process page payloads
-                                    if let Some(ref cid) = cell_id {
+                                    if let Some(_cid) = cell_id {
                                         for payload in &reply.payload {
                                             if let jupyter_protocol::Payload::Page {
                                                 data, ..
@@ -1893,41 +1817,10 @@ impl KernelConnection for JupyterKernel {
                                                 );
                                                 }
 
-                                                let merge_ok = match shell_state.merge(&mut fork) {
-                                                    Ok(()) => true,
-                                                    Err(e) => {
-                                                        warn!("[runtime-state] merge: {}", e);
-                                                        false
-                                                    }
-                                                };
-
-                                                if merge_ok {
-                                                    let _ = shell_broadcast_tx.send(
-                                                        NotebookBroadcast::Output {
-                                                            cell_id: cid.clone(),
-                                                            execution_id: execution_id
-                                                                .clone()
-                                                                .unwrap_or_default(),
-                                                            output_type: "display_data".to_string(),
-                                                            output_json: manifest_json.to_string(),
-                                                            output_index: None,
-                                                        },
-                                                    );
+                                                if let Err(e) = shell_state.merge(&mut fork) {
+                                                    warn!("[runtime-state] merge: {}", e);
                                                 }
                                             }
-                                        }
-                                    }
-
-                                    if reply.status != jupyter_protocol::ReplyStatus::Ok {
-                                        if let Some(ref cid) = cell_id {
-                                            let _ = shell_broadcast_tx.send(
-                                                NotebookBroadcast::ExecutionDone {
-                                                    cell_id: cid.clone(),
-                                                    execution_id: execution_id
-                                                        .clone()
-                                                        .unwrap_or_default(),
-                                                },
-                                            );
                                         }
                                     }
                                 }

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -12,12 +12,11 @@ use std::collections::VecDeque;
 
 use anyhow::Result;
 use runtime_doc::RuntimeStateHandle;
-use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
 use crate::kernel_connection::KernelConnection;
 use crate::output_prep::{KernelStatus, QueuedCell};
-use crate::protocol::{NotebookBroadcast, QueueEntry};
+use crate::protocol::QueueEntry;
 use runtime_doc::QueueEntry as DocQueueEntry;
 
 /// Maximum execution entries retained in the RuntimeStateDoc.
@@ -62,23 +61,17 @@ pub struct KernelState {
     // ── Shared references (not owned, just held) ───────────────────────
     /// Per-notebook runtime state handle (daemon-authoritative).
     state: RuntimeStateHandle,
-    /// Broadcast channel for execution events to connected peers.
-    broadcast_tx: broadcast::Sender<NotebookBroadcast>,
 }
 
 impl KernelState {
     /// Create a new `KernelState` with initial status `Starting`.
-    pub fn new(
-        state: RuntimeStateHandle,
-        broadcast_tx: broadcast::Sender<NotebookBroadcast>,
-    ) -> Self {
+    pub fn new(state: RuntimeStateHandle) -> Self {
         Self {
             queue: VecDeque::new(),
             executing: None,
             execution_had_error: false,
             status: KernelStatus::Starting,
             state,
-            broadcast_tx,
         }
     }
 
@@ -144,12 +137,6 @@ impl KernelState {
             code: source,
         });
 
-        // Broadcast queue state
-        let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-            executing: self.executing_entry(),
-            queued: self.queued_entries(),
-        });
-
         // Write to state doc
         {
             let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
@@ -186,18 +173,6 @@ impl KernelState {
             self.executing = None;
             self.execution_had_error = false;
             self.status = KernelStatus::Idle;
-
-            // Broadcast done
-            let _ = self.broadcast_tx.send(NotebookBroadcast::ExecutionDone {
-                cell_id: cell_id.to_string(),
-                execution_id: execution_id.to_string(),
-            });
-
-            // Broadcast queue state
-            let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-                executing: None,
-                queued: self.queued_entries(),
-            });
 
             // Write to state doc
             {
@@ -251,12 +226,6 @@ impl KernelState {
             })
             .collect();
 
-        // Broadcast queue state
-        let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-            executing: self.executing_entry(),
-            queued: vec![],
-        });
-
         cleared
     }
 
@@ -294,18 +263,6 @@ impl KernelState {
             );
         }
 
-        // Broadcast error status to all peers
-        let _ = self.broadcast_tx.send(NotebookBroadcast::KernelStatus {
-            status: "error".to_string(),
-            cell_id: None,
-        });
-
-        // Broadcast empty queue state
-        let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-            executing: None,
-            queued: vec![],
-        });
-
         // Note: state_doc writes for kernel_died happen in the async command
         // processor (notebook_sync_server.rs QueueCommand::KernelDied handler).
         // state_doc.set_kernel_status("error") + set_queue(None, &[])
@@ -332,13 +289,6 @@ impl KernelState {
 
         self.executing = Some((cell.cell_id.clone(), cell.execution_id.clone()));
         self.status = KernelStatus::Busy;
-
-        // Broadcast queue state
-        let executing = self.executing_entry();
-        let queued = self.queued_entries();
-        let _ = self
-            .broadcast_tx
-            .send(NotebookBroadcast::QueueChanged { executing, queued });
 
         // Write to state doc
         {
@@ -506,23 +456,18 @@ mod tests {
     }
 
     /// Build a `KernelState` wired to a fresh `RuntimeStateHandle`.
-    fn test_state() -> (
-        KernelState,
-        RuntimeStateHandle,
-        broadcast::Receiver<NotebookBroadcast>,
-    ) {
-        let (state_changed_tx, _) = broadcast::channel(64);
+    fn test_state() -> (KernelState, RuntimeStateHandle) {
+        let (state_changed_tx, _) = tokio::sync::broadcast::channel(64);
         let handle = RuntimeStateHandle::new(runtime_doc::RuntimeStateDoc::new(), state_changed_tx);
-        let (broadcast_tx, broadcast_rx) = broadcast::channel(64);
-        let state = KernelState::new(handle.clone(), broadcast_tx);
-        (state, handle, broadcast_rx)
+        let state = KernelState::new(handle.clone());
+        (state, handle)
     }
 
     // ── kernel_died tests ────────────────────────────────────────────────
 
     #[tokio::test]
     async fn kernel_died_returns_interrupted_execution_and_cleared_queue() {
-        let (mut state, _handle, _rx) = test_state();
+        let (mut state, _handle) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 
@@ -558,7 +503,7 @@ mod tests {
 
     #[tokio::test]
     async fn kernel_died_idempotent_when_already_dead() {
-        let (mut state, _handle, _rx) = test_state();
+        let (mut state, _handle) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 
@@ -579,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn kernel_died_with_empty_queue() {
-        let (mut state, _handle, _rx) = test_state();
+        let (mut state, _handle) = test_state();
         state.set_idle();
 
         let (interrupted, cleared) = state.kernel_died();
@@ -591,7 +536,7 @@ mod tests {
 
     #[tokio::test]
     async fn reset_clears_executing_and_queue() {
-        let (mut state, _handle, _rx) = test_state();
+        let (mut state, _handle) = test_state();
         let mut mock = MockKernel::new();
         state.set_idle();
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -683,7 +683,7 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
     if is_tracking {
         // Kernel launched with inline deps - compute drift
         let diff = compute_env_sync_diff(&launched, &current_metadata);
-        let in_sync = diff.is_none();
+        let _in_sync = diff.is_none();
 
         // Write to RuntimeStateDoc
         if let Err(e) = room.state.with_doc(|sd| match &diff {
@@ -698,10 +698,6 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
         }) {
             warn!("[runtime-state] {}", e);
         }
-
-        let _ = room
-            .kernel_broadcast_tx
-            .send(NotebookBroadcast::EnvSyncState { in_sync, diff });
     } else {
         // Kernel launched with prewarmed - check if metadata now has inline deps
         let current_inline = check_inline_deps(&current_metadata);
@@ -725,32 +721,7 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
                 {
                     warn!("[runtime-state] {}", e);
                 }
-                let _ = room
-                    .kernel_broadcast_tx
-                    .send(NotebookBroadcast::EnvSyncState {
-                        in_sync: false,
-                        diff: Some(EnvSyncDiff {
-                            added,
-                            removed: vec![],
-                            channels_changed: false,
-                            deno_changed: false,
-                        }),
-                    });
-            } else {
-                let _ = room
-                    .kernel_broadcast_tx
-                    .send(NotebookBroadcast::EnvSyncState {
-                        in_sync: true,
-                        diff: None,
-                    });
             }
-        } else {
-            let _ = room
-                .kernel_broadcast_tx
-                .send(NotebookBroadcast::EnvSyncState {
-                    in_sync: true,
-                    diff: None,
-                });
         }
     }
 }
@@ -1653,7 +1624,7 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
 async fn acquire_pool_env_for_source(
     env_source: &str,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
-    room: &NotebookRoom,
+    _room: &NotebookRoom,
 ) -> Option<Option<crate::PooledEnv>> {
     use notebook_protocol::connection::{EnvSource, PackageManager};
     let parsed = EnvSource::parse(env_source);
@@ -1685,12 +1656,6 @@ async fn acquire_pool_env_for_source(
             }
             None => {
                 error!("[notebook-sync] Conda pool empty, cannot launch");
-                let _ = room
-                    .kernel_broadcast_tx
-                    .send(NotebookBroadcast::KernelStatus {
-                        status: "error: Conda pool empty".to_string(),
-                        cell_id: None,
-                    });
                 None // Signal caller to return early
             }
         }
@@ -1706,12 +1671,6 @@ async fn acquire_pool_env_for_source(
             }
             None => {
                 error!("[notebook-sync] UV pool empty, cannot launch");
-                let _ = room
-                    .kernel_broadcast_tx
-                    .send(NotebookBroadcast::KernelStatus {
-                        status: "error: UV pool empty".to_string(),
-                        cell_id: None,
-                    });
                 None // Signal caller to return early
             }
         }
@@ -2479,12 +2438,6 @@ pub(crate) async fn auto_launch_kernel(
                 }
                 Err(e) => {
                     error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
-                    let _ = room
-                        .kernel_broadcast_tx
-                        .send(NotebookBroadcast::KernelStatus {
-                            status: format!("error: Failed to prepare environment: {}", e),
-                            cell_id: None,
-                        });
                     reset_starting_state(room, None).await;
                     return;
                 }
@@ -2550,15 +2503,6 @@ pub(crate) async fn auto_launch_kernel(
                             }
                             Err(e) => {
                                 error!("[notebook-sync] Failed to prepare inline env: {}", e);
-                                let _ = room.kernel_broadcast_tx.send(
-                                    NotebookBroadcast::KernelStatus {
-                                        status: format!(
-                                            "error: Failed to prepare environment: {}",
-                                            e
-                                        ),
-                                        cell_id: None,
-                                    },
-                                );
                                 reset_starting_state(room, None).await;
                                 return;
                             }
@@ -2594,12 +2538,6 @@ pub(crate) async fn auto_launch_kernel(
                     }
                     Err(e) => {
                         error!("[notebook-sync] Failed to prepare inline env: {}", e);
-                        let _ = room
-                            .kernel_broadcast_tx
-                            .send(NotebookBroadcast::KernelStatus {
-                                status: format!("error: Failed to prepare environment: {}", e),
-                                cell_id: None,
-                            });
                         reset_starting_state(room, None).await;
                         return;
                     }
@@ -2671,15 +2609,6 @@ pub(crate) async fn auto_launch_kernel(
                             }
                             Err(e) => {
                                 error!("[notebook-sync] Failed to prepare conda inline env: {}", e);
-                                let _ = room.kernel_broadcast_tx.send(
-                                    NotebookBroadcast::KernelStatus {
-                                        status: format!(
-                                            "error: Failed to prepare conda environment: {}",
-                                            e
-                                        ),
-                                        cell_id: None,
-                                    },
-                                );
                                 reset_starting_state(room, None).await;
                                 return;
                             }
@@ -3536,19 +3465,6 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
     let sync_request =
         notebook_protocol::protocol::RuntimeAgentRequest::SyncEnvironment(env_kind.clone());
 
-    // Notify frontend that sync is starting
-    let _ = room
-        .kernel_broadcast_tx
-        .send(NotebookBroadcast::EnvSyncState {
-            in_sync: false,
-            diff: Some(EnvSyncDiff {
-                added: packages_to_install.clone(),
-                removed: vec![],
-                channels_changed: false,
-                deno_changed: false,
-            }),
-        });
-
     match send_runtime_agent_request(room, sync_request).await {
         Ok(notebook_protocol::protocol::RuntimeAgentResponse::EnvironmentSynced {
             synced_packages,
@@ -3595,13 +3511,6 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
             {
                 warn!("[runtime-state] {}", e);
             }
-
-            let _ = room
-                .kernel_broadcast_tx
-                .send(NotebookBroadcast::EnvSyncState {
-                    in_sync: true,
-                    diff: None,
-                });
 
             NotebookResponse::SyncEnvironmentComplete { synced_packages }
         }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1965,31 +1965,6 @@ where
             result = kernel_broadcast_rx.recv() => {
                 match result {
                     Ok(broadcast) => {
-                        // Drop broadcasts that are redundant with RuntimeStateDoc
-                        // (synced via frame 0x05). The daemon still emits these
-                        // internally (e.g. ExecutionDone drives the command loop),
-                        // but peers no longer need them — RuntimeStateDoc is the
-                        // single source of truth for kernel status, queue, execution
-                        // lifecycle, and env sync state.
-                        if matches!(
-                            &broadcast,
-                            NotebookBroadcast::KernelStatus { .. }
-                                | NotebookBroadcast::ExecutionStarted { .. }
-                                | NotebookBroadcast::ExecutionDone { .. }
-                                | NotebookBroadcast::QueueChanged { .. }
-                                | NotebookBroadcast::EnvSyncState { .. }
-                        ) {
-                            // ExecutionDone previously triggered a doc sync flush
-                            // to ensure outputs arrived before the signal. Now that
-                            // the broadcast is dropped, the sync still happens via
-                            // the RuntimeStateDoc update path — the daemon writes
-                            // execution status to the RuntimeStateDoc *after*
-                            // writing outputs to the notebook doc, so the
-                            // frame-0x05 sync message is the new "outputs ready"
-                            // signal for peers.
-                            continue;
-                        }
-
                         connection::send_typed_json_frame(
                             writer,
                             NotebookFrameType::Broadcast,

--- a/crates/runtimed/src/requests/clear_outputs.rs
+++ b/crates/runtimed/src/requests/clear_outputs.rs
@@ -1,7 +1,7 @@
 //! `NotebookRequest::ClearOutputs` handler.
 
 use crate::notebook_sync_server::NotebookRoom;
-use crate::protocol::{NotebookBroadcast, NotebookResponse};
+use crate::protocol::NotebookResponse;
 
 pub(crate) async fn handle(room: &NotebookRoom, cell_id: String) -> NotebookResponse {
     // Clear outputs by nulling the execution_id pointer on the cell.
@@ -35,13 +35,6 @@ pub(crate) async fn handle(room: &NotebookRoom, cell_id: String) -> NotebookResp
     if let Some(ref tx) = room.persist_tx {
         let _ = tx.send(Some(persist_bytes));
     }
-
-    // Broadcast for cross-window UI sync (fast path)
-    let _ = room
-        .kernel_broadcast_tx
-        .send(NotebookBroadcast::OutputsCleared {
-            cell_id: cell_id.clone(),
-        });
 
     NotebookResponse::OutputsCleared { cell_id }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -110,7 +110,7 @@ pub async fn run_runtime_agent(
 
     let mut kernel: Option<JupyterKernel> = None;
     let mut interrupt_handle: Option<crate::jupyter_kernel::InterruptHandle> = None;
-    let mut kernel_state = KernelState::new(state.clone(), broadcast_tx.clone());
+    let mut kernel_state = KernelState::new(state.clone());
     let mut seen_execution_ids = HashSet::new();
     let mut cmd_rx: Option<mpsc::Receiver<QueueCommand>> = None;
 
@@ -1125,7 +1125,7 @@ mod tests {
             presence,
             presence_tx,
         };
-        let state = KernelState::new(handle.clone(), broadcast_tx);
+        let state = KernelState::new(handle.clone());
         (ctx, state, handle)
     }
 


### PR DESCRIPTION
## Summary

Remove 8 broadcast types fully superseded by RuntimeStateDoc CRDT sync. Net -285 lines.

**Already filtered at relay (never reached frontend):**
- KernelStatus, ExecutionStarted, ExecutionDone, QueueChanged, EnvSyncState

**Reached frontend but redundant with CellChangeset/CRDT materialization:**
- Output, DisplayUpdate, OutputsCleared

**Remaining broadcasts (kept):**
- Comm (ephemeral widget messages, not CRDT-able)
- EnvProgress (transient UI progress)
- PathChanged (notebook doc concern)
- NotebookAutosaved (event, not state)
- KernelError (not in CRDT yet)

## Why

The CRDT changeset pipeline (`CellChangeset` + `scheduleMaterialize`) is the source of truth for outputs, execution state, kernel status, and queue state. The broadcast path was a parallel channel that predated the CRDT. It could cause double-renders or stale overwrites if messages arrived out of order with CRDT sync.

Also removes `broadcast_tx` from `KernelState` (no broadcasts left to send) and the peer relay filter that was dropping the already-filtered broadcasts.

## Test plan

- [x] `cargo test -p runtimed` - 389 tests pass
- [x] `cargo xtask clippy` - clean
- [x] `cargo xtask lint` - clean
- [x] Full workspace builds