### PR TITLE
fix(notebook): await blob port in bootstrap to prevent binary output on reload

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -209,7 +209,10 @@ export function useAutomergeNotebook() {
     handleRef.current?.free();
     handleRef.current = handle;
     handle.set_mime_priority(DEFAULT_MIME_PRIORITY);
-    const initialBlobPort = getBlobPort();
+    let initialBlobPort = getBlobPort();
+    if (initialBlobPort === null) {
+      initialBlobPort = await refreshBlobPort();
+    }
     if (initialBlobPort !== null) {
       handle.set_blob_port(initialBlobPort);
     }


### PR DESCRIPTION
## Summary

On `window.location.reload()`, parquet outputs show raw binary bytes and "Error: URL is not valid" instead of rendering a sift table.

**Root cause:** `refreshBlobPort()` is async but `bootstrap()` called `getBlobPort()` synchronously and skipped setting the blob port when it returned null. The WASM handle was initialized without a blob port, so `resolve_content_ref` couldn't construct blob server URLs for binary MIME types. Parquet data fell through as raw bytes instead of `http://127.0.0.1:PORT/blob/HASH`.

**Fix:** Bootstrap now awaits `refreshBlobPort()` when the port isn't cached, ensuring the WASM handle always has a valid blob port before the first materialization.

## Test plan

- [ ] Manual: open a notebook with parquet output, run `window.location.reload()` in console, verify sift table renders correctly without errors
- [ ] Manual: cold start (quit app, reopen) still works

🪶 Generated with Quill Agent