### PR TITLE
refactor(frontend): delete @deprecated KernelState string shims

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -93,12 +93,10 @@ export function useDaemonKernel({
   const envSyncState = useMemo(() => deriveEnvSyncState(runtimeState), [runtimeState]);
 
   // ── Busy throttle ────────────────────────────────────────────────
-  // Project the typed lifecycle back to the legacy status vocabulary
+  // Project the typed lifecycle back to the compressed status vocabulary
   // (`"idle"`, `"busy"`, `"starting"`, `"error"`, …) so the existing
   // busy-throttle machinery — which treats IDLE/BUSY as the high-frequency
-  // pair — keeps working unchanged. Reading `lifecycle` (rather than
-  // `kernel.status`) means the throttle tracks the authoritative typed
-  // shape; legacy string drift in the CRDT can no longer confuse it.
+  // pair — keeps working unchanged.
   const rawStatus = lifecycleToLegacyStatus(runtimeState.kernel.lifecycle);
   const [throttledStatus, setThrottledStatus] = useState<KernelStatus>(rawStatus);
   const busyTimerRef = useRef<number | null>(null);

--- a/apps/notebook/src/lib/__tests__/kernel-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/kernel-status.test.ts
@@ -3,7 +3,6 @@ import {
   getLifecycleLabel,
   isKernelStatus,
   KERNEL_STATUS,
-  KERNEL_STATUS_LABELS,
   RUNTIME_STATUS,
   RUNTIME_STATUS_LABELS,
   type RuntimeLifecycle,
@@ -38,15 +37,6 @@ describe("KERNEL_STATUS", () => {
     expect(KERNEL_STATUS.ERROR).toBe("error");
     expect(KERNEL_STATUS.SHUTDOWN).toBe("shutdown");
     expect(KERNEL_STATUS.AWAITING_TRUST).toBe("awaiting_trust");
-  });
-});
-
-describe("KERNEL_STATUS_LABELS", () => {
-  it("has a label for every status", () => {
-    for (const status of Object.values(KERNEL_STATUS)) {
-      expect(KERNEL_STATUS_LABELS[status]).toBeDefined();
-      expect(typeof KERNEL_STATUS_LABELS[status]).toBe("string");
-    }
   });
 });
 

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -16,31 +16,11 @@ export {
 } from "runtimed";
 
 import {
-  KERNEL_STATUS,
   RUNTIME_STATUS,
   runtimeStatusKey,
-  type KernelStatus,
   type RuntimeLifecycle,
   type RuntimeStatusKey,
 } from "runtimed";
-
-/**
- * User-facing label for each compressed [`KernelStatus`].
- *
- * Covers the seven-bucket UI vocabulary. For the expanded 11-key runtime
- * vocabulary (which preserves every starting sub-phase and the
- * `Running(Unknown)` case), use [`RUNTIME_STATUS_LABELS`] via
- * [`getLifecycleLabel`] instead.
- */
-export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
-  [KERNEL_STATUS.NOT_STARTED]: "initializing",
-  [KERNEL_STATUS.STARTING]: "starting",
-  [KERNEL_STATUS.IDLE]: "idle",
-  [KERNEL_STATUS.BUSY]: "busy",
-  [KERNEL_STATUS.ERROR]: "error",
-  [KERNEL_STATUS.SHUTDOWN]: "shutdown",
-  [KERNEL_STATUS.AWAITING_TRUST]: "awaiting approval",
-};
 
 /**
  * User-facing label for each expanded [`RuntimeStatusKey`].

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -56,22 +56,6 @@ export type RuntimeLifecycle =
   | { lifecycle: "Shutdown" };
 
 export interface KernelState {
-  /**
-   * Flat status bucket string projected from [`lifecycle`]. Kept as a
-   * deprecated shim for pre-migration consumers; new code should match
-   * on `lifecycle` directly (or use `lifecycleToLegacyStatus` from
-   * `runtimed` when the bucket vocabulary is what you want).
-   * @deprecated Read `lifecycle` instead.
-   */
-  status: string;
-  /**
-   * Starting sub-phase string projected from [`lifecycle`]. Only
-   * non-empty when `status === "starting"`. Kept as a deprecated shim
-   * for pre-migration consumers; new code should match on `lifecycle`
-   * directly.
-   * @deprecated Read `lifecycle` instead.
-   */
-  starting_phase: string;
   /** Typed lifecycle. The authoritative view of kernel state. */
   lifecycle: RuntimeLifecycle;
   /**
@@ -158,8 +142,6 @@ export interface RuntimeState {
 
 export const DEFAULT_RUNTIME_STATE: RuntimeState = {
   kernel: {
-    status: "not_started",
-    starting_phase: "",
     lifecycle: { lifecycle: "NotStarted" },
     error_reason: null,
     name: "",

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -637,7 +637,7 @@ export class SyncEngine {
               this.prevExecutions = state.executions;
 
               log.debug(
-                `[sync-engine] runtime state: kernel=${state.kernel?.status ?? "?"}, transitions=${transitions.length}`,
+                `[sync-engine] runtime state: kernel=${state.kernel?.lifecycle?.lifecycle ?? "?"}, transitions=${transitions.length}`,
               );
 
               this._runtimeState$.next(state);

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -102,8 +102,6 @@ function makeRuntimeState(
 ): RuntimeState {
   return {
     kernel: {
-      status: "idle",
-      starting_phase: "",
       lifecycle: { lifecycle: "Running", activity: "Idle" },
       error_reason: null,
       name: "python3",
@@ -117,10 +115,12 @@ function makeRuntimeState(
       removed: [],
       channels_changed: false,
       deno_changed: false,
+      prewarmed_packages: [],
     },
     trust: { status: "trusted", needs_approval: false },
     last_saved: null,
     executions: executions as RuntimeState["executions"],
+    comms: {},
   };
 }
 
@@ -599,8 +599,6 @@ describe("SyncEngine", () => {
     it("emits runtime state on state sync", () => {
       const state: RuntimeState = {
         kernel: {
-          status: "busy",
-          starting_phase: "",
           lifecycle: { lifecycle: "Running", activity: "Busy" },
           error_reason: null,
           name: "python3",
@@ -614,10 +612,12 @@ describe("SyncEngine", () => {
           removed: [],
           channels_changed: false,
           deno_changed: false,
+          prewarmed_packages: [],
         },
         trust: { status: "trusted", needs_approval: false },
         last_saved: null,
         executions: {},
+        comms: {},
       };
 
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
@@ -633,7 +633,7 @@ describe("SyncEngine", () => {
       transport.deliver(Array.from([0x05, 1]));
 
       expect(received).toHaveLength(1);
-      expect(received[0].kernel.status).toBe("busy");
+      expect(received[0].kernel.lifecycle).toEqual({ lifecycle: "Running", activity: "Busy" });
       expect(received[0].kernel.name).toBe("python3");
       engine.stop();
     });
@@ -645,8 +645,6 @@ describe("SyncEngine", () => {
     it("detects started transition", () => {
       const state: RuntimeState = {
         kernel: {
-          status: "busy",
-          starting_phase: "",
           lifecycle: { lifecycle: "Running", activity: "Busy" },
           error_reason: null,
           name: "python3",
@@ -660,6 +658,7 @@ describe("SyncEngine", () => {
           removed: [],
           channels_changed: false,
           deno_changed: false,
+          prewarmed_packages: [],
         },
         trust: { status: "trusted", needs_approval: false },
         last_saved: null,
@@ -671,6 +670,7 @@ describe("SyncEngine", () => {
             success: null,
           },
         },
+        comms: {},
       };
 
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
@@ -2001,8 +2001,6 @@ describe("diffExecutions", () => {
 describe("getExecutionCountForCell", () => {
   const baseState = {
     kernel: {
-      status: "idle",
-      starting_phase: "",
       lifecycle: { lifecycle: "Running", activity: "Idle" } as RuntimeLifecycle,
       error_reason: null,
       name: "",


### PR DESCRIPTION
## Summary

Final cleanup for the RuntimeLifecycle refactor tracked in #2096. PR #2108 already retired the legacy `kernel.status` / `starting_phase` fields on the CRDT side; this PR removes the TypeScript shims that were kept one release so pre-migration consumers could compile.

Typed `RuntimeLifecycle` is now the only view of runtime state, end to end.

### Deleted

- `KernelState.status` and `KernelState.starting_phase` (plus their scaffold defaults in `DEFAULT_RUNTIME_STATE`) in `packages/runtimed/src/runtime-state.ts`.
- `KERNEL_STATUS_LABELS` constant and its test block in `apps/notebook/src/lib/kernel-status.ts`. `RUNTIME_STATUS_LABELS` + `getLifecycleLabel` cover every variant the seven-bucket map covered.
- Stale `state.kernel?.status` read in the sync-engine debug log (now logs `state.kernel?.lifecycle?.lifecycle`).

`KERNEL_STATUS` (the compressed vocabulary used by the toolbar and App.tsx color classes) and `lifecycleToLegacyStatus` stay — both are still active.

### Call sites touched

- `packages/runtimed/src/sync-engine.ts` — debug log swapped to read `lifecycle.lifecycle`.
- `packages/runtimed/tests/sync-engine.test.ts` — fixtures now match the tightened `RuntimeState` shape (added `prewarmed_packages: []` and `comms: {}` to cases missing them, swapped the `kernel.status === "busy"` assertion for the typed lifecycle check).
- `apps/notebook/src/lib/__tests__/kernel-status.test.ts` — removed the `KERNEL_STATUS_LABELS` import and describe block.
- `apps/notebook/src/hooks/useDaemonKernel.ts` — updated a stale comment referencing `kernel.status`.

No runtime callers of `STARTING_PHASE_LABELS` or `getKernelStatusLabel` were found; both had already been deleted in #2108.

### Verification

- `cargo xtask lint --fix` — passes (Rust fmt, vp, ruff, ty).
- `pnpm vp test run` — 60 test files, 1073 passing (3 pre-existing skipped).
- `npx tsc --noEmit` — 225 errors, identical count to `main`. No new type errors introduced.

Refs #2096. Closes the frontend half of #2108.

## Test plan

- [x] `pnpm vp test run packages/runtimed/tests/sync-engine.test.ts apps/notebook/src/lib/__tests__/kernel-status.test.ts` passes
- [x] Full test suite (`pnpm vp test run`) passes
- [x] `cargo xtask lint --fix` clean
- [x] `tsc --noEmit` error count unchanged vs. `main`