### PR TITLE
perf(sift): exclude inlined WASM from renderer plugin (7.4 MB -> 382 kB)

### DIFF
--- a/apps/notebook/src/renderer-plugins/sift.js
+++ b/apps/notebook/src/renderer-plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d900159605f9c93f94b7497e7dad4d67be6c2fb4d84b1e783f9e013899896f6
-size 7629534
+oid sha256:c58e3ec4e5702f8b2927649acaba251cc20222e41eba9e200cde58fce9d4b78c
+size 391864

--- a/crates/runt-mcp/assets/plugins/sift.js
+++ b/crates/runt-mcp/assets/plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfec66d6bd3681b7906d99e38206bd0c21947ca4661b4bafc616dcb95db6119f
-size 7629727
+oid sha256:bacf998a848260fcd4cb7ff98489e8e3c0c52e877a034aeb2d56c0f1fe9f18e3
+size 392057

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -110,6 +110,28 @@ export function extractBuildOutput(result: unknown, label: string): { code: stri
  * @param pluginName Plugin name (used for output file name)
  * @returns Promise resolving to the built code and CSS
  */
+/**
+ * Vite plugin that prevents the sift-wasm binary from being inlined.
+ *
+ * The wasm-bindgen glue contains `new URL('sift_wasm_bg.wasm', import.meta.url)`
+ * which Vite resolves and base64-inlines into the JS bundle (~6.9 MB). The sift
+ * renderer plugin loads the WASM from the blob server via setWasmUrl() instead,
+ * so the inline copy is never used. This plugin rewrites the URL reference to a
+ * dummy string, preventing the inline.
+ */
+function excludeWasmInline(): import("vite-plus").Plugin {
+  return {
+    name: "exclude-wasm-inline",
+    transform(code, id) {
+      if (!id.includes("sift_wasm") || !code.includes("sift_wasm_bg.wasm")) return;
+      return code.replace(
+        /new URL\(['"]sift_wasm_bg\.wasm['"],\s*import\.meta\.url\)/g,
+        `"__wasm_loaded_via_setWasmUrl__"`,
+      );
+    },
+  };
+}
+
 export async function buildRendererPlugin(
   pluginEntry: string,
   pluginName: string,
@@ -119,7 +141,7 @@ export async function buildRendererPlugin(
   const result = await build({
     configFile: false,
     mode: "production",
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss(), excludeWasmInline()],
     esbuild: {
       jsx: "automatic",
       jsxImportSource: "react",


### PR DESCRIPTION
## Summary

- The wasm-bindgen glue contains `new URL('sift_wasm_bg.wasm', import.meta.url)` which Vite base64-inlines into the CJS bundle. The 5.2 MB WASM binary expands to 6.9 MB of base64, making the sift.js plugin 7.4 MB.
- The sift renderer already loads WASM from the blob server via `setWasmUrl()`, so the inline copy was never used.
- A build plugin rewrites the URL reference to a dummy string, preventing the inline. sift.js drops from 7.4 MB to 382 kB.

## Test plan

- [x] 137 sift unit tests pass
- [x] Lint clean
- [ ] Manual: open a notebook with parquet output, verify sift table renders (WASM loads from blob server as before)

🪶 Generated with Quill Agent