### PR TITLE
refactor(runtimed): extract RoomBroadcasts substruct

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -563,7 +563,7 @@ where
         }
 
         // Notify other peers in the room
-        let _ = room.changed_tx.send(());
+        let _ = room.broadcasts.changed_tx.send(());
         // RuntimeStateDoc notification is automatic via with_doc heads check
 
         // Drain incoming sync replies to prevent deadlock
@@ -602,7 +602,7 @@ where
                 .await
                 .map_err(|e| format!("Failed to send metadata sync: {}", e))?;
         }
-        let _ = room.changed_tx.send(());
+        let _ = room.broadcasts.changed_tx.send(());
         drain_incoming_frames(reader, room, peer_state).await;
     }
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -634,7 +634,7 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
         doc.save()
     };
 
-    let _ = room.changed_tx.send(());
+    let _ = room.broadcasts.changed_tx.send(());
     if let Some(ref tx) = room.persist_tx {
         let _ = tx.send(Some(persist_bytes));
     }
@@ -982,7 +982,7 @@ pub(crate) async fn capture_env_into_metadata(
         // Without this, captured metadata lives only in the in-memory CRDT
         // and evaporates on room eviction, making the next reopen re-capture
         // from scratch.
-        let _ = room.changed_tx.send(());
+        let _ = room.broadcasts.changed_tx.send(());
     }
     changed
 }
@@ -1435,9 +1435,10 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
         "conda:prewarmed" => CapturedEnvRuntime::Conda,
         _ => return acquire_pool_env_for_source(env_source, daemon, room).await,
     };
-    let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
-        crate::inline_env::BroadcastProgressHandler::new(room.kernel_broadcast_tx.clone()),
-    );
+    let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
+        std::sync::Arc::new(crate::inline_env::BroadcastProgressHandler::new(
+            room.broadcasts.kernel_broadcast_tx.clone(),
+        ));
 
     // Reopen path: if the notebook has an env_id and the unified-hash env
     // exists on disk, route through prepare_environment_unified for an
@@ -2405,9 +2406,10 @@ pub(crate) async fn auto_launch_kernel(
     }
 
     // For inline deps, prepare a cached environment with rich progress
-    let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
-        crate::inline_env::BroadcastProgressHandler::new(room.kernel_broadcast_tx.clone()),
-    );
+    let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
+        std::sync::Arc::new(crate::inline_env::BroadcastProgressHandler::new(
+            room.broadcasts.kernel_broadcast_tx.clone(),
+        ));
 
     // Fetch feature flags now so inline env prep hashes match what the
     // kernel will actually receive (bootstrap_dx changes the install set).
@@ -2862,7 +2864,13 @@ pub(crate) async fn publish_kernel_state_presence(
     status: presence::KernelStatus,
     env_source: &str,
 ) {
-    update_kernel_presence(&room.presence, &room.presence_tx, status, env_source).await;
+    update_kernel_presence(
+        &room.broadcasts.presence,
+        &room.broadcasts.presence_tx,
+        status,
+        env_source,
+    )
+    .await;
 }
 
 /// Update kernel state in the shared presence state and relay to all peers.
@@ -3687,7 +3695,7 @@ pub(crate) async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, 
             warn!("{}", e);
             doc.rebuild_from_save();
         }
-        let _ = room.changed_tx.send(());
+        let _ = room.broadcasts.changed_tx.send(());
         info!(
             "[format] Formatted {} code cells (runtime: {})",
             formatted_count, runtime

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -129,7 +129,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     );
 
     // ── 5. Sync loop ─────────────────────────────────────────────────
-    let mut changed_rx = room.changed_tx.subscribe();
+    let mut changed_rx = room.broadcasts.changed_tx.subscribe();
     let mut state_changed_rx = room.state.subscribe();
     let mut pending_replies: std::collections::HashMap<
         String,
@@ -147,7 +147,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                                     let mut doc = room.doc.write().await;
                                     if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
-                                        let _ = room.changed_tx.send(());
+                                        let _ = room.broadcasts.changed_tx.send(());
                                     }
                                     // Send sync reply
                                     if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
@@ -560,10 +560,10 @@ where
     // generated before starting the sync loop, so it is always
     // available here. remove_peer is a no-op for unknown peers
     // (e.g. error before any presence was registered).
-    room.presence.write().await.remove_peer(&peer_id);
+    room.broadcasts.presence.write().await.remove_peer(&peer_id);
     match presence::encode_left(&peer_id) {
         Ok(left_bytes) => {
-            let _ = room.presence_tx.send((peer_id, left_bytes));
+            let _ = room.broadcasts.presence_tx.send((peer_id, left_bytes));
         }
         Err(e) => warn!("[notebook-sync] Failed to encode 'left' presence: {}", e),
     }
