### PR TITLE
refactor(settings): collapse Privacy, rename Advanced→Runtimes, resize window

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -74,7 +74,7 @@ function KeepAliveSlider({
     <div className="space-y-3 pt-4 border-t border-border/50">
       <div>
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          Advanced
+          Runtimes
         </span>
       </div>
       <div className="space-y-1">
@@ -286,16 +286,6 @@ export default function App() {
           </div>
         </div>
 
-        <PrivacySection
-          telemetryEnabled={telemetryEnabled}
-          onTelemetryChange={setTelemetryEnabled}
-          installId={installId}
-          onRotate={rotateInstallId}
-          lastDaemonPingAt={lastDaemonPingAt}
-          lastAppPingAt={lastAppPingAt}
-          lastMcpPingAt={lastMcpPingAt}
-        />
-
         {/* Default Runtime */}
         <div className="space-y-2">
           <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
@@ -453,8 +443,18 @@ export default function App() {
           </div>
         </div>
 
-        {/* Advanced */}
+        {/* Runtimes */}
         <KeepAliveSlider value={keepAliveSecs} onChange={setKeepAliveSecs} />
+
+        <PrivacySection
+          telemetryEnabled={telemetryEnabled}
+          onTelemetryChange={setTelemetryEnabled}
+          installId={installId}
+          onRotate={rotateInstallId}
+          lastDaemonPingAt={lastDaemonPingAt}
+          lastAppPingAt={lastAppPingAt}
+          lastMcpPingAt={lastMcpPingAt}
+        />
 
         {/* Feature Flags — only shown when there are flags to display */}
         {FEATURE_FLAGS.length > 0 && (

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -1,6 +1,8 @@
 import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { ChevronDown } from "lucide-react";
 import { useCallback, useState } from "react";
 import { TelemetryDisclosureCard } from "@/components/TelemetryDisclosureCard";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
 
 interface PrivacySectionProps {
@@ -59,48 +61,52 @@ export function PrivacySection({
   }, [isRotating, onRotate]);
 
   return (
-    <div className="space-y-3">
-      <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-        Privacy
-      </span>
+    <Collapsible className="space-y-3 pt-4 border-t border-border/50">
+      <CollapsibleTrigger className="flex items-center gap-1.5 w-full group">
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Privacy
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-3 pl-5">
+        <TelemetryDisclosureCard
+          onOpenLearnMore={openOrFallThrough}
+          footer={
+            <div className="flex items-center justify-between pt-1">
+              <span className="text-xs text-muted-foreground">Send anonymous daily ping</span>
+              <Switch checked={telemetryEnabled} onCheckedChange={onTelemetryChange} />
+            </div>
+          }
+        />
 
-      <TelemetryDisclosureCard
-        onOpenLearnMore={openOrFallThrough}
-        footer={
-          <div className="flex items-center justify-between pt-1">
-            <span className="text-xs text-muted-foreground">Send anonymous daily ping</span>
-            <Switch checked={telemetryEnabled} onCheckedChange={onTelemetryChange} />
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-muted-foreground shrink-0">Install ID</span>
+            <code
+              className="text-[11px] text-foreground truncate bg-muted/50 px-2 py-0.5 rounded"
+              title={installId}
+            >
+              {installId || "(not yet set)"}
+            </code>
+            <button
+              type="button"
+              onClick={handleRotate}
+              disabled={isRotating || !installId}
+              className="text-xs text-primary underline hover:text-foreground disabled:opacity-50"
+            >
+              {isRotating ? "Rotating..." : "Rotate"}
+            </button>
           </div>
-        }
-      />
 
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between gap-3">
-          <span className="text-xs text-muted-foreground shrink-0">Install ID</span>
-          <code
-            className="text-[11px] text-foreground truncate bg-muted/50 px-2 py-0.5 rounded"
-            title={installId}
-          >
-            {installId || "(not yet set)"}
-          </code>
-          <button
-            type="button"
-            onClick={handleRotate}
-            disabled={isRotating || !installId}
-            className="text-xs text-primary underline hover:text-foreground disabled:opacity-50"
-          >
-            {isRotating ? "Rotating..." : "Rotate"}
-          </button>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Last ping</span>
+            <span className="text-xs text-foreground tabular-nums">
+              app {formatRelative(lastAppPingAt)} · daemon {formatRelative(lastDaemonPingAt)} · mcp{" "}
+              {formatRelative(lastMcpPingAt)}
+            </span>
+          </div>
         </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">Last ping</span>
-          <span className="text-xs text-foreground tabular-nums">
-            app {formatRelative(lastAppPingAt)} · daemon {formatRelative(lastDaemonPingAt)} · mcp{" "}
-            {formatRelative(lastMcpPingAt)}
-          </span>
-        </div>
-      </div>
-    </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3398,8 +3398,8 @@ async fn open_settings_window(app: tauri::AppHandle) -> Result<(), String> {
         "{} Settings",
         runt_workspace::desktop_display_name()
     ))
-    .inner_size(560.0, 580.0)
-    .min_inner_size(450.0, 400.0)
+    .inner_size(640.0, 760.0)
+    .min_inner_size(520.0, 520.0)
     .resizable(true)
     .center()
     .build()

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3398,8 +3398,8 @@ async fn open_settings_window(app: tauri::AppHandle) -> Result<(), String> {
         "{} Settings",
         runt_workspace::desktop_display_name()
     ))
-    .inner_size(640.0, 760.0)
-    .min_inner_size(520.0, 520.0)
+    .inner_size(640.0, 880.0)
+    .min_inner_size(528.0, 826.0)
     .resizable(true)
     .center()
     .build()
@@ -4171,7 +4171,7 @@ pub fn run(
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                .with_denylist(&["main", "onboarding", "upgrade"])
+                .with_denylist(&["main", "onboarding", "upgrade", "settings"])
                 .build(),
         );
 


### PR DESCRIPTION
## Summary

- **Privacy** is now collapsed by default and sits above Feature Flags at the bottom. Same `<Collapsible>` pattern as Feature Flags.
- **Advanced** section renamed to **Runtimes** — Keep Alive is a runtime-lifecycle setting, not a generic "advanced" bucket.
- **Settings window** opens at 640×880 with a 528×826 minimum. Both values match the content's natural size after the reorg.
- **Window-state plugin** now denylists `settings` alongside `main`/`onboarding`/`upgrade`. Without this, `.window-state.json` restored a stale geometry on every open, overriding `inner_size()` and forcing a manual resize each session.

## Test plan

- [ ] Open Settings (Cmd+,) - window opens at 640×880 centered
- [ ] Resize smaller - stops at 528×826, no clipped content
- [ ] Close and reopen - opens at default size again (no stale geometry)
- [ ] Privacy section is collapsed, chevron matches Feature Flags
- [ ] Expand Privacy - telemetry card, Install ID, Last ping, Rotate all render correctly
- [ ] "Runtimes" header above the Keep Alive slider