### PR TITLE
fix(runtimed-py): poll RuntimeStateDoc for wait_for_ready instead of broadcast

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -722,23 +722,21 @@ pub(crate) async fn restart_kernel(
         }
     }
 
-    // Wait for kernel ready
+    // Wait for kernel ready by polling RuntimeStateDoc (the CRDT source of truth).
     if wait_for_ready {
-        let mut st = state.lock().await;
-        if let Some(rx) = st.broadcast_rx.as_mut() {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-            while std::time::Instant::now() < deadline {
-                match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
-                    Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
-                        if status == "idle" =>
-                    {
-                        return Ok(progress_messages);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            {
+                let st = state.lock().await;
+                if let Some(handle) = st.handle.as_ref() {
+                    if let Ok(rs) = handle.get_runtime_state() {
+                        if rs.kernel.status == "idle" {
+                            return Ok(progress_messages);
+                        }
                     }
-                    Ok(Some(_)) => continue,
-                    Ok(None) => return Err(to_py_err("Broadcast channel closed")),
-                    Err(_) => continue,
                 }
             }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
     }
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -723,14 +723,20 @@ pub(crate) async fn restart_kernel(
     }
 
     // Wait for kernel ready by polling RuntimeStateDoc (the CRDT source of truth).
+    // Two phases: first wait for status to leave "idle" (restart in progress),
+    // then wait for it to return to "idle" (new kernel ready). This prevents
+    // returning immediately against the pre-restart idle snapshot.
     if wait_for_ready {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut saw_non_idle = false;
         while std::time::Instant::now() < deadline {
             {
                 let st = state.lock().await;
                 if let Some(handle) = st.handle.as_ref() {
                     if let Ok(rs) = handle.get_runtime_state() {
-                        if rs.kernel.status == "idle" {
+                        if rs.kernel.status != "idle" {
+                            saw_non_idle = true;
+                        } else if saw_non_idle {
                             return Ok(progress_messages);
                         }
                     }


### PR DESCRIPTION
## Summary

`wait_for_ready` in `restart_kernel` was listening for `KernelStatus` broadcast which was removed in #2065. Switch to polling `handle.get_runtime_state()` for `kernel.status == "idle"`, which is the CRDT source of truth.

The old pattern polled a broadcast channel. The new pattern polls the RuntimeStateDoc every 50ms with a 30s deadline - same timeout, same semantics, but uses the CRDT instead of a removed broadcast.

For the `OutputsCleared` P2 finding: the CRDT already nulls `execution_count` and `success` in `clear_execution_outputs()`. The frontend changeset pipeline should pick this up. If it doesn't, that's a frontend materialization gap, not a daemon broadcast gap.

## Test plan

- [x] `cargo check -p runtimed-py` - compiles clean
- [x] `cargo xtask lint` - clean