### PR TITLE
fix(runtimed): rename pool env to inline cache after sync so restarts cache-hit

### DIFF
--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -135,6 +135,125 @@ pub async fn prepare_conda_inline_env(
     })
 }
 
+/// Rename a pool-derived UV env to the inline-cache hash location so the
+/// next launch with the same inline deps cache-hits via
+/// [`check_uv_inline_cache`] instead of taking another pool env.
+///
+/// Idempotent and best-effort: skips when the env is already at the target,
+/// when another flow beat us to the target path, or when the rename fails.
+/// Updates `venv_path` / `python_path` on success so callers can continue
+/// using the `PooledEnv` without thinking about the rename.
+///
+/// See #2089 / #2083: without this, a pool-reuse inline launch leaves the
+/// env at `runtimed-uv-XXXX` and the next restart misses the inline cache,
+/// takes a fresh pool env, and re-solves from scratch.
+pub async fn claim_pool_env_for_uv_inline_cache(
+    env: &mut crate::PooledEnv,
+    deps: &[String],
+    prerelease: Option<&str>,
+    bootstrap_dx: bool,
+) {
+    let uv_deps = kernel_env::UvDependencies {
+        dependencies: inline_deps_with_bootstrap(deps, bootstrap_dx),
+        requires_python: Some(">=3.13".to_string()),
+        prerelease: prerelease.map(|s| s.to_string()),
+    };
+    let hash = kernel_env::uv::compute_env_hash(&uv_deps, None);
+    let target = get_inline_cache_dir().join(&hash);
+    rename_env_to_target(&mut env.venv_path, &mut env.python_path, target).await;
+}
+
+/// Rename a pool-derived Conda env to the inline-cache hash location. See
+/// [`claim_pool_env_for_uv_inline_cache`] for the rationale; same mechanism,
+/// conda hash function.
+pub async fn claim_pool_env_for_conda_inline_cache(
+    env: &mut crate::PooledEnv,
+    deps: &[String],
+    channels: &[String],
+) {
+    let conda_deps = kernel_env::CondaDependencies {
+        dependencies: deps.to_vec(),
+        channels: if channels.is_empty() {
+            vec!["conda-forge".to_string()]
+        } else {
+            channels.to_vec()
+        },
+        python: None,
+        env_id: None,
+    };
+    let hash = kernel_env::conda::compute_env_hash(&conda_deps);
+    let target = get_inline_cache_dir().join(&hash);
+    rename_env_to_target(&mut env.venv_path, &mut env.python_path, target).await;
+}
+
+/// Shared rename logic: move `venv_path` to `target` and rewrite the python
+/// path relative to the new root. Preserves the original `python_path`
+/// layout (e.g. `bin/python` vs `Scripts/python.exe`).
+async fn rename_env_to_target(
+    venv_path: &mut std::path::PathBuf,
+    python_path: &mut std::path::PathBuf,
+    target: std::path::PathBuf,
+) {
+    if *venv_path == target {
+        return; // already at target (e.g. prior claim)
+    }
+    if !venv_path.exists() {
+        tracing::warn!(
+            "[inline-env] claim_pool_env: source {:?} no longer exists, skipping rename",
+            venv_path
+        );
+        return;
+    }
+    if target.exists() {
+        // Concurrent build produced the same cache entry first. Leave our
+        // env at the pool path; the next launch will cache-hit on their
+        // entry and our pool path becomes orphan for the normal cleanup
+        // paths. No correctness issue.
+        tracing::info!(
+            "[inline-env] claim_pool_env: target {:?} already exists, leaving env at {:?}",
+            target,
+            venv_path
+        );
+        return;
+    }
+    if let Some(parent) = target.parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            tracing::warn!(
+                "[inline-env] claim_pool_env: failed to create cache parent {:?}: {}",
+                parent,
+                e
+            );
+            return;
+        }
+    }
+    // Preserve the python_path's layout relative to the old venv root.
+    let rel_python = python_path
+        .strip_prefix(&*venv_path)
+        .ok()
+        .map(|p| p.to_path_buf());
+    match tokio::fs::rename(&*venv_path, &target).await {
+        Ok(()) => {
+            tracing::info!(
+                "[inline-env] claim_pool_env: renamed {:?} -> {:?} for inline-cache reuse",
+                venv_path,
+                target
+            );
+            *venv_path = target.clone();
+            if let Some(rel) = rel_python {
+                *python_path = target.join(rel);
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "[inline-env] claim_pool_env: rename {:?} -> {:?} failed: {}",
+                venv_path,
+                target,
+                e
+            );
+        }
+    }
+}
+
 /// Result of comparing inline deps against pool packages.
 #[derive(Debug)]
 pub enum PoolDepRelation {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1859,7 +1859,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     }
 
     // Take the env, then compare against what it *actually* has installed
