### PR TITLE
fix(runtimed): daemon-owned trust re-sign and settings broadcast coalescing

### DIFF
--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -87,65 +87,52 @@ export function useCondaDependencies() {
     }
   }, [environmentYmlInfo, loadEnvironmentYmlDeps]);
 
-  // Re-sign the notebook after user modifications to keep it trusted
-  const resignTrust = useCallback(async () => {
+  // Trust re-signing lives on the daemon now (issue #2118). The daemon
+  // keeps a previously Trusted notebook Trusted by auto re-signing when
+  // the WASM dep write arrives via Automerge sync.
+  const withLoading = useCallback(async (op: () => Promise<void>, label: string) => {
+    setLoading(true);
     try {
-      await invoke("approve_notebook_trust");
+      await op();
     } catch (e) {
-      // Signing may fail if no trust key yet - that's okay
-      logger.debug("[conda] Could not resign trust:", e);
+      logger.error(`Failed to ${label}:`, e);
+    } finally {
+      setLoading(false);
     }
   }, []);
-
-  // Wrap a mutating WASM op with the shared loading + trust-resign + error log
-  // shape. `label` appears in the error message so grep still works.
-  const withTrustResign = useCallback(
-    async (op: () => Promise<void>, label: string) => {
-      setLoading(true);
-      try {
-        await op();
-        await resignTrust();
-      } catch (e) {
-        logger.error(`Failed to ${label}:`, e);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [resignTrust],
-  );
 
   const addDependency = useCallback(
     async (pkg: string) => {
       if (!pkg.trim()) return;
-      await withTrustResign(() => addCondaDepWasm(pkg.trim()), "add conda dependency");
+      await withLoading(() => addCondaDepWasm(pkg.trim()), "add conda dependency");
     },
-    [withTrustResign],
+    [withLoading],
   );
 
   const removeDependency = useCallback(
     async (pkg: string) => {
-      await withTrustResign(() => removeCondaDepWasm(pkg), "remove conda dependency");
+      await withLoading(() => removeCondaDepWasm(pkg), "remove conda dependency");
     },
-    [withTrustResign],
+    [withLoading],
   );
 
   // Remove the entire conda dependency section from notebook metadata
   const clearAllDependencies = useCallback(async () => {
-    await withTrustResign(() => clearCondaSection(), "clear conda dependencies");
-  }, [withTrustResign]);
+    await withLoading(() => clearCondaSection(), "clear conda dependencies");
+  }, [withLoading]);
 
   const setChannels = useCallback(
     async (channels: string[]) => {
-      await withTrustResign(() => setCondaChannelsWasm(channels), "set channels");
+      await withLoading(() => setCondaChannelsWasm(channels), "set channels");
     },
-    [withTrustResign],
+    [withLoading],
   );
 
   const setPython = useCallback(
     async (version: string | null) => {
-      await withTrustResign(() => setCondaPythonWasm(version), "set python version");
+      await withLoading(() => setCondaPythonWasm(version), "set python version");
     },
-    [withTrustResign],
+    [withLoading],
   );
 
   const hasDependencies = dependencies !== null && dependencies.dependencies.length > 0;

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -69,89 +69,67 @@ export function useDependencies() {
       }
     : null;
 
-  // Re-sign the notebook after user modifications to keep it trusted
-  const resignTrust = useCallback(async () => {
+  // Trust re-signing lives on the daemon now (issue #2118). When the WASM
+  // dep write arrives via Automerge sync, the daemon keeps a previously
+  // Trusted notebook Trusted by auto re-signing. Frontend hooks just
+  // write to the CRDT.
+
+  const addDependency = useCallback(async (pkg: string) => {
+    if (!pkg.trim()) return;
+    setLoading(true);
     try {
-      await invoke("approve_notebook_trust");
+      await addUvDependency(pkg.trim());
     } catch (e) {
-      // Signing may fail if no trust key yet - that's okay
-      logger.debug("[deps] Could not resign trust:", e);
+      logger.error("Failed to add dependency:", e);
+    } finally {
+      setLoading(false);
     }
   }, []);
 
-  const addDependency = useCallback(
-    async (pkg: string) => {
-      if (!pkg.trim()) return;
-      setLoading(true);
-      try {
-        await addUvDependency(pkg.trim());
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to add dependency:", e);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [resignTrust],
-  );
-
-  const removeDependency = useCallback(
-    async (pkg: string) => {
-      setLoading(true);
-      try {
-        await removeUvDependency(pkg);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to remove dependency:", e);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [resignTrust],
-  );
+  const removeDependency = useCallback(async (pkg: string) => {
+    setLoading(true);
+    try {
+      await removeUvDependency(pkg);
+    } catch (e) {
+      logger.error("Failed to remove dependency:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   // Remove the entire uv dependency section from notebook metadata
   const clearAllDependencies = useCallback(async () => {
     setLoading(true);
     try {
       await clearUvSection();
-      await resignTrust();
     } catch (e) {
       logger.error("Failed to clear UV dependencies:", e);
     } finally {
       setLoading(false);
     }
-  }, [resignTrust]);
+  }, []);
 
-  const setRequiresPython = useCallback(
-    async (version: string | null) => {
-      setLoading(true);
-      try {
-        await setUvRequiresPython(version);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to set requires-python:", e);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [resignTrust],
-  );
+  const setRequiresPython = useCallback(async (version: string | null) => {
+    setLoading(true);
+    try {
+      await setUvRequiresPython(version);
+    } catch (e) {
+      logger.error("Failed to set requires-python:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-  const setPrerelease = useCallback(
-    async (prerelease: string | null) => {
-      setLoading(true);
-      try {
-        await setUvPrerelease(prerelease);
-        await resignTrust();
-      } catch (e) {
-        logger.error("Failed to set prerelease:", e);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [resignTrust],
-  );
+  const setPrerelease = useCallback(async (prerelease: string | null) => {
+    setLoading(true);
+    try {
+      await setUvPrerelease(prerelease);
+    } catch (e) {
+      logger.error("Failed to set prerelease:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   const hasDependencies = dependencies !== null && dependencies.dependencies.length > 0;
 
@@ -180,15 +158,13 @@ export function useDependencies() {
     setLoading(true);
     try {
       await invoke("import_pyproject_dependencies");
-      // Re-sign to keep notebook trusted after user modification
-      await resignTrust();
       logger.info("[deps] Imported dependencies from pyproject.toml");
     } catch (e) {
       logger.error("Failed to import from pyproject.toml:", e);
     } finally {
       setLoading(false);
     }
-  }, [resignTrust]);
+  }, []);
 
   // Refresh pyproject detection
   const refreshPyproject = useCallback(async () => {

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1013,6 +1013,17 @@ impl SettingsDoc {
         self.doc.sync().receive_sync_message(peer_state, message)
     }
 
+    /// Current document heads. Used to detect whether a sync exchange
+    /// actually applied changes — identical heads before and after
+    /// `receive_sync_message` means the peer's message was an ack or a
+    /// duplicate and no broadcast is warranted.
+    ///
+    /// Takes `&mut` because `AutoCommit` commits any pending transaction
+    /// before reporting heads.
+    pub fn heads(&mut self) -> Vec<automerge::ChangeHash> {
+        self.doc.get_heads()
+    }
+
     /// Selectively apply external JSON changes to the Automerge doc.
     ///
     /// Only updates fields that are **present** in the JSON and **differ** from

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -328,6 +328,19 @@ fn pixi_prewarmed_packages(extra: &[String]) -> Vec<String> {
     packages
 }
 
+/// Settings changes that arrive close together (e.g. a user adding several
+/// default packages in the Settings panel, each dispatching its own sync
+/// round trip) would otherwise trigger a separate pool eviction + rewarm
+/// per signal. Absorb additional wake-ups within `quiet` of the last one
+/// before returning so the warming loop collapses them into a single cycle.
+/// See #2120.
+async fn absorb_rapid_settings_signals(
+    rx: &mut tokio::sync::broadcast::Receiver<()>,
+    quiet: std::time::Duration,
+) {
+    while let Ok(Ok(())) = tokio::time::timeout(quiet, rx.recv()).await {}
+}
+
 impl Pool {
     fn new(target: usize, max_age_secs: u64) -> Self {
         Self {
@@ -3694,7 +3707,12 @@ impl Daemon {
 
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
-                _ = settings_rx.recv() => {}
+                _ = settings_rx.recv() => {
+                    absorb_rapid_settings_signals(
+                        &mut settings_rx,
+                        std::time::Duration::from_millis(500),
+                    ).await;
+                }
             }
         }
     }
@@ -3811,7 +3829,12 @@ impl Daemon {
 
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
-                _ = settings_rx.recv() => {}
+                _ = settings_rx.recv() => {
+                    absorb_rapid_settings_signals(
+                        &mut settings_rx,
+                        std::time::Duration::from_millis(500),
+                    ).await;
+                }
             }
         }
     }
@@ -3925,7 +3948,12 @@ impl Daemon {
 
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
-                _ = settings_rx.recv() => {}
+                _ = settings_rx.recv() => {
+                    absorb_rapid_settings_signals(
+                        &mut settings_rx,
+                        std::time::Duration::from_millis(500),
+                    ).await;
+                }
             }
         }
     }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -751,11 +751,37 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
 
     let new_trust = verify_trust_from_snapshot(&current_metadata);
 
-    // Check if trust state actually changed
     let current_status = {
         let ts = room.trust_state.read().await;
         ts.status.clone()
     };
+
+    // Auto re-sign: if the user has already approved this notebook, deps
+    // changes shouldn't flip it back to SignatureInvalid (which would kill
+    // the kernel). Re-compute the signature in place and keep the notebook
+    // Trusted. This covers both the UI-driven dep add path (primary case)
+    // and external file edits on an already-approved notebook.
+    if matches!(current_status, runt_trust::TrustStatus::Trusted)
+        && matches!(new_trust.status, runt_trust::TrustStatus::SignatureInvalid)
+    {
+        match resign_trusted_snapshot(room).await {
+            Ok(true) => {
+                // Fresh snapshot/state now reflect Trusted — nothing else to do.
+                return;
+            }
+            Ok(false) => {
+                // Nothing to re-sign (snapshot vanished). Fall through.
+            }
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] Failed to auto re-sign trusted notebook, \
+                     falling back to SignatureInvalid: {}",
+                    e
+                );
+                // Fall through to the normal transition path.
+            }
+        }
+    }
 
     if current_status != new_trust.status {
         info!(
@@ -788,6 +814,43 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
             warn!("[runtime-state] {}", e);
         }
     }
+}
+
+/// Re-sign the notebook's current metadata with the daemon's trust key and
+/// write the new signature back into the Automerge doc. Used when deps have
+/// changed on a previously-Trusted notebook, so the user doesn't have to
+/// re-approve through the UI for every dependency edit.
+///
+/// Returns `Ok(true)` if a re-sign was applied, `Ok(false)` if there was
+/// nothing to sign (no metadata snapshot). Errors propagate so the caller
+/// can fall back to the normal SignatureInvalid transition.
+async fn resign_trusted_snapshot(room: &NotebookRoom) -> Result<bool, String> {
+    let mut doc = room.doc.write().await;
+
+    let Some(mut snapshot) = doc.get_metadata_snapshot() else {
+        return Ok(false);
+    };
+
+    let runt_value = serde_json::to_value(&snapshot.runt)
+        .map_err(|e| format!("serialize runt metadata: {}", e))?;
+    let mut additional = std::collections::HashMap::new();
+    additional.insert("runt".to_string(), runt_value);
+    let signature = runt_trust::sign_notebook_dependencies(&additional)?;
+
+    snapshot.runt.trust_signature = Some(signature);
+    snapshot.runt.trust_timestamp = Some(chrono::Utc::now().to_rfc3339());
+
+    doc.fork_and_merge(|fork| {
+        let _ = fork.set_metadata_snapshot(&snapshot);
+    });
+    drop(doc);
+
+    // Persist the new signature to disk so reopening after a restart keeps
+    // the notebook Trusted without another sync round-trip.
+    let _ = room.broadcasts.changed_tx.send(());
+
+    info!("[notebook-sync] Auto re-signed trusted notebook after deps change");
+    Ok(true)
 }
 
 /// Resolve the metadata snapshot for a notebook, trying the Automerge doc first

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3363,18 +3363,18 @@ async fn test_check_and_update_trust_state_idempotent() {
     assert_eq!(ts.status, runt_trust::TrustStatus::NoDependencies);
 }
 
-/// Simulates the file-watcher path: a notebook starts Trusted (signed
-/// metadata on disk), then an external editor / `uv add numpy` rewrites
-/// the dependency list. The signature no longer covers the new dep set,
-/// so `check_and_update_trust_state` should flip trust_state to
-/// SignatureInvalid and emit a state_changed_tx notification.
+/// Issue #2118: a previously-approved notebook must stay Trusted when the
+/// user adds a dependency. Before the fix, any dep write — whether from
+/// the UI (WASM → daemon) or an external file edit — would arrive with the
+/// stale signature, flip trust to SignatureInvalid, and kill the running
+/// kernel before the sidecar's `approve_notebook_trust` RPC landed.
 ///
-/// This is the regression this PR fixes: before the fix the file watcher
-/// merged new deps into the CRDT but never re-verified trust, so
-/// room.trust_state stayed Trusted and auto-launch used a stale signature.
+/// The fix: when the room is already Trusted and new deps would produce a
+/// SignatureInvalid verification, re-sign in place with the daemon's trust
+/// key and keep the notebook Trusted.
 #[tokio::test]
 #[serial]
-async fn test_check_and_update_trust_state_external_dep_add_invalidates() {
+async fn test_check_and_update_trust_state_auto_resigns_trusted_notebook() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
     std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
@@ -3406,51 +3406,86 @@ async fn test_check_and_update_trust_state_external_dep_add_invalidates() {
             .unwrap();
     }
 
-    // Sanity check: starting state is Trusted.
     {
         let ts = room.trust_state.read().await;
         assert_eq!(ts.status, runt_trust::TrustStatus::Trusted);
     }
 
-    // Simulate external edit: user runs `uv add pandas` + saves. The
-    // file watcher merges the new deps into the CRDT but carries over
-    // the stale signature (because the external tool doesn't resign).
+    // User (or external editor) adds `pandas`. Carries over the stale
+    // signature, which is now over a different dep set.
     let mut edited = snapshot_with_uv(vec!["numpy".to_string(), "pandas".to_string()]);
-    edited.runt.trust_signature = Some(signature);
+    edited.runt.trust_signature = Some(signature.clone());
     {
         let mut doc = room.doc.write().await;
         doc.set_metadata_snapshot(&edited).unwrap();
     }
 
-    // Subscribe before the re-verification so we can observe the flip.
-    let mut rx = room.state.subscribe();
-
     check_and_update_trust_state(&room).await;
 
-    // Trust should flip to SignatureInvalid — the signature is over the
-    // numpy-only dep set, so adding pandas breaks it.
+    // Trust must stay Trusted — the daemon auto re-signed the new dep set.
     {
         let ts = room.trust_state.read().await;
         assert_eq!(
             ts.status,
-            runt_trust::TrustStatus::SignatureInvalid,
-            "external dep add must flip trust from Trusted to SignatureInvalid"
+            runt_trust::TrustStatus::Trusted,
+            "dep add on a trusted notebook must auto re-sign, not flip to SignatureInvalid"
         );
     }
 
-    // RuntimeStateDoc should reflect the flip for the frontend banner.
+    // The new signature in the doc must cover the new deps.
+    let resigned = {
+        let doc = room.doc.read().await;
+        doc.get_metadata_snapshot().unwrap()
+    };
+    let new_sig = resigned
+        .runt
+        .trust_signature
+        .as_deref()
+        .expect("signature present after auto re-sign");
+    assert_ne!(
+        new_sig, signature,
+        "signature must be refreshed to cover the new dep list"
+    );
+    let verified = verify_trust_from_snapshot(&resigned);
+    assert_eq!(verified.status, runt_trust::TrustStatus::Trusted);
+
+    // RuntimeStateDoc should not flip to signature_invalid — the user is
+    // still trusted so no banner should appear.
     {
         let state = room.state.read(|sd| sd.read_state()).unwrap();
-        assert_eq!(state.trust.status, "signature_invalid");
-        assert!(state.trust.needs_approval);
+        assert_eq!(state.trust.status, "trusted");
+        assert!(!state.trust.needs_approval);
     }
 
-    // state_changed_tx must have fired at least once so subscribers
-    // (frontend, auto-launch) pick up the new trust state.
-    assert!(
-        rx.try_recv().is_ok(),
-        "trust flip must emit state_changed_tx notification"
-    );
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
+/// Auto re-sign must only apply when the notebook was already Trusted.
+/// A brand-new notebook with unsigned deps must still land in Untrusted —
+/// the user has not approved anything yet.
+#[tokio::test]
+#[serial]
+async fn test_check_and_update_trust_state_no_autoresign_when_not_previously_trusted() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _path) = test_room_with_path(&tmp, "fresh_notebook.ipynb");
+
+    // Room starts Untrusted (default). Write deps with no signature —
+    // simulates the frontend WASM adding a dep to a brand-new notebook.
+    let snapshot = snapshot_with_uv(vec!["numpy".to_string()]);
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&snapshot).unwrap();
+    }
+
+    check_and_update_trust_state(&room).await;
+
+    // Should land in Untrusted (no prior approval, no auto sign).
+    let ts = room.trust_state.read().await;
+    assert_eq!(ts.status, runt_trust::TrustStatus::Untrusted);
 
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -76,11 +76,20 @@ where
                             .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
 
                         let mut doc = settings.write().await;
+                        // Compare heads before/after so pure acks or duplicate
+                        // messages don't fire `settings_changed`. Without this
+                        // the pool warming loops wake up on every sync-protocol
+                        // round-trip, which thrashes the pools when several
+                        // per-`invoke` clients land back-to-back (#2120).
+                        let before = doc.heads();
                         doc.receive_sync_message(&mut peer_state, message)?;
+                        let after = doc.heads();
+                        let doc_changed = before != after;
 
-                        // Persist and notify others
-                        persist_settings(&mut doc, &automerge_path, &json_path);
-                        let _ = changed_tx.send(());
+                        if doc_changed {
+                            persist_settings(&mut doc, &automerge_path, &json_path);
+                            let _ = changed_tx.send(());
+                        }
 
                         // Send our response
                         if let Some(reply) = doc.generate_sync_message(&mut peer_state) {


### PR DESCRIPTION
## Summary

Fixes #2118 and #2120. Both are daemon-side changes.

### #2118 — Kernel restart on dep add

Adding a package in the notebook UI was killing the kernel because the WASM dep write reached the daemon over Automerge sync before the Tauri sidecar's `approve_notebook_trust` RPC landed. The daemon saw new deps with a stale signature, flipped trust to `SignatureInvalid`, and shut the kernel down.

Move re-signing into `check_and_update_trust_state`. When a previously Trusted notebook would flip to `SignatureInvalid`, the daemon signs the new deps with its local trust key via `fork_and_merge` and keeps the notebook Trusted. `approve_notebook_trust` stays for the initial approval flow. The frontend's `resignTrust()` wrappers in `useDependencies.ts` and `useCondaDependencies.ts` are gone — they were what fought the race in the first place.

New tests cover both the auto re-sign path and the guardrail that a brand-new untrusted notebook with unsigned deps still lands in Untrusted.

### #2120 — Settings edits thrashing the pool

Each default-package edit fires `invoke("set_synced_setting")`, which opens a fresh `SyncClient`, sends one sync message, and disconnects. On the daemon, `handle_settings_sync_connection` was firing `settings_changed` unconditionally on every received sync message — including acks and duplicates — so four rapid edits triggered four full UV + Conda + Pixi pool evictions and blocked notebook launches while the pools recovered.

Two small daemon-side fixes:

- **Broadcast only on real doc change.** Compare `SettingsDoc` heads before and after `receive_sync_message` and only fire `settings_changed` when the doc actually moved.
- **Coalesce rapid signals.** After the first `settings_rx.recv()` in each warming loop, absorb additional signals for 500ms of quiet before running the eviction + warm cycle.

No frontend debounce, no WASM bindings for settings yet — `set_synced_setting` stays as-is. Filing the frontend-owned settings CRDT (parallel to `useAutomergeNotebook`) as a separate effort.

## Test plan

- [x] `cargo test -p runtimed --lib notebook_sync_server::` (150 pass including new trust auto re-sign + untrusted-stays-untrusted tests)
- [x] `cargo test -p runtimed-client --lib` (179 pass)
- [x] `cargo xtask lint` clean
- [ ] Manual: open a trusted notebook, add a UV dep; kernel keeps running (no `SignatureInvalid` in `runtimed.log`, no restart)
- [ ] Manual: add 4 conda packages to defaults in quick succession; observe one pool eviction cycle instead of four
