### PR TITLE
fix(runtimed): unflake integration suite under parallel load

### DIFF
--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -39,18 +39,31 @@ use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 /// bump budget stays in sync with the per-channel range carve-out.
 const PREFERRED_PORT_ATTEMPTS: u16 = runt_workspace::PREFERRED_BLOB_PORT_RANGE;
 
-/// Start the blob HTTP server on a random localhost port.
+/// Start the blob HTTP server.
 ///
 /// Returns the port the server is listening on. The server runs as a
 /// spawned task on the current tokio runtime.
 ///
 /// When `daemon` is provided, a panic in the accept loop triggers shutdown.
 /// Pass `None` in tests where no daemon is available.
+///
+/// When `use_preferred_port` is `true`, binds against the channel's
+/// preferred port with a bounded bump range before falling back to an
+/// OS-assigned port. When `false`, skips straight to OS-assigned.
+/// Integration tests and other contexts that run dozens of daemons in
+/// close proximity should pass `false` to avoid `EADDRINUSE` retry
+/// chains pushing boot past their `wait_for_daemon` timeout.
 pub async fn start_blob_server(
     store: Arc<BlobStore>,
     daemon: Option<Arc<Daemon>>,
+    use_preferred_port: bool,
 ) -> std::io::Result<u16> {
-    start_blob_server_with_listener(bind_preferred_or_random().await?, store, daemon).await
+    let listener = if use_preferred_port {
+        bind_preferred_or_random().await?
+    } else {
+        TcpListener::bind("127.0.0.1:0").await?
+    };
+    start_blob_server_with_listener(listener, store, daemon).await
 }
 
 /// Start the blob HTTP server on an already-bound listener. Exposed for tests

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1262,7 +1262,7 @@ impl Daemon {
     /// Automerge settings document. Self-writes (from `persist_settings`) are
     /// automatically skipped because the file contents match the doc state.
     async fn watch_settings_json(self: Arc<Self>) {
-        let json_path = crate::settings_json_path();
+        let json_path = self.config.resolved_settings_json_path();
 
         // Determine which path to watch: the file itself if it exists,
         // or the parent directory if it doesn't exist yet.
@@ -1681,6 +1681,8 @@ impl Daemon {
                     self.settings.clone(),
                     changed_tx,
                     changed_rx,
+                    self.config.resolved_settings_doc_path(),
+                    self.config.resolved_settings_json_path(),
                 )
                 .await
             }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -64,6 +64,29 @@ pub struct DaemonConfig {
     pub env_cache_max_age_secs: u64,
     /// Maximum number of content-addressed cached environments per cache directory.
     pub env_cache_max_count: usize,
+    /// Whether the blob HTTP server should try `runt_workspace::preferred_blob_port()`
+    /// and its bump range before falling back to an OS-assigned port.
+    ///
+    /// `true` (default) keeps the port stable across daemon restarts so
+    /// MCP Apps with baked-in CSPs (`http://127.0.0.1:<port>`) keep
+    /// working. Set to `false` for integration tests, where dozens of
+    /// daemons compete for a 10-port range and sequential `EADDRINUSE`
+    /// retries push boot past the test's `wait_for_daemon` timeout, and
+    /// for any other context where the stable-port UX isn't load-bearing.
+    pub use_preferred_blob_port: bool,
+    /// Override for the persisted Automerge settings-document path.
+    ///
+    /// `None` (default) uses the channel's global path
+    /// (`daemon_base_dir()/settings.automerge`). Integration tests
+    /// override this to a per-test temp-dir path so dozens of parallel
+    /// daemons don't contend on the same on-disk file during boot.
+    pub settings_doc_path: Option<PathBuf>,
+    /// Override for the JSON mirror of the settings doc.
+    ///
+    /// Same story as `settings_doc_path`: global by default, per-test
+    /// when overridden. Integration tests set both to avoid write
+    /// contention under parallel boot.
+    pub settings_json_path: Option<PathBuf>,
 }
 
 impl Default for DaemonConfig {
@@ -81,7 +104,28 @@ impl Default for DaemonConfig {
             room_eviction_delay_ms: None,
             env_cache_max_age_secs: 86400, // 1 day
             env_cache_max_count: 10,
+            use_preferred_blob_port: true,
+            settings_doc_path: None,
+            settings_json_path: None,
         }
+    }
+}
+
+impl DaemonConfig {
+    /// Resolve the Automerge settings-doc path: override when set,
+    /// otherwise the channel's global path.
+    pub fn resolved_settings_doc_path(&self) -> PathBuf {
+        self.settings_doc_path
+            .clone()
+            .unwrap_or_else(runtimed_client::default_settings_doc_path)
+    }
+
+    /// Resolve the JSON mirror path: override when set, otherwise the
+    /// channel's global path.
+    pub fn resolved_settings_json_path(&self) -> PathBuf {
+        self.settings_json_path
+            .clone()
+            .unwrap_or_else(runt_workspace::settings_json_path)
     }
 }
 
