### PR TITLE
feat(xtask): chain renderer-plugins after sift-wasm rebuild

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,11 +170,15 @@ cargo xtask dev-daemon
 RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) cargo xtask notebook
 ```
 
-### WASM rebuild (after changing notebook-doc or runtimed-wasm)
+### WASM rebuild (after changing notebook-doc, runtimed-wasm, or sift-wasm)
 
 ```bash
-wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm
-# Commit the output — WASM artifacts are checked into the repo
+cargo xtask wasm             # rebuild both runtimed-wasm and sift-wasm;
+                             # also chains into `renderer-plugins` so the
+                             # plugin JS bundles re-embed fresh sift-wasm glue.
+cargo xtask wasm runtimed    # only runtimed-wasm (no plugin chain)
+cargo xtask wasm sift        # only sift-wasm (chains plugins)
+# Commit the output — WASM + plugin artifacts are checked into the repo via LFS.
 ```
 
 ### Subsystem guides

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -122,8 +122,13 @@ fn main() {
             cmd_integration(filter);
         }
         "wasm" => {
-            let target = args.get(1).map(|s| s.as_str());
-            cmd_wasm(target);
+            let skip_renderer_plugins = args.iter().any(|a| a == "--skip-renderer-plugins");
+            let target = args
+                .iter()
+                .skip(1)
+                .find(|a| !a.starts_with('-'))
+                .map(|s| s.as_str());
+            cmd_wasm(target, skip_renderer_plugins);
         }
         "renderer-plugins" => cmd_renderer_plugins(),
         "verify-plugins" => cmd_verify_plugins(),
@@ -196,10 +201,16 @@ Testing:
                              E2E testing (build, run, manage fixtures)
 
 Other:
-  wasm                       Rebuild all WASM targets (runtimed-wasm + sift-wasm)
+  wasm                       Rebuild all WASM targets (runtimed-wasm + sift-wasm).
+                             If sift-wasm was (re)built, also runs renderer-plugins
+                             so the sift.js bundles re-embed the fresh wasm-bindgen glue.
   wasm runtimed              Rebuild only runtimed-wasm
   wasm sift                  Rebuild only sift-wasm (bindings for @nteract/sift);
                              also copies the binary to crates/runt-mcp/assets/plugins/
+                             and rebuilds renderer plugins.
+  wasm --skip-renderer-plugins
+                             Skip the chained renderer-plugins rebuild (escape hatch
+                             for intentionally testing drift between the two).
   renderer-plugins           Rebuild pre-built renderer plugins (notebook + MCP)
   verify-plugins             Check renderer plugin bundles match their wasm artifacts
                              (every wasm-bindgen import in the plugin JS must be
@@ -1187,7 +1198,7 @@ fn cmd_e2e_test_all() {
     println!("\nAll E2E tests passed!");
 }
 
-fn cmd_wasm(target: Option<&str>) {
+fn cmd_wasm(target: Option<&str>, skip_renderer_plugins: bool) {
     // `wasm-pack build crates/<name>` and the subsequent `fs::copy`/
     // `fs::read_dir` calls here all use repo-relative paths. cd to the
     // workspace root so this works whether the user invoked xtask from
@@ -1279,6 +1290,20 @@ fn cmd_wasm(target: Option<&str>) {
         println!(
             "WASM build complete. Output: crates/sift-wasm/pkg/ (mirrored to packages/sift/public/wasm/)"
         );
+    }
+
+    // Renderer plugin bundles embed wasm-bindgen glue from sift-wasm (the
+    // `__wbg_*_<hash>` import names). Rebuilding sift-wasm without rebuilding
+    // the plugins leaves them pointing at stale names — see #2048 (the
+    // `__wbg_call_<hash> must be callable` runtime error). Chain the plugin
+    // build by default so that class of drift can't happen via this command.
+    //
+    // `--skip-renderer-plugins` is the escape hatch for cases where you
+    // explicitly want the drift (e.g. reproducing a bug against an older
+    // bundle, or CI steps that intentionally test one half of the chain).
+    if build_sift && !skip_renderer_plugins {
+        println!();
+        cmd_renderer_plugins();
     }
 }
 


### PR DESCRIPTION
## Summary

Makes the #2048 class of bug architecturally impossible through the xtask command surface. `cargo xtask wasm` (default) and `cargo xtask wasm sift` now automatically rebuild the renderer plugin bundles after building sift-wasm, since the plugin JS embeds wasm-bindgen glue (`__wbg_*_<hash>` import names) that only matches the wasm it was built from.

## Why this is the right shape

The #2048 failure mode is a **propagation rule in people's heads**: "if you rebuilt sift-wasm, also rebuild the plugins." Every tripwire like that eventually fires. This PR replaces the human rule with a build-chain edge: you can't run `cargo xtask wasm` and end up with stale plugins.

Belt + suspenders with #2063 (verify-plugins CI check): the CI check is the safety net for drift introduced through other paths (e.g. a rebase that brings back an old plugin bundle). The chain here stops it from being introduced via the primary rebuild path in the first place.

## What chains when

| Command | Behavior |
|---|---|
| `cargo xtask wasm` | build runtimed-wasm + sift-wasm, then **renderer-plugins** |
| `cargo xtask wasm runtimed` | build runtimed-wasm only; **no** plugin rebuild (no dependency) |
| `cargo xtask wasm sift` | build sift-wasm + **renderer-plugins** |
| `cargo xtask wasm --skip-renderer-plugins` | escape hatch; skip the chain |

`runtimed-wasm` is unaffected because the notebook app consumes it directly — no renderer plugin embeds its glue.

## Escape hatch

`--skip-renderer-plugins` stays available for:

- Testing drift scenarios on purpose (e.g. reproducing a past bug against an older plugin bundle).
- CI steps that want to exercise one half of the chain (`verify-plugins` itself, if we ever want to assert it fails-closed on synthetic drift in CI).

## Docs

Updates the WASM rebuild recipe in `AGENTS.md` (CLAUDE.md symlink) to use `cargo xtask wasm` instead of the raw `wasm-pack build` invocation.

## Verified

- ✅ `cargo xtask wasm runtimed`: rebuilds only runtimed-wasm; no plugin build.
- ✅ `cargo xtask wasm sift`: rebuilds sift-wasm, then runs renderer-plugins, emits `Renderer plugins built.`
- ✅ `cargo xtask wasm sift --skip-renderer-plugins`: rebuilds sift-wasm only.
- ✅ `cargo xtask verify-plugins` passes after the chained rebuild.
- ✅ `cargo test -p xtask` 9/9 green. `cargo clippy -p xtask --all-targets -- -D warnings` clean.
- ✅ `cargo xtask check-dep-budget`: xtask still 28/30.

## Test plan

- [ ] CI green.