### PR TITLE
refactor(automunge): expose read_str_if_present helper

### DIFF
--- a/crates/automunge/src/lib.rs
+++ b/crates/automunge/src/lib.rs
@@ -10,6 +10,27 @@
 
 use automerge::{transaction::Transactable, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
 
+/// Read a string scalar at `prop`, distinguishing "absent" from "empty".
+///
+/// Returns `None` only when the key itself is not present on the object.
+/// An explicit empty-string value returns `Some(String::new())`, so callers
+/// can tell "scaffolded but unset" apart from "key not present at all."
+/// Non-string scalars and object values also return `None`.
+pub fn read_str_if_present<P: Into<automerge::Prop>>(
+    doc: &AutoCommit,
+    obj: &ObjId,
+    prop: P,
+) -> Option<String> {
+    let (value, _) = doc.get(obj, prop).ok().flatten()?;
+    match value {
+        automerge::Value::Scalar(s) => match s.as_ref() {
+            automerge::ScalarValue::Str(s) => Some(s.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn scalar_to_json(s: &automerge::ScalarValue) -> Option<serde_json::Value> {
     match s {
         automerge::ScalarValue::Null => Some(serde_json::Value::Null),
@@ -298,4 +319,46 @@ pub fn update_json_at_index(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use automerge::ROOT;
+
+    #[test]
+    fn read_str_if_present_returns_none_for_absent_key() {
+        let doc = AutoCommit::new();
+        assert_eq!(read_str_if_present(&doc, &ROOT, "missing"), None);
+    }
+
+    #[test]
+    fn read_str_if_present_returns_empty_string_when_scaffolded() -> Result<(), AutomergeError> {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "scaffolded", "")?;
+        assert_eq!(
+            read_str_if_present(&doc, &ROOT, "scaffolded"),
+            Some(String::new())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn read_str_if_present_returns_value_when_set() -> Result<(), AutomergeError> {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "name", "charming-toucan")?;
+        assert_eq!(
+            read_str_if_present(&doc, &ROOT, "name"),
+            Some("charming-toucan".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn read_str_if_present_returns_none_for_non_string_scalar() -> Result<(), AutomergeError> {
+        let mut doc = AutoCommit::new();
+        doc.put(ROOT, "count", 7i64)?;
+        assert_eq!(read_str_if_present(&doc, &ROOT, "count"), None);
+        Ok(())
+    }
 }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -661,21 +661,6 @@ impl RuntimeStateDoc {
             })
     }
 
-    /// Read a string scalar from a map object, returning `None` only when
-    /// the key itself is absent. Unlike `read_opt_str`, an explicit `""`
-    /// value returns `Some("")` so callers can distinguish "scaffolded
-    /// but unset" from "key not present at all."
-    fn read_str_if_present(&self, obj: &automerge::ObjId, key: &str) -> Option<String> {
-        let (value, _) = self.doc.get(obj, key).ok().flatten()?;
-        match value {
-            Value::Scalar(s) => match s.as_ref() {
-                ScalarValue::Str(s) => Some(s.to_string()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
     /// Read a bool scalar from a map object.
     fn read_bool(&self, obj: &automerge::ObjId, key: &str) -> bool {
         self.doc
@@ -2051,11 +2036,11 @@ impl RuntimeStateDoc {
                 );
                 // error_reason is Option<String> so callers can tell "no
                 // kernel map at all" (None) from "scaffolded but unset"
-                // (Some("")). read_str_if_present returns None only when
-                // the key itself is absent — important for docs scaffolded
-                // before Phase 2 added the key, which have the `kernel`
-                // map but no `error_reason` field yet.
-                let error_reason = self.read_str_if_present(k, "error_reason");
+                // (Some("")). automunge::read_str_if_present returns None
+                // only when the key itself is absent, important for docs
+                // scaffolded before Phase 2 added the key (they have the
+                // `kernel` map but no `error_reason` field yet).
+                let error_reason = automunge::read_str_if_present(&self.doc, k, "error_reason");
                 KernelState {
                     status,
                     starting_phase,


### PR DESCRIPTION
## Summary

Move `read_str_if_present` from a private `RuntimeStateDoc` method into the `automunge` crate as a public free function, matching the style of `read_json_value`, `put_json_at_key`, etc.

The helper distinguishes "key is absent from the map" from "key is set to `\"\"`". `runtime-doc` was using it so docs scaffolded before Phase 2 of the RuntimeLifecycle refactor (which don't have `error_reason` yet) read `None` instead of a spurious `Some("")`. Other crates can reuse the same primitive.

## Changes

- `crates/automunge/src/lib.rs` — new `pub fn read_str_if_present<P: Into<Prop>>(doc, obj, prop) -> Option<String>`, plus four unit tests (absent key, scaffolded-empty, set value, non-string scalar).
- `crates/runtime-doc/src/doc.rs` — delete the private method at line 668, update the one caller at line ~2058 to call `automunge::read_str_if_present`.

Tree-wide grep confirmed no other callers of that helper name. Similar `ScalarValue::Str` matches in `notebook-sync`, `notebook-doc`, `runtimed-client` live inside other helpers with different semantics (default-to-empty, enum parsing), not the "absent vs empty" distinction.

## Test plan

- [x] `cargo build -p automunge -p runtime-doc`
- [x] `cargo test -p automunge` (4 new, all pass)
- [x] `cargo test -p runtime-doc` (145 existing, all pass)
- [x] `cargo xtask lint --fix`

Refs #2096 (Group 4 of the RuntimeLifecycle cleanup).
