### PR TITLE
fix(runtimed): pass all deps to conda solver in pool env additive path

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2032,8 +2032,13 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
                 env_path: env.venv_path.clone(),
                 python_path: env.python_path.clone(),
             };
+            // Pass ALL inline deps to sync_dependencies, not just the delta.
+            // The conda solver treats the spec list as the complete desired
+            // state: packages not in the specs get removed by the Installer.
+            // Passing only the delta would drop the original user packages
+            // that are already installed in the pool env. See #2134.
             let conda_deps = kernel_env::CondaDependencies {
-                dependencies: delta.clone(),
+                dependencies: deps.to_vec(),
                 channels: vec!["conda-forge".to_string()],
                 python: None,
                 env_id: None,


### PR DESCRIPTION
## Summary
- When reusing a conda pool env for inline deps with additive packages (e.g. `add_dependency("scipy")` on a notebook with `[pandas, numpy, matplotlib]`), `sync_dependencies` was called with only the delta (new packages). The conda solver treats the spec list as the complete desired state, so packages not in the delta were removed by the Installer — silently dropping the user's original dependencies.
- Fix: pass all inline deps (`deps.to_vec()`) instead of just the delta to `sync_dependencies` so the solver preserves existing packages while adding new ones.

## Test plan
- [ ] Gremlin `conda-inline` suite: create notebook with `[pandas, numpy, matplotlib]`, add `scipy` via `add_dependency("scipy", after="restart")`, verify all 4 packages are present in the rebuilt env
- [ ] Verify no regression on `Subset` path (pool env reuse without sync) — unchanged
- [ ] Verify no regression on UV inline additive path — UV uses `pip install` which is inherently additive, so passing delta is correct there