@@ -1102,9 +1102,9 @@ where
 {
     // Subscribe before sending bootstrap traffic so any writes that land
     // during connection setup are still observed as steady-state deltas.
-    let mut changed_rx = room.changed_tx.subscribe();
-    let mut kernel_broadcast_rx = room.kernel_broadcast_tx.subscribe();
-    let mut presence_rx = room.presence_tx.subscribe();
+    let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+    let mut kernel_broadcast_rx = room.broadcasts.kernel_broadcast_tx.subscribe();
+    let mut presence_rx = room.broadcasts.presence_tx.subscribe();
     let mut state_changed_rx = room.state.subscribe();
 
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
@@ -1217,7 +1217,7 @@ where
                         let mut doc = room.doc.write().await;
                         let _ = doc.clear_all_cells();
                     }
-                    let _ = room.changed_tx.send(());
+                    let _ = room.broadcasts.changed_tx.send(());
                     warn!(
                         "[notebook-sync] Streaming load failed for {}: {}",
                         load_path.display(),
@@ -1274,7 +1274,7 @@ where
     // their own cursor as a remote peer (clients don't know their server-assigned ID).
     {
         let snapshot_bytes = {
-            let presence_state = room.presence.read().await;
+            let presence_state = room.broadcasts.presence.read().await;
             if presence_state.peer_count() > 0 {
                 // Build snapshot excluding this peer (they shouldn't see themselves)
                 let other_peers: Vec<presence::PeerSnapshot> = presence_state
@@ -1362,7 +1362,7 @@ where
                                     let bytes = doc.save();
 
                                     // Notify other peers in this room
-                                    let _ = room.changed_tx.send(());
+                                    let _ = room.broadcasts.changed_tx.send(());
 
                                     let encoded = match catch_automerge_panic("doc-sync-reply", || {
                                         doc.generate_sync_message(&mut peer_state)
@@ -1491,7 +1491,7 @@ where
                                             let sanitized_label = Some(label.clone());
                                             // Update the room's presence state (using our known peer_id,
                                             // not the one in the frame — clients don't know their peer_id).
-                                            let is_new = room.presence.write().await.update_peer(
+                                            let is_new = room.broadcasts.presence.write().await.update_peer(
                                                 peer_id,
                                                 &label,
                                                 actor_label.as_deref(),
@@ -1502,6 +1502,7 @@ where
                                             if is_new {
                                                 // New peer — send snapshot of everyone else (excluding self)
                                                 let other_peers: Vec<presence::PeerSnapshot> = room
+                                                    .broadcasts
                                                     .presence
                                                     .read()
                                                     .await
@@ -1545,18 +1546,18 @@ where
                                                     data: data_for_relay,
                                                 },
                                             ) {
-                                                let _ = room.presence_tx.send((peer_id.to_string(), bytes));
+                                                let _ = room.broadcasts.presence_tx.send((peer_id.to_string(), bytes));
                                             }
                                         }
                                     }
                                     Ok(presence::PresenceMessage::Heartbeat { .. }) => {
-                                        room.presence.write().await.mark_seen(peer_id, now_ms);
+                                        room.broadcasts.presence.write().await.mark_seen(peer_id, now_ms);
                                     }
                                     Ok(presence::PresenceMessage::ClearChannel { channel, .. }) => {
-                                        room.presence.write().await.clear_channel(peer_id, channel);
+                                        room.broadcasts.presence.write().await.clear_channel(peer_id, channel);
                                         match presence::encode_clear_channel(peer_id, channel) {
                                             Ok(bytes) => {
-                                                let _ = room.presence_tx.send((peer_id.to_string(), bytes));
+                                                let _ = room.broadcasts.presence_tx.send((peer_id.to_string(), bytes));
                                             }
                                             Err(e) => warn!(
                                                 "[notebook-sync] Failed to encode clear_channel presence: {}",
@@ -1939,7 +1940,7 @@ where
                             "[notebook-sync] Peer {} lagged {} presence updates, sending snapshot",
                             peer_id, n
                         );
-                        match room.presence.read().await.encode_snapshot(peer_id) {
+                        match room.broadcasts.presence.read().await.encode_snapshot(peer_id) {
                             Ok(snapshot_bytes) => {
                                 connection::send_typed_frame(
                                     writer,
@@ -2003,14 +2004,14 @@ where
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis() as u64;
-                let mut presence_state = room.presence.write().await;
+                let mut presence_state = room.broadcasts.presence.write().await;
                 presence_state.mark_seen(peer_id, now_ms);
                 let pruned = presence_state.prune_stale(now_ms, presence::DEFAULT_PEER_TTL_MS);
                 drop(presence_state);
                 for pruned_peer_id in pruned {
                     match presence::encode_left(&pruned_peer_id) {
                         Ok(left_bytes) => {
-                            let _ = room.presence_tx.send((pruned_peer_id, left_bytes));
+                            let _ = room.broadcasts.presence_tx.send((pruned_peer_id, left_bytes));
                         }
                         Err(e) => warn!(
                             "[notebook-sync] Failed to encode 'left' for pruned peer: {}",

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -361,6 +361,7 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
 
     // Broadcast path change to all peers.
     let _ = room
+        .broadcasts
         .kernel_broadcast_tx
         .send(NotebookBroadcast::PathChanged {
             path: Some(canonical.to_string_lossy().into_owned()),
@@ -758,7 +759,7 @@ fn spawn_autosave_debouncer_with_config(
     room: Arc<NotebookRoom>,
     config: AutosaveDebouncerConfig,
 ) {
-    let mut changed_rx = room.changed_tx.subscribe();
+    let mut changed_rx = room.broadcasts.changed_tx.subscribe();
     spawn_supervised(
         "autosave-debouncer",
         async move {
@@ -836,7 +837,7 @@ fn spawn_autosave_debouncer_with_config(
                                     } else {
                                         last_receive = None;
                                         // Broadcast to connected clients so they can clear dirty state
-                                        let _ = room.kernel_broadcast_tx.send(
+                                        let _ = room.broadcasts.kernel_broadcast_tx.send(
                                             NotebookBroadcast::NotebookAutosaved {
                                                 path,
                                             },
@@ -1088,7 +1089,7 @@ pub(crate) fn spawn_notebook_file_watcher(
 
                                 // Notify peers of the change — actual data
                                 // arrives via Automerge sync frames
-                                let _ = room.changed_tx.send(());
+                                let _ = room.broadcasts.changed_tx.send(());
                             }
 
                             // Re-verify trust after external metadata edits.

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -32,22 +32,48 @@ impl RoomIdentity {
     }
 }
 
+/// Per-room broadcast fan-out.
+///
+/// Groups the four channels that distribute room-scoped events to peer sync
+/// loops: document-change notifications, kernel broadcasts (PathChanged,
+/// NotebookAutosaved, EnvProgress, Comm), and presence traffic. `presence`
+/// holds the per-peer state that `presence_tx` relays between connections.
+pub struct RoomBroadcasts {
+    /// Broadcast channel to notify all peers in this room of doc changes.
+    pub changed_tx: broadcast::Sender<()>,
+    /// Broadcast channel for kernel events: PathChanged, NotebookAutosaved,
+    /// EnvProgress, and Comm (widget messages).
+    pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
+    /// Broadcast channel for presence frames (cursor, selection, kernel state).
+    /// Carries raw presence bytes plus the peer_id to relay to other peers.
+    pub presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    /// Transient peer state (cursors, selections, kernel status).
+    /// Protected by RwLock for concurrent reads from multiple peer loops.
+    pub presence: Arc<RwLock<PresenceState>>,
+}
+
+impl Default for RoomBroadcasts {
+    fn default() -> Self {
+        let (changed_tx, _) = broadcast::channel(16);
+        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
+        let (presence_tx, _) = broadcast::channel(64);
+        Self {
+            changed_tx,
+            kernel_broadcast_tx,
+            presence_tx,
+            presence: Arc::new(RwLock::new(PresenceState::new())),
+        }
+    }
+}
+
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room. Used as the map key once
     /// Phase 5 lands; for now coexists with the string-keyed map.
     pub id: uuid::Uuid,
     /// The canonical Automerge notebook document.
     pub doc: Arc<RwLock<NotebookDoc>>,
-    /// Broadcast channel to notify all peers in this room of changes.
-    pub changed_tx: broadcast::Sender<()>,
-    /// Broadcast channel for kernel events (outputs, status changes).
-    pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
-    /// Broadcast channel for presence frames (cursor, selection, kernel state).
-    /// Carries raw presence bytes to relay to other peers.
-    pub presence_tx: broadcast::Sender<(String, Vec<u8>)>,
-    /// Transient peer state (cursors, selections, kernel status).
-    /// Protected by RwLock for concurrent reads from multiple peer loops.
-    pub presence: Arc<RwLock<PresenceState>>,
+    /// Broadcast channels + presence state for fan-out to peer sync loops.
+    pub broadcasts: RoomBroadcasts,
     /// Channel to send doc bytes to the debounced persistence task.
     /// Uses watch for "latest value" semantics - always keeps most recent state.
     pub persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
@@ -187,9 +213,6 @@ impl NotebookRoom {
             // TODO(phase-6): tighten NotebookDoc to accept Uuid directly
             NotebookDoc::new_with_actor(&notebook_id_str, runtimed_actor)
         };
-        let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
-
         // Spawn debounced persistence task (watch channel keeps latest value only)
         // Ephemeral rooms skip persistence entirely.
         // Store ephemeral flag in doc metadata so the GUI can show a banner
@@ -229,18 +252,13 @@ impl NotebookRoom {
             notebook_id_str, trust_state.status
         );
 
-        let (presence_tx, _) = broadcast::channel(64);
-
         let (state_changed_tx, _) = broadcast::channel(16);
         let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
 
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
-            changed_tx,
-            kernel_broadcast_tx,
-            presence_tx,
-            presence: Arc::new(RwLock::new(PresenceState::new())),
+            broadcasts: RoomBroadcasts::default(),
             persist_tx,
             flush_request_tx,
             identity: RoomIdentity::new(persist_path, path, ephemeral),
@@ -294,12 +312,9 @@ impl NotebookRoom {
         let filename = notebook_doc_filename(notebook_id);
         let persist_path = docs_dir.join(filename);
         let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
-        let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
         spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
-        let (presence_tx, _) = broadcast::channel(64);
         let path = if is_untitled_notebook(notebook_id) {
             None
         } else {
@@ -326,10 +341,7 @@ impl NotebookRoom {
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
-            changed_tx,
-            kernel_broadcast_tx,
-            presence_tx,
-            presence: Arc::new(RwLock::new(PresenceState::new())),
+            broadcasts: RoomBroadcasts::default(),
             persist_tx: Some(persist_tx),
             flush_request_tx: Some(flush_request_tx),
             identity: RoomIdentity::new(persist_path, path, false),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -638,24 +638,17 @@ fn test_room_with_path(
     let notebook_id = notebook_path.to_string_lossy().to_string();
 
     let doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
-    let (changed_tx, _) = broadcast::channel(16);
-    let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
     let persist_path = tmp.path().join("doc.automerge");
     let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
     let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
     spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
-
-    let (presence_tx, _) = broadcast::channel(64);
 
     let (state_changed_tx, _) = broadcast::channel(16);
     let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
     let room = NotebookRoom {
         id: uuid::Uuid::new_v4(),
         doc: Arc::new(RwLock::new(doc)),
-        changed_tx,
-        kernel_broadcast_tx,
-        presence_tx,
-        presence: Arc::new(RwLock::new(PresenceState::new())),
+        broadcasts: RoomBroadcasts::default(),
         persist_tx: Some(persist_tx),
         flush_request_tx: Some(flush_request_tx),
         identity: RoomIdentity::new(persist_path, Some(notebook_path.clone()), false),
@@ -2553,7 +2546,7 @@ async fn test_promote_untitled_starts_autosave() {
         doc.add_cell(1, "cell-2", "code").unwrap();
         doc.update_source("cell-2", "y = 2").unwrap();
     }
-    let _ = room.changed_tx.send(());
+    let _ = room.broadcasts.changed_tx.send(());
 
     // 6. Poll until the autosave debouncer flushes both cells to disk.
     //    Each sleep(100ms) advances the paused clock and yields to the

--- a/crates/runtimed/src/requests/clear_outputs.rs
+++ b/crates/runtimed/src/requests/clear_outputs.rs
@@ -17,7 +17,7 @@ pub(crate) async fn handle(room: &NotebookRoom, cell_id: String) -> NotebookResp
         let mut doc = room.doc.write().await;
         let _ = doc.set_execution_id(&cell_id, None);
         let bytes = doc.save();
-        let _ = room.changed_tx.send(());
+        let _ = room.broadcasts.changed_tx.send(());
         bytes
     };
 

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -116,7 +116,7 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
             {
                 let mut doc = room.doc.write().await;
                 let _ = doc.set_execution_id(&cell_id, Some(&execution_id));
-                let _ = room.changed_tx.send(());
+                let _ = room.broadcasts.changed_tx.send(());
             }
 
             // Best-effort background formatting via fork+merge
@@ -149,7 +149,7 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
                                 warn!("{}", e);
                                 doc.rebuild_from_save();
                             }
-                            let _ = room_clone.changed_tx.send(());
+                            let _ = room_clone.broadcasts.changed_tx.send(());
                         }
                     }
                 }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -563,7 +563,7 @@ pub(crate) async fn handle(
     // For inline deps, prepare a cached environment with rich progress
     let launch_progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> =
         std::sync::Arc::new(crate::inline_env::BroadcastProgressHandler::new(
-            room.kernel_broadcast_tx.clone(),
+            room.broadcasts.kernel_broadcast_tx.clone(),
         ));
 
     // Fetch feature flags up front so inline env hashing matches

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -72,7 +72,7 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
                 for (execution_id, cell_id, _, _) in &entries {
                     let _ = doc.set_execution_id(cell_id, Some(execution_id));
                 }
-                let _ = room.changed_tx.send(());
+                let _ = room.broadcasts.changed_tx.send(());
             }
 
             return NotebookResponse::AllCellsQueued { queued };

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -145,6 +145,7 @@ pub(crate) async fn handle(
             }
             *room.identity.path.write().await = Some(canonical.clone());
             let _ = room
+                .broadcasts
                 .kernel_broadcast_tx
                 .send(NotebookBroadcast::PathChanged {
                     path: Some(canonical.to_string_lossy().into_owned()),

--- a/crates/runtimed/src/requests/set_metadata_snapshot.rs
+++ b/crates/runtimed/src/requests/set_metadata_snapshot.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handle(room: &NotebookRoom, snapshot: String) -> NotebookRes
                 match doc.set_metadata_snapshot(&snap) {
                     Ok(()) => {
                         // Notify peers of the change
-                        let _ = room.changed_tx.send(());
+                        let _ = room.broadcasts.changed_tx.send(());
                         // Persist
                         if let Some(ref tx) = room.persist_tx {
                             let bytes = doc.save();

--- a/crates/runtimed/src/requests/set_raw_metadata.rs
+++ b/crates/runtimed/src/requests/set_raw_metadata.rs
@@ -8,7 +8,7 @@ pub(crate) async fn handle(room: &NotebookRoom, key: String, value: String) -> N
     match doc.set_metadata(&key, &value) {
         Ok(()) => {
             // Notify peers of the change
-            let _ = room.changed_tx.send(());
+            let _ = room.broadcasts.changed_tx.send(());
             // Persist
             if let Some(ref tx) = room.persist_tx {
                 let bytes = doc.save();


### PR DESCRIPTION
## Summary

Second of four substruct extractions. Groups the four broadcast fan-out fields — `changed_tx`, `kernel_broadcast_tx`, `presence_tx`, `presence` — into a focused `RoomBroadcasts` struct accessed via `room.broadcasts.X`.

Follows the same pattern as #2064 (`RoomIdentity`): define substruct, migrate callsites in one atomic commit, compiler verifies.

## Why these four together

They share a purpose: **fan-out to peer sync loops**.

- `changed_tx` — notify sync/autosave loops of doc mutation
- `kernel_broadcast_tx` — 4 real event types (`PathChanged`, `NotebookAutosaved`, `EnvProgress`, `Comm`); the legacy state-carrying variants (`KernelStatus`, `Output`, `QueueChanged`, etc.) are obsoleted by RuntimeStateDoc sync
- `presence_tx` — relay raw presence frames
- `presence` — the per-peer state map that `presence_tx` relays

## Details

- New `RoomBroadcasts` struct in `crates/runtimed/src/notebook_sync_server/room.rs` with a `Default` impl that creates the three channels + empty presence state.
- Removed four fields from `NotebookRoom`, added `pub broadcasts: RoomBroadcasts`.
- Updated `new_fresh`, `load_or_create`, and the test helper.
- Migrated ~42 callsites from `room.X` to `room.broadcasts.X` across `notebook_sync_server/{peer,load,metadata,persist,tests}.rs`, `requests/{launch_kernel,save_notebook,execute_cell,run_all_cells,clear_outputs,set_metadata_snapshot,set_raw_metadata}.rs`.

## Scope

PR 2 of 4 per the spec at `docs/superpowers/specs/2026-04-22-notebook-room-substructs.md`. Remaining: `RoomPersistence` (the `Option<_>` one) and `RoomConnections` (2 fields, palate-cleanser).

## Test plan

- [x] `cargo test -p runtimed --lib` — 389 passing
- [x] `cargo build --workspace --exclude runtimed-py --all-targets` — clean
- [x] `cargo xtask clippy` — clean
- [x] `cargo xtask lint` — clean
- [x] Wire format unchanged — `kernel_broadcast_tx` still dispatches the same `NotebookBroadcast` variants
- [x] Broadcast channel capacities unchanged (16, 256, 64 — same defaults as before)