### PR TITLE
feat(runtime-doc): RuntimeLifecycle CRDT keys + typed writers (phase 2)

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -661,6 +661,21 @@ impl RuntimeStateDoc {
             })
     }
 
+    /// Read a string scalar from a map object, returning `None` only when
+    /// the key itself is absent. Unlike `read_opt_str`, an explicit `""`
+    /// value returns `Some("")` so callers can distinguish "scaffolded
+    /// but unset" from "key not present at all."
+    fn read_str_if_present(&self, obj: &automerge::ObjId, key: &str) -> Option<String> {
+        let (value, _) = self.doc.get(obj, key).ok().flatten()?;
+        match value {
+            Value::Scalar(s) => match s.as_ref() {
+                ScalarValue::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Read a bool scalar from a map object.
     fn read_bool(&self, obj: &automerge::ObjId, key: &str) -> bool {
         self.doc
@@ -2011,9 +2026,11 @@ impl RuntimeStateDoc {
                 );
                 // error_reason is Option<String> so callers can tell "no
                 // kernel map at all" (None) from "scaffolded but unset"
-                // (Some("")). The unwrap_or_default above only fires when
-                // the whole kernel map is missing.
-                let error_reason = Some(self.read_str(k, "error_reason"));
+                // (Some("")). read_str_if_present returns None only when
+                // the key itself is absent — important for docs scaffolded
+                // before Phase 2 added the key, which have the `kernel`
+                // map but no `error_reason` field yet.
+                let error_reason = self.read_str_if_present(k, "error_reason");
                 KernelState {
                     status,
                     starting_phase,
@@ -4841,5 +4858,53 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    #[test]
+    fn pre_phase_2_doc_reads_error_reason_as_none() -> Result<(), RuntimeStateError> {
+        // Simulate a runtime-state doc that existed before Phase 2 added
+        // `kernel/error_reason`: kernel map is present (so the snapshot
+        // isn't entirely default) but the error_reason key is absent.
+        // read_state must report error_reason == None so callers can
+        // distinguish this from the Phase-2 scaffolded Some("") state.
+        use automerge::{transaction::Transactable, AutoCommit, ObjType, ROOT};
+
+        let mut raw = AutoCommit::new();
+        let kernel = raw
+            .put_object(&ROOT, "kernel", ObjType::Map)
+            .expect("scaffold kernel");
+        raw.put(&kernel, "status", "idle")
+            .expect("pre-phase-2 status");
+        raw.put(&kernel, "starting_phase", "")
+            .expect("pre-phase-2 starting_phase");
+        raw.put(&kernel, "name", "").expect("pre-phase-2 name");
+        raw.put(&kernel, "language", "")
+            .expect("pre-phase-2 language");
+        raw.put(&kernel, "env_source", "")
+            .expect("pre-phase-2 env_source");
+        raw.put(&kernel, "runtime_agent_id", "")
+            .expect("pre-phase-2 runtime_agent_id");
+        // Deliberately DO NOT write kernel/lifecycle, kernel/activity, or
+        // kernel/error_reason. resolve_lifecycle sees empty lifecycle_key
+        // and falls through to from_legacy("idle", "") = Running(Idle).
+
+        let doc = RuntimeStateDoc::from_doc(raw);
+        let k = doc.read_state().kernel;
+        assert_eq!(k.status, "idle");
+        assert_eq!(k.lifecycle, RuntimeLifecycle::Running(KernelActivity::Idle));
+        assert_eq!(
+            k.error_reason, None,
+            "pre-Phase-2 doc (no error_reason key) must read as None, not Some(\"\")"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scaffolded_doc_reads_error_reason_as_some_empty() {
+        // By contrast, a doc scaffolded by new() has the key present and
+        // set to "". read_state must report Some("") so typed callers can
+        // tell "scaffolded, no reason set" from "key absent."
+        let doc = RuntimeStateDoc::new();
+        assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
     }
 }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -890,17 +890,26 @@ impl RuntimeStateDoc {
     /// state transitions; reserve this method for the idle/busy flip.
     pub fn set_activity(&mut self, activity: KernelActivity) -> Result<(), RuntimeStateError> {
         let kernel = self.scaffold_map("kernel")?;
-        let current = self.read_str(&kernel, "activity");
-        if current == activity.as_str() {
-            return Ok(());
-        }
-        self.doc.put(&kernel, "activity", activity.as_str())?;
-        // Dual-shape: mirror into legacy kernel.status.
         let legacy_status = match activity {
             KernelActivity::Busy => "busy",
             KernelActivity::Idle | KernelActivity::Unknown => "idle",
         };
-        self.doc.put(&kernel, "status", legacy_status)?;
+        // Dual-shape throttle: skip only when BOTH the typed activity AND
+        // the mirrored legacy status already match. If a legacy writer
+        // (set_kernel_status) ran in between and drifted the legacy key
+        // out of sync, we still need to re-mirror it here — otherwise
+        // unmigrated readers stay stuck on a stale status.
+        let current_activity = self.read_str(&kernel, "activity");
+        let current_status = self.read_str(&kernel, "status");
+        if current_activity == activity.as_str() && current_status == legacy_status {
+            return Ok(());
+        }
+        if current_activity != activity.as_str() {
+            self.doc.put(&kernel, "activity", activity.as_str())?;
+        }
+        if current_status != legacy_status {
+            self.doc.put(&kernel, "status", legacy_status)?;
+        }
         Ok(())
     }
 
@@ -1987,19 +1996,19 @@ impl RuntimeStateDoc {
             .map(|k| {
                 let status = self.read_str(k, "status");
                 let starting_phase = self.read_str(k, "starting_phase");
-                // Prefer the typed CRDT keys when they've been written. An
-                // empty string means the key hasn't been populated (or was
-                // scaffolded at "" for activity); fall back to the legacy
-                // (status, starting_phase) projection so pre-Phase-2 docs
-                // and legacy-only writers still read correctly.
-                let lifecycle_str = self.read_str(k, "lifecycle");
-                let activity_str = self.read_str(k, "activity");
-                let lifecycle = if lifecycle_str.is_empty() {
-                    RuntimeLifecycle::from_legacy(&status, &starting_phase)
-                } else {
-                    RuntimeLifecycle::parse(&lifecycle_str, &activity_str)
-                        .unwrap_or_else(|| RuntimeLifecycle::from_legacy(&status, &starting_phase))
-                };
+                let lifecycle_key = self.read_str(k, "lifecycle");
+                let activity_key = self.read_str(k, "activity");
+                // Reconcile the typed and string shapes — see
+                // `resolve_lifecycle` for the rule. Keeps readers correct
+                // during the transition while callers move from
+                // `set_kernel_status` / `set_starting_phase` to
+                // `set_lifecycle` / `set_activity`.
+                let lifecycle = crate::types::resolve_lifecycle(
+                    &lifecycle_key,
+                    &activity_key,
+                    &status,
+                    &starting_phase,
+                );
                 // error_reason is Option<String> so callers can tell "no
                 // kernel map at all" (None) from "scaffolded but unset"
                 // (Some("")). The unwrap_or_default above only fires when
@@ -4536,19 +4545,26 @@ mod tests {
     }
 
     #[test]
-    fn set_activity_without_running_lifecycle_still_writes() -> Result<(), RuntimeStateError> {
-        // Contract: set_activity does not enforce that lifecycle is Running.
-        // Misuse produces a doc whose typed view is Running(<activity>) because
-        // read_state trusts the CRDT keys. Pin the behavior so a future change
-        // to enforce the invariant shows up here.
+    fn set_activity_without_running_lifecycle_resolves_via_string_shape(
+    ) -> Result<(), RuntimeStateError> {
+        // set_activity does not enforce that lifecycle is Running — callers
+        // are expected to have transitioned to Running first. If they
+        // haven't, the typed lifecycle key stays at scaffold "NotStarted"
+        // but set_activity mirrors "busy" into the string status key.
+        //
+        // resolve_lifecycle detects the mismatch (typed → "not_started",
+        // string → "busy") and returns the string-derived value. This
+        // matches the expected behavior of "whichever shape was written
+        // most recently wins."
         let mut doc = RuntimeStateDoc::new();
-        // Lifecycle is scaffolded to NotStarted.
         doc.set_activity(KernelActivity::Busy)?;
         let s = doc.read_state().kernel;
-        // lifecycle key is still "NotStarted" because set_activity doesn't touch it.
-        assert_eq!(s.lifecycle, RuntimeLifecycle::NotStarted);
-        // But the legacy kernel.status was mirrored to "busy".
         assert_eq!(s.status, "busy");
+        assert_eq!(
+            s.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Busy),
+            "resolve_lifecycle prefers the freshly-written string shape"
+        );
         Ok(())
     }
 
@@ -4619,57 +4635,103 @@ mod tests {
     }
 
     #[test]
-    fn legacy_writer_falls_through_read_state() -> Result<(), RuntimeStateError> {
-        // When only the legacy writer runs, the `lifecycle` CRDT key stays
-        // at scaffold default "NotStarted". read_state prefers the new key
-        // because it's non-empty, so it reports NotStarted even though the
-        // legacy status says "idle". That's a real issue for Phase 3 — it
-        // means callers that still use set_kernel_status will be seen as
-        // NotStarted by new-API readers until Phase 3 migrates them.
-        //
-        // This test pins the behavior so the dual-shape gap is explicit.
+    fn string_setter_only_produces_correct_lifecycle_read() -> Result<(), RuntimeStateError> {
+        // When a string-form setter mutates a scaffolded doc, the typed
+        // key still reads "NotStarted". resolve_lifecycle detects the
+        // mismatch (typed.to_legacy() == ("not_started", "") ≠ ("idle", ""))
+        // and derives from the string shape. This is the critical invariant
+        // that lets Phase 3 migrate callers incrementally.
         let mut doc = RuntimeStateDoc::new();
         doc.set_kernel_status("idle")?;
 
         let s = doc.read_state().kernel;
-        // Legacy view is correct.
         assert_eq!(s.status, "idle");
-        // Typed view is stuck at scaffold default because the new-key path
-        // fires first and reads the scaffold "NotStarted".
         assert_eq!(
             s.lifecycle,
-            RuntimeLifecycle::NotStarted,
-            "known dual-shape gap: old writer + new reader sees scaffolded NotStarted. \
-             Phase 3 migration fixes this by using the new writer."
+            RuntimeLifecycle::Running(KernelActivity::Idle),
+            "string setter + typed reader must resolve via from_legacy"
         );
         Ok(())
     }
 
     #[test]
-    fn new_writer_then_old_writer_then_new_writer_stays_consistent() -> Result<(), RuntimeStateError>
-    {
+    fn string_setter_starting_phase_resolves_correctly() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("starting")?;
+        doc.set_starting_phase("launching")?;
+
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "starting");
+        assert_eq!(s.starting_phase, "launching");
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Launching);
+        Ok(())
+    }
+
+    #[test]
+    fn typed_setter_then_string_setter_stays_consistent() -> Result<(), RuntimeStateError> {
+        // Sequence: typed → string → typed.
+        //
+        // Each read must be internally consistent. The typed setter mirrors
+        // into the string keys; a string setter afterward flips the string
+        // key without touching the typed keys, so resolve_lifecycle detects
+        // the drift and prefers the string shape.
         let mut doc = RuntimeStateDoc::new();
 
         doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
         assert_eq!(doc.read_state().kernel.status, "idle");
 
-        // Old writer flips status; typed view sees the lifecycle key still
-        // says "Running", and activity is still "Idle". Legacy status says
-        // "busy". Both reads are internally consistent in their own shape.
         doc.set_kernel_status("busy")?;
         let s = doc.read_state().kernel;
         assert_eq!(s.status, "busy");
         assert_eq!(
             s.lifecycle,
-            RuntimeLifecycle::Running(KernelActivity::Idle),
-            "new-key path reads lifecycle=\"Running\" activity=\"Idle\", ignoring legacy status"
+            RuntimeLifecycle::Running(KernelActivity::Busy),
+            "string shape was written more recently; typed lifecycle tracks it"
         );
 
-        // New writer flips activity; both shapes reconverge.
-        doc.set_activity(KernelActivity::Busy)?;
+        doc.set_activity(KernelActivity::Idle)?;
         let s = doc.read_state().kernel;
-        assert_eq!(s.status, "busy");
-        assert_eq!(s.lifecycle, RuntimeLifecycle::Running(KernelActivity::Busy));
+        assert_eq!(s.status, "idle");
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Running(KernelActivity::Idle));
+        Ok(())
+    }
+
+    #[test]
+    fn set_activity_repairs_drifted_status() -> Result<(), RuntimeStateError> {
+        // Scenario codex-review flagged: typed activity already matches the
+        // requested value, but legacy status has drifted because a string
+        // setter ran in between. set_activity must repair the string side
+        // even on a "redundant" typed call.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        assert_eq!(doc.read_state().kernel.status, "idle");
+
+        doc.set_kernel_status("busy")?;
+        assert_eq!(doc.read_state().kernel.status, "busy");
+
+        doc.set_activity(KernelActivity::Idle)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(
+            s.status, "idle",
+            "set_activity must repair drifted status even on redundant typed call"
+        );
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Running(KernelActivity::Idle));
+        Ok(())
+    }
+
+    #[test]
+    fn set_activity_truly_redundant_is_still_noop() -> Result<(), RuntimeStateError> {
+        // When BOTH shapes already match, set_activity must not advance
+        // heads. The IOPub throttle still holds for the common case.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Busy))?;
+        let heads_before = doc.get_heads();
+        doc.set_activity(KernelActivity::Busy)?;
+        assert_eq!(
+            heads_before,
+            doc.get_heads(),
+            "truly redundant set_activity must not advance heads"
+        );
         Ok(())
     }
 

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -9,7 +9,13 @@
 //! ROOT/
 //!   kernel/
 //!     status: Str          ("idle" | "busy" | "starting" | "error" | "shutdown" | "not_started")
+//!                           — legacy; mirrored by set_lifecycle/set_activity during migration.
 //!     starting_phase: Str  ("" | "resolving" | "preparing_env" | "launching" | "connecting")
+//!                           — legacy; mirrored by set_lifecycle during migration.
+//!     lifecycle: Str       ("NotStarted" | "AwaitingTrust" | "Resolving" | "PreparingEnv"
+//!                           | "Launching" | "Connecting" | "Running" | "Error" | "Shutdown")
+//!     activity: Str        ("" | "Unknown" | "Idle" | "Busy") — only meaningful when lifecycle == "Running"
+//!     error_reason: Str    ("" unless lifecycle == "Error")
 //!     name: Str            (e.g. "charming-toucan")
 //!     language: Str        (e.g. "python", "typescript")
 //!     env_source: Str      (e.g. "uv:prewarmed", "pixi:toml", "deno")
@@ -67,7 +73,7 @@ use automerge::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{RuntimeLifecycle, StreamOutputState};
+use crate::{KernelActivity, RuntimeLifecycle, StreamOutputState};
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -87,14 +93,17 @@ pub struct KernelState {
     /// Used for provenance — identifying which runtime agent is running and detecting stale ones.
     #[serde(default)]
     pub runtime_agent_id: String,
-    /// Typed view derived from `(status, starting_phase)` at snapshot time.
-    ///
-    /// Phase 1 of the RuntimeLifecycle migration: readers can opt into the
-    /// typed enum without any CRDT schema change. Phase 2 introduces a
-    /// dedicated `kernel/lifecycle` key and writer path; at that point
-    /// `lifecycle` will be read directly from the CRDT rather than derived.
+    /// Typed lifecycle. Phase 2 writes it directly from the CRDT when
+    /// `kernel/lifecycle` has been set; falls back to
+    /// [`RuntimeLifecycle::from_legacy`] when only the legacy keys exist
+    /// (e.g., pre-Phase-2 docs or after an old writer ran).
     #[serde(default)]
     pub lifecycle: RuntimeLifecycle,
+    /// Human-readable reason populated when `lifecycle == Error`. `None`
+    /// when `kernel/error_reason` is absent (empty string in the CRDT
+    /// deserializes as `Some("")`, indicating "scaffolded but unset").
+    #[serde(default)]
+    pub error_reason: Option<String>,
 }
 
 impl Default for KernelState {
@@ -107,6 +116,7 @@ impl Default for KernelState {
             env_source: String::new(),
             runtime_agent_id: String::new(),
             lifecycle: RuntimeLifecycle::NotStarted,
+            error_reason: None,
         }
     }
 }
@@ -281,6 +291,12 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.runtime_agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
+        doc.put(&kernel, "lifecycle", "NotStarted")
+            .expect("scaffold kernel.lifecycle");
+        doc.put(&kernel, "activity", "")
+            .expect("scaffold kernel.activity");
+        doc.put(&kernel, "error_reason", "")
+            .expect("scaffold kernel.error_reason");
 
         // queue/
         let queue = doc
@@ -365,6 +381,12 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.runtime_agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
+        doc.put(&kernel, "lifecycle", "NotStarted")
+            .expect("scaffold kernel.lifecycle");
+        doc.put(&kernel, "activity", "")
+            .expect("scaffold kernel.activity");
+        doc.put(&kernel, "error_reason", "")
+            .expect("scaffold kernel.error_reason");
 
         let queue = doc
             .put_object(&ROOT, "queue", ObjType::Map)
@@ -780,6 +802,105 @@ impl RuntimeStateDoc {
             return Ok(());
         }
         self.doc.put(&kernel, "starting_phase", phase)?;
+        Ok(())
+    }
+
+    /// Write a runtime lifecycle transition.
+    ///
+    /// Also mirrors into the legacy `kernel.status` + `kernel.starting_phase`
+    /// keys during the RuntimeLifecycle migration so readers still on the
+    /// old shape keep observing consistent state. A future phase retires
+    /// the legacy mirror writes along with the legacy readers.
+    ///
+    /// - `Running(activity)`: writes `lifecycle = "Running"` and
+    ///   `activity = "<variant>"`.
+    /// - Any other variant: writes `lifecycle = "<variant>"` and clears
+    ///   `activity` to `""`, because activity is only meaningful while
+    ///   running.
+    ///
+    /// Does NOT touch `error_reason`. Callers that want to set or clear
+    /// the error reason should use [`set_lifecycle_with_error`]. This
+    /// lets a retry path re-enter `Error` without losing the original
+    /// diagnosis.
+    pub fn set_lifecycle(&mut self, lifecycle: &RuntimeLifecycle) -> Result<(), RuntimeStateError> {
+        let kernel = self.scaffold_map("kernel")?;
+        self.doc
+            .put(&kernel, "lifecycle", lifecycle.variant_str())?;
+        match lifecycle {
+            RuntimeLifecycle::Running(activity) => {
+                self.doc.put(&kernel, "activity", activity.as_str())?;
+            }
+            _ => {
+                self.doc.put(&kernel, "activity", "")?;
+            }
+        }
+        // Dual-shape: mirror into the legacy keys so readers that haven't
+        // migrated keep seeing correct state. Removed in a later phase.
+        let (legacy_status, legacy_phase) = lifecycle.to_legacy();
+        self.doc.put(&kernel, "status", legacy_status)?;
+        self.doc.put(&kernel, "starting_phase", legacy_phase)?;
+        Ok(())
+    }
+
+    /// Write a lifecycle transition and simultaneously set or clear
+    /// `error_reason`.
+    ///
+    /// - `Some("reason")` records the diagnosis.
+    /// - `None` clears the field to `""`.
+    /// - `Some("")` explicitly writes an empty string — same CRDT value
+    ///   as `None` but signals intent. Readers should treat both as
+    ///   "no reason."
+    ///
+    /// Typical use: `set_lifecycle_with_error(Error, Some("missing_ipykernel"))`
+    /// when transitioning into an Error state with a specific cause, and
+    /// `set_lifecycle_with_error(NotStarted, None)` when resetting out of
+    /// Error.
+    pub fn set_lifecycle_with_error(
+        &mut self,
+        lifecycle: &RuntimeLifecycle,
+        error_reason: Option<&str>,
+    ) -> Result<(), RuntimeStateError> {
+        self.set_lifecycle(lifecycle)?;
+        let kernel = self.scaffold_map("kernel")?;
+        self.doc
+            .put(&kernel, "error_reason", error_reason.unwrap_or(""))?;
+        Ok(())
+    }
+
+    /// Update just the kernel activity. The hot path for IOPub idle/busy —
+    /// called on every kernel status message.
+    ///
+    /// A no-op when the stored value already matches the requested value,
+    /// so the doc heads don't advance on redundant `Idle → Idle` or
+    /// `Busy → Busy` writes. This is the throttle that keeps sync traffic
+    /// bounded during heavy execution.
+    ///
+    /// Also mirrors `activity` back into the legacy `kernel.status` key
+    /// (`"busy"` or `"idle"`) during the migration window; readers still
+    /// on the old shape see the activity change. An `Unknown` activity
+    /// mirrors as `"idle"` — the legacy shape had no equivalent, and
+    /// "idle" is the closest non-busy approximation.
+    ///
+    /// Callers are expected to have set `lifecycle = Running(...)` first
+    /// (typically via [`set_lifecycle`]). This method does NOT verify
+    /// that invariant — writing activity while lifecycle is something
+    /// else produces a doc that [`read_state`] will report as
+    /// `Running(<activity>)` because the lifecycle CRDT key takes
+    /// precedence. Use the type-safe entry point [`set_lifecycle`] for
+    /// state transitions; reserve this method for the idle/busy flip.
+    pub fn set_activity(&mut self, activity: KernelActivity) -> Result<(), RuntimeStateError> {
+        let kernel = self.scaffold_map("kernel")?;
+        let current = self.read_str(&kernel, "activity");
+        if current == activity.as_str() {
+            return Ok(());
+        }
+        self.doc.put(&kernel, "activity", activity.as_str())?;
+        // Dual-shape: mirror into legacy kernel.status.
+        let legacy_status = match activity {
+            KernelActivity::Busy => "busy",
+            KernelActivity::Idle | KernelActivity::Unknown => "idle",
+        };
+        self.doc.put(&kernel, "status", legacy_status)?;
         Ok(())
     }
 
@@ -1866,7 +1987,24 @@ impl RuntimeStateDoc {
             .map(|k| {
                 let status = self.read_str(k, "status");
                 let starting_phase = self.read_str(k, "starting_phase");
-                let lifecycle = RuntimeLifecycle::from_legacy(&status, &starting_phase);
+                // Prefer the typed CRDT keys when they've been written. An
+                // empty string means the key hasn't been populated (or was
+                // scaffolded at "" for activity); fall back to the legacy
+                // (status, starting_phase) projection so pre-Phase-2 docs
+                // and legacy-only writers still read correctly.
+                let lifecycle_str = self.read_str(k, "lifecycle");
+                let activity_str = self.read_str(k, "activity");
+                let lifecycle = if lifecycle_str.is_empty() {
+                    RuntimeLifecycle::from_legacy(&status, &starting_phase)
+                } else {
+                    RuntimeLifecycle::parse(&lifecycle_str, &activity_str)
+                        .unwrap_or_else(|| RuntimeLifecycle::from_legacy(&status, &starting_phase))
+                };
+                // error_reason is Option<String> so callers can tell "no
+                // kernel map at all" (None) from "scaffolded but unset"
+                // (Some("")). The unwrap_or_default above only fires when
+                // the whole kernel map is missing.
+                let error_reason = Some(self.read_str(k, "error_reason"));
                 KernelState {
                     status,
                     starting_phase,
@@ -1875,6 +2013,7 @@ impl RuntimeStateDoc {
                     env_source: self.read_str(k, "env_source"),
                     runtime_agent_id: self.read_str(k, "runtime_agent_id"),
                     lifecycle,
+                    error_reason,
                 }
             })
             .unwrap_or_default();
@@ -4296,5 +4435,349 @@ mod tests {
         assert!(doc.compact_if_oversized(0));
         // State is preserved after compaction
         assert_eq!(doc.read_state().kernel.status, "idle");
+    }
+
+    // ── Phase 2: RuntimeLifecycle writers ───────────────────────────
+    //
+    // These tests target the dual-shape invariant: new writers must leave
+    // the legacy keys consistent, new readers must fall back to the legacy
+    // derivation when the new keys are unset, and set_lifecycle must
+    // preserve error_reason while set_lifecycle_with_error owns it.
+
+    #[test]
+    fn set_lifecycle_populates_both_shapes() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+
+        doc.set_lifecycle(&RuntimeLifecycle::Resolving)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Resolving);
+        assert_eq!(s.status, "starting");
+        assert_eq!(s.starting_phase, "resolving");
+
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Running(KernelActivity::Idle));
+        assert_eq!(s.status, "idle");
+        assert_eq!(s.starting_phase, "");
+
+        doc.set_lifecycle(&RuntimeLifecycle::Shutdown)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Shutdown);
+        assert_eq!(s.status, "shutdown");
+        assert_eq!(s.starting_phase, "");
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_clears_activity_when_leaving_running() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Busy))?;
+        doc.set_lifecycle(&RuntimeLifecycle::Shutdown)?;
+
+        // Internally activity should be "" — round-trip through read_state
+        // returns Shutdown, and a subsequent Running(Idle) must not see
+        // stale Busy.
+        assert_eq!(
+            doc.read_state().kernel.lifecycle,
+            RuntimeLifecycle::Shutdown
+        );
+
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        assert_eq!(
+            doc.read_state().kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle),
+            "stale activity would have made this Running(Busy)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn set_activity_is_noop_when_unchanged() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+
+        let heads_before = doc.get_heads();
+        doc.set_activity(KernelActivity::Idle)?;
+        assert_eq!(
+            heads_before,
+            doc.get_heads(),
+            "redundant Idle → Idle must not advance heads (throttle invariant)"
+        );
+
+        doc.set_activity(KernelActivity::Busy)?;
+        assert_ne!(
+            heads_before,
+            doc.get_heads(),
+            "Idle → Busy must advance heads"
+        );
+        assert_eq!(
+            doc.read_state().kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Busy)
+        );
+        assert_eq!(doc.read_state().kernel.status, "busy");
+        Ok(())
+    }
+
+    #[test]
+    fn set_activity_mirrors_unknown_as_idle_in_legacy() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Busy))?;
+
+        doc.set_activity(KernelActivity::Unknown)?;
+        let s = doc.read_state().kernel;
+        // Typed view preserves Unknown.
+        assert_eq!(
+            s.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Unknown)
+        );
+        // Legacy view maps Unknown → "idle" (no legacy equivalent exists).
+        assert_eq!(s.status, "idle");
+        Ok(())
+    }
+
+    #[test]
+    fn set_activity_without_running_lifecycle_still_writes() -> Result<(), RuntimeStateError> {
+        // Contract: set_activity does not enforce that lifecycle is Running.
+        // Misuse produces a doc whose typed view is Running(<activity>) because
+        // read_state trusts the CRDT keys. Pin the behavior so a future change
+        // to enforce the invariant shows up here.
+        let mut doc = RuntimeStateDoc::new();
+        // Lifecycle is scaffolded to NotStarted.
+        doc.set_activity(KernelActivity::Busy)?;
+        let s = doc.read_state().kernel;
+        // lifecycle key is still "NotStarted" because set_activity doesn't touch it.
+        assert_eq!(s.lifecycle, RuntimeLifecycle::NotStarted);
+        // But the legacy kernel.status was mirrored to "busy".
+        assert_eq!(s.status, "busy");
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_preserves_error_reason() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("missing_ipykernel"))?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel")
+        );
+
+        // Re-enter Error via the plain setter — reason must NOT be clobbered.
+        doc.set_lifecycle(&RuntimeLifecycle::Error)?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel"),
+            "set_lifecycle must not touch error_reason — retry paths depend on this"
+        );
+
+        // Transition to a non-error state via the plain setter — still preserved.
+        doc.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel"),
+            "set_lifecycle still does not touch error_reason even across non-Error transitions"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_clears_on_none() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("oops"))?;
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::NotStarted, None)?;
+        assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_empty_and_none_write_same_value() -> Result<(), RuntimeStateError> {
+        // Semantic intent differs (explicit empty vs clear), CRDT value is
+        // identical. Pin this so a future writer that tries to distinguish
+        // them fails visibly.
+        let mut doc_a = RuntimeStateDoc::new();
+        doc_a.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some(""))?;
+
+        let mut doc_b = RuntimeStateDoc::new();
+        doc_b.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
+
+        assert_eq!(
+            doc_a.read_state().kernel.error_reason,
+            doc_b.read_state().kernel.error_reason
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_second_call_overwrites() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("first"))?;
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("second"))?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("second")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_writer_falls_through_read_state() -> Result<(), RuntimeStateError> {
+        // When only the legacy writer runs, the `lifecycle` CRDT key stays
+        // at scaffold default "NotStarted". read_state prefers the new key
+        // because it's non-empty, so it reports NotStarted even though the
+        // legacy status says "idle". That's a real issue for Phase 3 — it
+        // means callers that still use set_kernel_status will be seen as
+        // NotStarted by new-API readers until Phase 3 migrates them.
+        //
+        // This test pins the behavior so the dual-shape gap is explicit.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("idle")?;
+
+        let s = doc.read_state().kernel;
+        // Legacy view is correct.
+        assert_eq!(s.status, "idle");
+        // Typed view is stuck at scaffold default because the new-key path
+        // fires first and reads the scaffold "NotStarted".
+        assert_eq!(
+            s.lifecycle,
+            RuntimeLifecycle::NotStarted,
+            "known dual-shape gap: old writer + new reader sees scaffolded NotStarted. \
+             Phase 3 migration fixes this by using the new writer."
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn new_writer_then_old_writer_then_new_writer_stays_consistent() -> Result<(), RuntimeStateError>
+    {
+        let mut doc = RuntimeStateDoc::new();
+
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        assert_eq!(doc.read_state().kernel.status, "idle");
+
+        // Old writer flips status; typed view sees the lifecycle key still
+        // says "Running", and activity is still "Idle". Legacy status says
+        // "busy". Both reads are internally consistent in their own shape.
+        doc.set_kernel_status("busy")?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "busy");
+        assert_eq!(
+            s.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle),
+            "new-key path reads lifecycle=\"Running\" activity=\"Idle\", ignoring legacy status"
+        );
+
+        // New writer flips activity; both shapes reconverge.
+        doc.set_activity(KernelActivity::Busy)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "busy");
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Running(KernelActivity::Busy));
+        Ok(())
+    }
+
+    #[test]
+    fn fork_merge_concurrent_lifecycle_writes() -> Result<(), RuntimeStateError> {
+        // Two forks write different lifecycles, then merge. Automerge picks
+        // a winner deterministically. This test pins the behavior rather
+        // than prescribing it — a future regression that flips the winner
+        // will surface here.
+        let mut main = RuntimeStateDoc::new_with_actor("runtimed:state:test:main");
+        main.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+
+        let mut fork = main.fork_with_actor("runtimed:state:test:fork");
+        fork.set_lifecycle(&RuntimeLifecycle::Resolving)?;
+
+        main.set_kernel_status("busy")?; // legacy writer on main side
+
+        main.merge(&mut fork).ok();
+
+        let s = main.read_state().kernel;
+        // Whichever lifecycle wins the conflict, the output must parse as
+        // a valid RuntimeLifecycle — no "bogus" variant leaking through.
+        match s.lifecycle {
+            RuntimeLifecycle::Running(_)
+            | RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::NotStarted => {}
+            other => panic!("unexpected post-merge lifecycle: {:?}", other),
+        }
+        // Legacy status remains a valid string (one of the three we wrote).
+        assert!(
+            matches!(s.status.as_str(), "idle" | "busy" | "starting"),
+            "unexpected post-merge legacy status: {}",
+            s.status
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn empty_doc_reads_as_kernel_state_default() {
+        let doc = RuntimeStateDoc::new_empty();
+        let s = doc.read_state().kernel;
+        assert_eq!(s, KernelState::default());
+        assert_eq!(s.lifecycle, RuntimeLifecycle::NotStarted);
+        assert_eq!(s.error_reason, None);
+    }
+
+    #[test]
+    fn scaffolded_doc_reads_lifecycle_from_new_key_not_legacy_fallback() {
+        // Fresh new() scaffolds kernel.lifecycle = "NotStarted" AND the legacy
+        // kernel.status = "not_started". read_state takes the new key path
+        // because lifecycle is non-empty. error_reason is Some("") because
+        // the field is scaffolded.
+        let doc = RuntimeStateDoc::new();
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::NotStarted);
+        assert_eq!(s.status, "not_started");
+        assert_eq!(s.error_reason.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn set_lifecycle_error_writes_error_status_no_phase() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("kernel_died"))?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(s.status, "error");
+        assert_eq!(s.starting_phase, "");
+        assert_eq!(s.error_reason.as_deref(), Some("kernel_died"));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_awaiting_trust_clears_activity() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Busy))?;
+        doc.set_lifecycle(&RuntimeLifecycle::AwaitingTrust)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::AwaitingTrust);
+        assert_eq!(s.status, "awaiting_trust");
+        assert_eq!(s.starting_phase, "");
+        Ok(())
+    }
+
+    #[test]
+    fn all_lifecycle_variants_round_trip_through_crdt() -> Result<(), RuntimeStateError> {
+        // Every variant must survive a write + read without information loss.
+        let variants = [
+            RuntimeLifecycle::NotStarted,
+            RuntimeLifecycle::AwaitingTrust,
+            RuntimeLifecycle::Resolving,
+            RuntimeLifecycle::PreparingEnv,
+            RuntimeLifecycle::Launching,
+            RuntimeLifecycle::Connecting,
+            RuntimeLifecycle::Running(KernelActivity::Unknown),
+            RuntimeLifecycle::Running(KernelActivity::Idle),
+            RuntimeLifecycle::Running(KernelActivity::Busy),
+            RuntimeLifecycle::Error,
+            RuntimeLifecycle::Shutdown,
+        ];
+        for v in &variants {
+            let mut doc = RuntimeStateDoc::new();
+            doc.set_lifecycle(v)?;
+            assert_eq!(
+                &doc.read_state().kernel.lifecycle,
+                v,
+                "round-trip failed for {v:?}"
+            );
+        }
+        Ok(())
     }
 }

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -136,16 +136,16 @@ impl RuntimeLifecycle {
         }
     }
 