-    let env = match daemon.take_uv_env().await {
+    let mut env = match daemon.take_uv_env().await {
         Some(env) => env,
         None => {
             info!("[notebook-sync] UV pool empty, falling back to full build");
@@ -1873,6 +1873,11 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {
             info!("[notebook-sync] Inline UV deps are subset of pool env, reusing directly");
+            // Promote the pool env into the inline-env cache so the next
+            // restart with the same deps cache-hits instead of taking
+            // another pool env. See #2089 / #2083.
+            crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None, false)
+                .await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -1894,6 +1899,12 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                         "[notebook-sync] Installed {} delta packages into pool env",
                         delta.len()
                     );
+                    // Promote the pool env into the inline-env cache so
+                    // the next restart cache-hits. See #2089 / #2083.
+                    crate::inline_env::claim_pool_env_for_uv_inline_cache(
+                        &mut env, deps, None, false,
+                    )
+                    .await;
                     progress_handler.on_progress(
                         "uv",
                         kernel_env::EnvProgressPhase::Ready {
@@ -1975,7 +1986,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     }
 
     // Take the env, then compare against what it *actually* has installed
-    let env = match daemon.take_conda_env().await {
+    let mut env = match daemon.take_conda_env().await {
         Some(env) => env,
         None => {
             info!("[notebook-sync] Conda pool empty, falling back to full build");
@@ -1989,6 +2000,10 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {
             info!("[notebook-sync] Inline Conda deps are subset of pool env, reusing directly");
+            // Promote the pool env into the inline-env cache so the next
+            // restart cache-hits. See #2089 / #2083.
+            crate::inline_env::claim_pool_env_for_conda_inline_cache(&mut env, deps, channels)
+                .await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -2016,6 +2031,12 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                         "[notebook-sync] Installed {} delta packages into Conda pool env",
                         delta.len()
                     );
+                    // Promote the pool env into the inline-env cache so
+                    // the next restart cache-hits. See #2089 / #2083.
+                    crate::inline_env::claim_pool_env_for_conda_inline_cache(
+                        &mut env, deps, channels,
+                    )
+                    .await;
                     progress_handler.on_progress(
                         "conda",
                         kernel_env::EnvProgressPhase::Ready {


### PR DESCRIPTION
Closes #2089 and #2083.

## The two issues were the same bug

On an inline (uv/conda) notebook, the first launch takes a pool env (`runtimed-uv-XXXX` / `runtimed-conda-XXXX`), delta-installs the user's deps, and runs the kernel from that pool-prefixed directory. Second restart:

1. `auto_launch_kernel` resolves to `conda:inline` / `uv:inline` (same deps, same hash).
2. `check_conda_inline_cache` / `check_uv_inline_cache` looks in `inline-envs/<hash>/`.
3. **Miss** — the env lives at the pool-prefixed path, not the inline-cache hash path.
4. Takes another fresh pool env, re-solves, re-installs everything. For conda that's 3+ min of rattler + ~180 packages.

Two observed failure modes that stem from this:

- **#2089:** under load, the full re-solve can produce a partial install or race with `confirm_sync`, leaving previously-added deps missing.
- **#2083:** every restart stalls 3+ minutes even when nothing changed.

## Fix

After a successful pool reuse — either `Subset` (no install needed) or `Additive { delta }` (delta sync'd) — rename `env.venv_path` to the inline-cache hash location. Next launch's `check_*_inline_cache` hits instead of taking another pool env.

Two small helpers in `crates/runtimed/src/inline_env.rs`:

- `claim_pool_env_for_uv_inline_cache(env, deps, prerelease, bootstrap_dx)`
- `claim_pool_env_for_conda_inline_cache(env, deps, channels)`

Both compute the same hash `check_*_inline_cache` uses and `tokio::fs::rename` the env dir. Idempotent and best-effort:

- Already at target? No-op.
- Target exists (concurrent build got there first)? Leave our env at the pool path; next launch cache-hits on theirs.
- Rename fails? Log, keep going — old behavior.

The helpers also rewrite `python_path` relative to the new root so callers (kernel launch, GC registration) keep using correct paths.

## Wiring

`try_uv_pool_for_inline_deps` and `try_conda_pool_for_inline_deps` call the helper on both success arms:

- `PoolDepRelation::Subset` → rename directly (no install happened)
- `PoolDepRelation::Additive { delta }` → rename after `sync_dependencies` succeeds

Independent and failure paths still clean up the pool env as before.

## Test plan

- [x] `cargo test -p runtimed --lib` → 390 passing
- [x] `cargo xtask lint` → clean
- [ ] Manual #2089 repro: conda notebook with `[pandas, matplotlib]` → `add_dependency("scipy", after=restart)` → bare `restart_kernel()` → confirm `get_dependencies()` still reports `scipy`, `pandas`, `matplotlib`.
- [ ] Manual #2083 repro: observe second restart completes in seconds instead of minutes.