### PR TITLE
feat(runtime-doc): RuntimeLifecycle enum (phase 1 — derived field only)

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -67,7 +67,7 @@ use automerge::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::StreamOutputState;
+use crate::{RuntimeLifecycle, StreamOutputState};
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -87,6 +87,14 @@ pub struct KernelState {
     /// Used for provenance — identifying which runtime agent is running and detecting stale ones.
     #[serde(default)]
     pub runtime_agent_id: String,
+    /// Typed view derived from `(status, starting_phase)` at snapshot time.
+    ///
+    /// Phase 1 of the RuntimeLifecycle migration: readers can opt into the
+    /// typed enum without any CRDT schema change. Phase 2 introduces a
+    /// dedicated `kernel/lifecycle` key and writer path; at that point
+    /// `lifecycle` will be read directly from the CRDT rather than derived.
+    #[serde(default)]
+    pub lifecycle: RuntimeLifecycle,
 }
 
 impl Default for KernelState {
@@ -98,6 +106,7 @@ impl Default for KernelState {
             language: String::new(),
             env_source: String::new(),
             runtime_agent_id: String::new(),
+            lifecycle: RuntimeLifecycle::NotStarted,
         }
     }
 }
@@ -1854,13 +1863,19 @@ impl RuntimeStateDoc {
 
         let kernel_state = kernel
             .as_ref()
-            .map(|k| KernelState {
-                status: self.read_str(k, "status"),
-                starting_phase: self.read_str(k, "starting_phase"),
-                name: self.read_str(k, "name"),
-                language: self.read_str(k, "language"),
-                env_source: self.read_str(k, "env_source"),
-                runtime_agent_id: self.read_str(k, "runtime_agent_id"),
+            .map(|k| {
+                let status = self.read_str(k, "status");
+                let starting_phase = self.read_str(k, "starting_phase");
+                let lifecycle = RuntimeLifecycle::from_legacy(&status, &starting_phase);
+                KernelState {
+                    status,
+                    starting_phase,
+                    name: self.read_str(k, "name"),
+                    language: self.read_str(k, "language"),
+                    env_source: self.read_str(k, "env_source"),
+                    runtime_agent_id: self.read_str(k, "runtime_agent_id"),
+                    lifecycle,
+                }
             })
             .unwrap_or_default();
 

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -1,5 +1,287 @@
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone)]
 pub struct StreamOutputState {
     pub index: usize,
     pub blob_hash: String,
+}
+
+/// Observable activity of a running kernel.
+///
+/// Only meaningful when the runtime lifecycle is [`RuntimeLifecycle::Running`].
+/// `Unknown` is the transient state between runtime agent connect and the
+/// first IOPub status from the kernel; it also covers non-Jupyter backends
+/// that do not report idle/busy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KernelActivity {
+    #[default]
+    Unknown,
+    Idle,
+    Busy,
+}
+
+impl KernelActivity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "Unknown",
+            Self::Idle => "Idle",
+            Self::Busy => "Busy",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "Unknown" => Some(Self::Unknown),
+            "Idle" => Some(Self::Idle),
+            "Busy" => Some(Self::Busy),
+            _ => None,
+        }
+    }
+}
+
+/// Lifecycle of a runtime, from not-started through running to shutdown.
+///
+/// Replaces the string-valued `KernelState.status` + `starting_phase` pair
+/// with a typed sum. `Running` is the only variant that carries an
+/// activity — it is impossible to represent a "busy kernel that hasn't
+/// launched yet" in the type system. Error details are carried
+/// out-of-band via `KernelState::error_reason` (not added in this phase)
+/// so the enum stays `Eq`-able.
+///
+/// Serde format is tag+content:
+/// - non-`Running` variants serialize as `{"lifecycle": "NotStarted"}`.
+/// - `Running(activity)` serializes as `{"lifecycle": "Running", "activity": "Idle"}`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "lifecycle", content = "activity")]
+pub enum RuntimeLifecycle {
+    #[default]
+    NotStarted,
+    AwaitingTrust,
+    Resolving,
+    PreparingEnv,
+    Launching,
+    Connecting,
+    Running(KernelActivity),
+    Error,
+    Shutdown,
+}
+
+impl RuntimeLifecycle {
+    /// Variant name as a static string (no payload).
+    ///
+    /// Used when projecting to the future CRDT `kernel/lifecycle` string key
+    /// and when bridging back to the legacy `(status, starting_phase)` pair.
+    pub fn variant_str(&self) -> &'static str {
+        match self {
+            Self::NotStarted => "NotStarted",
+            Self::AwaitingTrust => "AwaitingTrust",
+            Self::Resolving => "Resolving",
+            Self::PreparingEnv => "PreparingEnv",
+            Self::Launching => "Launching",
+            Self::Connecting => "Connecting",
+            Self::Running(_) => "Running",
+            Self::Error => "Error",
+            Self::Shutdown => "Shutdown",
+        }
+    }
+
+    /// Parse a `(lifecycle, activity)` pair.
+    ///
+    /// `activity` is consulted only when `lifecycle == "Running"`. An empty
+    /// or unknown activity on a `Running` read is treated as
+    /// [`KernelActivity::Unknown`] so consumers never observe a broken doc.
+    pub fn parse(lifecycle: &str, activity: &str) -> Option<Self> {
+        match lifecycle {
+            "NotStarted" => Some(Self::NotStarted),
+            "AwaitingTrust" => Some(Self::AwaitingTrust),
+            "Resolving" => Some(Self::Resolving),
+            "PreparingEnv" => Some(Self::PreparingEnv),
+            "Launching" => Some(Self::Launching),
+            "Connecting" => Some(Self::Connecting),
+            "Running" => {
+                let act = if activity.is_empty() {
+                    KernelActivity::Unknown
+                } else {
+                    KernelActivity::parse(activity).unwrap_or(KernelActivity::Unknown)
+                };
+                Some(Self::Running(act))
+            }
+            "Error" => Some(Self::Error),
+            "Shutdown" => Some(Self::Shutdown),
+            _ => None,
+        }
+    }
+
+    /// Derive a lifecycle from the legacy `(status, starting_phase)` string
+    /// pair used by `KernelState`. Phase 1 uses this to populate
+    /// `KernelState.lifecycle` without any CRDT schema change.
+    pub fn from_legacy(status: &str, starting_phase: &str) -> Self {
+        match status {
+            "idle" => Self::Running(KernelActivity::Idle),
+            "busy" => Self::Running(KernelActivity::Busy),
+            "starting" => match starting_phase {
+                "resolving" => Self::Resolving,
+                "preparing_env" => Self::PreparingEnv,
+                "launching" => Self::Launching,
+                "connecting" => Self::Connecting,
+                // Unknown or empty sub-phase — fall back to the first phase
+                // so consumers still see "we're starting, somewhere in the
+                // pipeline" rather than a default `NotStarted`.
+                _ => Self::Resolving,
+            },
+            "error" => Self::Error,
+            "shutdown" => Self::Shutdown,
+            "awaiting_trust" => Self::AwaitingTrust,
+            _ => Self::NotStarted,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activity_as_str_round_trips() {
+        assert_eq!(KernelActivity::Unknown.as_str(), "Unknown");
+        assert_eq!(KernelActivity::Idle.as_str(), "Idle");
+        assert_eq!(KernelActivity::Busy.as_str(), "Busy");
+    }
+
+    #[test]
+    fn activity_parse_valid() {
+        assert_eq!(
+            KernelActivity::parse("Unknown"),
+            Some(KernelActivity::Unknown)
+        );
+        assert_eq!(KernelActivity::parse("Idle"), Some(KernelActivity::Idle));
+        assert_eq!(KernelActivity::parse("Busy"), Some(KernelActivity::Busy));
+        assert_eq!(KernelActivity::parse("nope"), None);
+        assert_eq!(KernelActivity::parse(""), None);
+    }
+
+    #[test]
+    fn lifecycle_variant_str() {
+        use RuntimeLifecycle::*;
+        assert_eq!(NotStarted.variant_str(), "NotStarted");
+        assert_eq!(AwaitingTrust.variant_str(), "AwaitingTrust");
+        assert_eq!(Resolving.variant_str(), "Resolving");
+        assert_eq!(PreparingEnv.variant_str(), "PreparingEnv");
+        assert_eq!(Launching.variant_str(), "Launching");
+        assert_eq!(Connecting.variant_str(), "Connecting");
+        assert_eq!(Running(KernelActivity::Idle).variant_str(), "Running");
+        assert_eq!(Error.variant_str(), "Error");
+        assert_eq!(Shutdown.variant_str(), "Shutdown");
+    }
+
+    #[test]
+    fn lifecycle_parse_non_running_variants() {
+        use RuntimeLifecycle::*;
+        assert_eq!(RuntimeLifecycle::parse("NotStarted", ""), Some(NotStarted));
+        assert_eq!(
+            RuntimeLifecycle::parse("AwaitingTrust", ""),
+            Some(AwaitingTrust)
+        );
+        assert_eq!(RuntimeLifecycle::parse("Resolving", ""), Some(Resolving));
+        assert_eq!(
+            RuntimeLifecycle::parse("PreparingEnv", ""),
+            Some(PreparingEnv)
+        );
+        assert_eq!(RuntimeLifecycle::parse("Launching", ""), Some(Launching));
+        assert_eq!(RuntimeLifecycle::parse("Connecting", ""), Some(Connecting));
+        assert_eq!(RuntimeLifecycle::parse("Error", ""), Some(Error));
+        assert_eq!(RuntimeLifecycle::parse("Shutdown", ""), Some(Shutdown));
+        assert_eq!(RuntimeLifecycle::parse("bogus", ""), None);
+    }
+
+    #[test]
+    fn lifecycle_parse_running_with_activity() {
+        assert_eq!(
+            RuntimeLifecycle::parse("Running", "Idle"),
+            Some(RuntimeLifecycle::Running(KernelActivity::Idle)),
+        );
+        assert_eq!(
+            RuntimeLifecycle::parse("Running", "Busy"),
+            Some(RuntimeLifecycle::Running(KernelActivity::Busy)),
+        );
+        assert_eq!(
+            RuntimeLifecycle::parse("Running", ""),
+            Some(RuntimeLifecycle::Running(KernelActivity::Unknown)),
+        );
+        assert_eq!(
+            RuntimeLifecycle::parse("Running", "bogus"),
+            Some(RuntimeLifecycle::Running(KernelActivity::Unknown)),
+        );
+    }
+
+    #[test]
+    fn lifecycle_serde_tag_content() -> Result<(), serde_json::Error> {
+        let running = RuntimeLifecycle::Running(KernelActivity::Busy);
+        let json = serde_json::to_string(&running)?;
+        assert_eq!(json, r#"{"lifecycle":"Running","activity":"Busy"}"#);
+        let back: RuntimeLifecycle = serde_json::from_str(&json)?;
+        assert_eq!(back, running);
+
+        let not_started = RuntimeLifecycle::NotStarted;
+        let json = serde_json::to_string(&not_started)?;
+        assert_eq!(json, r#"{"lifecycle":"NotStarted"}"#);
+        let back: RuntimeLifecycle = serde_json::from_str(&json)?;
+        assert_eq!(back, not_started);
+        Ok(())
+    }
+
+    #[test]
+    fn lifecycle_default_is_not_started() {
+        assert_eq!(RuntimeLifecycle::default(), RuntimeLifecycle::NotStarted);
+    }
+
+    #[test]
+    fn lifecycle_from_legacy_idle_busy() {
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("idle", ""),
+            RuntimeLifecycle::Running(KernelActivity::Idle),
+        );
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("busy", ""),
+            RuntimeLifecycle::Running(KernelActivity::Busy),
+        );
+    }
+
+    #[test]
+    fn lifecycle_from_legacy_starting_phases() {
+        use RuntimeLifecycle::*;
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("starting", "resolving"),
+            Resolving
+        );
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("starting", "preparing_env"),
+            PreparingEnv
+        );
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("starting", "launching"),
+            Launching
+        );
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("starting", "connecting"),
+            Connecting
+        );
+        // Empty phase falls back to the first phase so the UI still reads
+        // "we're starting" rather than "not started."
+        assert_eq!(RuntimeLifecycle::from_legacy("starting", ""), Resolving);
+    }
+
+    #[test]
+    fn lifecycle_from_legacy_terminal_states() {
+        use RuntimeLifecycle::*;
+        assert_eq!(RuntimeLifecycle::from_legacy("error", ""), Error);
+        assert_eq!(RuntimeLifecycle::from_legacy("shutdown", ""), Shutdown);
+        assert_eq!(
+            RuntimeLifecycle::from_legacy("awaiting_trust", ""),
+            AwaitingTrust
+        );
+        assert_eq!(RuntimeLifecycle::from_legacy("not_started", ""), NotStarted);
+        assert_eq!(RuntimeLifecycle::from_legacy("", ""), NotStarted);
+        assert_eq!(RuntimeLifecycle::from_legacy("gibberish", ""), NotStarted);
+    }
 }

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-1.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-1.md
@@ -1,0 +1,55 @@
+# RuntimeLifecycle Phase 1 — Add Enums
+
+**Goal:** Add `RuntimeLifecycle` and `KernelActivity` enums to `runtime-doc`. Read `lifecycle` into `KernelState` snapshots as a derived field. Do NOT touch any writer or caller.
+
+**Why only this much:** the full refactor is a coordinated change across Rust, TS, and Python. Before we commit to that scope, we want to shake out the type shape (serde format, `Running(KernelActivity)` ergonomics) and see it compile end-to-end. Phase 2 adds the writers; Phase 3 migrates callers; Phase 4 retires the string fields.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+
+## Scope
+
+- `crates/runtime-doc/src/types.rs`: define `KernelActivity` + `RuntimeLifecycle` with serde tag+content format.
+- `crates/runtime-doc/src/doc.rs`: add a `lifecycle: RuntimeLifecycle` field to `KernelState` (new field, `#[serde(default)]`, derived from `status` + `starting_phase` during `read_state`).
+- Unit tests in `types.rs` for serde round-trip.
+
+## Out of scope
+
+- `set_lifecycle` / `set_activity` writers. Phase 2.
+- Daemon / TS / Python caller migration. Phase 3.
+- Removing `KernelState.status` / `KernelState.starting_phase`. Phase 4.
+- New CRDT keys (`kernel/lifecycle`, `kernel/activity`). Phase 2.
+
+## Acceptance
+
+- `cargo test -p runtime-doc` passes, including new serde round-trip tests.
+- `cargo check --workspace` succeeds (no downstream breakage — we're only adding fields and types).
+- Existing `KernelState.status` + `starting_phase` still populate as before; new `lifecycle` field shows the equivalent typed view derived from them.
+
+## Sketch (not a script — just the target API)
+
+```rust
+// types.rs
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KernelActivity { #[default] Unknown, Idle, Busy }
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "lifecycle", content = "activity")]
+pub enum RuntimeLifecycle {
+    #[default] NotStarted, AwaitingTrust,
+    Resolving, PreparingEnv, Launching, Connecting,
+    Running(KernelActivity),
+    Error, Shutdown,
+}
+```
+
+`KernelState` gains:
+```rust
+#[serde(default)]
+pub lifecycle: RuntimeLifecycle,
+```
+
+`read_state` fills `lifecycle` by mapping `(status, starting_phase)` — see spec. No CRDT schema change.
+
+## Checkpoint for reviewer
+
+Look at the type shape, the serde JSON (`{"lifecycle": "Running", "activity": "Idle"}` vs `{"lifecycle": "NotStarted"}`), and whether `Running(KernelActivity)` feels right. If those are good, Phase 2 writes into CRDT and adds setters.

--- a/docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md
+++ b/docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md
@@ -1,0 +1,253 @@
+# RuntimeLifecycle Enum
+
+## Summary
+
+Replace the string-based `kernel.status` + `kernel.starting_phase` fields in RuntimeStateDoc with a single `RuntimeLifecycle` enum. `Running` carries a `KernelActivity` payload, making it impossible to represent a busy kernel when the runtime hasn't launched yet.
+
+## Problem
+
+`KernelState` in RuntimeStateDoc uses two string fields:
+- `status`: "not_started", "starting", "idle", "busy", "error", "shutdown", "awaiting_trust"
+- `starting_phase`: "", "resolving", "preparing_env", "launching", "connecting"
+
+"idle" and "busy" are overloaded onto `status` alongside lifecycle states. The frontend stitches them together in `getKernelStatusLabel`. The Python bindings match on string literals. Nobody gets compile-time exhaustiveness checks.
+
+`starting_phase` is only meaningful when `status == "starting"`. Nothing prevents setting `starting_phase = "launching"` while `status == "idle"`.
+
+## Design
+
+### RuntimeLifecycle enum
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "lifecycle", content = "activity")]
+pub enum RuntimeLifecycle {
+    NotStarted,
+    AwaitingTrust,
+    Resolving,
+    PreparingEnv,
+    Launching,
+    Connecting,
+    Running(KernelActivity),
+    Error,
+    Shutdown,
+}
+```
+
+### KernelActivity enum
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KernelActivity {
+    Unknown,
+    Idle,
+    Busy,
+}
+```
+
+`Unknown` is the initial state when the runtime agent has connected but the kernel hasn't reported its first status yet. Also used for non-Jupyter backends that might not have the idle/busy concept.
+
+### Why Running holds KernelActivity
+
+Only a running runtime has a kernel. A `Resolving` runtime is installing packages, not running code. Encoding this in the type means:
+
+- You can't set `Busy` while `Resolving`. It won't compile.
+- Pattern matching is exhaustive. Add a new lifecycle state, the compiler tells you every place that needs updating.
+- The idle/busy throttle only applies inside `Running`. Lifecycle transitions are never throttled.
+
+### KernelState struct changes
+
+```rust
+pub struct KernelState {
+    pub lifecycle: RuntimeLifecycle,
+    pub name: String,
+    pub language: String,
+    pub env_source: String,
+    pub runtime_agent_id: String,
+    pub error_reason: Option<String>,
+}
+```
+
+`status` and `starting_phase` are gone. `lifecycle` replaces both. `error_reason` is populated when `lifecycle == Error` (kept separate so the enum stays `Eq`-able).
+
+### CRDT storage
+
+RuntimeStateDoc writes Automerge keys manually (not through serde). `lifecycle` and `activity` are two separate string keys in the `kernel` map:
+
+```
+kernel/
+  lifecycle: "Running"     (or "PreparingEnv", "Error", etc.)
+  activity: "Idle"         (or "Busy", "Unknown", "" when not Running)
+  error_reason: ""         (populated when lifecycle == "Error")
+  name: "charming-toucan"
+  ...
+```
+
+`read_state()` reconstructs `RuntimeLifecycle` from these two keys:
+- If `lifecycle == "Running"`, parse `activity` into `KernelActivity` and return `Running(activity)`
+- Otherwise, parse `lifecycle` into the variant directly, ignore `activity`
+
+`set_lifecycle()` writes `lifecycle` and clears `activity` to `""` when leaving `Running`. `set_activity()` writes only `activity` (hot path for IOPub idle/busy).
+
+### RuntimeStateDoc API changes
+
+```rust
+impl RuntimeStateDoc {
+    pub fn set_lifecycle(&mut self, lifecycle: &RuntimeLifecycle) -> Result<(), RuntimeStateError> {
+        let kernel = self.scaffold_map("kernel")?;
+        // Write lifecycle variant as string
+        self.doc.put(&kernel, "lifecycle", lifecycle.variant_str())?;
+        // Write or clear activity
+        match lifecycle {
+            RuntimeLifecycle::Running(activity) => {
+                self.doc.put(&kernel, "activity", activity.as_str())?;
+            }
+            _ => {
+                self.doc.put(&kernel, "activity", "")?;
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+The old `set_kernel_status` and `set_starting_phase` are removed. All callers switch to `set_lifecycle`.
+
+### Idle/busy throttle
+
+Today, the IOPub handler suppresses redundant `set_kernel_status("busy")` / `set_kernel_status("idle")` writes. With the enum:
+
+```rust
+// Only write if activity actually changed
+pub fn set_activity(&mut self, activity: KernelActivity) -> Result<(), RuntimeStateError> {
+    let kernel = self.scaffold_map("kernel")?;
+    let current = self.read_str(&kernel, "activity");
+    if current == activity.as_str() {
+        return Ok(());
+    }
+    self.doc.put(&kernel, "activity", activity.as_str())?;
+    Ok(())
+}
+```
+
+`set_activity` only writes the `activity` field, not the full lifecycle. This is the hot path (every IOPub status message). `set_lifecycle` is for lifecycle transitions (infrequent).
+
+### IOPub status handler
+
+The IOPub handler maps Jupyter `ExecutionState` to both lifecycle transitions and activity changes. Today this is one `set_kernel_status` call. With the enum it branches:
+
+```rust
+match status.execution_state {
+    ExecutionState::Busy => set_activity(KernelActivity::Busy),
+    ExecutionState::Idle => set_activity(KernelActivity::Idle),
+    ExecutionState::Starting | ExecutionState::Restarting => set_lifecycle(RuntimeLifecycle::Connecting),
+    ExecutionState::Terminating | ExecutionState::Dead => set_lifecycle(RuntimeLifecycle::Shutdown),
+}
+```
+
+`Busy`/`Idle` are activity changes (hot path, throttled). `Starting`/`Restarting`/`Dead`/`Terminating` are lifecycle transitions (infrequent, not throttled).
+
+### Running(Unknown) in practice
+
+Current launch paths eagerly write `Running(Idle)` on successful kernel_info handshake. `Running(Unknown)` will not appear in the Jupyter backend. It exists for future non-Jupyter backends that may not report idle/busy, and as a brief transient state if a backend connects before reporting its first status.
+
+### Caller migration (complete list)
+
+All current `set_kernel_status` call sites, mapped to the new API:
+
+| File | Current | New |
+|------|---------|-----|
+| `jupyter_kernel.rs` | `set_kernel_status("busy"/"idle")` | `set_activity(Busy/Idle)` |
+| `jupyter_kernel.rs` | `set_kernel_status("starting"/"shutdown")` | `set_lifecycle(Connecting/Shutdown)` |
+| `runtime_agent.rs` | `set_kernel_status("error")` | `set_lifecycle(Error)` |
+| `peer.rs` | `set_kernel_status("starting"/"error"/"awaiting_trust")` | `set_lifecycle(Connecting/Error/AwaitingTrust)` |
+| `metadata.rs` | `set_kernel_status("not_started"/"error"/"idle")` | `set_lifecycle(NotStarted/Error/Running(Idle))` |
+| `launch_kernel.rs` | `set_kernel_status("starting")` + `set_starting_phase(...)` | `set_lifecycle(Resolving/PreparingEnv/etc.)` |
+| `launch_kernel.rs` | `set_kernel_status("idle")` | `set_lifecycle(Running(Idle))` |
+| `shutdown_kernel.rs` | `set_kernel_status("shutdown")` | `set_lifecycle(Shutdown)` |
+
+### Frontend changes
+
+TypeScript types mirror the Rust enum:
+
+```typescript
+type RuntimeLifecycle =
+  | { lifecycle: "NotStarted" }
+  | { lifecycle: "AwaitingTrust" }
+  | { lifecycle: "Resolving" }
+  | { lifecycle: "PreparingEnv" }
+  | { lifecycle: "Launching" }
+  | { lifecycle: "Connecting" }
+  | { lifecycle: "Running"; activity: KernelActivity }
+  | { lifecycle: "Error" }
+  | { lifecycle: "Shutdown" };
+
+type KernelActivity = "Unknown" | "Idle" | "Busy";
+```
+
+`getKernelStatusLabel` simplifies to a single switch on `lifecycle`:
+
+```typescript
+function getLifecycleLabel(lc: RuntimeLifecycle): string {
+  switch (lc.lifecycle) {
+    case "NotStarted": return "initializing";
+    case "AwaitingTrust": return "awaiting approval";
+    case "Resolving": return "resolving environment";
+    case "PreparingEnv": return "preparing environment";
+    case "Launching": return "launching kernel";
+    case "Connecting": return "connecting to kernel";
+    case "Running": return lc.activity === "Busy" ? "busy" : "idle";
+    case "Error": return "error";
+    case "Shutdown": return "shutdown";
+  }
+}
+```
+
+No more `KERNEL_STATUS` constants or `STARTING_PHASE_LABELS` lookup table.
+
+### Python changes
+
+The `runtimed-py` bindings read `RuntimeState.kernel.lifecycle` instead of `kernel.status`:
+
+```python
+rs = notebook.runtime
+if rs.kernel.lifecycle == "Running":
+    print(f"Kernel is {rs.kernel.activity}")
+```
+
+`wait_for_ready` becomes: wait for `lifecycle == "Running"` and `activity == "Idle"`.
+
+### Migration path
+
+1. Add `RuntimeLifecycle` and `KernelActivity` enums to `runtime-doc`
+2. Add `set_lifecycle` and `set_activity` methods to RuntimeStateDoc
+3. Migrate daemon callers from `set_kernel_status`/`set_starting_phase` to `set_lifecycle`/`set_activity`
+4. Update `read_state` snapshot to populate `lifecycle` from the CRDT fields
+5. Update frontend TypeScript types and `getKernelStatusLabel`
+6. Update Python bindings
+7. Remove old `status` and `starting_phase` fields from KernelState snapshot type
+
+The CRDT field names change from `status`/`starting_phase` to `lifecycle`/`activity`. The scaffold in `RuntimeStateDoc::new()` updates accordingly. Since RuntimeStateDoc is ephemeral (recreated on daemon restart), there's no migration concern for existing documents.
+
+### Backward compatibility
+
+No on-disk migration needed. RuntimeStateDoc is ephemeral (in-memory, recreated per room). Clients start empty and receive state via CRDT sync.
+
+The app bundles daemon + frontend + WASM together, so there's no version skew within a release. The MCP server (`runt mcp`) reads `RuntimeState` and ships in the same release.
+
+Live consumers that read `kernel.status` directly (packages/runtimed TypeScript, runtimed-py Python, runt-mcp Rust) all need updating in the same release. This is a coordinated schema change across Rust, TypeScript, and Python - but since the app ships as one artifact, it's safe.
+
+## Testing
+
+- Unit tests for `RuntimeLifecycle` serde round-trip (tag + content format)
+- Unit tests for `set_lifecycle` / `set_activity` in RuntimeStateDoc
+- Verify `set_activity` is a no-op when value unchanged (throttle behavior)
+- Verify `read_state` correctly populates the `lifecycle` field from CRDT
+- Frontend: verify `getLifecycleLabel` covers all variants
+
+## Future
+
+- **Runtime that isn't Jupyter**: `KernelActivity` works for any REPL-like backend. `Unknown` covers backends that don't report idle/busy.
+- **Richer error states**: `Error` could eventually carry structured error info (missing package, launch timeout, crash) beyond a string reason.
+- **wait_for_ready cleanup** (#74): becomes trivial - poll for `Running(Idle)` or subscribe to lifecycle changes.
+- **Actor-pattern runtime fields** (#70): the actor manages `RuntimeLifecycle` transitions as its core state machine.


### PR DESCRIPTION
## Summary

Phase 1 of the `RuntimeLifecycle` refactor spec'd at `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`. Adds the enums + a derived field on `KernelState`. **No writers, no caller migration, no CRDT schema change.** The point is to lock in the type shape on a small diff before we commit to the larger migration.

## What lands

- `RuntimeLifecycle` + `KernelActivity` enums in `crates/runtime-doc/src/types.rs` with serde tag+content format.
- `KernelState.lifecycle: RuntimeLifecycle` — a new field derived from `(status, starting_phase)` at snapshot time via `RuntimeLifecycle::from_legacy`.
- 13 new unit tests (as_str, parse, serde round-trip, default, legacy mapping).

## What's next

- **Phase 2:** write `kernel/lifecycle` + `kernel/activity` keys directly in the CRDT, add `set_lifecycle` / `set_activity` writers, dual-shape maintain `status` + `starting_phase`.
- **Phase 3:** migrate callers crate by crate (daemon, runt-mcp, runtimed-py, frontend).
- **Phase 4:** retire `KernelState.status` / `KernelState.starting_phase`, drop the legacy CRDT keys.

Splitting this way because the full migration is coordinated across Rust, TS, and Python — we want the type shape reviewed before scope explodes.

## Test plan

- [x] `cargo test -p runtime-doc --lib` — 103 tests passing (13 new).
- [x] `cargo check --workspace` — clean.
- [x] `cargo xtask lint` — clean.

Serde shape on the wire:
- `RuntimeLifecycle::NotStarted` → `{"lifecycle":"NotStarted"}`
- `RuntimeLifecycle::Running(KernelActivity::Busy)` → `{"lifecycle":"Running","activity":"Busy"}`