### PR TITLE
test(runtimed-wasm): assert RuntimeState shape from committed WASM

### DIFF
--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -92,6 +92,49 @@ Deno.test("NotebookHandle: create new empty doc", () => {
   handle.free();
 });
 
+// Regression guard: the committed WASM bundle must emit a RuntimeState
+// shape the TS consumers in apps/notebook and packages/runtimed can
+// actually read. Past incident: Rust RuntimeLifecycle landed in
+// runtime-doc (#2081/#2085/#2091/#2092) and the frontend migrated to
+// state.kernel.lifecycle.lifecycle (#2093), but the committed
+// runtimed_wasm_bg.wasm was stale. Every render threw TypeError
+// "Cannot read properties of undefined (reading 'lifecycle')", the
+// App ErrorBoundary swallowed it, and every E2E failed with
+// "toolbar not found." CI's existing byte-diff guard can't catch this
+// because WASM isn't reproducible across platforms.
+//
+// This runs against the committed `.wasm` file (via the import above),
+// so it catches the "forgot to rebuild WASM" failure mode directly.
+Deno.test("RuntimeState: committed WASM emits the shape TS consumers expect", () => {
+  const handle = new NotebookHandle("shape-test");
+  const state = handle.get_runtime_state();
+
+  // Kernel state — RuntimeLifecycle is the field the frontend reads;
+  // error_reason must be present (Option<String>, null or string).
+  assertExists(state.kernel, "state.kernel missing");
+  assertExists(state.kernel.lifecycle, "state.kernel.lifecycle missing");
+  assertEquals(
+    state.kernel.lifecycle.lifecycle,
+    "NotStarted",
+    "default lifecycle tag must be NotStarted",
+  );
+  // error_reason is Option<String>. Deserialized as null or string —
+  // must at least be a defined property so `kernel.error_reason` doesn't
+  // throw on access.
+  assert(
+    "error_reason" in state.kernel,
+    "state.kernel.error_reason property must be defined",
+  );
+
+  // Top-level RuntimeState fields the derived-state helpers read.
+  assertExists(state.queue, "state.queue missing");
+  assertExists(state.env, "state.env missing");
+  assertExists(state.trust, "state.trust missing");
+  assertExists(state.executions, "state.executions missing");
+
+  handle.free();
+});
+
 Deno.test("NotebookHandle: add cell and read back", () => {
   const handle = new NotebookHandle("test-nb");
   handle.add_cell(0, "cell-1", "code");


### PR DESCRIPTION
## Summary

Adds a Deno smoke test that loads the committed `runtimed_wasm_bg.wasm`, reads a fresh `RuntimeState` via `get_runtime_state()`, and asserts the shape TS consumers expect — catching the "forgot to rebuild WASM after a schema change" failure mode directly.

Asserts:
- `state.kernel.lifecycle.lifecycle === "NotStarted"` — proves the tagged union from `RuntimeLifecycle` is actually emitted
- `state.kernel.error_reason` key exists (Option<String>, null or string)
- Top-level `queue`, `env`, `trust`, `executions` are present

## Why — plugs a hole that took down every E2E today

CI's existing WASM guard ([build.yml#L162-167](https://github.com/nteract/desktop/blob/main/.github/workflows/build.yml#L162-L167)) rebuilds WASM then runs:

```bash
git diff --exit-code -- apps/notebook/src/wasm/runtimed-wasm/ ':!*.wasm'
```

The `:!*.wasm` pathspec excludes the binary from the diff. That was added in #1172 with good reason — WASM compilation isn't reproducible across platforms, so byte-diffing a macOS-built commit against a Linux CI rebuild false-fires. But that leaves the actual binary unchecked. That gap let #2081/#2085/#2091/#2092 (Rust `RuntimeLifecycle`) + #2093 (TS migration to the new shape) land without a WASM rebuild. The frontend then read `state.kernel.lifecycle.lifecycle` from a stale bundle that didn't emit `lifecycle`, threw `TypeError`, got caught by the App `ErrorBoundary`, and every E2E spec failed with "App not ready — toolbar not found." See #2103.

This test sidesteps the non-determinism: it checks the JSON shape the WASM emits, not its bytes. Platform-independent. Direct.

## Verification

Ran locally:

- Against committed main WASM (stale) → fails with `state.kernel.lifecycle missing` ✅ proves the guard catches the bug.
- Against the rebuilt bundle in #2103 → passes ✅.

## Dependency

Depends on #2103 (WASM rebuild) to go green. Ordering the merges:

1. #2103 rebuilds WASM (on auto-merge)
2. This PR rebases cleanly and turns green

Ship #2103 first, then this.

## Test plan

- [x] Shape test passes against freshly-built WASM
- [x] Shape test fails against pre-#2103 WASM (demonstrated locally)
- [ ] CI `E2E Deno` job runs the new assertion