### PR TITLE
fix(runtimed): emit MissingIpykernel for uv and conda envs

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -8,7 +8,7 @@ import {
   RotateCcw,
   Square,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
@@ -392,22 +392,89 @@ export function NotebookToolbar({
           </div>
         </div>
       )}
-      {/* Pixi ipykernel install prompt — only when daemon signals missing_ipykernel */}
+      {/* ipykernel install prompt — only when daemon signals missing_ipykernel.
+          Pixi and uv/conda inline envs reach this state through different
+          mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
+          same shape: explain where ipykernel should go for the current env,
+          then tell the user to restart. */}
       {runtime === "python" &&
         lifecycle.lifecycle === "Error" &&
-        envSource?.startsWith("pixi:") &&
-        errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL && (
-          <div className="border-t px-3 py-2">
-            <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
-              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-              <span>
-                <span className="font-medium">ipykernel not found in pixi.toml.</span> Run{" "}
-                <code className="rounded bg-amber-500/20 px-1">pixi add ipykernel</code> in your
-                project directory and restart.
-              </span>
-            </div>
-          </div>
-        )}
+        errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL &&
+        envSource &&
+        renderMissingIpykernelPrompt(envSource)}
     </header>
+  );
+}
+
+/** Remediation copy for `KernelErrorReason::MissingIpykernel`, branched by
+ * env source. Returns `null` for env sources the daemon does not gate on
+ * (prewarmed pools, uv:pyproject, conda:env_yml, deno) — those either
+ * self-heal at launch or should never reach this state. */
+function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
+  // Pixi project: the .toml is the source of truth.
+  if (envSource.startsWith("pixi:")) {
+    return (
+      <MissingIpykernelBanner
+        headline="ipykernel not found in pixi.toml."
+        instruction={
+          <>
+            Run <code className="rounded bg-amber-500/20 px-1">pixi add ipykernel</code> in your
+            project directory and restart.
+          </>
+        }
+      />
+    );
+  }
+  // Inline or PEP 723 UV dependencies.
+  if (envSource === "uv:inline" || envSource === "uv:pep723") {
+    return (
+      <MissingIpykernelBanner
+        headline="ipykernel missing from prepared uv environment."
+        instruction={
+          <>
+            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the notebook's
+            dependencies (or run{" "}
+            <code className="rounded bg-amber-500/20 px-1">uv pip install ipykernel</code> in the
+            env) and restart.
+          </>
+        }
+      />
+    );
+  }
+  // Inline Conda dependencies.
+  if (envSource === "conda:inline") {
+    return (
+      <MissingIpykernelBanner
+        headline="ipykernel missing from prepared conda environment."
+        instruction={
+          <>
+            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the notebook's
+            dependencies (or run{" "}
+            <code className="rounded bg-amber-500/20 px-1">conda install ipykernel</code> in the
+            env) and restart.
+          </>
+        }
+      />
+    );
+  }
+  return null;
+}
+
+function MissingIpykernelBanner({
+  headline,
+  instruction,
+}: {
+  headline: string;
+  instruction: ReactNode;
+}): ReactElement {
+  return (
+    <div className="border-t px-3 py-2">
+      <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+        <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span>
+          <span className="font-medium">{headline}</span> {instruction}
+        </span>
+      </div>
+    </div>
   );
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -409,9 +409,19 @@ export function NotebookToolbar({
 /** Remediation copy for `KernelErrorReason::MissingIpykernel`, branched by
  * env source. Returns `null` for env sources the daemon does not gate on
  * (prewarmed pools, uv:pyproject, conda:env_yml, deno) — those either
- * self-heal at launch or should never reach this state. */
+ * self-heal at launch or should never reach this state.
+ *
+ * For inline/PEP 723 envs the daemon has already deleted the corrupt
+ * cache dir; `prepare_*_inline_env` always includes `ipykernel` in its
+ * install set, so the next launch rebuilds correctly. The banner tells
+ * users exactly that instead of sending them to edit deps that already
+ * had nothing wrong with them.
+ *
+ * For pixi:toml the daemon does NOT delete anything — pixi manages its
+ * own env and the user's `pixi.toml` genuinely needs editing. */
 function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
-  // Pixi project: the .toml is the source of truth.
+  // Pixi project: the .toml is the source of truth; user must add
+  // ipykernel explicitly.
   if (envSource.startsWith("pixi:")) {
     return (
       <MissingIpykernelBanner
@@ -425,52 +435,13 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
       />
     );
   }
-  // Inline UV dependencies — edit notebook-level deps.
-  if (envSource === "uv:inline") {
+  // Inline / PEP 723 / inline conda: daemon deleted the stale env;
+  // the next launch rebuilds with ipykernel. No user deps edit needed.
+  if (envSource === "uv:inline" || envSource === "uv:pep723" || envSource === "conda:inline") {
     return (
       <MissingIpykernelBanner
-        headline="ipykernel missing from prepared uv environment."
-        instruction={
-          <>
-            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the notebook's
-            dependencies (or run{" "}
-            <code className="rounded bg-amber-500/20 px-1">uv pip install ipykernel</code> in the
-            env) and restart.
-          </>
-        }
-      />
-    );
-  }
-  // PEP 723 — deps live in the `# /// script` inline metadata block in
-  // a cell, not in notebook metadata. Editing notebook deps is ignored
-  // on the next launch.
-  if (envSource === "uv:pep723") {
-    return (
-      <MissingIpykernelBanner
-        headline="ipykernel missing from PEP 723 script metadata."
-        instruction={
-          <>
-            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the inline{" "}
-            <code className="rounded bg-amber-500/20 px-1">{"# /// script"}</code> dependency block
-            in your notebook and restart.
-          </>
-        }
-      />
-    );
-  }
-  // Inline Conda dependencies.
-  if (envSource === "conda:inline") {
-    return (
-      <MissingIpykernelBanner
-        headline="ipykernel missing from prepared conda environment."
-        instruction={
-          <>
-            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the notebook's
-            dependencies (or run{" "}
-            <code className="rounded bg-amber-500/20 px-1">conda install ipykernel</code> in the
-            env) and restart.
-          </>
-        }
+        headline="Environment cache was corrupt."
+        instruction={<>Click Restart to rebuild the environment.</>}
       />
     );
   }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -425,8 +425,8 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
       />
     );
   }
-  // Inline or PEP 723 UV dependencies.
-  if (envSource === "uv:inline" || envSource === "uv:pep723") {
+  // Inline UV dependencies — edit notebook-level deps.
+  if (envSource === "uv:inline") {
     return (
       <MissingIpykernelBanner
         headline="ipykernel missing from prepared uv environment."
@@ -436,6 +436,23 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
             dependencies (or run{" "}
             <code className="rounded bg-amber-500/20 px-1">uv pip install ipykernel</code> in the
             env) and restart.
+          </>
+        }
+      />
+    );
+  }
+  // PEP 723 — deps live in the `# /// script` inline metadata block in
+  // a cell, not in notebook metadata. Editing notebook deps is ignored
+  // on the next launch.
+  if (envSource === "uv:pep723") {
+    return (
+      <MissingIpykernelBanner
+        headline="ipykernel missing from PEP 723 script metadata."
+        instruction={
+          <>
+            Add <code className="rounded bg-amber-500/20 px-1">ipykernel</code> to the inline{" "}
+            <code className="rounded bg-amber-500/20 px-1">{"# /// script"}</code> dependency block
+            in your notebook and restart.
           </>
         }
       />

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -408,7 +408,7 @@ describe("NotebookToolbar", () => {
       expect(screen.getByText(/uv pip install ipykernel/)).toBeInTheDocument();
     });
 
-    it("shows uv inline remediation for PEP 723 env source", () => {
+    it("shows PEP 723 script-metadata remediation for uv:pep723", () => {
       render(
         <NotebookToolbar
           {...baseProps}
@@ -420,8 +420,11 @@ describe("NotebookToolbar", () => {
         />,
       );
       expect(
-        screen.getByText(/ipykernel missing from prepared uv environment/),
+        screen.getByText(/ipykernel missing from PEP 723 script metadata/),
       ).toBeInTheDocument();
+      // PEP 723 edits live in the inline `# /// script` block — must NOT
+      // direct users to notebook-level dependency edits.
+      expect(screen.queryByText(/notebook's dependencies/)).not.toBeInTheDocument();
     });
 
     it("shows conda inline remediation when envSource=conda:inline", () => {

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -391,58 +391,33 @@ describe("NotebookToolbar", () => {
   describe("uv/conda ipykernel prompt", () => {
     const errorLifecycle: RuntimeLifecycle = { lifecycle: "Error" };
 
-    it("shows uv inline remediation when envSource=uv:inline, errorReason=missing_ipykernel", () => {
-      render(
-        <NotebookToolbar
-          {...baseProps}
-          runtime="python"
-          kernelStatus={KERNEL_STATUS.ERROR}
-          lifecycle={errorLifecycle}
-          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
-          envSource="uv:inline"
-        />,
-      );
-      expect(
-        screen.getByText(/ipykernel missing from prepared uv environment/),
-      ).toBeInTheDocument();
-      expect(screen.getByText(/uv pip install ipykernel/)).toBeInTheDocument();
-    });
-
-    it("shows PEP 723 script-metadata remediation for uv:pep723", () => {
-      render(
-        <NotebookToolbar
-          {...baseProps}
-          runtime="python"
-          kernelStatus={KERNEL_STATUS.ERROR}
-          lifecycle={errorLifecycle}
-          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
-          envSource="uv:pep723"
-        />,
-      );
-      expect(
-        screen.getByText(/ipykernel missing from PEP 723 script metadata/),
-      ).toBeInTheDocument();
-      // PEP 723 edits live in the inline `# /// script` block — must NOT
-      // direct users to notebook-level dependency edits.
-      expect(screen.queryByText(/notebook's dependencies/)).not.toBeInTheDocument();
-    });
-
-    it("shows conda inline remediation when envSource=conda:inline", () => {
-      render(
-        <NotebookToolbar
-          {...baseProps}
-          runtime="python"
-          kernelStatus={KERNEL_STATUS.ERROR}
-          lifecycle={errorLifecycle}
-          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
-          envSource="conda:inline"
-        />,
-      );
-      expect(
-        screen.getByText(/ipykernel missing from prepared conda environment/),
-      ).toBeInTheDocument();
-      expect(screen.getByText(/conda install ipykernel/)).toBeInTheDocument();
-    });
+    // Inline / PEP 723 / inline conda all share the same "just restart"
+    // remediation — the daemon has already deleted the corrupt env dir
+    // and `prepare_*_inline_env` auto-includes ipykernel in its install
+    // set, so the next launch rebuilds successfully. The banner must
+    // NOT ask users to edit deps (a no-op) or run install commands
+    // against the env (which no longer exists).
+    for (const envSource of ["uv:inline", "uv:pep723", "conda:inline"] as const) {
+      it(`shows "restart to rebuild" prompt for envSource=${envSource}`, () => {
+        render(
+          <NotebookToolbar
+            {...baseProps}
+            runtime="python"
+            kernelStatus={KERNEL_STATUS.ERROR}
+            lifecycle={errorLifecycle}
+            errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+            envSource={envSource}
+          />,
+        );
+        expect(screen.getByText(/Environment cache was corrupt/)).toBeInTheDocument();
+        expect(screen.getByText(/Click Restart to rebuild/)).toBeInTheDocument();
+        // Backends already rebuild these envs — no user dep edits needed.
+        expect(screen.queryByText(/notebook's dependencies/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/uv pip install/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/conda install/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/# \/\/\/ script/)).not.toBeInTheDocument();
+      });
+    }
 
     it("does not render any prompt for uv:pyproject (self-heals via uv run --with ipykernel)", () => {
       render(

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -371,7 +371,7 @@ describe("NotebookToolbar", () => {
       expect(screen.queryByText(/ipykernel not found in pixi.toml/)).not.toBeInTheDocument();
     });
 
-    it("does not show pixi prompt when envSource is not pixi", () => {
+    it("does not show pixi prompt when envSource is prewarmed uv", () => {
       render(
         <NotebookToolbar
           {...baseProps}
@@ -382,7 +382,93 @@ describe("NotebookToolbar", () => {
           envSource="uv:prewarmed"
         />,
       );
-      expect(screen.queryByText(/ipykernel not found in pixi.toml/)).not.toBeInTheDocument();
+      // Prewarmed envs should never reach MissingIpykernel — defensive: render nothing.
+      expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/ipykernel missing/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("uv/conda ipykernel prompt", () => {
+    const errorLifecycle: RuntimeLifecycle = { lifecycle: "Error" };
+
+    it("shows uv inline remediation when envSource=uv:inline, errorReason=missing_ipykernel", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+          envSource="uv:inline"
+        />,
+      );
+      expect(
+        screen.getByText(/ipykernel missing from prepared uv environment/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/uv pip install ipykernel/)).toBeInTheDocument();
+    });
+
+    it("shows uv inline remediation for PEP 723 env source", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+          envSource="uv:pep723"
+        />,
+      );
+      expect(
+        screen.getByText(/ipykernel missing from prepared uv environment/),
+      ).toBeInTheDocument();
+    });
+
+    it("shows conda inline remediation when envSource=conda:inline", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+          envSource="conda:inline"
+        />,
+      );
+      expect(
+        screen.getByText(/ipykernel missing from prepared conda environment/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/conda install ipykernel/)).toBeInTheDocument();
+    });
+
+    it("does not render any prompt for uv:pyproject (self-heals via uv run --with ipykernel)", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+          envSource="uv:pyproject"
+        />,
+      );
+      expect(screen.queryByText(/ipykernel missing from/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
+    });
+
+    it("does not render any prompt for conda:env_yml (daemon injects ipykernel into deps)", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.MISSING_IPYKERNEL}
+          envSource="conda:env_yml"
+        />,
+      );
+      expect(screen.queryByText(/ipykernel missing from/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
     });
   });
 });

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -68,6 +68,88 @@ pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
         .collect()
 }
 
+/// Check if a prepared UV venv or Conda env has `ipykernel` installed in its
+/// site-packages.
+///
+/// Used by the inline/pep723 launch paths to detect missing `ipykernel` before
+/// spawning the kernel. `prepare_environment_in` always adds `ipykernel` to
+/// the install set, but cache hits and hand-edited venvs can route around
+/// that, and the kernel then fails at spawn with a generic `ModuleNotFoundError`.
+/// Gating here surfaces the typed `MissingIpykernel` reason so the UI can
+/// render env-specific remediation.
+///
+/// Scans for a direct child directory named `ipykernel` or any
+/// `ipykernel-*.dist-info` metadata dir under site-packages. Returns `false`
+/// on any filesystem error or if site-packages cannot be found.
+///
+/// Layouts handled:
+/// - UV venvs (POSIX): `{venv}/lib/python*/site-packages/ipykernel`
+/// - UV venvs (Windows): `{venv}/Lib/site-packages/ipykernel`
+/// - Conda envs (POSIX): `{env}/lib/python*/site-packages/ipykernel`
+/// - Conda envs (Windows): `{env}/Lib/site-packages/ipykernel`
+#[cfg(feature = "runtime")]
+pub fn venv_has_ipykernel(env_path: &std::path::Path) -> bool {
+    let Some(site_packages) = find_site_packages(env_path) else {
+        return false;
+    };
+    site_packages_has_ipykernel(&site_packages)
+}
+
+/// Return the path to the environment's site-packages directory if it can be
+/// located. Handles both POSIX (`lib/python*/site-packages`) and Windows
+/// (`Lib/site-packages`) layouts used by UV venvs and Conda envs.
+#[cfg(feature = "runtime")]
+fn find_site_packages(env_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Windows layout: {env}/Lib/site-packages
+    let windows_sp = env_path.join("Lib").join("site-packages");
+    if windows_sp.is_dir() {
+        return Some(windows_sp);
+    }
+    // POSIX layout: {env}/lib/python*/site-packages — python minor version varies.
+    let lib = env_path.join("lib");
+    let entries = std::fs::read_dir(&lib).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.starts_with("python") {
+            let sp = path.join("site-packages");
+            if sp.is_dir() {
+                return Some(sp);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "runtime")]
+fn site_packages_has_ipykernel(site_packages: &std::path::Path) -> bool {
+    // Fast path: the importable package directory.
+    if site_packages.join("ipykernel").is_dir() {
+        return true;
+    }
+    // Fallback: dist-info metadata directory (covers odd install layouts
+    // where the package is packaged differently, e.g. editable installs).
+    let Ok(entries) = std::fs::read_dir(site_packages) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if name_str.starts_with("ipykernel-") && name_str.ends_with(".dist-info") {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(all(test, feature = "runtime"))]
 mod strip_base_tests {
     use super::*;
@@ -157,5 +239,81 @@ mod strip_base_tests {
                 "matplotlib".to_string()
             ]
         );
+    }
+}
+
+#[cfg(all(test, feature = "runtime"))]
+mod venv_has_ipykernel_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_posix_venv_with(files: &[(&str, &str)]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let sp = tmp
+            .path()
+            .join("lib")
+            .join("python3.12")
+            .join("site-packages");
+        std::fs::create_dir_all(&sp).unwrap();
+        for (name, kind) in files {
+            let path = sp.join(name);
+            match *kind {
+                "dir" => std::fs::create_dir_all(&path).unwrap(),
+                "file" => std::fs::write(&path, "").unwrap(),
+                _ => panic!("unknown kind: {kind}"),
+            }
+        }
+        tmp
+    }
+
+    #[test]
+    fn venv_without_ipykernel_returns_false() {
+        let tmp = make_posix_venv_with(&[("numpy", "dir"), ("pandas", "dir")]);
+        assert!(!venv_has_ipykernel(tmp.path()));
+    }
+
+    #[test]
+    fn venv_with_ipykernel_package_dir_returns_true() {
+        let tmp = make_posix_venv_with(&[("ipykernel", "dir"), ("numpy", "dir")]);
+        assert!(venv_has_ipykernel(tmp.path()));
+    }
+
+    #[test]
+    fn venv_with_ipykernel_dist_info_returns_true() {
+        let tmp = make_posix_venv_with(&[("ipykernel-6.29.5.dist-info", "dir")]);
+        assert!(venv_has_ipykernel(tmp.path()));
+    }
+
+    #[test]
+    fn empty_venv_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!venv_has_ipykernel(tmp.path()));
+    }
+
+    #[test]
+    fn nonexistent_path_returns_false() {
+        assert!(!venv_has_ipykernel(std::path::Path::new(
+            "/definitely/does/not/exist"
+        )));
+    }
+
+    #[test]
+    fn similar_prefix_without_ipykernel_returns_false() {
+        // Defensive: a package like `ipykernel_something` must not trip
+        // the dist-info fallback. We only accept `ipykernel-*.dist-info`.
+        let tmp = make_posix_venv_with(&[
+            ("ipykernel_contrib", "dir"),
+            ("ipykernelfoo-1.0.dist-info", "dir"),
+        ]);
+        assert!(!venv_has_ipykernel(tmp.path()));
+    }
+
+    #[test]
+    fn windows_layout_is_supported() {
+        let tmp = TempDir::new().unwrap();
+        let sp = tmp.path().join("Lib").join("site-packages");
+        std::fs::create_dir_all(&sp).unwrap();
+        std::fs::create_dir_all(sp.join("ipykernel")).unwrap();
+        assert!(venv_has_ipykernel(tmp.path()));
     }
 }

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -78,53 +78,51 @@ pub fn strip_base(installed: &[String], base: &[&str]) -> Vec<String> {
 /// Gating here surfaces the typed `MissingIpykernel` reason so the UI can
 /// render env-specific remediation.
 ///
-/// Scans for a direct child directory named `ipykernel` or any
-/// `ipykernel-*.dist-info` metadata dir under site-packages. Returns `false`
-/// on any filesystem error or if site-packages cannot be found.
+/// Resolves site-packages by asking the interpreter itself
+/// (`sysconfig.get_paths()['purelib']`) rather than scanning `lib/python*`
+/// — `read_dir` order would pick an arbitrary Python-version directory on
+/// envs with more than one (stale cache, interpreter upgrade), which can
+/// false-negative a working env. The subprocess adds ~50ms; kernel launch
+/// is already seconds.
 ///
-/// Layouts handled:
-/// - UV venvs (POSIX): `{venv}/lib/python*/site-packages/ipykernel`
-/// - UV venvs (Windows): `{venv}/Lib/site-packages/ipykernel`
-/// - Conda envs (POSIX): `{env}/lib/python*/site-packages/ipykernel`
-/// - Conda envs (Windows): `{env}/Lib/site-packages/ipykernel`
+/// Returns `false` on any failure (interpreter missing, spawn error,
+/// non-zero exit, empty output) — conservative: we'd rather surface a
+/// misleading "missing ipykernel" than try to launch a broken env.
+///
+/// Scans for a direct child directory named `ipykernel` or any
+/// `ipykernel-*.dist-info` metadata dir under site-packages.
 #[cfg(feature = "runtime")]
-pub fn venv_has_ipykernel(env_path: &std::path::Path) -> bool {
-    let Some(site_packages) = find_site_packages(env_path) else {
+pub fn venv_has_ipykernel(python_path: &std::path::Path) -> bool {
+    let Some(site_packages) = resolve_site_packages(python_path) else {
         return false;
     };
     site_packages_has_ipykernel(&site_packages)
 }
 
-/// Return the path to the environment's site-packages directory if it can be
-/// located. Handles both POSIX (`lib/python*/site-packages`) and Windows
-/// (`Lib/site-packages`) layouts used by UV venvs and Conda envs.
+/// Ask the given interpreter for its site-packages path.
+///
+/// Uses `sysconfig.get_paths()['purelib']` which is the canonical
+/// pure-Python install target for that interpreter. Returns `None` if
+/// the interpreter cannot be executed or if the output is unexpected.
 #[cfg(feature = "runtime")]
-fn find_site_packages(env_path: &std::path::Path) -> Option<std::path::PathBuf> {
-    // Windows layout: {env}/Lib/site-packages
-    let windows_sp = env_path.join("Lib").join("site-packages");
-    if windows_sp.is_dir() {
-        return Some(windows_sp);
+fn resolve_site_packages(python_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new(python_path)
+        .args([
+            "-c",
+            "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
     }
-    // POSIX layout: {env}/lib/python*/site-packages — python minor version varies.
-    let lib = env_path.join("lib");
-    let entries = std::fs::read_dir(&lib).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let name = match path.file_name().and_then(|n| n.to_str()) {
-            Some(n) => n,
-            None => continue,
-        };
-        if name.starts_with("python") {
-            let sp = path.join("site-packages");
-            if sp.is_dir() {
-                return Some(sp);
-            }
-        }
+    let sp = String::from_utf8(output.stdout).ok()?;
+    let sp = sp.trim();
+    if sp.is_empty() {
+        return None;
     }
-    None
+    let path = std::path::PathBuf::from(sp);
+    path.is_dir().then_some(path)
 }
 
 #[cfg(feature = "runtime")]
@@ -243,20 +241,14 @@ mod strip_base_tests {
 }
 
 #[cfg(all(test, feature = "runtime"))]
-mod venv_has_ipykernel_tests {
+mod site_packages_has_ipykernel_tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_posix_venv_with(files: &[(&str, &str)]) -> TempDir {
+    fn make_site_packages_with(files: &[(&str, &str)]) -> TempDir {
         let tmp = TempDir::new().unwrap();
-        let sp = tmp
-            .path()
-            .join("lib")
-            .join("python3.12")
-            .join("site-packages");
-        std::fs::create_dir_all(&sp).unwrap();
         for (name, kind) in files {
-            let path = sp.join(name);
+            let path = tmp.path().join(name);
             match *kind {
                 "dir" => std::fs::create_dir_all(&path).unwrap(),
                 "file" => std::fs::write(&path, "").unwrap(),
@@ -267,53 +259,53 @@ mod venv_has_ipykernel_tests {
     }
 
     #[test]
-    fn venv_without_ipykernel_returns_false() {
-        let tmp = make_posix_venv_with(&[("numpy", "dir"), ("pandas", "dir")]);
-        assert!(!venv_has_ipykernel(tmp.path()));
+    fn no_ipykernel_returns_false() {
+        let tmp = make_site_packages_with(&[("numpy", "dir"), ("pandas", "dir")]);
+        assert!(!site_packages_has_ipykernel(tmp.path()));
     }
 
     #[test]
-    fn venv_with_ipykernel_package_dir_returns_true() {
-        let tmp = make_posix_venv_with(&[("ipykernel", "dir"), ("numpy", "dir")]);
-        assert!(venv_has_ipykernel(tmp.path()));
+    fn ipykernel_package_dir_returns_true() {
+        let tmp = make_site_packages_with(&[("ipykernel", "dir"), ("numpy", "dir")]);
+        assert!(site_packages_has_ipykernel(tmp.path()));
     }
 
     #[test]
-    fn venv_with_ipykernel_dist_info_returns_true() {
-        let tmp = make_posix_venv_with(&[("ipykernel-6.29.5.dist-info", "dir")]);
-        assert!(venv_has_ipykernel(tmp.path()));
+    fn ipykernel_dist_info_returns_true() {
+        let tmp = make_site_packages_with(&[("ipykernel-6.29.5.dist-info", "dir")]);
+        assert!(site_packages_has_ipykernel(tmp.path()));
     }
 
     #[test]
-    fn empty_venv_returns_false() {
+    fn empty_site_packages_returns_false() {
         let tmp = TempDir::new().unwrap();
-        assert!(!venv_has_ipykernel(tmp.path()));
+        assert!(!site_packages_has_ipykernel(tmp.path()));
     }
 
     #[test]
     fn nonexistent_path_returns_false() {
-        assert!(!venv_has_ipykernel(std::path::Path::new(
+        assert!(!site_packages_has_ipykernel(std::path::Path::new(
             "/definitely/does/not/exist"
         )));
     }
 
     #[test]
     fn similar_prefix_without_ipykernel_returns_false() {
-        // Defensive: a package like `ipykernel_something` must not trip
-        // the dist-info fallback. We only accept `ipykernel-*.dist-info`.
-        let tmp = make_posix_venv_with(&[
+        // Defensive: `ipykernel_something` must not trip the dist-info
+        // fallback. Only `ipykernel-*.dist-info` counts.
+        let tmp = make_site_packages_with(&[
             ("ipykernel_contrib", "dir"),
             ("ipykernelfoo-1.0.dist-info", "dir"),
         ]);
-        assert!(!venv_has_ipykernel(tmp.path()));
+        assert!(!site_packages_has_ipykernel(tmp.path()));
     }
 
     #[test]
-    fn windows_layout_is_supported() {
-        let tmp = TempDir::new().unwrap();
-        let sp = tmp.path().join("Lib").join("site-packages");
-        std::fs::create_dir_all(&sp).unwrap();
-        std::fs::create_dir_all(sp.join("ipykernel")).unwrap();
-        assert!(venv_has_ipykernel(tmp.path()));
+    fn venv_has_ipykernel_returns_false_for_nonexistent_interpreter() {
+        // The outer `venv_has_ipykernel` delegates to a subprocess call
+        // on the interpreter. Bad paths must surface as `false`, not panic.
+        assert!(!venv_has_ipykernel(std::path::Path::new(
+            "/definitely/not/a/python/interpreter"
+        )));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2764,6 +2764,52 @@ pub(crate) async fn auto_launch_kernel(
         (pooled_env, None)
     };
 
+    // Verify ipykernel is actually present in the prepared env before we
+    // spawn the kernel. For UV/Conda inline + PEP 723, `prepare_environment_in`
+    // always adds `ipykernel` to the install set, but cache hits skip the
+    // install step and re-use whatever's on disk. Stale caches (pre-base-
+    // packages daemon builds, hand-edited venvs, partial installs) can slip
+    // through and then fail at kernel spawn with a generic
+    // `ModuleNotFoundError: ipykernel_launcher`. Gating here surfaces the
+    // typed `MissingIpykernel` reason so the UI can render env-specific
+    // remediation instead of a raw stderr dump.
+    //
+    // Skipped for:
+    // - Prewarmed pool envs (daemon-managed; base packages are invariant)
+    // - `pixi:inline` / `pixi:pep723` (no pooled_env, pixi exec handles it)
+    // - `uv:pyproject` (launched via `uv run --with ipykernel` — auto-injects)
+    // - `conda:env_yml` (daemon appends ipykernel to the dep set pre-sync)
+    // - `deno` (not a Python env)
+    // - `pixi:toml` (already gated above via `pixi_info().has_ipykernel()`)
+    if matches!(
+        env_source,
+        EnvSource::Inline(PackageManager::Uv)
+            | EnvSource::Inline(PackageManager::Conda)
+            | EnvSource::Pep723(PackageManager::Uv)
+    ) {
+        if let Some(ref env) = pooled_env {
+            if !kernel_env::venv_has_ipykernel(&env.venv_path) {
+                warn!(
+                    "[notebook-sync] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
+                    env.venv_path,
+                    env_source.as_str()
+                );
+                let env_source_label = env_source.as_str().to_string();
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::MissingIpykernel),
+                    )?;
+                    sd.set_kernel_info("python", "python", &env_source_label)?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
+            }
+        }
+    }
+
     // Register the env path for GC protection immediately after pool.take(),
     // BEFORE any async work (agent spawn, connect timeout, delta install).
     // Without this, there's a race window where GC sees the taken env as an

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2794,19 +2794,18 @@ pub(crate) async fn auto_launch_kernel(
                     env.venv_path,
                     env_source.as_str()
                 );
-                // Delete the corrupt env dir. We already `take()`d it
-                // from the pool; putting it back would just hand the
-                // same broken env to the next caller. A fresh warm-up
-                // will land on a clean base.
-                let doomed = env.venv_path.clone();
-                tokio::task::spawn_blocking(move || {
-                    if let Err(e) = std::fs::remove_dir_all(&doomed) {
-                        warn!(
-                            "[notebook-sync] failed to remove corrupt env {:?}: {}",
-                            doomed, e
-                        );
-                    }
-                });
+                // Delete the corrupt env dir synchronously before we
+                // return — `prepare_*_inline_env` treats the cache-hash
+                // dir as a cache hit while it exists, so a quick retry
+                // (user hits restart, automated flow) would reacquire
+                // the same broken env and we'd loop on MissingIpykernel.
+                // Await the removal so the next launch rebuilds.
+                if let Err(e) = tokio::fs::remove_dir_all(&env.venv_path).await {
+                    warn!(
+                        "[notebook-sync] failed to remove corrupt env {:?}: {}",
+                        env.venv_path, e
+                    );
+                }
                 let env_source_label = env_source.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2788,12 +2788,25 @@ pub(crate) async fn auto_launch_kernel(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            if !kernel_env::venv_has_ipykernel(&env.venv_path) {
+            if !kernel_env::venv_has_ipykernel(&env.python_path) {
                 warn!(
                     "[notebook-sync] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
                     env.venv_path,
                     env_source.as_str()
                 );
+                // Delete the corrupt env dir. We already `take()`d it
+                // from the pool; putting it back would just hand the
+                // same broken env to the next caller. A fresh warm-up
+                // will land on a clean base.
+                let doomed = env.venv_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    if let Err(e) = std::fs::remove_dir_all(&doomed) {
+                        warn!(
+                            "[notebook-sync] failed to remove corrupt env {:?}: {}",
+                            doomed, e
+                        );
+                    }
+                });
                 let env_source_label = env_source.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1068,6 +1068,49 @@ pub(crate) async fn handle(
         (pooled_env, None)
     };
 
+    // Verify ipykernel is present in the prepared env before we launch.
+    // Mirrors the auto-launch gate in `notebook_sync_server/metadata.rs`:
+    // the LaunchKernel RPC serves the toolbar restart button,
+    // restart-and-run-all, post-trust approval, and other retry paths,
+    // so a stale cache or hand-edited venv must surface the typed
+    // `MissingIpykernel` reason here too — otherwise retries silently
+    // regress to a generic kernel spawn failure. Skipped env sources
+    // match the auto-launch site (prewarmed pools, pixi:*, uv:pyproject,
+    // conda:env_yml, deno); pixi:toml is gated earlier in this function.
+    if matches!(
+        parsed_resolved,
+        EnvSource::Inline(PackageManager::Uv)
+            | EnvSource::Inline(PackageManager::Conda)
+            | EnvSource::Pep723(PackageManager::Uv)
+    ) {
+        if let Some(ref env) = pooled_env {
+            if !kernel_env::venv_has_ipykernel(&env.venv_path) {
+                warn!(
+                    "[launch-kernel] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
+                    env.venv_path,
+                    parsed_resolved.as_str()
+                );
+                let env_source_label = parsed_resolved.as_str().to_string();
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::MissingIpykernel),
+                    )?;
+                    sd.set_kernel_info("python", "python", &env_source_label)?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return NotebookResponse::Error {
+                    error: format!(
+                        "ipykernel not found in prepared {} environment",
+                        parsed_resolved.as_str()
+                    ),
+                };
+            }
+        }
+    }
+
     // Register the env path for GC protection immediately after pool.take(),
     // BEFORE any async work (agent spawn, connect timeout, delta install).
     if let Some(ref env) = pooled_env {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1084,12 +1084,24 @@ pub(crate) async fn handle(
             | EnvSource::Pep723(PackageManager::Uv)
     ) {
         if let Some(ref env) = pooled_env {
-            if !kernel_env::venv_has_ipykernel(&env.venv_path) {
+            if !kernel_env::venv_has_ipykernel(&env.python_path) {
                 warn!(
                     "[launch-kernel] prepared env at {:?} ({}) is missing ipykernel — cannot launch kernel",
                     env.venv_path,
                     parsed_resolved.as_str()
                 );
+                // Delete the corrupt env dir. We already `take()`d it
+                // from the pool; putting it back would just hand the
+                // same broken env to the next caller.
+                let doomed = env.venv_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    if let Err(e) = std::fs::remove_dir_all(&doomed) {
+                        warn!(
+                            "[launch-kernel] failed to remove corrupt env {:?}: {}",
+                            doomed, e
+                        );
+                    }
+                });
                 let env_source_label = parsed_resolved.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1090,18 +1090,18 @@ pub(crate) async fn handle(
                     env.venv_path,
                     parsed_resolved.as_str()
                 );
-                // Delete the corrupt env dir. We already `take()`d it
-                // from the pool; putting it back would just hand the
-                // same broken env to the next caller.
-                let doomed = env.venv_path.clone();
-                tokio::task::spawn_blocking(move || {
-                    if let Err(e) = std::fs::remove_dir_all(&doomed) {
-                        warn!(
-                            "[launch-kernel] failed to remove corrupt env {:?}: {}",
-                            doomed, e
-                        );
-                    }
-                });
+                // Delete the corrupt env dir synchronously before we
+                // return — `prepare_*_inline_env` treats the cache-hash
+                // dir as a cache hit while it exists, so a quick retry
+                // (toolbar restart, automated flow) would reacquire
+                // the same broken env and we'd loop on MissingIpykernel.
+                // Await the removal so the next launch rebuilds.
+                if let Err(e) = tokio::fs::remove_dir_all(&env.venv_path).await {
+                    warn!(
+                        "[launch-kernel] failed to remove corrupt env {:?}: {}",
+                        env.venv_path, e
+                    );
+                }
                 let env_source_label = parsed_resolved.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(


### PR DESCRIPTION
## Diagnosis

`KernelErrorReason::MissingIpykernel` has been pixi-only since #2102. UV/Conda envs that are missing `ipykernel` today fail at kernel spawn with a generic `ModuleNotFoundError: ipykernel_launcher` — the toolbar can classify the error but cannot render env-specific remediation. Tracked under #2096.

`prepare_environment_in` (both UV and Conda) always adds `ipykernel` to the install set, so fresh envs are fine. But the inline-env cache fast path only checks that `python` exists before returning a hit. Stale caches from pre-base-packages daemon builds, hand-edited venvs, and partial installs slip through that check and land at spawn with no typed reason.

## What this PR does

### Rust

- New `kernel_env::venv_has_ipykernel(env_path: &Path) -> bool` helper that scans the env's site-packages for `ipykernel/` or `ipykernel-*.dist-info/`. Handles POSIX (`lib/python*/site-packages`) and Windows (`Lib/site-packages`) layouts. Used by both UV venvs and Conda envs — same shape on disk.
- `notebook_sync_server::metadata` calls the helper after env prep for `EnvSource::Inline(Uv|Conda)` and `EnvSource::Pep723(Uv)`. On miss it writes `RuntimeLifecycle::Error` + `KernelErrorReason::MissingIpykernel` the same way the pixi path does, then returns before spawning the runtime agent.
- Skipped paths (all documented in the gate's comment):
  - Prewarmed pool envs (daemon-managed; base packages are invariant)
  - `pixi:inline` / `pixi:pep723` (no pooled_env; pixi exec handles it)
  - `uv:pyproject` (launched via `uv run --with ipykernel`)
  - `conda:env_yml` (daemon appends ipykernel to the dep set pre-sync)
  - `deno`
  - `pixi:toml` (already gated above)

### Frontend

- `NotebookToolbar.tsx` now branches the MissingIpykernel banner on env source:
  - `pixi:*` → `pixi add ipykernel`
  - `uv:inline` / `uv:pep723` → `uv pip install ipykernel` (and a nudge to add it to notebook deps)
  - `conda:inline` → `conda install ipykernel`
  - Everything else → render nothing (self-healing paths never reach this state)
- Extracted `MissingIpykernelBanner` so the three copies share one chrome.

## Files changed

- `crates/kernel-env/src/lib.rs` — new `venv_has_ipykernel` helper + 7 unit tests
- `crates/runtimed/src/notebook_sync_server/metadata.rs` — post-prep gate, 46 lines including comment
- `apps/notebook/src/components/NotebookToolbar.tsx` — branched remediation renderer
- `apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx` — 5 new test cases

## Tests

- `cargo test -p kernel-env --lib` — 57 passed (7 new for `venv_has_ipykernel`)
- `cargo test -p runtimed --lib` — 389 passed
- `cargo clippy -p kernel-env -p runtimed --all-targets` — clean
- `pnpm exec vp test apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx` — 34 passed (5 new)
- `cargo xtask lint` — clean (one pre-existing `Privacy.tsx` warning unrelated to this change)

## Manual test plan

Reproduce the missing-ipykernel state on an inline UV env:

1. Create a notebook with `metadata.runt.uv.dependencies = ["pandas"]` (or use the MCP `create_notebook` + `add_dependency` flow).
2. Wait for env prep to complete, then manually `rm -rf ~/.cache/runt-nightly/inline-envs/<hash>/lib/python*/site-packages/ipykernel*` on the cached env.
3. Restart the kernel.
4. Expect: toolbar shows `ipykernel missing from prepared uv environment` with `uv pip install ipykernel` remediation. No generic stderr dump in the error message.
5. Swap the notebook to `metadata.runt.conda` deps and repeat — expect `conda install ipykernel` copy.

The inline fast path is the realistic failure mode. The alternative (corrupted install on first prep) is rare enough that the unit test coverage plus the fast-path check is sufficient.

Refs #2096. Builds on #2102 which fixed the pixi RPC path.