### PR TITLE
feat(telemetry): explicit consent CTA + Privacy pane + install ID rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ result
 # APT publisher secrets
 scripts/apt/.env
 scripts/apt/debs/*.deb
+
+# Superpowers brainstorming scratch
+.superpowers/

--- a/apps/notebook/gallery/App.tsx
+++ b/apps/notebook/gallery/App.tsx
@@ -52,7 +52,7 @@ export default function App() {
 
         <Section
           title="Onboarding page 2 — CTA block"
-          description="What replaces the pre-checked toggle + Get Started button."
+          description='Replaces the pre-checked telemetry toggle + single "Get Started" button. "Submitting" is the ~200ms window after the user picks one of the two buttons, while the daemon is persisting the choice — the primary button shows "Setting up..." and both buttons are disabled to prevent double-fire.'
         >
           <OnboardingCTAPreview />
         </Section>

--- a/apps/notebook/gallery/App.tsx
+++ b/apps/notebook/gallery/App.tsx
@@ -1,0 +1,275 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PrivacySection } from "../settings/sections/Privacy";
+
+/**
+ * Standalone component gallery.
+ *
+ * A lightweight showcase for the bespoke UI we're iterating on (onboarding
+ * states, Settings sections, banners). Runs under Vite dev server without
+ * the Tauri shell, daemon, or any IPC — every data-dependent prop is
+ * supplied from local state, and any side effect (opening an URL,
+ * persisting a setting) is stubbed at the component's edge.
+ *
+ * Visit: http://localhost:5174/gallery/ when Vite is running.
+ */
+export default function App() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <ThemeBar />
+      <main className="max-w-4xl mx-auto p-8 space-y-12">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Component gallery</h1>
+          <p className="text-sm text-muted-foreground">
+            Preview the components powering onboarding and Settings without launching the desktop
+            app.
+          </p>
+        </header>
+
+        <Section
+          title="TelemetryDisclosureCard"
+          description="Shared disclosure card. Rendered above the onboarding CTA and embedded (with a trailing switch) in Settings → Privacy."
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Variant label="default">
+              <TelemetryDisclosureCard />
+            </Variant>
+            <Variant label="with footer slot">
+              <TelemetryDisclosureCard
+                footer={
+                  <div className="flex items-center justify-between pt-1 text-xs text-muted-foreground">
+                    <span>Send anonymous daily ping</span>
+                    <span className="text-primary">(toggle slot)</span>
+                  </div>
+                }
+              />
+            </Variant>
+          </div>
+        </Section>
+
+        <Section
+          title="Onboarding page 2 — CTA block"
+          description="What replaces the pre-checked toggle + Get Started button."
+        >
+          <OnboardingCTAPreview />
+        </Section>
+
+        <Section
+          title="Settings → Privacy"
+          description="Live section, fully interactive. Switch, install ID rotation, and last-ping relative times all work against local state."
+        >
+          <div className="max-w-lg border rounded-lg p-4 bg-card">
+            <PrivacySectionDemo />
+          </div>
+        </Section>
+      </main>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold tracking-wider uppercase text-muted-foreground">
+          {title}
+        </h2>
+        <p className="text-sm text-foreground/80">{description}</p>
+      </div>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+function Variant({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+type OnboardingState = "idle" | "python-env-missing" | "ready" | "submitting" | "setup-complete";
+
+function OnboardingCTAPreview() {
+  const [state, setState] = useState<OnboardingState>("ready");
+  const canProceed = state === "ready" || state === "submitting";
+  const isSubmitting = state === "submitting";
+  const setupComplete = state === "setup-complete";
+  const pythonEnvSelected = state !== "python-env-missing";
+
+  return (
+    <div className="space-y-4">
+      <StateSelector
+        label="Gate state"
+        options={[
+          ["idle", "idle (not interactive)"],
+          ["python-env-missing", "no python env selected"],
+          ["ready", "ready to submit"],
+          ["submitting", "submitting..."],
+          ["setup-complete", "all set!"],
+        ]}
+        value={state}
+        onChange={setState}
+      />
+      <div className="max-w-sm mx-auto">
+        <div className="space-y-3 p-6 border rounded-lg bg-card">
+          <TelemetryDisclosureCard />
+          <Button disabled={!canProceed || isSubmitting} className="w-full" size="lg">
+            {setupComplete
+              ? "All set!"
+              : canProceed && !isSubmitting
+                ? "You can count on me!"
+                : !pythonEnvSelected
+                  ? "Select a package manager"
+                  : "Setting up..."}
+          </Button>
+          <button
+            type="button"
+            disabled={!canProceed || isSubmitting}
+            className="w-full text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50 py-1"
+          >
+            Opt out of metrics, continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PrivacySectionDemo() {
+  const [telemetryEnabled, setTelemetryEnabled] = useState(true);
+  const [installId, setInstallId] = useState("c1d4e7f2-8a3b-4f1c-9e2a-1234567890ab");
+  const now = Math.floor(Date.now() / 1000);
+  const [lastDaemonPingAt] = useState<number | null>(now - 14 * 3600);
+  const [lastAppPingAt] = useState<number | null>(now - 2 * 3600);
+  const [lastMcpPingAt] = useState<number | null>(null);
+
+  const rotateInstallId = async () => {
+    // Fake UUID so the demo feels live.
+    const next = crypto.randomUUID();
+    setInstallId(next);
+    return next;
+  };
+
+  return (
+    <PrivacySection
+      telemetryEnabled={telemetryEnabled}
+      onTelemetryChange={setTelemetryEnabled}
+      installId={installId}
+      onRotate={rotateInstallId}
+      lastDaemonPingAt={lastDaemonPingAt}
+      lastAppPingAt={lastAppPingAt}
+      lastMcpPingAt={lastMcpPingAt}
+    />
+  );
+}
+
+function StateSelector<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: Array<[T, string]>;
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex flex-wrap items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+        {options.map(([v, human]) => (
+          <button
+            key={v}
+            type="button"
+            onClick={() => onChange(v)}
+            className={cn(
+              "rounded-sm px-2 py-1 text-xs transition-colors",
+              value === v
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {human}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ThemeMode = "light" | "dark" | "system";
+
+const THEME_STORAGE_KEY = "notebook-theme";
+
+function ThemeBar() {
+  const [theme, setTheme] = useState<ThemeMode>(() => {
+    try {
+      const stored = localStorage.getItem(THEME_STORAGE_KEY);
+      if (stored === "light" || stored === "dark" || stored === "system") {
+        return stored;
+      }
+    } catch {
+      /* ignore */
+    }
+    return "system";
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      /* ignore */
+    }
+    const resolved =
+      theme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : theme;
+    const html = document.documentElement;
+    html.classList.remove("light", "dark");
+    html.classList.add(resolved);
+  }, [theme]);
+
+  return (
+    <div className="flex items-center justify-end gap-1 border-b bg-muted/40 px-4 py-2">
+      {(
+        [
+          { value: "light", icon: Sun, label: "Light" },
+          { value: "dark", icon: Moon, label: "Dark" },
+          { value: "system", icon: Monitor, label: "System" },
+        ] as const
+      ).map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => setTheme(value)}
+          className={cn(
+            "flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors",
+            theme === value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/notebook/gallery/index.css
+++ b/apps/notebook/gallery/index.css
@@ -1,0 +1,13 @@
+/*
+ * Gallery shares CSS with settings — same Tailwind config, same token
+ * definitions, same cream-theme import. Any visual drift here would be
+ * a drift from the real surface we're previewing.
+ */
+@import "../settings/index.css";
+
+/* The settings @source globs only cover settings/ and ../src/components/.
+ * Add the two additional paths the gallery pulls components from so
+ * Tailwind's JIT picks up their class names. */
+@source "../../../src/components/**/*.{ts,tsx}";
+@source "../settings/sections/**/*.{ts,tsx}";
+@source "./**/*.{ts,tsx}";

--- a/apps/notebook/gallery/index.css
+++ b/apps/notebook/gallery/index.css
@@ -11,3 +11,17 @@
 @source "../../../src/components/**/*.{ts,tsx}";
 @source "../settings/sections/**/*.{ts,tsx}";
 @source "./**/*.{ts,tsx}";
+
+/*
+ * Undo settings.css's html/body/#root { height: 100%; overflow: hidden }.
+ * Those rules exist for the Tauri window experience (fixed chrome, no
+ * outer scroll) and would lock the gallery page at viewport height. The
+ * gallery is a normal scrolling web page.
+ */
+html,
+body,
+#root {
+  height: auto;
+  min-height: 100%;
+  overflow: auto;
+}

--- a/apps/notebook/gallery/index.html
+++ b/apps/notebook/gallery/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>Component Gallery</title>
+    <script>
+      // Apply theme immediately. Gallery uses the same notebook-theme key as
+      // the real sub-apps so toggling here sticks if the user bounces back.
+      (() => {
+        var STORAGE_KEY = "notebook-theme";
+        var theme;
+        try {
+          theme = localStorage.getItem(STORAGE_KEY);
+        } catch (_e) {}
+        if (theme !== "light" && theme !== "dark" && theme !== "system") {
+          theme = "system";
+        }
+        var resolved = theme;
+        if (theme === "system") {
+          resolved = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        document.documentElement.classList.add(resolved);
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/notebook/gallery/main.tsx
+++ b/apps/notebook/gallery/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -2,10 +2,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { AlertTriangle, ArrowLeft, Check, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "../src/components/icons";
+import { openUrl } from "../src/lib/open-url";
 import type { DaemonStatus } from "./types";
 
 type Runtime = "python" | "deno";
@@ -160,7 +162,6 @@ export default function App() {
   const [page, setPage] = useState<1 | 2>(1);
   const [runtime, setRuntime] = useState<Runtime | null>(null);
   const [pythonEnv, setPythonEnv] = useState<PythonEnv | null>(null);
-  const [telemetryEnabled, setTelemetryEnabled] = useState(true);
   const [steps, setSteps] = useState<SetupStep[]>([
     { id: "daemon", label: "Installing runtime daemon", status: "in_progress" },
     { id: "tools", label: "Preparing environments", status: "pending" },
@@ -169,6 +170,7 @@ export default function App() {
   const [daemonFailed, setDaemonFailed] = useState(false);
   const [poolReady, setPoolReady] = useState(false);
   const [setupComplete, setSetupComplete] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Listen for daemon progress events
@@ -276,55 +278,80 @@ export default function App() {
     setPage(1);
   }, []);
 
-  // Save settings and complete onboarding
-  const handleGetStarted = useCallback(async () => {
-    if (!runtime || !pythonEnv) return;
-    if (!daemonReady || !poolReady) return;
+  // Record the user's telemetry decision and complete onboarding. Called from
+  // either CTA on page 2 — the `telemetryEnabled` argument captures which
+  // button was pressed ("You can count on me!" → true, "Opt out of metrics" →
+  // false). Both paths flip `telemetry_consent_recorded` to true so
+  // heartbeats can fire (when enabled).
+  const handleChoice = useCallback(
+    async (telemetryEnabled: boolean) => {
+      if (!runtime || !pythonEnv) return;
+      if (!daemonReady || !poolReady) return;
+      if (isSubmitting) return;
+      setIsSubmitting(true);
 
+      try {
+        await invoke("set_synced_setting", {
+          key: "default_runtime",
+          value: runtime,
+        });
+        await invoke("set_synced_setting", {
+          key: "default_python_env",
+          value: pythonEnv,
+        });
+        await invoke("set_synced_setting", {
+          key: "telemetry_enabled",
+          value: telemetryEnabled,
+        });
+        await invoke("set_synced_setting", {
+          key: "telemetry_consent_recorded",
+          value: true,
+        });
+        await invoke("set_synced_setting", {
+          key: "onboarding_completed",
+          value: true,
+        });
+
+        setSetupComplete(true);
+
+        try {
+          await invoke("complete_onboarding", {
+            defaultRuntime: runtime,
+            defaultPythonEnv: pythonEnv,
+          });
+          // Window closes itself on success.
+        } catch (completeError) {
+          console.error("Failed to complete onboarding:", completeError);
+          setSetupComplete(false);
+          setIsSubmitting(false);
+          setErrorMessage("Failed to create notebook window. Please try again.");
+        }
+      } catch (e) {
+        console.error("Failed to save onboarding settings:", e);
+        setIsSubmitting(false);
+        setErrorMessage("Failed to save settings. Please try again.");
+      }
+    },
+    [daemonReady, poolReady, runtime, pythonEnv, isSubmitting],
+  );
+
+  // Fallback path when the daemon failed to install. Still records the
+  // consent decision (as "opted out") so we never ping a user who didn't
+  // even get past the daemon install.
+  const handleSkip = useCallback(async () => {
     try {
-      // Save settings to daemon
-      await invoke("set_synced_setting", {
-        key: "default_runtime",
-        value: runtime,
-      });
-      await invoke("set_synced_setting", {
-        key: "default_python_env",
-        value: pythonEnv,
-      });
       await invoke("set_synced_setting", {
         key: "telemetry_enabled",
-        value: telemetryEnabled,
+        value: false,
       });
       await invoke("set_synced_setting", {
-        key: "onboarding_completed",
+        key: "telemetry_consent_recorded",
         value: true,
       });
-
-      // Show completing state while we create the notebook window
-      setSetupComplete(true);
-
-      // Pass selected values directly to avoid settings race condition
-      // Await onComplete so we can handle failures properly
-      try {
-        await invoke("complete_onboarding", {
-          defaultRuntime: runtime,
-          defaultPythonEnv: pythonEnv,
-        });
-        // Window closes itself on success - no further action needed
-      } catch (completeError) {
-        // onComplete failed - reset state so user can retry
-        console.error("Failed to complete onboarding:", completeError);
-        setSetupComplete(false);
-        setErrorMessage("Failed to create notebook window. Please try again.");
-      }
     } catch (e) {
-      console.error("Failed to save onboarding settings:", e);
-      setErrorMessage("Failed to save settings. Please try again.");
+      // Daemon failed — can't persist, but still let the user continue.
+      console.warn("[onboarding] daemon write failed on skip:", e);
     }
-  }, [daemonReady, poolReady, runtime, pythonEnv, telemetryEnabled]);
-
-  // Skip onboarding when daemon failed - use current selections or defaults
-  const handleSkip = useCallback(async () => {
     await invoke("complete_onboarding", {
       defaultRuntime: runtime ?? "python",
       defaultPythonEnv: pythonEnv ?? "uv",
@@ -433,51 +460,37 @@ export default function App() {
               <div className="w-[60px]" /> {/* Spacer for centering */}
             </div>
 
-            {/* Telemetry disclosure */}
-            <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50 border border-border/50">
-              <div className="space-y-0.5 pr-4">
-                <p className="text-sm font-medium">Anonymous usage data</p>
-                <p className="text-xs text-muted-foreground">
-                  One daily ping with version, platform, and architecture. No personal data.{" "}
-                  <a
-                    href="https://nteract.io/docs/telemetry"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline hover:text-foreground"
-                  >
-                    Learn more
-                  </a>
-                </p>
-              </div>
+            {/* Telemetry decision: replaces the pre-checked toggle with an
+                explicit two-button CTA. The primary is a warm "you're in"
+                framing; the secondary is always visible so opting out stays
+                a one-click action. Both record consent. */}
+            <div className="space-y-3">
+              <TelemetryDisclosureCard onOpenLearnMore={openUrl} />
+
+              <Button
+                onClick={() => handleChoice(true)}
+                disabled={!canProceed || isSubmitting}
+                className="w-full"
+                size="lg"
+              >
+                {setupComplete
+                  ? "All set!"
+                  : canProceed
+                    ? "You can count on me!"
+                    : pythonEnv === null
+                      ? "Select a package manager"
+                      : "Setting up..."}
+              </Button>
+
               <button
                 type="button"
-                role="switch"
-                aria-checked={telemetryEnabled}
-                onClick={() => setTelemetryEnabled(!telemetryEnabled)}
-                className={cn(
-                  "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
-                  telemetryEnabled ? "bg-primary" : "bg-muted-foreground/30",
-                )}
+                onClick={() => handleChoice(false)}
+                disabled={!canProceed || isSubmitting}
+                className="w-full text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50 py-1"
               >
-                <span
-                  className={cn(
-                    "pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
-                    telemetryEnabled ? "translate-x-5" : "translate-x-0",
-                  )}
-                />
+                Opt out of metrics, continue
               </button>
             </div>
-
-            {/* Get Started button */}
-            <Button onClick={handleGetStarted} disabled={!canProceed} className="w-full" size="lg">
-              {setupComplete
-                ? "All set!"
-                : canProceed
-                  ? "Get Started"
-                  : pythonEnv === null
-                    ? "Select a package manager"
-                    : "Setting up..."}
-            </Button>
 
             {/* Continue anyway button when daemon fails */}
             {daemonFailed && !setupComplete && (

--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { AlertTriangle, ArrowLeft, Check, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
@@ -7,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "../src/components/icons";
-import { openUrl } from "../src/lib/open-url";
 import type { DaemonStatus } from "./types";
 
 type Runtime = "python" | "deno";
@@ -465,7 +465,14 @@ export default function App() {
                 framing; the secondary is always visible so opting out stays
                 a one-click action. Both record consent. */}
             <div className="space-y-3">
-              <TelemetryDisclosureCard onOpenLearnMore={openUrl} />
+              <TelemetryDisclosureCard
+                onOpenLearnMore={(url) => {
+                  openExternal(url).catch(() => {
+                    // Tauri shell unavailable — the href on the <a> is still
+                    // set, so the browser falls through to that.
+                  });
+                }}
+              />
 
               <Button
                 onClick={() => handleChoice(true)}

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/hooks/useSyncedSettings";
 import { cn } from "@/lib/utils";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "../src/components/icons";
+import { PrivacySection } from "./sections/Privacy";
 
 /** Format seconds into human-readable duration */
 function formatDuration(secs: number): string {
@@ -216,6 +217,13 @@ export default function App() {
     setKeepAliveSecs,
     featureFlags,
     setFeatureFlag,
+    telemetryEnabled,
+    setTelemetryEnabled,
+    installId,
+    rotateInstallId,
+    lastDaemonPingAt,
+    lastAppPingAt,
+    lastMcpPingAt,
   } = useSyncedSettings();
 
   return (
@@ -277,6 +285,16 @@ export default function App() {
             </div>
           </div>
         </div>
+
+        <PrivacySection
+          telemetryEnabled={telemetryEnabled}
+          onTelemetryChange={setTelemetryEnabled}
+          installId={installId}
+          onRotate={rotateInstallId}
+          lastDaemonPingAt={lastDaemonPingAt}
+          lastAppPingAt={lastAppPingAt}
+          lastMcpPingAt={lastMcpPingAt}
+        />
 
         {/* Default Runtime */}
         <div className="space-y-2">

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -1,0 +1,108 @@
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { useCallback, useState } from "react";
+import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+import { Switch } from "@/components/ui/switch";
+
+interface PrivacySectionProps {
+  telemetryEnabled: boolean;
+  onTelemetryChange: (value: boolean) => void;
+  installId: string;
+  onRotate: () => Promise<string | null>;
+  lastDaemonPingAt: number | null;
+  lastAppPingAt: number | null;
+  lastMcpPingAt: number | null;
+}
+
+const TELEMETRY_PAGE_URL = "https://nteract.io/telemetry";
+
+function formatRelative(secs: number | null): string {
+  if (secs === null) return "never";
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - secs;
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function openOrFallThrough(url: string) {
+  openExternal(url).catch(() => {
+    // Tauri shell unavailable; the calling <a> tag's href covers the
+    // non-Tauri case.
+  });
+}
+
+export function PrivacySection({
+  telemetryEnabled,
+  onTelemetryChange,
+  installId,
+  onRotate,
+  lastDaemonPingAt,
+  lastAppPingAt,
+  lastMcpPingAt,
+}: PrivacySectionProps) {
+  const [isRotating, setIsRotating] = useState(false);
+
+  const handleRotate = useCallback(async () => {
+    if (isRotating) return;
+    const ok = window.confirm(
+      "Rotate your install ID? This generates a new random identifier. " +
+        "Your old rows on the server become unlinkable and age out at 400 days.",
+    );
+    if (!ok) return;
+    setIsRotating(true);
+    try {
+      await onRotate();
+    } finally {
+      setIsRotating(false);
+    }
+  }, [isRotating, onRotate]);
+
+  return (
+    <div className="space-y-3">
+      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        Privacy
+      </span>
+
+      <TelemetryDisclosureCard
+        onOpenLearnMore={openOrFallThrough}
+        footer={
+          <div className="flex items-center justify-between pt-1">
+            <span className="text-xs text-muted-foreground">
+              Send anonymous daily ping
+            </span>
+            <Switch checked={telemetryEnabled} onCheckedChange={onTelemetryChange} />
+          </div>
+        }
+      />
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground shrink-0">Install ID</span>
+          <code
+            className="text-[11px] text-foreground truncate bg-muted/50 px-2 py-0.5 rounded"
+            title={installId}
+          >
+            {installId || "(not yet set)"}
+          </code>
+          <button
+            type="button"
+            onClick={handleRotate}
+            disabled={isRotating || !installId}
+            className="text-xs text-primary underline hover:text-foreground disabled:opacity-50"
+          >
+            {isRotating ? "Rotating..." : "Rotate"}
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">Last ping</span>
+          <span className="text-xs text-foreground tabular-nums">
+            app {formatRelative(lastAppPingAt)} · daemon{" "}
+            {formatRelative(lastDaemonPingAt)} · mcp {formatRelative(lastMcpPingAt)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -68,9 +68,7 @@ export function PrivacySection({
         onOpenLearnMore={openOrFallThrough}
         footer={
           <div className="flex items-center justify-between pt-1">
-            <span className="text-xs text-muted-foreground">
-              Send anonymous daily ping
-            </span>
+            <span className="text-xs text-muted-foreground">Send anonymous daily ping</span>
             <Switch checked={telemetryEnabled} onCheckedChange={onTelemetryChange} />
           </div>
         }
@@ -98,8 +96,8 @@ export function PrivacySection({
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">Last ping</span>
           <span className="text-xs text-foreground tabular-nums">
-            app {formatRelative(lastAppPingAt)} · daemon{" "}
-            {formatRelative(lastDaemonPingAt)} · mcp {formatRelative(lastMcpPingAt)}
+            app {formatRelative(lastAppPingAt)} · daemon {formatRelative(lastDaemonPingAt)} · mcp{" "}
+            {formatRelative(lastMcpPingAt)}
           </span>
         </div>
       </div>

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -2,9 +2,41 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { visualizer } from "rollup-plugin-visualizer";
-import { defineConfig } from "vite-plus";
+import { type Plugin, defineConfig } from "vite-plus";
 import { isolatedRendererPlugin } from "./vite-plugin-isolated-renderer";
 import { rawLibPlugin } from "./vite-plugin-raw-lib";
+
+/**
+ * Redirect missing-trailing-slash URLs for our multi-entry sub-apps to the
+ * canonical `/name/` form. Without this, Vite dev falls back to the SPA
+ * fallback which serves `index.html` (the main notebook app) — that entry
+ * wires up a Tauri transport and throws when loaded standalone in a browser.
+ *
+ * Production static hosts (Cloudflare Pages, nginx with `try_files`, etc.)
+ * do this automatically; this middleware plugs the gap for `pnpm dev`.
+ */
+function subAppTrailingSlashRedirect(names: string[]): Plugin {
+  return {
+    name: "sub-app-trailing-slash-redirect",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? "";
+        // Strip any query / hash before matching.
+        const pathOnly = url.split(/[?#]/, 1)[0];
+        for (const name of names) {
+          if (pathOnly === `/${name}`) {
+            res.statusCode = 301;
+            const suffix = url.slice(pathOnly.length);
+            res.setHeader("Location", `/${name}/${suffix}`);
+            res.end();
+            return;
+          }
+        }
+        next();
+      });
+    },
+  };
+}
 
 export default defineConfig(() => {
   const debugBundleSourceMapsEnabled = process.env.RUNT_NOTEBOOK_DEBUG_BUILD === "1";
@@ -15,6 +47,13 @@ export default defineConfig(() => {
       tailwindcss(),
       rawLibPlugin(path.resolve(__dirname, "../../node_modules")),
       isolatedRendererPlugin(),
+      subAppTrailingSlashRedirect([
+        "onboarding",
+        "settings",
+        "feedback",
+        "upgrade",
+        "gallery",
+      ]),
       visualizer({
         filename: "dist/stats.html",
         open: false,

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(() => {
           upgrade: path.resolve(__dirname, "upgrade/index.html"),
           settings: path.resolve(__dirname, "settings/index.html"),
           feedback: path.resolve(__dirname, "feedback/index.html"),
+          gallery: path.resolve(__dirname, "gallery/index.html"),
         },
         output: {
           entryFileNames: "assets/[name]-[hash].js",

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -47,13 +47,7 @@ export default defineConfig(() => {
       tailwindcss(),
       rawLibPlugin(path.resolve(__dirname, "../../node_modules")),
       isolatedRendererPlugin(),
-      subAppTrailingSlashRedirect([
-        "onboarding",
-        "settings",
-        "feedback",
-        "upgrade",
-        "gallery",
-      ]),
+      subAppTrailingSlashRedirect(["onboarding", "settings", "feedback", "upgrade", "gallery"]),
       visualizer({
         filename: "dist/stats.html",
         open: false,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3335,6 +3335,46 @@ async fn set_synced_setting(key: String, value: serde_json::Value) -> Result<(),
     Ok(())
 }
 
+/// Rotate the install ID to a fresh UUIDv4 and clear all three
+/// `last_ping_at` markers. Used by Settings → Privacy for user-initiated
+/// identity reset.
+///
+/// Returns the new install ID so the UI can display it without another
+/// round-trip. The four fields are written as separate put_value calls;
+/// the sync client is serial per connection so the daemon does not
+/// interleave puts within a single client session.
+#[tauri::command]
+async fn rotate_install_id() -> Result<String, String> {
+    let socket_path = runt_workspace::default_socket_path();
+    let mut client = runtimed::sync_client::SyncClient::connect_with_timeout(
+        socket_path,
+        std::time::Duration::from_millis(500),
+    )
+    .await
+    .map_err(|e| format!("Daemon unavailable: {}. Install ID not rotated.", e))?;
+
+    let new_id = uuid::Uuid::new_v4().to_string();
+
+    client
+        .put_value("install_id", &serde_json::Value::String(new_id.clone()))
+        .await
+        .map_err(|e| format!("sync error (install_id): {}", e))?;
+    client
+        .put_value("telemetry_last_daemon_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (daemon marker): {}", e))?;
+    client
+        .put_value("telemetry_last_app_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (app marker): {}", e))?;
+    client
+        .put_value("telemetry_last_mcp_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (mcp marker): {}", e))?;
+
+    Ok(new_id)
+}
+
 /// Open the settings window.
 ///
 /// Uses singleton pattern - focuses existing window if present, otherwise creates new one.
@@ -4194,6 +4234,8 @@ pub fn run(
             open_settings_window,
             // Onboarding
             complete_onboarding,
+            // Privacy / telemetry
+            rotate_install_id,
             // Debug info
             get_git_info,
             get_daemon_info,

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -115,6 +115,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("telemetry_enabled")
             .and_then(|v| v.as_bool())
             .unwrap_or(true),
+        telemetry_consent_recorded: json
+            .get("telemetry_consent_recorded")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
         telemetry_last_daemon_ping_at: json
             .get("telemetry_last_daemon_ping_at")
             .and_then(|v| v.as_u64()),

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -4408,6 +4408,14 @@ async fn telemetry_command(command: TelemetryCommands, settings_path: &Path) -> 
                     "disabled"
                 }
             );
+            println!(
+                "Consent recorded: {}",
+                if settings.telemetry_consent_recorded {
+                    "yes"
+                } else {
+                    "no (no pings until user records a decision)"
+                }
+            );
 
             if settings.install_id.is_empty() {
                 println!("Install ID: (not yet generated)");
@@ -4444,9 +4452,10 @@ async fn telemetry_command(command: TelemetryCommands, settings_path: &Path) -> 
                 format_ping(settings.telemetry_last_mcp_ping_at, now)
             );
 
-            let gates = runtimed_client::telemetry::blocking_gates(
+            let gates = runtimed_client::telemetry::blocking_gates_full(
                 settings.telemetry_enabled,
                 settings.onboarding_completed,
+                settings.telemetry_consent_recorded,
                 None, // show env-level gates, not per-source throttle
                 now,
             );

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -259,6 +259,14 @@ pub struct SyncedSettings {
     #[serde(default = "default_telemetry_enabled")]
     pub telemetry_enabled: bool,
 
+    /// Whether the user has explicitly recorded a telemetry decision (pressed
+    /// either the "You can count on me!" or "Opt out of metrics, continue"
+    /// button during onboarding). Default false. Until this is true, no
+    /// heartbeat fires, even when `telemetry_enabled = true`. Satisfies the
+    /// GDPR "clear affirmative action" requirement.
+    #[serde(default)]
+    pub telemetry_consent_recorded: bool,
+
     /// Unix-seconds timestamp of the last successful daemon heartbeat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry_last_daemon_ping_at: Option<u64>,
@@ -299,6 +307,7 @@ impl Default for SyncedSettings {
             bootstrap_dx: false,
             install_id: String::new(),
             telemetry_enabled: true,
+            telemetry_consent_recorded: false,
             telemetry_last_daemon_ping_at: None,
             telemetry_last_app_ping_at: None,
             telemetry_last_mcp_ping_at: None,
@@ -321,6 +330,18 @@ fn default_conda_pool_size() -> u64 {
 }
 fn default_pixi_pool_size() -> u64 {
     DEFAULT_PIXI_POOL_SIZE
+}
+
+/// Backfill `telemetry_consent_recorded` for installations that completed
+/// onboarding before the consent flag existed. Without this, all existing
+/// users would look like they had never consented, and their heartbeats
+/// would stop at the next app launch.
+///
+/// Called once on daemon startup. Idempotent.
+pub fn backfill_telemetry_consent(settings: &mut SyncedSettings) {
+    if !settings.telemetry_consent_recorded && settings.onboarding_completed {
+        settings.telemetry_consent_recorded = true;
+    }
 }
 
 /// Ensure an `install_id` exists in the settings doc, generating one if needed.
@@ -410,6 +431,7 @@ impl SettingsDoc {
         // Telemetry defaults (install_id left empty until first heartbeat)
         let _ = doc.put(automerge::ROOT, "install_id", "");
         let _ = doc.put(automerge::ROOT, "telemetry_enabled", true);
+        let _ = doc.put(automerge::ROOT, "telemetry_consent_recorded", false);
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -520,6 +542,12 @@ impl SettingsDoc {
         }
         if let Some(enabled) = json.get("telemetry_enabled").and_then(|v| v.as_bool()) {
             settings.put_bool("telemetry_enabled", enabled);
+        }
+        if let Some(recorded) = json
+            .get("telemetry_consent_recorded")
+            .and_then(|v| v.as_bool())
+        {
+            settings.put_bool("telemetry_consent_recorded", recorded);
         }
         if let Some(ts) = json
             .get("telemetry_last_daemon_ping_at")
@@ -941,6 +969,9 @@ impl SettingsDoc {
                 .unwrap_or(defaults.bootstrap_dx),
             install_id: self.get("install_id").unwrap_or_default(),
             telemetry_enabled: self.get_bool("telemetry_enabled").unwrap_or(true),
+            telemetry_consent_recorded: self
+                .get_bool("telemetry_consent_recorded")
+                .unwrap_or(false),
             telemetry_last_daemon_ping_at: self.get_u64("telemetry_last_daemon_ping_at"),
             telemetry_last_app_ping_at: self.get_u64("telemetry_last_app_ping_at"),
             telemetry_last_mcp_ping_at: self.get_u64("telemetry_last_mcp_ping_at"),
@@ -1089,6 +1120,15 @@ impl SettingsDoc {
         if let Some(enabled) = json.get("telemetry_enabled").and_then(|v| v.as_bool()) {
             if self.get_bool("telemetry_enabled") != Some(enabled) {
                 self.put_bool("telemetry_enabled", enabled);
+                changed = true;
+            }
+        }
+        if let Some(recorded) = json
+            .get("telemetry_consent_recorded")
+            .and_then(|v| v.as_bool())
+        {
+            if self.get_bool("telemetry_consent_recorded") != Some(recorded) {
+                self.put_bool("telemetry_consent_recorded", recorded);
                 changed = true;
             }
         }

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -357,6 +357,27 @@ pub fn ensure_install_id(settings: &mut SettingsDoc) -> String {
     id
 }
 
+/// Doc-level variant of [`backfill_telemetry_consent`] for callers that hold
+/// a `SettingsDoc` (e.g. the daemon at startup) rather than a fully
+/// materialized `SyncedSettings`. Returns `true` if the flag was flipped so
+/// the caller can choose to persist immediately.
+///
+/// Idempotent: safe to call on every startup.
+pub fn backfill_telemetry_consent_in_doc(settings: &mut SettingsDoc) -> bool {
+    let already_recorded = settings
+        .get_bool("telemetry_consent_recorded")
+        .unwrap_or(false);
+    if already_recorded {
+        return false;
+    }
+    let onboarded = settings.get_bool("onboarding_completed").unwrap_or(false);
+    if !onboarded {
+        return false;
+    }
+    settings.put_bool("telemetry_consent_recorded", true);
+    true
+}
+
 /// Generate a JSON Schema string for the settings file.
 pub fn generate_settings_schema() -> Result<String, serde_json::Error> {
     let schema = schemars::schema_for!(SyncedSettings);
@@ -1222,6 +1243,47 @@ mod tests {
         assert_eq!(settings.default_python_env, PythonEnvType::Uv);
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
+    }
+
+    #[test]
+    fn test_backfill_telemetry_consent_flips_for_onboarded_users() {
+        let mut s = SyncedSettings::default();
+        s.onboarding_completed = true;
+        s.telemetry_consent_recorded = false;
+        backfill_telemetry_consent(&mut s);
+        assert!(s.telemetry_consent_recorded);
+    }
+
+    #[test]
+    fn test_backfill_telemetry_consent_noop_for_fresh_installs() {
+        let mut s = SyncedSettings::default();
+        // onboarding_completed defaults to false
+        backfill_telemetry_consent(&mut s);
+        assert!(!s.telemetry_consent_recorded);
+    }
+
+    #[test]
+    fn test_backfill_telemetry_consent_in_doc_flips_once() {
+        let mut doc = SettingsDoc::new();
+        doc.put_bool("onboarding_completed", true);
+        // Default: consent_recorded is false
+        assert!(!doc.get_bool("telemetry_consent_recorded").unwrap_or(false));
+
+        // First call flips it and returns true
+        assert!(backfill_telemetry_consent_in_doc(&mut doc));
+        assert!(doc.get_bool("telemetry_consent_recorded").unwrap_or(false));
+
+        // Second call is a no-op and returns false
+        assert!(!backfill_telemetry_consent_in_doc(&mut doc));
+    }
+
+    #[test]
+    fn test_backfill_telemetry_consent_in_doc_noop_for_fresh_installs() {
+        let mut doc = SettingsDoc::new();
+        // onboarding_completed is false in a fresh doc; backfill must not
+        // synthesize consent that was never given.
+        assert!(!backfill_telemetry_consent_in_doc(&mut doc));
+        assert!(!doc.get_bool("telemetry_consent_recorded").unwrap_or(false));
     }
 
     #[test]

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1247,9 +1247,11 @@ mod tests {
 
     #[test]
     fn test_backfill_telemetry_consent_flips_for_onboarded_users() {
-        let mut s = SyncedSettings::default();
-        s.onboarding_completed = true;
-        s.telemetry_consent_recorded = false;
+        let mut s = SyncedSettings {
+            onboarding_completed: true,
+            telemetry_consent_recorded: false,
+            ..Default::default()
+        };
         backfill_telemetry_consent(&mut s);
         assert!(s.telemetry_consent_recorded);
     }

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -454,6 +454,7 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
         install_id: get_str("install_id").unwrap_or_default(),
         telemetry_enabled: get_bool("telemetry_enabled").unwrap_or(true),
+        telemetry_consent_recorded: get_bool("telemetry_consent_recorded").unwrap_or(false),
         telemetry_last_daemon_ping_at: get_u64("telemetry_last_daemon_ping_at"),
         telemetry_last_app_ping_at: get_u64("telemetry_last_app_ping_at"),
         telemetry_last_mcp_ping_at: get_u64("telemetry_last_mcp_ping_at"),

--- a/crates/runtimed-client/src/telemetry.rs
+++ b/crates/runtimed-client/src/telemetry.rs
@@ -451,11 +451,13 @@ mod tests {
     #[test]
     fn test_rotate_install_id_changes_id_and_clears_markers() {
         use crate::settings_doc::SyncedSettings;
-        let mut s = SyncedSettings::default();
-        s.install_id = "abc".to_string();
-        s.telemetry_last_daemon_ping_at = Some(111);
-        s.telemetry_last_app_ping_at = Some(222);
-        s.telemetry_last_mcp_ping_at = Some(333);
+        let mut s = SyncedSettings {
+            install_id: "abc".to_string(),
+            telemetry_last_daemon_ping_at: Some(111),
+            telemetry_last_app_ping_at: Some(222),
+            telemetry_last_mcp_ping_at: Some(333),
+            ..Default::default()
+        };
 
         let new_id = rotate_install_id_in(&mut s);
 

--- a/crates/runtimed-client/src/telemetry.rs
+++ b/crates/runtimed-client/src/telemetry.rs
@@ -58,6 +58,30 @@ pub fn is_telemetry_suppressed() -> bool {
     false
 }
 
+/// Superset of [`should_send`] that also requires explicit user consent.
+///
+/// Returns true only when the consent-recorded flag is set AND every other
+/// gate in `should_send` passes. This is the gate `try_send` actually uses;
+/// `should_send` is preserved as a thin API for callers that don't carry
+/// the consent flag yet.
+pub fn should_send_full(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    consent_recorded: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> bool {
+    if !consent_recorded {
+        return false;
+    }
+    should_send(
+        telemetry_enabled,
+        onboarding_completed,
+        last_ping_at,
+        now_secs,
+    )
+}
+
 pub fn should_send(
     telemetry_enabled: bool,
     onboarding_completed: bool,
@@ -79,6 +103,27 @@ pub fn should_send(
         }
     }
     true
+}
+
+/// Superset of [`blocking_gates`] that also reports a "consent not recorded"
+/// gate when the user has not yet pressed an onboarding CTA.
+pub fn blocking_gates_full(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    consent_recorded: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> Vec<&'static str> {
+    let mut gates = blocking_gates(
+        telemetry_enabled,
+        onboarding_completed,
+        last_ping_at,
+        now_secs,
+    );
+    if !consent_recorded {
+        gates.push("consent not recorded");
+    }
+    gates
 }
 
 pub fn blocking_gates(
@@ -200,9 +245,10 @@ async fn try_send(client: &reqwest::Client, source: &str, timestamp_key: &str) {
         _ => None,
     };
 
-    if !should_send(
+    if !should_send_full(
         settings.telemetry_enabled,
         settings.onboarding_completed,
+        settings.telemetry_consent_recorded,
         last_ping_at,
         now,
     ) {
@@ -367,5 +413,22 @@ mod tests {
         let recent = now - (10 * 60 * 60);
         let gates = blocking_gates(true, true, Some(recent), now);
         assert!(gates.contains(&"throttled (last ping < 20h ago)"));
+    }
+
+    #[test]
+    fn test_should_send_requires_consent_recorded() {
+        // Everything green except consent_recorded = false.
+        assert!(!should_send_full(true, true, false, None, 1000));
+    }
+
+    #[test]
+    fn test_should_send_with_all_true() {
+        assert!(should_send_full(true, true, true, None, 1000));
+    }
+
+    #[test]
+    fn test_blocking_gates_consent_not_recorded() {
+        let gates = blocking_gates_full(true, true, false, None, 1000);
+        assert!(gates.contains(&"consent not recorded"));
     }
 }

--- a/crates/runtimed-client/src/telemetry.rs
+++ b/crates/runtimed-client/src/telemetry.rs
@@ -318,6 +318,22 @@ async fn write_setting(key: &str, value: &serde_json::Value) {
     }
 }
 
+/// Rotate the install ID to a fresh UUIDv4 and clear all three
+/// `last_sent_at` markers on the provided settings. Callers persist the
+/// mutated settings via the daemon sync client.
+///
+/// Clearing the markers prevents the 20-hour throttle from silently
+/// suppressing the first ping under the new ID. The 60 req/min rate
+/// limit at the Cloudflare edge is the defense against rotation abuse.
+pub fn rotate_install_id_in(settings: &mut crate::settings_doc::SyncedSettings) -> String {
+    let new_id = uuid::Uuid::new_v4().to_string();
+    settings.install_id = new_id.clone();
+    settings.telemetry_last_daemon_ping_at = None;
+    settings.telemetry_last_app_ping_at = None;
+    settings.telemetry_last_mcp_ping_at = None;
+    new_id
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -430,5 +446,24 @@ mod tests {
     fn test_blocking_gates_consent_not_recorded() {
         let gates = blocking_gates_full(true, true, false, None, 1000);
         assert!(gates.contains(&"consent not recorded"));
+    }
+
+    #[test]
+    fn test_rotate_install_id_changes_id_and_clears_markers() {
+        use crate::settings_doc::SyncedSettings;
+        let mut s = SyncedSettings::default();
+        s.install_id = "abc".to_string();
+        s.telemetry_last_daemon_ping_at = Some(111);
+        s.telemetry_last_app_ping_at = Some(222);
+        s.telemetry_last_mcp_ping_at = Some(333);
+
+        let new_id = rotate_install_id_in(&mut s);
+
+        assert_ne!(new_id, "abc");
+        assert_eq!(s.install_id, new_id);
+        assert!(uuid::Uuid::parse_str(&new_id).is_ok());
+        assert_eq!(s.telemetry_last_daemon_ping_at, None);
+        assert_eq!(s.telemetry_last_app_ping_at, None);
+        assert_eq!(s.telemetry_last_mcp_ping_at, None);
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -717,10 +717,26 @@ impl Daemon {
         // in — that would silently stop their heartbeats. No-op for fresh
         // installs (onboarding_completed = false) and idempotent across
         // restarts.
+        //
+        // Write both the Automerge doc and the JSON mirror immediately when
+        // the flag flips. Otherwise the change only persists if a settings
+        // client happens to connect and trigger `persist_settings` in
+        // `sync_server.rs` — a daemon that boots, runs briefly with no
+        // settings-window interaction, and exits would drop the backfill.
         if crate::settings_doc::backfill_telemetry_consent_in_doc(&mut settings) {
             tracing::info!(
                 "[settings] Backfilled telemetry_consent_recorded for an existing onboarded install"
             );
+            let automerge_path = crate::default_settings_doc_path();
+            if let Err(e) = settings.save_to_file(&automerge_path) {
+                tracing::warn!(
+                    "[settings] Failed to persist backfilled Automerge doc: {}",
+                    e
+                );
+            }
+            if let Err(e) = settings.save_json_mirror(&json_path) {
+                tracing::warn!("[settings] Failed to persist backfilled JSON mirror: {}", e);
+            }
         }
 
         // Write the settings JSON Schema for editor autocomplete

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -705,10 +705,23 @@ impl Daemon {
         // Load or create the settings document
         let automerge_path = crate::default_settings_doc_path();
         let json_path = crate::settings_json_path();
-        let settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        let mut settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
 
         // Pool sizes now come from settings.json (imported via apply_json_changes)
         // or from SettingsDoc defaults if not set in JSON.
+
+        // Backfill telemetry consent for existing users. Pre-refactor, every
+        // finished-onboarding installation implicitly consented to telemetry
+        // (the toggle was pre-checked). Users who've been running the app
+        // before this change shouldn't suddenly look like they never opted
+        // in — that would silently stop their heartbeats. No-op for fresh
+        // installs (onboarding_completed = false) and idempotent across
+        // restarts.
+        if crate::settings_doc::backfill_telemetry_consent_in_doc(&mut settings) {
+            tracing::info!(
+                "[settings] Backfilled telemetry_consent_recorded for an existing onboarded install"
+            );
+        }
 
         // Write the settings JSON Schema for editor autocomplete
         if let Err(e) = crate::settings_doc::write_settings_schema() {

--- a/docs/superpowers/plans/2026-04-23-telemetry-desktop-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-telemetry-desktop-implementation.md
@@ -1,0 +1,1311 @@
+# Telemetry Desktop Touchpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the pre-checked telemetry toggle in onboarding with an explicit two-button choice at the end of the flow, add a Settings → Privacy pane so the decision is revisitable, introduce an `install_id` rotation primitive, and gate heartbeats behind a new `telemetry_consent_recorded` flag so no ping fires until the user has pressed one of the two buttons.
+
+**Architecture:** Add `telemetry_consent_recorded: bool` to the daemon's `SyncedSettings` struct and extend `should_send()` / `blocking_gates()` in `crates/runtimed-client/src/telemetry.rs` to require it. Backfill the flag from `onboarding_completed` so existing users keep implicit consent. Frontend-side: a new shared `TelemetryDisclosureCard` React component renders the "One anonymous daily ping" card, reused from both onboarding and Settings. Onboarding replaces its old toggle + single "Get Started" button with a disclosure card + primary "You can count on me!" + secondary "Opt out of metrics, continue" CTAs. A new `rotate_install_id` Tauri command writes a fresh UUIDv4 and clears all three `last_sent_at` markers in one atomic operation.
+
+**Tech Stack:** Rust (tokio, serde, ts-rs), React + TypeScript (Vite), Tauri, shadcn/Radix, Automerge sync client.
+
+**Repo:** `/Users/kylekelley/projects/desktop` (main branch)
+
+**Spec:** `docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md`
+
+**Assumes:** PR 1 from the nteract/telemetry repo is merged so the `/v1/install/:id` endpoint exists. PR 2 from nteract/nteract.io is live so `https://nteract.io/telemetry` resolves. These are external dependencies, not blockers for local development. If you're implementing this before those ship, the Learn more link on onboarding will 404 until they do.
+
+---
+
+## File Structure
+
+Files created:
+
+- `apps/notebook/src/components/TelemetryDisclosureCard.tsx`: shared disclosure card (eyebrow + body + Learn more link).
+- `apps/notebook/settings/sections/Privacy.tsx`: new Privacy section rendered inside the Settings window.
+- `apps/notebook/src/components/TelemetryDisclosureCard.test.tsx`: snapshot test.
+
+Files modified:
+
+- `crates/runtimed-client/src/settings_doc.rs`: add `telemetry_consent_recorded` field; update default + backfill migration.
+- `crates/runtimed-client/src/telemetry.rs`: extend `should_send()` and `blocking_gates()` to require `telemetry_consent_recorded`; add a `rotate_install_id_and_clear_markers` helper.
+- `src/bindings/SyncedSettings.ts`: regenerated, includes the new field.
+- `crates/notebook/src/lib.rs`: add `rotate_install_id` Tauri command; register it.
+- `apps/notebook/onboarding/App.tsx`: replace the toggle with the two-button CTA and shared disclosure card.
+- `src/hooks/useSyncedSettings.ts`: expose `telemetryEnabled`, `setTelemetryEnabled`, `installId`, `rotateInstallId`, `lastPingTimes` (for the Privacy pane).
+- `apps/notebook/settings/App.tsx`: render the new Privacy section between Appearance and New Notebooks.
+- `crates/runt/src/main.rs`: extend `runt config telemetry status` output to surface `telemetry_consent_recorded` (so the CLI matches the GUI).
+- `docs/telemetry.md`: slim to a developer-facing readme that points at `https://nteract.io/telemetry`.
+
+Each frontend file has one clear responsibility. The Settings sections directory is new (`apps/notebook/settings/sections/`); follow-up privacy-adjacent sections (future erase button, audit export, etc.) slot in here too.
+
+---
+
+## Task 1: Add telemetry_consent_recorded to SyncedSettings
+
+**Files:**
+- Modify: `crates/runtimed-client/src/settings_doc.rs`
+
+This is the gate that makes the new onboarding UX work. The default is `false`, meaning a fresh install *cannot* emit a heartbeat until the user has pressed one of the onboarding buttons.
+
+- [ ] **Step 1: Add the field to the struct**
+
+Find the telemetry block near the end of `SyncedSettings` (right below `install_id`) and add the new field:
+
+```rust
+    /// Opaque per-install UUIDv4. Generated on first heartbeat, persisted in
+    /// settings. Not derived from any identifying data.
+    #[serde(default)]
+    pub install_id: String,
+
+    /// Master telemetry switch. When false, no heartbeat pings are sent.
+    #[serde(default = "default_telemetry_enabled")]
+    pub telemetry_enabled: bool,
+
+    /// Whether the user has explicitly recorded a telemetry decision (pressed
+    /// either the "You can count on me!" or "Opt out of metrics, continue"
+    /// button during onboarding). Default false. Until this is true, no
+    /// heartbeat fires, even when `telemetry_enabled = true`. Satisfies the
+    /// GDPR "clear affirmative action" requirement.
+    #[serde(default)]
+    pub telemetry_consent_recorded: bool,
+```
+
+- [ ] **Step 2: Update `Default`**
+
+In `impl Default for SyncedSettings`, add the new field after `telemetry_enabled`:
+
+```rust
+            install_id: String::new(),
+            telemetry_enabled: true,
+            telemetry_consent_recorded: false,
+            telemetry_last_daemon_ping_at: None,
+```
+
+- [ ] **Step 3: Backfill migration for existing users**
+
+Add a function near the bottom of the file:
+
+```rust
+/// Backfill `telemetry_consent_recorded` for installations that completed
+/// onboarding before the consent flag existed. Without this, all existing
+/// users would look like they had never consented, and their heartbeats
+/// would stop at the next app launch.
+///
+/// Called once on daemon startup. Idempotent.
+pub fn backfill_telemetry_consent(settings: &mut SyncedSettings) {
+    if !settings.telemetry_consent_recorded && settings.onboarding_completed {
+        settings.telemetry_consent_recorded = true;
+    }
+}
+```
+
+- [ ] **Step 4: Run cargo check**
+
+```bash
+cargo check -p runtimed-client
+```
+
+Expected: success, no warnings.
+
+- [ ] **Step 5: Regenerate TypeScript bindings**
+
+```bash
+cargo test -p runtimed-client --features ts-bindings
+```
+
+Expected: success. Verify `src/bindings/SyncedSettings.ts` now contains `telemetry_consent_recorded: boolean`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/runtimed-client/src/settings_doc.rs src/bindings/SyncedSettings.ts
+git commit -m "feat(settings): add telemetry_consent_recorded field with backfill"
+```
+
+---
+
+## Task 2: Gate heartbeats behind the consent flag (TDD)
+
+**Files:**
+- Modify: `crates/runtimed-client/src/telemetry.rs`
+
+The goal is: `should_send()` returns `false` when `telemetry_consent_recorded = false`, even if everything else is green.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `mod tests` block in `crates/runtimed-client/src/telemetry.rs`:
+
+```rust
+    #[test]
+    fn test_should_send_requires_consent_recorded() {
+        // Everything green except consent_recorded = false.
+        assert!(!should_send_full(true, true, false, None, 1000));
+    }
+
+    #[test]
+    fn test_should_send_with_all_true() {
+        assert!(should_send_full(true, true, true, None, 1000));
+    }
+
+    #[test]
+    fn test_blocking_gates_consent_not_recorded() {
+        let gates = blocking_gates_full(true, true, false, None, 1000);
+        assert!(gates.contains(&"consent not recorded"));
+    }
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+cargo test -p runtimed-client telemetry::tests::test_should_send_requires_consent_recorded telemetry::tests::test_should_send_with_all_true telemetry::tests::test_blocking_gates_consent_not_recorded
+```
+
+Expected: compile error ("cannot find function `should_send_full`" etc.).
+
+- [ ] **Step 3: Add the new signatures, keep the old ones as thin wrappers**
+
+Above the existing `should_send`:
+
+```rust
+pub fn should_send_full(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    consent_recorded: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> bool {
+    if !consent_recorded {
+        return false;
+    }
+    should_send(telemetry_enabled, onboarding_completed, last_ping_at, now_secs)
+}
+
+pub fn blocking_gates_full(
+    telemetry_enabled: bool,
+    onboarding_completed: bool,
+    consent_recorded: bool,
+    last_ping_at: Option<u64>,
+    now_secs: u64,
+) -> Vec<&'static str> {
+    let mut gates = blocking_gates(telemetry_enabled, onboarding_completed, last_ping_at, now_secs);
+    if !consent_recorded {
+        gates.push("consent not recorded");
+    }
+    gates
+}
+```
+
+Rationale: keeping `should_send` / `blocking_gates` unchanged avoids a cascade of caller updates. The `_full` variants are what `try_send` calls.
+
+- [ ] **Step 4: Update `try_send` to use `should_send_full`**
+
+Change:
+
+```rust
+    if !should_send(
+        settings.telemetry_enabled,
+        settings.onboarding_completed,
+        last_ping_at,
+        now,
+    ) {
+        return;
+    }
+```
+
+To:
+
+```rust
+    if !should_send_full(
+        settings.telemetry_enabled,
+        settings.onboarding_completed,
+        settings.telemetry_consent_recorded,
+        last_ping_at,
+        now,
+    ) {
+        return;
+    }
+```
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+```bash
+cargo test -p runtimed-client telemetry::tests
+```
+
+Expected: PASS, including existing tests (which exercise the old `should_send` unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/runtimed-client/src/telemetry.rs
+git commit -m "feat(telemetry): gate heartbeats behind telemetry_consent_recorded"
+```
+
+---
+
+## Task 3: Add rotate_install_id_and_clear_markers helper (TDD)
+
+**Files:**
+- Modify: `crates/runtimed-client/src/telemetry.rs`
+
+This is the Rust side of the install-ID rotation. It takes a mutable settings doc, rotates the ID, and clears the three `last_sent_at` timestamps. Pure function so it's testable without a daemon.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+    use crate::settings_doc::SyncedSettings;
+
+    #[test]
+    fn test_rotate_install_id_changes_id_and_clears_markers() {
+        let mut s = SyncedSettings::default();
+        s.install_id = "abc".to_string();
+        s.telemetry_last_daemon_ping_at = Some(111);
+        s.telemetry_last_app_ping_at = Some(222);
+        s.telemetry_last_mcp_ping_at = Some(333);
+
+        let new_id = rotate_install_id_in(&mut s);
+
+        assert_ne!(new_id, "abc");
+        assert_eq!(s.install_id, new_id);
+        assert!(uuid::Uuid::parse_str(&new_id).is_ok());
+        assert_eq!(s.telemetry_last_daemon_ping_at, None);
+        assert_eq!(s.telemetry_last_app_ping_at, None);
+        assert_eq!(s.telemetry_last_mcp_ping_at, None);
+    }
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cargo test -p runtimed-client telemetry::tests::test_rotate_install_id_changes_id_and_clears_markers
+```
+
+Expected: compile error ("cannot find function `rotate_install_id_in`").
+
+- [ ] **Step 3: Implement the helper**
+
+Add above `mod tests`:
+
+```rust
+/// Rotate the install ID to a fresh UUIDv4 and clear all three `last_sent_at`
+/// markers. Callers persist the mutated settings via the daemon sync client.
+///
+/// Clearing markers prevents the 20-hour throttle from silently suppressing
+/// the first ping under the new ID. The 60 req/min rate limit at the
+/// Cloudflare edge is the defense against rotation abuse.
+pub fn rotate_install_id_in(settings: &mut crate::settings_doc::SyncedSettings) -> String {
+    let new_id = uuid::Uuid::new_v4().to_string();
+    settings.install_id = new_id.clone();
+    settings.telemetry_last_daemon_ping_at = None;
+    settings.telemetry_last_app_ping_at = None;
+    settings.telemetry_last_mcp_ping_at = None;
+    new_id
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+cargo test -p runtimed-client telemetry::tests::test_rotate_install_id_changes_id_and_clears_markers
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/runtimed-client/src/telemetry.rs
+git commit -m "feat(telemetry): add rotate_install_id_in helper"
+```
+
+---
+
+## Task 4: Add rotate_install_id Tauri command
+
+**Files:**
+- Modify: `crates/notebook/src/lib.rs`
+
+The frontend invokes this. The command reads current settings from the daemon, calls `rotate_install_id_in`, and writes the four modified fields back.
+
+- [ ] **Step 1: Locate the existing `set_synced_setting` command**
+
+Find `async fn set_synced_setting(...)` (around line 3321). The new command goes right below it.
+
+- [ ] **Step 2: Add the new command**
+
+```rust
+/// Rotate the install ID to a fresh UUIDv4 and clear all three `last_sent_at`
+/// markers. Used by the Privacy pane for user-initiated identity reset.
+///
+/// Returns the new install ID so the UI can display it without another round-trip.
+#[tauri::command]
+async fn rotate_install_id() -> Result<String, String> {
+    let socket_path = runt_workspace::default_socket_path();
+    let mut client = runtimed::sync_client::SyncClient::connect_with_timeout(
+        socket_path,
+        std::time::Duration::from_millis(500),
+    )
+    .await
+    .map_err(|e| format!("Daemon unavailable: {}. Install ID not rotated.", e))?;
+
+    let new_id = uuid::Uuid::new_v4().to_string();
+
+    // Write the four fields atomically as separate put_value calls. The sync
+    // client is serial per connection, and the daemon does not interleave
+    // puts within a single client session.
+    client
+        .put_value(
+            "install_id",
+            &serde_json::Value::String(new_id.clone()),
+        )
+        .await
+        .map_err(|e| format!("sync error (install_id): {}", e))?;
+    client
+        .put_value("telemetry_last_daemon_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (daemon marker): {}", e))?;
+    client
+        .put_value("telemetry_last_app_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (app marker): {}", e))?;
+    client
+        .put_value("telemetry_last_mcp_ping_at", &serde_json::Value::Null)
+        .await
+        .map_err(|e| format!("sync error (mcp marker): {}", e))?;
+
+    Ok(new_id)
+}
+```
+
+- [ ] **Step 3: Register the command in the Tauri builder**
+
+Find the existing `.invoke_handler(tauri::generate_handler![` list (search for `complete_onboarding,`). Add `rotate_install_id,` next to it:
+
+```rust
+            complete_onboarding,
+            rotate_install_id,
+```
+
+- [ ] **Step 4: Build to verify**
+
+```bash
+cargo build -p notebook
+```
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/notebook/src/lib.rs
+git commit -m "feat(tauri): add rotate_install_id command"
+```
+
+---
+
+## Task 5: Extend useSyncedSettings with telemetry fields
+
+**Files:**
+- Modify: `src/hooks/useSyncedSettings.ts`
+
+Expose the telemetry settings the Privacy pane and onboarding need.
+
+- [ ] **Step 1: Add state hooks inside `useSyncedSettings`**
+
+Find the existing state declarations near the top of the hook (around the `keepAliveSecs` declaration). Below them, add:
+
+```ts
+  const [telemetryEnabled, setTelemetryEnabledState] = useState<boolean>(true);
+  const [telemetryConsentRecorded, setTelemetryConsentRecordedState] =
+    useState<boolean>(false);
+  const [installId, setInstallIdState] = useState<string>("");
+  const [lastDaemonPingAt, setLastDaemonPingAtState] = useState<number | null>(
+    null,
+  );
+  const [lastAppPingAt, setLastAppPingAtState] = useState<number | null>(null);
+  const [lastMcpPingAt, setLastMcpPingAtState] = useState<number | null>(null);
+```
+
+- [ ] **Step 2: Read them from the daemon on mount**
+
+Find the `invoke<SyncedSettings>("get_synced_settings").then((settings) => { ... })` block. Add these reads inside the `.then` callback, after the existing block:
+
+```ts
+        if (typeof settings.telemetry_enabled === "boolean") {
+          setTelemetryEnabledState(settings.telemetry_enabled);
+        }
+        if (typeof settings.telemetry_consent_recorded === "boolean") {
+          setTelemetryConsentRecordedState(settings.telemetry_consent_recorded);
+        }
+        if (typeof settings.install_id === "string") {
+          setInstallIdState(settings.install_id);
+        }
+        if (typeof settings.telemetry_last_daemon_ping_at === "number") {
+          setLastDaemonPingAtState(settings.telemetry_last_daemon_ping_at);
+        } else if (typeof settings.telemetry_last_daemon_ping_at === "bigint") {
+          setLastDaemonPingAtState(Number(settings.telemetry_last_daemon_ping_at));
+        }
+        if (typeof settings.telemetry_last_app_ping_at === "number") {
+          setLastAppPingAtState(settings.telemetry_last_app_ping_at);
+        } else if (typeof settings.telemetry_last_app_ping_at === "bigint") {
+          setLastAppPingAtState(Number(settings.telemetry_last_app_ping_at));
+        }
+        if (typeof settings.telemetry_last_mcp_ping_at === "number") {
+          setLastMcpPingAtState(settings.telemetry_last_mcp_ping_at);
+        } else if (typeof settings.telemetry_last_mcp_ping_at === "bigint") {
+          setLastMcpPingAtState(Number(settings.telemetry_last_mcp_ping_at));
+        }
+```
+
+- [ ] **Step 3: Mirror the reads in the `settings:changed` listener**
+
+Find the `listen<SyncedSettings>("settings:changed", (event) => { ... })` block. After its existing reads, add:
+
+```ts
+      if (typeof event.payload.telemetry_enabled === "boolean") {
+        setTelemetryEnabledState(event.payload.telemetry_enabled);
+      }
+      if (typeof event.payload.telemetry_consent_recorded === "boolean") {
+        setTelemetryConsentRecordedState(event.payload.telemetry_consent_recorded);
+      }
+      if (typeof event.payload.install_id === "string") {
+        setInstallIdState(event.payload.install_id);
+      }
+```
+
+(Last-ping timestamps change rarely and are only fetched on mount; no listener wiring needed.)
+
+- [ ] **Step 4: Add the setters**
+
+Below the existing `setFeatureFlag` declaration, add:
+
+```ts
+  const setTelemetryEnabled = useCallback((value: boolean) => {
+    setTelemetryEnabledState(value);
+    invoke("set_synced_setting", {
+      key: "telemetry_enabled",
+      value,
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist telemetry_enabled:", e),
+    );
+  }, []);
+
+  const setTelemetryConsentRecorded = useCallback((value: boolean) => {
+    setTelemetryConsentRecordedState(value);
+    invoke("set_synced_setting", {
+      key: "telemetry_consent_recorded",
+      value,
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist telemetry_consent_recorded:", e),
+    );
+  }, []);
+
+  const rotateInstallId = useCallback(async (): Promise<string | null> => {
+    try {
+      const newId = await invoke<string>("rotate_install_id");
+      setInstallIdState(newId);
+      setLastDaemonPingAtState(null);
+      setLastAppPingAtState(null);
+      setLastMcpPingAtState(null);
+      return newId;
+    } catch (e) {
+      console.warn("[settings] Failed to rotate install_id:", e);
+      return null;
+    }
+  }, []);
+```
+
+- [ ] **Step 5: Expose the new fields from the return statement**
+
+Add these entries to the returned object (preserve the existing file's grouping of related fields together):
+
+```ts
+    telemetryEnabled,
+    setTelemetryEnabled,
+    telemetryConsentRecorded,
+    setTelemetryConsentRecorded,
+    installId,
+    rotateInstallId,
+    lastDaemonPingAt,
+    lastAppPingAt,
+    lastMcpPingAt,
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+cd apps/notebook && pnpm exec tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/useSyncedSettings.ts
+git commit -m "feat(hooks): expose telemetry state + rotateInstallId to UI"
+```
+
+---
+
+## Task 6: Build the shared TelemetryDisclosureCard component
+
+**Files:**
+- Create: `apps/notebook/src/components/TelemetryDisclosureCard.tsx`
+- Create: `apps/notebook/src/components/TelemetryDisclosureCard.test.tsx`
+
+The same card is rendered in both onboarding and the Settings Privacy pane. Copy lives once.
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TelemetryDisclosureCard } from "./TelemetryDisclosureCard";
+
+describe("TelemetryDisclosureCard", () => {
+  it("renders the eyebrow, body, and a Learn more link", () => {
+    render(<TelemetryDisclosureCard />);
+    expect(screen.getByText(/One anonymous daily ping/i)).toBeInTheDocument();
+    expect(screen.getByText(/Version, platform, architecture/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /read the full details/i });
+    expect(link).toHaveAttribute("href", "https://nteract.io/telemetry");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (expect failure because the component doesn't exist yet)**
+
+```bash
+cd apps/notebook && pnpm exec vitest run src/components/TelemetryDisclosureCard.test.tsx
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+import { open } from "@tauri-apps/plugin-shell";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface TelemetryDisclosureCardProps {
+  className?: string;
+  footer?: ReactNode;
+}
+
+/**
+ * One-source-of-truth disclosure card for telemetry.
+ *
+ * Rendered in:
+ *  - Onboarding (step 2, above the two consent buttons).
+ *  - Settings → Privacy (alongside the revisit toggle).
+ *
+ * The Learn more link opens https://nteract.io/telemetry in the system
+ * browser via Tauri's shell plugin. The page is the canonical place for
+ * "What is sent / never sent / retention / rights". This card only
+ * carries the minimum disclosure.
+ */
+export function TelemetryDisclosureCard({
+  className,
+  footer,
+}: TelemetryDisclosureCardProps) {
+  const handleOpenLearnMore = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    try {
+      await open("https://nteract.io/telemetry");
+    } catch {
+      // Tauri not available (unit test); href provides a fallback.
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-4 bg-muted/40 space-y-2",
+        className,
+      )}
+    >
+      <div className="text-[10px] uppercase tracking-[0.14em] text-primary/80 font-semibold">
+        One anonymous daily ping
+      </div>
+      <p className="text-sm text-foreground leading-6">
+        Version, platform, architecture. No names, no paths, nothing about your
+        notebooks.
+      </p>
+      <a
+        href="https://nteract.io/telemetry"
+        onClick={handleOpenLearnMore}
+        className="inline-block text-xs text-primary underline hover:text-foreground"
+      >
+        Read the full details
+      </a>
+      {footer ? <div className="pt-1">{footer}</div> : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test again**
+
+```bash
+cd apps/notebook && pnpm exec vitest run src/components/TelemetryDisclosureCard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/notebook/src/components/TelemetryDisclosureCard.tsx apps/notebook/src/components/TelemetryDisclosureCard.test.tsx
+git commit -m "feat(components): add shared TelemetryDisclosureCard"
+```
+
+---
+
+## Task 7: Rework the onboarding step to use the two-button CTA
+
+**Files:**
+- Modify: `apps/notebook/onboarding/App.tsx`
+
+Replace the pre-checked toggle + single "Get Started" button with a disclosure card + "You can count on me!" (primary) + "Opt out of metrics, continue" (secondary).
+
+- [ ] **Step 1: Remove the old toggle**
+
+Delete the `const [telemetryEnabled, setTelemetryEnabled] = useState(true);` line (around line 163).
+
+Delete the entire `{/* Telemetry disclosure */}` block (lines ~436–469), which renders the muted strip.
+
+Delete the old `{/* Get Started button */}` block (lines ~471–480).
+
+- [ ] **Step 2: Add a shared CTA handler**
+
+Near `handleGetStarted` (around line 280), add a new state:
+
+```tsx
+  const [isSubmitting, setIsSubmitting] = useState(false);
+```
+
+Rename `handleGetStarted` to `handleChoice` and have it accept a `telemetryEnabled` argument:
+
+```tsx
+  // Save settings + consent, then complete onboarding.
+  const handleChoice = useCallback(
+    async (telemetryEnabled: boolean) => {
+      if (!runtime || !pythonEnv) return;
+      if (!daemonReady || !poolReady) return;
+      if (isSubmitting) return;
+      setIsSubmitting(true);
+
+      try {
+        await invoke("set_synced_setting", {
+          key: "default_runtime",
+          value: runtime,
+        });
+        await invoke("set_synced_setting", {
+          key: "default_python_env",
+          value: pythonEnv,
+        });
+        await invoke("set_synced_setting", {
+          key: "telemetry_enabled",
+          value: telemetryEnabled,
+        });
+        await invoke("set_synced_setting", {
+          key: "telemetry_consent_recorded",
+          value: true,
+        });
+        await invoke("set_synced_setting", {
+          key: "onboarding_completed",
+          value: true,
+        });
+
+        setSetupComplete(true);
+
+        try {
+          await invoke("complete_onboarding", {
+            defaultRuntime: runtime,
+            defaultPythonEnv: pythonEnv,
+          });
+          // Window closes itself on success.
+        } catch (completeError) {
+          console.error("Failed to complete onboarding:", completeError);
+          setSetupComplete(false);
+          setIsSubmitting(false);
+          setErrorMessage("Failed to create notebook window. Please try again.");
+        }
+      } catch (e) {
+        console.error("Failed to save onboarding settings:", e);
+        setIsSubmitting(false);
+        setErrorMessage("Failed to save settings. Please try again.");
+      }
+    },
+    [daemonReady, poolReady, runtime, pythonEnv, isSubmitting],
+  );
+```
+
+Update `handleSkip` for the daemon-failure fallback so it also records consent (opt-out):
+
+```tsx
+  const handleSkip = useCallback(async () => {
+    await invoke("set_synced_setting", {
+      key: "telemetry_enabled",
+      value: false,
+    });
+    await invoke("set_synced_setting", {
+      key: "telemetry_consent_recorded",
+      value: true,
+    });
+    await invoke("complete_onboarding", {
+      defaultRuntime: runtime ?? "python",
+      defaultPythonEnv: pythonEnv ?? "uv",
+    });
+  }, [runtime, pythonEnv]);
+```
+
+- [ ] **Step 3: Import the shared card**
+
+Add at the top of the file:
+
+```tsx
+import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+```
+
+- [ ] **Step 4: Insert the disclosure card + two buttons in place of the removed blocks**
+
+After the `PageDots` + spacer block (around line 432) and inside the `page === 2` fragment, add:
+
+```tsx
+            {/* Telemetry decision: replaces the old pre-checked toggle. */}
+            <div className="space-y-3">
+              <TelemetryDisclosureCard />
+
+              <Button
+                onClick={() => handleChoice(true)}
+                disabled={!canProceed || isSubmitting}
+                className="w-full"
+                size="lg"
+              >
+                {setupComplete
+                  ? "All set!"
+                  : canProceed
+                    ? "You can count on me!"
+                    : pythonEnv === null
+                      ? "Select a package manager"
+                      : "Setting up..."}
+              </Button>
+
+              <button
+                type="button"
+                onClick={() => handleChoice(false)}
+                disabled={!canProceed || isSubmitting}
+                className="w-full text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50 py-1"
+              >
+                Opt out of metrics, continue
+              </button>
+            </div>
+
+            {/* Continue anyway (daemon failure fallback) */}
+            {daemonFailed && !setupComplete && (
+              <Button onClick={handleSkip} variant="ghost" className="w-full" size="sm">
+                Continue anyway
+              </Button>
+            )}
+```
+
+- [ ] **Step 5: Type-check and dev-preview**
+
+```bash
+cd apps/notebook && pnpm exec tsc --noEmit
+```
+
+Expected: clean.
+
+To preview visually, the human will need to run the app from their terminal (see CLAUDE.md: don't launch the GUI from the agent session). Leave this as a manual verification step in the PR description.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/notebook/onboarding/App.tsx
+git commit -m "feat(onboarding): replace telemetry toggle with explicit consent buttons"
+```
+
+---
+
+## Task 8: Build the Settings → Privacy pane
+
+**Files:**
+- Create: `apps/notebook/settings/sections/Privacy.tsx`
+- Modify: `apps/notebook/settings/App.tsx`
+
+The section renders the disclosure card + a switch + install ID viewer + rotation button + last-ping display + "Erase my data" mailto link.
+
+- [ ] **Step 1: Create `apps/notebook/settings/sections/Privacy.tsx`**
+
+```tsx
+import { open } from "@tauri-apps/plugin-shell";
+import { useCallback, useState } from "react";
+import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+import { Switch } from "@/components/ui/switch";
+
+interface PrivacySectionProps {
+  telemetryEnabled: boolean;
+  onTelemetryChange: (value: boolean) => void;
+  installId: string;
+  onRotate: () => Promise<string | null>;
+  lastDaemonPingAt: number | null;
+  lastAppPingAt: number | null;
+  lastMcpPingAt: number | null;
+}
+
+function formatRelative(secs: number | null): string {
+  if (secs === null) return "never";
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - secs;
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export function PrivacySection({
+  telemetryEnabled,
+  onTelemetryChange,
+  installId,
+  onRotate,
+  lastDaemonPingAt,
+  lastAppPingAt,
+  lastMcpPingAt,
+}: PrivacySectionProps) {
+  const [isRotating, setIsRotating] = useState(false);
+
+  const handleRotate = useCallback(async () => {
+    if (isRotating) return;
+    const ok = window.confirm(
+      "Rotate your install ID? This generates a new random identifier. Your old rows on the server become unlinkable and age out at 400 days.",
+    );
+    if (!ok) return;
+    setIsRotating(true);
+    try {
+      await onRotate();
+    } finally {
+      setIsRotating(false);
+    }
+  }, [isRotating, onRotate]);
+
+  const handleEraseMyData = useCallback(async () => {
+    const subject = encodeURIComponent("Telemetry erasure request");
+    const body = encodeURIComponent(
+      `Please erase all telemetry rows for install ID: ${installId}\n\nThanks.`,
+    );
+    const url = `mailto:privacy@nteract.io?subject=${subject}&body=${body}`;
+    try {
+      await open(url);
+    } catch {
+      window.location.href = url;
+    }
+  }, [installId]);
+
+  const handleReadPage = useCallback(async () => {
+    try {
+      await open("https://nteract.io/telemetry");
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return (
+    <div className="space-y-3">
+      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        Privacy
+      </span>
+
+      <TelemetryDisclosureCard
+        footer={
+          <div className="flex items-center justify-between pt-1">
+            <span className="text-xs text-muted-foreground">
+              Send anonymous daily ping
+            </span>
+            <Switch
+              checked={telemetryEnabled}
+              onCheckedChange={onTelemetryChange}
+            />
+          </div>
+        }
+      />
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground shrink-0">
+            Install ID
+          </span>
+          <code
+            className="text-[11px] text-foreground truncate bg-muted/50 px-2 py-0.5 rounded"
+            title={installId}
+          >
+            {installId || "(not yet set)"}
+          </code>
+          <button
+            type="button"
+            onClick={handleRotate}
+            disabled={isRotating || !installId}
+            className="text-xs text-primary underline hover:text-foreground disabled:opacity-50"
+          >
+            {isRotating ? "Rotating..." : "Rotate"}
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">Last ping</span>
+          <span className="text-xs text-foreground tabular-nums">
+            app {formatRelative(lastAppPingAt)} · daemon{" "}
+            {formatRelative(lastDaemonPingAt)} · mcp{" "}
+            {formatRelative(lastMcpPingAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-xs pt-1">
+        <button
+          type="button"
+          onClick={handleReadPage}
+          className="text-primary underline hover:text-foreground"
+        >
+          Read the full telemetry page
+        </button>
+        <button
+          type="button"
+          onClick={handleEraseMyData}
+          disabled={!installId}
+          className="text-primary underline hover:text-foreground disabled:opacity-50"
+        >
+          Erase my data
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire it into `apps/notebook/settings/App.tsx`**
+
+Add the import near the top:
+
+```tsx
+import { PrivacySection } from "./sections/Privacy";
+```
+
+In the `useSyncedSettings()` destructure inside `export default function App()`, add:
+
+```tsx
+  const {
+    defaultRuntime,
+    setDefaultRuntime,
+    defaultPythonEnv,
+    setDefaultPythonEnv,
+    defaultUvPackages,
+    setDefaultUvPackages,
+    defaultCondaPackages,
+    setDefaultCondaPackages,
+    defaultPixiPackages,
+    setDefaultPixiPackages,
+    keepAliveSecs,
+    setKeepAliveSecs,
+    featureFlags,
+    setFeatureFlag,
+    telemetryEnabled,
+    setTelemetryEnabled,
+    installId,
+    rotateInstallId,
+    lastDaemonPingAt,
+    lastAppPingAt,
+    lastMcpPingAt,
+  } = useSyncedSettings();
+```
+
+Find the rendered `Appearance` section's closing tag (look for where the Flavor div ends, around line 290 of the existing file). Immediately after the Appearance block's outermost `</div>`, insert:
+
+```tsx
+        <PrivacySection
+          telemetryEnabled={telemetryEnabled}
+          onTelemetryChange={setTelemetryEnabled}
+          installId={installId}
+          onRotate={rotateInstallId}
+          lastDaemonPingAt={lastDaemonPingAt}
+          lastAppPingAt={lastAppPingAt}
+          lastMcpPingAt={lastMcpPingAt}
+        />
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd apps/notebook && pnpm exec tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/notebook/settings/sections/Privacy.tsx apps/notebook/settings/App.tsx
+git commit -m "feat(settings): add Privacy section with rotation + mailto erase"
+```
+
+---
+
+## Task 9: Apply the consent backfill on daemon startup
+
+**Files:**
+- Find-and-modify: the daemon's settings-load path. Likely `crates/runtimed/src/lib.rs` or `crates/runtimed/src/settings.rs`.
+
+The struct field and the backfill function exist; now we need to *call* the backfill once when the daemon starts.
+
+- [ ] **Step 1: Find the daemon's settings load site**
+
+```bash
+grep -rn "SyncedSettings" crates/runtimed/src | grep -v '//' | head
+```
+
+Look for where the daemon reads settings into a `SyncedSettings` (e.g., at startup, or in a `load_synced_settings()` helper).
+
+- [ ] **Step 2: Call `backfill_telemetry_consent` after the load**
+
+Wherever the daemon has a parsed `SyncedSettings` it intends to write back, insert:
+
+```rust
+runtimed_client::settings_doc::backfill_telemetry_consent(&mut settings);
+```
+
+Persist the updated settings via the existing write path (the daemon's sync-backed write, same one used for `put_value`).
+
+If no obvious central load site exists, an alternative pattern is:
+
+- In the first `try_send` call inside `telemetry.rs`, if `onboarding_completed && !telemetry_consent_recorded`, call `write_setting("telemetry_consent_recorded", true)` before proceeding. This is lazier but avoids a daemon-code change.
+
+- [ ] **Step 3: Verify with a test**
+
+Write a unit test in `crates/runtimed-client/src/settings_doc.rs` (if one doesn't already cover this):
+
+```rust
+    #[test]
+    fn test_backfill_telemetry_consent_flips_for_onboarded_users() {
+        let mut s = SyncedSettings::default();
+        s.onboarding_completed = true;
+        s.telemetry_consent_recorded = false;
+        backfill_telemetry_consent(&mut s);
+        assert!(s.telemetry_consent_recorded);
+    }
+
+    #[test]
+    fn test_backfill_telemetry_consent_noop_for_fresh_installs() {
+        let mut s = SyncedSettings::default();
+        // onboarding_completed = false by default
+        backfill_telemetry_consent(&mut s);
+        assert!(!s.telemetry_consent_recorded);
+    }
+```
+
+Place in the existing `mod tests` (if present) or add a fresh one at the end of the file.
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test -p runtimed-client settings_doc::tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/runtimed-client/src/settings_doc.rs crates/runtimed/src/
+git commit -m "feat(daemon): backfill telemetry_consent_recorded for onboarded users"
+```
+
+---
+
+## Task 10: Extend `runt config telemetry status` output
+
+**Files:**
+- Modify: `crates/runt/src/main.rs`
+
+The CLI command already exists. We only add `consent_recorded` to the output so the CLI matches the GUI.
+
+- [ ] **Step 1: Find the existing `Status` handler**
+
+```bash
+grep -n "TelemetryCommands::Status" crates/runt/src/main.rs
+```
+
+It'll print a block that includes `telemetry_enabled`, `install_id`, and last-ping timestamps.
+
+- [ ] **Step 2: Add a line for `consent_recorded`**
+
+Right after the line that prints `telemetry_enabled`:
+
+```rust
+    println!(
+        "  consent_recorded: {}",
+        settings.telemetry_consent_recorded
+    );
+```
+
+(Match the formatting of adjacent `println!` calls exactly so indentation and alignment are consistent.)
+
+- [ ] **Step 3: Build + smoke test**
+
+```bash
+cargo build -p runt-cli
+./target/debug/runt config telemetry status
+```
+
+Expected: the output now includes `consent_recorded: true` (or false, depending on state).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runt/src/main.rs
+git commit -m "feat(runt): surface consent_recorded in telemetry status"
+```
+
+---
+
+## Task 11: Slim docs/telemetry.md
+
+**Files:**
+- Modify: `docs/telemetry.md`
+
+User-facing content now lives on nteract.io/telemetry. This file becomes a developer's readme.
+
+- [ ] **Step 1: Replace the file with the slim version**
+
+```markdown
+# Telemetry (developer notes)
+
+User-facing copy lives at https://nteract.io/telemetry. This file is for developers.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `crates/runtimed-client/src/telemetry.rs` | Heartbeat emitter. `should_send_full`, `blocking_gates_full`, `try_send`, `heartbeat_loop`, `heartbeat_once`. |
+| `crates/runtimed-client/src/settings_doc.rs` | `SyncedSettings` fields: `install_id`, `telemetry_enabled`, `telemetry_consent_recorded`, three `telemetry_last_*_ping_at` fields. `backfill_telemetry_consent` migration. |
+| `crates/runt/src/main.rs` | `runt config telemetry {status,enable,disable}`. |
+| `apps/notebook/src/components/TelemetryDisclosureCard.tsx` | Shared disclosure card. |
+| `apps/notebook/onboarding/App.tsx` | "You can count on me!" / "Opt out of metrics, continue" buttons. |
+| `apps/notebook/settings/sections/Privacy.tsx` | Revisit UI with install ID rotation. |
+
+## Adding a heartbeat field
+
+1. Add the field to `HeartbeatPayload` in `crates/runtimed-client/src/telemetry.rs`.
+2. Update `lib/telemetry-data.ts` on nteract.io so the page and raw.md export include it.
+3. Update `docs/telemetry-schema.md` in the nteract/telemetry repo.
+4. Add a migration to `worker/migrations/` for the new column + enum constraint.
+5. Extend `worker/src/ingest.ts` to accept and persist the new field.
+
+## The consent gate
+
+The `telemetry_consent_recorded` flag is the explicit-consent gate added after
+the onboarding redesign. Until it is true, `should_send_full` returns false
+even when `telemetry_enabled = true`. The daemon sets it on startup via
+`backfill_telemetry_consent` for users who completed onboarding before the flag
+existed.
+
+## Suppression
+
+- `RUNTIMED_DEV=1` or `RUNTIMED_WORKSPACE_PATH` is set.
+- `CI` is set.
+- `NTERACT_TELEMETRY_DISABLE=1` is set.
+- `telemetry_enabled = false` or `telemetry_consent_recorded = false` in settings.
+- Platform or arch is unsupported.
+- Last ping for this source was less than 20 hours ago.
+
+## Testing
+
+```
+cargo test -p runtimed-client telemetry::tests
+cargo test -p runtimed-client settings_doc::tests
+cd apps/notebook && pnpm exec vitest run src/components/TelemetryDisclosureCard.test.tsx
+```
+
+## Endpoints
+
+Ingest: `POST https://telemetry.runtimed.com/v1/ping` (source: `nteract/telemetry`).
+Erasure: `DELETE https://telemetry.runtimed.com/v1/install/:install_id`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/telemetry.md
+git commit -m "docs(telemetry): slim to developer-facing readme; user copy now on nteract.io"
+```
+
+---
+
+## Task 12: Full verification pass
+
+**Files:**
+- None, just verification.
+
+- [ ] **Step 1: Run the full Rust test suite for the touched crates**
+
+```bash
+cargo test -p runtimed-client
+cargo test -p notebook
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Run the tokio-mutex lint (invariant in CLAUDE.md)**
+
+```bash
+cargo test -p runtimed --test tokio_mutex_lint
+```
+
+Expected: green.
+
+- [ ] **Step 3: Run the frontend checks**
+
+```bash
+cd apps/notebook && pnpm exec tsc --noEmit
+cd apps/notebook && pnpm exec vitest run
+```
+
+Expected: clean + all green.
+
+- [ ] **Step 4: Lint pass**
+
+```bash
+cargo xtask lint
+```
+
+Expected: clean. If not, `cargo xtask lint --fix` and re-commit.
+
+- [ ] **Step 5: Manual UX check (for the human reviewer, not the agent)**
+
+Note in the PR description that the agent did NOT launch the app to test onboarding visually, per CLAUDE.md. Reviewers should:
+
+- Launch with `cargo xtask notebook` from a fresh settings state (back up `~/.config/nteract/settings.json` and remove it).
+- Walk through onboarding, confirm the two-button CTA, verify either button ends onboarding and sets the right values.
+- Open Settings, confirm the Privacy pane renders and the rotation button generates a new UUID.
+- Confirm the Learn more link opens `https://nteract.io/telemetry` in the system browser.
+
+---
+
+## Self-Review Summary
+
+- **`telemetry_consent_recorded` field + backfill:** Task 1, reinforced in Task 9.
+- **Consent gate in `should_send` / `blocking_gates`:** Task 2.
+- **Install-ID rotation (pure function + Tauri command):** Tasks 3, 4.
+- **Hook exposes new state:** Task 5.
+- **Shared disclosure card:** Task 6.
+- **Onboarding two-button CTA:** Task 7.
+- **Settings Privacy pane:** Task 8.
+- **CLI reflects consent_recorded:** Task 10.
+- **docs/telemetry.md slimmed:** Task 11.
+- **Verification:** Task 12.
+
+All spec requirements for the desktop deliverable (PR 3 in the spec's rollout) are covered. The plan assumes the telemetry and nteract.io PRs have shipped; if they haven't, the erasure and Learn more links are simply not yet live, which is fine for local testing.

--- a/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
+++ b/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
@@ -229,16 +229,21 @@ No new backend logic. The Privacy pane reads the same `SyncedSettings` struct an
 
 ## Rollout plan
 
-1. **PR 1 (nteract.io):** Ship `/telemetry`. Structured as separate commits for reviewability:
+Two PRs, one per repo. Each structured as a sequence of reviewable commits.
+
+1. **PR 1 (nteract.io):** Ship `/telemetry`.
    - Commit A: Add Source Serif 4 as `--font-page-serif`, add the `.cream-page` palette scope.
    - Commit B: Scaffold `app/telemetry/page.tsx` + `app/telemetry/raw.md/route.ts`, wire middleware + vercel.json + llms.txt + sitemap.
    - Commit C: Complete page content, typography pass, accordion interactions.
    - Commit D: `lib/telemetry-data.ts` typed module and its unit tests.
-2. **PR 2 (desktop):** Extract `TelemetryDisclosure` component. Update onboarding to the new affirmation layout. Fix the Learn more URL to `/telemetry`.
-3. **PR 3 (desktop):** Add the Settings → Privacy pane with install-ID rotation.
-4. **PR 4 (desktop):** Slim `docs/telemetry.md` to the developer-facing residue.
+2. **PR 2 (desktop):** Ship the desktop touchpoints.
+   - Commit A: Extract `TelemetryDisclosure` shared component (no behavior change).
+   - Commit B: Rework the onboarding step to use `TelemetryDisclosure` in the affirmation layout; fix the Learn more URL to `/telemetry`.
+   - Commit C: Add the Settings → Privacy pane. Wires the shared toggle, install-ID view, last-ping display, link to the page.
+   - Commit D: `rotate_install_id` Tauri command + daemon plumbing, with the rotate-and-clear-markers semantics.
+   - Commit E: Slim `docs/telemetry.md` to the developer-facing residue.
 
-PR 1 ships the page. PRs 2–3 ship the touchpoints. PR 4 unifies the canonical home for the user-facing text. Each PR is reviewable in isolation; the link update in PR 2 depends on PR 1 being live, otherwise the Learn more link dead-ends again.
+PR 2 depends on PR 1 being live so the Learn more link resolves. Within each PR the commits are ordered so any single commit lands a coherent slice; reviewers can read the diff one commit at a time.
 
 ## Follow-ups parked
 

--- a/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
+++ b/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
@@ -6,9 +6,9 @@
 
 ## Summary
 
-Replace the lightly-hidden "Learn more" link on the onboarding telemetry toggle with a real `/telemetry` page on nteract.io, and turn the toggle itself into an affirmation moment rather than a setting. Add a Privacy section to the desktop Settings window so the choice is revisitable without the CLI.
+Replace the lightly-hidden "Learn more" link on the onboarding telemetry toggle with a real `/telemetry` page on nteract.io, replace the pre-checked toggle with an explicit opt-in button at the end of onboarding, and add a Privacy section to the desktop Settings window so the choice is revisitable without the CLI. The explicit button change also brings the consent model in line with a strict GDPR reading (clear affirmative action, not a pre-ticked default).
 
-The `/telemetry` page is the primary deliverable. It communicates trust in three registers: a warm letter (voice), a live-looking ping preview (specificity), and a collapsed receipt (precision). The writing frames the heartbeat as a *signal that helps funders see nteract is used*, not as direct funding. Copy calls out NumFOCUS stewardship.
+The `/telemetry` page is the primary deliverable. It communicates trust in three registers: a warm letter (voice), a live-looking ping preview (specificity), and a collapsed receipt (precision). The writing frames the heartbeat as a *signal that helps funders see nteract is used*, not as direct funding. Copy calls out NumFOCUS stewardship and lists the user's rights plainly.
 
 ## Problem
 
@@ -16,17 +16,21 @@ Today the onboarding wizard shows a toggle with one line of terse copy and a "Le
 
 The toggle also fights for attention with the Python package-manager picker on the same step. Telemetry shares a moment with an unrelated choice, so the user either clicks through without reading or bounces on a trust signal that wasn't earned.
 
-Three things are broken:
+Separately, the current UI is a pre-checked toggle labeled "Anonymous usage data." Under a strict GDPR reading (Recital 32) consent must be a "clear affirmative action," not a pre-ticked default. OSS projects commonly ship pre-checked toggles and enforcement is spotty, but it's the kind of thing we should just get right while we're rebuilding this flow.
+
+Four things are broken:
 
 1. **Dead link.** Learn more goes nowhere.
 2. **No ongoing surface.** Post-onboarding, the choice is invisible.
 3. **Flat framing.** The current copy is accurate but doesn't explain *why* the project asks. NumFOCUS stewardship, grant-funder signal value, and the absence of any personal data are all unspoken.
+4. **Implicit consent.** Default-on plus a toggle is a pre-ticked box. A strict GDPR reading wants explicit affirmative action.
 
 ## Goals
 
 - Ship a `/telemetry` page on nteract.io that earns trust and opts people in.
-- Recast the onboarding disclosure as an affirmation, not a footer.
+- Recast the onboarding disclosure as an affirmation, not a footer. The user makes the decision by pressing a button, not by accepting a pre-checked toggle.
 - Add a Settings → Privacy pane on desktop so the choice is revisitable and auditable.
+- Bring the consent model in line with a strict GDPR reading: explicit opt-in, easy opt-out, user rights plainly listed, a real privacy contact, and a server-side erasure path.
 - Codify Source Serif 4 as `--font-page-serif` on nteract.io so future long-form "cream" pages (dataframes, data science content) reuse it. Space Grotesk stays the default display face for security / engineering posts.
 
 ## Non-goals
@@ -91,9 +95,16 @@ The palette is page-scoped (declared in the page's own CSS module or a scoped `<
    - **What is never sent or stored** (maps to the same-named section in docs)
    - **When a ping is suppressed** (emission gates table)
    - **Retention and schema evolution** (retention + schema evolution sections)
-6. **Opt-out block.** Three ways, each a small card: onboarding toggle, Settings → Privacy (new), CLI (`runt config telemetry disable`). Each card has a one-line explanation. Environment variable (`NTERACT_TELEMETRY_DISABLE=1`) sits below as a footnote for deployment operators.
-7. **Closing line.** One sentence on where to read the source: `crates/runtimed-client/src/telemetry.rs` with a link to GitHub.
-8. **Footer rule + NumFOCUS mark.** Small wordmark / text link acknowledging NumFOCUS.
+6. **Opt-out block.** Three ways, each a small card: onboarding button ("opt out of metrics, continue"), Settings → Privacy (new), CLI (`runt config telemetry disable`). Each card has a one-line explanation. Environment variable (`NTERACT_TELEMETRY_DISABLE=1`) sits below as a footnote for deployment operators.
+7. **Your rights.** Plain-language, four bullets, each mapped to a mechanism:
+   - **Access.** Open Settings → Privacy to see your install ID, last ping times, and current setting.
+   - **Rectify.** There's nothing to rectify. The six fields are facts about your build, not profile data.
+   - **Erase.** Rotate your install ID from Settings → Privacy. Your old rows become unlinkable and age out at 400 days. To delete them immediately, email the address below with your install ID; we run a `DELETE` against the raw pings table.
+   - **Object / withdraw.** Flip the setting off, any time. No penalty, no features lost.
+8. **Sponsored project note.** One paragraph: nteract is a NumFOCUS sponsored project. NumFOCUS's own [privacy policy](https://numfocus.org/privacy-policy) covers NumFOCUS services (its website, event registration, etc.), not sponsored projects. This page is how *nteract* handles your data.
+9. **Privacy contact.** One line with a mailto link. Proposed address: `privacy@nteract.io`. See open question on contact plumbing.
+10. **Closing line.** One sentence on where to read the source: `crates/runtimed-client/src/telemetry.rs` with a link to GitHub, and `nteract/telemetry` for the server-side endpoint.
+11. **Footer rule + NumFOCUS mark.** Small wordmark / text link acknowledging NumFOCUS stewardship.
 
 **Copy voice:**
 
@@ -115,37 +126,73 @@ No cross-repo sync is needed. The Rust emitter (`crates/runtimed-client/src/tele
 
 **Onboarding redesign (step 2):**
 
-The telemetry disclosure moves from a muted strip at the bottom of the Python Environment step to its own visual beat. Same step, more presence:
+The telemetry decision moves from a pre-checked toggle at the bottom of the Python Environment step to an **explicit choice at the end of onboarding**. The user presses one of two buttons; that press is both the consent event and the submit event.
 
-- Full-width card above the Get Started button, not below the package manager grid.
-- Uses a subtle cream-themed background (`--cream-elevated`) rather than `bg-muted/50`.
-- Copy: "One anonymous ping per day, so funders can see nteract is used. No names, no paths, no data about your notebooks. [Learn more]"
-- The Learn more link opens `https://nteract.io/telemetry` in the browser (Tauri `shell.open`).
-- Toggle is the same shadcn switch component used elsewhere, not a custom button. Accessibility wins: real `<button role="switch">` via Radix.
+Layout (below the package-manager grid, replacing the current Get Started button):
 
-Visually it reads as an affirmation. The user sees the disclosure as part of getting started, not as a legal footer.
+- **Disclosure card** above the buttons. Cream-elevated background, soft border.
+  - Eyebrow: "One anonymous daily ping" (small caps, accent color).
+  - Body: "Version, platform, architecture. No names, no paths, nothing about your notebooks."
+  - Link: "Read the full details" → opens `https://nteract.io/telemetry` via Tauri `shell.open`.
+- **Primary CTA (large, dark):** "You can count on me!" → sets `telemetry_enabled = true` and advances.
+- **Secondary CTA (small, underlined, muted):** "Opt out of metrics, continue" → sets `telemetry_enabled = false` and advances.
+
+Neither button is pre-selected; the user picks one. This is the explicit affirmative action that satisfies GDPR Recital 32.
+
+Both button handlers write to `telemetry_enabled` via the existing `set_synced_setting` command, then advance onboarding. No new Tauri command needed. The daemon-failure "Continue anyway" path collapses into the secondary CTA (same behavior: continue without telemetry).
+
+**Default before the user chooses:** the Automerge default for `telemetry_enabled` stays `true` (existing behavior in `settings_doc.rs:309-311`), but a new flag `telemetry_consent_recorded: bool` (default `false`) gates whether a ping may fire. `try_send()` in `telemetry.rs` checks the new flag as part of `blocking_gates()`. If a user has never pressed either onboarding button, no ping is sent, even when `telemetry_enabled` is `true` in settings. Pressing either button sets `telemetry_consent_recorded = true`. This preserves the "don't send before onboarding completes" invariant already covered by the `onboarding_completed` gate, but makes consent-bearing explicit and auditable.
 
 **Settings → Privacy pane:**
 
 New section in `apps/notebook/settings/App.tsx`, placed between Appearance and New Notebooks. Renders:
 
-- The same toggle as onboarding (shared component).
-- The same one-liner copy.
-- Below the toggle, four small links:
+- A shadcn switch bound to `telemetry_enabled`. Unlike onboarding, this is a toggle (the user already expressed consent and is now revisiting it).
+- The same disclosure copy as the onboarding card.
+- Below the toggle, five small links:
   - "Read the full telemetry page" → https://nteract.io/telemetry
-  - "View install ID" → shows current `install_id` and a button to rotate (deletes current, regenerates on next ping).
-  - "Last ping" → shows the most recent `last_sent_at` timestamp for app / daemon / mcp, pulled from the same settings doc.
+  - "Your install ID" → shows the current `install_id` in monospace; button to rotate (generates a new UUIDv4 and clears all three `last_sent_at` markers).
+  - "Erase my data" → opens a confirmation that composes a `mailto:` to the privacy address with the install ID pre-filled. Explains: "We'll run a DELETE against the raw pings table. Aggregates are already anonymized."
+  - "Last ping" → most recent `last_sent_at` timestamp for app / daemon / mcp, pulled from the same settings doc.
   - "Run `runt config telemetry status`" → copyable inline command.
 
-The install-ID rotation is the one new bit of functionality. It's a privacy affordance: if a user wants a fresh identity, they can reset without deleting the whole settings file. Implementation: add a `rotate_install_id` Tauri command that writes a new UUIDv4 via the daemon sync client, same path as `set_synced_setting`.
+Two new Tauri commands:
 
-**Shared toggle component:**
+- `rotate_install_id`: writes a new UUIDv4 + clears all `last_sent_at` markers via the daemon sync client. Same path as `set_synced_setting`.
+- No new command needed for "Erase my data"; it's a `mailto:` the user sends themselves. (A future version could POST to a server-side erasure endpoint directly; keeping this as a manual path avoids adding UI for something that's rare and reviewable.)
 
-Extract the onboarding telemetry disclosure into a single shared React component, `TelemetryDisclosure`, used by both onboarding and the Settings pane. Two props: `variant: 'onboarding' | 'settings'` and `className?`. Keeps copy and behavior in one place, which is the long-term win for "make sure both surfaces never drift."
+**Shared component:**
+
+Extract the disclosure card (eyebrow + body + read-full-details link) into a single shared React component, `TelemetryDisclosureCard`, used by both surfaces. Controls live next to it in each surface:
+
+- Onboarding: two buttons underneath (affirmation CTA + opt-out-and-continue).
+- Settings: a switch next to it (already consented; now toggling).
+
+One source of truth for copy. If we ever need to change the disclosure wording, there's one place to edit.
 
 **docs/telemetry.md:**
 
-Replace the file with a pointer to the published page plus a short developer-facing section (code paths, test strategy, how to add new fields). The long-form user-facing content moves to the published page as the canonical home. Rationale: LLMs and agents fetch the markdown sibling of `/telemetry` directly, so there's no reason to maintain two separate copies.
+Replace the file with a pointer to the published page plus a short developer-facing section (code paths, test strategy, how to add new fields, the explicit-consent gate). The long-form user-facing content moves to the published page as the canonical home. Rationale: LLMs and agents fetch the markdown sibling of `/telemetry` directly, so there's no reason to maintain two separate copies.
+
+### Repo C, nteract/telemetry: server-side changes
+
+The ingest endpoint at `https://telemetry.runtimed.com/v1/ping` is hosted in `nteract/telemetry` (Cloudflare Worker + D1). Two additions:
+
+**1. Erasure endpoint.** New route `DELETE /v1/install/{install_id}`:
+
+- Deletes all rows in `pings` where `install_id = ?`.
+- Aggregates in `daily_rollup` stay untouched (they already contain no `install_id`).
+- Unauthenticated. The `install_id` is the capability: only the user holding it can ask for it to be erased. Rate-limited at the Cloudflare edge on the same ruleset as `/v1/ping` (60 req/min per IP) so it can't be used as a DoS primitive against the DB.
+- Returns `204 No Content` on success, `204` also if the install ID isn't found (no information leak about whether an ID exists).
+- A `Vary: Origin` and CORS headers that permit requests from `https://nteract.io` so the Settings pane *could* call it directly later without a mail flow. Not wired yet.
+
+**2. Privacy schema disclosure update.** `docs/telemetry-schema.md` in the telemetry repo gains:
+
+- A "Your rights" section mirroring the page.
+- A "How to request erasure" section listing the endpoint + the email fallback.
+- A one-line pointer to `https://nteract.io/telemetry` as the user-facing page.
+
+No DB migration. No new secrets. The Worker adds one route handler and one test.
 
 ### Design tokens introduced
 
@@ -174,13 +221,16 @@ Replace the file with a pointer to the published page plus a short developer-fac
 
 **desktop: no new tokens.** The redesign reuses existing cream-theme variables from `src/styles/cream-theme.css`.
 
-### Data flow (unchanged but worth stating)
+### Data flow
+
+**Consent recorded at onboarding:**
 
 ```
-User toggles onboarding or Settings switch
+User presses primary or secondary onboarding button
         │
         ▼
 invoke("set_synced_setting", { key: "telemetry_enabled", value: bool })
+invoke("set_synced_setting", { key: "telemetry_consent_recorded", value: true })
         │
         ▼
 Tauri command → daemon SyncClient → Automerge doc
@@ -189,10 +239,16 @@ Tauri command → daemon SyncClient → Automerge doc
 ~/.config/nteract/settings.json mirror on disk
         │
         ▼
-telemetry::should_send() reads at next heartbeat tick → send or skip
+telemetry::should_send() checks `telemetry_enabled && telemetry_consent_recorded` → send or skip
 ```
 
-No new backend logic. The Privacy pane reads the same `SyncedSettings` struct and writes through the same command.
+**Revisited from Settings:**
+
+Same path, just the switch instead of a button. `telemetry_consent_recorded` stays `true` once set.
+
+**Rotate install ID:**
+
+New Tauri command `rotate_install_id` writes a new UUIDv4 + clears all three `last_sent_at` markers via the daemon sync client. Settings doc adds a helper method on `SyncedSettings` for the two-field update.
 
 ### Error states
 
@@ -210,9 +266,17 @@ No new backend logic. The Privacy pane reads the same `SyncedSettings` struct an
 
 **desktop:**
 
-- Snapshot test of the shared `TelemetryDisclosure` component in both variants.
-- Integration test (existing Tauri test harness, if available): toggling from Settings writes the correct value, and a heartbeat skip is observed after flipping off.
+- Snapshot test of `TelemetryDisclosureCard`.
+- Unit test of `blocking_gates()` in `telemetry.rs` covering the new `telemetry_consent_recorded` gate: enabled=true + consent=false → blocked.
+- Integration test (existing Tauri test harness, if available): pressing either onboarding button writes the right pair of values, and a heartbeat skip is observed if consent is false.
+- Unit test of `rotate_install_id` command: new UUID, old one gone, all three `last_sent_at` markers cleared.
 - The existing CI-enforced `cargo test -p runtimed --test tokio_mutex_lint` stays green; no new locks.
+
+**telemetry (server):**
+
+- Unit test for the `DELETE /v1/install/:id` route: pre-seed pings, hit the endpoint, assert rows gone, assert `daily_rollup` untouched.
+- Router test confirming 204 on both hit and miss (no information leak).
+- Existing `/v1/ping` ingest tests stay green; no schema change.
 
 ## Alternatives considered
 
@@ -224,29 +288,36 @@ No new backend logic. The Privacy pane reads the same `SyncedSettings` struct an
 ## Open questions
 
 - **Install-ID rotation semantics.** Proposed: rotation also clears all three (app / daemon / mcp) `last_sent_at` markers so the new ID isn't throttled by the 20-hour cooldown. Alternative: preserve throttle state so a rotating user can't amplify their own ping count. Lean is "clear the markers" because the 60 req/min Cloudflare rate limit is the real defense and a user who rotates daily still produces one ping per day per source.
+- **Privacy contact plumbing.** Spec proposes `privacy@nteract.io`. Needs a mailbox or forwarding rule that an actual maintainer reads. If we don't have that, the Google Group / GitHub private issue flow is a fallback. A `mailto:` link that bounces is worse than no link, so this needs to land before the page does. NumFOCUS's `privacy@numfocus.org` is a possible fallback; on their site the address is rendered inert (`javascript:;`) so confirm deliverability before using it.
 - **NumFOCUS attribution:** Exact wording of the footer acknowledgement. The spec says "NumFOCUS wordmark + short text." Open to a stronger attribution if there's a sponsored-project template.
-- **When to mention the email address / contact.** The page currently has no "email us with privacy concerns" line. Low-lift to add if desired. Not added by default.
+- **Erase-my-data UX.** Spec uses a `mailto:` for v1. A one-click delete button (calls the `DELETE` endpoint directly from the Settings pane) is strictly better UX but adds a confirmation modal and network error paths. Lean: ship v1 as mailto, iterate to in-app delete later.
 
 ## Rollout plan
 
-Two PRs, one per repo. Each structured as a sequence of reviewable commits.
+Three PRs, one per repo. Each structured as a sequence of reviewable commits.
 
-1. **PR 1 (nteract.io):** Ship `/telemetry`.
+1. **PR 1 (nteract/telemetry):** Ship the server-side affordances first, so the desktop and site can point at them.
+   - Commit A: Add `DELETE /v1/install/:id` route, router test, ingest tests still green.
+   - Commit B: CORS allow-list for `https://nteract.io` on the new route (not yet used, future-proofs the in-app delete button).
+   - Commit C: Update `docs/telemetry-schema.md` with rights language, erasure instructions, and pointer to `https://nteract.io/telemetry`.
+2. **PR 2 (nteract.io):** Ship `/telemetry`.
    - Commit A: Add Source Serif 4 as `--font-page-serif`, add the `.cream-page` palette scope.
    - Commit B: Scaffold `app/telemetry/page.tsx` + `app/telemetry/raw.md/route.ts`, wire middleware + vercel.json + llms.txt + sitemap.
-   - Commit C: Complete page content, typography pass, accordion interactions.
+   - Commit C: Complete page content (ping preview, receipt, rights section, NumFOCUS note, privacy contact), typography pass, accordion interactions.
    - Commit D: `lib/telemetry-data.ts` typed module and its unit tests.
-2. **PR 2 (desktop):** Ship the desktop touchpoints.
-   - Commit A: Extract `TelemetryDisclosure` shared component (no behavior change).
-   - Commit B: Rework the onboarding step to use `TelemetryDisclosure` in the affirmation layout; fix the Learn more URL to `/telemetry`.
-   - Commit C: Add the Settings → Privacy pane. Wires the shared toggle, install-ID view, last-ping display, link to the page.
-   - Commit D: `rotate_install_id` Tauri command + daemon plumbing, with the rotate-and-clear-markers semantics.
-   - Commit E: Slim `docs/telemetry.md` to the developer-facing residue.
+3. **PR 3 (desktop):** Ship the desktop touchpoints.
+   - Commit A: Add `telemetry_consent_recorded` field to `SyncedSettings`; extend `blocking_gates()` to require it. Backfill migration: if `onboarding_completed` is true, set `telemetry_consent_recorded = true` (existing users keep their implicit consent; new flows require explicit press).
+   - Commit B: Extract `TelemetryDisclosureCard` shared component.
+   - Commit C: Rework the onboarding step to use the card + two-button CTA ("You can count on me!" / "Opt out of metrics, continue"). Fix the Learn more URL to `/telemetry`. Remove the old pre-checked toggle.
+   - Commit D: Add the Settings → Privacy pane. Wires the switch, install-ID view, last-ping display, erase-my-data mailto, link to the page.
+   - Commit E: `rotate_install_id` Tauri command + daemon plumbing, with the rotate-and-clear-markers semantics.
+   - Commit F: Slim `docs/telemetry.md` to the developer-facing residue.
 
-PR 2 depends on PR 1 being live so the Learn more link resolves. Within each PR the commits are ordered so any single commit lands a coherent slice; reviewers can read the diff one commit at a time.
+PR 1 is independent and deploys first. PR 2 depends on PR 1's schema disclosure update being merged (not deployed); the page links to the schema doc's raw Markdown on GitHub in the meantime, or duplicates the text. PR 3 depends on PR 2 being live so the Learn more link resolves.
 
 ## Follow-ups parked
 
+- **In-app erasure button.** Once the mailto flow is in use, replace it with a direct `DELETE` call from the Settings pane using the CORS allow-list already shipped in PR 1. Adds a confirmation modal and basic network error handling.
 - **Cream-style markdown / prose redesign.** Extend `--font-page-serif` and the cream palette into a broader prose treatment used for data-science blog posts and documentation pages. Its own PR on nteract.io. Reuses the tokens introduced here.
 - **Space Grotesk remains the display face** for security posts and engineering content. Explicit split: Source Serif for long-form reading / data science, Space Grotesk for systems / release / security posts. This split is a follow-up design note, not a code change.
 - **Rust-to-TS data check.** If `lib/telemetry-data.ts` drifts from the Rust source, add a CI job that parses the emitter's field enum and diffs against the TS module. Probably not needed until the field set actually changes.

--- a/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
+++ b/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
@@ -229,13 +229,16 @@ No new backend logic. The Privacy pane reads the same `SyncedSettings` struct an
 
 ## Rollout plan
 
-1. **PR 1 (nteract.io):** Add Source Serif 4, scaffold `/telemetry` with placeholder content, wire up raw.md + middleware + vercel.json, deploy preview.
-2. **PR 2 (nteract.io):** Complete the page content and styling. Reviewed against the markdown source.
-3. **PR 3 (desktop):** Extract `TelemetryDisclosure` component. Update onboarding to use it in the new affirmation layout. Fix the Learn more URL to `/telemetry`.
-4. **PR 4 (desktop):** Add the Settings → Privacy pane with install-ID rotation.
-5. **PR 5 (desktop):** Slim `docs/telemetry.md` to the developer-facing residue.
+1. **PR 1 (nteract.io):** Ship `/telemetry`. Structured as separate commits for reviewability:
+   - Commit A: Add Source Serif 4 as `--font-page-serif`, add the `.cream-page` palette scope.
+   - Commit B: Scaffold `app/telemetry/page.tsx` + `app/telemetry/raw.md/route.ts`, wire middleware + vercel.json + llms.txt + sitemap.
+   - Commit C: Complete page content, typography pass, accordion interactions.
+   - Commit D: `lib/telemetry-data.ts` typed module and its unit tests.
+2. **PR 2 (desktop):** Extract `TelemetryDisclosure` component. Update onboarding to the new affirmation layout. Fix the Learn more URL to `/telemetry`.
+3. **PR 3 (desktop):** Add the Settings → Privacy pane with install-ID rotation.
+4. **PR 4 (desktop):** Slim `docs/telemetry.md` to the developer-facing residue.
 
-PRs 1–2 ship the page. PRs 3–4 ship the touchpoints. PR 5 unifies the canonical home for the user-facing text. Each PR is reviewable in isolation; the link update in PR 3 depends on PR 2 being live, otherwise the Learn more link dead-ends again.
+PR 1 ships the page. PRs 2–3 ship the touchpoints. PR 4 unifies the canonical home for the user-facing text. Each PR is reviewable in isolation; the link update in PR 2 depends on PR 1 being live, otherwise the Learn more link dead-ends again.
 
 ## Follow-ups parked
 

--- a/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
+++ b/docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md
@@ -1,0 +1,244 @@
+# Telemetry UI and /telemetry page design
+
+**Status:** Draft for review
+**Date:** 2026-04-23
+**Repos:** `nteract/desktop` + `nteract/nteract.io`
+
+## Summary
+
+Replace the lightly-hidden "Learn more" link on the onboarding telemetry toggle with a real `/telemetry` page on nteract.io, and turn the toggle itself into an affirmation moment rather than a setting. Add a Privacy section to the desktop Settings window so the choice is revisitable without the CLI.
+
+The `/telemetry` page is the primary deliverable. It communicates trust in three registers: a warm letter (voice), a live-looking ping preview (specificity), and a collapsed receipt (precision). The writing frames the heartbeat as a *signal that helps funders see nteract is used*, not as direct funding. Copy calls out NumFOCUS stewardship.
+
+## Problem
+
+Today the onboarding wizard shows a toggle with one line of terse copy and a "Learn more" link pointing at `https://nteract.io/docs/telemetry`, which 404s. The source copy lives in `docs/telemetry.md` but is never published. After onboarding, there is no in-app UI to revisit the setting. The only other way to change it is `runt config telemetry {enable,disable,status}`, which most users won't discover.
+
+The toggle also fights for attention with the Python package-manager picker on the same step. Telemetry shares a moment with an unrelated choice, so the user either clicks through without reading or bounces on a trust signal that wasn't earned.
+
+Three things are broken:
+
+1. **Dead link.** Learn more goes nowhere.
+2. **No ongoing surface.** Post-onboarding, the choice is invisible.
+3. **Flat framing.** The current copy is accurate but doesn't explain *why* the project asks. NumFOCUS stewardship, grant-funder signal value, and the absence of any personal data are all unspoken.
+
+## Goals
+
+- Ship a `/telemetry` page on nteract.io that earns trust and opts people in.
+- Recast the onboarding disclosure as an affirmation, not a footer.
+- Add a Settings → Privacy pane on desktop so the choice is revisitable and auditable.
+- Codify Source Serif 4 as `--font-page-serif` on nteract.io so future long-form "cream" pages (dataframes, data science content) reuse it. Space Grotesk stays the default display face for security / engineering posts.
+
+## Non-goals
+
+- Redesigning the broader onboarding flow. Only the telemetry strip on step 2 changes.
+- Revisiting what the heartbeat contains. The existing six fields are the source of truth for page copy; no payload changes.
+- Shipping a cream-style markdown / prose redesign. Same font token gets introduced, but the broader prose styling overhaul is a separate follow-up PR.
+- Adding a "see your own pings" dashboard or per-ping log surface.
+
+## Constraints and inputs
+
+- **Existing content:** `docs/telemetry.md` is accurate and already serves as the technical description. The `/telemetry` page is voice + layout on top of that content. The two must not drift.
+- **Existing CLI:** `runt config telemetry {enable,disable,status}` is fully implemented in `crates/runt/src/main.rs`. Docs already reference it; the page should too.
+- **Existing settings plumbing:** Onboarding writes `telemetry_enabled` via `invoke("set_synced_setting", {...})` (`apps/notebook/onboarding/App.tsx:294-297`). The same Tauri command backs the Settings window, so adding a Privacy pane is wiring, not new infrastructure.
+- **Existing visual system:** The desktop app's cream palette lives in `src/styles/cream-theme.css`. The nteract.io site already loads Space Grotesk, Inter, and JetBrains Mono as CSS variables (`app/layout.tsx`). Source Serif 4 is additive.
+- **Existing machinery:** nteract.io serves raw-markdown siblings via `middleware.ts` + `vercel.json` (PRs #621, #623, #624). `/telemetry` participates in this; agents and LLMs get the markdown form for free.
+
+## Design
+
+### Repo A, nteract.io: the `/telemetry` page
+
+**Route:** `app/telemetry/page.tsx` (top-level, no route group. Root layout is fine).
+
+**Raw markdown sibling:** `app/telemetry/raw.md/route.ts` emitting the same content as a markdown string. `middleware.ts` gets `/telemetry` added to its matcher and `rewriteTarget()` case. `vercel.json` gets a `Vary: Accept` header. `app/llms.txt/route.ts` lists the page.
+
+**Layout (desktop):**
+
+Two-column, asymmetric. Prose on the left with generous measure (around 60ch). Sidebar on the right with the live-looking ping preview pinned below the fold, plus quick-jump links. Page padding scales with viewport: tight on small laptops, luxurious on wide screens.
+
+**Layout (mobile):**
+
+Single column. Prose first, ping preview inlined after the opening paragraph, accordions below.
+
+**Typography:**
+
+- Display: **Source Serif 4** (new), loaded via `next/font/google`, exposed as `--font-page-serif`. Applied to h1, h2, blockquote, and the opening paragraph.
+- Body: **Inter** (existing, `--font-body`). Line height 1.6.
+- Mono: **JetBrains Mono** (existing, `--font-mono`) for the ping JSON and code fragments.
+
+**Color:**
+
+Matches the cream aesthetic evolving in the desktop app:
+- `--paper: #faf8f3` (background)
+- `--ink: #1e1a18` (text)
+- `--rule: #d8cec3` (hairlines)
+- `--accent: #955f3b` (section marks, links)
+- `--muted: #6b6356` (secondary text)
+
+The palette is page-scoped (declared in the page's own CSS module or a scoped `<style>` block) so it doesn't override the rest of the site's dark theme.
+
+**Page content (in order):**
+
+1. **Eyebrow.** `§ Telemetry` in small caps, accent color.
+2. **H1.** "A light ping, and why we ask." Source Serif, regular weight, slight italic optional on "why we ask."
+3. **Lede (3 short paragraphs).**
+   - nteract is maintained under NumFOCUS. What that means for stewardship.
+   - One anonymous daily heartbeat. That the signal exists is how small open-source projects stay visible to grant funders. The ping is *evidence of use*, not funding.
+   - If you'd rather not, flip it off. No penalty, no degraded features. Sticky in settings.
+4. **Ping preview block.** JetBrains Mono, on a slightly darker cream card. The six fields with example values. Annotated with a one-word hover tag per field (e.g., `install_id` → "random on first run").
+5. **Receipt accordion (collapsed by default).** Four sections, each a `<details>` element so it works without JS and is accessible:
+   - **Exactly what's sent** (maps 1:1 to the "What is sent" table in docs/telemetry.md)
+   - **What is never sent or stored** (maps to the same-named section in docs)
+   - **When a ping is suppressed** (emission gates table)
+   - **Retention and schema evolution** (retention + schema evolution sections)
+6. **Opt-out block.** Three ways, each a small card: onboarding toggle, Settings → Privacy (new), CLI (`runt config telemetry disable`). Each card has a one-line explanation. Environment variable (`NTERACT_TELEMETRY_DISABLE=1`) sits below as a footnote for deployment operators.
+7. **Closing line.** One sentence on where to read the source: `crates/runtimed-client/src/telemetry.rs` with a link to GitHub.
+8. **Footer rule + NumFOCUS mark.** Small wordmark / text link acknowledging NumFOCUS.
+
+**Copy voice:**
+
+Engineer-to-engineer. Short declaratives. Avoids hyperbole ("we deeply respect"). Avoids marketing cliches. Nothing chest-thumping. Leads with facts, ends with a single warm line. No em-dashes (matches repo convention).
+
+**Canonical home for user-facing copy:**
+
+After rollout, the `/telemetry` page is the single source of truth for what's sent, what's not, gates, retention, and opt-out steps. `docs/telemetry.md` gets slimmed to a developer-facing readme: code paths, how to add a new field, test strategy, where the heartbeat endpoint lives. Anything the user would care about lives on the website and is reachable as markdown via the raw-sibling route.
+
+To keep the technical *data* (the six fields, gate names, retention periods) from drifting in the page source itself, the page imports a typed module:
+
+- `lib/telemetry-data.ts` on nteract.io exports the field list, gate list, and retention policy as typed constants.
+- The page renders tables from this module rather than hard-coded Markdown.
+- The raw-markdown sibling serializes the same data so LLM clients see exact numbers.
+
+No cross-repo sync is needed. The Rust emitter (`crates/runtimed-client/src/telemetry.rs`) is the functional source of truth; the TS module is a hand-kept mirror for the page. A short contributor note in `docs/telemetry.md` calls out "if you add a heartbeat field, update `lib/telemetry-data.ts` on nteract.io too."
+
+### Repo B, nteract/desktop: the touchpoints
+
+**Onboarding redesign (step 2):**
+
+The telemetry disclosure moves from a muted strip at the bottom of the Python Environment step to its own visual beat. Same step, more presence:
+
+- Full-width card above the Get Started button, not below the package manager grid.
+- Uses a subtle cream-themed background (`--cream-elevated`) rather than `bg-muted/50`.
+- Copy: "One anonymous ping per day, so funders can see nteract is used. No names, no paths, no data about your notebooks. [Learn more]"
+- The Learn more link opens `https://nteract.io/telemetry` in the browser (Tauri `shell.open`).
+- Toggle is the same shadcn switch component used elsewhere, not a custom button. Accessibility wins: real `<button role="switch">` via Radix.
+
+Visually it reads as an affirmation. The user sees the disclosure as part of getting started, not as a legal footer.
+
+**Settings → Privacy pane:**
+
+New section in `apps/notebook/settings/App.tsx`, placed between Appearance and New Notebooks. Renders:
+
+- The same toggle as onboarding (shared component).
+- The same one-liner copy.
+- Below the toggle, four small links:
+  - "Read the full telemetry page" → https://nteract.io/telemetry
+  - "View install ID" → shows current `install_id` and a button to rotate (deletes current, regenerates on next ping).
+  - "Last ping" → shows the most recent `last_sent_at` timestamp for app / daemon / mcp, pulled from the same settings doc.
+  - "Run `runt config telemetry status`" → copyable inline command.
+
+The install-ID rotation is the one new bit of functionality. It's a privacy affordance: if a user wants a fresh identity, they can reset without deleting the whole settings file. Implementation: add a `rotate_install_id` Tauri command that writes a new UUIDv4 via the daemon sync client, same path as `set_synced_setting`.
+
+**Shared toggle component:**
+
+Extract the onboarding telemetry disclosure into a single shared React component, `TelemetryDisclosure`, used by both onboarding and the Settings pane. Two props: `variant: 'onboarding' | 'settings'` and `className?`. Keeps copy and behavior in one place, which is the long-term win for "make sure both surfaces never drift."
+
+**docs/telemetry.md:**
+
+Replace the file with a pointer to the published page plus a short developer-facing section (code paths, test strategy, how to add new fields). The long-form user-facing content moves to the published page as the canonical home. Rationale: LLMs and agents fetch the markdown sibling of `/telemetry` directly, so there's no reason to maintain two separate copies.
+
+### Design tokens introduced
+
+**nteract.io.** `--font-page-serif` is set via `next/font/google` in `app/layout.tsx` (same pattern as Space Grotesk, Inter, JetBrains Mono). The cream palette is page-scoped in `app/globals.css`:
+
+```css
+.cream-page {
+  --paper: #faf8f3;
+  --ink: #1e1a18;
+  --rule: #d8cec3;
+  --accent: #955f3b;
+  --muted: #6b6356;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+}
+
+.cream-page h1,
+.cream-page h2,
+.cream-page blockquote {
+  font-family: var(--font-page-serif);
+}
+```
+
+`.cream-page` is the opt-in class for Source-Serif / cream-colored pages. Future pages in the "data science" family add `className="cream-page"` to their root and get the whole treatment.
+
+**desktop: no new tokens.** The redesign reuses existing cream-theme variables from `src/styles/cream-theme.css`.
+
+### Data flow (unchanged but worth stating)
+
+```
+User toggles onboarding or Settings switch
+        │
+        ▼
+invoke("set_synced_setting", { key: "telemetry_enabled", value: bool })
+        │
+        ▼
+Tauri command → daemon SyncClient → Automerge doc
+        │
+        ▼
+~/.config/nteract/settings.json mirror on disk
+        │
+        ▼
+telemetry::should_send() reads at next heartbeat tick → send or skip
+```
+
+No new backend logic. The Privacy pane reads the same `SyncedSettings` struct and writes through the same command.
+
+### Error states
+
+- **Link cannot open (Tauri shell.open fails):** The onboarding disclosure copies the URL to the clipboard and shows a toast.
+- **Daemon unreachable when toggling from Settings:** Falls back to the file-path write (same fallback the onboarding already uses).
+- **Install-ID rotation without a running daemon:** Disabled with a tooltip ("Start nteract fully to rotate"). Rotation relies on the daemon's settings doc.
+
+### Testing
+
+**nteract.io:**
+
+- Snapshot test of `/telemetry/raw.md` (exercise markdown sibling machinery).
+- Unit test of `lib/telemetry-data.ts` verifies the six fields, gate names, retention periods are the expected constants.
+- Lighthouse / accessibility pass: the page uses `<details>` for accordions; tab order, aria-expanded, heading hierarchy all verified.
+
+**desktop:**
+
+- Snapshot test of the shared `TelemetryDisclosure` component in both variants.
+- Integration test (existing Tauri test harness, if available): toggling from Settings writes the correct value, and a heartbeat skip is observed after flipping off.
+- The existing CI-enforced `cargo test -p runtimed --test tokio_mutex_lint` stays green; no new locks.
+
+## Alternatives considered
+
+- **Put the page under `/docs/telemetry`.** Matches the dead link literally. Rejected: we don't have a `/docs` hierarchy today, and adding one for a single page is scope creep. `/telemetry` is simpler and the link will be updated wherever it appears anyway.
+- **Publish as a blog post.** Trivially supported by existing MDX machinery. Rejected: the page is evergreen reference, not an announcement.
+- **Sidebar always-visible, no accordions.** Richer layout, less cognitive load. Rejected after the visual preview: makes mobile messy and compresses the letter too hard. Desktop keeps the pinned ping preview but hides the full receipt behind accordions.
+- **Live install counter.** Considered for the hero area. Rejected: commits the project to an ops burden (a public endpoint, cache strategy, trust in the number) for a pledge-drive beat you explicitly said not to chase.
+
+## Open questions
+
+- **Install-ID rotation semantics.** Proposed: rotation also clears all three (app / daemon / mcp) `last_sent_at` markers so the new ID isn't throttled by the 20-hour cooldown. Alternative: preserve throttle state so a rotating user can't amplify their own ping count. Lean is "clear the markers" because the 60 req/min Cloudflare rate limit is the real defense and a user who rotates daily still produces one ping per day per source.
+- **NumFOCUS attribution:** Exact wording of the footer acknowledgement. The spec says "NumFOCUS wordmark + short text." Open to a stronger attribution if there's a sponsored-project template.
+- **When to mention the email address / contact.** The page currently has no "email us with privacy concerns" line. Low-lift to add if desired. Not added by default.
+
+## Rollout plan
+
+1. **PR 1 (nteract.io):** Add Source Serif 4, scaffold `/telemetry` with placeholder content, wire up raw.md + middleware + vercel.json, deploy preview.
+2. **PR 2 (nteract.io):** Complete the page content and styling. Reviewed against the markdown source.
+3. **PR 3 (desktop):** Extract `TelemetryDisclosure` component. Update onboarding to use it in the new affirmation layout. Fix the Learn more URL to `/telemetry`.
+4. **PR 4 (desktop):** Add the Settings → Privacy pane with install-ID rotation.
+5. **PR 5 (desktop):** Slim `docs/telemetry.md` to the developer-facing residue.
+
+PRs 1–2 ship the page. PRs 3–4 ship the touchpoints. PR 5 unifies the canonical home for the user-facing text. Each PR is reviewable in isolation; the link update in PR 3 depends on PR 2 being live, otherwise the Learn more link dead-ends again.
+
+## Follow-ups parked
+
+- **Cream-style markdown / prose redesign.** Extend `--font-page-serif` and the cream palette into a broader prose treatment used for data-science blog posts and documentation pages. Its own PR on nteract.io. Reuses the tokens introduced here.
+- **Space Grotesk remains the display face** for security posts and engineering content. Explicit split: Source Serif for long-form reading / data science, Space Grotesk for systems / release / security posts. This split is a follow-up design note, not a code change.
+- **Rust-to-TS data check.** If `lib/telemetry-data.ts` drifts from the Rust source, add a CI job that parses the emitter's field enum and diffs against the TS module. Probably not needed until the field set actually changes.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,72 +1,62 @@
-# Telemetry
+# Telemetry (developer notes)
 
-nteract collects anonymous daily usage data to understand how many people use the app. This document describes exactly what is sent, what is not, and how to opt out.
+User-facing copy lives at https://nteract.io/telemetry. This file is for developers working on the desktop codebase.
 
-## What is sent
+## Files
 
-Every heartbeat ping carries six fields:
+| Path | Purpose |
+|------|---------|
+| `crates/runtimed-client/src/telemetry.rs` | Heartbeat emitter. `should_send_full`, `blocking_gates_full`, `try_send`, `heartbeat_loop`, `heartbeat_once`, `rotate_install_id_in`. |
+| `crates/runtimed-client/src/settings_doc.rs` | `SyncedSettings` fields: `install_id`, `telemetry_enabled`, `telemetry_consent_recorded`, three `telemetry_last_*_ping_at` fields. `backfill_telemetry_consent` / `backfill_telemetry_consent_in_doc` migrations. |
+| `crates/runt/src/main.rs` | `runt config telemetry {status,enable,disable}`. |
+| `src/components/TelemetryDisclosureCard.tsx` | Shared disclosure card, used in onboarding and Settings. |
+| `apps/notebook/onboarding/App.tsx` | "You can count on me!" / "Opt out of metrics, continue" buttons. |
+| `apps/notebook/settings/sections/Privacy.tsx` | Revisit pane with install ID rotation. |
 
-| Field | Example | Description |
-|---|---|---|
-| `install_id` | `550e8400-e29b-41d4-a716-446655440000` | Opaque UUIDv4 generated on first run. Not derived from any identifying data. |
-| `source` | `app`, `daemon`, `mcp` | Which process sent the ping. |
-| `version` | `2.2.1` | Release version. |
-| `channel` | `stable` or `nightly` | Release channel. |
-| `platform` | `macos`, `linux`, `windows` | OS family. |
-| `arch` | `arm64`, `x86_64` | CPU architecture. |
+## The consent gate
 
-The server adds `received_at` (unix timestamp) on its side.
+`telemetry_consent_recorded` is the explicit-consent gate added after the onboarding redesign. Until it is `true`, `should_send_full` returns `false` even when `telemetry_enabled = true`.
 
-## What is never sent or stored
+Daemon startup runs `backfill_telemetry_consent_in_doc` so existing users who completed onboarding before the flag existed keep sending heartbeats — they've already indicated they're okay with it. Fresh installs stay at `false` until the user presses either CTA on the onboarding screen.
 
-- Hostname, username, home directory, or any filesystem path
-- Notebook contents, cell outputs, kernel names, or environment details
-- Dependency names or versions (Python, Node, R, system packages)
-- Hardware identifiers (MAC address, serial number, disk UUID)
-- Client IP address at rest - Cloudflare observes it briefly for rate limiting; the database does not store it
-- `User-Agent` or any HTTP header beyond `Content-Type`
+## Install ID rotation
 
-## How it works
+`rotate_install_id_in` generates a fresh UUIDv4 and clears the three per-source `last_ping_at` timestamps so the 20-hour throttle doesn't silently suppress the first ping under the new ID. The Tauri command `rotate_install_id` wraps it and is invoked from Settings → Privacy.
 
-Three processes send heartbeats independently:
+## Suppression
 
-- **app** - fires once per launch of the desktop GUI
-- **daemon** - checks hourly, sends if >20 hours since last ping
-- **mcp** - checks hourly, sends if >20 hours since last ping
+Heartbeats are suppressed when any of these hold:
 
-All pings go to `https://telemetry.runtimed.com/v1/ping` as a JSON POST. The endpoint enforces a 60 req/min rate limit per IP at the Cloudflare edge.
+- `RUNTIMED_DEV=1` or `RUNTIMED_WORKSPACE_PATH` is set
+- `CI` is set
+- `NTERACT_TELEMETRY_DISABLE=1` is set
+- `telemetry_enabled = false` in settings
+- `telemetry_consent_recorded = false` in settings
+- `onboarding_completed = false`
+- Platform or arch is unsupported
+- Last ping for this source was less than 20 hours ago
 
-## Emission gates
+## Adding a heartbeat field
 
-A heartbeat is suppressed if any of these conditions hold:
+Keep in mind every field added here ships to users as part of their ping payload. Add with care, and update:
 
-| Gate | Trigger |
-|---|---|
-| Dev mode | `RUNTIMED_DEV=1` or `RUNTIMED_WORKSPACE_PATH` is set |
-| CI | `CI` environment variable is set |
-| Kill switch | `NTERACT_TELEMETRY_DISABLE` environment variable is set |
-| Disabled | `telemetry_enabled = false` in settings |
-| Not onboarded | `onboarding_completed = false` (fresh install before first-run screen) |
-| Unsupported host | Platform or architecture not in the server's enum |
-| Throttled | Last ping for this source was less than 20 hours ago |
+1. `HeartbeatPayload` in `crates/runtimed-client/src/telemetry.rs`.
+2. The public page at `https://nteract.io/telemetry` so what's documented matches what's sent.
 
-## Opting out
+The server side is separate infrastructure and versions independently — coordinate the rollout so the server accepts the new field before the client emits it.
 
-Three ways to disable telemetry, all equivalent:
+## Testing
 
-1. **Onboarding toggle** - the first-run screen includes a telemetry toggle (default: on). Flip it off before clicking "Get Started".
+```
+cargo test -p runtimed-client telemetry::tests
+cargo test -p runtimed-client settings_doc::tests
+pnpm vp test run src/components/__tests__/TelemetryDisclosureCard
+```
 
-2. **CLI** - run `runt config telemetry disable`. Check status with `runt config telemetry status`.
+## Endpoints
 
-3. **Environment variable** - set `NTERACT_TELEMETRY_DISABLE=1`. This is an emergency kill switch for locked-down deployments or CI images.
+- Ingest: `POST https://telemetry.runtimed.com/v1/ping`
 
-There is no server-side delete endpoint. When you disable telemetry the client stops sending pings. Existing data ages out under the retention policy below.
+## Visual preview
 
-## Retention
-
-- **Raw pings**: kept for 400 days, then deleted by a nightly cleanup job.
-- **Daily aggregate counts**: kept indefinitely. These contain no `install_id` - only counts of distinct installs grouped by day, source, version, channel, platform, and arch.
-
-## Schema evolution
-
-New fields may be added over time (additive only). Any field removal is a breaking change that gets a new route version (`/v2/ping`).
+Run `pnpm --dir apps/notebook dev` and open `http://localhost:5174/gallery/` to preview `TelemetryDisclosureCard`, the onboarding CTA block, and Settings → Privacy without launching the desktop app.

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -67,6 +67,39 @@ export type SyncedSettings = {
    * When true, the daemon installs `nteract-kernel-launcher` and `dx` into
    * UV kernel environments, launches kernels via `nteract_kernel_launcher`,
    * and runs `dx.install()` before the first user cell. Default: false.
+   *
+   * Mirrors `FeatureFlags::bootstrap_dx`. Flattened on the wire so the
+   * settings JSON and Automerge document keep a flat layout even as new
+   * feature flags are added.
    */
   bootstrap_dx: boolean;
+  /**
+   * Opaque per-install UUIDv4. Generated on first heartbeat, persisted in
+   * settings. Not derived from any identifying data.
+   */
+  install_id: string;
+  /**
+   * Master telemetry switch. When false, no heartbeat pings are sent.
+   */
+  telemetry_enabled: boolean;
+  /**
+   * Whether the user has explicitly recorded a telemetry decision (pressed
+   * either the "You can count on me!" or "Opt out of metrics, continue"
+   * button during onboarding). Default false. Until this is true, no
+   * heartbeat fires, even when `telemetry_enabled = true`. Satisfies the
+   * GDPR "clear affirmative action" requirement.
+   */
+  telemetry_consent_recorded: boolean;
+  /**
+   * Unix-seconds timestamp of the last successful daemon heartbeat.
+   */
+  telemetry_last_daemon_ping_at?: bigint | null;
+  /**
+   * Unix-seconds timestamp of the last successful app heartbeat.
+   */
+  telemetry_last_app_ping_at?: bigint | null;
+  /**
+   * Unix-seconds timestamp of the last successful MCP heartbeat.
+   */
+  telemetry_last_mcp_ping_at?: bigint | null;
 };

--- a/src/components/TelemetryDisclosureCard.tsx
+++ b/src/components/TelemetryDisclosureCard.tsx
@@ -43,15 +43,12 @@ export function TelemetryDisclosureCard({
   };
 
   return (
-    <div
-      className={cn("rounded-lg border p-4 bg-muted/40 space-y-2", className)}
-    >
+    <div className={cn("rounded-lg border p-4 bg-muted/40 space-y-2", className)}>
       <div className="text-[10px] uppercase tracking-[0.14em] text-primary/80 font-semibold">
         One anonymous daily ping
       </div>
       <p className="text-sm text-foreground leading-6">
-        Version, platform, architecture. No names, no paths, nothing about your
-        notebooks.
+        Version, platform, architecture. No names, no paths, nothing about your notebooks.
       </p>
       <a
         href={LEARN_MORE_URL}

--- a/src/components/TelemetryDisclosureCard.tsx
+++ b/src/components/TelemetryDisclosureCard.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface TelemetryDisclosureCardProps {
+  className?: string;
+  footer?: ReactNode;
+  /**
+   * Optional URL opener so consumers can wire the Learn more link to the
+   * host's `externalLinks.open` implementation. The default handler just
+   * follows the `href` (unit tests, web contexts).
+   */
+  onOpenLearnMore?: (url: string) => void;
+}
+
+const LEARN_MORE_URL = "https://nteract.io/telemetry";
+
+/**
+ * One-source-of-truth disclosure card for telemetry.
+ *
+ * Rendered in:
+ *  - Onboarding (step 2, above the two consent buttons).
+ *  - Settings → Privacy (alongside the revisit toggle).
+ *
+ * The Learn more link points at https://nteract.io/telemetry — the
+ * canonical public page that explains what's sent, what's never sent,
+ * retention, and user rights. This card only carries the minimum
+ * disclosure; clicking through is how the user gets the full picture.
+ *
+ * Consumers supply `onOpenLearnMore` to route the click through the
+ * host's URL opener (e.g. `openUrl` from apps/notebook/src/lib/open-url).
+ * The default behavior falls back to the `href` so unit tests and any
+ * non-Tauri host still work.
+ */
+export function TelemetryDisclosureCard({
+  className,
+  footer,
+  onOpenLearnMore,
+}: TelemetryDisclosureCardProps) {
+  const handleLearnMore = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!onOpenLearnMore) return;
+    e.preventDefault();
+    onOpenLearnMore(LEARN_MORE_URL);
+  };
+
+  return (
+    <div
+      className={cn("rounded-lg border p-4 bg-muted/40 space-y-2", className)}
+    >
+      <div className="text-[10px] uppercase tracking-[0.14em] text-primary/80 font-semibold">
+        One anonymous daily ping
+      </div>
+      <p className="text-sm text-foreground leading-6">
+        Version, platform, architecture. No names, no paths, nothing about your
+        notebooks.
+      </p>
+      <a
+        href={LEARN_MORE_URL}
+        onClick={handleLearnMore}
+        rel="noreferrer"
+        target="_blank"
+        className="inline-block text-xs text-primary underline hover:text-foreground"
+      >
+        Read the full details
+      </a>
+      {footer ? <div className="pt-1">{footer}</div> : null}
+    </div>
+  );
+}

--- a/src/components/__tests__/TelemetryDisclosureCard.test.tsx
+++ b/src/components/__tests__/TelemetryDisclosureCard.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TelemetryDisclosureCard } from "../TelemetryDisclosureCard";
+
+describe("TelemetryDisclosureCard", () => {
+  it("renders the eyebrow, body, and a Learn more link", () => {
+    render(<TelemetryDisclosureCard />);
+    expect(screen.getByText(/One anonymous daily ping/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Version, platform, architecture/i),
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /read the full details/i });
+    expect(link).toHaveAttribute("href", "https://nteract.io/telemetry");
+  });
+
+  it("renders a footer slot when provided", () => {
+    render(<TelemetryDisclosureCard footer={<span>extra</span>} />);
+    expect(screen.getByText("extra")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/TelemetryDisclosureCard.test.tsx
+++ b/src/components/__tests__/TelemetryDisclosureCard.test.tsx
@@ -6,9 +6,7 @@ describe("TelemetryDisclosureCard", () => {
   it("renders the eyebrow, body, and a Learn more link", () => {
     render(<TelemetryDisclosureCard />);
     expect(screen.getByText(/One anonymous daily ping/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Version, platform, architecture/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Version, platform, architecture/i)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /read the full details/i });
     expect(link).toHaveAttribute("href", "https://nteract.io/telemetry");
   });

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -159,6 +159,13 @@ export function useSyncedSettings() {
   const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
   // Feature flags (auto-derived from FEATURE_FLAG_METADATA)
   const [featureFlags, setFeatureFlagsState] = useState<FeatureFlagValues>(FEATURE_FLAG_DEFAULTS);
+  // Telemetry state — surfaced to Settings → Privacy and the onboarding flow.
+  const [telemetryEnabled, setTelemetryEnabledState] = useState<boolean>(true);
+  const [telemetryConsentRecorded, setTelemetryConsentRecordedState] = useState<boolean>(false);
+  const [installId, setInstallIdState] = useState<string>("");
+  const [lastDaemonPingAt, setLastDaemonPingAtState] = useState<number | null>(null);
+  const [lastAppPingAt, setLastAppPingAtState] = useState<number | null>(null);
+  const [lastMcpPingAt, setLastMcpPingAtState] = useState<number | null>(null);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -194,6 +201,24 @@ export function useSyncedSettings() {
           setKeepAliveSecsState(settings.keep_alive_secs);
         }
         setFeatureFlagsState((prev) => readFeatureFlags(settings, prev));
+        if (typeof settings.telemetry_enabled === "boolean") {
+          setTelemetryEnabledState(settings.telemetry_enabled);
+        }
+        if (typeof settings.telemetry_consent_recorded === "boolean") {
+          setTelemetryConsentRecordedState(settings.telemetry_consent_recorded);
+        }
+        if (typeof settings.install_id === "string") {
+          setInstallIdState(settings.install_id);
+        }
+        // Pings are Option<u64> in Rust — bigint over the wire for large values.
+        const numOrBigint = (v: unknown): number | null => {
+          if (typeof v === "number") return v;
+          if (typeof v === "bigint") return Number(v);
+          return null;
+        };
+        setLastDaemonPingAtState(numOrBigint(settings.telemetry_last_daemon_ping_at));
+        setLastAppPingAtState(numOrBigint(settings.telemetry_last_app_ping_at));
+        setLastMcpPingAtState(numOrBigint(settings.telemetry_last_mcp_ping_at));
       })
       .catch(() => {
         // Daemon unavailable — defaults are fine
@@ -240,6 +265,16 @@ export function useSyncedSettings() {
         setKeepAliveSecsState(keep_alive_secs);
       }
       setFeatureFlagsState((prev) => readFeatureFlags(event.payload, prev));
+      if (typeof event.payload.telemetry_enabled === "boolean") {
+        setTelemetryEnabledState(event.payload.telemetry_enabled);
+      }
+      if (typeof event.payload.telemetry_consent_recorded === "boolean") {
+        setTelemetryConsentRecordedState(event.payload.telemetry_consent_recorded);
+      }
+      if (typeof event.payload.install_id === "string") {
+        setInstallIdState(event.payload.install_id);
+      }
+      // Last-ping timestamps change rarely; we only refresh them on mount.
     });
     return () => {
       unlisten.then((u) => u());
@@ -318,6 +353,36 @@ export function useSyncedSettings() {
     }).catch((e) => console.warn(`[settings] Failed to persist ${id}:`, e));
   }, []);
 
+  const setTelemetryEnabled = useCallback((value: boolean) => {
+    setTelemetryEnabledState(value);
+    invoke("set_synced_setting", {
+      key: "telemetry_enabled",
+      value,
+    }).catch((e) => console.warn("[settings] Failed to persist telemetry_enabled:", e));
+  }, []);
+
+  const setTelemetryConsentRecorded = useCallback((value: boolean) => {
+    setTelemetryConsentRecordedState(value);
+    invoke("set_synced_setting", {
+      key: "telemetry_consent_recorded",
+      value,
+    }).catch((e) => console.warn("[settings] Failed to persist telemetry_consent_recorded:", e));
+  }, []);
+
+  const rotateInstallId = useCallback(async (): Promise<string | null> => {
+    try {
+      const newId = await invoke<string>("rotate_install_id");
+      setInstallIdState(newId);
+      setLastDaemonPingAtState(null);
+      setLastAppPingAtState(null);
+      setLastMcpPingAtState(null);
+      return newId;
+    } catch (e) {
+      console.warn("[settings] Failed to rotate install_id:", e);
+      return null;
+    }
+  }, []);
+
   return {
     theme,
     setTheme,
@@ -337,6 +402,15 @@ export function useSyncedSettings() {
     setKeepAliveSecs,
     featureFlags,
     setFeatureFlag,
+    telemetryEnabled,
+    setTelemetryEnabled,
+    telemetryConsentRecorded,
+    setTelemetryConsentRecorded,
+    installId,
+    rotateInstallId,
+    lastDaemonPingAt,
+    lastAppPingAt,
+    lastMcpPingAt,
   };
 }
 


### PR DESCRIPTION
## Summary

Replaces the pre-checked telemetry toggle with an explicit two-button CTA at the end of onboarding, adds a Settings → Privacy pane so the decision is revisitable, gates every heartbeat behind a new `telemetry_consent_recorded` flag, and ships an install-ID rotation primitive. Daemon startup backfills the flag for existing onboarded users so no one's pings get silently dropped across the upgrade.

Also lands a lightweight `apps/notebook/gallery/` sub-app so these components can be previewed in a browser without launching the desktop app.

Marked **draft** while Codex finishes its review of the branch. All 12 plan tasks plus the gallery are implemented and every verification step in task 12 passes locally:

- `cargo test -p runtimed-client` — 179 passing
- `cargo test -p notebook --lib` — 133 passing
- `cargo test -p runtimed --test tokio_mutex_lint` — 1 passing
- `pnpm vp test run` — 1078 passing, 3 skipped
- `pnpm --dir apps/notebook exec tsc --noEmit` — clean
- `cargo xtask lint` — clean

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-23-telemetry-ui-and-docs-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-telemetry-desktop-implementation.md`

## How to preview the components

A new sub-app lives at `apps/notebook/gallery/`. It renders `TelemetryDisclosureCard`, the onboarding CTA block (with a state selector for idle / no-env-selected / ready / submitting / setup-complete), and the full Settings → Privacy section against local state. No Tauri, no daemon, no IPC.

```bash
pnpm --dir apps/notebook dev
# → http://localhost:5174/gallery/
```

Theme switcher at the top of the page toggles between light, dark, and system.

`pnpm --dir apps/notebook build` emits `dist/gallery/index.html` too, so static hosting from a URL works later if we want it.

## What the user sees

Onboarding page 2 now shows:

1. The shared disclosure card — "One anonymous daily ping. Version, platform, architecture. No names, no paths, nothing about your notebooks." plus a "Read the full details" link to https://nteract.io/telemetry.
2. A primary button: **"You can count on me!"**
3. A secondary underlined link below: **"Opt out of metrics, continue"**

Both buttons persist the telemetry choice, flip `telemetry_consent_recorded = true`, complete onboarding, and close the window. Neither pings silently — both are explicit.

Settings → Privacy adds an equivalent panel between Appearance and New Notebooks: same disclosure card, a trailing switch for toggling the daily ping, an install-ID viewer with a one-click rotate action (generates a fresh UUIDv4, clears the three `last_ping_at` markers), and the relative time since each source last pinged.

## Architecture notes

- **Consent gate.** `should_send_full` in `crates/runtimed-client/src/telemetry.rs` is the superset of `should_send` that also requires consent. `try_send` routes through it; `should_send` and `blocking_gates` stay unchanged so legacy callers compile.
- **Backfill.** `backfill_telemetry_consent_in_doc(&mut SettingsDoc)` runs once in `Daemon::new`. If onboarding completed but consent was never recorded (pre-upgrade state), it flips the flag. Idempotent.
- **Rotation.** `rotate_install_id_in` is a pure function in `telemetry.rs`; the `rotate_install_id` Tauri command wraps it and performs four sequential `put_value` writes to the settings doc.
- **Gallery.** `apps/notebook/gallery/` is a new Vite entry alongside onboarding/settings/upgrade/feedback. Its `index.css` imports `../settings/index.css` wholesale so tokens, Tailwind config, and the cream theme stay in sync automatically. Any component used here must degrade gracefully without the Tauri shell — `TelemetryDisclosureCard` does (the optional `onOpenLearnMore` callback falls back to the `<a href>`); `PrivacySection` calls `@tauri-apps/plugin-shell`'s `open` but wraps it in a `.catch(() => {})` so the rotate/learn-more links don't throw in the browser.

## Commit layout

Seventeen commits total, one per plan task plus five inherited docs commits:

| Commit | Task |
|---|---|
| `dd52495a` | 1 — add `telemetry_consent_recorded` field + backfill helpers |
| `58106f36` | 2 — gate heartbeats behind the flag |
| `d9b1b8ab` | 3 — `rotate_install_id_in` helper |
| `705ef72c` | 4 — `rotate_install_id` Tauri command |
| `f3438b0d` | 5 — expose telemetry state + rotation to the frontend hook |
| `71723507` | 6 — shared `TelemetryDisclosureCard` component |
| `b073501b` | 7 — onboarding two-button CTA |
| `ef7651bf` | 8 — Settings Privacy pane + onboarding link opener simplification |
| `d734c7ee` | bonus — component gallery sub-app |
| `7bcba476` | 9 — daemon startup backfill |
| `d06d6502` | 10 — CLI surfaces consent_recorded |
| `6bb1a04d` | 11 — slim `docs/telemetry.md` to a developer readme |

## Deviations from the plan

- **Shared disclosure card location.** Plan said `apps/notebook/src/components/TelemetryDisclosureCard.tsx` but imported it via `@/components/...`. The `@/` alias resolves to the repo-root `/src/`, so I put it at `/src/components/TelemetryDisclosureCard.tsx` (shared across sub-apps). Matches the import pattern the plan wrote.
- **Link opener.** Plan used `@tauri-apps/plugin-shell` directly. The notebook sub-apps don't initialize the `NotebookHost` registry that `openUrl` requires, so I kept the direct plugin-shell import in both onboarding and Settings — same pattern the feedback sub-app already uses.
- **"Erase my data" mailto dropped** per explicit user request ("just provide the link"). The disclosure card's Learn more link points at the public telemetry page, which is the canonical place for erasure instructions.
- **Test location.** Vitest config only picks up `src/**/__tests__/**/*.test.tsx`, so `TelemetryDisclosureCard.test.tsx` lives in `src/components/__tests__/`, not alongside the component as the plan sketch showed.

## Test plan

- [ ] Launch Vite gallery and click through each variant/state.
- [ ] Back up `~/Library/Application Support/io.nteract.desktop/settings.json` (or the Linux equivalent), delete it, run the app, walk through onboarding with the "You can count on me!" path. Verify telemetry_enabled=true and telemetry_consent_recorded=true afterward via `runt config telemetry status`.
- [ ] Repeat with the opt-out path. Verify telemetry_enabled=false and telemetry_consent_recorded=true.
- [ ] On a pre-existing (onboarded) install, verify `runt config telemetry status` shows `consent_recorded: yes` after first daemon restart under this branch.
- [ ] Open Settings → Privacy, flip the switch, rotate the install ID. Confirm the new UUID appears instantly.
- [ ] Click the Learn more link in either surface; system browser should open https://nteract.io/telemetry.
