### PR TITLE
fix(runtimed): fix CRLF corruption and hardcoded indent in env.yml promotion

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3234,6 +3234,10 @@ pub(crate) struct EnvYmlInsertionPoint {
     pub indent: String,
     /// The line ending used by the file (`"\n"` or `"\r\n"`).
     pub newline: &'static str,
+    /// True when the content before `offset` doesn't end with a newline
+    /// (e.g. file has no trailing newline). Callers must prepend `newline`
+    /// before the first inserted dep.
+    pub needs_leading_newline: bool,
 }
 
 /// Find the insertion point for new conda deps in an environment.yml string.
@@ -3291,10 +3295,14 @@ pub(crate) fn find_env_yml_deps_insertion_point(content: &str) -> Option<EnvYmlI
         byte_offset += line_len;
     }
 
-    last_dep_end.map(|offset| EnvYmlInsertionPoint {
-        offset,
-        indent: baseline_indent.unwrap_or_else(|| "  ".to_string()),
-        newline,
+    last_dep_end.map(|offset| {
+        let needs_leading_newline = offset > 0 && content.as_bytes()[offset - 1] != b'\n';
+        EnvYmlInsertionPoint {
+            offset,
+            indent: baseline_indent.unwrap_or_else(|| "  ".to_string()),
+            newline,
+            needs_leading_newline,
+        }
     })
 }
 
@@ -3498,6 +3506,9 @@ pub(crate) async fn promote_inline_deps_to_project(
                         let insertion = find_env_yml_deps_insertion_point(&content);
                         if let Some(ins) = insertion {
                             let mut insert_str = String::new();
+                            if ins.needs_leading_newline {
+                                insert_str.push_str(ins.newline);
+                            }
                             for dep in &to_add {
                                 insert_str
                                     .push_str(&format!("{}- {}{}", ins.indent, dep, ins.newline));

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3226,46 +3226,76 @@ pub(crate) async fn handle_notebook_request(
 /// Find the byte offset in an environment.yml string where new dependencies
 /// should be inserted (end of the `dependencies:` list, before the next
 /// top-level key or EOF).
-pub(crate) fn find_env_yml_deps_insertion_point(content: &str) -> Option<usize> {
-    let mut in_deps = false;
-    let mut last_dep_end = None;
-    let mut baseline_indent: Option<usize> = None;
+/// Where and how to insert new conda deps into an environment.yml.
+pub(crate) struct EnvYmlInsertionPoint {
+    /// Byte offset where new lines should be inserted.
+    pub offset: usize,
+    /// The indent prefix to use for each new `- dep` line (e.g. `"  "`).
+    pub indent: String,
+    /// The line ending used by the file (`"\n"` or `"\r\n"`).
+    pub newline: &'static str,
+}
 
-    for (i, line) in content.lines().enumerate() {
+/// Find the insertion point for new conda deps in an environment.yml string.
+///
+/// Returns the byte offset, detected indent, and line ending style so callers
+/// can insert deps that match the file's existing formatting. Uses
+/// `split_inclusive` for correct byte offsets on both LF and CRLF files.
+pub(crate) fn find_env_yml_deps_insertion_point(content: &str) -> Option<EnvYmlInsertionPoint> {
+    let newline: &'static str = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+
+    let mut in_deps = false;
+    let mut last_dep_end: Option<usize> = None;
+    let mut baseline_indent: Option<String> = None;
+    let mut byte_offset = 0usize;
+
+    for raw_line in content.split_inclusive('\n') {
+        let line_len = raw_line.len();
+        let line = raw_line.trim_end_matches('\n').trim_end_matches('\r');
         let trimmed = line.trim();
 
         if !line.starts_with(' ') && !line.starts_with('\t') {
             if trimmed == "dependencies:" {
                 in_deps = true;
-                // Position after this line (clamped for files without trailing newline)
-                let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-                last_dep_end = Some(offset.min(content.len()));
+                last_dep_end = Some(byte_offset + line_len);
+                byte_offset += line_len;
                 continue;
             } else if in_deps && !trimmed.is_empty() && !trimmed.starts_with('#') {
-                // Hit a new top-level key — insert before it
-                return last_dep_end;
+                break;
             }
         }
 
         if in_deps && trimmed.starts_with("- ") {
-            let indent = line.len() - line.trim_start().len();
-            match baseline_indent {
-                None => baseline_indent = Some(indent),
-                Some(base) if indent != base => continue,
+            let indent_str = &line[..line.len() - line.trim_start().len()];
+            match &baseline_indent {
+                None => baseline_indent = Some(indent_str.to_string()),
+                Some(base) if indent_str != base.as_str() => {
+                    byte_offset += line_len;
+                    continue;
+                }
                 _ => {}
             }
-            // Skip YAML sub-section entries like "- pip:" — they introduce
-            // nested blocks, not package specs.
+            // Skip YAML sub-section entries like "- pip:"
             let entry = trimmed.trim_start_matches("- ");
             if entry.ends_with(':') && !entry.contains(' ') {
+                byte_offset += line_len;
                 continue;
             }
-            let offset: usize = content.lines().take(i + 1).map(|l| l.len() + 1).sum();
-            last_dep_end = Some(offset.min(content.len()));
+            last_dep_end = Some(byte_offset + line_len);
         }
+
+        byte_offset += line_len;
     }
 
-    last_dep_end
+    last_dep_end.map(|offset| EnvYmlInsertionPoint {
+        offset,
+        indent: baseline_indent.unwrap_or_else(|| "  ".to_string()),
+        newline,
+    })
 }
 
 /// Parsed package names from an environment.yml, split by namespace.
@@ -3465,27 +3495,29 @@ pub(crate) async fn promote_inline_deps_to_project(
 
                     if !to_add.is_empty() {
                         let mut new_content = content.clone();
-                        let insertion_point = find_env_yml_deps_insertion_point(&content);
-                        if let Some(pos) = insertion_point {
+                        let insertion = find_env_yml_deps_insertion_point(&content);
+                        if let Some(ins) = insertion {
                             let mut insert_str = String::new();
                             for dep in &to_add {
-                                insert_str.push_str(&format!("  - {}\n", dep));
+                                insert_str
+                                    .push_str(&format!("{}- {}{}", ins.indent, dep, ins.newline));
                                 promoted.push(format!("+{}", dep));
                             }
-                            new_content.insert_str(pos, &insert_str);
-                            if let Err(e) = std::fs::write(yml_path, &new_content) {
-                                errors.push(format!("Failed to write environment.yml: {}", e));
-                            }
+                            new_content.insert_str(ins.offset, &insert_str);
                         } else {
-                            let mut append_str = String::from("\ndependencies:\n");
+                            new_content.push_str("\ndependencies:\n");
                             for dep in &to_add {
-                                append_str.push_str(&format!("  - {}\n", dep));
+                                new_content.push_str(&format!("  - {}\n", dep));
                                 promoted.push(format!("+{}", dep));
                             }
-                            new_content.push_str(&append_str);
-                            if let Err(e) = std::fs::write(yml_path, &new_content) {
-                                errors.push(format!("Failed to write environment.yml: {}", e));
-                            }
+                        }
+                        // Validate the result parses before writing
+                        if let Err(e) =
+                            rattler_conda_types::EnvironmentYaml::from_yaml_str(&new_content)
+                        {
+                            errors.push(format!("Inserted deps produced invalid YAML: {}", e));
+                        } else if let Err(e) = std::fs::write(yml_path, &new_content) {
+                            errors.push(format!("Failed to write environment.yml: {}", e));
                         }
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3859,12 +3859,22 @@ async fn test_reset_generation_guard_with_concurrent_spawn() {
 
 #[test]
 fn test_env_yml_insertion_point_no_trailing_newline() {
-    // File without trailing newline — must not panic or return out-of-bounds offset
+    use rattler_conda_types::EnvironmentYaml;
     let content = "dependencies:\n  - numpy";
     let ins = find_env_yml_deps_insertion_point(content).unwrap();
     assert!(ins.offset <= content.len());
     assert_eq!(ins.indent, "  ");
     assert_eq!(ins.newline, "\n");
+    assert!(ins.needs_leading_newline);
+    // Simulate insertion and verify the result parses
+    let mut result = content.to_string();
+    let mut insert_str = String::new();
+    if ins.needs_leading_newline {
+        insert_str.push_str(ins.newline);
+    }
+    insert_str.push_str(&format!("{}- pandas{}", ins.indent, ins.newline));
+    result.insert_str(ins.offset, &insert_str);
+    EnvironmentYaml::from_yaml_str(&result).expect("inserted YAML should parse");
 }
 
 #[test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3861,24 +3861,24 @@ async fn test_reset_generation_guard_with_concurrent_spawn() {
 fn test_env_yml_insertion_point_no_trailing_newline() {
     // File without trailing newline — must not panic or return out-of-bounds offset
     let content = "dependencies:\n  - numpy";
-    let point = find_env_yml_deps_insertion_point(content);
-    assert!(point.is_some());
-    assert!(point.unwrap() <= content.len());
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
+    assert!(ins.offset <= content.len());
+    assert_eq!(ins.indent, "  ");
+    assert_eq!(ins.newline, "\n");
 }
 
 #[test]
 fn test_env_yml_insertion_point_with_trailing_newline() {
     let content = "dependencies:\n  - numpy\n  - pandas\n";
-    let point = find_env_yml_deps_insertion_point(content);
-    assert_eq!(point, Some(content.len()));
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
+    assert_eq!(ins.offset, content.len());
 }
 
 #[test]
 fn test_env_yml_insertion_point_before_next_key() {
     let content = "dependencies:\n  - numpy\nchannels:\n  - conda-forge\n";
-    let point = find_env_yml_deps_insertion_point(content);
-    // Should insert after "  - numpy\n", before "channels:"
-    assert_eq!(point, Some("dependencies:\n  - numpy\n".len()));
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
+    assert_eq!(ins.offset, "dependencies:\n  - numpy\n".len());
 }
 
 /// Pre-v4 .ipynb (no output_id fields) gets IDs minted on load,
@@ -5003,20 +5003,36 @@ async fn capture_migrates_pre_upgrade_notebook() {
 #[test]
 fn test_env_yml_insertion_point_skips_pip_block() {
     let content = "name: test\ndependencies:\n  - numpy\n  - pip:\n    - pyyaml\n    - requests\n  - scipy\nchannels:\n  - conda-forge\n";
-    let point = find_env_yml_deps_insertion_point(content);
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
     let expected =
         "name: test\ndependencies:\n  - numpy\n  - pip:\n    - pyyaml\n    - requests\n  - scipy\n"
             .len();
-    assert_eq!(point, Some(expected));
+    assert_eq!(ins.offset, expected);
 }
 
 #[test]
 fn test_env_yml_insertion_point_pip_block_at_end() {
     let content = "dependencies:\n  - numpy\n  - pandas\n  - pip:\n    - pyyaml\n";
-    let point = find_env_yml_deps_insertion_point(content);
-    // Insert after last top-level conda dep, before pip block
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
     let expected = "dependencies:\n  - numpy\n  - pandas\n".len();
-    assert_eq!(point, Some(expected));
+    assert_eq!(ins.offset, expected);
+}
+
+#[test]
+fn test_env_yml_insertion_point_crlf() {
+    let content = "dependencies:\r\n  - numpy\r\n  - pandas\r\n";
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
+    assert_eq!(ins.offset, content.len());
+    assert_eq!(ins.newline, "\r\n");
+    assert_eq!(ins.indent, "  ");
+}
+
+#[test]
+fn test_env_yml_insertion_point_four_space_indent() {
+    let content = "dependencies:\n    - numpy\n    - pandas\n";
+    let ins = find_env_yml_deps_insertion_point(content).unwrap();
+    assert_eq!(ins.offset, content.len());
+    assert_eq!(ins.indent, "    ");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two bugs in `find_env_yml_deps_insertion_point` and the env.yml writer, caught by cross-model review on #2129:

1. **CRLF files get corrupted** — byte offsets were computed with `content.lines()` + `len() + 1`. `lines()` strips both `\r` and `\n` but only one byte was added back, so every line's offset was short by one byte on CRLF files. Switched to `split_inclusive('\n')` for correct byte arithmetic.

2. **Existing indentation ignored** — the writer hardcoded `"  - {dep}\n"` (2-space indent). A valid file using 4-space dep indentation became invalid YAML after promotion. Now detects the baseline indent from the first existing dep entry and matches it.

Also: validates the modified content with `EnvironmentYaml::from_yaml_str` before writing to disk, so a bad insertion produces an error instead of silently corrupting the file.

Restructured `find_env_yml_deps_insertion_point` to return `EnvYmlInsertionPoint { offset, indent, newline }` instead of a bare `Option<usize>`.

## Test plan

- [x] `cargo test -p runtimed --lib insertion_point` — 7 tests pass (5 existing updated + 2 new: CRLF, 4-space indent)
- [x] `cargo test -p runtimed --lib` — 397 tests pass, no warnings
- [x] `cargo xtask lint --fix` — clean