### PR TITLE
fix(runtimed): warn when environment.yml dedup parse fails

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3284,6 +3284,9 @@ pub(crate) fn extract_env_yml_package_names(content: &str) -> EnvYmlPackageNames
     };
 
     let Ok(env) = EnvironmentYaml::from_yaml_str(content) else {
+        warn!(
+            "[notebook-sync] Failed to parse environment.yml for dedup; skipping duplicate check"
+        );
         return result;
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #2129. If rattler can't parse the `environment.yml` for the dedup check, `extract_env_yml_package_names` returns empty sets and candidates pass through unfiltered. This is fine (the file is already broken), but adds a `warn!` log so it shows up in daemon diagnostics rather than being silently swallowed.

## Test plan

- [x] `cargo test -p runtimed --lib extract_env_yml` — 2 tests pass (including malformed case)
- [x] `cargo xtask lint --fix` — clean