### PR TITLE
refactor(runt-mcp): migrate kernel wait and session emit to typed RuntimeLifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7124,6 +7124,7 @@ dependencies = [
  "nteract-predicate",
  "parquet",
  "runt-workspace",
+ "runtime-doc",
  "runtimed-client",
  "serde",
  "serde_json",

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -177,10 +177,13 @@ pub async fn restart_kernel(
                     continue;
                 };
                 if let Ok(state) = h.get_runtime_state() {
-                    if state.kernel.status == "idle" || state.kernel.status == "busy" {
+                    if matches!(
+                        state.kernel.lifecycle,
+                        runtime_doc::RuntimeLifecycle::Running(_)
+                    ) {
                         break;
                     }
-                    if state.kernel.status == "error" {
+                    if matches!(state.kernel.lifecycle, runtime_doc::RuntimeLifecycle::Error) {
                         return tool_error("Kernel failed to start");
                     }
                 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -146,10 +146,12 @@ fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::V
     let mut info = serde_json::Map::new();
     match handle.get_runtime_state() {
         Ok(state) => {
-            info.insert(
-                "kernel_status".into(),
-                serde_json::json!(state.kernel.status),
-            );
+            // Project the typed lifecycle through to_legacy() so the MCP wire
+            // shape (string `kernel_status`) stays unchanged. Group 6 of the
+            // RuntimeLifecycle refactor (#2096) decides whether to add a
+            // typed wire field; that's intentionally deferred here.
+            let (legacy_status, _legacy_phase) = state.kernel.lifecycle.to_legacy();
+            info.insert("kernel_status".into(), serde_json::json!(legacy_status));
             if !state.kernel.language.is_empty() {
                 info.insert("language".into(), serde_json::json!(state.kernel.language));
             }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5177,6 +5177,10 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
                 println!("Notebook: {}", result.notebook_id);
                 println!("Source: {}", result.source);
                 if let Some(kernel) = &result.kernel_info {
+                    // `NotebookKernelInfo.status` is the wire-level string shape
+                    // (NotebookResponse). Migrating this field to the typed
+                    // RuntimeLifecycle is a wire change and lives in Group 6 of
+                    // the RuntimeLifecycle refactor (#2096). Leave as-is here.
                     println!(
                         "Kernel: {} ({}) - {}",
                         kernel.kernel_type, kernel.env_source, kernel.status

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -17,6 +17,7 @@ runtimed-client = { path = "../runtimed-client" }
 notebook-doc = { path = "../notebook-doc" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
+runtime-doc = { path = "../runtime-doc" }
 runt-workspace = { path = "../runt-workspace" }
 nteract-predicate = { path = "../nteract-predicate" }
 arrow = { version = "54", default-features = false, features = ["ipc"] }

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -340,7 +340,10 @@ pub async fn open_notebook(
         let started = rs
             .as_ref()
             .map(|r| {
-                r.kernel.status == "ready" || r.kernel.status == "busy" || r.kernel.status == "idle"
+                matches!(
+                    r.kernel.lifecycle,
+                    runtime_doc::RuntimeLifecycle::Running(_)
+                )
             })
             .unwrap_or(false);
         let runtime = rs


### PR DESCRIPTION
## Summary

Group 2 of the RuntimeLifecycle cleanup tracked in #2096. Three small consumers still read the string-shape `kernel.status`; switch them to match on the typed lifecycle. The MCP wire shape is intentionally unchanged.

- **`runtimed-node` `open_notebook`**: readiness check now matches `RuntimeLifecycle::Running(_)` instead of comparing against `"ready" / "idle" / "busy"`. The pre-existing `"ready"` arm was defensive; no writer produces it.
- **`runt-mcp` `restart_kernel`** wait loop: `Running(_)` breaks the poll, `Error` returns the failure. Same observable behavior as the string compares.
- **`runt-mcp` session info emit** (`read_runtime_info`): project the typed lifecycle through `to_legacy()` so the MCP wire field stays string-shaped. A typed wire field is Group 6 of #2096 and is deliberately out of scope here.
- **`runt inspect`** kernel print stays as-is. That reads the wire-level `NotebookKernelInfo.status`, which is a wire change (Group 6). Added a comment pointing at #2096.

### Wire-shape decision

Kept `to_legacy()` projection in `runt-mcp`. The MCP `kernel_status` field remains the string shape (`"idle"`, `"busy"`, `"starting"`, `"error"`, `"shutdown"`, `"awaiting_trust"`, `"not_started"`). Adding a typed field on the wire is Group 6 of #2096 and is explicitly deferred.

### Notes

- Adds `runtime-doc` as a direct dep of `runtimed-node` (`runt-mcp` already had it).
- Legacy shape retirement is Group 5 of #2096, not this PR.
- No MCP protocol version bump.

## Test plan

- [x] `cargo build -p runtimed-node -p runt-mcp -p runt-cli`
- [x] `cargo test -p runtimed-node -p runt-mcp` (95 passed, 0 failed)
- [x] `cargo clippy -p runtimed-node -p runt-mcp -p runt-cli --all-targets` clean
- [x] `cargo xtask lint --fix`
- [ ] Manual smoke: `runt mcp` reports kernel status via the string `kernel_status` field unchanged.

Refs #2096.
