### PR TITLE
fix(runtimed,notebook): don't delete inline env caches + tear down agent on restart-time MissingIpykernel

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -406,14 +406,12 @@ export function NotebookToolbar({
  * (prewarmed pools, uv:pyproject, conda:env_yml, deno) — those either
  * self-heal at launch or should never reach this state.
  *
- * For inline/PEP 723 envs the daemon has already deleted the corrupt
- * cache dir; `prepare_*_inline_env` always includes `ipykernel` in its
- * install set, so the next launch rebuilds correctly. The banner tells
- * users exactly that instead of sending them to edit deps that already
- * had nothing wrong with them.
- *
- * For pixi:toml the daemon does NOT delete anything — pixi manages its
- * own env and the user's `pixi.toml` genuinely needs editing. */
+ * For inline/PEP 723 envs the daemon previously deleted the corrupt
+ * cache dir so a plain restart would rebuild. That delete was reverted
+ * (shared content-addressed cache + concurrent-install race), so a
+ * restart alone now re-hits the same broken cache. Until we add an
+ * in-place repair, the way out is to bump the dep hash — add, pin, or
+ * remove anything in the notebook's deps — or clear the daemon cache. */
 function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
   // Pixi project: the .toml is the source of truth; user must add
   // ipykernel explicitly.
@@ -430,13 +428,19 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
       />
     );
   }
