### PR TITLE
feat(outputs): rich traceback renderer + break plugin-log feedback loop

### DIFF
--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -1,5 +1,7 @@
 import { NotebookHostProvider } from "@nteract/notebook-host";
 import { createTauriHost } from "@nteract/notebook-host/tauri";
+import { isTauri } from "@tauri-apps/api/core";
+import { attachLogger, LogLevel } from "@tauri-apps/plugin-log";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
@@ -50,12 +52,21 @@ setErrorBoundarySink((error, componentStack) => {
   );
 });
 
+// Capture original console methods BEFORE wrapping. The Rust-log mirror
+// below uses these originals to avoid re-entering the `console.error`
+// wrapper (which would immediately feed back into plugin-log → Rust →
+// attachLogger → here → plugin-log → …, an infinite loop).
+const originalConsoleError = console.error.bind(console);
+const originalConsoleWarn = console.warn.bind(console);
+const originalConsoleInfo = console.info.bind(console);
+const originalConsoleDebug = console.debug.bind(console);
+const originalConsoleLog = console.log.bind(console);
+
 // Forward `console.error` into the host logger so it lands in notebook.log in
 // packaged / CI builds, not just dev devtools. Specifically: WASM panics
 // routed via `console_error_panic_hook` become visible in `e2e-logs/app.log`
 // with file:line:message — without this, they disappear in production.
 // Preserves the original console behavior so devtools stays unchanged.
