### PR TITLE
refactor(runtimed): extract RoomConnections substruct (PR 4 of 4)

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2769,8 +2769,14 @@ impl Daemon {
 
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
-                        active_peers: room.active_peers.load(std::sync::atomic::Ordering::Relaxed),
-                        had_peers: room.had_peers.load(std::sync::atomic::Ordering::Relaxed),
+                        active_peers: room
+                            .connections
+                            .active_peers
+                            .load(std::sync::atomic::Ordering::Relaxed),
+                        had_peers: room
+                            .connections
+                            .had_peers
+                            .load(std::sync::atomic::Ordering::Relaxed),
                         has_kernel: room.has_kernel().await,
                         kernel_type,
                         env_source,

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2011,7 +2011,12 @@ pub(crate) async fn auto_launch_kernel(
 ) {
     // Check if room still has peers (protect against race condition where client disconnects
     // before we finish launching)
-    if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
+    if room
+        .connections
+        .active_peers
+        .load(std::sync::atomic::Ordering::Relaxed)
+        == 0
+    {
         debug!("[notebook-sync] Auto-launch aborted: no peers remaining");
         reset_starting_state(room, None).await;
         return;
@@ -2052,7 +2057,12 @@ pub(crate) async fn auto_launch_kernel(
     }
 
     // Re-check peers (another race check)
-    if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
+    if room
+        .connections
+        .active_peers
+        .load(std::sync::atomic::Ordering::Relaxed)
+        == 0
+    {
         debug!("[notebook-sync] Auto-launch aborted: no peers (after status check)");
         reset_starting_state(room, None).await;
         return;

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -414,9 +414,11 @@ where
     // initial_metadata seeded above).
     check_and_update_trust_state(&room).await;
 
-    room.active_peers.fetch_add(1, Ordering::Relaxed);
-    room.had_peers.store(true, Ordering::Relaxed);
-    let peers = room.active_peers.load(Ordering::Relaxed);
+    room.connections
+        .active_peers
+        .fetch_add(1, Ordering::Relaxed);
+    room.connections.had_peers.store(true, Ordering::Relaxed);
+    let peers = room.connections.active_peers.load(Ordering::Relaxed);
     info!(
         "[notebook-sync] Client connected to room {} ({} peer{})",
         notebook_id,
@@ -569,7 +571,11 @@ where
     }
 
     // Peer disconnected — decrement and possibly evict the room
-    let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
+    let remaining = room
+        .connections
+        .active_peers
+        .fetch_sub(1, Ordering::Relaxed)
+        - 1;
     if remaining == 0 {
         // Schedule delayed eviction check. This handles:
         // 1. Grace period during auto-launch (client may reconnect)
@@ -598,7 +604,12 @@ where
                 tokio::time::sleep(delay).await;
 
                 // Check if peers reconnected during the delay
-                if room_for_eviction.active_peers.load(Ordering::Relaxed) > 0 {
+                if room_for_eviction
+                    .connections
+                    .active_peers
+                    .load(Ordering::Relaxed)
+                    > 0
+                {
                     info!(
                         "[notebook-sync] Eviction cancelled for {} (peers reconnected)",
                         notebook_id_for_eviction
@@ -682,7 +693,12 @@ where
             // guards against double-eviction races.
             let (should_teardown, evicted_uuid) = {
                 let mut rooms_guard = rooms_for_eviction.lock().await;
-                if room_for_eviction.active_peers.load(Ordering::Relaxed) == 0 {
+                if room_for_eviction
+                    .connections
+                    .active_peers
+                    .load(Ordering::Relaxed)
+                    == 0
+                {
                     // Find the room's UUID key by Arc pointer identity
                     let current_key = rooms_guard
                         .iter()

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -178,6 +178,27 @@ impl RoomPersistence {
     }
 }
 
+/// Per-connection accounting for room eviction + `is_draining` reporting.
+///
+/// - `active_peers`: live counter, drives room eviction when it hits zero.
+/// - `had_peers`: one-way latch flipped on first connect. Kept because the
+///   Python SDK's `is_draining = (active_peers == 0 && had_peers)` check
+///   needs to distinguish "brand-new, no one has connected yet" from
+///   "drained, awaiting eviction." Exposed on the `RoomInfo` wire type.
+pub struct RoomConnections {
+    pub active_peers: AtomicUsize,
+    pub had_peers: AtomicBool,
+}
+
+impl Default for RoomConnections {
+    fn default() -> Self {
+        Self {
+            active_peers: AtomicUsize::new(0),
+            had_peers: AtomicBool::new(false),
+        }
+    }
+}
+
 pub struct NotebookRoom {
     /// Permanent, immutable UUID for this room. Used as the map key once
     /// Phase 5 lands; for now coexists with the string-keyed map.
@@ -192,10 +213,8 @@ pub struct NotebookRoom {
     pub persistence: RoomPersistence,
     /// Notebook identity: persist_path, is_ephemeral, .ipynb path, working_dir.
     pub identity: RoomIdentity,
-    /// Number of active peer connections in this room.
-    pub active_peers: AtomicUsize,
-    /// Whether at least one peer has ever connected to this room.
-    pub had_peers: AtomicBool,
+    /// Per-connection accounting: active_peers + had_peers.
+    pub connections: RoomConnections,
     /// Blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
     /// Trust state for this notebook (for auto-launch decisions).
@@ -344,8 +363,7 @@ impl NotebookRoom {
             broadcasts: RoomBroadcasts::default(),
             persistence,
             identity: RoomIdentity::new(persist_path, path, ephemeral),
-            active_peers: AtomicUsize::new(0),
-            had_peers: AtomicBool::new(false),
+            connections: RoomConnections::default(),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             state,
@@ -405,8 +423,7 @@ impl NotebookRoom {
             broadcasts: RoomBroadcasts::default(),
             persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
             identity: RoomIdentity::new(persist_path, path, false),
-            active_peers: AtomicUsize::new(0),
-            had_peers: AtomicBool::new(false),
+            connections: RoomConnections::default(),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             state,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -160,7 +160,7 @@ async fn test_room_load_or_create_new() {
     let doc = room.doc.try_read().unwrap();
     assert_eq!(doc.notebook_id(), Some("test-nb".to_string()));
     assert_eq!(doc.cell_count(), 0);
-    assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
+    assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test]
@@ -262,17 +262,25 @@ async fn test_room_peer_counting() {
     let blob_store = test_blob_store(&tmp);
     let room = NotebookRoom::load_or_create("peer-test", tmp.path(), blob_store);
 
-    assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
+    assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 0);
 
-    room.active_peers.fetch_add(1, Ordering::Relaxed);
-    room.active_peers.fetch_add(1, Ordering::Relaxed);
-    assert_eq!(room.active_peers.load(Ordering::Relaxed), 2);
+    room.connections
+        .active_peers
+        .fetch_add(1, Ordering::Relaxed);
+    room.connections
+        .active_peers
+        .fetch_add(1, Ordering::Relaxed);
+    assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 2);
 
-    room.active_peers.fetch_sub(1, Ordering::Relaxed);
-    assert_eq!(room.active_peers.load(Ordering::Relaxed), 1);
+    room.connections
+        .active_peers
+        .fetch_sub(1, Ordering::Relaxed);
+    assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 1);
 
-    room.active_peers.fetch_sub(1, Ordering::Relaxed);
-    assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
+    room.connections
+        .active_peers
+        .fetch_sub(1, Ordering::Relaxed);
+    assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test]
@@ -651,8 +659,7 @@ fn test_room_with_path(
         broadcasts: RoomBroadcasts::default(),
         persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
         identity: RoomIdentity::new(persist_path, Some(notebook_path.clone()), false),
-        active_peers: AtomicUsize::new(0),
-        had_peers: AtomicBool::new(false),
+        connections: RoomConnections::default(),
         blob_store,
         trust_state: Arc::new(RwLock::new(TrustState {
             status: runt_trust::TrustStatus::Untrusted,


### PR DESCRIPTION
## Summary

Final substruct extraction per the spec at `docs/superpowers/specs/2026-04-22-notebook-room-substructs.md`. Groups the two per-connection accounting fields into \`RoomConnections\` accessed via \`room.connections.X\`.

- \`active_peers\` — live counter, drives room eviction when it hits zero
- \`had_peers\` — one-way latch flipped on first connect. Python SDK's \`is_draining = (active_peers == 0 && had_peers)\` check needs this to distinguish 'brand-new, no one has connected yet' from 'drained, awaiting eviction.' Flows through to \`RoomInfo\` on the wire.

~19 callsites migrated across \`peer.rs\`, \`tests.rs\`, \`metadata.rs\`, \`daemon.rs\`.

## What NotebookRoom looks like now

After this lands, all non-kernel fields are grouped:

- \`identity: RoomIdentity\` — path, persist_path, is_ephemeral, working_dir
- \`broadcasts: RoomBroadcasts\` — changed_tx, kernel_broadcast_tx, presence_tx, presence
- \`persistence: RoomPersistence\` — always-present disk bookkeeping + nested \`Option<PersistDebouncer>\`
- \`connections: RoomConnections\` — active_peers, had_peers
- Top-level: \`doc\`, \`state\`, \`trust_state\`, \`blob_store\`, \`id\`
- The 8 runtime-agent fields remain at the top level for the runtime-agent-work branch to refactor into an actor pattern.

## Test plan

- [x] \`cargo test -p runtimed --lib\` — 389 passing
- [x] \`cargo build --workspace --exclude runtimed-py --all-targets\` — clean
- [x] \`cargo xtask clippy\` — clean
- [x] \`cargo xtask lint\` — clean
- [x] Wire format unchanged (\`RoomInfo.had_peers\` still serialized, Python \`is_draining\` unaffected)