@@ -702,9 +746,11 @@ impl Daemon {
         let lock = DaemonLock::try_acquire(config.lock_dir.as_ref())
             .map_err(|info| DaemonAlreadyRunning { info })?;
 
-        // Load or create the settings document
-        let automerge_path = crate::default_settings_doc_path();
-        let json_path = crate::settings_json_path();
+        // Load or create the settings document. Use the config-resolved
+        // paths so integration tests can point each daemon at a per-test
+        // temp file and avoid contention on the global settings doc.
+        let automerge_path = config.resolved_settings_doc_path();
+        let json_path = config.resolved_settings_json_path();
         let mut settings = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
 
         // Pool sizes now come from settings.json (imported via apply_json_changes)
@@ -727,7 +773,6 @@ impl Daemon {
             tracing::info!(
                 "[settings] Backfilled telemetry_consent_recorded for an existing onboarded install"
             );
-            let automerge_path = crate::default_settings_doc_path();
             if let Err(e) = settings.save_to_file(&automerge_path) {
                 tracing::warn!(
                     "[settings] Failed to persist backfilled Automerge doc: {}",
@@ -871,19 +916,23 @@ impl Daemon {
         }
 
         // Start the blob HTTP server (also serves renderer plugin assets)
-        let blob_port =
-            match blob_server::start_blob_server(self.blob_store.clone(), Some(self.clone())).await
-            {
-                Ok(port) => {
-                    info!("[runtimed] Blob server started on port {}", port);
-                    *self.blob_port.lock().await = Some(port);
-                    Some(port)
-                }
-                Err(e) => {
-                    error!("[runtimed] Failed to start blob server: {}", e);
-                    None
-                }
-            };
+        let blob_port = match blob_server::start_blob_server(
+            self.blob_store.clone(),
+            Some(self.clone()),
+            self.config.use_preferred_blob_port,
+        )
+        .await
+        {
+            Ok(port) => {
+                info!("[runtimed] Blob server started on port {}", port);
+                *self.blob_port.lock().await = Some(port);
+                Some(port)
+            }
+            Err(e) => {
+                error!("[runtimed] Failed to start blob server: {}", e);
+                None
+            }
+        };
 
         // Bind the Unix socket early so clients can connect (and ping) while
         // the rest of initialisation finishes.  The accept loop runs later.
@@ -1307,7 +1356,7 @@ impl Daemon {
                                     // the JSON mirror back, as serde_json formatting
                                     // differs from editors (e.g. arrays expand to one
                                     // element per line) which causes unwanted churn.
-                                    let automerge_path = crate::default_settings_doc_path();
+                                    let automerge_path = self.config.resolved_settings_doc_path();
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
                                     }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -4,6 +4,7 @@
 //! daemon's unified socket. Exchanges Automerge sync messages to keep a
 //! shared settings document in sync across all notebook windows.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use automerge::sync;
@@ -42,6 +43,8 @@ pub async fn handle_settings_sync_connection<R, W>(
     settings: Arc<RwLock<SettingsDoc>>,
     changed_tx: broadcast::Sender<()>,
     mut changed_rx: broadcast::Receiver<()>,
+    automerge_path: PathBuf,
+    json_path: PathBuf,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -76,7 +79,7 @@ where
                         doc.receive_sync_message(&mut peer_state, message)?;
 
                         // Persist and notify others
-                        persist_settings(&mut doc);
+                        persist_settings(&mut doc, &automerge_path, &json_path);
                         let _ = changed_tx.send(());
 
                         // Send our response
@@ -103,14 +106,11 @@ where
 }
 
 /// Persist the settings document to disk (both Automerge binary and JSON mirror).
-fn persist_settings(doc: &mut SettingsDoc) {
-    let automerge_path = crate::default_settings_doc_path();
-    let json_path = crate::settings_json_path();
-
-    if let Err(e) = doc.save_to_file(&automerge_path) {
+fn persist_settings(doc: &mut SettingsDoc, automerge_path: &Path, json_path: &Path) {
+    if let Err(e) = doc.save_to_file(automerge_path) {
         warn!("[sync] Failed to save Automerge doc: {}", e);
     }
-    if let Err(e) = doc.save_json_mirror(&json_path) {
+    if let Err(e) = doc.save_json_mirror(json_path) {
         warn!("[sync] Failed to write JSON mirror: {}", e);
     }
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -84,14 +84,40 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
         room_eviction_delay_ms: Some(50), // Fast eviction for tests
+        // Integration tests run dozens of daemons in parallel; the
+        // preferred-port path's 10-slot budget gets saturated and the
+        // sequential `EADDRINUSE` retries push daemon boot past the
+        // test's `wait_for_daemon` timeout. Skip straight to OS-assigned.
+        use_preferred_blob_port: false,
+        // Pin settings files per-temp-dir so parallel daemons don't
+        // contend on the global `~/.cache/runt*/settings.automerge` +
+        // `~/.config/runt*/settings.json` pair at boot.
+        settings_doc_path: Some(temp_dir.path().join("settings.automerge")),
+        settings_json_path: Some(temp_dir.path().join("settings.json")),
         ..Default::default()
     }
 }
 
+/// Max time we'll wait for a test daemon's socket to accept `ping`.
+///
+/// Daemon boot is a few hundred ms in isolation but can stretch to
+/// many seconds under CPU thrash when the whole suite runs in parallel.
+/// Keep the budget generous so the suite isn't flaky under load; a
+/// truly hung daemon still surfaces within the `cargo test` timeout.
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Max time we'll wait for initial Automerge sync to hit session-ready.
+///
+/// Same shape as `DAEMON_READY_TIMEOUT`: fine in isolation, slow under
+/// parallel load. Callers at heavy steps (`add_cell_after`, multi-client
+/// sync) have their own per-step assertions; this one just gates the
+/// initial handshake.
+const SESSION_READY_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Wait for the daemon to be ready by polling the client.
-async fn wait_for_daemon(client: &PoolClient, timeout: Duration) -> bool {
+async fn wait_for_daemon(client: &PoolClient) -> bool {
     let start = std::time::Instant::now();
-    while start.elapsed() < timeout {
+    while start.elapsed() < DAEMON_READY_TIMEOUT {
         if client.ping().await.is_ok() {
             return true;
         }
@@ -184,7 +210,7 @@ async fn test_daemon_ping_pong() {
 
     // Create client and wait for daemon
     let client = PoolClient::new(socket_path);
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Test ping
     let result = client.ping().await;
@@ -210,7 +236,7 @@ async fn test_daemon_status() {
     });
 
     let client = PoolClient::new(socket_path);
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Get status
     let state = client.status().await.unwrap();
@@ -234,7 +260,7 @@ async fn test_daemon_take_empty_pool() {
     });
 
     let client = PoolClient::new(socket_path);
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Try to take from empty pool
     let result = client.take(EnvType::Uv).await.unwrap();
@@ -261,7 +287,7 @@ async fn test_singleton_prevents_second_daemon() {
     });
 
     let client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Try to start second daemon with same paths - should fail
     let config2 = DaemonConfig {
@@ -312,7 +338,7 @@ async fn test_multiple_client_connections() {
     let client2 = PoolClient::new(socket_path.clone());
     let client3 = PoolClient::new(socket_path.clone());
 
-    assert!(wait_for_daemon(&client1, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client1).await);
 
     // All clients should be able to ping concurrently
     let (r1, r2, r3) = tokio::join!(client1.ping(), client2.ping(), client3.ping());
@@ -352,7 +378,7 @@ async fn test_settings_sync_via_unified_socket() {
 
     // Wait for daemon to be ready (via pool channel)
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Connect a SyncClient through the unified socket
     let sync_client = SyncClient::connect_with_timeout(socket_path, Duration::from_secs(2))
@@ -382,7 +408,7 @@ async fn test_blob_server_health() {
     });
 
     let client = PoolClient::new(socket_path);
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Read daemon info to find blob port
     let info_path = temp_dir.path().join("daemon.json");
@@ -425,7 +451,7 @@ async fn test_notebook_sync_via_unified_socket() {
 
     // Wait for daemon to be ready
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create first notebook via connect_create — should get empty notebook
     let result1 = connect::connect_create(
@@ -443,7 +469,7 @@ async fn test_notebook_sync_via_unified_socket() {
     let client1 = result1.handle;
 
     assert!(
-        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
         "client1 should reach session-ready state within 2s"
     );
 
@@ -461,7 +487,7 @@ async fn test_notebook_sync_via_unified_socket() {
         .handle;
 
     assert!(
-        wait_for_session_ready(&client2, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client2, SESSION_READY_TIMEOUT).await,
         "client2 should reach session-ready state within 2s"
     );
 
@@ -486,7 +512,7 @@ async fn test_notebook_sync_via_unified_socket() {
     .handle;
 
     assert!(
-        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client3, SESSION_READY_TIMEOUT).await,
         "client3 should reach session-ready state within 2s"
     );
 
@@ -510,7 +536,7 @@ async fn test_notebook_sync_cross_window_propagation() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // First client creates a notebook; second client joins it
     let result = connect::connect_create(
@@ -532,11 +558,11 @@ async fn test_notebook_sync_cross_window_propagation() {
         .handle;
 
     assert!(
-        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
         "client1 should reach session-ready state within 2s"
     );
     assert!(
-        wait_for_session_ready(&client2, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client2, SESSION_READY_TIMEOUT).await,
         "client2 should reach session-ready state within 2s"
     );
 
@@ -591,7 +617,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Phase 1: Two clients connect, add cells, then both disconnect
     let notebook_id;
@@ -615,7 +641,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
             .handle;
 
         assert!(
-            wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+            wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
             "client1 should reach session-ready state within 2s"
         );
 
@@ -673,7 +699,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
         .handle;
 
     assert!(
-        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client3, SESSION_READY_TIMEOUT).await,
         "reconnected client should reach session-ready state within 2s"
     );
 
@@ -723,7 +749,7 @@ async fn test_eviction_flushes_before_reconnect() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create an untitled notebook with a few cells, then drop the client to
     // trigger eviction. No autosave path exists for untitled notebooks, so
@@ -745,7 +771,7 @@ async fn test_eviction_flushes_before_reconnect() {
         let client = result.handle;
 
         assert!(
-            wait_for_session_ready(&client, Duration::from_secs(2)).await,
+            wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state within 2s"
         );
 
@@ -808,7 +834,7 @@ async fn test_notebook_cell_delete_propagation() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Client1 creates a notebook with three cells
     let result = connect::connect_create(
@@ -826,7 +852,7 @@ async fn test_notebook_cell_delete_propagation() {
     let client1 = result.handle;
 
     assert!(
-        wait_for_session_ready(&client1, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
         "client1 should reach session-ready state within 2s"
     );
 
@@ -917,7 +943,7 @@ async fn test_multiple_notebooks_concurrent_isolation() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create three notebooks concurrently via connect_create
     let (nb_a, nb_b, nb_c) = tokio::join!(
@@ -1079,7 +1105,7 @@ async fn test_streaming_load_via_open_notebook() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create a notebook with 7 cells (enough for 3 batches of 3 + partial)
     let nb_path = temp_dir.path().join("streaming_test.ipynb");
@@ -1220,7 +1246,7 @@ async fn test_streaming_load_second_client_joins() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create notebook
     let nb_path = temp_dir.path().join("multi_client.ipynb");
@@ -1304,7 +1330,7 @@ async fn test_legacy_client_no_preamble() {
 
     // Wait for daemon with a modern client first
     let client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&client).await);
 
     // Now connect as a legacy client: send a raw length-prefixed JSON
     // handshake WITHOUT the magic bytes preamble.
@@ -1360,7 +1386,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create a pipe channel
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
@@ -1436,7 +1462,7 @@ async fn test_pipe_mode_preserves_initial_session_status_frame() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
@@ -1479,7 +1505,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
@@ -1563,7 +1589,7 @@ async fn test_pipe_mode_does_not_forward_response_frames() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
@@ -1635,7 +1661,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
@@ -1735,7 +1761,7 @@ async fn test_pipe_mode_preserves_frame_order() {
     .unwrap()
     .handle;
     assert!(
-        wait_for_session_ready(&client3, Duration::from_secs(2)).await,
+        wait_for_session_ready(&client3, SESSION_READY_TIMEOUT).await,
         "third client should reach session-ready state within 2s"
     );
     let cells = client3.get_cells();
@@ -1945,7 +1971,7 @@ async fn test_create_notebook_with_deps() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create notebook with conda + two deps
     let result = connect::connect_create(
@@ -2018,7 +2044,7 @@ async fn test_create_notebook_with_explicit_manager_no_deps() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create notebook with pixi manager, no deps
     let result = connect::connect_create(
@@ -2088,7 +2114,7 @@ async fn test_create_notebook_default_manager_with_deps() {
     });
 
     let pool_client = PoolClient::new(socket_path.clone());
-    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+    assert!(wait_for_daemon(&pool_client).await);
 
     // Create notebook with deps but no explicit package manager
     let result = connect::connect_create(


### PR DESCRIPTION
## Canary

`#2108`'s CI run flaked on `test_untitled_notebook_persists_through_eviction` with "reconnected client should see persisted cells for untitled notebook, got: []". Investigated per the "flakes as canaries" rule rather than retrying.

The real failure is upstream. The test panics at its 5s `wait_for_daemon` timeout during boot — the daemon hadn't finished starting up in 5s under 29-way parallel load. Same panic trips a handful of other tests in the same run, with the same shape.

Reproduces deterministically locally: `cargo test -p runtimed --test integration` fails ~6 tests with `wait_for_daemon` timing out.

## Three fixes, defense in depth

### 1. Blob port: let integration tests skip the preferred-port path

`start_blob_server` calls `bind_preferred_or_random`, which walks a 10-port range looking for a free port before falling back to OS-assigned. With 29 daemons racing for 10 ports, the losers hit sequential `EADDRINUSE` retries that stretch daemon boot.

Added `DaemonConfig::use_preferred_blob_port: bool`, default `true`. Production behavior unchanged (MCP Apps with baked-in CSPs still get the stable port). `test_config` sets it `false`, so integration tests bind `127.0.0.1:0` straight away.

### 2. Settings file: let integration tests have their own

`Daemon::new` was loading `SettingsDoc` from the channel's global paths (`~/.cache/runt-nightly/settings.automerge` and the `~/.config/runt-nightly/settings.json` mirror). 29 parallel daemons hit the same two files at boot.

Added `DaemonConfig::settings_doc_path` and `settings_json_path` as `Option<PathBuf>` overrides, threaded through to `Daemon::new` AND the settings-watch save site. Resolver methods on the config type so the three call sites share one lookup. `test_config` pins both to the per-test temp dir.

### 3. Daemon-ready timeout: actually the dominant cause

The first two helped but didn't fully resolve it. Turns out `wait_for_daemon` had a 5s timeout at every call site (22 of them). Daemon boot is sub-second in isolation; under CPU thrash it stretches to 10+ seconds.

Bumped to 20s for the daemon socket, 15s for the initial Automerge sync (`wait_for_session_ready`, 19 sites). Named constants (`DAEMON_READY_TIMEOUT`, `SESSION_READY_TIMEOUT`) so there's one place to tune. A genuinely hung daemon still surfaces — `cargo test`'s own timeout catches anything the integration helpers miss.

## Why keep all three

Tested the timeout bump alone: it's enough to make the suite pass reliably. The other two could be saved for later. But:

- `use_preferred_blob_port` is the right API regardless. Dev throwaway daemons in cloud sandboxes and any future parallel test runner benefit from it. Without the opt-out, the preferred-port path is mandatory.
- Per-test settings isolation is correct hygiene. 29 tests shouldn't share a user-level file, full stop.

## Test plan

- [x] `cargo test -p runtimed --test integration`: 29 passed, 3 consecutive runs (14-15s each)
- [x] `cargo test -p runtimed --lib`: 389 passed
- [x] `cargo xtask clippy`: clean
- [x] `cargo xtask lint --fix`: clean

## Out of scope (separate canaries)

- `test_uv_inline_deps_trusted` (Python integration). Different root cause: uv env resolution under load. Needs its own investigation.
- `E2E: UV Pyproject` "should execute code". Test pollution between `it()` blocks on webdriver retry — the first test writes `sys.executable` to cell 0, the second writes `httpx.__version__` to the same cell, and a retry of the first reads the stale output. Test isolation fix, not a daemon fix.
