### PR TITLE
fix(notebook-doc): migrate v3 schema docs instead of discarding them

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -63,8 +63,9 @@ use std::collections::HashMap;
 /// - **4** — Addressable outputs: `OutputManifest` carries a required `output_id` (UUIDv4).
 ///   Outputs live in RuntimeStateDoc keyed by `execution_id`; manifests carry `output_id`.
 ///
-/// v1–v3 predate the nteract 2.0 pre-release series and are no longer
-/// supported. `load_or_create_inner` discards pre-v4 documents on load.
+/// v1–v2 predate the nteract 2.0 pre-release series and are no longer
+/// supported. `load_or_create_inner` discards pre-v3 documents on load.
+/// v3 documents are migrated in-place (version bump only).
 pub const SCHEMA_VERSION: u64 = 4;
 
 use automerge::sync;
@@ -786,26 +787,33 @@ impl NotebookDoc {
                             }
                             return loaded;
                         }
-                        // CRITICAL: one-time cleanup for pre-release schemas
-                        // (v1–v3 predate nteract 2.0). All current users are on
-                        // v4, so dropping older docs on the floor is safe here
-                        // by historical accident, not by policy.
-                        //
-                        // DO NOT COPY THIS PATTERN FOR FUTURE SCHEMA BUMPS.
-                        // Any real migration (v4 → v5 onward) MUST implement a
-                        // `migrate_vN_to_v(N+1)` function that preserves user
-                        // data. Falling back to a fresh doc is a data-loss
-                        // operation and only acceptable when there is no
-                        // meaningful data to lose.
-                        //
-                        // Belt-and-suspenders: rename the unexpected-version doc
-                        // to `{path}.corrupt` before we replace it. That leaves
-                        // the original bytes on disk for manual recovery if a
-                        // future downgrade ever lands someone here (e.g. user
-                        // runs a newer build once, then rolls back).
+
+                        // v3 → v4: output_id was added to OutputManifest, but
+                        // it's minted at capture time (#[serde(default)]), so
+                        // the migration is a version-bump no-op.
+                        if version == 3 {
+                            info!(
+                                "[notebook-doc] Migrating schema v3 → v{} for {} at {:?}",
+                                SCHEMA_VERSION, notebook_id, path
+                            );
+                            let _ =
+                                loaded
+                                    .doc
+                                    .put(automerge::ROOT, "schema_version", SCHEMA_VERSION);
+                            if let Some(label) = actor_label {
+                                loaded.set_actor(label);
+                            }
+                            return loaded;
+                        }
+
+                        // v1–v2 predate nteract 2.0 and use incompatible cell
+                        // schemas (ordered List vs fractional-indexed Map).
+                        // Preserve the file for manual recovery, then start fresh.
                         warn!(
-                            "[notebook-doc] Rejecting schema v{} notebook at {:?} for {}; only v{} is supported. Preserving as .corrupt and starting fresh untitled notebook.",
-                            version, path, notebook_id, SCHEMA_VERSION
+                            "[notebook-doc] Rejecting schema v{} notebook at {:?} for {}; \
+                             migration is only supported from v3. \
+                             Preserving as .corrupt and starting fresh.",
+                            version, path, notebook_id
                         );
                         Self::preserve_corrupt(path);
                     }
@@ -2481,6 +2489,45 @@ mod tests {
         assert_eq!(
             std::fs::read(&corrupt_path).unwrap(),
             b"this is not a valid automerge document"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "persistence")]
+    fn test_load_v3_doc_migrates_to_v4() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("notebook.automerge");
+
+        // Create a doc with cells and deps, then downgrade to v3
+        let mut doc = NotebookDoc::new("migrate-test");
+        doc.add_cell(0, "c1", "code").unwrap();
+        doc.update_source("c1", "import numpy").unwrap();
+        doc.add_conda_dependency("numpy").unwrap();
+        let _ = doc.doc.put(automerge::ROOT, "schema_version", 3u64);
+        assert_eq!(doc.schema_version(), Some(3));
+        doc.save_to_file(&path).unwrap();
+
+        // load_or_create should migrate, not discard
+        let loaded = NotebookDoc::load_or_create(&path, "migrate-test");
+        assert_eq!(loaded.schema_version(), Some(SCHEMA_VERSION));
+        assert_eq!(loaded.cell_count(), 1);
+        let cells = loaded.get_cells();
+        assert_eq!(cells[0].source, "import numpy");
+
+        let snap = loaded.get_metadata_snapshot().unwrap();
+        let conda = snap.runt.conda.unwrap();
+        assert!(
+            conda.dependencies.contains(&"numpy".to_string()),
+            "conda deps must survive migration: {:?}",
+            conda.dependencies
+        );
+
+        // Original file should NOT be renamed to .corrupt
+        assert!(path.exists(), "migrated file should remain in place");
+        let corrupt_path = path.with_extension("automerge.corrupt");
+        assert!(
+            !corrupt_path.exists(),
+            "v3 migration should not create .corrupt"
         );
     }
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -901,7 +901,7 @@ If latency becomes an issue during rapid output bursts (e.g., training loops), t
 
 ### Schema versioning: lightweight, not a framework
 
-The notebook doc root contains a `schema_version: u64` field. Current docs are v4 (cells as a `Map` with fractional indexing, outputs in `RuntimeStateDoc` keyed by `execution_id`, per-output `output_id` UUIDs on manifests). `load_or_create_inner` only accepts v4 docs; anything else drops to a fresh doc with a loud warning. v1–v3 predate the nteract 2.0 pre-release series and have no real users, so dropping them is a no-op in practice — **not** a template for future bumps. Any v5 schema MUST ship a `migrate_v4_to_v5` function that preserves user data. No formal migration framework — the schema is simple enough that version-checking `if` branches suffice, but the branch is only correct when the migration actually carries data forward.
+The notebook doc root contains a `schema_version: u64` field. Current docs are v4 (cells as a `Map` with fractional indexing, outputs in `RuntimeStateDoc` keyed by `execution_id`, per-output `output_id` UUIDs on manifests). `load_or_create_inner` migrates v3 docs to v4 in-place (version bump only — `output_id` is minted at capture time). v1–v2 predate the nteract 2.0 pre-release series and use incompatible cell schemas; those are discarded on load. Any v5 schema MUST ship a `migrate_v4_to_v5` function that preserves user data. No formal migration framework — the schema is simple enough that version-checking `if` branches suffice, but the branch is only correct when the migration actually carries data forward.
 
 For output manifests, the `output_type` field provides structural versioning. New fields can be added without breaking old readers.
 


### PR DESCRIPTION
## Summary

- **Migrate v3 Automerge docs to v4 in-place** instead of rejecting them and creating fresh empty notebooks. The v3→v4 change (`output_id` on `OutputManifest`) is minted at capture time via `#[serde(default)]`, so the migration is a version-bump no-op.
- Fixes data loss on nightly auto-update from 2.1.0 (v3) to 2.2.1 (v4) — users lost all persisted untitled notebook state including inline dependency metadata (conda/uv deps).
- Only v1–v2 (incompatible cell schemas: ordered List vs fractional-indexed Map) are still rejected and preserved as `.corrupt`.

## Test plan

- [x] `test_load_v3_doc_migrates_to_v4` — creates a doc with cells + conda deps, downgrades to v3, persists, verifies `load_or_create` migrates to v4 with all data intact and no `.corrupt` file
- [x] Existing persistence tests pass (`test_save_and_load`, `test_save_to_file_and_load_or_create`, `test_load_or_create_missing_file`, `test_load_or_create_corrupt_file_preserved`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)