### PR TITLE
chore(runtimed): add eviction-lifecycle logs for #2094

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -565,7 +565,10 @@ where
     room.broadcasts.presence.write().await.remove_peer(&peer_id);
     match presence::encode_left(&peer_id) {
         Ok(left_bytes) => {
-            let _ = room.broadcasts.presence_tx.send((peer_id, left_bytes));
+            let _ = room
+                .broadcasts
+                .presence_tx
+                .send((peer_id.clone(), left_bytes));
         }
         Err(e) => warn!("[notebook-sync] Failed to encode 'left' presence: {}", e),
     }
@@ -588,8 +591,10 @@ where
         let notebook_id_for_eviction = notebook_id.clone();
 
         info!(
-            "[notebook-sync] All peers disconnected from room {}, scheduling eviction check in {:?}",
+            "[notebook-sync] All peers disconnected from room {} (uuid={}, peer_id={}), scheduling eviction check in {:?}",
             notebook_id,
+            room.id,
+            peer_id,
             eviction_delay
         );
 
@@ -681,6 +686,14 @@ where
                     delay = FLUSH_RETRY_DELAY;
                     continue;
                 }
+                if flush_retries > 0 {
+                    info!(
+                        "[notebook-sync] Eviction flush succeeded for {} after {} retr{}",
+                        notebook_id_for_eviction,
+                        flush_retries,
+                        if flush_retries == 1 { "y" } else { "ies" }
+                    );
+                }
                 break;
             }
 
@@ -730,6 +743,10 @@ where
             }
 
             if should_teardown {
+                info!(
+                    "[notebook-sync] Eviction teardown starting for {} (uuid={:?})",
+                    notebook_id_for_eviction, evicted_uuid
+                );
                 // Shut down runtime agent subprocess if running. RuntimeAgentHandle::spawn
                 // moves Child into a background task, so kill_on_drop doesn't
                 // trigger on room drop — we need explicit shutdown via RPC.
@@ -945,15 +962,17 @@ where
                 }
 
                 info!(
-                    "[notebook-sync] Evicted room {} (idle timeout)",
+                    "[notebook-sync] Eviction teardown finished for {} (idle timeout)",
                     notebook_id_for_eviction
                 );
             }
         });
     } else {
         info!(
-            "[notebook-sync] Client disconnected from room {} ({} peer{} remaining)",
+            "[notebook-sync] Client disconnected from room {} (uuid={}, peer_id={}): {} peer{} remaining",
             notebook_id,
+            room.id,
+            peer_id,
             remaining,
             if remaining == 1 { "" } else { "s" }
         );


### PR DESCRIPTION
## Summary

Adds four `info!` lines in `peer.rs` to narrate the peer-disconnect + eviction path so the next 24-gremlin rerun can tell us which stage is actually wedging for #2094. No behavior change.

Ref #2094 — investigation comment: https://github.com/nteract/desktop/issues/2094#issuecomment-4308605041

## Log points

- `peer.rs:594` — "All peers disconnected" now includes `room.id` (UUID) and `peer_id` so it correlates with the existing "Client connected" log.
- `peer.rs:972` — Same correlation fields on the non-last-peer disconnect log.
- `peer.rs:691` — Fires once after the flush-retry loop exits successfully. Prints retry count. Silence here for a leaked room means it's stuck in the indefinite flush-retry loop.
- `peer.rs:747` / `peer.rs:965` — Brackets the teardown block with "Eviction teardown starting" / "Eviction teardown finished (idle timeout)". "starting" without "finished" means teardown is wedged (most likely on the 5s runtime-agent `ShutdownKernel` RPC that "force-drops" without actually killing the child).

## Reading the logs after a rerun

For each orphan room, grep by UUID:

| Pattern | Hypothesis |
|---|---|
| "Client connected" only, no "disconnected" | Daemon never saw EOF — stuck in `handle_notebook_request` (LaunchKernel, etc.) |
| "All peers disconnected", no "teardown starting" | Stuck in flush-retry loop. The existing `warn!` "Eviction flush failed" has the reason. |
| "teardown starting", no "teardown finished" | Wedged in teardown (probably runtime-agent shutdown). Look for "Runtime agent shutdown timed out". |
| "teardown finished" but still orphaned | Something else entirely — worth a close read. |

## Test plan

- [x] `cargo build -p runtimed` clean
- [x] `cargo xtask lint --fix` clean
- [ ] Install to nightly and rerun 24-gremlin suite; decide root cause from logs
