### PR TITLE
chore(wasm): rebuild runtimed-wasm for RuntimeLifecycle phase 4

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e5a53718c82c2d8b079aa5cc95a3a0711aa398a161f5b5d2af25ebc85e16e79
-size 1721668
+oid sha256:478efc698c0a880101966324de5e183e8140f83371d8534dadc5fd641112bbfc
+size 1726361


### PR DESCRIPTION
## Summary

Rebuilds `apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm`. The JS glue and `.d.ts` are unchanged (the affected types round-trip through `serde_wasm_bindgen::to_value`, not typed `wasm-bindgen`), so this is a pure binary refresh.

## Why — fixes every E2E failure on main

The committed WASM was last rebuilt in #2060. Since then, the `RuntimeLifecycle` refactor landed in `crates/runtime-doc`:

- #2081 phase 1 — derived field only
- #2085 phase 2 — CRDT keys + typed writers
- #2091 typed `KernelErrorReason` + `set_activity` stale-phase fix
- #2092 migrate typed Rust callers

Phase 5 (#2093) then migrated the TS frontend to the new shape:

```ts
// packages/runtimed/src/derived-state.ts:89
const lc = state.kernel.lifecycle.lifecycle;
```

With a stale WASM, `read_state` does not emit `kernel.lifecycle` at all. The frontend reads `state.kernel.lifecycle === undefined`, dereferencing `.lifecycle` on it throws a `TypeError`, and the React ErrorBoundary in `App.tsx` replaces the entire tree with "Something went wrong."

That's why every E2E spec from run [24839322000](https://github.com/nteract/desktop/actions/runs/24839322000) and earlier on this week's main fails with `App not ready — toolbar not found within 15s`. The toolbar selector never mounts because the subtree is unmounted. Screenshot evidence:

- `should-load-app-and-show-toolbar-2026-04-23T14-07-55-241Z.png` → the "Something went wrong" fallback
- `app.log` shows a healthy startup followed immediately by `Cleanup: flushing and stopping engine` (the boundary tearing down the bad tree)

## Test plan

- [x] `cargo xtask wasm runtimed` — rebuild succeeds
- [x] `pnpm exec vp test packages/runtimed` — 194 passing
- [x] `pnpm exec vp test apps/notebook` — 444 passing
- [ ] CI E2E jobs return to green on this PR

Ship after #2101 (ErrorBoundary logger) or independently — they're orthogonal.

## Follow-up

The underlying process bug — landing Rust runtime-doc changes without rebuilding the WASM bundle that consumers depend on — is worth a guard: a CI check that greps for changes under `crates/runtime-doc/`, `crates/notebook-doc/`, or `crates/runtimed-wasm/` and fails if `runtimed_wasm_bg.wasm` hasn't been re-committed. Not in this PR.