### PR TITLE
fix(notebook-doc): reject PEP 508 extras in conda/pixi deps before they reach the kernel

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -63,10 +63,17 @@ export class NotebookHandle {
     /**
      * Add a Conda dependency, deduplicating by package name (case-insensitive).
      * Initializes the Conda section with ["conda-forge"] channels if absent.
+     *
+     * Rejects PEP 508 extras syntax (`pkg[extra]`) — conda matchspecs
+     * don't accept brackets, and letting one through SIGKILLs the
+     * kernel at install time. See issue #2119.
      */
     add_conda_dependency(pkg: string): void;
     /**
      * Add a Pixi conda dependency (matchspec). Deduplicates by package name.
+     *
+     * Rejects PEP 508 extras syntax (`pkg[extra]`) — pixi uses
+     * rattler-style matchspecs which don't accept brackets. See #2119.
      */
     add_pixi_dependency(pkg: string): void;
     /**

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -284,6 +284,10 @@ export class NotebookHandle {
     /**
      * Add a Conda dependency, deduplicating by package name (case-insensitive).
      * Initializes the Conda section with ["conda-forge"] channels if absent.
+     *
+     * Rejects PEP 508 extras syntax (`pkg[extra]`) — conda matchspecs
+     * don't accept brackets, and letting one through SIGKILLs the
+     * kernel at install time. See issue #2119.
      * @param {string} pkg
      */
     add_conda_dependency(pkg) {
@@ -303,6 +307,9 @@ export class NotebookHandle {
     }
     /**
      * Add a Pixi conda dependency (matchspec). Deduplicates by package name.
+     *
+     * Rejects PEP 508 extras syntax (`pkg[extra]`) — pixi uses
+     * rattler-style matchspecs which don't accept brackets. See #2119.
      * @param {string} pkg
      */
     add_pixi_dependency(pkg) {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c8de6f88de532c4a248150b70316bbff4d9c67dc8680bb859b38679a0f0e485
-size 1729085
+oid sha256:00c65a34649b53c31c5617b7e60ec11485a2ba54a245a8da1fcaff19d6e2732b
+size 1733067

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -711,6 +711,35 @@ pub fn validate_package_specifier(spec: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Strict specifier check for conda/pixi envs.
+///
+/// Same base rules as [`validate_package_specifier`] plus a rejection
+/// of PEP 508 extras syntax (`pkg[extra]`). Conda matchspecs and
+/// rattler package names don't accept brackets — without this guard,
+/// a UI-accepted spec like `dx[polars]` lands in the Automerge doc,
+/// hits rattler's installer, and SIGKILLs the kernel with an
+/// `invalid bracket` error. See issue #2119.
+///
+/// # Examples
+///
+/// ```
+/// use notebook_doc::metadata::validate_conda_package_specifier;
+/// assert!(validate_conda_package_specifier("pandas>=2.0").is_ok());
+/// assert!(validate_conda_package_specifier("conda-forge::numpy").is_ok());
+/// assert!(validate_conda_package_specifier("dx[polars]").is_err());
+/// assert!(validate_conda_package_specifier("requests[security]").is_err());
+/// ```
+pub fn validate_conda_package_specifier(spec: &str) -> Result<(), String> {
+    if spec.contains('[') || spec.contains(']') {
+        return Err(format!(
+            "'{spec}' uses PEP 508 extras syntax (brackets), which conda \
+             and pixi don't accept. Add the extra as a separate dependency, \
+             or switch to a uv-managed environment."
+        ));
+    }
+    validate_package_specifier(spec)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -988,6 +1017,37 @@ mod tests {
         assert!(validate_package_specifier("[\"pandas\"").is_err());
         assert!(validate_package_specifier("\"numpy\"").is_err());
         assert!(validate_package_specifier("\"seaborn\"]").is_err());
+    }
+
+    // ── validate_conda_package_specifier ───────────────────────
+
+    #[test]
+    fn test_validate_conda_specifier_accepts_plain_and_versioned() {
+        assert!(validate_conda_package_specifier("pandas").is_ok());
+        assert!(validate_conda_package_specifier("pandas>=2.0").is_ok());
+        assert!(validate_conda_package_specifier("numpy==1.24.0").is_ok());
+        assert!(validate_conda_package_specifier("python=3.12").is_ok());
+        assert!(validate_conda_package_specifier("conda-forge::numpy").is_ok());
+        assert!(validate_conda_package_specifier("conda-forge::numpy>=1.24").is_ok());
+    }
+
+    #[test]
+    fn test_validate_conda_specifier_rejects_pep508_extras() {
+        // The exact case from #2119 — must reject rather than silently
+        // letting rattler SIGKILL the kernel.
+        let err = validate_conda_package_specifier("dx[polars]").unwrap_err();
+        assert!(err.contains("brackets"), "got: {err}");
+        assert!(validate_conda_package_specifier("requests[security]").is_err());
+        assert!(validate_conda_package_specifier("pkg[a,b]>=1.0").is_err());
+        // Stray closing bracket still caught.
+        assert!(validate_conda_package_specifier("pandas]").is_err());
+    }
+
+    #[test]
+    fn test_validate_conda_specifier_rejects_empty_and_mangled() {
+        assert!(validate_conda_package_specifier("").is_err());
+        assert!(validate_conda_package_specifier("   ").is_err());
+        assert!(validate_conda_package_specifier("\"numpy\"").is_err());
     }
 
     // ── detect_runtime ───────────────────────────────────────────

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -130,12 +130,21 @@ pub(crate) fn add_dep_for_manager(
 ) -> Result<(), String> {
     use notebook_protocol::connection::PackageManager;
     match manager {
-        PackageManager::Conda => handle
-            .add_conda_dependency(package)
-            .map_err(|e| format!("Failed to add conda dependency: {e}")),
-        PackageManager::Pixi => handle
-            .add_pixi_dependency(package)
-            .map_err(|e| format!("Failed to add pixi dependency: {e}")),
+        PackageManager::Conda => {
+            // Reject PEP 508 extras (`pkg[extra]`) before they land in
+            // the doc — conda matchspecs crash rattler with `invalid
+            // bracket` and take the kernel with them. See #2119.
+            notebook_doc::metadata::validate_conda_package_specifier(package)?;
+            handle
+                .add_conda_dependency(package)
+                .map_err(|e| format!("Failed to add conda dependency: {e}"))
+        }
+        PackageManager::Pixi => {
+            notebook_doc::metadata::validate_conda_package_specifier(package)?;
+            handle
+                .add_pixi_dependency(package)
+                .map_err(|e| format!("Failed to add pixi dependency: {e}"))
+        }
         PackageManager::Uv | PackageManager::Unknown(_) => handle
             .add_uv_dependency(package)
             .map_err(|e| format!("Failed to add uv dependency: {e}")),

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -910,6 +910,9 @@ impl AsyncSession {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
         future_into_py(py, async move {
+            // Reject PEP 508 extras before they land in the doc — see #2119.
+            notebook_doc::metadata::validate_conda_package_specifier(&package)
+                .map_err(pyo3::exceptions::PyValueError::new_err)?;
             let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             snapshot.add_conda_dependency(&package);
             session_core::set_notebook_metadata(&state, &snapshot).await
@@ -924,6 +927,10 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
+            for package in &packages {
+                notebook_doc::metadata::validate_conda_package_specifier(package)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+            }
             let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             for package in &packages {
                 snapshot.add_conda_dependency(package);
@@ -972,6 +979,9 @@ impl AsyncSession {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
         future_into_py(py, async move {
+            // Reject PEP 508 extras before they land in the doc — see #2119.
+            notebook_doc::metadata::validate_conda_package_specifier(&package)
+                .map_err(pyo3::exceptions::PyValueError::new_err)?;
             let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             snapshot.add_pixi_dependency(&package);
             session_core::set_notebook_metadata(&state, &snapshot).await
@@ -986,6 +996,10 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
+            for package in &packages {
+                notebook_doc::metadata::validate_conda_package_specifier(package)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?;
+            }
             let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             for package in &packages {
                 snapshot.add_pixi_dependency(package);

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1252,7 +1252,13 @@ impl NotebookHandle {
 
     /// Add a Conda dependency, deduplicating by package name (case-insensitive).
     /// Initializes the Conda section with ["conda-forge"] channels if absent.
+    ///
+    /// Rejects PEP 508 extras syntax (`pkg[extra]`) — conda matchspecs
+    /// don't accept brackets, and letting one through SIGKILLs the
+    /// kernel at install time. See issue #2119.
     pub fn add_conda_dependency(&mut self, pkg: &str) -> Result<(), JsError> {
+        notebook_doc::metadata::validate_conda_package_specifier(pkg)
+            .map_err(|e| JsError::new(&e))?;
         self.invalidate_metadata_cache();
         self.doc
             .add_conda_dependency(pkg)
@@ -1299,7 +1305,12 @@ impl NotebookHandle {
     // ── Pixi dependency operations ──────────────────────────────────
 
     /// Add a Pixi conda dependency (matchspec). Deduplicates by package name.
+    ///
+    /// Rejects PEP 508 extras syntax (`pkg[extra]`) — pixi uses
+    /// rattler-style matchspecs which don't accept brackets. See #2119.
     pub fn add_pixi_dependency(&mut self, pkg: &str) -> Result<(), JsError> {
+        notebook_doc::metadata::validate_conda_package_specifier(pkg)
+            .map_err(|e| JsError::new(&e))?;
         self.invalidate_metadata_cache();
         self.doc
             .add_pixi_dependency(pkg)


### PR DESCRIPTION
Closes #2119.

## Summary

`dx[polars]` (valid PEP 508 for pip/uv) was accepted by the UI, WASM bindings, MCP tool, and Python bindings unchecked. The spec landed in the Automerge doc, rattler crashed at install time with `invalid bracket`, and the kernel + runtime agent got SIGKILL'd. User saw a dead kernel with no clear remediation.

## Fix

New `notebook_doc::metadata::validate_conda_package_specifier` — same base rule as the existing `validate_package_specifier` (`[a-zA-Z0-9-_.]` after name extraction) plus a rejection of `[` and `]` in the raw spec. Kept separate so the uv / PEP 508 path stays permissive (`requests[security]` is still valid there).

Wired in at every user-facing entry point that writes into the CRDT:

- `crates/runtimed-wasm/src/lib.rs` — frontend path (DependencyHeader → WASM)
- `crates/runt-mcp/src/tools/deps.rs` — MCP tool (agent-side)
- `crates/runtimed-py/src/async_session.rs` — Python bindings (all four `add_{conda,pixi}_dependency{,s}` methods)

Internal re-bootstrap paths (`promote_inline_deps_to_project` etc.) are exempt — they read from project files we've already parsed.

Errors bubble up as:
- JS: `JsError` from WASM → caller's `catch`
- MCP: tool error string → LLM self-corrects
- Python: `ValueError`

## Test plan

- [x] 3 new unit tests covering accept/reject cases + the doctest on `validate_conda_package_specifier`
- [x] `cargo test -p notebook-doc --lib` → 265 passing
- [x] `cargo xtask lint` → clean
- [x] WASM rebuilt + committed
- [ ] Manual: add `dx[polars]` to a conda notebook in the UI; expect inline error, no daemon crash