### PR TITLE
fix(runtimed): thread bootstrap_dx through try_uv_pool_for_inline_deps

### DIFF
--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -65,7 +65,7 @@ fn get_inline_cache_dir() -> std::path::PathBuf {
 /// has to ride along with the inline env. Folding `dx` into the dep list
 /// also changes the env hash so bootstrap and non-bootstrap envs don't
 /// collide in the cache.
-fn inline_deps_with_bootstrap(deps: &[String], bootstrap_dx: bool) -> Vec<String> {
+pub(crate) fn inline_deps_with_bootstrap(deps: &[String], bootstrap_dx: bool) -> Vec<String> {
     if bootstrap_dx {
         let mut out = deps.to_vec();
         out.push("dx".to_string());

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1844,6 +1844,7 @@ pub(crate) async fn reset_starting_state(
 /// Returns `Ok((PooledEnv, actual_packages))` on success, `Err(())` on failure.
 pub(crate) async fn try_uv_pool_for_inline_deps(
     deps: &[String],
+    bootstrap_dx: bool,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
@@ -1876,8 +1877,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // Promote the pool env into the inline-env cache so the next
             // restart with the same deps cache-hits instead of taking
             // another pool env. See #2089 / #2083.
-            crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None, false)
-                .await;
+            crate::inline_env::claim_pool_env_for_uv_inline_cache(
+                &mut env,
+                deps,
+                None,
+                bootstrap_dx,
+            )
+            .await;
             Ok((env, actual_packages))
         }
         crate::inline_env::PoolDepRelation::Additive { delta } => {
@@ -1902,7 +1908,10 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     // Promote the pool env into the inline-env cache so
                     // the next restart cache-hits. See #2089 / #2083.
                     crate::inline_env::claim_pool_env_for_uv_inline_cache(
-                        &mut env, deps, None, false,
+                        &mut env,
+                        deps,
+                        None,
+                        bootstrap_dx,
                     )
                     .await;
                     progress_handler.on_progress(
@@ -2609,7 +2618,14 @@ pub(crate) async fn auto_launch_kernel(
                 (env, Some(deps))
             } else if prerelease.is_none() {
                 // Try pool reuse for bare deps without prerelease
-                match try_uv_pool_for_inline_deps(&deps, &daemon, progress_handler.clone()).await {
+                match try_uv_pool_for_inline_deps(
+                    &deps,
+                    bootstrap_dx,
+                    &daemon,
+                    progress_handler.clone(),
+                )
+                .await
+                {
                     Ok((env, pool_pkgs)) => {
                         let mut pooled = env;
                         pooled.prewarmed_packages = pool_pkgs;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1848,11 +1848,19 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
+    // The effective install set includes `dx` when `bootstrap_dx` is on.
+    // Using it for both the pool-compat check and the delta install
+    // keeps the env content consistent with the inline cache hash we
+    // rename to below — otherwise we'd cache a pool env under the
+    // bootstrap key without `dx` actually installed, and subsequent
+    // cache hits would silently fail `import dx` in the kernel.
+    let effective_deps = crate::inline_env::inline_deps_with_bootstrap(deps, bootstrap_dx);
+
     // Quick pre-check: if any dep has version specifiers, skip pool entirely
     // (avoids consuming a pool env we'd have to discard)
     let settings_packages = daemon.uv_pool_packages().await;
     if matches!(
-        crate::inline_env::compare_deps_to_pool(deps, &settings_packages),
+        crate::inline_env::compare_deps_to_pool(&effective_deps, &settings_packages),
         crate::inline_env::PoolDepRelation::Independent
     ) {
         debug!("[notebook-sync] UV inline deps have version constraints, skipping pool reuse");
@@ -1869,7 +1877,7 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
     };
 
     let actual_packages = env.prewarmed_packages.clone();
-    let relation = crate::inline_env::compare_deps_to_pool(deps, &actual_packages);
+    let relation = crate::inline_env::compare_deps_to_pool(&effective_deps, &actual_packages);
 
     match relation {
         crate::inline_env::PoolDepRelation::Subset => {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -695,8 +695,13 @@ pub(crate) async fn handle(
                 (env, Some(deps))
             } else if prerelease.is_none() {
                 // Try pool reuse for bare deps without prerelease
-                match try_uv_pool_for_inline_deps(&deps, daemon, launch_progress_handler.clone())
-                    .await
+                match try_uv_pool_for_inline_deps(
+                    &deps,
+                    bootstrap_dx,
+                    daemon,
+                    launch_progress_handler.clone(),
+                )
+                .await
                 {
                     Ok((env, pool_pkgs)) => {
                         let mut pooled = env;


### PR DESCRIPTION
Follow-up to #2127. Codex v1 review flagged a real P2 that got posted after merge.

## Issue

The new inline-cache claim for pool-reused UV envs in #2127 hard-coded `bootstrap_dx = false`. Both `check_uv_inline_cache` and `prepare_uv_inline_env` key the cache on that flag — `bootstrap_dx=true` adds `dx` to the install set and shifts the hash.

That means:
- `bootstrap_dx=true` pool-reuse launch renames the env under the non-bootstrap hash → the next restart's cache lookup (with the flag on) misses anyway, defeating #2127's optimization for that flow.
- Worse: if the flag flipped between launches, a subsequent check could reuse a `dx`-bootstrapped env under the plain inline-cache key.

## Fix

Added `bootstrap_dx: bool` parameter to `try_uv_pool_for_inline_deps` and updated the two call sites (`requests/launch_kernel.rs` and `notebook_sync_server/metadata.rs`) to pass their already-resolved `bootstrap_dx`. Used at both `claim_pool_env_for_uv_inline_cache` sites (Subset and post-sync Additive) so the rename target matches the hash `check_uv_inline_cache` will look up next time.

Conda isn't affected — no equivalent flag.

## Test plan

- [x] `cargo test -p runtimed --lib` → 390 passing
- [x] `cargo xtask lint` → clean

cc #2089 #2083 #2127