### PR TITLE
fix(notebook): eliminate TOCTOU race in trust signature approval

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -455,22 +455,6 @@ async fn get_raw_metadata_additional(
     Some(additional)
 }
 
-/// Write trust fields into the daemon's metadata.
-async fn set_raw_trust_in_metadata(
-    handle: &RelayHandle,
-    signature: &str,
-    timestamp: &str,
-) -> Result<(), String> {
-    let mut snapshot = get_metadata_snapshot(handle)
-        .await
-        .ok_or("No metadata in Automerge doc")?;
-
-    snapshot.runt.trust_signature = Some(signature.to_string());
-    snapshot.runt.trust_timestamp = Some(timestamp.to_string());
-
-    set_metadata_snapshot(handle, &snapshot).await
-}
-
 /// Reconstruct an nbformat Metadata from a NotebookMetadataSnapshot.
 /// Used to bridge sync-handle metadata to extraction functions that expect nbformat types.
 fn metadata_from_snapshot(
@@ -3066,16 +3050,23 @@ async fn approve_notebook_trust(
     let guard = notebook_sync.lock().await;
     let handle = guard.as_ref().ok_or("Not connected to daemon")?;
 
-    // Use raw metadata to read trust-relevant fields without stripping unknown runt keys
-    let additional = get_raw_metadata_additional(handle)
+    // Single snapshot fetch: sign and set trust fields on the same snapshot to
+    // avoid a TOCTOU race where deps change between signing and writing.
+    let mut snapshot = get_metadata_snapshot(handle)
         .await
-        .unwrap_or_default();
-    let signature = trust::sign_notebook_dependencies(&additional)?;
-    let timestamp = chrono::Utc::now().to_rfc3339();
+        .ok_or("No metadata in Automerge doc")?;
 
-    // Write trust fields directly into the raw Automerge JSON — avoids the typed
-    // NotebookMetadataSnapshot round-trip which would strip trust_signature/trust_timestamp
-    set_raw_trust_in_metadata(handle, &signature, &timestamp).await
+    let runt_value = serde_json::to_value(&snapshot.runt)
+        .map_err(|e| format!("serialize runt metadata: {e}"))?;
+    let mut additional = HashMap::new();
+    additional.insert("runt".to_string(), runt_value);
+
+    let signature = trust::sign_notebook_dependencies(&additional)?;
+
+    snapshot.runt.trust_signature = Some(signature);
+    snapshot.runt.trust_timestamp = Some(chrono::Utc::now().to_rfc3339());
+
+    set_metadata_snapshot(handle, &snapshot).await
 }
 
 /// Check packages for typosquatting (similar names to popular packages).


### PR DESCRIPTION
## Summary

- **Fix**: `approve_notebook_trust` fetched the metadata snapshot twice via separate async RPCs — once to sign, once to write the signature back. If deps changed between those fetches (user editing, concurrent sync), the HMAC was computed over stale content and immediately failed daemon-side verification (`SignatureInvalid`).
- **Change**: Collapse to a single `get_metadata_snapshot` call — sign the snapshot's deps and set the signature on the same object before sending it back. Remove the now-unused `set_raw_trust_in_metadata` helper.

## Details

The race window was between `get_raw_metadata_additional` (line 3070) and the second `get_metadata_snapshot` inside `set_raw_trust_in_metadata` (line 464). Observed in nightly diagnostics as:

```
Trust state: NoDependencies -> Untrusted          ← deps synced into doc
SetMetadataSnapshot: deps=["pandas"] + signature  ← signature for old snapshot
Trust state: Untrusted -> SignatureInvalid         ← verification fails
```

## Test plan

- [x] `cargo check -p notebook` — compiles clean
- [x] `cargo test -p runt-trust` — 6/6 pass
- [x] `cargo test -p runtimed --lib -- notebook_sync_server::tests::test_verify_trust` — 5/5 pass
- [ ] Manual: open notebook, add deps, approve trust → should reach `Trusted` state (not `SignatureInvalid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)