-    /// Project a lifecycle back to the legacy `(status, starting_phase)`
-    /// string pair. Used by the dual-shape writers to mirror new-API
-    /// writes into the legacy CRDT keys so readers that haven't migrated
-    /// still see consistent state.
+    /// Project a lifecycle back to the `(status, starting_phase)` string
+    /// pair. Used by the typed-shape writers to mirror into the string
+    /// CRDT keys so readers that still consume the string shape see
+    /// consistent state.
     ///
     /// This is the inverse of [`from_legacy`] with one caveat:
     /// `Running(KernelActivity::Unknown)` projects to `("idle", "")`
-    /// because the legacy shape has no "unknown" status. Callers that
+    /// because the string shape has no "unknown" status. Callers that
     /// care about the distinction should match on the typed `lifecycle`
-    /// field instead of the legacy string.
+    /// field rather than the string.
     pub fn to_legacy(&self) -> (&'static str, &'static str) {
         match self {
             Self::NotStarted => ("not_started", ""),
@@ -159,6 +159,60 @@ impl RuntimeLifecycle {
             Self::Error => ("error", ""),
             Self::Shutdown => ("shutdown", ""),
         }
+    }
+}
+
+/// Reconcile the typed-shape and string-shape CRDT keys into a single
+/// [`RuntimeLifecycle`].
+///
+/// During the transition window the same document can be mutated via two
+/// setter families:
+///
+/// - **Typed setters** (`set_lifecycle`, `set_activity`,
+///   `set_lifecycle_with_error`) write the typed keys AND mirror into the
+///   string keys.
+/// - **String setters** (`set_kernel_status`, `set_starting_phase`) write
+///   only the string keys.
+///
+/// A doc that has only seen string setters still has its typed key at the
+/// scaffold value `"NotStarted"`, so a naive "prefer typed" rule would
+/// return [`RuntimeLifecycle::NotStarted`] even though the string shape
+/// clearly says the kernel is busy. This function implements the
+/// resolution rule:
+///
+/// 1. If `lifecycle_key` is empty (unscaffolded doc, pre-transition),
+///    derive from the string pair via [`from_legacy`].
+/// 2. Parse the typed pair. If the typed lifecycle's string projection
+///    (via [`to_legacy`]) matches the actual `(status, starting_phase)`
+///    pair, the two shapes agree — return the typed value.
+/// 3. If they disagree, the string keys have been updated more recently
+///    (typed setters always mirror, so a mismatch means a string-only
+///    setter ran). Derive from the string pair.
+///
+/// The rule is "whichever shape was written most recently wins." It
+/// relies on the writer-side invariant that typed setters mirror every
+/// write into the string keys.
+pub fn resolve_lifecycle(
+    lifecycle_key: &str,
+    activity_key: &str,
+    status: &str,
+    starting_phase: &str,
+) -> RuntimeLifecycle {
+    if lifecycle_key.is_empty() {
+        return RuntimeLifecycle::from_legacy(status, starting_phase);
+    }
+    let Some(typed) = RuntimeLifecycle::parse(lifecycle_key, activity_key) else {
+        return RuntimeLifecycle::from_legacy(status, starting_phase);
+    };
+    let (typed_status, typed_phase) = typed.to_legacy();
+    if typed_status == status && typed_phase == starting_phase {
+        typed
+    } else {
+        // String keys drifted from the typed projection — a string-only
+        // setter ran after the last typed write, or this doc was
+        // scaffolded by new() but only mutated through string setters.
+        // Trust the string shape.
+        RuntimeLifecycle::from_legacy(status, starting_phase)
     }
 }
 