-  // Inline / PEP 723 / inline conda: daemon deleted the stale env;
-  // the next launch rebuilds with ipykernel. No user deps edit needed.
+  // Inline / PEP 723 / inline conda: env is a shared content-addressed
+  // cache — we can't safely delete it from the launch path. Bump the
+  // hash instead.
   if (envSource === "uv:inline" || envSource === "uv:pep723" || envSource === "conda:inline") {
     return (
       <MissingIpykernelBanner
-        headline="Environment cache was corrupt."
-        instruction={<>Click Restart to rebuild the environment.</>}
+        headline="Dependency cache is missing ipykernel."
+        instruction={
+          <>
+            Edit any notebook dependency (add, remove, or pin a version) to rebuild the environment,
+            or clear the daemon cache.
+          </>
+        }
       />
     );
   }

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -417,13 +417,12 @@ describe("NotebookToolbar", () => {
     const errorLifecycle: RuntimeLifecycle = { lifecycle: "Error" };
 
     // Inline / PEP 723 / inline conda all share the same "just restart"
-    // remediation — the daemon has already deleted the corrupt env dir
-    // and `prepare_*_inline_env` auto-includes ipykernel in its install
-    // set, so the next launch rebuilds successfully. The banner must
-    // NOT ask users to edit deps (a no-op) or run install commands
-    // against the env (which no longer exists).
+    // remediation — the env is a shared content-addressed cache and
+    // the daemon no longer deletes it from the launch path (that would
+    // race with concurrent installs + corrupt caches of other notebooks
+    // with the same dep hash). Users bump the dep hash to rebuild.
     for (const envSource of ["uv:inline", "uv:pep723", "conda:inline"] as const) {
-      it(`shows "restart to rebuild" prompt for envSource=${envSource}`, () => {
+      it(`shows "edit a dep" prompt for envSource=${envSource}`, () => {
         render(
           <NotebookToolbar
             {...baseProps}
@@ -434,13 +433,10 @@ describe("NotebookToolbar", () => {
             envSource={envSource}
           />,
         );
-        expect(screen.getByText(/Environment cache was corrupt/)).toBeInTheDocument();
-        expect(screen.getByText(/Click Restart to rebuild/)).toBeInTheDocument();
-        // Backends already rebuild these envs — no user dep edits needed.
-        expect(screen.queryByText(/notebook's dependencies/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/uv pip install/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/conda install/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/# \/\/\/ script/)).not.toBeInTheDocument();
+        expect(screen.getByText(/Dependency cache is missing ipykernel/)).toBeInTheDocument();
+        expect(screen.getByText(/Edit any notebook dependency/)).toBeInTheDocument();
+        // Restart alone no longer self-heals — banner must not promise it.
+        expect(screen.queryByText(/Click Restart to rebuild/)).not.toBeInTheDocument();
       });
     }
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2794,18 +2794,15 @@ pub(crate) async fn auto_launch_kernel(
                     env.venv_path,
                     env_source.as_str()
                 );
-                // Delete the corrupt env dir synchronously before we
-                // return — `prepare_*_inline_env` treats the cache-hash
-                // dir as a cache hit while it exists, so a quick retry
-                // (user hits restart, automated flow) would reacquire
-                // the same broken env and we'd loop on MissingIpykernel.
-                // Await the removal so the next launch rebuilds.
-                if let Err(e) = tokio::fs::remove_dir_all(&env.venv_path).await {
-                    warn!(
-                        "[notebook-sync] failed to remove corrupt env {:?}: {}",
-                        env.venv_path, e
-                    );
-                }
+                // Don't delete the env dir here: it's a content-addressed
+                // cache shared with any other notebook using the same
+                // dep set, and there's a race where a concurrent launch
+                // could observe a partial build (python present,
+                // ipykernel not yet installed) and nuke the env out
+                // from under the in-progress installer. A proper heal
+                // (install ipykernel in place, or atomic invalidation
+                // marker) is a follow-up; for now we surface the typed
+                // error and let the user edit deps to bump the hash.
                 let env_source_label = env_source.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1090,18 +1090,24 @@ pub(crate) async fn handle(
                     env.venv_path,
                     parsed_resolved.as_str()
                 );
-                // Delete the corrupt env dir synchronously before we
-                // return — `prepare_*_inline_env` treats the cache-hash
-                // dir as a cache hit while it exists, so a quick retry
-                // (toolbar restart, automated flow) would reacquire
-                // the same broken env and we'd loop on MissingIpykernel.
-                // Await the removal so the next launch rebuilds.
-                if let Err(e) = tokio::fs::remove_dir_all(&env.venv_path).await {
-                    warn!(
-                        "[launch-kernel] failed to remove corrupt env {:?}: {}",
-                        env.venv_path, e
-                    );
-                }
+                // Don't delete the env dir: for inline/pep723 it's a
+                // content-addressed cache shared across notebooks and
+                // vulnerable to a racy nuke of a concurrent install.
+                //
+                // Tear down the existing runtime agent (if any) BEFORE
+                // we write the Error lifecycle. This path can be
+                // reached from a restart (prior_lifecycle == Running),
+                // in which case an agent is still holding request/
+                // response channels. Leaving them up while the UI
+                // flips to Error leaves the notebook split-brained
+                // (old kernel still executes; UI thinks start failed).
+                // `reset_starting_state` first writes NotStarted and
+                // clears agent handles; we then overwrite lifecycle
+                // with Error + MissingIpykernel so the UI sees the
+                // correct reason. Minor TOCTOU against a concurrent
+                // retry is accepted — a second retry observing Error
+                // will simply start a fresh launch.
+                reset_starting_state(room, None).await;
                 let env_source_label = parsed_resolved.as_str().to_string();
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error(


### PR DESCRIPTION
Follow-up to #2117 addressing two codex findings from the v5 review (posted post-merge).

## P1 — cache corruption

The previous fix deleted `env.venv_path` on gate failure. For `uv:inline`, `conda:inline`, and `uv:pep723`, that path is a **shared content-addressed cache** keyed by the dep hash.

- Multi-notebook blast radius: a failed probe on one notebook would delete the env any other notebook with the same deps is using.
- Concurrent-install race: a second launch observing an in-progress build (`bin/python` present, `ipykernel` not yet installed) would `remove_dir_all()` the env out from under the installer.

Dropped the deletes from both the auto-launch gate (`notebook_sync_server/metadata.rs`) and the LaunchKernel gate (`requests/launch_kernel.rs`).

**Trade-off:** a plain restart no longer self-heals the cache. The typed error still fires so the UI can explain what's wrong; users bump the dep hash to rebuild. A proper in-place repair (install ipykernel without rebuilding, or an atomic invalidation marker) is a follow-up.

## P2 — split-brain on restart

The LaunchKernel gate fires *before* the in-place restart path. If a notebook already has a connected runtime agent and its cached env has lost ipykernel, the gate flipped state to Error and returned without tearing down the agent — old kernel kept executing while the UI showed a failed restart.

Added a `reset_starting_state(room, None).await` before the Error write so the agent request/response/connect channels are cleared. Minor TOCTOU against a concurrent retry is acceptable; pattern matches the other error paths in `requests/launch_kernel.rs`.

## Banner copy

Before: "Environment cache was corrupt. Click Restart to rebuild." (incorrect — without the delete, restart re-hits the same cache)

After: "Dependency cache is missing ipykernel. Edit any notebook dependency (add, remove, or pin a version) to rebuild the environment, or clear the daemon cache."

Pixi path is unchanged — it's a file the user owns and must edit.

## Test plan

- [x] `cargo test -p runtimed --lib` → 390 passing
- [x] `pnpm test:run apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx` → 34 passing (banner tests updated)
- [x] `cargo xtask lint` → clean
- [ ] Manual: corrupt a uv:inline env, trigger restart from toolbar, confirm agent tears down and banner shows the edit-a-dep copy