### PR TITLE
refactor(runtimed): extract RoomPersistence substruct

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2025,7 +2025,7 @@ impl Daemon {
         } else {
             let doc = room.doc.read().await;
             let existing_count = doc.cell_count();
-            if existing_count == 0 && !room.is_loading.load(std::sync::atomic::Ordering::Acquire) {
+            if existing_count == 0 && !room.is_loading() {
                 // Room is empty and nobody is loading yet — this connection
                 // will do the streaming load inside the sync loop.
                 info!(
@@ -2038,7 +2038,7 @@ impl Daemon {
                     "[runtimed] Room for {} has {} cells (joining existing{})",
                     path,
                     existing_count,
-                    if room.is_loading.load(std::sync::atomic::Ordering::Acquire) {
+                    if room.is_loading() {
                         ", load in progress"
                     } else {
                         ""

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -83,7 +83,7 @@ pub async fn get_or_create_room(
         if notebook_path.extension().is_some_and(|ext| ext == "ipynb") {
             let shutdown_tx = spawn_notebook_file_watcher(notebook_path.clone(), room.clone());
             // Blocking lock is OK here — room is brand new, no contention.
-            if let Ok(mut guard) = room.watcher_shutdown_tx.try_lock() {
+            if let Ok(mut guard) = room.persistence.watcher_shutdown_tx.try_lock() {
                 *guard = Some(shutdown_tx);
             }
         }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -463,7 +463,7 @@ where
 
     let (cells, metadata, nbformat_attachments) = parse_notebook_jiter(&bytes)?;
     {
-        let mut cache = room.nbformat_attachments.write().await;
+        let mut cache = room.persistence.nbformat_attachments.write().await;
         *cache = nbformat_attachments.clone();
     }
 
@@ -955,7 +955,7 @@ pub(crate) async fn apply_ipynb_changes(
     };
 
     {
-        let mut cache = room.nbformat_attachments.write().await;
+        let mut cache = room.persistence.nbformat_attachments.write().await;
         *cache = external_attachments.clone();
     }
 
@@ -1126,10 +1126,12 @@ pub(crate) async fn apply_ipynb_changes(
 
         // Update saved_sources baseline so subsequent external edits are
         // detected correctly (same as the non-order-change path).
-        let mut saved = room.last_save_sources.write().await;
-        saved.clear();
-        for ext_cell in external_cells {
-            saved.insert(ext_cell.id.clone(), ext_cell.source.clone());
+        {
+            let mut saved = room.persistence.last_save_sources.write().await;
+            saved.clear();
+            for ext_cell in external_cells {
+                saved.insert(ext_cell.id.clone(), ext_cell.source.clone());
+            }
         }
 
         return true;
@@ -1137,10 +1139,7 @@ pub(crate) async fn apply_ipynb_changes(
 
     // Snapshot saved_sources before the doc write lock to avoid holding
     // doc across saved_sources `.await` (deadlock prevention).
-    let saved_sources_snapshot: HashMap<String, String> = {
-        let saved_sources = room.last_save_sources.read().await;
-        saved_sources.clone()
-    };
+    let saved_sources_snapshot = room.last_save_sources_snapshot().await;
     let have_save_snapshot = !saved_sources_snapshot.is_empty();
 
     // Find cells to delete — only cells that existed in our last save
@@ -1397,7 +1396,7 @@ pub(crate) async fn apply_ipynb_changes(
     // that subsequent external edits are detected correctly (P2-a) and
     // externally-added cells become deletable if later removed (P2-b).
     if changed {
-        let mut saved = room.last_save_sources.write().await;
+        let mut saved = room.persistence.last_save_sources.write().await;
         for ext_cell in external_cells {
             saved.insert(ext_cell.id.clone(), ext_cell.source.clone());
         }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -583,7 +583,7 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
         .await
         .clone()
         .filter(|p| p.exists());
-    let nbformat_attachments = room.nbformat_attachments.read().await.clone();
+    let nbformat_attachments = room.nbformat_attachments_snapshot().await;
 
     // Fork BEFORE async resolution so the fork's baseline predates
     // any concurrent edits. Asset updates on the fork are treated as
@@ -635,8 +635,8 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
     };
 
     let _ = room.broadcasts.changed_tx.send(());
-    if let Some(ref tx) = room.persist_tx {
-        let _ = tx.send(Some(persist_bytes));
+    if let Some(ref d) = room.persistence.debouncer {
+        let _ = d.persist_tx.send(Some(persist_bytes));
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -632,9 +632,9 @@ where
                 const FLUSH_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
                 let mut flush_ok = true;
                 let mut flush_failure_kind: Option<&'static str> = None;
-                if let Some(ref flush_tx) = room_for_eviction.flush_request_tx {
+                if let Some(ref d) = room_for_eviction.persistence.debouncer {
                     let (ack_tx, ack_rx) = oneshot::channel::<bool>();
-                    if flush_tx.send(ack_tx).is_ok() {
+                    if d.flush_request_tx.send(ack_tx).is_ok() {
                         match tokio::time::timeout(FLUSH_TIMEOUT, ack_rx).await {
                             Ok(Ok(true)) => {}
                             Ok(Ok(false)) => {
@@ -758,8 +758,15 @@ where
                     }
                 }
 
-                // Stop file watcher if running
-                if let Some(shutdown_tx) = room_for_eviction.watcher_shutdown_tx.lock().await.take()
+                // Stop file watcher if running. `watcher_shutdown_tx` is
+                // always present on `RoomPersistence`, but the Option inside
+                // is None until a watcher is actually spawned.
+                if let Some(shutdown_tx) = room_for_eviction
+                    .persistence
+                    .watcher_shutdown_tx
+                    .lock()
+                    .await
+                    .take()
                 {
                     let _ = shutdown_tx.send(());
                     debug!(
@@ -1412,8 +1419,8 @@ where
                                 }
 
                                 // Send to debounced persistence task
-                                if let Some(ref tx) = room.persist_tx {
-                                    let _ = tx.send(Some(persist_bytes));
+                                if let Some(ref d) = room.persistence.debouncer {
+                                    let _ = d.persist_tx.send(Some(persist_bytes));
                                 }
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
@@ -1763,9 +1770,7 @@ where
                 if matches!(
                     initial_load_phase,
                     notebook_protocol::protocol::InitialLoadPhaseWire::Streaming
-                ) && !room
-                    .is_loading
-                    .load(std::sync::atomic::Ordering::Acquire)
+                ) && !room.is_loading()
                 {
                     initial_load_phase =
                         notebook_protocol::protocol::InitialLoadPhaseWire::Ready;

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -126,7 +126,7 @@ pub(crate) async fn save_notebook_to_disk(
         })
         .unwrap_or_default();
 
-    let nbformat_attachments = room.nbformat_attachments.read().await.clone();
+    let nbformat_attachments = room.nbformat_attachments_snapshot().await;
 
     // Reconstruct cells as JSON
     // Cell metadata now comes from the CellSnapshot (populated during load)
@@ -241,12 +241,17 @@ pub(crate) async fn save_notebook_to_disk(
             }
         })?;
 
-    // Update last_self_write timestamp so file watcher skips this change
+    // Update last_self_write timestamp so the file watcher skips our own write.
+    // Applies to all rooms (including ephemeral that were just promoted to
+    // file-backed via this save) — a watcher may start up right after
+    // `finalize_untitled_promotion` and will consult this baseline.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
-    room.last_self_write.store(now, Ordering::Relaxed);
+    room.persistence
+        .last_self_write
+        .store(now, Ordering::Relaxed);
 
     // Snapshot cell sources at save time so the file watcher can distinguish
     // our own writes from genuine external changes. Only update when saving
@@ -259,7 +264,7 @@ pub(crate) async fn save_notebook_to_disk(
         for cell in &cells {
             saved.insert(cell.id.clone(), cell.source.clone());
         }
-        *room.last_save_sources.write().await = saved;
+        *room.persistence.last_save_sources.write().await = saved;
     }
 
     info!(
@@ -343,10 +348,12 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
         }
     }
 
-    // Spawn .ipynb file watcher.
+    // Spawn .ipynb file watcher. RoomPersistence is always present, so the
+    // shutdown sender finds a home whether the room was born file-backed or
+    // promoted from ephemeral.
     if canonical.extension().is_some_and(|ext| ext == "ipynb") {
         let shutdown_tx = spawn_notebook_file_watcher(canonical.clone(), Arc::clone(room));
-        *room.watcher_shutdown_tx.lock().await = Some(shutdown_tx);
+        *room.persistence.watcher_shutdown_tx.lock().await = Some(shutdown_tx);
     }
 
     // Spawn autosave debouncer so subsequent edits persist to .ipynb.
@@ -409,7 +416,7 @@ pub(crate) async fn clone_notebook_to_disk(
         (doc.get_cells(), doc.get_metadata_snapshot())
     };
 
-    let nbformat_attachments = room.nbformat_attachments.read().await.clone();
+    let nbformat_attachments = room.nbformat_attachments_snapshot().await;
 
     // Read existing source notebook to preserve unknown top-level metadata keys.
     let source_notebook_path = room.identity.path.read().await.clone();
@@ -785,7 +792,7 @@ fn spawn_autosave_debouncer_with_config(
                             Err(broadcast::error::RecvError::Closed) => {
                                 // Room is being evicted — do a final autosave
                                 if !is_untitled_notebook(&notebook_id)
-                                    && !room.is_loading.load(Ordering::Acquire)
+                                    && !room.is_loading()
                                 {
                                     match save_notebook_to_disk(&room, None).await {
                                         Ok(path) => {
@@ -818,7 +825,7 @@ fn spawn_autosave_debouncer_with_config(
 
                         if should_flush {
                             // Skip during initial load
-                            if room.is_loading.load(Ordering::Acquire) {
+                            if room.is_loading() {
                                 continue;
                             }
 
@@ -990,12 +997,12 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 continue;
                             }
 
-                            // Check if this is a self-write (within skip window of our last save)
+                            // Check if this is a self-write (within skip window of our last save).
                             let now = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_millis() as u64)
                                 .unwrap_or(0);
-                            let last_write = room.last_self_write.load(Ordering::Relaxed);
+                            let last_write = room.persistence.last_self_write.load(Ordering::Relaxed);
                             if now.saturating_sub(last_write) < SELF_WRITE_SKIP_WINDOW_MS {
                                 debug!(
                                     "[notebook-watch] Skipping self-write event for {:?}",

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -66,6 +66,118 @@ impl Default for RoomBroadcasts {
     }
 }
 
+/// Per-room persistence bookkeeping.
+///
+/// Always present on every room. The optional `debouncer` field nests the
+/// two debouncer channels that only exist for non-ephemeral rooms
+/// (untitled-saved or file-backed); everything else (save-baseline
+/// snapshots, file-watcher shutdown, streaming-load gate, attachment
+/// cache) is needed whether the room is ephemeral today or will be
+/// promoted to file-backed later.
+///
+/// When an ephemeral room is saved via `finalize_untitled_promotion`, the
+/// watcher shutdown sender and save baselines start getting populated
+/// without any struct-level resurrection — the fields were waiting for
+/// the file-backed state to arrive.
+pub struct RoomPersistence {
+    /// Debouncer channels — present only when the room writes to a
+    /// persisted Automerge doc (`notebook-docs/*.automerge`). Ephemeral
+    /// rooms keep this `None`, and so do rooms promoted via Save (the
+    /// `.automerge` stream isn't restarted post-promotion — see comment
+    /// in `finalize_untitled_promotion`).
+    pub debouncer: Option<PersistDebouncer>,
+    /// Cell sources as they were written to disk at last save.
+    ///
+    /// The file watcher compares disk content against this snapshot (not the
+    /// live CRDT) to distinguish our own autosave writes from genuine external
+    /// changes (git pull, external editor).
+    pub last_save_sources: RwLock<HashMap<String, String>>,
+    /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
+    /// Used to skip file watcher events triggered by our own saves.
+    pub last_self_write: AtomicU64,
+    /// Shutdown signal for the file watcher task.
+    /// Sent when the room is evicted to stop the watcher.
+    pub watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Raw nbformat attachments preserved from disk, keyed by cell ID.
+    ///
+    /// Populated only by `.ipynb` load paths. Resolved image data already
+    /// lives in the Automerge doc as blob URLs per cell; this map is the
+    /// raw base64 payload kept in memory so save can round-trip back to
+    /// `.ipynb` byte-identically without re-encoding the blob bytes.
+    ///
+    /// Transitional: this should eventually live in the doc alongside
+    /// cells (as blob references with a stable schema) so user-authored
+    /// attachments become first-class CRDT data. When that lands, this
+    /// field is deleted outright rather than relocated.
+    pub nbformat_attachments: RwLock<HashMap<String, serde_json::Value>>,
+    /// Whether a streaming load is in progress for this room.
+    /// Prevents two connections from both attempting to load from disk.
+    is_loading: AtomicBool,
+}
+
+/// The debounced `.automerge` persist channels. See `spawn_persist_debouncer`.
+pub struct PersistDebouncer {
+    /// Channel to send doc bytes to the debounced persistence task.
+    /// Uses watch for "latest value" semantics — always keeps most recent state.
+    pub persist_tx: watch::Sender<Option<Vec<u8>>>,
+    /// Channel to request a synchronous flush from the persist debouncer.
+    /// Receiver handles the request and replies on the oneshot after the write
+    /// completes. Used by room eviction to guarantee disk consistency *before*
+    /// the room is removed from the map, closing the race where a fast reconnect
+    /// would load stale bytes from the still-pending .automerge file.
+    pub flush_request_tx: mpsc::UnboundedSender<FlushRequest>,
+}
+
+impl RoomPersistence {
+    /// Build a persistence struct with no active debouncer (ephemeral rooms).
+    pub fn ephemeral() -> Self {
+        Self {
+            debouncer: None,
+            last_save_sources: RwLock::new(HashMap::new()),
+            last_self_write: AtomicU64::new(0),
+            watcher_shutdown_tx: Mutex::new(None),
+            nbformat_attachments: RwLock::new(HashMap::new()),
+            is_loading: AtomicBool::new(false),
+        }
+    }
+
+    /// Build a persistence struct with an active .automerge debouncer.
+    pub fn with_debouncer(
+        persist_tx: watch::Sender<Option<Vec<u8>>>,
+        flush_request_tx: mpsc::UnboundedSender<FlushRequest>,
+    ) -> Self {
+        Self {
+            debouncer: Some(PersistDebouncer {
+                persist_tx,
+                flush_request_tx,
+            }),
+            last_save_sources: RwLock::new(HashMap::new()),
+            last_self_write: AtomicU64::new(0),
+            watcher_shutdown_tx: Mutex::new(None),
+            nbformat_attachments: RwLock::new(HashMap::new()),
+            is_loading: AtomicBool::new(false),
+        }
+    }
+
+    /// Atomically claim the loading role. Returns `true` if this caller won
+    /// the race and should perform the streaming load.
+    pub fn try_start_loading(&self) -> bool {
+        self.is_loading
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Mark loading complete (success or failure).
+    pub fn finish_loading(&self) {
+        self.is_loading.store(false, Ordering::Release);
+    }
+
+    /// True if a streaming load is currently in progress.
+    pub fn is_loading(&self) -> bool {
+        self.is_loading.load(Ordering::Acquire)
+    }
+}
+
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room. Used as the map key once
     /// Phase 5 lands; for now coexists with the string-keyed map.
@@ -74,17 +186,10 @@ pub struct NotebookRoom {
     pub doc: Arc<RwLock<NotebookDoc>>,
     /// Broadcast channels + presence state for fan-out to peer sync loops.
     pub broadcasts: RoomBroadcasts,
-    /// Channel to send doc bytes to the debounced persistence task.
-    /// Uses watch for "latest value" semantics - always keeps most recent state.
-    pub persist_tx: Option<watch::Sender<Option<Vec<u8>>>>,
-    /// Channel to request a synchronous flush from the persist debouncer.
-    /// Receiver handles the request and replies on the oneshot after the write
-    /// completes. Used by room eviction to guarantee disk consistency *before*
-    /// the room is removed from the map, closing the race where a fast reconnect
-    /// would load stale bytes from the still-pending .automerge file.
-    ///
-    /// `None` for ephemeral rooms (persistence skipped) and matches `persist_tx`.
-    pub flush_request_tx: Option<mpsc::UnboundedSender<FlushRequest>>,
+    /// Disk persistence state. Always present; ephemeral rooms carry an
+    /// `ephemeral()` instance with no active debouncer, and gain the
+    /// file watcher + save-baseline tracking when promoted via Save.
+    pub persistence: RoomPersistence,
     /// Notebook identity: persist_path, is_ephemeral, .ipynb path, working_dir.
     pub identity: RoomIdentity,
     /// Number of active peer connections in this room.
@@ -95,33 +200,6 @@ pub struct NotebookRoom {
     pub blob_store: Arc<BlobStore>,
     /// Trust state for this notebook (for auto-launch decisions).
     pub trust_state: Arc<RwLock<TrustState>>,
-    /// Raw nbformat attachments preserved from disk, keyed by cell ID.
-    /// These are not user-editable in the current UI, so the file remains the source of truth.
-    pub nbformat_attachments: Arc<RwLock<HashMap<String, serde_json::Value>>>,
-    /// Comm channel state for widgets.
-    /// Whether a streaming load is in progress for this room.
-    /// Prevents two connections from both attempting to load from disk.
-    pub is_loading: AtomicBool,
-    /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
-    /// Used to skip file watcher events triggered by our own saves.
-    pub last_self_write: AtomicU64,
-    /// Cell sources as they were written to disk at last save.
-    ///
-    /// The file watcher compares disk content against this snapshot (not the
-    /// live CRDT) to distinguish our own autosave writes from genuine external
-    /// changes (git pull, external editor). Without this, the file watcher
-    /// would see the autosave'd content as "different" from the live CRDT
-    /// (which has progressed with new user typing since the save) and
-    /// overwrite the user's recent edits.
-    ///
-    /// This is a workaround for the fact that we can't use
-    /// `fork_at(save_heads)` to read the doc at the save point due to
-    /// automerge/automerge#1327.
-    pub last_save_sources: Arc<RwLock<HashMap<String, String>>>,
-    /// Shutdown signal for the file watcher task.
-    /// Wrapped in Mutex to allow setting after Arc creation.
-    /// Sent when the room is evicted to stop the watcher.
-    pub(crate) watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     /// Per-notebook RuntimeStateDoc handle — daemon-authoritative ephemeral state
     /// (kernel status, queue, env sync). Clients sync read-only.
     /// Uses `std::sync::Mutex` internally (no `.await` needed).
@@ -255,23 +333,21 @@ impl NotebookRoom {
         let (state_changed_tx, _) = broadcast::channel(16);
         let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
 
+        let persistence = match persist_tx.zip(flush_request_tx) {
+            Some((p, f)) => RoomPersistence::with_debouncer(p, f),
+            None => RoomPersistence::ephemeral(),
+        };
+
         Self {
             id,
             doc: Arc::new(RwLock::new(doc)),
             broadcasts: RoomBroadcasts::default(),
-            persist_tx,
-            flush_request_tx,
+            persistence,
             identity: RoomIdentity::new(persist_path, path, ephemeral),
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
-            nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-
-            is_loading: AtomicBool::new(false),
-            last_self_write: AtomicU64::new(0),
-            last_save_sources: Arc::new(RwLock::new(HashMap::new())),
-            watcher_shutdown_tx: Mutex::new(None),
             state,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -282,21 +358,6 @@ impl NotebookRoom {
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
-    }
-
-    /// Atomically claim the loading role for this room.
-    ///
-    /// Returns `true` if the caller won the race and should perform the load.
-    /// Returns `false` if another connection is already loading.
-    pub fn try_start_loading(&self) -> bool {
-        self.is_loading
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-    }
-
-    /// Mark loading as complete (success or failure).
-    pub fn finish_loading(&self) {
-        self.is_loading.store(false, Ordering::Release);
     }
 
     /// Create a new room by loading a persisted document or creating a fresh one.
@@ -342,19 +403,12 @@ impl NotebookRoom {
             id,
             doc: Arc::new(RwLock::new(doc)),
             broadcasts: RoomBroadcasts::default(),
-            persist_tx: Some(persist_tx),
-            flush_request_tx: Some(flush_request_tx),
+            persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
             identity: RoomIdentity::new(persist_path, path, false),
             active_peers: AtomicUsize::new(0),
             had_peers: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
-            nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-
-            is_loading: AtomicBool::new(false),
-            last_self_write: AtomicU64::new(0),
-            last_save_sources: Arc::new(RwLock::new(HashMap::new())),
-            watcher_shutdown_tx: Mutex::new(None),
             state,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -372,6 +426,35 @@ impl NotebookRoom {
         // Check runtime agent handle
         let ra = self.runtime_agent_handle.lock().await;
         ra.as_ref().is_some_and(|a| a.is_alive())
+    }
+
+    /// Snapshot of nbformat attachments. Empty before the first `.ipynb`
+    /// load populates the cache.
+    pub async fn nbformat_attachments_snapshot(&self) -> HashMap<String, serde_json::Value> {
+        self.persistence.nbformat_attachments.read().await.clone()
+    }
+
+    /// Snapshot of cell sources as they were at last save. Empty before
+    /// the first save, which is the correct baseline for "no disk write
+    /// has happened yet."
+    pub async fn last_save_sources_snapshot(&self) -> HashMap<String, String> {
+        self.persistence.last_save_sources.read().await.clone()
+    }
+
+    /// True if a streaming load is currently in progress.
+    pub fn is_loading(&self) -> bool {
+        self.persistence.is_loading()
+    }
+
+    /// Atomically claim the streaming-load role. Returns `true` if the
+    /// caller won the race and should perform the load.
+    pub fn try_start_loading(&self) -> bool {
+        self.persistence.try_start_loading()
+    }
+
+    /// Mark the streaming load complete.
+    pub fn finish_loading(&self) {
+        self.persistence.finish_loading();
     }
 
     /// Get kernel info if a kernel is running (runtime-agent-backed).

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -425,7 +425,7 @@ async fn test_ephemeral_room_skips_persistence() {
     let notebook_uuid = uuid::Uuid::new_v4();
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, true);
 
-    assert!(room.persist_tx.is_none());
+    assert!(room.persistence.debouncer.is_none());
     assert!(room
         .identity
         .is_ephemeral
@@ -443,7 +443,7 @@ async fn test_session_room_persists() {
     let notebook_uuid = uuid::Uuid::new_v4();
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, false);
 
-    assert!(room.persist_tx.is_some());
+    assert!(room.persistence.debouncer.is_some());
     assert!(!room
         .identity
         .is_ephemeral
@@ -649,8 +649,7 @@ fn test_room_with_path(
         id: uuid::Uuid::new_v4(),
         doc: Arc::new(RwLock::new(doc)),
         broadcasts: RoomBroadcasts::default(),
-        persist_tx: Some(persist_tx),
-        flush_request_tx: Some(flush_request_tx),
+        persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
         identity: RoomIdentity::new(persist_path, Some(notebook_path.clone()), false),
         active_peers: AtomicUsize::new(0),
         had_peers: AtomicBool::new(false),
@@ -665,12 +664,6 @@ fn test_room_with_path(
             },
             pending_launch: false,
         })),
-        nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
-
-        is_loading: AtomicBool::new(false),
-        last_self_write: AtomicU64::new(0),
-        last_save_sources: Arc::new(RwLock::new(HashMap::new())),
-        watcher_shutdown_tx: Mutex::new(None),
         state,
         runtime_agent_handle: Arc::new(Mutex::new(None)),
         runtime_agent_env_path: Arc::new(RwLock::new(None)),
@@ -1125,7 +1118,7 @@ async fn test_apply_ipynb_changes_clears_all_cells() {
 
     // Populate last_save_sources — simulates a save that included the cell
     {
-        let mut saved = room.last_save_sources.write().await;
+        let mut saved = room.persistence.last_save_sources.write().await;
         saved.insert("cell-1".to_string(), "x = 1".to_string());
     }
 
@@ -1416,7 +1409,7 @@ async fn test_apply_ipynb_changes_partial_overlap_preserves_unsaved() {
         doc.update_source("remove", "y = 2").unwrap();
     }
     {
-        let mut saved = room.last_save_sources.write().await;
+        let mut saved = room.persistence.last_save_sources.write().await;
         saved.insert("keep".to_string(), "x = 1".to_string());
         saved.insert("remove".to_string(), "y = 2".to_string());
     }
@@ -1491,7 +1484,7 @@ async fn test_apply_ipynb_changes_no_save_snapshot_preserves_crdt_cells() {
 
     // Do NOT populate last_save_sources — simulates the case where
     // the only save was with 0 cells (empty HashMap is the default).
-    assert!(room.last_save_sources.read().await.is_empty());
+    assert!(room.persistence.last_save_sources.read().await.is_empty());
 
     // External file has 0 cells (the autosave wrote an empty notebook)
     let external_cells: Vec<CellSnapshot> = vec![];
@@ -1859,7 +1852,7 @@ async fn test_save_notebook_to_disk_preserves_nbformat_attachments_from_cache() 
             .unwrap();
     }
     {
-        let mut attachments = room.nbformat_attachments.write().await;
+        let mut attachments = room.persistence.nbformat_attachments.write().await;
         attachments.insert(
             "markdown-1".to_string(),
             serde_json::json!({
@@ -1895,7 +1888,7 @@ async fn test_save_notebook_to_disk_preserves_raw_cell_attachments_from_cache() 
         doc.update_source("raw-1", "attachment ref").unwrap();
     }
     {
-        let mut attachments = room.nbformat_attachments.write().await;
+        let mut attachments = room.persistence.nbformat_attachments.write().await;
         attachments.insert(
             "raw-1".to_string(),
             serde_json::json!({

--- a/crates/runtimed/src/requests/clear_outputs.rs
+++ b/crates/runtimed/src/requests/clear_outputs.rs
@@ -32,8 +32,8 @@ pub(crate) async fn handle(room: &NotebookRoom, cell_id: String) -> NotebookResp
     }
 
     // Send to debounced persistence task
-    if let Some(ref tx) = room.persist_tx {
-        let _ = tx.send(Some(persist_bytes));
+    if let Some(ref d) = room.persistence.debouncer {
+        let _ = d.persist_tx.send(Some(persist_bytes));
     }
 
     NotebookResponse::OutputsCleared { cell_id }

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -85,7 +85,9 @@ pub(crate) async fn handle(
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
-            if room.identity.is_ephemeral.load(Ordering::Relaxed) && room.persist_tx.is_none() {
+            if room.identity.is_ephemeral.load(Ordering::Relaxed)
+                && room.persistence.debouncer.is_none()
+            {
                 let bytes = room.doc.write().await.save();
                 persist_notebook_bytes(&bytes, &room.identity.persist_path);
                 warn!(

--- a/crates/runtimed/src/requests/set_metadata_snapshot.rs
+++ b/crates/runtimed/src/requests/set_metadata_snapshot.rs
@@ -18,9 +18,9 @@ pub(crate) async fn handle(room: &NotebookRoom, snapshot: String) -> NotebookRes
                         // Notify peers of the change
                         let _ = room.broadcasts.changed_tx.send(());
                         // Persist
-                        if let Some(ref tx) = room.persist_tx {
+                        if let Some(ref d) = room.persistence.debouncer {
                             let bytes = doc.save();
-                            let _ = tx.send(Some(bytes));
+                            let _ = d.persist_tx.send(Some(bytes));
                         }
                         Ok(())
                     }

--- a/crates/runtimed/src/requests/set_raw_metadata.rs
+++ b/crates/runtimed/src/requests/set_raw_metadata.rs
@@ -10,9 +10,9 @@ pub(crate) async fn handle(room: &NotebookRoom, key: String, value: String) -> N
             // Notify peers of the change
             let _ = room.broadcasts.changed_tx.send(());
             // Persist
-            if let Some(ref tx) = room.persist_tx {
+            if let Some(ref d) = room.persistence.debouncer {
                 let bytes = doc.save();
-                let _ = tx.send(Some(bytes));
+                let _ = d.persist_tx.send(Some(bytes));
             }
             NotebookResponse::MetadataSet {}
         }


### PR DESCRIPTION
## Summary

Third of four substruct extractions. Groups the six disk-round-trip fields into `persistence: Option<RoomPersistence>` on `NotebookRoom`. `None` for ephemeral rooms, `Some` for file-backed — which codifies the 'both `persist_tx` and `flush_request_tx` are Some together' invariant in the type system.

## Fields moved

- `persist_tx`, `flush_request_tx` — debounced write + synchronous flush
- `last_save_sources`, `last_self_write` — file watcher baseline
- `watcher_shutdown_tx` — file watcher lifecycle
- `nbformat_attachments` — disk-round-trip cache for .ipynb-level cell attachments

## Design notes

**`nbformat_attachments` is transitional.** Today it's a base64-in-memory cache so `.ipynb` → doc → `.ipynb` round-trips byte-identically without re-encoding blobs (cells' resolved attachments already live as blob URLs in the doc). Kyle wants user-authored attachments to become first-class CRDT data; when that lands this field is deleted outright rather than relocated. Comment on the field says as much.

**`is_loading` is now private on `RoomPersistence`** with `try_start_loading()` / `finish_loading()` / `is_loading()` as the API. `NotebookRoom` wraps them so callers don't have to reach through the `Option<_>`. Ephemeral rooms return `false` / no-op.

**Dropped nested `Arc<>` wrappers** on `last_save_sources` and `nbformat_attachments` — the room is already behind `Arc<NotebookRoom>`, so the extra indirection was dead weight.

Two helpers on `NotebookRoom` keep callsites clean:
- `nbformat_attachments_snapshot()` — async, returns empty map for ephemeral
- `last_save_sources_snapshot()` — async, returns empty map for ephemeral

## Scope

PR 3 of 4 per `docs/superpowers/specs/2026-04-22-notebook-room-substructs.md`. One substruct remaining: `RoomConnections` (2 fields — `active_peers`, `had_peers`).

## Test plan

- [x] `cargo test -p runtimed --lib` — 389 passing
- [x] `cargo build --workspace --exclude runtimed-py --all-targets` — clean
- [x] `cargo xtask clippy` — clean
- [x] `cargo xtask lint` — clean
- [x] `test_session_room_is_ephemeral` and `test_session_room_persists` updated to check `persistence.is_none()` / `persistence.is_some()` directly (stronger invariant than before)
- [x] Wire format unchanged