### PR TITLE
refactor(notebook-app): migrate TS frontend to RuntimeLifecycle (phase 5)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -311,7 +311,8 @@ function AppContent() {
   // Daemon-owned kernel execution
   const {
     kernelStatus,
-    startingPhase,
+    lifecycle,
+    errorReason,
     kernelInfo,
     queueState,
     envSyncState,
@@ -1166,7 +1167,8 @@ function AppContent() {
           )}
         <NotebookToolbar
           kernelStatus={kernelStatus}
-          startingPhase={startingPhase}
+          lifecycle={lifecycle}
+          errorReason={errorReason}
           envSource={envSource}
           envTypeHint={envTypeHint}
           envProgress={envProgress.isActive || envProgress.error ? envProgress : null}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -103,7 +103,20 @@ export function NotebookToolbar({
     kernelStatus === KERNEL_STATUS.IDLE ||
     kernelStatus === KERNEL_STATUS.BUSY ||
     kernelStatus === KERNEL_STATUS.STARTING;
-  const kernelStatusText = getLifecycleLabel(lifecycle, errorReason);
+
+  // When the kernel is Running, use the throttled `kernelStatus` (which the
+  // parent hook smooths over sub-60ms busy/idle blips) instead of the raw
+  // lifecycle activity. For every other lifecycle variant the throttle
+  // doesn't apply, so we read the lifecycle directly to keep its richer
+  // sub-state labels (`"resolving environment"`, `"launching kernel"`, …).
+  const labelLifecycle: RuntimeLifecycle =
+    lifecycle.lifecycle === "Running"
+      ? {
+          lifecycle: "Running",
+          activity: kernelStatus === KERNEL_STATUS.BUSY ? "Busy" : "Idle",
+        }
+      : lifecycle;
+  const kernelStatusText = getLifecycleLabel(labelLifecycle, errorReason);
   const envErrorMessage = envProgress?.error ?? null;
   const envStatusText = envProgress?.statusText ?? kernelStatusText;
   const kernelStatusDescription = envProgress?.isActive

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -13,6 +13,7 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { cn } from "@/lib/utils";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
 import type { UpdateStatus } from "../hooks/useUpdater";
+import { KERNEL_ERROR_REASON } from "runtimed";
 import {
   getLifecycleLabel,
   KERNEL_STATUS,
@@ -395,7 +396,7 @@ export function NotebookToolbar({
       {runtime === "python" &&
         lifecycle.lifecycle === "Error" &&
         envSource?.startsWith("pixi:") &&
-        errorReason === "missing_ipykernel" && (
+        errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL && (
           <div className="border-t px-3 py-2">
             <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -13,7 +13,12 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { cn } from "@/lib/utils";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
 import type { UpdateStatus } from "../hooks/useUpdater";
-import { getKernelStatusLabel, KERNEL_STATUS, type KernelStatus } from "../lib/kernel-status";
+import {
+  getLifecycleLabel,
+  KERNEL_STATUS,
+  type KernelStatus,
+  type RuntimeLifecycle,
+} from "../lib/kernel-status";
 import type { KernelspecInfo } from "../types";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "./icons";
 
@@ -22,7 +27,8 @@ type EnvBadgeVariant = "uv" | "conda" | "pixi";
 
 interface NotebookToolbarProps {
   kernelStatus: KernelStatus;
-  startingPhase?: string;
+  lifecycle: RuntimeLifecycle;
+  errorReason: string | null;
   kernelErrorMessage?: string | null;
   envSource: string | null;
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
@@ -48,7 +54,8 @@ interface NotebookToolbarProps {
 
 export function NotebookToolbar({
   kernelStatus,
-  startingPhase,
+  lifecycle,
+  errorReason,
   kernelErrorMessage,
   envSource,
   envTypeHint,
@@ -96,7 +103,7 @@ export function NotebookToolbar({
     kernelStatus === KERNEL_STATUS.IDLE ||
     kernelStatus === KERNEL_STATUS.BUSY ||
     kernelStatus === KERNEL_STATUS.STARTING;
-  const kernelStatusText = getKernelStatusLabel(kernelStatus, startingPhase);
+  const kernelStatusText = getLifecycleLabel(lifecycle, errorReason);
   const envErrorMessage = envProgress?.error ?? null;
   const envStatusText = envProgress?.statusText ?? kernelStatusText;
   const kernelStatusDescription = envProgress?.isActive
@@ -373,9 +380,9 @@ export function NotebookToolbar({
       )}
       {/* Pixi ipykernel install prompt — only when daemon signals missing_ipykernel */}
       {runtime === "python" &&
-        kernelStatus === KERNEL_STATUS.ERROR &&
+        lifecycle.lifecycle === "Error" &&
         envSource?.startsWith("pixi:") &&
-        startingPhase === "missing_ipykernel" && (
+        errorReason === "missing_ipykernel" && (
           <div className="border-t px-3 py-2">
             <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -12,7 +12,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { EnvProgressState } from "../../hooks/useEnvProgress";
-import { KERNEL_STATUS, type KernelStatus } from "../../lib/kernel-status";
+import { KERNEL_STATUS, type KernelStatus, type RuntimeLifecycle } from "../../lib/kernel-status";
 import { NotebookToolbar } from "../NotebookToolbar";
 
 function makeEnvProgress(overrides: Partial<EnvProgressState>): EnvProgressState {
@@ -32,6 +32,8 @@ function makeEnvProgress(overrides: Partial<EnvProgressState>): EnvProgressState
 
 const baseProps = {
   kernelStatus: KERNEL_STATUS.IDLE as KernelStatus,
+  lifecycle: { lifecycle: "Running", activity: "Idle" } as RuntimeLifecycle,
+  errorReason: null as string | null,
   envSource: null as string | null,
   envProgress: null as EnvProgressState | null,
   onStartKernel: vi.fn(),
@@ -307,25 +309,33 @@ describe("NotebookToolbar", () => {
   });
 
   describe("pixi ipykernel prompt", () => {
-    it("shows pixi prompt when runtime=python, status=error, envSource=pixi:, startingPhase=missing_ipykernel", () => {
+    const errorLifecycle: RuntimeLifecycle = { lifecycle: "Error" };
+    const idleLifecycle: RuntimeLifecycle = {
+      lifecycle: "Running",
+      activity: "Idle",
+    };
+
+    it("shows pixi prompt when runtime=python, lifecycle=Error, envSource=pixi:, errorReason=missing_ipykernel", () => {
       render(
         <NotebookToolbar
           {...baseProps}
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason="missing_ipykernel"
           envSource="pixi:toml"
-          startingPhase="missing_ipykernel"
         />,
       );
       expect(screen.getByText(/ipykernel not found in pixi.toml/)).toBeInTheDocument();
     });
 
-    it("does not show pixi prompt for generic pixi error (no missing_ipykernel phase)", () => {
+    it("does not show pixi prompt for generic pixi error (no missing_ipykernel reason)", () => {
       render(
         <NotebookToolbar
           {...baseProps}
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
           envSource="pixi:toml"
         />,
       );
@@ -338,8 +348,9 @@ describe("NotebookToolbar", () => {
           {...baseProps}
           runtime="deno"
           kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason="missing_ipykernel"
           envSource="pixi:toml"
-          startingPhase="missing_ipykernel"
         />,
       );
       expect(screen.queryByText(/ipykernel not found in pixi.toml/)).not.toBeInTheDocument();
@@ -351,8 +362,9 @@ describe("NotebookToolbar", () => {
           {...baseProps}
           runtime="python"
           kernelStatus={KERNEL_STATUS.IDLE}
+          lifecycle={idleLifecycle}
+          errorReason="missing_ipykernel"
           envSource="pixi:toml"
-          startingPhase="missing_ipykernel"
         />,
       );
       expect(screen.queryByText(/ipykernel not found in pixi.toml/)).not.toBeInTheDocument();
@@ -364,8 +376,9 @@ describe("NotebookToolbar", () => {
           {...baseProps}
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason="missing_ipykernel"
           envSource="uv:prewarmed"
-          startingPhase="missing_ipykernel"
         />,
       );
       expect(screen.queryByText(/ipykernel not found in pixi.toml/)).not.toBeInTheDocument();

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -12,6 +12,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 import type { EnvProgressState } from "../../hooks/useEnvProgress";
+import { KERNEL_ERROR_REASON } from "runtimed";
 import { KERNEL_STATUS, type KernelStatus, type RuntimeLifecycle } from "../../lib/kernel-status";
 import { NotebookToolbar } from "../NotebookToolbar";
 
@@ -322,7 +323,7 @@ describe("NotebookToolbar", () => {
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
           lifecycle={errorLifecycle}
-          errorReason="missing_ipykernel"
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
           envSource="pixi:toml"
         />,
       );
@@ -349,7 +350,7 @@ describe("NotebookToolbar", () => {
           runtime="deno"
           kernelStatus={KERNEL_STATUS.ERROR}
           lifecycle={errorLifecycle}
-          errorReason="missing_ipykernel"
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
           envSource="pixi:toml"
         />,
       );
@@ -363,7 +364,7 @@ describe("NotebookToolbar", () => {
           runtime="python"
           kernelStatus={KERNEL_STATUS.IDLE}
           lifecycle={idleLifecycle}
-          errorReason="missing_ipykernel"
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
           envSource="pixi:toml"
         />,
       );
@@ -377,7 +378,7 @@ describe("NotebookToolbar", () => {
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
           lifecycle={errorLifecycle}
-          errorReason="missing_ipykernel"
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
           envSource="uv:prewarmed"
         />,
       );

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -14,9 +14,9 @@ import {
   deriveEnvSyncState,
   deriveKernelInfo,
   deriveQueueState,
-  isKernelStatus,
   KERNEL_STATUS,
   type KernelStatus,
+  lifecycleToLegacyStatus,
   type NotebookClient,
   type NotebookResponse,
 } from "runtimed";
@@ -93,10 +93,14 @@ export function useDaemonKernel({
   const envSyncState = useMemo(() => deriveEnvSyncState(runtimeState), [runtimeState]);
 
   // ── Busy throttle ────────────────────────────────────────────────
-  const rawStatus = runtimeState.kernel.status;
-  const [throttledStatus, setThrottledStatus] = useState<KernelStatus>(
-    isKernelStatus(rawStatus) ? rawStatus : KERNEL_STATUS.NOT_STARTED,
-  );
+  // Project the typed lifecycle back to the legacy status vocabulary
+  // (`"idle"`, `"busy"`, `"starting"`, `"error"`, …) so the existing
+  // busy-throttle machinery — which treats IDLE/BUSY as the high-frequency
+  // pair — keeps working unchanged. Reading `lifecycle` (rather than
+  // `kernel.status`) means the throttle tracks the authoritative typed
+  // shape; legacy string drift in the CRDT can no longer confuse it.
+  const rawStatus = lifecycleToLegacyStatus(runtimeState.kernel.lifecycle);
+  const [throttledStatus, setThrottledStatus] = useState<KernelStatus>(rawStatus);
   const busyTimerRef = useRef<number | null>(null);
   const prevRawStatusRef = useRef(rawStatus);
 
@@ -104,7 +108,6 @@ export function useDaemonKernel({
     const prev = prevRawStatusRef.current;
     prevRawStatusRef.current = rawStatus;
     if (rawStatus === prev) return;
-    if (!isKernelStatus(rawStatus)) return;
     const status: KernelStatus = rawStatus;
 
     if (status === KERNEL_STATUS.BUSY) {
@@ -391,7 +394,8 @@ export function useDaemonKernel({
 
   return {
     kernelStatus,
-    startingPhase: runtimeState.kernel.starting_phase,
+    lifecycle: runtimeState.kernel.lifecycle,
+    errorReason: runtimeState.kernel.error_reason,
     queueState,
     kernelInfo,
     envSyncState,

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -7,17 +7,31 @@
 export {
   isKernelStatus,
   KERNEL_STATUS,
-  type KernelStatus,
+  RUNTIME_STATUS,
+  runtimeStatusKey,
   type KernelActivity,
+  type KernelStatus,
   type RuntimeLifecycle,
+  type RuntimeStatusKey,
 } from "runtimed";
 
 import {
   KERNEL_STATUS,
+  RUNTIME_STATUS,
+  runtimeStatusKey,
   type KernelStatus,
   type RuntimeLifecycle,
+  type RuntimeStatusKey,
 } from "runtimed";
 
+/**
+ * User-facing label for each compressed [`KernelStatus`].
+ *
+ * Covers the legacy 7-string vocabulary. For the expanded 11-key
+ * runtime vocabulary (which preserves every starting sub-phase and the
+ * Running(Unknown) case), use [`RUNTIME_STATUS_LABELS`] via
+ * [`getLifecycleLabel`] instead.
+ */
 export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.NOT_STARTED]: "initializing",
   [KERNEL_STATUS.STARTING]: "starting",
@@ -26,6 +40,28 @@ export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.ERROR]: "error",
   [KERNEL_STATUS.SHUTDOWN]: "shutdown",
   [KERNEL_STATUS.AWAITING_TRUST]: "awaiting approval",
+};
+
+/**
+ * User-facing label for each expanded [`RuntimeStatusKey`].
+ *
+ * Keyed by the flat runtime vocabulary so that every lifecycle variant
+ * (including each starting sub-phase and all three `Running(_)` cases)
+ * gets a dedicated label. Exhaustive `Record` — adding a variant to
+ * `RuntimeLifecycle` will fail to typecheck here until a label is added.
+ */
+export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
+  [RUNTIME_STATUS.NOT_STARTED]: "initializing",
+  [RUNTIME_STATUS.AWAITING_TRUST]: "awaiting approval",
+  [RUNTIME_STATUS.RESOLVING]: "resolving environment",
+  [RUNTIME_STATUS.PREPARING_ENV]: "preparing environment",
+  [RUNTIME_STATUS.LAUNCHING]: "launching kernel",
+  [RUNTIME_STATUS.CONNECTING]: "connecting to kernel",
+  [RUNTIME_STATUS.RUNNING_IDLE]: "idle",
+  [RUNTIME_STATUS.RUNNING_BUSY]: "busy",
+  [RUNTIME_STATUS.RUNNING_UNKNOWN]: "running",
+  [RUNTIME_STATUS.ERROR]: "error",
+  [RUNTIME_STATUS.SHUTDOWN]: "shutdown",
 };
 
 const STARTING_PHASE_LABELS: Record<string, string> = {
@@ -52,34 +88,17 @@ export function getKernelStatusLabel(
 /**
  * Render a user-facing label for the typed runtime lifecycle.
  *
- * Uses the full typed shape: each starting sub-phase and the Error-with-
- * reason case get their own label. `errorReason` is consulted only when
- * the lifecycle is `Error`; other states ignore it.
+ * Uses the expanded vocabulary — each starting sub-phase and each
+ * `Running(_)` activity get their own label. The `Error` case appends
+ * the typed reason when one is present; other states ignore `errorReason`.
  */
 export function getLifecycleLabel(
   lifecycle: RuntimeLifecycle,
   errorReason: string | null,
 ): string {
-  switch (lifecycle.lifecycle) {
-    case "NotStarted":
-      return "initializing";
-    case "AwaitingTrust":
-      return "awaiting approval";
-    case "Resolving":
-      return "resolving environment";
-    case "PreparingEnv":
-      return "preparing environment";
-    case "Launching":
-      return "launching kernel";
-    case "Connecting":
-      return "connecting to kernel";
-    case "Running":
-      return lifecycle.activity === "Busy" ? "busy" : "idle";
-    case "Error":
-      return errorReason && errorReason.length > 0
-        ? `error: ${errorReason}`
-        : "error";
-    case "Shutdown":
-      return "shutdown";
+  const key = runtimeStatusKey(lifecycle);
+  if (key === RUNTIME_STATUS.ERROR && errorReason && errorReason.length > 0) {
+    return `error: ${errorReason}`;
   }
+  return RUNTIME_STATUS_LABELS[key];
 }

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -4,9 +4,19 @@
  * Core types re-exported from runtimed; UI-specific labels live here.
  */
 
-export { isKernelStatus, KERNEL_STATUS, type KernelStatus } from "runtimed";
+export {
+  isKernelStatus,
+  KERNEL_STATUS,
+  type KernelStatus,
+  type KernelActivity,
+  type RuntimeLifecycle,
+} from "runtimed";
 
-import { KERNEL_STATUS, type KernelStatus } from "runtimed";
+import {
+  KERNEL_STATUS,
+  type KernelStatus,
+  type RuntimeLifecycle,
+} from "runtimed";
 
 export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.NOT_STARTED]: "initializing",
@@ -25,6 +35,10 @@ const STARTING_PHASE_LABELS: Record<string, string> = {
   connecting: "connecting to kernel",
 };
 
+/**
+ * @deprecated Use `getLifecycleLabel(lifecycle, errorReason)` instead.
+ * Retained for any caller outside NotebookToolbar that hasn't migrated.
+ */
 export function getKernelStatusLabel(
   status: KernelStatus,
   startingPhase?: string,
@@ -33,4 +47,39 @@ export function getKernelStatusLabel(
     return STARTING_PHASE_LABELS[startingPhase] ?? "starting";
   }
   return KERNEL_STATUS_LABELS[status];
+}
+
+/**
+ * Render a user-facing label for the typed runtime lifecycle.
+ *
+ * Uses the full typed shape: each starting sub-phase and the Error-with-
+ * reason case get their own label. `errorReason` is consulted only when
+ * the lifecycle is `Error`; other states ignore it.
+ */
+export function getLifecycleLabel(
+  lifecycle: RuntimeLifecycle,
+  errorReason: string | null,
+): string {
+  switch (lifecycle.lifecycle) {
+    case "NotStarted":
+      return "initializing";
+    case "AwaitingTrust":
+      return "awaiting approval";
+    case "Resolving":
+      return "resolving environment";
+    case "PreparingEnv":
+      return "preparing environment";
+    case "Launching":
+      return "launching kernel";
+    case "Connecting":
+      return "connecting to kernel";
+    case "Running":
+      return lifecycle.activity === "Busy" ? "busy" : "idle";
+    case "Error":
+      return errorReason && errorReason.length > 0
+        ? `error: ${errorReason}`
+        : "error";
+    case "Shutdown":
+      return "shutdown";
+  }
 }

--- a/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-5.md
+++ b/docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-5.md
@@ -1,0 +1,68 @@
+# RuntimeLifecycle Phase 5 — Migrate TypeScript Frontend
+
+**Goal:** Give the frontend typed access to `RuntimeLifecycle` and `KernelActivity`, and replace every `status`-string-based read in `packages/runtimed` + `apps/notebook` with pattern-matches on the typed shape. The `NotebookToolbar`'s `startingPhase` prop becomes `lifecycle + errorReason`, which closes the Phase 2 pixi-install-prompt compat bridge from the reader side.
+
+**Why only this much:** frontend migration is a self-contained unit. Python bindings (`runtimed-py`) and the wire-level `NotebookKernelInfo.status` field are separate later phases.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
+**Prior phases:** 1 (Rust enum), 2 (CRDT keys + writers), 3 (`KernelErrorReason`), 4 (Rust callers migrated).
+
+## What lands
+
+### `packages/runtimed/src/runtime-state.ts`
+
+- New TS types mirroring the Rust enums:
+  - `KernelActivity = "Unknown" | "Idle" | "Busy"`
+  - `RuntimeLifecycle` — discriminated union on the `lifecycle` tag, with `{ lifecycle: "Running", activity: KernelActivity }` as the only payload-bearing variant. Matches Rust's serde tag+content format.
+- Extend `KernelState` interface with `lifecycle: RuntimeLifecycle`, `activity: KernelActivity`, `error_reason: string | null`. Keep `status` + `starting_phase` for dual-shape compat — nothing deletes them in this phase.
+- `DEFAULT_RUNTIME_STATE` gets `lifecycle: { lifecycle: "NotStarted" }`, `activity: "Unknown"`, `error_reason: null`.
+
+### `packages/runtimed/src/derived-state.ts`
+
+- `deriveEnvSyncState` matches on `state.kernel.lifecycle.lifecycle` instead of string comparison. Behavior unchanged.
+- `kernelStatus$` is deprecated — it only existed to bridge the stringly `kernel.status` to the UI. Frontend consumers move onto `state.kernel.lifecycle` directly; internal shim retained for backwards compat during the transition, but marked `@deprecated` with a JSDoc pointer to the new path.
+
+### `apps/notebook/src/lib/kernel-status.ts`
+
+- Adds `getLifecycleLabel(lc: RuntimeLifecycle, reason: string | null): string`. Returns the user-facing kernel-state label directly from the typed shape — "resolving environment", "launching kernel", "idle", "busy", "error: missing ipykernel", etc.
+- Keeps `getKernelStatusLabel(status, startingPhase)` exported (deprecated) so any caller outside `NotebookToolbar` that we missed still works.
+
+### `apps/notebook/src/components/NotebookToolbar.tsx`
+
+- `startingPhase?: string` prop → `lifecycle: RuntimeLifecycle` + `errorReason: string | null`.
+- `kernelStatusText` derived from `getLifecycleLabel(lifecycle, errorReason)`.
+- The `missing_ipykernel` gate (line 378 pre-migration) moves from `startingPhase === "missing_ipykernel"` to `errorReason === "missing_ipykernel"`. The reason propagates through the typed `error_reason` CRDT key (Phase 2) and `KernelErrorReason::MissingIpykernel` writer (Phase 3), so this closes the loop.
+
+### `apps/notebook/src/hooks/useDaemonKernel.ts`
+
+- `rawStatus` read replaced with `runtimeState.kernel.lifecycle` + `.activity`.
+- Return value grows `lifecycle` and `errorReason`; drops `startingPhase`.
+
+### `apps/notebook/src/App.tsx`
+
+- Threads `lifecycle` and `errorReason` through to the toolbar instead of `startingPhase`.
+
+### Tests
+
+- `packages/runtimed/tests/sync-engine.test.ts` — fixtures gain `lifecycle` / `activity` / `error_reason` fields. Keep the legacy `status` / `starting_phase` so other fixture-sharing tests don't break.
+- `apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx` — pixi-prompt tests switch their fixture from `startingPhase="missing_ipykernel"` to `lifecycle={{ lifecycle: "Error" }}` + `errorReason="missing_ipykernel"`. Adds a coverage case for non-Error + error_reason (should NOT show the prompt).
+
+## Out of scope
+
+- Deleting `status` / `starting_phase` from the TS `KernelState` — Phase 6 or retire phase.
+- `runtimed-py` / `runtimed-node` bindings — Phase 6.
+- Wire `NotebookKernelInfo.status` field — wire-level rename needs its own PR.
+- Retiring `getKernelStatusLabel` — waits until greps show no callers outside tests.
+
+## Invariants preserved
+
+- Runtime snapshot JSON shape on the wire is unchanged — Rust already emits `lifecycle` / `activity` / `error_reason` (Phase 2). This phase is just teaching TS to read those fields.
+- Dual-shape: the TS `KernelState` keeps `status` and `starting_phase`. Any consumer we don't touch keeps working.
+- The toolbar pixi-install prompt continues to fire on `missing_ipykernel` — now through the typed `errorReason` field instead of the legacy `startingPhase` prop. Phase 3 already wired the daemon to populate both the CRDT `error_reason` and the legacy `starting_phase` mirror.
+
+## Acceptance
+
+- `pnpm -C packages/runtimed test` passes.
+- `pnpm -C apps/notebook typecheck` and `test` pass.
+- `cargo xtask lint` clean (runs vp on the TS files too).
+- A manual trace through the pixi-install-prompt path (toolbar test) confirms the prompt still fires on `errorReason === "missing_ipykernel"` but not on other errors.

--- a/packages/runtimed/src/derived-state.ts
+++ b/packages/runtimed/src/derived-state.ts
@@ -86,11 +86,12 @@ export function deriveQueueState(state: RuntimeState): DaemonQueueState {
  * "unknown" to consumers. Returns the sync state otherwise.
  */
 export function deriveEnvSyncState(state: RuntimeState): EnvSyncState | null {
+  const lc = state.kernel.lifecycle.lifecycle;
   if (
-    (state.kernel.status === "not_started" && !state.kernel.env_source) ||
-    state.kernel.status === "shutdown" ||
-    state.kernel.status === "error" ||
-    state.kernel.status === "awaiting_trust"
+    (lc === "NotStarted" && !state.kernel.env_source) ||
+    lc === "Shutdown" ||
+    lc === "Error" ||
+    lc === "AwaitingTrust"
   ) {
     return null;
   }
@@ -142,16 +143,47 @@ export function throttleBusyStatus(
 }
 
 /**
+ * Project a typed RuntimeLifecycle back to the legacy string status
+ * vocabulary (`"idle"`, `"busy"`, `"starting"`, `"error"`, `"shutdown"`,
+ * `"not_started"`, `"awaiting_trust"`).
+ *
+ * Kept for bridging throttleBusyStatus and other legacy-shape consumers.
+ * New code should match on `RuntimeLifecycle` directly.
+ */
+export function lifecycleToLegacyStatus(lc: RuntimeState["kernel"]["lifecycle"]): KernelStatus {
+  switch (lc.lifecycle) {
+    case "NotStarted":
+      return KERNEL_STATUS.NOT_STARTED;
+    case "AwaitingTrust":
+      return KERNEL_STATUS.AWAITING_TRUST;
+    case "Resolving":
+    case "PreparingEnv":
+    case "Launching":
+    case "Connecting":
+      return KERNEL_STATUS.STARTING;
+    case "Running":
+      return lc.activity === "Busy" ? KERNEL_STATUS.BUSY : KERNEL_STATUS.IDLE;
+    case "Error":
+      return KERNEL_STATUS.ERROR;
+    case "Shutdown":
+      return KERNEL_STATUS.SHUTDOWN;
+  }
+}
+
+/**
  * Derive a throttled kernel status observable from a RuntimeState stream.
  *
- * Convenience wrapper: extracts `kernel.status` and applies `throttleBusyStatus()`.
+ * Convenience wrapper: projects `kernel.lifecycle` back to the legacy
+ * status vocabulary and applies `throttleBusyStatus()`. Retained for
+ * consumers of the pre-lifecycle API; new code should match on
+ * `RuntimeLifecycle` directly.
  */
 export function kernelStatus$(
   runtimeState$: Observable<RuntimeState>,
   threshold?: number,
 ): Observable<KernelStatus> {
   return runtimeState$.pipe(
-    map((s) => s.kernel.status),
+    map((s) => lifecycleToLegacyStatus(s.kernel.lifecycle)),
     throttleBusyStatus(threshold),
   );
 }

--- a/packages/runtimed/src/derived-state.ts
+++ b/packages/runtimed/src/derived-state.ts
@@ -148,7 +148,9 @@ export function throttleBusyStatus(
  * `"not_started"`, `"awaiting_trust"`).
  *
  * Kept for bridging throttleBusyStatus and other legacy-shape consumers.
- * New code should match on `RuntimeLifecycle` directly.
+ * New code should match on `RuntimeLifecycle` directly, or — for a flat
+ * string key with every sub-state preserved — project through
+ * [`runtimeStatusKey`] instead.
  */
 export function lifecycleToLegacyStatus(lc: RuntimeState["kernel"]["lifecycle"]): KernelStatus {
   switch (lc.lifecycle) {
@@ -167,6 +169,76 @@ export function lifecycleToLegacyStatus(lc: RuntimeState["kernel"]["lifecycle"])
       return KERNEL_STATUS.ERROR;
     case "Shutdown":
       return KERNEL_STATUS.SHUTDOWN;
+  }
+}
+
+// ── Expanded runtime status vocabulary ──────────────────────────────
+
+/**
+ * One flat string key per runtime state.
+ *
+ * Unlike the compressed [`KERNEL_STATUS`] vocabulary (where the four
+ * starting sub-phases collapse to `"starting"` and `Running`'s activity
+ * is a separate axis), `RUNTIME_STATUS` preserves every variant with its
+ * own key. The `Running` cases are prefixed `"running-"` so the family
+ * relationship is grep-able and so table lookups can be exhaustive
+ * `Record<RuntimeStatusKey, X>` without a special-case `Unknown` duck.
+ *
+ * Use this for CSS classes, icon tables, label tables, and any other
+ * lookup keyed on "what is the runtime doing right now." Use
+ * [`KERNEL_STATUS`] only when interoperating with the compressed legacy
+ * wire vocabulary.
+ */
+export const RUNTIME_STATUS = {
+  NOT_STARTED: "not_started",
+  AWAITING_TRUST: "awaiting_trust",
+  RESOLVING: "resolving",
+  PREPARING_ENV: "preparing_env",
+  LAUNCHING: "launching",
+  CONNECTING: "connecting",
+  RUNNING_IDLE: "running-idle",
+  RUNNING_BUSY: "running-busy",
+  RUNNING_UNKNOWN: "running-unknown",
+  ERROR: "error",
+  SHUTDOWN: "shutdown",
+} as const;
+
+export type RuntimeStatusKey = (typeof RUNTIME_STATUS)[keyof typeof RUNTIME_STATUS];
+
+/**
+ * Project a typed RuntimeLifecycle to its flat [`RuntimeStatusKey`].
+ *
+ * Exhaustive over both the lifecycle union and the inner activity, so
+ * adding a variant will fail to typecheck here until handled.
+ */
+export function runtimeStatusKey(lc: RuntimeState["kernel"]["lifecycle"]): RuntimeStatusKey {
+  switch (lc.lifecycle) {
+    case "NotStarted":
+      return RUNTIME_STATUS.NOT_STARTED;
+    case "AwaitingTrust":
+      return RUNTIME_STATUS.AWAITING_TRUST;
+    case "Resolving":
+      return RUNTIME_STATUS.RESOLVING;
+    case "PreparingEnv":
+      return RUNTIME_STATUS.PREPARING_ENV;
+    case "Launching":
+      return RUNTIME_STATUS.LAUNCHING;
+    case "Connecting":
+      return RUNTIME_STATUS.CONNECTING;
+    case "Running":
+      switch (lc.activity) {
+        case "Idle":
+          return RUNTIME_STATUS.RUNNING_IDLE;
+        case "Busy":
+          return RUNTIME_STATUS.RUNNING_BUSY;
+        case "Unknown":
+          return RUNTIME_STATUS.RUNNING_UNKNOWN;
+      }
+    // eslint-disable-next-line no-fallthrough -- inner switch is exhaustive
+    case "Error":
+      return RUNTIME_STATUS.ERROR;
+    case "Shutdown":
+      return RUNTIME_STATUS.SHUTDOWN;
   }
 }
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -39,7 +39,9 @@ export {
   type EnvState,
   type ExecutionState,
   type ExecutionTransition,
+  KERNEL_ERROR_REASON,
   type KernelActivity,
+  type KernelErrorReasonKey,
   type KernelState,
   type QueueEntry,
   type QueueState,
@@ -96,6 +98,9 @@ export {
   type KernelInfo,
   type KernelStatus,
   lifecycleToLegacyStatus,
+  RUNTIME_STATUS,
+  runtimeStatusKey,
+  type RuntimeStatusKey,
   throttleBusyStatus,
 } from "./derived-state";
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -39,9 +39,11 @@ export {
   type EnvState,
   type ExecutionState,
   type ExecutionTransition,
+  type KernelActivity,
   type KernelState,
   type QueueEntry,
   type QueueState,
+  type RuntimeLifecycle,
   type RuntimeState,
   type TrustState,
   diffExecutions,
@@ -93,6 +95,7 @@ export {
   kernelStatus$,
   type KernelInfo,
   type KernelStatus,
+  lifecycleToLegacyStatus,
   throttleBusyStatus,
 } from "./derived-state";
 

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -7,9 +7,48 @@
 
 // ── Types ────────────────────────────────────────────────────────────
 
+/**
+ * Observable activity of a running kernel.
+ *
+ * Mirror of `runtime_doc::KernelActivity`. Only meaningful when the
+ * runtime lifecycle is `Running`.
+ */
+export type KernelActivity = "Unknown" | "Idle" | "Busy";
+
+/**
+ * Lifecycle of a runtime, from not-started through running to shutdown.
+ *
+ * Discriminated union on the `lifecycle` tag, matching Rust's serde
+ * tag+content format (`#[serde(tag = "lifecycle", content = "activity")]`).
+ * Only `Running` carries an `activity` payload — everything else is a
+ * lone tag.
+ *
+ * Mirror of `runtime_doc::RuntimeLifecycle`.
+ */
+export type RuntimeLifecycle =
+  | { lifecycle: "NotStarted" }
+  | { lifecycle: "AwaitingTrust" }
+  | { lifecycle: "Resolving" }
+  | { lifecycle: "PreparingEnv" }
+  | { lifecycle: "Launching" }
+  | { lifecycle: "Connecting" }
+  | { lifecycle: "Running"; activity: KernelActivity }
+  | { lifecycle: "Error" }
+  | { lifecycle: "Shutdown" };
+
 export interface KernelState {
+  /** @deprecated Legacy string-form status. Read `lifecycle` instead. */
   status: string;
+  /** @deprecated Legacy string-form starting sub-phase. Read `lifecycle` instead. */
   starting_phase: string;
+  /** Typed lifecycle — the authoritative view for new code. */
+  lifecycle: RuntimeLifecycle;
+  /**
+   * Human-readable reason populated when `lifecycle.lifecycle === "Error"`.
+   * `null` when the kernel map is absent; empty string when scaffolded but
+   * unset. Most consumers can treat both as "no reason."
+   */
+  error_reason: string | null;
   name: string;
   language: string;
   env_source: string;
@@ -90,6 +129,8 @@ export const DEFAULT_RUNTIME_STATE: RuntimeState = {
   kernel: {
     status: "not_started",
     starting_phase: "",
+    lifecycle: { lifecycle: "NotStarted" },
+    error_reason: null,
     name: "",
     language: "",
     env_source: "",

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -16,6 +16,25 @@
 export type KernelActivity = "Unknown" | "Idle" | "Busy";
 
 /**
+ * Typed reason accompanying a [`RuntimeLifecycle`] `Error` transition.
+ *
+ * Mirror of `runtime_doc::KernelErrorReason`. The daemon writes one of
+ * these strings to `kernel.error_reason`; readers can use the exported
+ * [`KERNEL_ERROR_REASON`] constants instead of bare string literals when
+ * gating UI on a specific cause.
+ */
+export type KernelErrorReasonKey = "missing_ipykernel";
+
+/**
+ * Typed error-reason strings. Mirrors
+ * `KernelErrorReason::MissingIpykernel.as_str()` on the Rust side —
+ * both ends use the same literal so the CRDT value is unambiguous.
+ */
+export const KERNEL_ERROR_REASON = {
+  MISSING_IPYKERNEL: "missing_ipykernel",
+} as const satisfies Record<string, KernelErrorReasonKey>;
+
+/**
  * Lifecycle of a runtime, from not-started through running to shutdown.
  *
  * Discriminated union on the `lifecycle` tag, matching Rust's serde

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -16,7 +16,7 @@ import { mergeChangesets } from "../src/cell-changeset";
 import { diffExecutions, getExecutionCountForCell } from "../src/runtime-state";
 import type { SessionStatus, SyncableHandle, FrameEvent } from "../src/handle";
 import type { CellChangeset } from "../src/cell-changeset";
-import type { RuntimeState } from "../src/runtime-state";
+import type { RuntimeLifecycle, RuntimeState } from "../src/runtime-state";
 
 // ── Mock factories ──────────────────────────────────────────────────
 
@@ -104,6 +104,8 @@ function makeRuntimeState(
     kernel: {
       status: "idle",
       starting_phase: "",
+      lifecycle: { lifecycle: "Running", activity: "Idle" },
+      error_reason: null,
       name: "python3",
       language: "python",
       env_source: "",
@@ -599,6 +601,8 @@ describe("SyncEngine", () => {
         kernel: {
           status: "busy",
           starting_phase: "",
+          lifecycle: { lifecycle: "Running", activity: "Busy" },
+          error_reason: null,
           name: "python3",
           language: "python",
           env_source: "",
@@ -643,6 +647,8 @@ describe("SyncEngine", () => {
         kernel: {
           status: "busy",
           starting_phase: "",
+          lifecycle: { lifecycle: "Running", activity: "Busy" },
+          error_reason: null,
           name: "python3",
           language: "python",
           env_source: "",
@@ -1994,7 +2000,15 @@ describe("diffExecutions", () => {
 
 describe("getExecutionCountForCell", () => {
   const baseState = {
-    kernel: { status: "idle", starting_phase: "", name: "", language: "", env_source: "" },
+    kernel: {
+      status: "idle",
+      starting_phase: "",
+      lifecycle: { lifecycle: "Running", activity: "Idle" } as RuntimeLifecycle,
+      error_reason: null,
+      name: "",
+      language: "",
+      env_source: "",
+    },
     queue: { executing: null, queued: [] },
     env: {
       in_sync: true,


### PR DESCRIPTION
## Summary

Phase 5 of the RuntimeLifecycle refactor. Adds typed `RuntimeLifecycle` + `KernelActivity` to `packages/runtimed` and migrates `apps/notebook` from the stringly `kernel.status`/`starting_phase` shape to the typed `lifecycle` + `error_reason` shape. Dual-shape in TS too — `status`/`starting_phase` stay for consumers we don't touch.

**Stack:** based on #2092 (Phase 4). Merge #2092 first.

## What lands

- `packages/runtimed/src/runtime-state.ts` — `RuntimeLifecycle`, `KernelActivity` types. `KernelState` grows `lifecycle`, `error_reason`.
- `packages/runtimed/src/derived-state.ts` — `deriveEnvSyncState` matches on `lifecycle`. New `lifecycleToLegacyStatus` helper for string-shape bridges. `kernelStatus$` rewritten to project from lifecycle so legacy string drift can't fool the busy-throttle.
- `packages/runtimed/src/index.ts` — re-exports `RuntimeLifecycle`, `KernelActivity`, `lifecycleToLegacyStatus` from the package root.
- `apps/notebook/src/lib/kernel-status.ts` — new `getLifecycleLabel(lifecycle, errorReason)`. Old `getKernelStatusLabel` kept deprecated.
- `apps/notebook/src/components/NotebookToolbar.tsx` — `startingPhase` prop replaced with `lifecycle` + `errorReason`. Pixi-install prompt gate moves to `errorReason === "missing_ipykernel"`. Closes the loop with Phase 3's `KernelErrorReason::MissingIpykernel`. Label uses a throttled Running activity so UX/accessibility match the existing indicator smoothing.
- `apps/notebook/src/hooks/useDaemonKernel.ts` — busy-throttle drives off lifecycle. Returns `lifecycle` + `errorReason`.
- `apps/notebook/src/App.tsx` — threads the typed shape to the toolbar.
- Test fixtures in `sync-engine.test.ts` + `notebook-toolbar.test.tsx`.

## Review trajectory

Codex review against Phase 4 surfaced two issues; both fixed in commit `33c0ffd1`:

- **[P0] Missing barrel exports**: `packages/runtimed/src/index.ts` didn't re-export `KernelActivity`, `RuntimeLifecycle`, or `lifecycleToLegacyStatus`. `apps/notebook` imported them from the package root and `pnpm --dir apps/notebook build` failed with TS2305. Fixed by adding the re-exports to both runtime-state and derived-state barrel blocks.
- **[P3] Label bypassed busy throttle**: `getLifecycleLabel(lifecycle, errorReason)` read raw lifecycle.activity, so the visible label and ARIA announcement flickered on every sub-60ms busy/idle blip even though the indicator dot was smoothed by the `useDaemonKernel` throttle. Fix: build a `labelLifecycle` that maps Running's activity through the throttled kernelStatus while keeping the rich sub-state labels (Resolving / PreparingEnv / …) for non-running transitions.

## Test plan

- `pnpm exec vp test` — 1076 passing.
- `pnpm exec vp check` — format + lint clean.
- `pnpm --dir apps/notebook build` — succeeds (codex repro'd the break pre-fix).
- `cargo xtask lint` clean.
- `cargo check --workspace` clean.

## Out of scope

- Deleting `status` / `starting_phase` from the TS `KernelState` — still mirrored from Rust, kept for dual-shape compat during the remaining migration.
- `runtimed-py` / `runtimed-node` bindings — still on `kernel.status`.
- Wire-level `NotebookKernelInfo.status` field — wire rename is its own PR.

Spec: `docs/superpowers/specs/2026-04-23-runtime-lifecycle-enum-design.md`
Plan: `docs/superpowers/plans/2026-04-23-runtime-lifecycle-phase-5.md`
