### PR TITLE
refactor(runtimed): migrate Rust callers to typed RuntimeLifecycle setters (phase 4)

### DIFF
--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -26,6 +26,8 @@
 
 use std::time::{Duration, Instant};
 
+use runtime_doc::RuntimeLifecycle;
+
 use crate::handle::DocHandle;
 
 /// Outcome of awaiting a single execution.
@@ -113,12 +115,12 @@ pub async fn await_execution_terminal(
             // Fallback: kernel fault aborts only if *this* execution is
             // still non-terminal. Otherwise the caller would spin until
             // the outer timeout fires.
-            if state.kernel.status == "error" {
+            if matches!(state.kernel.lifecycle, RuntimeLifecycle::Error) {
                 return Err(ExecutionTerminalError::KernelFailed {
                     reason: "kernel error".to_string(),
                 });
             }
-            if state.kernel.status == "shutdown" {
+            if matches!(state.kernel.lifecycle, RuntimeLifecycle::Shutdown) {
                 return Err(ExecutionTerminalError::KernelFailed {
                     reason: "kernel shutdown".to_string(),
                 });

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -812,7 +812,9 @@ mod tests {
         set_execution(&shared, "exec-1", "cell-1", "running", &[], None);
         {
             let mut st = shared.lock().unwrap();
-            st.state_doc.set_kernel_status("error").unwrap();
+            st.state_doc
+                .set_lifecycle(&runtime_doc::RuntimeLifecycle::Error)
+                .unwrap();
         }
 
         let err =
@@ -842,7 +844,9 @@ mod tests {
         // Kernel is now flagged as error AFTER the execution completed.
         {
             let mut st = shared.lock().unwrap();
-            st.state_doc.set_kernel_status("error").unwrap();
+            st.state_doc
+                .set_lifecycle(&runtime_doc::RuntimeLifecycle::Error)
+                .unwrap();
         }
 
         let state =

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -73,7 +73,7 @@ use automerge::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{KernelActivity, RuntimeLifecycle, StreamOutputState};
+use crate::{KernelActivity, KernelErrorReason, RuntimeLifecycle, StreamOutputState};
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -860,25 +860,41 @@ impl RuntimeStateDoc {
     /// Write a lifecycle transition and simultaneously set or clear
     /// `error_reason`.
     ///
-    /// - `Some("reason")` records the diagnosis.
+    /// - `Some(reason)` records the diagnosis — typed so we can't typo
+    ///   the reason string, and so the legacy-phase mirror gets the
+    ///   correct value from a single source of truth ([`KernelErrorReason::as_str`]).
     /// - `None` clears the field to `""`.
-    /// - `Some("")` explicitly writes an empty string — same CRDT value
-    ///   as `None` but signals intent. Readers should treat both as
-    ///   "no reason."
     ///
-    /// Typical use: `set_lifecycle_with_error(Error, Some("missing_ipykernel"))`
-    /// when transitioning into an Error state with a specific cause, and
-    /// `set_lifecycle_with_error(NotStarted, None)` when resetting out of
-    /// Error.
+    /// When `lifecycle == Error && reason.is_some()`, the reason is
+    /// ALSO mirrored into the legacy `starting_phase` key. Pre-typed-
+    /// writer code encoded error reasons via
+    /// `set_kernel_status("error") + set_starting_phase("missing_ipykernel")`,
+    /// and the frontend's pixi-install prompt gates on that legacy
+    /// phase. Keeping the mirror lets unmigrated readers continue to
+    /// work until Phase 5 flips them to the typed `error_reason` field.
+    ///
+    /// Typical use:
+    /// - `set_lifecycle_with_error(Error, Some(KernelErrorReason::MissingIpykernel))`
+    ///   when transitioning into Error with a specific cause.
+    /// - `set_lifecycle_with_error(NotStarted, None)` when resetting out
+    ///   of Error.
     pub fn set_lifecycle_with_error(
         &mut self,
         lifecycle: &RuntimeLifecycle,
-        error_reason: Option<&str>,
+        reason: Option<KernelErrorReason>,
     ) -> Result<(), RuntimeStateError> {
         self.set_lifecycle(lifecycle)?;
         let kernel = self.scaffold_map("kernel")?;
-        self.doc
-            .put(&kernel, "error_reason", error_reason.unwrap_or(""))?;
+        let reason_str = reason.map(|r| r.as_str()).unwrap_or("");
+        self.doc.put(&kernel, "error_reason", reason_str)?;
+        // Legacy-phase mirror for the Error transition. The pre-Phase-3
+        // channel used `starting_phase` to carry the reason. Only
+        // overwrite on Error — a non-Error lifecycle would already have
+        // a phase written by the `set_lifecycle` mirror and we don't
+        // want to step on it.
+        if matches!(lifecycle, RuntimeLifecycle::Error) && reason.is_some() {
+            self.doc.put(&kernel, "starting_phase", reason_str)?;
+        }
         Ok(())
     }
 
@@ -909,14 +925,20 @@ impl RuntimeStateDoc {
             KernelActivity::Busy => "busy",
             KernelActivity::Idle | KernelActivity::Unknown => "idle",
         };
-        // Dual-shape throttle: skip only when BOTH the typed activity AND
-        // the mirrored legacy status already match. If a legacy writer
-        // (set_kernel_status) ran in between and drifted the legacy key
-        // out of sync, we still need to re-mirror it here — otherwise
-        // unmigrated readers stay stuck on a stale status.
+        // Dual-shape throttle: skip only when the typed activity, the
+        // mirrored legacy status, AND the legacy starting_phase are all
+        // already at their target values. set_kernel_status itself clears
+        // starting_phase whenever it flips to a non-starting status; we
+        // keep that invariant so unmigrated readers don't observe
+        // status="idle"/"busy" alongside a stale phase like "connecting"
+        // left over from the launch path.
         let current_activity = self.read_str(&kernel, "activity");
         let current_status = self.read_str(&kernel, "status");
-        if current_activity == activity.as_str() && current_status == legacy_status {
+        let current_phase = self.read_str(&kernel, "starting_phase");
+        if current_activity == activity.as_str()
+            && current_status == legacy_status
+            && current_phase.is_empty()
+        {
             return Ok(());
         }
         if current_activity != activity.as_str() {
@@ -924,6 +946,9 @@ impl RuntimeStateDoc {
         }
         if current_status != legacy_status {
             self.doc.put(&kernel, "status", legacy_status)?;
+        }
+        if !current_phase.is_empty() {
+            self.doc.put(&kernel, "starting_phase", "")?;
         }
         Ok(())
     }
@@ -4588,7 +4613,10 @@ mod tests {
     #[test]
     fn set_lifecycle_preserves_error_reason() -> Result<(), RuntimeStateError> {
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("missing_ipykernel"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         assert_eq!(
             doc.read_state().kernel.error_reason.as_deref(),
             Some("missing_ipykernel")
@@ -4615,38 +4643,118 @@ mod tests {
     #[test]
     fn set_lifecycle_with_error_clears_on_none() -> Result<(), RuntimeStateError> {
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("oops"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         doc.set_lifecycle_with_error(&RuntimeLifecycle::NotStarted, None)?;
         assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
         Ok(())
     }
 
     #[test]
-    fn set_lifecycle_with_error_empty_and_none_write_same_value() -> Result<(), RuntimeStateError> {
-        // Semantic intent differs (explicit empty vs clear), CRDT value is
-        // identical. Pin this so a future writer that tries to distinguish
-        // them fails visibly.
-        let mut doc_a = RuntimeStateDoc::new();
-        doc_a.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some(""))?;
-
-        let mut doc_b = RuntimeStateDoc::new();
-        doc_b.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
-
+    fn set_lifecycle_with_error_mirrors_reason_into_starting_phase() -> Result<(), RuntimeStateError>
+    {
+        // The pre-Phase-3 channel encoded reasons via `starting_phase`.
+        // NotebookToolbar's pixi-install prompt still gates on that legacy
+        // phase. set_lifecycle_with_error must mirror the reason there
+        // when lifecycle is Error so the prompt continues to fire until
+        // Phase 5 migrates the frontend.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(s.status, "error");
         assert_eq!(
-            doc_a.read_state().kernel.error_reason,
-            doc_b.read_state().kernel.error_reason
+            s.starting_phase, "missing_ipykernel",
+            "legacy pixi-install prompt gate must continue to fire via starting_phase"
+        );
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_empty_reason_leaves_phase_empty() -> Result<(), RuntimeStateError> {
+        // Error with no reason: starting_phase stays "" (set_lifecycle's
+        // default Error mirror). We only overwrite the phase when the
+        // reason is Some.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "error");
+        assert_eq!(s.starting_phase, "");
+        assert_eq!(s.error_reason.as_deref(), Some(""));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_non_error_with_reason_does_not_touch_phase(
+    ) -> Result<(), RuntimeStateError> {
+        // A non-Error lifecycle with a Some(reason) argument is unusual
+        // but harmless. set_lifecycle's default mirror already wrote the
+        // variant's proper phase (e.g. "launching"); we must not clobber
+        // it just because a reason was supplied.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Launching,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "starting");
+        assert_eq!(s.starting_phase, "launching");
+        // error_reason is still recorded even for non-Error — harmless
+        // metadata, and it keeps the writer simple (no "only record
+        // reason when lifecycle is Error" special case at the
+        // error_reason key).
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
+        Ok(())
+    }
+
+    #[test]
+    fn set_lifecycle_with_error_second_call_updates_reason() -> Result<(), RuntimeStateError> {
+        // Only one variant today; exercise the overwrite path by toggling
+        // Some(MissingIpykernel) -> None -> Some(MissingIpykernel).
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel")
+        );
+        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
+        assert_eq!(doc.read_state().kernel.error_reason.as_deref(), Some(""));
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
+        assert_eq!(
+            doc.read_state().kernel.error_reason.as_deref(),
+            Some("missing_ipykernel")
         );
         Ok(())
     }
 
     #[test]
-    fn set_lifecycle_with_error_second_call_overwrites() -> Result<(), RuntimeStateError> {
+    fn set_activity_clears_stale_starting_phase() -> Result<(), RuntimeStateError> {
+        // After the string-shape launch path ends with
+        // set_starting_phase("connecting"), the first IOPub set_activity
+        // must clear the stale phase so unmigrated readers don't see
+        // status="idle" alongside starting_phase="connecting".
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("first"))?;
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("second"))?;
+        doc.set_kernel_status("starting")?;
+        doc.set_starting_phase("connecting")?;
+
+        doc.set_activity(KernelActivity::Idle)?;
+        let s = doc.read_state().kernel;
+        assert_eq!(s.status, "idle");
         assert_eq!(
-            doc.read_state().kernel.error_reason.as_deref(),
-            Some("second")
+            s.starting_phase, "",
+            "stale starting_phase must be cleared when set_activity mirrors to a non-starting status"
         );
         Ok(())
     }
@@ -4809,14 +4917,20 @@ mod tests {
     }
 
     #[test]
-    fn set_lifecycle_error_writes_error_status_no_phase() -> Result<(), RuntimeStateError> {
+    fn set_lifecycle_error_with_reason_writes_all_three_shapes() -> Result<(), RuntimeStateError> {
+        // Writing Error + reason must populate the typed `error_reason`
+        // key, the string `status = "error"`, AND mirror the reason into
+        // the legacy `starting_phase` for NotebookToolbar compat.
         let mut doc = RuntimeStateDoc::new();
-        doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, Some("kernel_died"))?;
+        doc.set_lifecycle_with_error(
+            &RuntimeLifecycle::Error,
+            Some(KernelErrorReason::MissingIpykernel),
+        )?;
         let s = doc.read_state().kernel;
         assert_eq!(s.lifecycle, RuntimeLifecycle::Error);
         assert_eq!(s.status, "error");
-        assert_eq!(s.starting_phase, "");
-        assert_eq!(s.error_reason.as_deref(), Some("kernel_died"));
+        assert_eq!(s.starting_phase, "missing_ipykernel");
+        assert_eq!(s.error_reason.as_deref(), Some("missing_ipykernel"));
         Ok(())
     }
 

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -39,6 +39,46 @@ impl KernelActivity {
     }
 }
 
+/// Typed reason accompanying a [`RuntimeLifecycle::Error`] transition.
+///
+/// Closed enum by design — every error reason the daemon surfaces gets
+/// its own variant. This is deliberately more rigid than a free-form
+/// string: reasons rarely change, and the compile-time guarantee that
+/// the frontend and daemon agree on the vocabulary is worth the cost
+/// of editing the enum.
+///
+/// The single [`as_str`](Self::as_str) method returns the string that
+/// serves BOTH as the CRDT `kernel.error_reason` value AND as the
+/// legacy `kernel.starting_phase` mirror (see
+/// `RuntimeStateDoc::set_lifecycle_with_error`). The two happen to be
+/// the same string because that's how the pre-Phase-3 channel encoded
+/// these reasons — `set_kernel_status("error") + set_starting_phase(
+/// "missing_ipykernel")`. Collapsing both into one method keeps the
+/// string-level contract in one place. If a future variant needs
+/// distinct values for the two channels, split into
+/// `as_crdt_str` / `as_legacy_phase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KernelErrorReason {
+    /// Pixi-managed environment is missing the `ipykernel` package.
+    /// `NotebookToolbar` gates its "install ipykernel" prompt on this.
+    MissingIpykernel,
+}
+
+impl KernelErrorReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingIpykernel => "missing_ipykernel",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "missing_ipykernel" => Some(Self::MissingIpykernel),
+            _ => None,
+        }
+    }
+}
+
 /// Lifecycle of a runtime, from not-started through running to shutdown.
 ///
 /// Replaces the string-valued `KernelState.status` + `starting_phase` pair
@@ -237,6 +277,46 @@ mod tests {
         assert_eq!(KernelActivity::parse("Busy"), Some(KernelActivity::Busy));
         assert_eq!(KernelActivity::parse("nope"), None);
         assert_eq!(KernelActivity::parse(""), None);
+    }
+
+    #[test]
+    fn error_reason_as_str() {
+        assert_eq!(
+            KernelErrorReason::MissingIpykernel.as_str(),
+            "missing_ipykernel"
+        );
+    }
+
+    #[test]
+    fn error_reason_parse() {
+        assert_eq!(
+            KernelErrorReason::parse("missing_ipykernel"),
+            Some(KernelErrorReason::MissingIpykernel)
+        );
+        assert_eq!(KernelErrorReason::parse(""), None);
+        assert_eq!(KernelErrorReason::parse("bogus"), None);
+        // Parse is case-sensitive — the CRDT and legacy phase channel
+        // both use exactly "missing_ipykernel".
+        assert_eq!(KernelErrorReason::parse("Missing_Ipykernel"), None);
+    }
+
+    #[test]
+    fn error_reason_as_str_round_trips_through_parse() {
+        let reasons = [KernelErrorReason::MissingIpykernel];
+        for r in reasons {
+            assert_eq!(KernelErrorReason::parse(r.as_str()), Some(r));
+        }
+    }
+
+    #[test]
+    fn error_reason_serde_round_trip() -> Result<(), serde_json::Error> {
+        // Variant-unit enums serialize as their variant name.
+        let r = KernelErrorReason::MissingIpykernel;
+        let json = serde_json::to_string(&r)?;
+        assert_eq!(json, r#""MissingIpykernel""#);
+        let back: KernelErrorReason = serde_json::from_str(&json)?;
+        assert_eq!(back, r);
+        Ok(())
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -21,6 +21,7 @@ use jupyter_protocol::{
     CompleteRequest, ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest,
     JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
 };
+use runtime_doc::{KernelActivity, RuntimeLifecycle};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
@@ -46,6 +47,17 @@ type PendingCompletions =
 
 /// Handle for interrupting a kernel without exclusive access.
 ///
+/// What an IOPub status message translates to on the RuntimeStateDoc.
+///
+/// Either a lifecycle transition (Starting/Restarting/Terminating/Dead —
+/// infrequent, always written) or an activity flip (Idle/Busy — hot path,
+/// throttled by `set_activity`). Kept local to this file because it is
+/// only a dispatch helper for the IOPub handler.
+enum IoPubStateUpdate {
+    Activity(KernelActivity),
+    Lifecycle(RuntimeLifecycle),
+}
+
 /// Created at kernel launch time, captures connection_info and session_id.
 /// Can be used concurrently with other kernel operations since interrupt
 /// creates its own ZMQ control connection.
@@ -739,27 +751,52 @@ impl KernelConnection for JupyterKernel {
                             // Handle different message types
                             match &message.content {
                                 JupyterMessageContent::Status(status) => {
-                                    let status_str = match status.execution_state {
-                                        jupyter_protocol::ExecutionState::Busy => "busy",
-                                        jupyter_protocol::ExecutionState::Idle => "idle",
-                                        jupyter_protocol::ExecutionState::Starting => "starting",
-                                        jupyter_protocol::ExecutionState::Restarting => "starting",
+                                    // Map the kernel's execution_state to either a typed
+                                    // activity flip (Idle/Busy — hot path, throttled) or a
+                                    // lifecycle transition (Starting/Restarting/Terminating/Dead).
+                                    let update = match status.execution_state {
+                                        jupyter_protocol::ExecutionState::Busy => {
+                                            Some(IoPubStateUpdate::Activity(KernelActivity::Busy))
+                                        }
+                                        jupyter_protocol::ExecutionState::Idle => {
+                                            Some(IoPubStateUpdate::Activity(KernelActivity::Idle))
+                                        }
+                                        // Starting and Restarting both land in Connecting —
+                                        // the kernel process has just come up and is
+                                        // reporting its first status; we treat those as
+                                        // "connected but pre-kernel_info" transitions.
+                                        jupyter_protocol::ExecutionState::Starting
+                                        | jupyter_protocol::ExecutionState::Restarting => {
+                                            Some(IoPubStateUpdate::Lifecycle(
+                                                RuntimeLifecycle::Connecting,
+                                            ))
+                                        }
                                         jupyter_protocol::ExecutionState::Terminating
-                                        | jupyter_protocol::ExecutionState::Dead => "shutdown",
-                                        _ => "unknown",
+                                        | jupyter_protocol::ExecutionState::Dead => Some(
+                                            IoPubStateUpdate::Lifecycle(RuntimeLifecycle::Shutdown),
+                                        ),
+                                        _ => None,
                                     };
 
-                                    if status_str != "unknown" {
+                                    if let Some(update) = update {
                                         // Non-execute messages (kernel_info, completions) have a
                                         // parent_header.msg_id that isn't in our execute map.
-                                        // cell_id is None for those — treat their status as transient.
-                                        let is_transient = cell_id.is_none()
-                                            && (status_str == "busy" || status_str == "idle");
+                                        // cell_id is None for those — treat activity flips from
+                                        // those as transient (they don't reflect user code state).
+                                        let is_transient_activity = cell_id.is_none()
+                                            && matches!(update, IoPubStateUpdate::Activity(_));
 
-                                        if !is_transient {
-                                            if let Err(e) = state_for_iopub
-                                                .with_doc(|sd| sd.set_kernel_status(status_str))
-                                            {
+                                        if !is_transient_activity {
+                                            let result =
+                                                state_for_iopub.with_doc(|sd| match update {
+                                                    IoPubStateUpdate::Activity(a) => {
+                                                        sd.set_activity(a)
+                                                    }
+                                                    IoPubStateUpdate::Lifecycle(lc) => {
+                                                        sd.set_lifecycle(&lc)
+                                                    }
+                                                });
+                                            if let Err(e) = result {
                                                 warn!("[runtime-state] {}", e);
                                             }
                                         }

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -265,8 +265,8 @@ impl KernelState {
 
         // Note: state_doc writes for kernel_died happen in the async command
         // processor (notebook_sync_server.rs QueueCommand::KernelDied handler).
-        // state_doc.set_lifecycle(&RuntimeLifecycle::Error) + set_queue(None, &[])
-        // + set_execution_done for interrupted + cleared entries
+        // state_doc.set_lifecycle_with_error(&RuntimeLifecycle::Error, None) +
+        // set_queue(None, &[]) + set_execution_done for interrupted + cleared entries
 
         (interrupted, cleared)
     }

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -265,7 +265,7 @@ impl KernelState {
 
         // Note: state_doc writes for kernel_died happen in the async command
         // processor (notebook_sync_server.rs QueueCommand::KernelDied handler).
-        // state_doc.set_kernel_status("error") + set_queue(None, &[])
+        // state_doc.set_lifecycle(&RuntimeLifecycle::Error) + set_queue(None, &[])
         // + set_execution_done for interrupted + cleared entries
 
         (interrupted, cleared)

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1,4 +1,5 @@
 use super::*;
+use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle};
 
 pub struct TrustState {
     pub status: runt_trust::TrustStatus,
@@ -670,11 +671,11 @@ pub(crate) async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
 
     // Check kernel is actually running via RuntimeStateDoc
     {
-        let status = room
+        let lifecycle = room
             .state
-            .read(|sd| sd.read_state().kernel.status.clone())
-            .unwrap_or_default();
-        if status != "idle" && status != "busy" {
+            .read(|sd| sd.read_state().kernel.lifecycle)
+            .unwrap_or(RuntimeLifecycle::NotStarted);
+        if !matches!(lifecycle, RuntimeLifecycle::Running(_)) {
             return;
         }
     }
@@ -1729,7 +1730,7 @@ pub(crate) async fn reset_starting_state(
     // state handle uses std::sync::Mutex - no lock ordering concern
     // with runtime_agent_handle (tokio::sync::Mutex).
     if let Err(e) = room.state.with_doc(|sd| {
-        sd.set_kernel_status("not_started")?;
+        sd.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
         sd.set_prewarmed_packages(&[])?;
         Ok(())
     }) {
@@ -2395,9 +2396,11 @@ pub(crate) async fn auto_launch_kernel(
                     detected.path
                 );
                 if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_kernel_status("error")?;
+                    sd.set_lifecycle_with_error(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::MissingIpykernel),
+                    )?;
                     sd.set_kernel_info("python", "python", env_source.as_str())?;
-                    sd.set_starting_phase("missing_ipykernel")?;
                     Ok(())
                 }) {
                     warn!("[runtime-state] {}", e);
@@ -2407,10 +2410,10 @@ pub(crate) async fn auto_launch_kernel(
         }
     }
 
-    // Transition to "preparing_env" phase now that runtime/env has been resolved
+    // Transition to PreparingEnv now that runtime/env has been resolved.
     if let Err(e) = room
         .state
-        .with_doc(|sd| sd.set_starting_phase("preparing_env"))
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
     {
         warn!("[runtime-state] {}", e);
     }
@@ -2713,7 +2716,10 @@ pub(crate) async fn auto_launch_kernel(
     );
 
     // Transition to "launching" phase before starting the kernel process
-    if let Err(e) = room.state.with_doc(|sd| sd.set_starting_phase("launching")) {
+    if let Err(e) = room
+        .state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    {
         warn!("[runtime-state] {}", e);
     }
 
@@ -2764,10 +2770,10 @@ pub(crate) async fn auto_launch_kernel(
                     *ra_guard = Some(ra);
                 }
 
-                // Write "connecting" phase — fills the gap between spawn and connect
+                // Connecting lifecycle — fills the gap between spawn and connect
                 if let Err(e) = room
                     .state
-                    .with_doc(|sd| sd.set_starting_phase("connecting"))
+                    .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
                 {
                     warn!("[runtime-state] {}", e);
                 }
@@ -2825,10 +2831,10 @@ pub(crate) async fn auto_launch_kernel(
                         publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
                             .await;
 
-                        // Write kernel status + info to RuntimeStateDoc so
-                        // frontends see "idle" via CRDT sync.
+                        // Write Running(Idle) + kernel info to RuntimeStateDoc
+                        // so frontends see "idle" via CRDT sync.
                         if let Err(e) = room.state.with_doc(|sd| {
-                            sd.set_kernel_status("idle")?;
+                            sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
                             sd.set_kernel_info(kernel_type, kernel_type, &es)?;
                             sd.set_runtime_agent_id(&runtime_agent_id)?;
                             // Fresh kernel is in sync with its launched config

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1,4 +1,5 @@
 use super::*;
+use runtime_doc::RuntimeLifecycle;
 
 /// Handle a single notebook sync client connection.
 ///
@@ -455,12 +456,11 @@ where
                 "[notebook-sync] Auto-launching kernel for notebook {} (trust: {:?}, new: {})",
                 notebook_id, trust_status, is_new_notebook
             );
-            // Write "starting" immediately so clients never see stale "not_started"
-            if let Err(e) = room.state.with_doc(|sd| {
-                sd.set_kernel_status("starting")?;
-                sd.set_starting_phase("resolving")?;
-                Ok(())
-            }) {
+            // Write Resolving immediately so clients never see stale NotStarted
+            if let Err(e) = room
+                .state
+                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+            {
                 warn!("[runtime-state] {}", e);
             }
             // Spawn auto-launch in background so we don't block sync
@@ -486,11 +486,10 @@ where
                     // to acquire the lock. But spawn_supervised's panic handler runs
                     // outside async context, so we still need spawn for the closure.
                     tokio::spawn(async move {
-                        if let Err(e) = r.state.with_doc(|sd| {
-                            sd.set_kernel_status("error")?;
-                            sd.set_starting_phase("")?;
-                            Ok(())
-                        }) {
+                        if let Err(e) = r
+                            .state
+                            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Error))
+                        {
                             tracing::warn!("[runtime-state] {}", e);
                         }
                     });
@@ -508,11 +507,10 @@ where
                 "[notebook-sync] Kernel blocked on trust approval for {} (trust: {:?})",
                 notebook_id, trust_status
             );
-            if let Err(e) = room.state.with_doc(|sd| {
-                sd.set_kernel_status("awaiting_trust")?;
-                sd.set_starting_phase("")?;
-                Ok(())
-            }) {
+            if let Err(e) = room
+                .state
+                .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::AwaitingTrust))
+            {
                 warn!("[runtime-state] {}", e);
             }
         } else {

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -486,10 +486,12 @@ where
                     // to acquire the lock. But spawn_supervised's panic handler runs
                     // outside async context, so we still need spawn for the closure.
                     tokio::spawn(async move {
-                        if let Err(e) = r
-                            .state
-                            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Error))
-                        {
+                        // Auto-launch panic — no specific typed reason. Clear
+                        // any stale error_reason so the frontend prompt isn't
+                        // stuck on an earlier missing_ipykernel, etc.
+                        if let Err(e) = r.state.with_doc(|sd| {
+                            sd.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)
+                        }) {
                             tracing::warn!("[runtime-state] {}", e);
                         }
                     });

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -487,11 +487,22 @@ impl NotebookRoom {
         if is_alive {
             let info = self.state.read(|sd| {
                 let state = sd.read_state();
-                if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
+                // The wire-level NotebookKernelInfo.status field is still a
+                // legacy string; derive it from the typed lifecycle via
+                // to_legacy so the wire contract is unchanged. This crate
+                // has migrated to the typed lifecycle internally; callers
+                // of kernel_info (currently NotebookKernelInfo on the
+                // wire) remain on strings until a later phase retires
+                // the wire field.
+                if !matches!(
+                    state.kernel.lifecycle,
+                    runtime_doc::RuntimeLifecycle::NotStarted
+                ) {
+                    let (legacy_status, _phase) = state.kernel.lifecycle.to_legacy();
                     Some((
                         state.kernel.name.clone(),
                         state.kernel.env_source.clone(),
-                        state.kernel.status.clone(),
+                        legacy_status.to_string(),
                     ))
                 } else {
                     None

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use runtime_doc::{KernelActivity, RuntimeLifecycle};
 use serial_test::serial;
 use uuid::Uuid;
 
@@ -3046,7 +3047,7 @@ async fn test_check_and_broadcast_sync_state_captured_uv_prewarmed_in_sync() {
     {
         room.state
             .with_doc(|sd| {
-                sd.set_kernel_status("idle")?;
+                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
                 // Pre-set to dirty so we can verify it flips to in_sync.
                 sd.set_env_sync(false, &["pandas".to_string()], &[], false, false)?;
                 Ok(())
@@ -3098,7 +3099,7 @@ async fn test_check_and_broadcast_sync_state_captured_uv_prewarmed_reports_addit
 
     {
         room.state
-            .with_doc(|sd| sd.set_kernel_status("idle"))
+            .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle)))
             .unwrap();
     }
 
@@ -3526,22 +3527,24 @@ async fn test_reset_starting_state_guard() {
         *id = Some("agent-B".to_string());
     }
 
-    // Set kernel status to "starting" (simulates in-progress launch)
+    // Move to Resolving (simulates in-progress launch — the earliest
+    // "starting" sub-state).
     room.state
-        .with_doc(|sd| sd.set_kernel_status("starting"))
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
         .unwrap();
 
-    // Call reset with expected="agent-A" (stale handler) — should skip
+    // Call reset with expected="agent-A" (stale handler) — should skip.
     reset_starting_state(&room, Some("agent-A")).await;
 
-    // Verify: kernel_status should still be "starting" (NOT reset)
+    // Verify: lifecycle should still be Resolving (NOT reset).
     {
-        let status = room
+        let lifecycle = room
             .state
-            .read(|sd| sd.read_state().kernel.status.clone())
+            .read(|sd| sd.read_state().kernel.lifecycle)
             .unwrap();
         assert_eq!(
-            status, "starting",
+            lifecycle,
+            RuntimeLifecycle::Resolving,
             "Guard should have prevented reset (agent-A != agent-B)"
         );
     }
@@ -3552,17 +3555,18 @@ async fn test_reset_starting_state_guard() {
         assert_eq!(id.as_deref(), Some("agent-B"));
     }
 
-    // Now call with matching expected="agent-B" — should reset
+    // Now call with matching expected="agent-B" — should reset.
     reset_starting_state(&room, Some("agent-B")).await;
 
-    // Verify: kernel_status should be "not_started"
+    // Verify: lifecycle should be NotStarted.
     {
-        let status = room
+        let lifecycle = room
             .state
-            .read(|sd| sd.read_state().kernel.status.clone())
+            .read(|sd| sd.read_state().kernel.lifecycle)
             .unwrap();
         assert_eq!(
-            status, "not_started",
+            lifecycle,
+            RuntimeLifecycle::NotStarted,
             "Reset should proceed when expected matches current"
         );
     }
@@ -3576,18 +3580,19 @@ async fn test_reset_starting_state_guard() {
         );
     }
 
-    // Call with None (pre-spawn) — should always reset
+    // Call with None (pre-spawn) — should always reset.
     room.state
-        .with_doc(|sd| sd.set_kernel_status("starting"))
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
         .unwrap();
     reset_starting_state(&room, None).await;
     {
-        let status = room
+        let lifecycle = room
             .state
-            .read(|sd| sd.read_state().kernel.status.clone())
+            .read(|sd| sd.read_state().kernel.lifecycle)
             .unwrap();
         assert_eq!(
-            status, "not_started",
+            lifecycle,
+            RuntimeLifecycle::NotStarted,
             "None (pre-spawn) should always reset"
         );
     }

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use runtime_doc::RuntimeLifecycle;
 use tracing::warn;
 
 use crate::notebook_sync_server::{
@@ -53,13 +54,16 @@ pub(crate) async fn handle(room: &Arc<NotebookRoom>, cell_id: String) -> Noteboo
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
             // Check if kernel is shut down — return NoKernel instead
-            // of silently queuing into a dead kernel
+            // of silently queuing into a dead kernel.
             {
-                let status = room
+                let lifecycle = room
                     .state
-                    .read(|sd| sd.read_state().kernel.status.clone())
-                    .unwrap_or_default();
-                if status == "shutdown" || status == "error" {
+                    .read(|sd| sd.read_state().kernel.lifecycle)
+                    .unwrap_or(RuntimeLifecycle::NotStarted);
+                if matches!(
+                    lifecycle,
+                    RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
+                ) {
                     return NotebookResponse::NoKernel {};
                 }
             }

--- a/crates/runtimed/src/requests/get_kernel_info.rs
+++ b/crates/runtimed/src/requests/get_kernel_info.rs
@@ -1,13 +1,16 @@
 //! `NotebookRequest::GetKernelInfo` handler.
 
+use runtime_doc::RuntimeLifecycle;
+
 use crate::notebook_sync_server::NotebookRoom;
 use crate::protocol::NotebookResponse;
 
 pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
-    // Read from RuntimeStateDoc (source of truth for runtime agent)
+    // Read from RuntimeStateDoc (source of truth for runtime agent).
     let state = room.state.read(|sd| sd.read_state());
     match state {
-        Ok(state) if state.kernel.status != "not_started" && !state.kernel.status.is_empty() => {
+        Ok(state) if !matches!(state.kernel.lifecycle, RuntimeLifecycle::NotStarted) => {
+            let (legacy_status, _phase) = state.kernel.lifecycle.to_legacy();
             NotebookResponse::KernelInfo {
                 kernel_type: if state.kernel.name.is_empty() {
                     None
@@ -19,7 +22,7 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
                 } else {
                     Some(state.kernel.env_source)
                 },
-                status: state.kernel.status,
+                status: legacy_status.to_string(),
             }
         }
         _ => NotebookResponse::KernelInfo {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -11,6 +11,7 @@ use tokio::sync::oneshot;
 use tracing::{error, info, warn};
 
 use notebook_doc::presence;
+use runtime_doc::{KernelActivity, RuntimeLifecycle};
 
 use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
@@ -54,44 +55,55 @@ pub(crate) async fn handle(
     //
     // Scope the write guard so it drops before any async work
     // (deadlock prevention: no lock held across `.await`).
-    let kernel_status = room
+    let prior_lifecycle = room
         .state
         .with_doc(|sd| {
-            let status = sd.read_state().kernel.status.clone();
-            if status != "idle" && status != "busy" && status != "starting" {
-                // not_started, error, shutdown — atomically claim the
-                // launch by writing "starting" while we hold the mutex.
-                // This prevents a concurrent LaunchKernel from also proceeding.
+            let prior = sd.read_state().kernel.lifecycle;
+            let already_progressing = matches!(
+                prior,
+                RuntimeLifecycle::Running(_)
+                    | RuntimeLifecycle::Resolving
+                    | RuntimeLifecycle::PreparingEnv
+                    | RuntimeLifecycle::Launching
+                    | RuntimeLifecycle::Connecting
+            );
+            if !already_progressing {
+                // Atomically claim the launch by moving into Resolving
+                // while we hold the sync mutex. Prevents a concurrent
+                // LaunchKernel from also proceeding past this gate.
                 sd.clear_comms().ok();
                 sd.set_trust("trusted", false).ok();
-                sd.set_kernel_status("starting").ok();
-                sd.set_starting_phase("resolving").ok();
+                sd.set_lifecycle(&RuntimeLifecycle::Resolving).ok();
             }
-            Ok(status)
+            Ok(prior)
         })
         .unwrap_or_else(|e| {
             warn!("[runtime-state] {}", e);
-            "not_started".to_string()
+            RuntimeLifecycle::NotStarted
         });
-    match kernel_status.as_str() {
-        "idle" | "busy" => {
-            // Agent already has a running kernel — check for restart path below
+    match prior_lifecycle {
+        RuntimeLifecycle::Running(_) => {
+            // Agent already has a running kernel — check for restart path below.
         }
-        "starting" => {
-            // Another launch in progress — wait for it to complete
+        RuntimeLifecycle::Resolving
+        | RuntimeLifecycle::PreparingEnv
+        | RuntimeLifecycle::Launching
+        | RuntimeLifecycle::Connecting => {
+            // Another launch in progress — wait for it to complete.
             let wait_result = tokio::time::timeout(std::time::Duration::from_secs(60), async {
                 loop {
-                    let s = room
+                    let lc = room
                         .state
-                        .read(|sd| sd.read_state().kernel.status.clone())
-                        .unwrap_or_default();
-                    if s == "idle"
-                        || s == "busy"
-                        || s == "error"
-                        || s == "shutdown"
-                        || s == "not_started"
-                    {
-                        return s;
+                        .read(|sd| sd.read_state().kernel.lifecycle)
+                        .unwrap_or(RuntimeLifecycle::NotStarted);
+                    if matches!(
+                        lc,
+                        RuntimeLifecycle::Running(_)
+                            | RuntimeLifecycle::Error
+                            | RuntimeLifecycle::Shutdown
+                            | RuntimeLifecycle::NotStarted
+                    ) {
+                        return lc;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 }
@@ -99,8 +111,8 @@ pub(crate) async fn handle(
             .await;
 
             match wait_result {
-                Ok(ref s) if s == "idle" || s == "busy" => {
-                    // Launch completed — fall through to restart check below
+                Ok(RuntimeLifecycle::Running(_)) => {
+                    // Launch completed — fall through to restart check below.
                 }
                 Ok(_) | Err(_) => {
                     return NotebookResponse::Error {
@@ -110,7 +122,8 @@ pub(crate) async fn handle(
             }
         }
         _ => {
-            // Already handled above (set to "starting") — fall through
+            // Not_started / Error / Shutdown / AwaitingTrust — already
+            // claimed above by writing Resolving; fall through.
         }
     }
 
@@ -462,7 +475,7 @@ pub(crate) async fn handle(
     // Transition to "preparing_env" phase
     if let Err(e) = room
         .state
-        .with_doc(|sd| sd.set_starting_phase("preparing_env"))
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::PreparingEnv))
     {
         warn!("[runtime-state] {}", e);
     }
@@ -1077,7 +1090,10 @@ pub(crate) async fn handle(
     );
 
     // Transition to "launching" phase before starting the kernel process
-    if let Err(e) = room.state.with_doc(|sd| sd.set_starting_phase("launching")) {
+    if let Err(e) = room
+        .state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+    {
         warn!("[runtime-state] {}", e);
     }
 
@@ -1108,7 +1124,7 @@ pub(crate) async fn handle(
 
                     publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es).await;
                     if let Err(e) = room.state.with_doc(|sd| {
-                        sd.set_kernel_status("idle")?;
+                        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
                         sd.set_kernel_info(&resolved_kernel_type, &resolved_kernel_type, &es)?;
                         sd.set_prewarmed_packages(&launched_config.prewarmed_packages)?;
                         // runtime_agent_id doesn't change on restart — same runtime agent
@@ -1191,10 +1207,10 @@ pub(crate) async fn handle(
                     *ra_guard = Some(ra);
                 }
 
-                // Write "connecting" phase — fills the gap between spawn and connect
+                // Connecting lifecycle — fills the gap between spawn and connect
                 if let Err(e) = room
                     .state
-                    .with_doc(|sd| sd.set_starting_phase("connecting"))
+                    .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Connecting))
                 {
                     warn!("[runtime-state] {}", e);
                 }
@@ -1254,7 +1270,7 @@ pub(crate) async fn handle(
                             // avoid holding two locks.
                             let agent_id = room.current_runtime_agent_id.read().await.clone();
                             if let Err(e) = room.state.with_doc(|sd| {
-                                sd.set_kernel_status("idle")?;
+                                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
                                 sd.set_kernel_info(
                                     &resolved_kernel_type,
                                     &resolved_kernel_type,

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -1,5 +1,6 @@
 //! `NotebookRequest::RunAllCells` handler.
 
+use runtime_doc::RuntimeLifecycle;
 use tracing::warn;
 
 use crate::notebook_sync_server::NotebookRoom;
@@ -10,13 +11,16 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
     {
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
-            // Check if kernel is shut down
+            // Check if kernel is shut down.
             {
-                let status = room
+                let lifecycle = room
                     .state
-                    .read(|sd| sd.read_state().kernel.status.clone())
-                    .unwrap_or_default();
-                if status == "shutdown" || status == "error" {
+                    .read(|sd| sd.read_state().kernel.lifecycle)
+                    .unwrap_or(RuntimeLifecycle::NotStarted);
+                if matches!(
+                    lifecycle,
+                    RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
+                ) {
                     return NotebookResponse::NoKernel {};
                 }
             }

--- a/crates/runtimed/src/requests/shutdown_kernel.rs
+++ b/crates/runtimed/src/requests/shutdown_kernel.rs
@@ -1,5 +1,7 @@
 //! `NotebookRequest::ShutdownKernel` handler.
 
+use runtime_doc::RuntimeLifecycle;
+
 use crate::notebook_sync_server::{send_runtime_agent_request, NotebookRoom};
 use crate::protocol::NotebookResponse;
 
@@ -16,12 +18,12 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         .await;
         // Keep runtime agent alive (runtime_agent_handle + runtime_agent_request_tx stay set)
         // so LaunchKernel can send RestartKernel. ExecuteCell/RunAllCells
-        // check kernel.status from RuntimeStateDoc and return NoKernel
-        // when status is "shutdown".
+        // check kernel.lifecycle from RuntimeStateDoc and return NoKernel
+        // when it's Shutdown.
         //
-        // Update RuntimeStateDoc to reflect shutdown
+        // Update RuntimeStateDoc to reflect shutdown.
         if let Err(e) = room.state.with_doc(|sd| {
-            sd.set_kernel_status("shutdown")?;
+            sd.set_lifecycle(&RuntimeLifecycle::Shutdown)?;
             sd.set_queue(None, &[])?;
             Ok(())
         }) {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -985,7 +985,11 @@ async fn handle_queue_command(
                 for entry in &cleared {
                     sd.set_execution_done(&entry.execution_id, false)?;
                 }
-                sd.set_lifecycle(&RuntimeLifecycle::Error)?;
+                // Generic kernel-died path — no specific typed reason. Clear
+                // any stale error_reason from a prior failure so the frontend
+                // doesn't misreport this death as (say) a repeat
+                // missing_ipykernel incident.
+                sd.set_lifecycle_with_error(&RuntimeLifecycle::Error, None)?;
                 sd.set_queue(None, &[])?;
                 Ok(())
             }) {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -40,7 +40,7 @@ use notebook_protocol::connection::{
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use runtime_doc::RuntimeStateHandle;
-use runtime_doc::{CommDocEntry, RuntimeStateDoc};
+use runtime_doc::{CommDocEntry, RuntimeLifecycle, RuntimeStateDoc};
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{debug, error, info, warn};
 
@@ -985,7 +985,7 @@ async fn handle_queue_command(
                 for entry in &cleared {
                     sd.set_execution_done(&entry.execution_id, false)?;
                 }
-                sd.set_kernel_status("error")?;
+                sd.set_lifecycle(&RuntimeLifecycle::Error)?;
                 sd.set_queue(None, &[])?;
                 Ok(())
             }) {
@@ -1177,8 +1177,8 @@ mod tests {
         assert!(queue.queue.executing.is_none());
         assert!(queue.queue.queued.is_empty());
 
-        // Kernel status should be error
-        assert_eq!(queue.kernel.status, "error");
+        // Kernel lifecycle should be Error
+        assert_eq!(queue.kernel.lifecycle, RuntimeLifecycle::Error);
     }
 
     #[tokio::test]
@@ -1197,7 +1197,7 @@ mod tests {
         .unwrap();
 
         let rs = handle.read(|sd| sd.read_state()).unwrap();
-        assert_eq!(rs.kernel.status, "error");
+        assert_eq!(rs.kernel.lifecycle, RuntimeLifecycle::Error);
         assert!(rs.queue.executing.is_none());
         assert!(rs.queue.queued.is_empty());
     }

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-3.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-3.md
@@ -1,0 +1,88 @@
+# RuntimeLifecycle Phase 3 — Typed Error Reasons
+
+**Goal:** Replace the free-form `Option<&str>` error-reason argument to `set_lifecycle_with_error` with a typed `KernelErrorReason` enum. Fix the two codex-v3 compat gaps from Phase 2 along the way. Still no caller migration.
+
+**Why only this much:** Phase 2 left `error_reason` as a free-form string at the call-site boundary. Kyle flagged `"missing_ipykernel"` sprinkled through writers and tests as the same string-shape smell we're trying to escape. Phase 3 makes reasons a first-class type. Phase 4 then migrates callers with type-safe construction.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+**Prior phases:** `2026-04-23-runtime-lifecycle-phase-1.md`, `2026-04-23-runtime-lifecycle-phase-2.md`
+
+## Scope
+
+- `crates/runtime-doc/src/types.rs`:
+  - New `KernelErrorReason` enum. Closed (no `Other(String)` escape). Variant `MissingIpykernel` only.
+  - `as_str()` returns `"missing_ipykernel"` — serves BOTH as the CRDT value AND the legacy `starting_phase` mirror. The two strings are the same because that's how the legacy channel already encoded it.
+  - `parse(&str) -> Option<Self>` for reading.
+  - Serde round-trip tests + parse-unknown tests.
+
+- `crates/runtime-doc/src/doc.rs`:
+  - Change `set_lifecycle_with_error` signature from `Option<&str>` to `Option<KernelErrorReason>`.
+  - When `lifecycle == Error && reason.is_some()`, mirror `reason.as_str()` into `starting_phase` (the codex-v3 missing_ipykernel compat fix — now via the enum's typed projection).
+  - `set_activity` clears stale `starting_phase` when mirroring to a non-starting status. Throttle widens to include all three keys (activity, status, starting_phase).
+  - Tests for both fixes.
+
+- `KernelState.error_reason: Option<String>` — **unchanged**. Snapshot stays stringly on purpose so newer daemons with unknown variants don't break older readers.
+
+## Out of scope
+
+- Any caller migration (Phase 4).
+- TS frontend changes (Phase 5).
+- Python bindings changes (Phase 6+).
+- Retiring string setters (later phase).
+- Moving `read_str_if_present` to `automunge` (follow-up).
+
+## Design notes
+
+### Why closed enum, no `Other(String)`
+
+Kyle's direction: "those look very string like … instead of enums." The point of the enum is to make reasons exhaustive and typo-proof. `Other(String)` reintroduces the stringly escape hatch we're trying to close. The cost of "closed" is that adding a reason requires a variant + recompile. That's the right cost.
+
+Today we ship one variant (`MissingIpykernel`). When a future path wants `KernelDied` or `EnvResolveTimeout`, add a variant.
+
+### Why `KernelState.error_reason` stays `Option<String>`
+
+Two reasons:
+
+1. **Schema robustness.** If a newer daemon writes a reason our reader doesn't know, `Option<KernelErrorReason>` would have to either drop it (silent info loss) or panic. `Option<String>` surfaces the raw string so readers can log or pass through.
+2. **No reader change needed.** Python bindings and frontend already handle `Option<String>`. Switching to enum in the snapshot would force them to also convert — work that Phase 5/6 will do if there's demand.
+
+The enum lives at the *writer* boundary. Readers see the string it projected to.
+
+### The missing_ipykernel `starting_phase` compat
+
+Codex v3 flagged: the current `NotebookToolbar` gates its pixi-install prompt on `starting_phase == "missing_ipykernel"`. When callers migrate to the typed writer, they'll pass `Error + Some(MissingIpykernel)`. My Phase 2 `set_lifecycle.to_legacy()` returns `("error", "")` for `Error`, wiping the phase.
+
+Fix: in `set_lifecycle_with_error`, when `lifecycle == Error && reason.is_some()`, overwrite `starting_phase` with `reason.as_str()` after the `set_lifecycle` mirror ran. That preserves the legacy channel without leaking strings into the writer — the string lives in the enum's `as_str` impl in exactly one place.
+
+### The `set_activity` stale-phase bug
+
+Codex v3 also flagged: after the old launch path ends with `set_starting_phase("connecting")`, the first IOPub `set_activity(Idle)` mirrors `status = "idle"` but leaves `starting_phase = "connecting"`. `set_kernel_status` would have cleared it. Same rule should apply.
+
+Fix: `set_activity` reads `starting_phase`; if non-empty, clears it. Throttle widens to check all three keys (activity, status, phase) — skip only when every key is already at target.
+
+## Acceptance
+
+- `cargo test -p runtime-doc` passes, including new tests.
+- `cargo check --workspace` clean.
+- Existing callers of `set_kernel_status` continue to work (not migrated in this phase).
+- Existing Phase 2 tests that passed `Some("missing_ipykernel")` updated to `Some(KernelErrorReason::MissingIpykernel)`.
+
+## Test plan — adversarial coverage
+
+1. `KernelErrorReason::MissingIpykernel.as_str() == "missing_ipykernel"` — single source of truth for the string.
+2. `parse("missing_ipykernel") == Some(MissingIpykernel)`, `parse("bogus") == None`.
+3. Serde round-trip.
+4. `set_lifecycle_with_error(Error, Some(MissingIpykernel))` writes `error_reason` AND `starting_phase` to `"missing_ipykernel"` — proves the pixi compat still works via the enum.
+5. `set_lifecycle_with_error(Error, None)` writes empty `error_reason` and empty `starting_phase` (the `Error`-variant default mirror).
+6. `set_lifecycle_with_error(Launching, Some(MissingIpykernel))` — non-Error with reason — writes `error_reason = "missing_ipykernel"` but does NOT touch `starting_phase` (`set_lifecycle` already wrote `"launching"` there; we don't overwrite on non-Error). Documents the asymmetry.
+7. `set_activity(Idle)` after `set_starting_phase("connecting")` clears the phase.
+8. `set_activity(Idle)` with all three keys at target is still a no-op (heads don't advance).
+9. `set_activity(Idle)` where legacy status drifted to "busy" repairs status WITHOUT touching phase (if phase is already empty).
+10. A pre-Phase-3 doc with `error_reason = "missing_ipykernel"` written as raw string parses correctly via `KernelErrorReason::parse` — backward compat with Phase 2 scaffolded docs.
+
+## Checkpoint for reviewer
+
+Look at:
+- Whether closed vs `Other(String)` is the right call. I argue closed: reasons are rare enough that adding a variant isn't painful, and closed forces good hygiene. Kyle's "instead of enums" steer supports this.
+- Whether `KernelState.error_reason: Option<String>` staying stringly is right. My claim: writer-side type safety is where the enum earns its keep; snapshot-side robustness argues for string.
+- Whether `as_str` doubling as both CRDT value and legacy phase is too clever. Alternative: two methods (`as_crdt_str` + `as_legacy_phase`). For one variant where both are identical, one method feels right; if a future variant has distinct values, split then.

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-4.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-4.md
@@ -1,0 +1,77 @@
+# RuntimeLifecycle Phase 4 — Migrate Rust Callers
+
+**Goal:** Replace every `set_kernel_status` / `set_starting_phase` call site in `runtimed` and `notebook-sync` with the typed writers from Phase 2/3. Replace every `kernel.status` / `kernel.starting_phase` snapshot read in those crates with pattern-matches on `kernel.lifecycle`. No wire-protocol or binding changes.
+
+**Why only this much:** one PR per conceptual boundary. Phase 4 touches only the code that lives inside the same crates as the typed writers. Phase 5 takes the TS frontend; Phase 6 takes Python bindings. Retiring the string setters waits until all consumers move.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+**Prior phases:** phase 1 (enum), phase 2 (CRDT keys + writers), phase 3 (`KernelErrorReason` + `set_activity` fix)
+
+## What lands
+
+### Writers migrated (every `set_kernel_status` / `set_starting_phase` in runtimed/notebook-sync)
+
+- `crates/runtimed/src/jupyter_kernel.rs` — IOPub hot path. Introduces a local `IoPubStateUpdate` enum (`Activity(KernelActivity)` vs `Lifecycle(RuntimeLifecycle)`) that makes the dispatch branching type-safe: Jupyter `ExecutionState::Busy/Idle` becomes an activity flip; `Starting/Restarting/Terminating/Dead` becomes a lifecycle transition. Retains the "transient busy/idle from non-execute messages" suppression; now it only applies to `IoPubStateUpdate::Activity`.
+- `crates/runtimed/src/runtime_agent.rs` — kernel-died → `set_lifecycle(Error)`.
+- `crates/runtimed/src/requests/launch_kernel.rs` — atomic claim, phase transitions (`Resolving → PreparingEnv → Launching → Connecting → Running(Idle)`), both the restart path and the fresh-spawn path. The wait-loop that previously spun on string status now matches on `RuntimeLifecycle`.
+- `crates/runtimed/src/requests/shutdown_kernel.rs` — `set_lifecycle(Shutdown)`.
+- `crates/runtimed/src/notebook_sync_server/peer.rs` — auto-launch claim, panic handler, trust-blocked path.
+- `crates/runtimed/src/notebook_sync_server/metadata.rs` — `not_started` reset, `missing_ipykernel` via `set_lifecycle_with_error(Error, Some(MissingIpykernel))`, `PreparingEnv → Launching → Connecting → Running(Idle)` transitions.
+- `crates/runtimed/src/notebook_sync_server/tests.rs` — 3 call sites migrated; `reset_starting_state` tests now pin `RuntimeLifecycle::Resolving` / `::NotStarted` directly.
+- `crates/notebook-sync/src/tests.rs` — 2 call sites, `runtime_doc::RuntimeLifecycle::Error`.
+
+### Readers migrated (every `kernel.status` snapshot read)
+
+- `crates/runtimed/src/requests/execute_cell.rs`, `run_all_cells.rs` — kernel-dead gates (`Shutdown | Error`).
+- `crates/runtimed/src/requests/get_kernel_info.rs` — still returns a legacy status string on the wire (NotebookResponse::KernelInfo.status); derives it from `RuntimeLifecycle::to_legacy()`.
+- `crates/runtimed/src/notebook_sync_server/room.rs::kernel_info` — same wire contract, same `to_legacy` projection.
+- `crates/runtimed/src/notebook_sync_server/metadata.rs:673` — "kernel is running" check now uses `matches!(lifecycle, Running(_))`.
+- `crates/runtimed/src/runtime_agent.rs` — `kernel_died_*` test asserts migrated to `kernel.lifecycle == Error`.
+- `crates/runtimed/src/notebook_sync_server/tests.rs` — 3 read sites in `reset_starting_state` tests.
+- `crates/notebook-sync/src/execution_wait.rs` — kernel-fault fallback (`Error | Shutdown`).
+
+### Stale comment cleanup
+
+- `crates/runtimed/src/kernel_state.rs:268` — historical note updated to reference `set_lifecycle(Error)`.
+
+## Out of scope
+
+- `runt-mcp` (wire status field) — Phase 5 or later.
+- `runtimed-py`, `runtimed-node` (language bindings) — Phase 5 or later.
+- `runt/src/main.rs` (CLI consumer of wire KernelInfo) — stays on the wire field.
+- TS frontend / `NotebookToolbar` — Phase 5.
+- Retiring `set_kernel_status` / `set_starting_phase` — waits for bindings + frontend to migrate.
+- Moving `read_str_if_present` to `automunge` — standing follow-up from Phase 2.
+
+## Invariants preserved
+
+- `with_doc` discipline: every mutation still routes through `RuntimeStateHandle::with_doc(|sd| ...)` — no direct `doc.set_*` calls on the handle surface.
+- Fork+merge for async CRDT mutations: untouched. The migration only swaps method names inside the same closures.
+- Dual-shape correctness: the typed setters continue to mirror into the string CRDT keys (Phase 2 behavior). Phase 4 removes Rust-side string consumers but leaves the mirror writes in place for the frontend and language bindings still on the string shape.
+- Error reason → legacy `starting_phase` mirror: Phase 3 added this; Phase 4 exercises it via `metadata.rs`'s `missing_ipykernel` path.
+
+## Acceptance
+
+- `cargo test -p runtime-doc -p notebook-sync -p runtimed --lib` passes.
+  - `runtime-doc`: 145 tests (+0 new; Phase 3 covered the writer changes).
+  - `notebook-sync`: 41 tests.
+  - `runtimed`: 389 tests.
+- `cargo check --workspace` clean.
+- `cargo xtask lint` clean.
+- `rg -n 'set_kernel_status|set_starting_phase' --glob '*.rs' --glob '!crates/runtime-doc/**'` returns empty.
+
+## Smoke scenarios the tests pin
+
+- IOPub `Idle → Busy → Idle` flip during execution — activity-throttled writes don't advance heads on redundant calls.
+- Launch path: `Resolving → PreparingEnv → Launching → Connecting → Running(Idle)`. The full sequence is exercised by `test_launch_kernel_auto_python` and friends.
+- Restart path via `RestartKernel` RPC goes to `Running(Idle)` without re-entering `Resolving` (the atomic claim sees `Running(_)` as "already progressing" and bypasses the reset).
+- `missing_ipykernel` error: `set_lifecycle_with_error(Error, Some(MissingIpykernel))` writes `error_reason = "missing_ipykernel"` AND mirrors into `starting_phase` for the frontend's pixi-install prompt gate.
+- Kernel died: `set_lifecycle(Error)` clears the queue, leaves `error_reason` untouched (retry paths preserve any prior reason).
+- Shutdown flow: `set_lifecycle(Shutdown)` clears the queue, kernel stays connected for a subsequent RestartKernel.
+
+## Review checkpoints
+
+- `jupyter_kernel.rs` IOPub handler — the `IoPubStateUpdate` local enum is the cleanest expression of "which CRDT channel does this status go to?" I could find. Alternative: inline the match. I prefer the named enum because it makes the transient-suppression logic trivially type-correct (`matches!(update, IoPubStateUpdate::Activity(_))`) and documents that only activity writes are transient.
+- `launch_kernel.rs` wait-loop — the terminal-state guard is `matches!(lc, Running(_) | Error | Shutdown | NotStarted)`. Pre-migration this was five string comparisons. Worth checking that `AwaitingTrust` isn't a terminal state here (it isn't — a doc in AwaitingTrust is waiting for the user, not the launch).
+- `room.rs::kernel_info` and `get_kernel_info.rs` — both still emit a legacy status string because the wire contract hasn't changed. The `to_legacy()` projection lives on `RuntimeLifecycle` (added in Phase 2) so neither file repeats the string table.
+- `set_lifecycle_with_error(Error, Some(MissingIpykernel))` in `metadata.rs` — replaces the Phase 1–3 pattern of `set_kernel_status("error") + set_kernel_info(...) + set_starting_phase("missing_ipykernel")` with a single typed call. The Phase 3 mirror handles the legacy `starting_phase` side.


### PR DESCRIPTION
## Summary

Phase 4 of the RuntimeLifecycle refactor. Replaces every `set_kernel_status` / `set_starting_phase` call in `runtimed` + `notebook-sync` with the typed writers from Phase 2/3, and every snapshot `kernel.status` read with a pattern-match on `kernel.lifecycle`. Wire-protocol and language bindings unchanged.

**Stack:** based on #2091 (Phase 3). Merge #2091 first.

## What lands

- `crates/runtimed/src/jupyter_kernel.rs` — IOPub hot path. New local `IoPubStateUpdate` enum dispatches `Busy/Idle` to `set_activity` (throttled) and `Starting/Restarting/Terminating/Dead` to `set_lifecycle`.
- `crates/runtimed/src/runtime_agent.rs` — kernel-died → `set_lifecycle_with_error(Error, None)`. Clears any stale reason from a prior specific failure.
- `crates/runtimed/src/requests/launch_kernel.rs` — atomic claim, phase transitions (`Resolving → PreparingEnv → Launching → Connecting → Running(Idle)`), restart and fresh-spawn paths, wait-loop matches on `RuntimeLifecycle`.
- `crates/runtimed/src/requests/shutdown_kernel.rs` — `set_lifecycle(Shutdown)`.
- `crates/runtimed/src/notebook_sync_server/peer.rs` — auto-launch (`Resolving`), panic handler (`set_lifecycle_with_error(Error, None)` — clears stale reason), trust-blocked (`AwaitingTrust`).
- `crates/runtimed/src/notebook_sync_server/metadata.rs` — `NotStarted` reset, `missing_ipykernel` via `set_lifecycle_with_error(Error, Some(MissingIpykernel))`, all phase transitions.
- `crates/runtimed/src/notebook_sync_server/tests.rs` + `crates/notebook-sync/src/tests.rs` fixtures.
- Readers in `execute_cell.rs`, `run_all_cells.rs`, `get_kernel_info.rs`, `room.rs::kernel_info`, `metadata.rs:673`, `execution_wait.rs` — migrated to `matches!(lifecycle, ...)`. Wire-contract consumers project back to the legacy status string via `RuntimeLifecycle::to_legacy()`.
- Stale comment cleanup in `kernel_state.rs`.

## Review trajectory

Codex review against Phase 3 flagged one P2 + one P3 that specifically apply to the Phase 4 code:

- **[P2] Clear stale `error_reason` on generic kernel failures** (commit `6439b7b7`): `set_lifecycle(Error)` preserves a prior `error_reason` by design, but the generic-death paths in `runtime_agent.rs` and `peer.rs` (auto-launch panic) shouldn't. Would have caused the toolbar's "install ipykernel" prompt to show on any unrelated Error after a previous `missing_ipykernel` incident. Fixed by switching both to `set_lifecycle_with_error(Error, None)`, which explicitly clears. Specific-cause paths (`metadata.rs` missing_ipykernel) keep using the typed reason unchanged.
- **[P1] `runtimed` package barrel missing new symbols** — actually a Phase 5 issue; fix lives in #2093.

## Test plan

- `cargo test -p runtime-doc -p notebook-sync -p runtimed --lib` — 575 passing.
- `cargo check --workspace` clean.
- `cargo xtask lint` clean.
- `rg -n 'set_kernel_status|set_starting_phase' --glob '*.rs' --glob '!crates/runtime-doc/**'` — empty.

## Out of scope

- `runt-mcp` / `runtimed-py` / `runtimed-node` consumers.
- Wire-level `NotebookKernelInfo.status` field.
- TS frontend — see #2093.
- Retiring the string setters — waits for all consumers to move.

Spec: \`docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md\`
Plan: \`docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-4.md\`