### PR TITLE
docs: update room substruct spec after PR 0 + PR A

### DIFF
--- a/docs/superpowers/specs/2026-04-22-notebook-room-substructs.md
+++ b/docs/superpowers/specs/2026-04-22-notebook-room-substructs.md
@@ -1,87 +1,78 @@
 # Refactor: Break up `NotebookRoom` into composed substructs
 
-> **Status: ready.** The `RuntimeStateHandle` migration (#2059) is on main. `state: RuntimeStateHandle` replaces the old `state_doc: Arc<RwLock<RuntimeStateDoc>>` + `state_changed_tx: broadcast::Sender<()>` pair — one self-notifying handle with its own `changed_tx` and sync Mutex. Field inventory below reflects post-merge state.
+> **Status: in-progress.** PR 0 (deletions, #2061) and PR A (RoomIdentity, #2064) are merged. `NotebookRoom` is now 24 direct fields + `identity: RoomIdentity` holding 4 more. Three substructs remain to extract: `RoomBroadcasts`, `RoomPersistence`, `RoomConnections`. Field inventory below reflects post-#2065 state (broadcast cleanup dropped two emissions without changing struct layout).
+
+## Progress
+
+**Done:**
+- **PR 0** (#2061): deleted `auto_launch_at`, `last_save_heads`, stripped redundant `Arc<>` on `last_self_write`. Audited and kept `had_peers` (Python API depends on it).
+- **PR A** (#2064): extracted `RoomIdentity` holding `persist_path`, `is_ephemeral`, `path`, `working_dir`. ~48 callsites migrated to `room.identity.X`. Dropped `Arc` on `working_dir`.
+
+**Remaining:**
+- **PR B** — `RoomBroadcasts`: `changed_tx`, `kernel_broadcast_tx`, `presence_tx`, `presence`.
+- **PR C** — `RoomPersistence`: `persist_tx`, `flush_request_tx`, `last_save_sources`, `last_self_write`, `watcher_shutdown_tx`, `nbformat_attachments`, `is_loading`.
+- **PR D** — `RoomConnections`: `active_peers`, `had_peers`.
 
 ## Problem
 
-`NotebookRoom` is a 27-field god struct in `crates/runtimed/src/notebook_sync_server/room.rs`. It mixes:
+`NotebookRoom` remains a 24-direct-field struct (plus `identity`). It still mixes:
 
-- Immutable notebook identity (`id`, `persist_path`, `blob_store`, `is_ephemeral`)
 - Automerge document + runtime state (`doc`, `state`, `nbformat_attachments`)
-- Persistence bookkeeping (`persist_tx`, `flush_request_tx`, `last_save_heads`, `last_save_sources`, `last_self_write`, `watcher_shutdown_tx`)
-- Broadcast channels (`changed_tx`, `kernel_broadcast_tx`, `presence_tx`)
-- Per-connection accounting (`active_peers`, `had_peers`, `is_loading`)
-- Path / working directory mutation (`path`, `working_dir`)
+- Persistence bookkeeping (`persist_tx`, `flush_request_tx`, `last_save_sources`, `last_self_write`, `watcher_shutdown_tx`, `is_loading`)
+- Broadcast channels (`changed_tx`, `kernel_broadcast_tx`, `presence_tx`, `presence`)
+- Per-connection accounting (`active_peers`, `had_peers`)
 - Trust state (`trust_state`)
+- Blob store handle (`blob_store`)
 - Runtime-agent lifecycle (eight fields — out of scope, see § Out of scope)
 
-Lock shapes are inconsistent: `Arc<RwLock<T>>`, `Arc<Mutex<T>>`, naked `RwLock<T>`, `AtomicBool`, `AtomicUsize`, `AtomicU64`, and `Option<channel_tx>`. Every function that touches `room.*` has to re-derive which fields are safe to hold across which awaits.
+Lock shapes remain inconsistent: `Arc<RwLock<T>>`, `Arc<Mutex<T>>`, naked `RwLock<T>`, `AtomicBool`, `AtomicUsize`, `AtomicU64`, and `Option<channel_tx>`. Every function that touches `room.*` has to re-derive which fields are safe to hold across which awaits.
 
-The test helper `test_room_with_path` builds a room by hand-constructing 27 fields with sensible defaults — because most production tests need only two or three of them, and there's no smaller unit to construct.
-
-This is the single biggest readability win available in `runtimed` today. It also unblocks the env-launch extraction from the code-review proposal: you can't cleanly move the auto-launch code out of `metadata.rs` while the room is an opaque 27-field bag.
+This is the single biggest readability win remaining in `runtimed` today. It also unblocks the env-launch extraction from the code-review proposal: you can't cleanly move the auto-launch code out of `metadata.rs` while the room is an opaque field bag.
 
 ## Fix
 
-Split `NotebookRoom`'s fields into five composed substructs, each owning its own fields directly (no extra `Arc` wrapping) and exposing focused methods. `NotebookRoom` becomes a thin container that composes them.
+Split `NotebookRoom`'s remaining fields into three more composed substructs (`RoomBroadcasts`, `RoomPersistence`, `RoomConnections`) on top of the already-shipped `RoomIdentity`. Each substruct owns its fields directly (no extra `Arc` wrapping) and exposes focused methods. `NotebookRoom` becomes a thin container that composes them.
 
-Field access count (from grep on `crates/runtimed/src`) informed the boundaries: the goal is substructs where **the fields that change together, travel together**, and where **a callsite typically uses fields from one substruct at a time**.
+Field access count (from grep on `crates/runtimed/src`, post-#2065) informed the boundaries: the goal is substructs where **the fields that change together, travel together**, and where **a callsite typically uses fields from one substruct at a time**.
 
-### Proposed shape
+### Target shape (after all three remaining PRs land)
 
 ```rust
 // crates/runtimed/src/notebook_sync_server/room.rs
 
 pub struct NotebookRoom {
     pub id: uuid::Uuid,
-    pub doc: Arc<RwLock<NotebookDoc>>,           // top-level — 123 callsites, no natural sibling
+    pub doc: Arc<RwLock<NotebookDoc>>,           // top-level — 125 callsites, no natural sibling
     pub state: runtime_doc::RuntimeStateHandle,  // top-level — self-contained handle (owns its own changed_tx and sync Mutex)
     pub trust_state: Arc<RwLock<TrustState>>,    // top-level — accessed from both launch + sync paths
     pub blob_store: Arc<BlobStore>,              // top-level — passed by value to many subsystems
 
-    pub identity: RoomIdentity,
-    pub broadcasts: RoomBroadcasts,
-    pub persistence: Option<RoomPersistence>,    // None for ephemeral rooms
-    pub connections: RoomConnections,
+    pub identity: RoomIdentity,                  // DONE (PR #2064)
+    pub broadcasts: RoomBroadcasts,              // PR B
+    pub persistence: Option<RoomPersistence>,    // PR C. None for ephemeral rooms.
+    pub connections: RoomConnections,            // PR D
 
-    // The 8 runtime-agent fields — stay as-is for PR 3 (actor pattern).
+    // The 8 runtime-agent fields — stay as-is. The runtime-agent-work branch
+    // will refactor these into an actor pattern; keeping them at the top
+    // level means this refactor doesn't collide with that work.
     pub runtime_agent_handle: Arc<Mutex<Option<RuntimeAgentHandle>>>,
     pub runtime_agent_request_tx: Arc<Mutex<Option<RuntimeAgentRequestSender>>>,
     pub pending_runtime_agent_connect_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
-    pub runtime_agent_generation: AtomicU64,
-    pub runtime_agent_env_path: RwLock<Option<PathBuf>>,
-    pub runtime_agent_launched_config: RwLock<Option<LaunchedEnvConfig>>,
-    pub current_runtime_agent_id: RwLock<Option<String>>,
-    pub next_queue_seq: AtomicU64,
+    pub runtime_agent_generation: Arc<AtomicU64>,
+    pub runtime_agent_env_path: Arc<RwLock<Option<PathBuf>>>,
+    pub runtime_agent_launched_config: Arc<RwLock<Option<LaunchedEnvConfig>>>,
+    pub current_runtime_agent_id: Arc<RwLock<Option<String>>>,
+    pub next_queue_seq: Arc<AtomicU64>,
 }
 ```
 
-Four substructs, not five — `RoomDocState` is dropped per D1.
+Four substructs total (`RoomIdentity` already shipped).
 
 ### Each substruct
 
-**`RoomIdentity`** — immutable-ish notebook identity.
-```rust
-pub struct RoomIdentity {
-    pub persist_path: PathBuf,
-    pub is_ephemeral: AtomicBool,
-    pub path: RwLock<Option<PathBuf>>,           // Some(x) once saved; changes on untitled → saved
-    pub working_dir: RwLock<Option<PathBuf>>,    // untitled-notebook project file detection
-}
-```
-Field count in source: `persist_path` (9), `is_ephemeral` (6), `path` (29), `working_dir` (4). 48 call sites total. No async locks — all std::sync because no accesses hold across awaits.
+**`RoomIdentity`** — DONE (PR #2064). `persist_path`, `is_ephemeral`, `path`, `working_dir`. Accessed via `room.identity.X` at 46 callsites. No async locks. Constructor: `RoomIdentity::new(persist_path, path, ephemeral)`. `Arc` on `working_dir` dropped during extraction.
 
-**`RoomDocState`** — Automerge doc only. Thinnest substruct; maybe too thin, but `doc` is the hottest field by a factor of 2× and deserves a clear home.
-```rust
-pub struct RoomDocState {
-    pub doc: Arc<RwLock<NotebookDoc>>,
-}
-```
-Field count: `doc` (123). If `RoomDocState` feels over-engineered for one field, consider skipping it and keeping `doc: Arc<RwLock<NotebookDoc>>` top-level. Calling it out as a decision point — see § Design decisions.
-
-*Why not pull `state: RuntimeStateHandle` in here?* The handle is already self-contained — it owns its sync Mutex and its own `changed_tx` — and it's `Clone`. Putting it inside another substruct buys nothing and costs a field-path level (`room.doc_state.state.with_doc(...)` vs `room.state.with_doc(...)`). Keep it top-level; this is the exception that proves the "group what changes together" rule: the handle's internals already do that job.
-
-**`RoomBroadcasts`** — fan-out channels that don't belong to a specific handle.
+**`RoomBroadcasts`** — PR B. Fan-out channels that don't belong to a specific handle.
 ```rust
 pub struct RoomBroadcasts {
     pub changed_tx: broadcast::Sender<()>,
@@ -90,9 +81,11 @@ pub struct RoomBroadcasts {
     pub presence: Arc<RwLock<PresenceState>>,
 }
 ```
-Field count: `changed_tx` (18), `kernel_broadcast_tx` (7), `presence_tx` (6), `presence` (8). `presence` is the state that goes with `presence_tx`; keep them together. `state.subscribe()` replaces the old `state_changed_tx.subscribe()` — no top-level channel needed.
+Field counts (current): `changed_tx` (18), `kernel_broadcast_tx` (5), `presence_tx` (6), `presence` (8). `presence` is the state that goes with `presence_tx`; keep them together. `state.subscribe()` handles the old "runtime state changed" channel — no top-level broadcast for that anymore.
 
-**`RoomPersistence`** — Option-shaped: `None` for ephemeral rooms, `Some` for file-backed.
+Total callsite migration for PR B: ~37.
+
+**`RoomPersistence`** — PR C. Option-shaped: `None` for ephemeral rooms, `Some` for file-backed.
 ```rust
 pub struct RoomPersistence {
     pub persist_tx: watch::Sender<Option<Vec<u8>>>,
@@ -110,86 +103,83 @@ pub struct RoomPersistence {
 
 `watcher_shutdown_tx` lives here because the watcher only runs for file-backed rooms (see `catalog.rs:82-89`).
 
-`nbformat_attachments` is disk-coupled (populated from the .ipynb file on load, read on save and on markdown-asset resolution). Ephemeral rooms don't need it — they never have nbformat attachments to round-trip. Moving it here drops the field from `RoomDocState`.
+`nbformat_attachments` is disk-coupled (populated from the .ipynb file on load, read on save and on markdown-asset resolution). Ephemeral rooms don't need it — they never have nbformat attachments to round-trip.
 
 `is_loading` is a streaming-load mutex used during initial .ipynb load to prevent double-loading. It gates the persistence-read path, not the general connection-count path, so it belongs here rather than in `RoomConnections`. The `try_start_loading()` / `finish_loading()` helpers on `NotebookRoom` move to `RoomPersistence` as inherent methods.
 
-Field count: `persist_tx` (9), `flush_request_tx` (0 — only constructed), `last_save_sources` (7), `last_self_write` (2), `watcher_shutdown_tx` (2), `nbformat_attachments` (7), `is_loading` (4).
+Field counts (current): `persist_tx` (9), `flush_request_tx` (1 — only constructed), `last_save_sources` (7), `last_self_write` (2), `watcher_shutdown_tx` (3), `nbformat_attachments` (7), `is_loading` (4).
 
-**`RoomConnections`** — per-connection accounting.
+Total callsite migration for PR C: ~33, with some turning into `Option::map`/`Option::and_then` chains. This is the biggest blast radius because of the `Option<_>` wrapping, and the one reviewers will want to see most carefully.
+
+**`RoomConnections`** — PR D. Per-connection accounting.
 ```rust
 pub struct RoomConnections {
     pub active_peers: AtomicUsize,
     pub had_peers: AtomicBool,
 }
 ```
-Field count: `active_peers` (15), `had_peers` (2).
+Field counts (current): `active_peers` (17), `had_peers` (2).
+
+Total callsite migration for PR D: ~19. Smallest substruct, good candidate to ship last as a palate-cleanser.
 
 ### What stays top-level
 
 **`id`** — one `uuid::Uuid`, read 14 times. No reason to nest.
 
-**`trust_state`** — 20 callsites across metadata, load, launch_kernel, requests. Not obviously "persistence" (trust is re-verified from the live doc) nor "doc state" (the TrustState struct is not an Automerge doc). Keep top-level. Revisit if it later gets a clear home.
+**`doc`** — 125 callsites, one field. The nesting would buy nothing. Stays top-level.
 
-**`blob_store`** — 9 callsites. A cloneable `Arc<BlobStore>` that's passed to subsystems (runtime agent spawn, output resolver, blob server). Doesn't belong to any one substruct.
+**`state: RuntimeStateHandle`** — self-contained handle (owns its sync Mutex and its own `changed_tx`, clone-cheap). Nesting it would just add a field-path level. Stays top-level.
 
-**`kernel` (the 8 runtime-agent fields)** — out of scope. Farmed out to the runtime-agent-work branch. These stay exactly where they are today in `NotebookRoom` for now, so this refactor is a pure move of the other 20 fields.
+**`trust_state`** — 20 callsites across metadata, load, launch_kernel, requests. Not obviously "persistence" (trust is re-verified from the live doc) nor "doc state" (the TrustState struct is not an Automerge doc). Stays top-level. Revisit if it later gets a clear home.
 
-### What gets deleted
+**`blob_store`** — 9 callsites. A cloneable `Arc<BlobStore>` that's passed to subsystems (runtime agent spawn, output resolver, blob server). Doesn't belong to any one substruct. Stays top-level.
 
-- 10 redundant `Arc<_>` wrappers. Today `runtime_agent_generation: Arc<AtomicU64>`, `next_queue_seq: Arc<AtomicU64>`, `last_self_write: Arc<AtomicU64>` are all `Arc`-wrapped atomics. `NotebookRoom` itself is already behind `Arc` everywhere (`Arc<NotebookRoom>` in the rooms map), so atomics inside it never need an extra `Arc`. Drop the extra allocations — callers that clone to move into tasks already clone the outer `Arc<NotebookRoom>`.
-- Similarly, `Arc<RwLock<T>>` where `T` is small: `Arc<RwLock<Option<PathBuf>>>` for `working_dir`, `Arc<RwLock<Vec<ChangeHash>>>` for `last_save_heads`, `Arc<RwLock<HashMap<...>>>` for `last_save_sources`, `last_save_heads`, `nbformat_attachments`. Drop the outer `Arc` for fields that are only ever read through the room.
-- `pub fn kernel_info` and `pub fn has_kernel` methods on `NotebookRoom` — these inspect runtime-agent fields + `state`. They don't cleanly fit either the kernel cluster or the doc cluster. Leave them on `NotebookRoom` as coordination helpers for now; PR 3 moves them.
+**The 8 runtime-agent fields** — out of scope. Farmed out to the runtime-agent-work branch, which plans to refactor them into an actor pattern. They stay at the top level for now so this refactor doesn't collide with that work.
 
-### Simplifications found during scoping (optional, should ship separately)
+### What gets deleted during each substruct PR
 
-Three "delete first, then split" cleanups surfaced during the field audit. Each is small enough to ship as a one-file PR *before* starting on substructs, which shrinks the substruct refactor's surface area.
-
-**S1 — Delete `auto_launch_at`.** Write-only field. `peer.rs:458` stores `Some(Instant::now())` when auto-launch triggers; nothing ever reads it. The comment claims a 30-second eviction grace period, but eviction reads `active_peers` + `room_eviction_delay_ms`, not `auto_launch_at`. Delete the field, delete the write.
-
-**S2 — Delete `last_save_heads`.** Written at `persist.rs:262`, read nowhere. The comment explains it was for `fork_at(last_save_heads)` which is disabled due to automerge/automerge#1327. Keeping it as "in case we re-enable" costs an `Arc<RwLock<_>>` allocation on every room construction and one write per save. Delete both sides; if we re-enable `fork_at` someday, bring it back.
-
-**S3 — Verify `had_peers` is still needed.** Written once at `peer.rs:418` (`= true` on first connect), read only at `daemon.rs:2773` inside a diagnostic `RoomInfo` response (the rooms-list RPC). Kyle recalls eviction using it historically; current code doesn't. Before deleting, grep all `.rs` for the atomic name, search recent git history for eviction logic that touched it, and confirm the RoomsList consumer (if any) actually uses the field. If the only reader is a never-consulted diagnostic field, delete both sides. Otherwise keep.
-
-Each simplification is independent and costs <30 lines to remove. Landing them first means fewer fields to relocate in PR B.
+- Redundant `Arc<_>` wrappers on fields that the room owns exclusively. `NotebookRoom` itself is already behind `Arc` (in the `NotebookRooms` map), so `Arc<AtomicU64>`, `Arc<RwLock<HashMap<_>>>`, etc. on fields are dead allocations. Drop the outer `Arc` when extracting each substruct.
+- Non-kernel examples already shipped: `working_dir` (in PR A), `last_self_write` (in PR 0).
+- Remaining: `last_save_sources`, `nbformat_attachments` (both `Arc<RwLock<HashMap<_, _>>>`) — drop when they move into `RoomPersistence`.
+- Kernel-cluster Arc atomics (`runtime_agent_generation`, `next_queue_seq`) deferred to the runtime-agent branch, which has a test that clones those individually and will need its own update alongside.
 
 ### Design decisions
 
-Four choices that merit calling out before implementation starts:
+Three choices locked in from the initial design phase, still applicable:
 
-**D1 — Keep `doc` in a `RoomDocState` substruct, or leave it top-level?**
-- *Pro substruct:* consistency with the other substructs; leaves a clear place to add per-doc helpers later (materializers, snapshots).
-- *Pro top-level:* 123 callsites, one field — the nesting buys nothing today. `RoomDocState` would be a one-field substruct.
-- *Recommendation:* leave `doc` top-level. Revisit only if a natural second field appears (it doesn't today — `nbformat_attachments` is disk-coupled, `state` is a separate handle). Drop `RoomDocState` from the plan.
+**D1 — Don't create a `RoomDocState` substruct.**
+`doc` is the only field that would live there — `state` is a separate handle, `nbformat_attachments` is disk-coupled. A one-field substruct buys nothing.
 
-**D2 — Put `is_loading` in `RoomConnections` or `RoomPersistence`?**
-The field is a streaming-load mutex. It gates the "read .ipynb from disk" path. If we read the name literally (`is_loading` = "a peer is currently loading"), it sounds like connection accounting. If we read the behavior (prevents two reads of the disk file), it's persistence. Behavior wins.
-- *Recommendation:* `RoomPersistence`. `try_start_loading`/`finish_loading` become methods on `RoomPersistence` (ephemeral rooms can't have `is_loading` because they have no persistence — even better, the caller pattern becomes `room.persistence.as_ref().and_then(|p| p.try_start_loading())`).
+**D2 — `is_loading` lives in `RoomPersistence`, not `RoomConnections`.**
+The field is a streaming-load mutex. It gates the "read .ipynb from disk" path. If we read the name literally it sounds like connection accounting, but behavior wins: ephemeral rooms can't have `is_loading` because they have no persistence. `try_start_loading`/`finish_loading` become methods on `RoomPersistence`.
 
-**D3 — Hold `nbformat_attachments` in `RoomDocState` or `RoomPersistence`?**
-Populated on .ipynb load (only for file-backed rooms), read on save and on markdown-asset resolution. Never written by live edits — it's a "preserve through round-trip" cache.
-- *Recommendation:* `RoomPersistence`. Ephemeral rooms don't need it.
+**D3 — `nbformat_attachments` lives in `RoomPersistence`.**
+Populated on .ipynb load (only for file-backed rooms), read on save and on markdown-asset resolution. Never written by live edits. Ephemeral rooms don't need it.
 
-**D4 — Keep the `Arc<RwLock<_>>` shell on fields that don't need shared ownership?**
-Fields like `last_save_sources` and `nbformat_attachments` are `Arc<RwLock<HashMap<_, _>>>` today. The `Arc` is unnecessary — `NotebookRoom` itself is always behind an `Arc`, so nested `Arc`s don't buy cheap cloning. Dropping the outer `Arc` means `room.persistence.as_ref().unwrap().last_save_sources.read().await` instead of `room.last_save_sources.read().await.clone()` — one fewer allocation per read.
-- *Recommendation:* drop nested `Arc`s on fields owned exclusively by the room. Callers that need to move the data into a task can `.clone()` the data itself (already happens at several callsites).
+**D4 — Drop the `Arc<_>` shell on fields the room owns exclusively.**
+`NotebookRoom` is always behind an `Arc`, so nested `Arc`s don't buy cheap cloning. Dropping them means one fewer allocation per read. Callers that need to move data into a task clone the data itself (already happens at several callsites).
 
 ### Callsite impact
 
-Every callsite that reads `room.X` where `X` moved to a substruct now reads `room.<sub>.X`. ~105 rewrites total across the affected files — the biggest reduction comes from D1 (keep `doc` top-level, preserves 123 callsites untouched).
+Every callsite that reads `room.X` where `X` moved to a substruct now reads `room.<sub>.X`. ~89 rewrites remaining across the affected files:
+
+- **PR B (RoomBroadcasts):** ~37 callsites
+- **PR C (RoomPersistence):** ~33 callsites (some turn into `Option::map` chains)
+- **PR D (RoomConnections):** ~19 callsites
+
+`doc` and `state` are left untouched at the top level per D1 — ~179 callsites preserved.
 
 The common access patterns:
 - `room.doc.read().await` — unchanged (top-level per D1)
 - `room.state.with_doc(|d| ...)` — unchanged (top-level)
 - `room.state.subscribe()` — unchanged (top-level)
+- `room.identity.path.read().await.clone()` — unchanged (already shipped)
 - `room.persist_tx.as_ref()` → `room.persistence.as_ref().map(|p| &p.persist_tx)` (tightened: single `Option` unwrap instead of two)
-- `room.path.read().await.clone()` → `room.identity.path.read().await.clone()`
 - `room.changed_tx.send(())` → `room.broadcasts.changed_tx.send(())`
 - `room.active_peers.fetch_add(1, Ordering::SeqCst)` → `room.connections.active_peers.fetch_add(1, Ordering::SeqCst)`
 - `room.try_start_loading()` → `room.persistence.as_ref().is_some_and(|p| p.try_start_loading())`
-- `room.nbformat_attachments.read().await.clone()` → `room.persistence.as_ref().map(|p| p.nbformat_attachments.read()).transpose()`...
 
-(The `is_loading` / `nbformat_attachments` rewrites get slightly noisier because they now live under `Option<RoomPersistence>`. Ephemeral rooms today treat these as always-present with "default empty" semantics; after the refactor, ephemeral rooms skip them entirely. At most callsites this is a small simplification: the ephemeral branch short-circuits instead of reading an empty map.)
+The `is_loading` / `nbformat_attachments` rewrites get slightly noisier because they live under `Option<RoomPersistence>`. Ephemeral rooms today treat these as always-present with "default empty" semantics; after the refactor, ephemeral rooms skip them entirely. At most callsites this is a small simplification: the ephemeral branch short-circuits instead of reading an empty map.
 
 ### Tests
 
@@ -204,44 +194,37 @@ let (state_changed_tx, _) = broadcast::channel(16);
 let room = NotebookRoom {
     id,
     identity: RoomIdentity::new(persist_path, path, /* ephemeral */ false),
-    doc_state: RoomDocState::new(doc),
     broadcasts: RoomBroadcasts::default(),
     persistence: Some(RoomPersistence::new_debounced(persist_path.clone())),
     connections: RoomConnections::default(),
+    doc: Arc::new(RwLock::new(doc)),
     state: RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx),
     trust_state: Arc::new(RwLock::new(trust)),
     blob_store,
-    kernel: RoomKernelState::default(),  // unchanged — stays for PR 3
+    // Runtime-agent fields unchanged (PR3 / actor pattern owns them).
+    runtime_agent_handle: Arc::new(Mutex::new(None)),
+    // ... etc.
 };
 ```
 
-Each substruct gets a `::new()` or `::default()` constructor, so most tests become five lines shorter.
+Each substruct gets a `::new()` or `::default()` constructor, so most tests become several lines shorter.
 
 ### Migration path
 
-Three PRs, each atomic and small-ish. Do them in order.
+Each remaining substruct ships as a single atomic PR. The pattern is proven (PR A shipped as #2064 and was mechanical): define the struct, move the fields, migrate callsites in one commit, compiler verifies.
 
-**PR 0 — Simplifications (deletions first).**
-- S1: delete `auto_launch_at`. One field, one writer, no readers. Drop the field, drop the write site (peer.rs:458-459), drop the two initializers in room.rs.
-- S2: delete `last_save_heads`. One field, one writer (persist.rs:262), no readers. Drop both sides.
-- S3: verify `had_peers` is still needed for eviction as Kyle recalls (grep recent git log for eviction code that touched it). If yes: keep. If no: delete both the write (peer.rs:418) and the diagnostic field (daemon.rs:2773 `RoomInfo.had_peers`, which is a wire type — will need a protocol version bump to remove safely, so probably keep for now).
-- Drop nested `Arc<_>` wrappers on `next_queue_seq`, `runtime_agent_generation`, `last_self_write` — the room is already behind `Arc` so these extra allocations are dead weight.
-- No new substructs yet. Everything stays on `NotebookRoom`, just smaller and cleaner.
-- Expected ~50-80 lines removed.
+The original spec planned a "scaffolding PR + migration PR" split with pass-through getters. Rust can't fake field access via methods without parens, so that split was impossible; one atomic PR per substruct turned out to be cleaner anyway — reviewers see one focused diff per substruct instead of a scaffolding-then-rename pair.
 
-**PR A — introduce the substructs with construction parity, don't move field access yet.**
-- Define the four substructs (`RoomIdentity`, `RoomBroadcasts`, `RoomPersistence`, `RoomConnections`).
-- Update `NotebookRoom::new_fresh` and `NotebookRoom::load_or_create` to construct through them.
-- Add pass-through getters on `NotebookRoom` that preserve the old `room.path` / `room.changed_tx` / etc. surface so every existing callsite keeps compiling without change.
-- Leave a `#[deprecated]` note on the pass-throughs so reviewers can see the target shape.
+**Done:**
+- **PR 0** (#2061): deletions + `Arc<AtomicU64>` → `AtomicU64` on `last_self_write`. ~50 lines removed.
+- **PR A** (#2064): `RoomIdentity`. ~48 callsites migrated, `Arc` dropped on `working_dir`.
 
-**PR B — migrate call sites.**
-- Remove the pass-through getters.
-- Update every `room.X` to `room.<sub>.X` for fields that moved.
-- `room.doc` and `room.state` stay untouched per D1.
-- Mechanical, ~105 lines of find/replace across the affected files.
+**Remaining (suggested order):**
+- **PR B** — `RoomBroadcasts`: define struct with 4 fields, migrate ~37 callsites. Smallest risk since broadcast channels don't hold state — they just dispatch.
+- **PR C** — `RoomPersistence`: the one with `Option<_>` shape. Define struct with 7 fields, migrate ~33 callsites (some become `Option::map`/`Option::and_then` chains). Drop nested `Arc<_>` on `last_save_sources` and `nbformat_attachments`. `try_start_loading`/`finish_loading` methods move onto `RoomPersistence`.
+- **PR D** — `RoomConnections`: define struct with 2 fields, migrate ~19 callsites. Palate-cleanser.
 
-Three PRs means PR 0 ships obvious cleanups first (low risk, zero mental overhead), PR A lands on its own and is verified with the existing test suite unchanged, and PR B is the churny one but reviewers can skim it knowing only field paths changed.
+Each PR stands alone: compiler verifies all callsites at commit time, test suite is the backstop, `cargo xtask clippy` + `cargo xtask lint` gate the commit.
 
 ## Out of scope
 
@@ -254,33 +237,32 @@ Three PRs means PR 0 ships obvious cleanups first (low risk, zero mental overhea
 
 - Wire format unchanged. No protocol or schema version bump.
 - No behavior change. Every field keeps its same lock discipline and same access pattern.
-- Tests continue to pass (after the migration — PR A keeps them all green via pass-through getters).
-- PR A ships in one atomic commit, workspace green at both ends.
-- PR B is mechanical: reviewer verifies "is `room.<sub>.field` the same field it used to be called `room.field`?" and nothing else.
+- Each substruct PR is atomic: the workspace compiles before and after the commit.
+- Reviewer's job is simple: "is `room.<sub>.field` the same field it used to be called `room.field`?"
 
 ## Non-goals
 
 - Not introducing traits or abstract interfaces.
 - Not changing any public API (Python bindings, MCP, wire protocol).
-- Not fixing the generation-counter race in the runtime-agent fields (PR 3's job).
+- Not fixing the generation-counter race in the runtime-agent fields (that's the runtime-agent-work branch's job).
 - Not renaming fields.
 
 ## Testing
 
-- Existing test suite passes unchanged after PR A.
-- No new tests required — this is a refactor, not a feature.
-- After PR B: one smoke test per substruct constructor (`RoomPersistence::new_debounced` spawns the debouncer, `RoomConnections::default` starts at zero, etc.).
+- Existing test suite passes unchanged — each PR verifies against the full `cargo test -p runtimed --lib` suite.
+- No new tests required for the moves themselves.
+- `test_room_with_path` helper shrinks incrementally as each substruct lands (a constructor call replaces 4-7 hand-placed fields).
 
 ## Risk
 
-- **Blast radius.** ~105 call-site edits in PR B (down from ~230 because D1 keeps `doc` top-level). Mechanical. Mitigation: PR A lands pass-throughs first so the field rename is a find/replace pass, not a semantic change.
-- **PR 0 deletions are irreversible once pushed.** If S3 turns out to be wrong and `had_peers` really was load-bearing, reverting means re-adding the atomic. Cheap to fix but worth a careful grep first.
-- **Atomic constructor invariant.** `persist_tx` and `flush_request_tx` being in one `RoomPersistence` is better than two separate `Option`s — but the test `room.persist_tx.is_none()` at `tests.rs:428` needs rewriting as `room.persistence.is_none()`. That's a semantic improvement (the test gets more faithful to the invariant), not a regression.
-- **Missed callers.** Use compiler errors to find them — deleting `pub doc: Arc<RwLock<NotebookDoc>>` and re-adding under `RoomDocState` will surface every `room.doc` usage at compile time.
+- **Blast radius, not mechanical risk.** ~89 callsite edits remaining across 3 PRs. The compiler surfaces every miss — no grep-and-hope.
+- **`RoomPersistence` is the riskiest of the three** because of the `Option<_>` wrapper. Some callsites currently treat "no persistence" as "empty maps" via always-present fields. After the refactor those callsites short-circuit instead. Expect some rewrites to read less naturally the first time through; trust the compiler to flag behavior-changing mistakes (type mismatches, missing arms).
+- **Kernel-cluster `Arc<_>` strips are explicitly out of scope.** PR 0 stripped `Arc<AtomicU64>` on `last_self_write`. `next_queue_seq`, `runtime_agent_generation`, and a few others remain `Arc`-wrapped because a test clones them individually into a spawned task. The runtime-agent branch will touch this when it actor-ifies those fields.
 
 ## Deliverables
 
-- `crates/runtimed/src/notebook_sync_server/room.rs` → substruct definitions, updated constructors.
-- (In PR B) every `room.<field>` access in the 26 affected files → `room.<sub>.<field>`.
-- Updated `test_room_with_path` helper.
+Per remaining PR:
+- `crates/runtimed/src/notebook_sync_server/room.rs` → substruct definition, updated constructors.
+- Every `room.<field>` access → `room.<sub>.<field>` across the affected files.
+- Updated `test_room_with_path` helper (one constructor call replaces the moved-field initializers).
 - No changes to protocol types, Automerge schema, or Python/TS bindings.


### PR DESCRIPTION
Reflects shipped state (PR #2061 deletions, PR #2064 RoomIdentity). Drops the RoomDocState substruct per D1. Updates field counts against post-#2065 code. Reshapes remaining plan as three atomic per-substruct PRs (RoomBroadcasts, RoomPersistence, RoomConnections) instead of the original scaffolding-then-migrate split — Rust can't fake field access via methods, so one atomic PR per substruct is cleaner.

~89 callsites remaining across the three PRs.