-const originalConsoleError = console.error.bind(console);
 console.error = (...args: unknown[]) => {
   originalConsoleError(...args);
   try {
@@ -64,6 +75,35 @@ console.error = (...args: unknown[]) => {
     // Never let the forwarding path break the original error.
   }
 };
+
+// Mirror Rust log entries into devtools during dev so plugin-log output is
+// visible alongside frontend logs. Uses `attachLogger` (not `attachConsole`,
+// which would route through the wrapped `console.error` above and loop) and
+// dispatches to the ORIGINAL console methods. The wrapped forwarder never
+// sees these writes, so no feedback cycle.
+if (isTauri() && import.meta.env.DEV) {
+  attachLogger(({ level, message }) => {
+    switch (level) {
+      case LogLevel.Trace:
+      case LogLevel.Debug:
+        originalConsoleDebug(message);
+        break;
+      case LogLevel.Info:
+        originalConsoleInfo(message);
+        break;
+      case LogLevel.Warn:
+        originalConsoleWarn(message);
+        break;
+      case LogLevel.Error:
+        originalConsoleError(message);
+        break;
+      default:
+        originalConsoleLog(message);
+    }
+  }).catch(() => {
+    // Plugin missing / IPC unavailable — dev mirror is a nice-to-have.
+  });
+}
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -13,12 +13,11 @@
  * and tighten the import direction.
  */
 
-import { invoke, isTauri } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open as pluginOpenDialog, save as pluginSaveDialog } from "@tauri-apps/plugin-dialog";
 import {
-  attachConsole as pluginAttachConsole,
   debug as pluginDebug,
   error as pluginError,
   info as pluginInfo,
@@ -259,7 +258,6 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   const commands = createCommandRegistry();
 
   // plugin-log always resolves; fire-and-forget so callers stay sync.
-  // `isTauri()` guards the one-time `attachConsole()` for tests and SSR.
   const log: HostLog = {
     debug(message) {
       pluginDebug(message).catch(() => {});
@@ -274,12 +272,17 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       pluginError(message).catch(() => {});
     },
   };
-  // In a real Tauri window, mirror plugin-log output to the browser console
-  // so devtools shows it alongside Rust-side entries. Safe to call outside
-  // Tauri — the plugin no-ops when IPC isn't available.
-  if (isTauri() && import.meta.env.DEV) {
-    pluginAttachConsole().catch(() => {});
-  }
+  // NOTE: the old `pluginAttachConsole()` mirror was removed because it
+  // created a feedback loop with apps that wrap `console.error` to forward
+  // back into plugin-log (our notebook app does this for panic visibility):
+  //
+  //   frontend error → wrapped console.error → logger.error → pluginError
+  //     → Rust log bus → attachConsole listener → console.error (wrapped!)
+  //     → logger.error → pluginError → … forever.
+  //
+  // Apps that want Rust logs in devtools should attach their own
+  // `attachLogger(…)` listener at boot that calls the *original* console
+  // methods captured before any wrapping. See `apps/notebook/src/main.tsx`.
 
   const host: NotebookHost = {
     name: "tauri",

--- a/src/components/editor/static-highlight.tsx
+++ b/src/components/editor/static-highlight.tsx
@@ -109,7 +109,7 @@ function getInlineHighlighter(isDark: boolean, colorTheme: ColorTheme) {
  *
  * Returns plain text if the language is not recognized.
  */
-function highlight(
+export function highlight(
   code: string,
   language: string | undefined,
   isDark: boolean,

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -196,8 +196,14 @@ describe("getSelectedMimeType", () => {
   });
 
   describe("DEFAULT_PRIORITY constant", () => {
-    it("has widget as highest priority", () => {
-      expect(DEFAULT_PRIORITY[0]).toBe("application/vnd.jupyter.widget-view+json");
+    it("has nteract traceback as highest priority", () => {
+      // We minted this MIME, so we trust it above everything else. Real
+      // kernels don't emit traceback alongside widget/plot/dataframe.
+      expect(DEFAULT_PRIORITY[0]).toBe("application/vnd.nteract.traceback+json");
+    });
+
+    it("places widget-view just after our traceback MIME", () => {
+      expect(DEFAULT_PRIORITY[1]).toBe("application/vnd.jupyter.widget-view+json");
     });
 
     it("has text/plain as lowest priority", () => {

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -45,11 +45,12 @@ function isInIframe(): boolean {
  * Platforms can override this with the `priority` prop.
  */
 export const DEFAULT_PRIORITY = [
-  // Rich formats first
-  "application/vnd.jupyter.widget-view+json",
-  // Our own rich traceback — must outrank text/plain and +json fallbacks
-  // so a display_data carrying both gets the rich component, not the tree.
+  // Our own rich traceback lives at the top — if we minted the MIME we
+  // trust it, and no reasonable kernel emits a traceback alongside a
+  // widget/plot/dataframe in the same output. Keeping it #1 also means
+  // the JSON-tree fallback never wins on a mistyped payload.
   "application/vnd.nteract.traceback+json",
+  "application/vnd.jupyter.widget-view+json",
   "application/vnd.plotly.v1+json",
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -21,6 +21,9 @@ const JavaScriptOutput = lazy(() =>
     default: m.JavaScriptOutput,
   })),
 );
+const TracebackOutput = lazy(() =>
+  import("./traceback-output").then((m) => ({ default: m.TracebackOutput })),
+);
 
 /**
  * Check if the current window is inside an iframe
@@ -44,6 +47,9 @@ function isInIframe(): boolean {
 export const DEFAULT_PRIORITY = [
   // Rich formats first
   "application/vnd.jupyter.widget-view+json",
+  // Our own rich traceback — must outrank text/plain and +json fallbacks
+  // so a display_data carrying both gets the rich component, not the tree.
+  "application/vnd.nteract.traceback+json",
   "application/vnd.plotly.v1+json",
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",
@@ -373,6 +379,13 @@ export function MediaRouter({
     // JavaScript (only in iframe)
     if (mimeType === "application/javascript") {
       return <JavaScriptOutput code={String(content)} className={className} />;
+    }
+
+    // Rich traceback — our own schema, main-DOM React, hackable from a
+    // notebook via `display_data` with this MIME. Precedes the generic
+    // `+json` fallback so we don't drop into the JSON tree viewer.
+    if (mimeType === "application/vnd.nteract.traceback+json") {
+      return <TracebackOutput data={content} className={className} />;
     }
 
     // JSON and structured data (but not custom +json types without a renderer)

--- a/src/components/outputs/safe-mime-types.ts
+++ b/src/components/outputs/safe-mime-types.ts
@@ -16,6 +16,9 @@ const MAIN_DOM_SAFE_TYPES = new Set([
   "image/bmp",
   // Structured data — tree viewer, no script risk
   "application/json",
+  // Rich traceback payloads — our own schema, rendered by TracebackOutput.
+  // Experimental; shape is not yet persisted to .ipynb.
+  "application/vnd.nteract.traceback+json",
 ]);
 
 /** Check if a MIME type can safely render in the main DOM (no iframe needed). */

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -1,0 +1,377 @@
+/**
+ * Rich traceback renderer — experimental.
+ *
+ * Consumes `application/vnd.nteract.traceback+json` payloads. Schema is
+ * deliberately loose while we iterate from a notebook; anything we don't
+ * recognize renders via a "raw JSON" escape hatch so we can't lock
+ * ourselves out of debugging the payload shape.
+ *
+ * Live iteration loop: emit a `display_data` message from a notebook cell
+ * with this MIME and hack on the component. No kernel-side dependency,
+ * no persistence, no plugin build step — main-DOM React all the way.
+ */
+
+import { Check, ChevronRight, Copy, OctagonAlert } from "lucide-react";
+import { useState } from "react";
+import { highlight } from "@/components/editor/static-highlight";
+import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
+import { cn } from "@/lib/utils";
+
+/** CodeMirror-matched mono stack so the traceback reads like the editor. */
+const CM_FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+
+/** Source-context line shown around the failing line in a frame. */
+interface Line {
+  lineno: number;
+  source: string;
+  /** True for the line that actually raised. One per frame. */
+  highlight?: boolean;
+}
+
+/** A single frame in the call stack. */
+interface Frame {
+  /** Absolute or relative path of the file the frame lives in. */
+  filename: string;
+  /** Line number of the failing call. */
+  lineno: number;
+  /** Enclosing function / method / module name. */
+  name: string;
+  /** Optional source-context window — lines around `lineno`. */
+  lines?: Line[];
+  /** Optional "in library code" flag; lets the UI dim non-user frames. */
+  library?: boolean;
+}
+
+interface TracebackPayload {
+  /** Exception class name, e.g. "ValueError". */
+  ename: string;
+  /** Exception message. */
+  evalue: string;
+  /** Frames, outermost first (Python convention). */
+  frames?: Frame[];
+  /**
+   * Language for syntax highlighting of source lines. Defaults to
+   * "python" since that's what we emit today; Deno notebooks will
+   * ship "typescript" here. Unknown values fall back to plain text.
+   */
+  language?: string;
+  /**
+   * Paste-ready plain text version of the traceback — ANSI-stripped,
+   * in the same shape the kernel would emit as `text/llm+plain`. Used
+   * by the Copy button. Kernel owns this; we don't re-synthesize.
+   */
+  text?: string;
+  /** Raw traceback strings, for cases where we couldn't parse. */
+  raw?: string[];
+}
+
+interface Props {
+  data: unknown;
+  className?: string;
+}
+
+/** A single frame, or a run of consecutive identical frames (recursion). */
+interface Cluster {
+  frame: Frame;
+  /** Number of consecutive frames this represents. >1 on recursion. */
+  count: number;
+  /** Original index of the representative frame, for key stability. */
+  firstIndex: number;
+}
+
+/**
+ * Group consecutive frames sharing (filename, lineno, name) into one
+ * cluster. Turns a 2978-frame RecursionError into a single row labeled
+ * "× 2978" instead of tanking the DOM with thousands of `<pre>` blocks.
+ */
+function clusterFrames(frames: Frame[]): Cluster[] {
+  const out: Cluster[] = [];
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+    const last = out[out.length - 1];
+    if (
+      last &&
+      last.frame.filename === f.filename &&
+      last.frame.lineno === f.lineno &&
+      last.frame.name === f.name
+    ) {
+      last.count += 1;
+    } else {
+      out.push({ frame: f, count: 1, firstIndex: i });
+    }
+  }
+  return out;
+}
+
+export function TracebackOutput({ data, className }: Props) {
+  const payload = toPayload(data);
+  if (!payload) {
+    return <RawJsonFallback data={data} className={className} />;
+  }
+  const frames = payload.frames ?? [];
+  const clusters = clusterFrames(frames);
+  const language = payload.language ?? "python";
+  // Expand user frames by default, collapse library frames. Matches how
+  // humans read tracebacks: their own code first, stdlib noise tucked
+  // away. Two extra rules:
+  //   - Recursion clusters (count > 1) stay collapsed; they're noise.
+  //   - If everything is library code, open the innermost so something
+  //     useful is visible.
+  const everythingIsLibrary = clusters.length > 0 && clusters.every((c) => c.frame.library);
+  const innermost = clusters.length - 1;
+  const shouldOpen = (c: Cluster, i: number): boolean => {
+    if (c.count > 1) return false;
+    if (everythingIsLibrary) return i === innermost;
+    return !c.frame.library;
+  };
+
+  return (
+    <div
+      data-slot="traceback"
+      className={cn(
+        "rounded-md border border-destructive/25 bg-destructive/5",
+        "text-sm",
+        className,
+      )}
+    >
+      <Header ename={payload.ename} evalue={payload.evalue} payload={payload} />
+      {clusters.length > 0 && (
+        <ol className="divide-y divide-destructive/15">
+          {clusters.map((cluster, i) => (
+            <FrameRow
+              key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
+              cluster={cluster}
+              defaultOpen={shouldOpen(cluster, i)}
+              language={language}
+            />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+// ─── Pieces ────────────────────────────────────────────────────────────
+
+function Header({
+  ename,
+  evalue,
+  payload,
+}: {
+  ename: string;
+  evalue: string;
+  payload: TracebackPayload;
+}) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 font-mono">
+      <OctagonAlert
+        aria-hidden="true"
+        className="mt-0.5 h-4 w-4 shrink-0 text-destructive"
+        strokeWidth={2.5}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="font-semibold text-destructive">{ename}</div>
+        {evalue && (
+          <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">
+            {evalue}
+          </div>
+        )}
+      </div>
+      <CopyButton payload={payload} />
+    </div>
+  );
+}
+
+function CopyButton({ payload }: { payload: TracebackPayload }) {
+  const [copied, setCopied] = useState(false);
+
+  const onClick = async () => {
+    // Paste-ready text comes from the payload. The kernel already has
+    // the ANSI-stripped traceback in the shape every AI and search
+    // engine expects — re-synthesizing it here would just drift.
+    const text =
+      payload.text ??
+      (payload.raw && payload.raw.length > 0
+        ? `${payload.raw.join("\n")}\n${payload.ename}: ${payload.evalue}`
+        : `${payload.ename}: ${payload.evalue}`);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      // Clipboard can fail in some iframe/permission contexts. Fall back
+      // silently — users can still select the rendered text by hand.
+      console.warn("[traceback] copy failed:", err);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={copied ? "Copied" : "Copy traceback"}
+      title={copied ? "Copied" : "Copy traceback"}
+      className={cn(
+        "shrink-0 rounded px-1.5 py-1 text-xs font-mono transition-colors",
+        "text-muted-foreground hover:bg-destructive/10 hover:text-destructive",
+      )}
+    >
+      <span className="flex items-center gap-1">
+        {copied ? (
+          <Check aria-hidden="true" className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+        ) : (
+          <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+        )}
+        <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
+      </span>
+    </button>
+  );
+}
+
+function FrameRow({
+  cluster,
+  defaultOpen,
+  language,
+}: {
+  cluster: Cluster;
+  defaultOpen: boolean;
+  language: string;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const { frame, count } = cluster;
+  return (
+    <li className={cn("px-3 py-1.5", frame.library && "opacity-60")}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 text-left font-mono text-xs hover:text-destructive"
+        aria-expanded={open}
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span className="truncate text-muted-foreground">{frame.filename}</span>
+        <span className="text-muted-foreground">:</span>
+        <span className="tabular-nums text-muted-foreground">{frame.lineno}</span>
+        <span className="text-muted-foreground">in</span>
+        <span className="truncate">{frame.name}</span>
+        {count > 1 && (
+          <span
+            className={cn(
+              "ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] tabular-nums",
+              "bg-destructive/15 text-destructive",
+            )}
+            title={`${count} consecutive identical frames (collapsed)`}
+          >
+            ×{count.toLocaleString()}
+          </span>
+        )}
+      </button>
+      {open && frame.lines && frame.lines.length > 0 && (
+        <SourceBlock lines={frame.lines} language={language} />
+      )}
+    </li>
+  );
+}
+
+function SourceBlock({ lines, language }: { lines: Line[]; language: string }) {
+  const isDark = useDarkMode();
+  const rawTheme = useColorTheme();
+  const colorTheme = rawTheme === "cream" ? "cream" : "classic";
+
+  const gutterWidth = String(Math.max(...lines.map((l) => l.lineno))).length;
+
+  return (
+    <pre
+      className={cn(
+        "mt-1.5 overflow-x-auto rounded border border-destructive/15 bg-muted/40",
+        "px-2 py-1.5 leading-5",
+      )}
+      style={{ fontFamily: CM_FONT_FAMILY, fontSize: "13px" }}
+    >
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          className={cn(
+            "grid grid-cols-[auto_1fr] gap-x-3 border-l-2 border-transparent pl-1.5",
+            line.highlight && "border-destructive bg-destructive/10",
+          )}
+        >
+          <span
+            className={cn(
+              "select-none text-right tabular-nums text-muted-foreground/70",
+              line.highlight && "font-semibold text-destructive",
+            )}
+            style={{ minWidth: `${gutterWidth}ch` }}
+          >
+            {line.highlight ? "▸" : " "}
+            {String(line.lineno).padStart(gutterWidth, " ")}
+          </span>
+          <code className="whitespace-pre">
+            {highlight(line.source, language, isDark, colorTheme)}
+          </code>
+        </div>
+      ))}
+    </pre>
+  );
+}
+
+function RawJsonFallback({ data, className }: { data: unknown; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-yellow-300 bg-yellow-50/60 p-3 text-xs",
+        "dark:border-yellow-800 dark:bg-yellow-950/30",
+        className,
+      )}
+    >
+      <div className="mb-1 font-semibold text-yellow-800 dark:text-yellow-200">
+        Unparsed traceback payload
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-yellow-900/80 dark:text-yellow-100/80">
+        {safeStringify(data)}
+      </pre>
+    </div>
+  );
+}
+
+// ─── Payload normalization ─────────────────────────────────────────────
+
+function toPayload(data: unknown): TracebackPayload | null {
+  // Payloads arrive as either an object (already parsed) or a JSON string
+  // (when a kernel sends it through paths that stringify custom +json).
+  let obj: unknown = data;
+  if (typeof data === "string") {
+    try {
+      obj = JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.ename !== "string" || typeof o.evalue !== "string") {
+    return null;
+  }
+  return {
+    ename: o.ename,
+    evalue: o.evalue,
+    frames: Array.isArray(o.frames) ? (o.frames as Frame[]) : undefined,
+    language: typeof o.language === "string" ? o.language : undefined,
+    text: typeof o.text === "string" ? o.text : undefined,
+    raw: Array.isArray(o.raw) ? (o.raw as string[]) : undefined,
+  };
+}
+
+function safeStringify(x: unknown): string {
+  try {
+    return typeof x === "string" ? x : JSON.stringify(x, null, 2);
+  } catch {
+    return String(x);
+  }
+}

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -173,9 +173,7 @@ function Header({
       <div className="min-w-0 flex-1">
         <div className="font-semibold text-destructive">{ename}</div>
         {evalue && (
-          <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">
-            {evalue}
-          </div>
+          <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">{evalue}</div>
         )}
       </div>
       <CopyButton payload={payload} />


### PR DESCRIPTION
## Summary

Two pieces that landed together. The log-loop fix is a prerequisite for using the UI during iteration — without it, Tauri devtools spam made the window unusable on HMR.

### Rich traceback component

New MIME `application/vnd.nteract.traceback+json` + `src/components/outputs/traceback-output.tsx`. Renders a structured traceback payload with:

- Header: Lucide `OctagonAlert` glyph, exception class + message, Copy button (pastes the payload's `text` field — kernel-side `traceback.format_exception` output)
- Per-frame rows: chevron, filename (truncated), line number, function name. Auto-expands user frames, auto-collapses library frames
- Source block with line-number gutter + left-border accent on the highlighted line
- **Lezer syntax highlighting** via `src/components/editor/static-highlight.tsx` — same parsers and theme palette as the CodeMirror editor (Python keywords, strings, numbers all colored). CodeMirror font stack, language per-payload (`payload.language`, defaults to `"python"`)
- **Consecutive identical frames cluster** into one row with a `×N` badge. A RecursionError with 3000 frames becomes two rows.

Color stack rebased on `--destructive` / `--muted` semantic tokens (not `red-X` Tailwind classes) — the cream theme inverts the red-scale lightness, so class-based colors rendered wrong in dark cream. Semantic tokens get theme-correct rendering for free.

Added to `safe-mime-types.ts` (main-DOM-safe: we control the schema). Priority promoted to `DEFAULT_PRIORITY[0]` — if we minted the MIME we trust it above everything else, and no reasonable kernel emits a traceback alongside a widget/plot/dataframe in the same output.

### plugin-log feedback loop

Removed `pluginAttachConsole()` from `createTauriHost()`. The old mirror routed Rust log events through `console.error`, which the app's panic-forwarder wraps to feed BACK into plugin-log:

```
frontend error → wrapped console.error → logger.error → pluginError
  → Rust log bus → attachConsole listener → console.error (wrapped!)
  → logger.error → pluginError → … forever
```

`main.tsx` now captures original `console.*` methods before wrapping `console.error`, then uses `attachLogger()` (the lower-level primitive) to dispatch Rust events to those originals. Dev-time mirror intact, feedback loop broken.

## Not in this PR

- **Load-time parse on Rust side.** A `.ipynb` loaded from disk carries the standard `output_type: "error"` shape with ANSI strings and still renders via the existing `AnsiErrorOutput`. The right fix is to parse ANSI → rich payload on the Rust side at load, emit the rich MIME into the CRDT, and save back to the standard shape. Parse once, not per-render. Tracked as a follow-up.
- **Launcher kernel-side emitter.** The rich payload is produced today by an in-cell helper. Moving it into `_bootstrap.py` (emitting via the standard `output_type: "error"` path so it persists to `.ipynb` naturally) is the next step.
- **Kernel-side frame cap.** Head + tail + "N frames omitted" sentinel. The renderer-side clustering in this PR handles recursion; the kernel cap is the primary defense.

## Test plan

- [ ] `pnpm test` — full JS suite passes (1083 tests)
- [ ] `cargo xtask lint` clean
- [ ] Manual: emit a `display_data` with `application/vnd.nteract.traceback+json` from a Python cell; confirm rich render
- [ ] Manual: test in classic-light, classic-dark, cream-light, cream-dark
- [ ] Manual: trigger a RecursionError, confirm the tower collapses to a `×N` row
- [ ] Manual: verify Tauri devtools no longer spam plugin-log errors on HMR save (the regression that motivated half of this PR)