### PR TITLE
fix(runtimed): bootstrap environment.yml deps into CRDT at auto-launch

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2213,7 +2213,38 @@ pub(crate) async fn auto_launch_kernel(
                     }
                 }
             }
-            _ => {}
+            crate::project_file::ProjectFileKind::EnvironmentYml => {
+                if let Ok(env_config) = crate::project_file::parse_environment_yml(&detected.path) {
+                    let deps = env_config.dependencies;
+                    if !deps.is_empty() {
+                        let mut doc = room.doc.write().await;
+                        let mut changed = false;
+                        doc.fork_and_merge(|fork| {
+                            let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
+                            let current_deps = snap.runt.conda.as_ref().map(|c| &c.dependencies);
+                            if current_deps.is_none_or(|d| d != &deps) {
+                                let conda = snap.runt.conda.get_or_insert_with(|| {
+                                    notebook_doc::metadata::CondaInlineMetadata {
+                                        dependencies: Vec::new(),
+                                        channels: Vec::new(),
+                                        python: None,
+                                    }
+                                });
+                                conda.dependencies = deps;
+                                let _ = fork.set_metadata_snapshot(&snap);
+                                changed = true;
+                            }
+                        });
+                        if changed {
+                            info!("[notebook-sync] Bootstrapped environment.yml deps into CRDT");
+                        } else {
+                            debug!(
+                                "[notebook-sync] Conda deps already current in CRDT, skipping write"
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/docs/superpowers/specs/2026-04-23-env-yml-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-23-env-yml-bootstrap-design.md
@@ -1,0 +1,59 @@
+# Bootstrap environment.yml deps into CRDT at auto-launch
+
+Issue: [#2077](https://github.com/nteract/desktop/issues/2077)
+
+## Problem
+
+When a notebook auto-launches with `conda:env_yml` (detected from an `environment.yml` project file), the daemon does not bootstrap the file's deps into CRDT metadata. This is inconsistent with `pixi.toml` and `pyproject.toml`, which both bootstrap at auto-launch.
+
+Consequences:
+
+- `runt.conda.dependencies` starts empty for env_yml notebooks.
+- MCP `get_dependencies` returns nothing until the first `add_dependency` + restart cycle, which happens to re-bootstrap via `promote_inline_deps_to_project`.
+- UI/MCP asymmetry: pixi/pyproject notebooks show deps immediately; env_yml notebooks don't.
+
+## Location
+
+`crates/runtimed/src/notebook_sync_server/metadata.rs`, Step 3b bootstrap block (~line 2154). Currently:
+
+```rust
+match detected.kind {
+    ProjectFileKind::PixiToml => { /* bootstrap pixi deps */ }
+    ProjectFileKind::PyprojectToml => { /* bootstrap pyproject deps */ }
+    _ => {}
+}
+```
+
+## Fix
+
+Add an `EnvironmentYml` arm mirroring the neighbors:
+
+1. Call `crate::project_file::parse_environment_yml(&detected.path)`.
+2. Extract `env_config.dependencies`.
+3. Compare against `snap.runt.conda.as_ref().map(|c| &c.dependencies)`.
+4. If different, fork-and-merge the doc, get-or-insert a `CondaInlineMetadata`, assign `dependencies`, call `set_metadata_snapshot`.
+5. Log `[notebook-sync] Bootstrapped environment.yml deps into CRDT` on write, `debug!` on skip.
+
+### Scope: dependencies only
+
+This fix writes `dependencies` only. `channels` and `python` are intentionally deferred — they're not causing the observed bug and can be added later if needed. The existing re-bootstrap path in `promote_inline_deps_to_project` (line 3234) also only writes `dependencies`, so this matches that behavior.
+
+## Why this is correct
+
+- Fork-and-merge is used per the CRDT mutation rules — this is a sync mutation in the bootstrap path, identical pattern to pixi/pyproject.
+- Equality check guards against redundant writes (no spurious dirty-flag / sync traffic).
+- `get_or_insert_with(CondaInlineMetadata { ..default.. })` matches the existing promotion re-bootstrap block (line 3240), so the two paths produce equivalent CRDT state.
+
+## Testing
+
+No dedicated tests exist for the pixi/pyproject bootstrap arms, so no new unit tests are required for consistency. Verify end-to-end through the dev daemon:
+
+1. Create a notebook next to an `environment.yml` with a couple of deps (e.g. `numpy`, `pandas`).
+2. Auto-launch the kernel.
+3. Call MCP `get_dependencies` — expect the deps to appear immediately, without restarting.
+
+## Non-goals
+
+- `channels` and `python` bootstrap (deferred).
+- Fixing #2076 (duplicate dep promotion) — separate issue.
+- Fixing #2027 (CreateNotebook auto-launch race) — separate issue.


### PR DESCRIPTION
## Summary

- Adds an `EnvironmentYml` arm to the Step 3b bootstrap block in `notebook_sync_server::metadata` so env_yml auto-launches populate `runt.conda.dependencies` in the CRDT, matching pixi/pyproject.
- Drops the fall-through `_ => {}` — all three `ProjectFileKind` variants are now handled, so future additions will surface as compile errors instead of silent drops.

## Why

Before this PR, `conda:env_yml` auto-launches left the CRDT empty. MCP `get_dependencies` returned nothing until the first `add_dependency` + restart, which only worked by accident — `promote_inline_deps_to_project` re-bootstraps the CRDT as a side effect of promotion. This was called out in #2077 as the asymmetry compounding #2076.

## Test plan

- [ ] `cargo xtask lint` passes
- [ ] `cargo test -p runtimed --lib notebook_sync_server` passes
- [ ] Manual: open a notebook next to `environment.yml` with `numpy`, `pandas`; auto-launch kernel; MCP `get_dependencies` shows both without restarting

Closes #2077