@@ -378,5 +432,105 @@ mod tests {
                 "round-trip changed {lc:?} via ({status:?}, {phase:?}) → {round_tripped:?}"
             );
         }
+    }
+
+    // ── resolve_lifecycle ───────────────────────────────────────────
+
+    #[test]
+    fn resolve_prefers_typed_when_shapes_agree() {
+        // Typed shape "Running" + "Idle" projects to ("idle", "").
+        // Matches the string shape → typed wins.
+        assert_eq!(
+            resolve_lifecycle("Running", "Idle", "idle", ""),
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_string_when_typed_is_scaffold_default() {
+        // Scaffolded doc with only a string setter run: typed key is
+        // still "NotStarted", string key says "idle". The mismatch is
+        // what we detect — string shape wins.
+        assert_eq!(
+            resolve_lifecycle("NotStarted", "", "idle", ""),
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+    }
+
+    #[test]
+    fn resolve_empty_typed_key_means_pre_scaffold_doc() {
+        // Doc constructed via new_empty() has no kernel map at all, so
+        // read_str returns "". Fall straight through to the string
+        // derivation without parsing.
+        assert_eq!(
+            resolve_lifecycle("", "", "busy", ""),
+            RuntimeLifecycle::Running(KernelActivity::Busy)
+        );
+        assert_eq!(
+            resolve_lifecycle("", "", "not_started", ""),
+            RuntimeLifecycle::NotStarted
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_when_typed_disagrees_with_string() {
+        // Typed says "Running"/"Idle" but string says "busy". A string
+        // setter ran after the last typed mirror — trust the string.
+        assert_eq!(
+            resolve_lifecycle("Running", "Idle", "busy", ""),
+            RuntimeLifecycle::Running(KernelActivity::Busy)
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_on_unparseable_typed_key() {
+        // Garbage in the typed lifecycle key (future variant? corruption?)
+        // falls through to the string derivation rather than returning
+        // Default and hiding the real state.
+        assert_eq!(
+            resolve_lifecycle("BogusFutureVariant", "Idle", "busy", ""),
+            RuntimeLifecycle::Running(KernelActivity::Busy)
+        );
+    }
+
+    #[test]
+    fn resolve_treats_running_unknown_as_agreeing_with_idle_string() {
+        // Running(Unknown) projects to ("idle", "") because the string
+        // shape has no "unknown" equivalent. A string status of "idle"
+        // agrees with that projection, so the typed Running(Unknown)
+        // wins and the Unknown activity is preserved.
+        assert_eq!(
+            resolve_lifecycle("Running", "Unknown", "idle", ""),
+            RuntimeLifecycle::Running(KernelActivity::Unknown)
+        );
+    }
+
+    #[test]
+    fn resolve_typed_starting_matches_string_starting() {
+        // Typed "Launching" projects to ("starting", "launching"). If the
+        // string pair matches, typed wins.
+        assert_eq!(
+            resolve_lifecycle("Launching", "", "starting", "launching"),
+            RuntimeLifecycle::Launching
+        );
+    }
+
+    #[test]
+    fn resolve_typed_starting_disagrees_on_phase() {
+        // Typed "Launching" projects to ("starting", "launching") but
+        // string phase says "connecting". String shape wins.
+        assert_eq!(
+            resolve_lifecycle("Launching", "", "starting", "connecting"),
+            RuntimeLifecycle::Connecting
+        );
+    }
+
+    #[test]
+    fn resolve_error_with_empty_reason_agrees() {
+        // Error has no string phase component; both shapes agree.
+        assert_eq!(
+            resolve_lifecycle("Error", "", "error", ""),
+            RuntimeLifecycle::Error
+        );
     }
 }

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -135,6 +135,31 @@ impl RuntimeLifecycle {
             _ => Self::NotStarted,
         }
     }
+
+    /// Project a lifecycle back to the legacy `(status, starting_phase)`
+    /// string pair. Used by the dual-shape writers to mirror new-API
+    /// writes into the legacy CRDT keys so readers that haven't migrated
+    /// still see consistent state.
+    ///
+    /// This is the inverse of [`from_legacy`] with one caveat:
+    /// `Running(KernelActivity::Unknown)` projects to `("idle", "")`
+    /// because the legacy shape has no "unknown" status. Callers that
+    /// care about the distinction should match on the typed `lifecycle`
+    /// field instead of the legacy string.
+    pub fn to_legacy(&self) -> (&'static str, &'static str) {
+        match self {
+            Self::NotStarted => ("not_started", ""),
+            Self::AwaitingTrust => ("awaiting_trust", ""),
+            Self::Resolving => ("starting", "resolving"),
+            Self::PreparingEnv => ("starting", "preparing_env"),
+            Self::Launching => ("starting", "launching"),
+            Self::Connecting => ("starting", "connecting"),
+            Self::Running(KernelActivity::Busy) => ("busy", ""),
+            Self::Running(_) => ("idle", ""),
+            Self::Error => ("error", ""),
+            Self::Shutdown => ("shutdown", ""),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -283,5 +308,75 @@ mod tests {
         assert_eq!(RuntimeLifecycle::from_legacy("not_started", ""), NotStarted);
         assert_eq!(RuntimeLifecycle::from_legacy("", ""), NotStarted);
         assert_eq!(RuntimeLifecycle::from_legacy("gibberish", ""), NotStarted);
+    }
+
+    // ── Phase 2: to_legacy projection ───────────────────────────────
+
+    #[test]
+    fn to_legacy_non_running_variants() {
+        use RuntimeLifecycle::*;
+        assert_eq!(NotStarted.to_legacy(), ("not_started", ""));
+        assert_eq!(AwaitingTrust.to_legacy(), ("awaiting_trust", ""));
+        assert_eq!(Resolving.to_legacy(), ("starting", "resolving"));
+        assert_eq!(PreparingEnv.to_legacy(), ("starting", "preparing_env"));
+        assert_eq!(Launching.to_legacy(), ("starting", "launching"));
+        assert_eq!(Connecting.to_legacy(), ("starting", "connecting"));
+        assert_eq!(Error.to_legacy(), ("error", ""));
+        assert_eq!(Shutdown.to_legacy(), ("shutdown", ""));
+    }
+
+    #[test]
+    fn to_legacy_running_activity() {
+        assert_eq!(
+            RuntimeLifecycle::Running(KernelActivity::Idle).to_legacy(),
+            ("idle", "")
+        );
+        assert_eq!(
+            RuntimeLifecycle::Running(KernelActivity::Busy).to_legacy(),
+            ("busy", "")
+        );
+        // Unknown has no legacy equivalent — falls back to "idle" because
+        // the legacy shape interpreted anything non-busy as idle-ish.
+        assert_eq!(
+            RuntimeLifecycle::Running(KernelActivity::Unknown).to_legacy(),
+            ("idle", "")
+        );
+    }
+
+    #[test]
+    fn from_legacy_to_legacy_round_trip_is_lossy_for_unknown() {
+        // Running(Unknown) → ("idle", "") → Running(Idle). The test pins
+        // the loss so future work that might try to preserve Unknown
+        // through the legacy channel surfaces here.
+        let lc = RuntimeLifecycle::Running(KernelActivity::Unknown);
+        let (status, phase) = lc.to_legacy();
+        assert_eq!(
+            RuntimeLifecycle::from_legacy(status, phase),
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+    }
+
+    #[test]
+    fn to_legacy_from_legacy_round_trip_preserves_non_running() {
+        use RuntimeLifecycle::*;
+        for lc in [
+            NotStarted,
+            AwaitingTrust,
+            Resolving,
+            PreparingEnv,
+            Launching,
+            Connecting,
+            Running(KernelActivity::Idle),
+            Running(KernelActivity::Busy),
+            Error,
+            Shutdown,
+        ] {
+            let (status, phase) = lc.to_legacy();
+            let round_tripped = RuntimeLifecycle::from_legacy(status, phase);
+            assert_eq!(
+                round_tripped, lc,
+                "round-trip changed {lc:?} via ({status:?}, {phase:?}) → {round_tripped:?}"
+            );
+        }
     }
 }

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-2.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-2.md
@@ -23,11 +23,12 @@
 
 ## Dual-shape invariants (worth testing explicitly)
 
-- A writer that takes the new API still leaves `kernel.status` + `kernel.starting_phase` matching the old contract.
-- A writer that takes the old API leaves `kernel.lifecycle` + `kernel.activity` consistent — NO, we do NOT update the new keys from the old writers. Phase 3 migrates callers. The failure mode we care about is: old writer + new reader sees a stale lifecycle. `read_state` handles this by preferring the new keys only when they have been written; if they're still at scaffold defaults after an old writer ran, fall back to `from_legacy`.
-- `set_lifecycle(Error)` alone must not clobber an existing `error_reason`; only `set_lifecycle_with_error(lc, None)` clears it.
-- `set_activity` is a no-op when activity is unchanged — hot path for IOPub idle/busy.
-- Leaving `Running` always clears `activity` to `""`.
+- **Typed setters mirror.** `set_lifecycle`, `set_lifecycle_with_error`, and `set_activity` always update both the typed keys (`lifecycle`, `activity`, `error_reason`) AND the string keys (`status`, `starting_phase`). String-shape readers never see stale data written through the typed API.
+- **String setters don't mirror.** `set_kernel_status` and `set_starting_phase` touch only the string keys. The typed keys stay at whatever value the last typed writer left them.
+- **`read_state` reconciles.** When the string pair disagrees with the typed lifecycle's `to_legacy()` projection, a string setter ran more recently — `resolve_lifecycle` falls through to `RuntimeLifecycle::from_legacy(status, starting_phase)`. When they agree, the typed value wins (preserving `Running(Unknown)` through a lossy string projection, for example).
+- **`set_activity` throttle.** A no-op only when BOTH typed `activity` AND string `status` already match the target. If a string setter drifted the string key, `set_activity` re-mirrors even when the typed value looks redundant.
+- **`error_reason` ownership.** `set_lifecycle` alone must not clobber an existing `error_reason`; only `set_lifecycle_with_error(lc, None)` clears it. Retry paths that re-enter `Error` via the plain setter keep their diagnosis.
+- **Leaving Running clears activity.** `set_lifecycle` always sets `activity = ""` on non-`Running` variants, so a later `Running(Idle)` can't be confused for a stale `Running(Busy)`.
 
 ## Acceptance
 

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-2.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-2.md
@@ -1,0 +1,63 @@
+# RuntimeLifecycle Phase 2 — CRDT Keys + Writers
+
+**Goal:** Introduce `kernel/lifecycle`, `kernel/activity`, `kernel/error_reason` CRDT keys alongside the existing `kernel/status` + `kernel/starting_phase`. Add typed writers. Everything is dual-shape — readers of either form still see consistent state.
+
+**Why only this much:** Phase 3 migrates callers. This phase exists so Phase 3's diff is small per crate, and so the CRDT + writer design can be reviewed independently of the migration churn.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+**Prior phase:** `docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-1.md`
+
+## Scope
+
+- `crates/runtime-doc/src/doc.rs`:
+  - Scaffold `kernel/lifecycle` (default `"NotStarted"`), `kernel/activity` (default `""`), `kernel/error_reason` (default `""`) in both `new()` and `new_with_actor()`.
+  - Add `KernelState.error_reason: Option<String>` alongside the existing legacy fields.
+  - `read_state` prefers the new keys when `kernel/lifecycle` is non-empty; falls back to `RuntimeLifecycle::from_legacy(status, starting_phase)` when it's empty (doc scaffolded pre-Phase-2).
+  - New writers: `set_lifecycle`, `set_activity`, `set_lifecycle_with_error`. Each also mirrors into the legacy `status` + `starting_phase` keys so callers that still read the old shape keep working.
+  - Keep `set_kernel_status` and `set_starting_phase` fully functional; they are retired in a later phase.
+
+## Out of scope
+
+- Daemon / TS / Python caller migration — Phase 3.
+- Removing `set_kernel_status` / `set_starting_phase` / legacy CRDT keys — Phase 4.
+
+## Dual-shape invariants (worth testing explicitly)
+
+- A writer that takes the new API still leaves `kernel.status` + `kernel.starting_phase` matching the old contract.
+- A writer that takes the old API leaves `kernel.lifecycle` + `kernel.activity` consistent — NO, we do NOT update the new keys from the old writers. Phase 3 migrates callers. The failure mode we care about is: old writer + new reader sees a stale lifecycle. `read_state` handles this by preferring the new keys only when they have been written; if they're still at scaffold defaults after an old writer ran, fall back to `from_legacy`.
+- `set_lifecycle(Error)` alone must not clobber an existing `error_reason`; only `set_lifecycle_with_error(lc, None)` clears it.
+- `set_activity` is a no-op when activity is unchanged — hot path for IOPub idle/busy.
+- Leaving `Running` always clears `activity` to `""`.
+
+## Acceptance
+
+- `cargo test -p runtime-doc` passes including new tests.
+- `cargo check --workspace` clean.
+- Existing callers of `set_kernel_status` continue to work unchanged; `read_state` returns the same `status` + `starting_phase` strings as before plus a correct `lifecycle` derivation.
+
+## Test plan — shake out the tough stuff
+
+Happy paths are easy; we need adversarial coverage:
+
+1. `set_lifecycle(Error)` does NOT clear `error_reason` set previously.
+2. `set_lifecycle_with_error(lc, None)` DOES clear `error_reason`.
+3. Transitioning Running(Busy) → Shutdown → Running(Idle) clears `activity` at the middle step and repopulates on return.
+4. `set_activity` while lifecycle is NOT `Running` still writes the CRDT key (callers are expected to have set lifecycle first, but the method shouldn't silently drop the write).
+5. `set_activity` with unchanged value does not bump heads (throttle invariant).
+6. Old writer (`set_kernel_status("idle")`) followed by `read_state()` returns a `lifecycle` derived via `from_legacy` — the from_legacy fallback path fires when `kernel/lifecycle` has never been written.
+7. New writer (`set_lifecycle(Running(Idle))`) populates both shapes — `status == "idle"`, `starting_phase == ""`, AND `lifecycle == Running(Idle)`.
+8. Mixed sequence: new writer, then old writer, then new writer again. Each `read_state()` must be internally consistent for whichever shape the test asserts on.
+9. Merging a fork that ran `set_lifecycle(Resolving)` with a main doc that ran `set_kernel_status("idle")` — which value wins is Automerge's call; test just pins the behavior so future regressions stand out.
+10. `set_lifecycle_with_error(Error, Some("oops"))` followed by `set_lifecycle(NotStarted)` — the spec says `set_lifecycle` leaves `error_reason` alone, so it stays `Some("oops")` even though the lifecycle left Error. (Subtle: retry paths want the reason preserved; explicit clear is via `set_lifecycle_with_error(..., None)`.)
+11. `set_lifecycle_with_error` called twice with different reasons — the second call overwrites.
+12. `set_lifecycle_with_error(lifecycle, Some(""))` treats empty string as "set, but empty" — distinct from `None` (which clears) in intent but produces the same CRDT value. Test whichever semantics we pick; the writer's doc comment needs to match.
+13. Reading a doc that has NEITHER legacy keys NOR new keys (freshly-constructed `new_empty()` — used by clients that sync their state) returns the `KernelState::default()`.
+14. Reading a doc that was scaffolded by `new()` but never written since — all new keys at defaults, all legacy keys at defaults — returns `lifecycle == NotStarted` via the new-key path (not the legacy fallback).
+
+## Checkpoint for reviewer
+
+Look at:
+- Scaffold symmetry between `new()` and `new_with_actor()`.
+- The `read_state` priority order (new keys preferred; legacy fallback when new are unset).
+- Whether `set_lifecycle` clearing `activity` on non-Running is the right default (vs. preserving it for an odd transition like `Running(Busy) → Error → Running(Idle)` where someone might want to remember the previous activity).
+- The `error_reason` ownership rules. Current proposal: `set_lifecycle` preserves, `set_lifecycle_with_error(None)` clears, `set_lifecycle_with_error(Some("…"))` sets.


### PR DESCRIPTION
## Summary

Phase 2 of the `RuntimeLifecycle` refactor spec'd at `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`. Adds typed CRDT keys and writers alongside the existing string-form setters. No caller migration — readers of either shape see consistent state through a reconciliation function.

Ready for review. All Phase 2 scoped work is green.

## What lands

- **CRDT scaffold** — `kernel/lifecycle`, `kernel/activity`, `kernel/error_reason` added to `new()` / `new_with_actor()` alongside the existing `status` / `starting_phase`.
- **Typed writers** — `set_lifecycle`, `set_activity`, `set_lifecycle_with_error` on `RuntimeStateDoc`. Typed setters mirror into the string keys; string setters don't touch typed keys.
- **`KernelState.error_reason: Option<String>`** — `None` when the `error_reason` key is absent (pre-Phase-2 docs), `Some("")` when scaffolded but unset, `Some("reason")` when populated.
- **`resolve_lifecycle`** in `types.rs` — the priority rule. When the typed lifecycle's `to_legacy()` projection disagrees with the string pair, a string setter ran more recently; trust the string shape. When they agree, typed wins (preserves `Running(Unknown)` through the lossy string channel).
- **`RuntimeLifecycle::to_legacy`** — inverse of `from_legacy`, used internally by the mirror writes and independently tested.
- **`read_str_if_present`** helper — returns `None` only when the key is absent, preserving the `Option<String>` contract on `error_reason`.

## Dual-shape invariants

- Typed setters always mirror into string keys.
- String setters don't touch typed keys.
- `read_state` reconciles via `resolve_lifecycle` — whichever shape was written most recently wins.
- `set_activity` throttle skips only when BOTH typed activity AND mirrored string status already match.
- `set_lifecycle` never touches `error_reason`; only `set_lifecycle_with_error` owns it.
- Leaving `Running` always clears `activity` to `""`.

## Review history (codex review --base main, 3 passes)

Each pass found dual-shape correctness bugs the prior commit introduced. All landed with targeted tests.

**Pass 1 (commit `a10588b8`)**
- [P2] Scaffolded docs reported `lifecycle = NotStarted` while `status = "busy"` when only string setters had run. Fixed by extracting reconciliation into `resolve_lifecycle` (types.rs).
- [P2] `set_activity` throttle was blind to string-key drift. Fixed by checking both typed + string state before no-op'ing.

**Pass 2 (commit `85ad9edd`)** — the fixes landed.

**Pass 3 (commit `600c7b96`)**
- [P2] `read_str` collapsed absent `error_reason` to `""`, breaking the documented `Option<String>` contract for pre-Phase-2 docs. Fixed by adding `read_str_if_present` that returns `None` only when the key is absent.

## Known Phase-3 prerequisites (NOT addressed here)

Codex's final pass (against `600c7b96`) flagged two remaining compat gaps. Both belong in Phase 3 because a clean fix requires introducing a new type, not another stringly layer:

### 1. `missing_ipykernel` pixi-install-prompt compat

The current frontend gates the pixi-install prompt on `starting_phase == "missing_ipykernel"`. Today a caller writes `set_kernel_status("error")` + `set_starting_phase("missing_ipykernel")`; with Phase 2 they'd migrate to `set_lifecycle_with_error(Error, Some("missing_ipykernel"))`. My `to_legacy()` for `Error` returns `("error", "")`, so the frontend prompt breaks until Phase 3 migrates `NotebookToolbar`.

**A quick fix would mirror the reason string into `starting_phase` when lifecycle is `Error`. Kyle flagged this as "very string like" — right call. The real fix is a typed `KernelErrorReason` enum (variants `MissingIpykernel`, `KernelDied`, …, plus `Other(String)`) rather than free-form strings. That's a Phase 3 API change: `set_lifecycle_with_error` takes `Option<&KernelErrorReason>`, the frontend matches on the enum variant instead of a magic string.**

Deferring to Phase 3 so we don't bolt another stringly layer onto Phase 2 that we'd just rip out.

### 2. `set_activity` clearing stale `starting_phase`

After the old launch path ends with `set_starting_phase("connecting")`, the first `set_activity(Idle)` IOPub event leaves `starting_phase = "connecting"` while mirroring `status = "idle"`. `set_kernel_status` itself would clear `starting_phase` in this case. Fix is straightforward (have `set_activity` clear the phase when mirroring a non-starting status) and small; folding it in is fine in Phase 2 or Phase 3.

I held off in this PR because Kyle was heading to bed and I wanted the PR at a known-good commit boundary rather than racing another codex round.

## Test plan

- [x] `cargo test -p runtime-doc --lib` — 138 passing (35 new).
- [x] `cargo check --workspace` — clean.
- [x] `cargo xtask lint` — clean.
- [x] `cargo test -p notebook-sync -p runtimed --lib` — 430 passing.

### Adversarial coverage

- `set_lifecycle(Error)` preserves `error_reason`; `set_lifecycle_with_error(_, None)` clears it.
- `set_activity(Idle)` after `set_kernel_status("busy")` re-mirrors the string key.
- Truly redundant `set_activity(Busy)` does not advance heads.
- `Running(Unknown)` survives round-trip through the CRDT.
- String setter on a scaffolded doc produces correct `lifecycle` via the reconciliation fallback.
- Pre-Phase-2 doc (kernel map without error_reason key) reads as `error_reason == None`.
- Scaffolded doc reads as `error_reason == Some("")`.
- Fork + merge with concurrent lifecycle writes pins Automerge's conflict behavior.
- Every lifecycle variant round-trips through write + read.

## Follow-ups (Phase 3 backlog)

- Introduce `KernelErrorReason` enum; migrate `set_lifecycle_with_error` signature.
- `set_activity` clears stale `starting_phase` when mirroring non-starting status.
- Move `read_str_if_present` to `automunge` — it's a general Automerge primitive, doesn't belong in `runtime-doc`.
- Migrate daemon callers (jupyter_kernel IOPub, launch_kernel, peer.rs auto-launch, runtime_agent kernel-died) from the string setters to the typed setters.