### PR TITLE
feat(notebook-app): route ErrorBoundary errors through host logger

### DIFF
--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -5,9 +5,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
+import { setErrorBoundarySink } from "@/lib/error-boundary";
 import { setBlobPortHost } from "./lib/blob-port";
 import { setKernelCompletionHost } from "./lib/kernel-completion";
-import { setLoggerHost } from "./lib/logger";
+import { logger, setLoggerHost } from "./lib/logger";
 import { setMetadataTransport } from "./lib/notebook-metadata";
 import { setOpenUrlHost } from "./lib/open-url";
 
@@ -40,6 +41,14 @@ setBlobPortHost(host);
 setLoggerHost(host);
 setOpenUrlHost(host);
 setKernelCompletionHost(host);
+setErrorBoundarySink((error, componentStack) => {
+  logger.error(
+    "[ErrorBoundary] render error:",
+    error,
+    "component stack:",
+    componentStack ?? "(unavailable)",
+  );
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/lib/error-boundary.tsx
+++ b/src/lib/error-boundary.tsx
@@ -1,5 +1,22 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
+/**
+ * Optional sink for caught render errors. Wire this to the host logger from
+ * the app entry so CI / production builds capture the React error and its
+ * component stack — the console.error in componentDidCatch is only visible
+ * in dev-mode devtools.
+ */
+type ErrorBoundarySink = (
+  error: Error,
+  componentStack: string | null | undefined,
+) => void;
+
+let _sink: ErrorBoundarySink | null = null;
+
+export function setErrorBoundarySink(sink: ErrorBoundarySink | null): void {
+  _sink = sink;
+}
+
 export interface ErrorBoundaryProps {
   children: ReactNode;
   /** Render prop called when an error is caught. Return the fallback UI. */
@@ -85,6 +102,11 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("[ErrorBoundary]", error, errorInfo.componentStack);
+    try {
+      _sink?.(error, errorInfo.componentStack);
+    } catch {
+      // Sink must never throw from the error path.
+    }
     this.props.onError?.(error, errorInfo);
   }
 


### PR DESCRIPTION
## Summary

- `ErrorBoundary.componentDidCatch` gains an opt-in module-scope sink; `main.tsx` wires it to `logger.error(...)` so caught render errors and their component stacks land in `notebook.log`.
- Until now, the boundary only did `console.error`. In packaged / CI builds that goes nowhere — which is why every E2E spec on 2026-04-23 failed with "App not ready — toolbar not found within 15s" but `app.log` showed nothing interesting.

## Motivation

While investigating why E2E is broken on `main` today, I pulled the failure screenshots from run [24839322000](https://github.com/nteract/desktop/actions/runs/24839322000). Every one shows the ErrorBoundary fallback — "Something went wrong. The notebook encountered an unexpected error." — rendered before the tests ever find the toolbar. The logs around it look healthy:

```
[INFO] webview: [automerge-notebook] Interactive materialization done
[INFO] webview: [window-focus] Handler stopped
[INFO] webview: [automerge-notebook] Cleanup: flushing and stopping engine
[INFO] webview: [sync-engine] Stopping
```

That "Cleanup" sequence is the boundary unmounting the thrown subtree. The actual error is invisible. This PR fixes that observability gap.

## Approach

`error-boundary.tsx` lives in `/src/` (shared code, no NotebookHost dependency), so I added a module-scope `setErrorBoundarySink()` setter rather than coupling the component to `@nteract/notebook-host`. `main.tsx` installs the sink right after `setLoggerHost(host)` — same pattern as the other boot-time setters. The sink is wrapped in `try { } catch {}` so a broken logger can never hide the original error.

## Test plan

- [ ] `cargo xtask lint --fix` passes
- [ ] Next failing CI run on any branch surfaces a `[ErrorBoundary] render error:` line in `e2e-logs/app.log`

Does **not** fix the underlying render error — that's a follow-up PR once we know what's actually throwing. This is purely observability.