### PR TITLE
fix(xtask): run pnpm install before build_mcp_widget

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -765,7 +765,19 @@ fn cmd_build(rust_only: bool) {
         require_pnpm();
     }
 
-    // Phase 0: Build the MCP widget HTML before any Rust compilation.
+    // Phase 0a: Install workspace pnpm deps up front. This was previously
+    // kicked off as a background thread alongside cargo build (which made
+    // sense when the MCP widget step below didn't also shell out to pnpm),
+    // but `build_mcp_widget` runs `pnpm --filter <pkg> install` which
+    // assumes the workspace is already initialized. On a fresh clone with
+    // no `node_modules`, that filtered install would spin up the root
+    // install itself — redundant at best, flaky at worst. Do it once,
+    // here, before anyone else touches pnpm.
+    if !rust_only {
+        ensure_pnpm_install();
+    }
+
+    // Phase 0b: Build the MCP widget HTML before any Rust compilation.
     // runt-mcp uses include_str!("../assets/_output.html") which fails
     // if the asset doesn't exist yet. This must run before cargo build.
     if !rust_only {
@@ -778,16 +790,6 @@ fn cmd_build(rust_only: bool) {
             build_mcp_widget();
         }
     }
-
-    // Start pnpm install in background — it only needs to finish before
-    // the frontend build in Phase 2, so overlap it with cargo build.
-    let pnpm_handle = if !rust_only {
-        Some(thread::spawn(|| {
-            ensure_pnpm_install();
-        }))
-    } else {
-        None
-    };
 
     // Phase 1: Build all Rust crates except `notebook`.
     // The `notebook` crate's build.rs declares `rerun-if-changed` on
@@ -817,14 +819,6 @@ fn cmd_build(rust_only: bool) {
     copy_sidecar_binary("runtimed", false);
     copy_sidecar_binary("runt", false);
     copy_sidecar_binary("nteract-mcp", false);
-
-    // Wait for pnpm install before starting frontend build
-    if let Some(handle) = pnpm_handle {
-        handle.join().unwrap_or_else(|_| {
-            eprintln!("pnpm install panicked");
-            exit(1);
-        });
-    }
 
     // Phase 2: Run independent tasks in parallel.
     // - Python env sync + maturin develop (builds .so for MCP server)
@@ -1620,6 +1614,12 @@ fn cmd_build_app() {
 fn build_with_bundle(bundle: &str) {
     require_pnpm();
     require_tauri();
+
+    // Ensure pnpm workspace deps are installed before anything else touches
+    // pnpm — `run_frontend_build` below and any tauri `beforeBuildCommand`
+    // assume node_modules is populated. Fresh clones would otherwise fail
+    // with missing-workspace-package errors.
+    ensure_pnpm_install();
 
     // Generate icons if source exists
     let source_path = "crates/notebook/icons/source.png";


### PR DESCRIPTION
## Summary

`cargo xtask build` on a fresh clone failed because `build_mcp_widget` was the **first** step to touch pnpm, and it runs `pnpm --filter nteract-mcp-app install` — which assumes the workspace is already initialized. Without a prior root `pnpm install`, that filtered install races with the background root install that `cmd_build` used to kick off afterwards.

Fix moves `ensure_pnpm_install()` up to Phase 0a, before the widget build. Drops the now-redundant background-install thread and its join point.

Also fixes the same class of bug in `build_with_bundle` (`cargo xtask build-app` / `build-dmg`): it called `run_frontend_build` without any upstream `pnpm install`, so a fresh-clone release build would fail with missing-workspace-package errors. Adds `ensure_pnpm_install()` right after `require_pnpm()`.

## Why the old order existed

`cmd_build`'s background-install thread made sense when `build_mcp_widget` didn't also shell out to pnpm. At some point the widget step was added and the fresh-clone case silently regressed.

## What's unchanged

- `cargo xtask dev`, `cargo xtask notebook`, `cargo xtask vite` all already call `ensure_pnpm_install()` synchronously up front. Their ordering is correct and untouched.
- `ensure_pnpm_install()` is still idempotent and short-circuits when `node_modules/.modules.yaml` is newer than `package.json` and `pnpm-lock.yaml` — no-op cost on warm trees.
- `build_mcp_widget`'s own `pnpm --filter nteract-mcp-app install` is kept as a safety belt for any future caller from a different code path.

## Test plan

- [x] `cargo build -p xtask`, `cargo test -p xtask` (9/9), `cargo clippy -p xtask --all-targets -- -D warnings` — all clean.
- [x] Ran `cargo xtask build` on the warm tree; confirmed order of operations is "Skipping pnpm install" → "Skipping MCP Apps widget build" → "Building Rust targets...".
- [ ] CI green.
- [ ] Optional follow-up: smoke test on a fresh checkout (`git clone && cargo xtask build`) to confirm the original fresh-clone path now succeeds.