### PR TITLE
feat(runtime-doc): KernelErrorReason enum + set_activity stale-phase fix (phase 3)

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -73,7 +73,7 @@ use automerge::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{KernelActivity, RuntimeLifecycle, StreamOutputState};
+use crate::{KernelActivity, KernelErrorReason, RuntimeLifecycle, StreamOutputState};
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -860,25 +860,41 @@ impl RuntimeStateDoc {
     /// Write a lifecycle transition and simultaneously set or clear
     /// `error_reason`.
     ///
-    /// - `Some("reason")` records the diagnosis.
+    /// - `Some(reason)` records the diagnosis — typed so we can't typo
+    ///   the reason string, and so the legacy-phase mirror gets the
+    ///   correct value from a single source of truth ([`KernelErrorReason::as_str`]).
     /// - `None` clears the field to `""`.
-    /// - `Some("")` explicitly writes an empty string — same CRDT value
-    ///   as `None` but signals intent. Readers should treat both as
-    ///   "no reason."
     ///
-    /// Typical use: `set_lifecycle_with_error(Error, Some("missing_ipykernel"))`
-    /// when transitioning into an Error state with a specific cause, and
-    /// `set_lifecycle_with_error(NotStarted, None)` when resetting out of
-    /// Error.
+    /// When `lifecycle == Error && reason.is_some()`, the reason is
+    /// ALSO mirrored into the legacy `starting_phase` key. Pre-typed-
+    /// writer code encoded error reasons via
+    /// `set_kernel_status("error") + set_starting_phase("missing_ipykernel")`,
+    /// and the frontend's pixi-install prompt gates on that legacy
+    /// phase. Keeping the mirror lets unmigrated readers continue to
+    /// work until Phase 5 flips them to the typed `error_reason` field.
+    ///
+    /// Typical use:
+    /// - `set_lifecycle_with_error(Error, Some(KernelErrorReason::MissingIpykernel))`
+    ///   when transitioning into Error with a specific cause.
+    /// - `set_lifecycle_with_error(NotStarted, None)` when resetting out
+    ///   of Error.
     pub fn set_lifecycle_with_error(
         &mut self,
         lifecycle: &RuntimeLifecycle,
-        error_reason: Option<&str>,
+        reason: Option<KernelErrorReason>,
     ) -> Result<(), RuntimeStateError> {
         self.set_lifecycle(lifecycle)?;
         let kernel = self.scaffold_map("kernel")?;
-        self.doc
-            .put(&kernel, "error_reason", error_reason.unwrap_or(""))?;
+        let reason_str = reason.map(|r| r.as_str()).unwrap_or("");
+        self.doc.put(&kernel, "error_reason", reason_str)?;
+        // Legacy-phase mirror for the Error transition. The pre-Phase-3
+        // channel used `starting_phase` to carry the reason. Only
+        // overwrite on Error — a non-Error lifecycle would already have
+        // a phase written by the `set_lifecycle` mirror and we don't
+        // want to step on it.
+        if matches!(lifecycle, RuntimeLifecycle::Error) && reason.is_some() {
+            self.doc.put(&kernel, "starting_phase", reason_str)?;
+        }
         Ok(())
     }
 
@@ -909,14 +925,20 @@ impl RuntimeStateDoc {
             KernelActivity::Busy => "busy",
             KernelActivity::Idle | KernelActivity::Unknown => "idle",
         };
-        // Dual-shape throttle: skip only when BOTH the typed activity AND
-        // the mirrored legacy status already match. If a legacy writer
-        // (set_kernel_status) ran in between and drifted the legacy key
-        // out of sync, we still need to re-mirror it here — otherwise
-        // unmigrated readers stay stuck on a stale status.
+        // Dual-shape throttle: skip only when the typed activity, the
+        // mirrored legacy status, AND the legacy starting_phase are all
+        // already at their target values. set_kernel_status itself clears
+        // starting_phase whenever it flips to a non-starting status; we
+        // keep that invariant so unmigrated readers don't observe
+        // status="idle"/"busy" alongside a stale phase like "connecting"
+        // left over from the launch path.
         let current_activity = self.read_str(&kernel, "activity");
         let current_status = self.read_str(&kernel, "status");
-        if current_activity == activity.as_str() && current_status == legacy_status {
+        let current_phase = self.read_str(&kernel, "starting_phase");
+        if current_activity == activity.as_str()
+            && current_status == legacy_status
+            && current_phase.is_empty()
+        {
             return Ok(());
         }
         if current_activity != activity.as_str() {
@@ -924,6 +946,9 @@ impl RuntimeStateDoc {
         }
         if current_status != legacy_status {
             self.doc.put(&kernel, "status", legacy_status)?;
+        }
+        if !current_phase.is_empty() {
+            self.doc.put(&kernel, "starting_phase", "")?;
         }
         Ok(())
     }
@@ -4588,7 +4613,10 @@ mod tests {
     #[test]
     fn set_lifecycle_preserves_error_reason() -> Result<(), RuntimeStateError> {
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("missing_ipykernel"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         assert_eq!(
             doc.read_state().kernel.error_reason.as_deref(),
             Some("missing_ipykernel")
@@ -4615,38 +4643,118 @@ mod tests {
     #[test]
     fn set_lifecycle_with_error_clears_on_none() -> Result<(), RuntimeStateError> {
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("oops"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         doc.set_lifecycle_with_error(&RuntimeLifecycle::NotStarted, None)?;
         assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
         Ok(())
     }
 
     #[test]
-    fn set_lifecycle_with_error_empty_and_none_write_same_value() -> Result<(), RuntimeStateError> {
-        // Semantic intent differs (explicit empty vs clear), CRDT value is
-        // identical. Pin this so a future writer that tries to distinguish
-        // them fails visibly.
-        let mut doc_a = RuntimeStateDoc::new();
-        doc_a.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some(""))?;
-
-        let mut doc_b = RuntimeStateDoc::new();
-        doc_b.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
-
+    fn set_lifecycle_with_error_mirrors_reason_into_starting_phase() -> Result<(), RuntimeStateError>
+    {
+        // The pre-Phase-3 channel encoded reasons via `starting_phase`.
+        // NotebookToolbar's pixi-install prompt still gates on that legacy
+        // phase. set_lifecycle_with_error must mirror the reason there
+        // when lifecycle is Error so the prompt continues to fire until
+        // Phase 5 migrates the frontend.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(s.status, "error");
         assert_eq!(
-            doc_a.read_state().kernel.error_reason,
-            doc_b.read_state().kernel.error_reason
+            s.starting_phase, "missing_ipykernel",
+            "legacy pixi-install prompt gate must continue to fire via starting_phase"
+        );
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_empty_reason_leaves_phase_empty() -> Result<(), RuntimeStateError> {
+        // Error with no reason: starting_phase stays "" (set_lifecycle's
+        // default Error mirror). We only overwrite the phase when the
+        // reason is Some.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "error");
+        assert_eq!(s.starting_phase, "");
+        assert_eq!(s.error_reason.as_deref(), Some(""));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_non_error_with_reason_does_not_touch_phase(
+    ) -> Result<(), RuntimeStateError> {
+        // A non-Error lifecycle with a Some(reason) argument is unusual
+        // but harmless. set_lifecycle's default mirror already wrote the
+        // variant's proper phase (e.g. "launching"); we must not clobber
+        // it just because a reason was supplied.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Launching,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "starting");
+        assert_eq!(s.starting_phase, "launching");
+        // error_reason is still recorded even for non-Error — harmless
+        // metadata, and it keeps the writer simple (no "only record
+        // reason when lifecycle is Error" special case at the
+        // error_reason key).
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_second_call_updates_reason() -> Result<(), RuntimeStateError> {
+        // Only one variant today; exercise the overwrite path by toggling
+        // Some(MissingIpykernel) -> None -> Some(MissingIpykernel).
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel")
+        );
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
+        assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel")
         );
         Ok(())
     }
 
     #[test]
-    fn set_lifecycle_with_error_second_call_overwrites() -> Result<(), RuntimeStateError> {
+    fn set_activity_clears_stale_starting_phase() -> Result<(), RuntimeStateError> {
+        // After the string-shape launch path ends with
+        // set_starting_phase("connecting"), the first IOPub set_activity
+        // must clear the stale phase so unmigrated readers don't see
+        // status="idle" alongside starting_phase="connecting".
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("first"))?;
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("second"))?;
+        doc.set_kernel_status("starting")?;
+        doc.set_starting_phase("connecting")?;
+
+        doc.set_activity(KernelActivity::Idle)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "idle");
         assert_eq!(
-            doc.read_state().kernel.error_reason.as_deref(),
-            Some("second")
+            s.starting_phase, "",
+            "stale starting_phase must be cleared when set_activity mirrors to a non-starting status"
         );
         Ok(())
     }
@@ -4809,14 +4917,20 @@ mod tests {
     }
 
     #[test]
-    fn set_lifecycle_error_writes_error_status_no_phase() -> Result<(), RuntimeStateError> {
+    fn set_lifecycle_error_with_reason_writes_all_three_shapes() -> Result<(), RuntimeStateError> {
+        // Writing Error + reason must populate the typed `error_reason`
+        // key, the string `status = "error"`, AND mirror the reason into
+        // the legacy `starting_phase` for NotebookToolbar compat.
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("kernel_died"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         let s = doc.read_state().kernel;
         assert_eq!(s.lifecycle, RuntimeLifecycle::Error);
         assert_eq!(s.status, "error");
-        assert_eq!(s.starting_phase, "");
-        assert_eq!(s.error_reason.as_deref(), Some("kernel_died"));
+        assert_eq!(s.starting_phase, "missing_ipykernel");
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
         Ok(())
     }
 

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -39,6 +39,46 @@ impl KernelActivity {
     }
 }
 
+/// Typed reason accompanying a [`RuntimeLifecycle::Error`] transition.
+///
+/// Closed enum by design — every error reason the daemon surfaces gets
+/// its own variant. This is deliberately more rigid than a free-form
+/// string: reasons rarely change, and the compile-time guarantee that
+/// the frontend and daemon agree on the vocabulary is worth the cost
+/// of editing the enum.
+///
+/// The single [`as_str`](Self::as_str) method returns the string that
+/// serves BOTH as the CRDT `kernel.error_reason` value AND as the
+/// legacy `kernel.starting_phase` mirror (see
+/// `RuntimeStateDoc::set_lifecycle_with_error`). The two happen to be
+/// the same string because that's how the pre-Phase-3 channel encoded
+/// these reasons — `set_kernel_status("error") + set_starting_phase(
+/// "missing_ipykernel")`. Collapsing both into one method keeps the
+/// string-level contract in one place. If a future variant needs
+/// distinct values for the two channels, split into
+/// `as_crdt_str` / `as_legacy_phase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KernelErrorReason {
+    /// Pixi-managed environment is missing the `ipykernel` package.
+    /// `NotebookToolbar` gates its "install ipykernel" prompt on this.
+    MissingIpykernel,
+}
+
+impl KernelErrorReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingIpykernel => "missing_ipykernel",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "missing_ipykernel" => Some(Self::MissingIpykernel),
+            _ => None,
+        }
+    }
+}
+
 /// Lifecycle of a runtime, from not-started through running to shutdown.
 ///
 /// Replaces the string-valued `KernelState.status` + `starting_phase` pair
@@ -237,6 +277,46 @@ mod tests {
         assert_eq!(KernelActivity::parse("Busy"), Some(KernelActivity::Busy));
         assert_eq!(KernelActivity::parse("nope"), None);
         assert_eq!(KernelActivity::parse(""), None);
+    }
+
+    #[test]
+    fn error_reason_as_str() {
+        assert_eq!(
+            KernelErrorReason::MissingIpykernel.as_str(),
+            "missing_ipykernel"
+        );
+    }
+
+    #[test]
+    fn error_reason_parse() {
+        assert_eq!(
+            KernelErrorReason::parse("missing_ipykernel"),
+            Some(KernelErrorReason::MissingIpykernel)
+        );
+        assert_eq!(KernelErrorReason::parse(""), None);
+        assert_eq!(KernelErrorReason::parse("bogus"), None);
+        // Parse is case-sensitive — the CRDT and legacy phase channel
+        // both use exactly "missing_ipykernel".
+        assert_eq!(KernelErrorReason::parse("Missing_Ipykernel"), None);
+    }
+
+    #[test]
+    fn error_reason_as_str_round_trips_through_parse() {
+        let reasons = [KernelErrorReason::MissingIpykernel];
+        for r in reasons {
+            assert_eq!(KernelErrorReason::parse(r.as_str()), Some(r));
+        }
+    }
+
+    #[test]
+    fn error_reason_serde_round_trip() -> Result<(), serde_json::Error> {
+        // Variant-unit enums serialize as their variant name.
+        let r = KernelErrorReason::MissingIpykernel;
+        let json = serde_json::to_string(&r)?;
+        assert_eq!(json, r#""MissingIpykernel""#);
+        let back: KernelErrorReason = serde_json::from_str(&json)?;
+        assert_eq!(back, r);
+        Ok(())
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-3.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-3.md
@@ -1,0 +1,88 @@
+# RuntimeLifecycle Phase 3 — Typed Error Reasons
+
+**Goal:** Replace the free-form `Option<&str>` error-reason argument to `set_lifecycle_with_error` with a typed `KernelErrorReason` enum. Fix the two codex-v3 compat gaps from Phase 2 along the way. Still no caller migration.
+
+**Why only this much:** Phase 2 left `error_reason` as a free-form string at the call-site boundary. Kyle flagged `"missing_ipykernel"` sprinkled through writers and tests as the same string-shape smell we're trying to escape. Phase 3 makes reasons a first-class type. Phase 4 then migrates callers with type-safe construction.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+**Prior phases:** `2026-04-23-runtime-lifecycle-phase-1.md`, `2026-04-23-runtime-lifecycle-phase-2.md`
+
+## Scope
+
+- `crates/runtime-doc/src/types.rs`:
+  - New `KernelErrorReason` enum. Closed (no `Other(String)` escape). Variant `MissingIpykernel` only.
+  - `as_str()` returns `"missing_ipykernel"` — serves BOTH as the CRDT value AND the legacy `starting_phase` mirror. The two strings are the same because that's how the legacy channel already encoded it.
+  - `parse(&str) -> Option<Self>` for reading.
+  - Serde round-trip tests + parse-unknown tests.
+
+- `crates/runtime-doc/src/doc.rs`:
+  - Change `set_lifecycle_with_error` signature from `Option<&str>` to `Option<KernelErrorReason>`.
+  - When `lifecycle == Error && reason.is_some()`, mirror `reason.as_str()` into `starting_phase` (the codex-v3 missing_ipykernel compat fix — now via the enum's typed projection).
+  - `set_activity` clears stale `starting_phase` when mirroring to a non-starting status. Throttle widens to include all three keys (activity, status, starting_phase).
+  - Tests for both fixes.
+
+- `KernelState.error_reason: Option<String>` — **unchanged**. Snapshot stays stringly on purpose so newer daemons with unknown variants don't break older readers.
+
+## Out of scope
+
+- Any caller migration (Phase 4).
+- TS frontend changes (Phase 5).
+- Python bindings changes (Phase 6+).
+- Retiring string setters (later phase).
+- Moving `read_str_if_present` to `automunge` (follow-up).
+
+## Design notes
+
+### Why closed enum, no `Other(String)`
+
+Kyle's direction: "those look very string like … instead of enums." The point of the enum is to make reasons exhaustive and typo-proof. `Other(String)` reintroduces the stringly escape hatch we're trying to close. The cost of "closed" is that adding a reason requires a variant + recompile. That's the right cost.
+
+Today we ship one variant (`MissingIpykernel`). When a future path wants `KernelDied` or `EnvResolveTimeout`, add a variant.
+
+### Why `KernelState.error_reason` stays `Option<String>`
+
+Two reasons:
+
+1. **Schema robustness.** If a newer daemon writes a reason our reader doesn't know, `Option<KernelErrorReason>` would have to either drop it (silent info loss) or panic. `Option<String>` surfaces the raw string so readers can log or pass through.
+2. **No reader change needed.** Python bindings and frontend already handle `Option<String>`. Switching to enum in the snapshot would force them to also convert — work that Phase 5/6 will do if there's demand.
+
+The enum lives at the *writer* boundary. Readers see the string it projected to.
+
+### The missing_ipykernel `starting_phase` compat
+
+Codex v3 flagged: the current `NotebookToolbar` gates its pixi-install prompt on `starting_phase == "missing_ipykernel"`. When callers migrate to the typed writer, they'll pass `Error + Some(MissingIpykernel)`. My Phase 2 `set_lifecycle.to_legacy()` returns `("error", "")` for `Error`, wiping the phase.
+
+Fix: in `set_lifecycle_with_error`, when `lifecycle == Error && reason.is_some()`, overwrite `starting_phase` with `reason.as_str()` after the `set_lifecycle` mirror ran. That preserves the legacy channel without leaking strings into the writer — the string lives in the enum's `as_str` impl in exactly one place.
+
+### The `set_activity` stale-phase bug
+
+Codex v3 also flagged: after the old launch path ends with `set_starting_phase("connecting")`, the first IOPub `set_activity(Idle)` mirrors `status = "idle"` but leaves `starting_phase = "connecting"`. `set_kernel_status` would have cleared it. Same rule should apply.
+
+Fix: `set_activity` reads `starting_phase`; if non-empty, clears it. Throttle widens to check all three keys (activity, status, phase) — skip only when every key is already at target.
+
+## Acceptance
+
+- `cargo test -p runtime-doc` passes, including new tests.
+- `cargo check --workspace` clean.
+- Existing callers of `set_kernel_status` continue to work (not migrated in this phase).
+- Existing Phase 2 tests that passed `Some("missing_ipykernel")` updated to `Some(KernelErrorReason::MissingIpykernel)`.
+
+## Test plan — adversarial coverage
+
+1. `KernelErrorReason::MissingIpykernel.as_str() == "missing_ipykernel"` — single source of truth for the string.
+2. `parse("missing_ipykernel") == Some(MissingIpykernel)`, `parse("bogus") == None`.
+3. Serde round-trip.
+4. `set_lifecycle_with_error(Error, Some(MissingIpykernel))` writes `error_reason` AND `starting_phase` to `"missing_ipykernel"` — proves the pixi compat still works via the enum.
+5. `set_lifecycle_with_error(Error, None)` writes empty `error_reason` and empty `starting_phase` (the `Error`-variant default mirror).
+6. `set_lifecycle_with_error(Launching, Some(MissingIpykernel))` — non-Error with reason — writes `error_reason = "missing_ipykernel"` but does NOT touch `starting_phase` (`set_lifecycle` already wrote `"launching"` there; we don't overwrite on non-Error). Documents the asymmetry.
+7. `set_activity(Idle)` after `set_starting_phase("connecting")` clears the phase.
+8. `set_activity(Idle)` with all three keys at target is still a no-op (heads don't advance).
+9. `set_activity(Idle)` where legacy status drifted to "busy" repairs status WITHOUT touching phase (if phase is already empty).
+10. A pre-Phase-3 doc with `error_reason = "missing_ipykernel"` written as raw string parses correctly via `KernelErrorReason::parse` — backward compat with Phase 2 scaffolded docs.
+
+## Checkpoint for reviewer
+
+Look at:
+- Whether closed vs `Other(String)` is the right call. I argue closed: reasons are rare enough that adding a variant isn't painful, and closed forces good hygiene. Kyle's "instead of enums" steer supports this.
+- Whether `KernelState.error_reason: Option<String>` staying stringly is right. My claim: writer-side type safety is where the enum earns its keep; snapshot-side robustness argues for string.
+- Whether `as_str` doubling as both CRDT value and legacy phase is too clever. Alternative: two methods (`as_crdt_str` + `as_legacy_phase`). For one variant where both are identical, one method feels right; if a future variant has distinct values, split then.


### PR DESCRIPTION
## Summary

Phase 3 of the `RuntimeLifecycle` refactor. Closes the two codex compat gaps from Phase 2 by introducing the `KernelErrorReason` enum Kyle asked for instead of another stringly layer. No caller migration.

**Stack:** base branch for #2092 (Phase 4), which is itself the base for #2093 (Phase 5).

## What lands

- `KernelErrorReason` enum in `crates/runtime-doc/src/types.rs` — closed (no `Other(String)` escape), variant `MissingIpykernel` only. `as_str()` returns `"missing_ipykernel"` — one source of truth for both the CRDT `error_reason` value AND the legacy `starting_phase` mirror.
- `set_lifecycle_with_error(lifecycle, reason: Option<KernelErrorReason>)` — signature changed from `Option<&str>`. When `lifecycle == Error && reason.is_some()`, mirrors the reason into `starting_phase` so the pre-Phase-5 `NotebookToolbar` pixi-install prompt (gated on `starting_phase == "missing_ipykernel"`) keeps firing until Phase 5 migrates that reader.
- `set_activity` clears stale `starting_phase` on any non-starting mirror. Throttle widened: no-op only when all three keys (activity, status, starting_phase) are already at target.
- `KernelState.error_reason` stays `Option<String>` in the snapshot — the enum is a writer-side type. Keeps reader robustness to unknown variants from a newer daemon.

## Test plan

- `cargo test -p runtime-doc --lib` — 145 passing.
- `cargo check --workspace` clean.
- `cargo xtask lint` clean.

New adversarial tests cover:
- `MissingIpykernel.as_str()` / parse / serde round-trip.
- `set_lifecycle_with_error(Error, Some(MissingIpykernel))` writes all three keys.
- `None` reason leaves `starting_phase` empty.
- Non-Error + reason does not overwrite the variant's own phase.
- Toggling Some→None→Some exercises overwrite semantics.
- `set_activity` clears stale phase when mirroring to a non-starting status.

## Review

Codex review against main found no regressions introduced by Phase 3 itself. Findings that surfaced when reviewing the full three-phase stack are addressed in #2092 and #2093.

Spec: \`docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md\`
Plan: \`docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-3.md\`