### PR TITLE
feat(sift): show time precision for Timestamp columns in cell display

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a20a9ff877cbd067ff4485432eb1a4ffb42134d8cb316cddf4bf24315bcddb0a
-size 1590653
+oid sha256:1b5cfd738392e3128228d91fca0927f330d825614d80bc5a21f884954f2091d1
+size 1593203

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77b51c76d4a1aba96a32be53d01f6a7c5667215d8d3cbd798df7a597f377ab80
-size 1466685
+oid sha256:d868bc37e91378f58f692bec456160afc824aebca01235a1ba81695f290fd859
+size 1472773

--- a/apps/notebook/src/renderer-plugins/sift.css
+++ b/apps/notebook/src/renderer-plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56fbd5c00a980c700c2bde35dea2cf9327f72f17418c93f0cfd43907f421dbf8
-size 136084
+oid sha256:d8d415a95be8023754a32f51af68b2010f8810879d0ef9f7490eea9c8487fea6
+size 137210

--- a/crates/runt-mcp/assets/plugins/sift.css
+++ b/crates/runt-mcp/assets/plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56fbd5c00a980c700c2bde35dea2cf9327f72f17418c93f0cfd43907f421dbf8
-size 136084
+oid sha256:d8d415a95be8023754a32f51af68b2010f8810879d0ef9f7490eea9c8487fea6
+size 137210

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77b7ce5a0af6cffd96d7d9a4362b0dfea5253ade440da55ffbbad98f87db64f6
-size 5428296
+oid sha256:c5063534ceec5ea0d51b2a8e14ced643b8d03d371e15f3231c84c0391ee4189c
+size 5428339

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77b7ce5a0af6cffd96d7d9a4362b0dfea5253ade440da55ffbbad98f87db64f6
-size 5428296
+oid sha256:c5063534ceec5ea0d51b2a8e14ced643b8d03d371e15f3231c84c0391ee4189c
+size 5428339

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -276,17 +276,24 @@ fn timestamp_cell_ms(column: &dyn Array, local_row: usize) -> Option<i64> {
     }
 }
 
-/// Format epoch milliseconds as "Apr 23, 2026", respecting the column timezone.
-fn format_timestamp_ms(ms: i64, tz: Option<&str>) -> String {
+/// Format epoch milliseconds for display, respecting the column timezone.
+/// Date-only types (Date32/Date64) use "Apr 23, 2026".
+/// Timestamp types with time precision use "Apr 23, 2026, 7:30 AM".
+fn format_timestamp_ms(ms: i64, tz: Option<&str>, has_time: bool) -> String {
     use chrono_tz::Tz;
     let secs = ms / 1000;
     let nanos = ((ms % 1000) * 1_000_000) as u32;
     let Some(utc_dt) = DateTime::from_timestamp(secs, nanos) else {
         return ms.to_string();
     };
+    let fmt = if has_time {
+        "%b %-d, %Y, %-I:%M %p"
+    } else {
+        "%b %-d, %Y"
+    };
     match tz.and_then(|s| s.parse::<Tz>().ok()) {
-        Some(tz) => utc_dt.with_timezone(&tz).format("%b %-d, %Y").to_string(),
-        None => utc_dt.format("%b %-d, %Y").to_string(),
+        Some(tz) => utc_dt.with_timezone(&tz).format(fmt).to_string(),
+        None => utc_dt.format(fmt).to_string(),
     }
 }
 
@@ -312,7 +319,8 @@ pub fn get_cell_string(handle: u32, row: usize, col: usize) -> Result<String, Js
         // Timestamps → human-readable date in the column's timezone (or UTC)
         if let Some(ms) = timestamp_cell_ms(column.as_ref(), local_row) {
             let tz = s.col_timezones.get(col).and_then(|t| t.as_deref());
-            return format_timestamp_ms(ms, tz);
+            let has_time = matches!(column.data_type(), DataType::Timestamp(_, _));
+            return format_timestamp_ms(ms, tz, has_time);
         }
 
         match column.data_type() {
@@ -1717,5 +1725,58 @@ fn get_string_value(arr: &dyn Array, row: usize) -> String {
             })
             .unwrap_or_default(),
         _ => format!("{:?}", arr.as_any()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_date_only() {
+        let ms = 1_776_902_400_000; // 2026-04-23 00:00:00 UTC
+        assert_eq!(format_timestamp_ms(ms, None, false), "Apr 23, 2026");
+    }
+
+    #[test]
+    fn format_datetime_utc() {
+        let ms = 1_776_929_400_000; // 2026-04-23 07:30:00 UTC
+        assert_eq!(format_timestamp_ms(ms, None, true), "Apr 23, 2026, 7:30 AM");
+    }
+
+    #[test]
+    fn format_datetime_with_timezone() {
+        let ms = 1_776_954_600_000; // 2026-04-23 14:30:00 UTC = 07:30 AM PDT
+        assert_eq!(
+            format_timestamp_ms(ms, Some("America/Los_Angeles"), true),
+            "Apr 23, 2026, 7:30 AM"
+        );
+    }
+
+    #[test]
+    fn format_date_with_timezone_shifts_day() {
+        // 2026-04-23 03:00:00 UTC = Apr 22 8:00 PM in LA
+        let ms = 1_776_902_400_000 + 3 * 3_600_000;
+        assert_eq!(
+            format_timestamp_ms(ms, Some("America/Los_Angeles"), false),
+            "Apr 22, 2026"
+        );
+    }
+
+    #[test]
+    fn format_midnight_utc_datetime() {
+        let ms = 1_776_902_400_000; // 2026-04-23 00:00:00 UTC
+        assert_eq!(
+            format_timestamp_ms(ms, None, true),
+            "Apr 23, 2026, 12:00 AM"
+        );
+    }
+
+    #[test]
+    fn format_invalid_timestamp() {
+        assert_eq!(
+            format_timestamp_ms(i64::MAX, None, false),
+            i64::MAX.to_string()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Timestamp columns (`datetime[us]`, `datetime[ns]`, etc.) now render as "Apr 23, 2026, 7:30 AM" instead of just "Apr 23, 2026"
- Date-only columns (`Date32`, `Date64`) continue to render as "Apr 23, 2026" since they have no time component
- `format_timestamp_ms` gains a `has_time` parameter, set based on whether the Arrow type is `Timestamp(_, _)` vs `Date32`/`Date64`

## Test plan

- [x] 9 Rust unit tests pass (`cargo test -p sift-wasm --lib`) covering date-only, datetime UTC, datetime with timezone, midnight, and invalid input
- [ ] Manual: Polars `dt.date()` column shows date only (e.g. "Jan 10, 1997")
- [ ] Manual: Polars `datetime` column shows date + time (e.g. "Apr 23, 2026, 7:30 AM")
- [ ] Manual: timezone-aware column renders time in correct timezone

🪶 Generated with Quill Agent