### PR TITLE
feat(runtimed-py): migrate session_core to typed RuntimeLifecycle + Python constants

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -14,6 +14,7 @@ use notebook_protocol::protocol::{
     NotebookBroadcast, NotebookRequest, NotebookResponse, SaveErrorKind,
 };
 use notebook_sync::{BroadcastReceiver, DocHandle};
+use runtime_doc::{KernelActivity, RuntimeLifecycle};
 
 use notebook_doc::metadata::NotebookMetadataSnapshot;
 
@@ -282,7 +283,17 @@ fn hydrate_kernel_state(state: &mut SessionState) {
     let Ok(rs) = handle.get_runtime_state() else {
         return;
     };
-    let running = matches!(rs.kernel.status.as_str(), "idle" | "busy" | "starting");
+    // A kernel is "usable" once it's running or mid-launch. That covers
+    // every lifecycle variant except `NotStarted`, `AwaitingTrust`,
+    // `Error`, and `Shutdown`.
+    let running = matches!(
+        rs.kernel.lifecycle,
+        RuntimeLifecycle::Running(_)
+            | RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::PreparingEnv
+            | RuntimeLifecycle::Launching
+            | RuntimeLifecycle::Connecting
+    );
     if running {
         state.kernel_started = true;
         state.kernel_type = Some(rs.kernel.language.clone());
@@ -304,27 +315,30 @@ async fn ensure_create_runtime_ready(
     let mut forced_launch = false;
 
     loop {
-        let (status, runtime) = {
+        let (lifecycle, runtime) = {
             let st = state.lock().await;
             let handle = st
                 .handle
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
-            let status = handle
+            let lifecycle = handle
                 .get_runtime_state()
                 .ok()
-                .map(|rs| rs.kernel.status)
-                .unwrap_or_else(|| "not_started".to_string());
-            (status, st.runtime.clone())
+                .map(|rs| rs.kernel.lifecycle)
+                .unwrap_or(RuntimeLifecycle::NotStarted);
+            (lifecycle, st.runtime.clone())
         };
 
-        match status.as_str() {
-            "idle" | "busy" => {
+        match lifecycle {
+            RuntimeLifecycle::Running(_) => {
                 let mut st = state.lock().await;
                 hydrate_kernel_state(&mut st);
                 return Ok(());
             }
-            "starting" => {
+            RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::PreparingEnv
+            | RuntimeLifecycle::Launching
+            | RuntimeLifecycle::Connecting => {
                 if start.elapsed() >= timeout {
                     return Err(to_py_err(format!(
                         "Kernel did not become ready within {} seconds",
@@ -332,12 +346,14 @@ async fn ensure_create_runtime_ready(
                     )));
                 }
             }
-            "error" => {
+            RuntimeLifecycle::Error => {
                 return Err(to_py_err(
                     "Kernel auto-launch failed during notebook creation",
                 ));
             }
-            _ => {
+            RuntimeLifecycle::NotStarted
+            | RuntimeLifecycle::AwaitingTrust
+            | RuntimeLifecycle::Shutdown => {
                 if !forced_launch {
                     start_kernel(state, &runtime, "auto", None).await?;
                     forced_launch = true;
@@ -723,8 +739,8 @@ pub(crate) async fn restart_kernel(
     }
 
     // Wait for kernel ready by polling RuntimeStateDoc (the CRDT source of truth).
-    // Two phases: first wait for status to leave "idle" (restart in progress),
-    // then wait for it to return to "idle" (new kernel ready). This prevents
+    // Two phases: first wait for the lifecycle to leave `Running(Idle)` (restart
+    // in progress), then wait for it to return (new kernel ready). This prevents
     // returning immediately against the pre-restart idle snapshot.
     if wait_for_ready {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
@@ -734,7 +750,11 @@ pub(crate) async fn restart_kernel(
                 let st = state.lock().await;
                 if let Some(handle) = st.handle.as_ref() {
                     if let Ok(rs) = handle.get_runtime_state() {
-                        if rs.kernel.status != "idle" {
+                        let is_idle = matches!(
+                            rs.kernel.lifecycle,
+                            RuntimeLifecycle::Running(KernelActivity::Idle)
+                        );
+                        if !is_idle {
                             saw_non_idle = true;
                         } else if saw_non_idle {
                             return Ok(progress_messages);
@@ -1462,12 +1482,16 @@ pub(crate) async fn collect_outputs(
                     // otherwise a kernel crash leaves us spinning until
                     // the outer timeout fires.
                     if !done {
-                        if rs.kernel.status == "error" {
-                            kernel_error = Some("Kernel error".to_string());
-                            done = true;
-                        } else if rs.kernel.status == "shutdown" {
-                            kernel_error = Some("Kernel shut down".to_string());
-                            done = true;
+                        match rs.kernel.lifecycle {
+                            RuntimeLifecycle::Error => {
+                                kernel_error = Some("Kernel error".to_string());
+                                done = true;
+                            }
+                            RuntimeLifecycle::Shutdown => {
+                                kernel_error = Some("Kernel shut down".to_string());
+                                done = true;
+                            }
+                            _ => {}
                         }
                     }
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -739,9 +739,16 @@ pub(crate) async fn restart_kernel(
     }
 
     // Wait for kernel ready by polling RuntimeStateDoc (the CRDT source of truth).
-    // Two phases: first wait for the lifecycle to leave `Running(Idle)` (restart
-    // in progress), then wait for it to return (new kernel ready). This prevents
+    // Two phases: first wait for the lifecycle to leave `Running` (restart in
+    // progress), then wait for it to return (new kernel ready). This prevents
     // returning immediately against the pre-restart idle snapshot.
+    //
+    // `Running(Unknown)` counts as ready. `to_legacy()` projects it to
+    // the legacy `"idle"` status for backends that don't yet report an
+    // explicit idle/busy signal, and the pre-typed reader treated that
+    // string as ready. Collapsing `Running(Unknown)` into the "not idle"
+    // bucket would strand restarts in the 30s polling window on those
+    // backends until the first IOPub status arrived.
     if wait_for_ready {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         let mut saw_non_idle = false;
@@ -752,7 +759,9 @@ pub(crate) async fn restart_kernel(
                     if let Ok(rs) = handle.get_runtime_state() {
                         let is_idle = matches!(
                             rs.kernel.lifecycle,
-                            RuntimeLifecycle::Running(KernelActivity::Idle)
+                            RuntimeLifecycle::Running(
+                                KernelActivity::Idle | KernelActivity::Unknown,
+                            )
                         );
                         if !is_idle {
                             saw_non_idle = true;

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -94,7 +94,8 @@ async with await client.create_notebook() as notebook:
         print(f"{cell.id[:8]}: {cell.source[:40]}")
 
     # Runtime state (sync read from local doc)
-    print(notebook.runtime.kernel.status)
+    if notebook.runtime.kernel.status == runtimed.KERNEL_STATUS.IDLE:
+        print("kernel is idle")
 
     # Runtime lifecycle
     await notebook.start(runtime="python")

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -6,6 +6,12 @@ from runtimed._cell import CellCollection, CellHandle
 
 # Primary API
 from runtimed._client import Client
+from runtimed._constants import (
+    KERNEL_ERROR_REASON,
+    KERNEL_STATUS,
+    KernelErrorReasonKey,
+    KernelStatusKey,
+)
 from runtimed._execution import Execution
 
 # Return-only data types (from native bindings)
@@ -48,6 +54,11 @@ __all__ = [
     "Presence",
     # Error type — raisable / catchable
     "RuntimedError",
+    # Typed string constants mirroring the Rust daemon enums
+    "KERNEL_ERROR_REASON",
+    "KERNEL_STATUS",
+    "KernelErrorReasonKey",
+    "KernelStatusKey",
     # Standalone functions
     "default_socket_path",
     "show_notebook_app",

--- a/python/runtimed/src/runtimed/__init__.pyi
+++ b/python/runtimed/src/runtimed/__init__.pyi
@@ -3,6 +3,10 @@
 from runtimed._cell import CellCollection as CellCollection
 from runtimed._cell import CellHandle as CellHandle
 from runtimed._client import Client as Client
+from runtimed._constants import KERNEL_ERROR_REASON as KERNEL_ERROR_REASON
+from runtimed._constants import KERNEL_STATUS as KERNEL_STATUS
+from runtimed._constants import KernelErrorReasonKey as KernelErrorReasonKey
+from runtimed._constants import KernelStatusKey as KernelStatusKey
 from runtimed._internals import Cell as Cell
 from runtimed._internals import EnvState as EnvState
 from runtimed._internals import ExecutionEvent as ExecutionEvent

--- a/python/runtimed/src/runtimed/_constants.py
+++ b/python/runtimed/src/runtimed/_constants.py
@@ -1,0 +1,87 @@
+"""Typed string constants mirroring the Rust daemon enums.
+
+These are the same literals the Rust ``runtime_doc`` crate writes to the
+CRDT and the TypeScript ``@runtimed`` package exposes to the frontend.
+Pulling them in as Python constants lets readers match on kernel state
+without typing bare strings. A typo in ``"missing_ipykernel"`` is
+caught at import time rather than producing a silent always-false
+comparison.
+
+The Rust enums (``KernelErrorReason``, ``RuntimeLifecycle``) are the
+authoritative API; this module only surfaces the wire strings they
+serialise to. If you're adding a new variant, add it here AND on the
+Rust/TS sides to keep the three languages in lockstep.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+# ── Kernel error reasons ────────────────────────────────────────────
+
+#: Pixi-managed environment is missing the ``ipykernel`` package.
+#: Matches ``KernelErrorReason::MissingIpykernel.as_str()`` on the Rust
+#: side and ``KERNEL_ERROR_REASON.MISSING_IPYKERNEL`` in TypeScript.
+KernelErrorReasonKey = Literal["missing_ipykernel"]
+
+
+class KERNEL_ERROR_REASON:
+    """Typed error-reason strings written to ``kernel.error_reason`` in the
+    RuntimeStateDoc when the lifecycle transitions to ``Error``.
+
+    Mirrors ``runtime_doc::KernelErrorReason`` (Rust) and
+    ``KERNEL_ERROR_REASON`` (TypeScript ``@runtimed`` package). Use the
+    class attributes instead of bare string literals so typos fail loud.
+    """
+
+    MISSING_IPYKERNEL: Final[KernelErrorReasonKey] = "missing_ipykernel"
+
+
+# ── Kernel status strings (legacy `kernel.status` vocabulary) ───────
+
+#: Flat kernel-status vocabulary written to ``kernel.status`` in the
+#: RuntimeStateDoc. This is the compressed legacy shape that predates
+#: ``RuntimeLifecycle``; it collapses the four starting sub-phases into
+#: ``"starting"`` and flattens ``Running(activity)`` down to ``"idle"``
+#: or ``"busy"``. Matches ``KERNEL_STATUS`` in the TypeScript
+#: ``@runtimed`` package.
+KernelStatusKey = Literal[
+    "not_started",
+    "awaiting_trust",
+    "starting",
+    "idle",
+    "busy",
+    "error",
+    "shutdown",
+]
+
+
+class KERNEL_STATUS:
+    """Typed kernel-status strings for the legacy ``kernel.status`` field
+    on the RuntimeStateDoc.
+
+    Mirror of the TypeScript ``KERNEL_STATUS`` constant object. Prefer
+    these over bare strings when polling ``notebook.runtime.kernel.status``
+    so typos and stale status names fail at import time instead of
+    silently producing always-false comparisons.
+
+    When you can, match on ``RuntimeLifecycle`` (the typed successor) via
+    the Rust side instead. This vocabulary exists for callers that still
+    consume the flat string field during the Phase 2-5 transition.
+    """
+
+    NOT_STARTED: Final[KernelStatusKey] = "not_started"
+    AWAITING_TRUST: Final[KernelStatusKey] = "awaiting_trust"
+    STARTING: Final[KernelStatusKey] = "starting"
+    IDLE: Final[KernelStatusKey] = "idle"
+    BUSY: Final[KernelStatusKey] = "busy"
+    ERROR: Final[KernelStatusKey] = "error"
+    SHUTDOWN: Final[KernelStatusKey] = "shutdown"
+
+
+__all__ = [
+    "KERNEL_ERROR_REASON",
+    "KERNEL_STATUS",
+    "KernelErrorReasonKey",
+    "KernelStatusKey",
+]

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -58,6 +58,11 @@ class TestModuleExports:
             "Presence",
             # Error type
             "RuntimedError",
+            # Typed string constants mirroring the Rust daemon enums
+            "KERNEL_ERROR_REASON",
+            "KERNEL_STATUS",
+            "KernelErrorReasonKey",
+            "KernelStatusKey",
             # Standalone functions
             "default_socket_path",
             "show_notebook_app",
@@ -168,6 +173,39 @@ class TestSyncGuards:
     def test_env_state_has_await_guard(self):
         """EnvState has __await__ guard method."""
         assert hasattr(runtimed.EnvState, "__await__")
+
+
+class TestKernelStatusConstants:
+    """Typed kernel-status constants mirror the Rust daemon strings."""
+
+    def test_kernel_status_values(self):
+        """Each constant matches the exact wire string the daemon writes."""
+        assert runtimed.KERNEL_STATUS.NOT_STARTED == "not_started"
+        assert runtimed.KERNEL_STATUS.AWAITING_TRUST == "awaiting_trust"
+        assert runtimed.KERNEL_STATUS.STARTING == "starting"
+        assert runtimed.KERNEL_STATUS.IDLE == "idle"
+        assert runtimed.KERNEL_STATUS.BUSY == "busy"
+        assert runtimed.KERNEL_STATUS.ERROR == "error"
+        assert runtimed.KERNEL_STATUS.SHUTDOWN == "shutdown"
+
+    def test_kernel_status_comparable_to_strings(self):
+        """Constants compare equal to the bare strings they replace."""
+        assert runtimed.KERNEL_STATUS.IDLE == "idle"
+        assert "busy" in (runtimed.KERNEL_STATUS.IDLE, runtimed.KERNEL_STATUS.BUSY)
+
+
+class TestKernelErrorReasonConstants:
+    """Typed error-reason constants mirror ``KernelErrorReason::as_str()``."""
+
+    def test_missing_ipykernel_value(self):
+        """``MISSING_IPYKERNEL`` matches the Rust enum's wire string."""
+        assert runtimed.KERNEL_ERROR_REASON.MISSING_IPYKERNEL == "missing_ipykernel"
+
+    def test_missing_ipykernel_matches_ts_mirror(self):
+        """Value matches the TypeScript ``KERNEL_ERROR_REASON.MISSING_IPYKERNEL``."""
+        # The TS mirror lives in packages/runtimed/src/runtime-state.ts;
+        # both ends must serialise to the same CRDT value.
+        assert runtimed.KERNEL_ERROR_REASON.MISSING_IPYKERNEL == "missing_ipykernel"
 
 
 class TestCreateNotebookValidation:

--- a/scripts/metrics/kernel-reliability.py
+++ b/scripts/metrics/kernel-reliability.py
@@ -21,7 +21,7 @@ import statistics
 import sys
 import time
 
-from runtimed import Client
+from runtimed import KERNEL_STATUS, Client
 
 # Cell battery: (source, expected_success, timeout_secs)
 CELL_BATTERY = [
@@ -68,7 +68,7 @@ async def measure_reliability(
 
     # Wait for kernel idle (may take a while if prewarmed pool is empty)
     deadline = time.monotonic() + 120
-    while notebook.runtime.kernel.status not in ("idle", "busy"):
+    while notebook.runtime.kernel.status not in (KERNEL_STATUS.IDLE, KERNEL_STATUS.BUSY):
         if time.monotonic() > deadline:
             status = notebook.runtime.kernel.status
             print(
@@ -79,7 +79,7 @@ async def measure_reliability(
             sys.exit(1)
         await asyncio.sleep(0.2)
     # If busy, wait for it to become idle
-    while notebook.runtime.kernel.status == "busy":
+    while notebook.runtime.kernel.status == KERNEL_STATUS.BUSY:
         if time.monotonic() > deadline:
             break
         await asyncio.sleep(0.1)
@@ -116,10 +116,10 @@ async def measure_reliability(
             # Check for zombie: kernel stuck busy after timeout
             await asyncio.sleep(1)
             kernel_status = notebook.runtime.kernel.status
-            if kernel_status == "busy":
+            if kernel_status == KERNEL_STATUS.BUSY:
                 # Give it more time before declaring zombie
                 await asyncio.sleep(5)
-                if notebook.runtime.kernel.status == "busy":
+                if notebook.runtime.kernel.status == KERNEL_STATUS.BUSY:
                     zombie += 1
                     log(f"  ZOMBIE detected at round {round_num + 1}")
                     # Interrupt to recover

--- a/scripts/metrics/sync-correctness.py
+++ b/scripts/metrics/sync-correctness.py
@@ -21,7 +21,7 @@ import random
 import sys
 import time
 
-from runtimed import Client
+from runtimed import KERNEL_STATUS, Client
 
 CODE_SNIPPETS = [
     "1 + 1",
@@ -187,11 +187,11 @@ async def measure_sync(
     try:
         await notebook.start()
         deadline = time.monotonic() + 30
-        while notebook.runtime.kernel.status not in ("idle", "busy"):
+        while notebook.runtime.kernel.status not in (KERNEL_STATUS.IDLE, KERNEL_STATUS.BUSY):
             if time.monotonic() > deadline:
                 break
             await asyncio.sleep(0.2)
-        kernel_ready = notebook.runtime.kernel.status in ("idle", "busy")
+        kernel_ready = notebook.runtime.kernel.status in (KERNEL_STATUS.IDLE, KERNEL_STATUS.BUSY)
     except Exception as e:
         log(f"Kernel start failed (non-fatal): {e}")
 


### PR DESCRIPTION
## Summary

Group 1 of the RuntimeLifecycle cleanup tracked in #2096. The Python bindings were still reading `rs.kernel.status` as a raw string, and the scripts + docs all hard-coded bare string literals. This PR flips the five `session_core` reads over to the typed `RuntimeLifecycle` API and adds a Python-side mirror of the enums so external callers get the same typo-proofing that Rust and TypeScript already have.

## Changes

**`crates/runtimed-py/src/session_core.rs`**: read `rs.kernel.lifecycle` instead of `rs.kernel.status` in `hydrate_kernel_state`, `ensure_create_runtime_ready`, the restart wait loop, and the execute-cell done-check. Matches the pattern `notebook-sync::execution_wait.rs` already uses for the kernel-fault fallback.

**`python/runtimed/src/runtimed/_constants.py`**: new module exporting `KERNEL_ERROR_REASON` and `KERNEL_STATUS` constant classes plus `KernelErrorReasonKey` and `KernelStatusKey` `Literal` types. Values mirror Rust's `KernelErrorReason::as_str()` and the TS `KERNEL_ERROR_REASON` / `KERNEL_STATUS` constants so all three languages serialise to the same CRDT strings.

Re-exported from `runtimed.__init__` and `__init__.pyi` so `from runtimed import KERNEL_STATUS, KERNEL_ERROR_REASON` works.

**`scripts/metrics/kernel-reliability.py`** (5 sites) and **`scripts/metrics/sync-correctness.py`** (2 sites) now use the new constants instead of bare strings.

**`python/runtimed/README.md`**: quick-start snippet demonstrates the constant usage.

**`python/runtimed/tests/test_session_unit.py`**: new `TestKernelStatusConstants` and `TestKernelErrorReasonConstants` classes pin the values; `test_all_exports` includes the new names.

## Out of scope

Legacy `status` / `starting_phase` fields and the `to_legacy` / `from_legacy` helpers stay put. Retiring those is Group 5.

`crates/runtime-doc/`, `crates/runtimed-node/`, `crates/runt-mcp/`, `crates/runt/`, `crates/runtimed/src/notebook_sync_server/metadata.rs`, and frontend code are owned by parallel agents in this wave.

## Test plan

- [x] `cargo check -p runtimed-py` clean
- [x] `cargo clippy -p runtimed-py --no-deps -- -D warnings` clean
- [x] `cargo test -p runtimed-py --lib` passes (10/10 Rust unit tests)
- [x] `cargo xtask lint --fix` passes (Rust fmt, vp JS/TS, ruff Python, ty)
- [x] Workspace venv (`./.venv`) built via `maturin develop`. 26 unit tests pass:
  ```
  python/runtimed/tests/test_session_unit.py ........... 26 passed in 0.06s
  ```
- [x] Attempted `python/runtimed/.venv` test-venv build. `uv` workspace resolution warned that `VIRTUAL_ENV` did not match the project environment path and used the workspace venv instead. The workspace venv is what the MCP server and pytest both use in this setup, so both consumers see the new bindings.
- [ ] Integration tests (`test_daemon_integration.py`) need a dev daemon. No daemon available in this agent session; recommend running `cargo xtask integration` locally before merge.

Refs #2096.
