### PR TITLE
fix(notebook): drop needless return in Windows cli_install branch

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -319,7 +319,6 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
         let _ = app;
         // On Windows, CLI install copies the binary — no symlink to check.
         // A future enhancement could compare binary hashes.
-        return;
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Drop the trailing `return;` in the `cfg(not(unix))` arm of `ensure_cli_current` so Windows clippy (`-D warnings`) stops failing the build.

## Test plan
- [ ] Windows CI passes clippy.
