### PR TITLE
feat(launcher): rich traceback emission via short-circuiting _showtraceback

### DIFF
--- a/crates/kernel-env/src/launcher.rs
+++ b/crates/kernel-env/src/launcher.rs
@@ -67,6 +67,12 @@ pub const LAUNCHER_FILES: &[(&str, &str)] = &[
         "_summary.py",
         include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_summary.py"),
     ),
+    (
+        "_traceback.py",
+        include_str!(
+            "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py"
+        ),
+    ),
 ];
 
 /// Ask the target Python for its `purelib` site-packages directory.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -34,7 +34,7 @@ import logging
 import os
 from typing import Any
 
-from nteract_kernel_launcher import _buffer_hook
+from nteract_kernel_launcher import _buffer_hook, _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import serialize_dataframe
 from nteract_kernel_launcher._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
@@ -261,6 +261,13 @@ def load_ipython_extension(ip: Any) -> None:
         _enable_third_party_renderers()
     except Exception as exc:  # noqa: BLE001
         log.warning("third-party renderer enable failed: %s", exc)
+
+    # Traceback install goes last so earlier failures can't prevent it.
+    # The wrapper itself is bulletproof — see `_traceback.install`.
+    try:
+        _traceback.install(ip)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("traceback install failed: %s", exc)
 
 
 def unload_ipython_extension(ip: Any) -> None:

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -1,0 +1,181 @@
+"""Rich traceback short-circuit for the nteract-kernel-launcher.
+
+Replaces ``ZMQInteractiveShell._showtraceback`` with a wrapper that
+builds a structured payload (file/line/name per frame with a source
+window and highlight) and publishes a ``display_data`` carrying
+``application/vnd.nteract.traceback+json``. One output per exception,
+same shape the in-session prototype used.
+
+**Safety invariant: this code MUST NEVER prevent a user from seeing a
+traceback.** Every code path is wrapped so the original
+``_showtraceback`` runs if anything goes wrong. The user would rather
+see plain ANSI output than nothing.
+
+Why this lives in a tiny module of its own: it has to be dead-simple
+to audit. Reviewers should be able to read the file end-to-end and
+convince themselves that no user-triggered exception can sabotage
+error reporting.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import linecache
+import logging
+import os
+import traceback as _pytraceback
+import types
+from typing import Any
+
+log = logging.getLogger("nteract_kernel_launcher")
+
+TRACEBACK_MIME = "application/vnd.nteract.traceback+json"
+"""Matches `src/components/outputs/traceback-output.tsx` on the frontend."""
+
+_LIBRARY_PATH_MARKERS = (
+    "site-packages",
+    "dist-packages",
+    "lib/python",
+    "lib\\python",
+    "python.framework",
+)
+
+_CONTEXT_BEFORE = 2
+_CONTEXT_AFTER = 2
+
+
+# ─── Payload construction ───────────────────────────────────────────────────
+
+
+def _is_library_frame(filename: str) -> bool:
+    if not filename:
+        return True
+    norm = os.path.normpath(filename).lower()
+    return any(m in norm for m in _LIBRARY_PATH_MARKERS)
+
+
+def _source_window(filename: str, lineno: int) -> list[dict[str, Any]]:
+    """Return the source-context lines around ``lineno`` (inclusive range)."""
+    out: list[dict[str, Any]] = []
+    start = max(1, lineno - _CONTEXT_BEFORE)
+    end = lineno + _CONTEXT_AFTER
+    for n in range(start, end + 1):
+        src = linecache.getline(filename, n)
+        if not src:
+            continue
+        entry: dict[str, Any] = {"lineno": n, "source": src.rstrip("\n")}
+        if n == lineno:
+            entry["highlight"] = True
+        out.append(entry)
+    return out
+
+
+def _strip_leading_library_frames(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop library frames above the first user frame.
+
+    IPython's ``run_code`` wraps every cell execution, so a cell raising
+    a bare ``NameError`` ends up with two frames: the IPython wrapper and
+    the user's cell. The wrapper is pure ceremony — no user code lives
+    there — so we strip it.
+
+    Any library frames *after* a user frame are kept: if a user call into
+    a library raised inside that library, those frames carry real info.
+
+    If *every* frame is library (e.g. a failing ``import`` inside a
+    worker thread before any user code runs), keep everything so we
+    don't emit an empty stack.
+    """
+    if not any(not f.get("library") for f in frames):
+        return frames
+    for i, f in enumerate(frames):
+        if not f.get("library"):
+            return frames[i:]
+    return frames
+
+
+def build_rich_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
+    """Structure an exception into the rich traceback payload.
+
+    Assumes the caller protects against exceptions from this function —
+    see `_safe_showtraceback` below.
+    """
+    raw_frames = []
+    for f in _pytraceback.extract_tb(tb):
+        # `FrameSummary.lineno` is typed as `int | None`; treat missing
+        # as 0 so the manifest stays numeric. `linecache.getline` with
+        # lineno=0 returns "" which is what we want (no context).
+        lineno = f.lineno or 0
+        raw_frames.append(
+            {
+                "filename": f.filename,
+                "lineno": lineno,
+                "name": f.name,
+                "lines": _source_window(f.filename, lineno),
+                "library": _is_library_frame(f.filename),
+            }
+        )
+    frames = _strip_leading_library_frames(raw_frames)
+    text = "".join(_pytraceback.format_exception(etype, evalue, tb))
+    ename = etype.__name__ if isinstance(etype, type) else str(etype)
+    return {
+        "ename": ename,
+        "evalue": str(evalue),
+        "frames": frames,
+        "language": "python",
+        "text": text,
+    }
+
+
+# ─── Safe showtraceback wrapper ─────────────────────────────────────────────
+
+
+def install(ip: Any) -> None:
+    """Install a safe, short-circuiting ``_showtraceback`` on *ip*.
+
+    Tagged with ``_nteract_installed`` so re-installs (e.g. dev
+    hot-reload) don't stack.
+    """
+    existing = getattr(ip, "_showtraceback", None)
+    if existing is not None and getattr(existing, "_nteract_installed", False):
+        return
+
+    original = existing
+
+    def _safe_showtraceback(self: Any, etype: Any, evalue: Any, stb: Any) -> None:
+        """Emit the rich payload, falling back to *original* on any error.
+
+        Catches ``BaseException`` rather than ``Exception`` so nothing a
+        user can trigger inside payload construction or the publish call
+        can take down the error path. ``SystemExit`` and
+        ``KeyboardInterrupt`` are re-raised — those are intentional
+        control flow.
+        """
+        try:
+            # Lazy import inside the function body so a missing IPython
+            # at extension-load time never strands us without a traceback
+            # path.
+            from IPython.display import publish_display_data
+
+            tb = evalue.__traceback__ if isinstance(evalue, BaseException) else None
+            payload = build_rich_payload(etype, evalue, tb)
+            publish_display_data(data={TRACEBACK_MIME: payload}, metadata={})
+        except (SystemExit, KeyboardInterrupt):
+            # Intentional control flow — propagate.
+            raise
+        except BaseException as err:  # noqa: BLE001
+            # Anything else — including MemoryError, RecursionError,
+            # OSError from IPython internals — must not starve the
+            # user of a traceback. Log at debug (we're literally inside
+            # the error path; loud logging is worse than silent fallback).
+            log.debug("rich traceback fallback: %r", err)
+            if original is not None:
+                # If the *original* also fails, there's nothing more we
+                # can usefully do. Swallow to avoid obscuring the root
+                # exception with a meta-error.
+                with contextlib.suppress(BaseException):
+                    original(etype, evalue, stb)
+
+    # Tag for idempotency.
+    _safe_showtraceback._nteract_installed = True  # type: ignore[attr-defined]
+
+    ip._showtraceback = types.MethodType(_safe_showtraceback, ip)

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -1,0 +1,261 @@
+"""Unit tests for the bulletproof traceback emitter.
+
+The short-circuit path is easy to test. The critical assertion is the
+safety invariant: the user ALWAYS gets a traceback, even when our own
+code blows up in creative ways.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from nteract_kernel_launcher import _traceback
+from nteract_kernel_launcher._traceback import TRACEBACK_MIME, build_rich_payload, install
+
+# ─── build_rich_payload ────────────────────────────────────────────────────
+
+
+def _capture_exc() -> BaseException:
+    try:
+        raise KeyError("missing_key")
+    except BaseException as exc:
+        return exc
+
+
+def test_build_payload_shape():
+    exc = _capture_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    assert payload["ename"] == "KeyError"
+    assert payload["evalue"] == "'missing_key'"
+    assert payload["language"] == "python"
+    assert payload["text"].startswith("Traceback (most recent call last):")
+    assert len(payload["frames"]) >= 1
+    top = payload["frames"][-1]
+    assert "filename" in top and "lineno" in top and "name" in top
+    assert isinstance(top["library"], bool)
+
+
+def test_build_payload_marks_highlight_on_fail_line():
+    exc = _capture_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    highlights = [
+        line
+        for frame in payload["frames"]
+        for line in (frame.get("lines") or [])
+        if line.get("highlight")
+    ]
+    # Each frame that has any lines should have exactly one highlighted entry
+    # at its failing lineno.
+    assert len(highlights) >= 1
+
+
+# ─── leading-library-frame strip ───────────────────────────────────────────
+
+
+def test_strip_leading_library_frames_removes_ipython_run_code():
+    # Simulate the real-world shape: [IPython.run_code, user <module>]
+    raw = [
+        {
+            "filename": "/opt/python/site-packages/IPython/core/interactiveshell.py",
+            "lineno": 3747,
+            "name": "run_code",
+            "lines": [],
+            "library": True,
+        },
+        {
+            "filename": "/tmp/ipykernel_1/abc.py",
+            "lineno": 1,
+            "name": "<module>",
+            "lines": [],
+            "library": False,
+        },
+    ]
+    out = _traceback._strip_leading_library_frames(raw)
+    assert len(out) == 1
+    assert out[0]["name"] == "<module>"
+
+
+def test_strip_leading_library_frames_keeps_intermediate_library():
+    raw = [
+        {
+            "filename": "/opt/py/site-packages/ipy.py",
+            "lineno": 1,
+            "name": "run_code",
+            "library": True,
+        },
+        {"filename": "/tmp/ipykernel_1/abc.py", "lineno": 1, "name": "<module>", "library": False},
+        {
+            "filename": "/opt/py/site-packages/pandas/x.py",
+            "lineno": 9,
+            "name": "helper",
+            "library": True,
+        },
+    ]
+    out = _traceback._strip_leading_library_frames(raw)
+    # Only the leading library frame is dropped; the pandas frame stays.
+    assert [f["name"] for f in out] == ["<module>", "helper"]
+
+
+def test_strip_leading_library_frames_keeps_everything_when_all_library():
+    raw = [
+        {"filename": "/opt/py/site-packages/a.py", "lineno": 1, "name": "load", "library": True},
+        {"filename": "/opt/py/site-packages/b.py", "lineno": 2, "name": "parse", "library": True},
+    ]
+    out = _traceback._strip_leading_library_frames(raw)
+    assert out == raw
+
+
+# ─── install: wrapping + idempotency ───────────────────────────────────────
+
+
+class _FakeShell:
+    """Minimal stand-in for ZMQInteractiveShell that exercises the hook."""
+
+    def __init__(self):
+        self.original_calls = []
+
+        def _original(_self, etype, evalue, stb):
+            self.original_calls.append((etype, evalue, stb))
+
+        # Bind as a bound method so MethodType can replicate the real shape.
+        import types as _t
+
+        self._showtraceback = _t.MethodType(_original, self)
+
+
+def test_install_replaces_showtraceback_and_tags_for_idempotency(monkeypatch):
+    captured = []
+
+    def _fake_publish(data=None, metadata=None):
+        captured.append({"data": data, "metadata": metadata})
+
+    monkeypatch.setattr("IPython.display.publish_display_data", _fake_publish)
+
+    ip = _FakeShell()
+    install(ip)
+    assert getattr(ip._showtraceback, "_nteract_installed", False) is True
+
+    # Trigger via a real exception.
+    try:
+        raise ValueError("boom")
+    except BaseException as exc:
+        ip._showtraceback(type(exc), exc, ["traceback-stb"])
+
+    assert len(captured) == 1
+    assert TRACEBACK_MIME in captured[0]["data"]
+    payload = captured[0]["data"][TRACEBACK_MIME]
+    assert payload["ename"] == "ValueError"
+    assert payload["evalue"] == "boom"
+
+    # Idempotent re-install must not wrap-the-wrapper.
+    install(ip)
+    assert getattr(ip._showtraceback, "_nteract_installed", False) is True
+    assert ip._showtraceback.__func__ is not None  # still bound
+
+
+def test_fallback_when_build_payload_fails(monkeypatch):
+    """If payload construction raises, the ORIGINAL shell must be called."""
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(_traceback, "build_rich_payload", _boom)
+
+    captured = []
+    monkeypatch.setattr(
+        "IPython.display.publish_display_data",
+        lambda *_a, **_kw: captured.append("should-not-be-called"),
+    )
+
+    ip = _FakeShell()
+    install(ip)
+
+    try:
+        raise ValueError("seen-by-user")
+    except BaseException as exc:
+        ip._showtraceback(type(exc), exc, ["stb-line-1"])
+
+    # Our publish path was aborted, original ran.
+    assert captured == []
+    assert len(ip.original_calls) == 1
+    et, ev, stb = ip.original_calls[0]
+    assert et is ValueError
+    assert str(ev) == "seen-by-user"
+    assert stb == ["stb-line-1"]
+
+
+def test_fallback_when_publish_fails(monkeypatch):
+    """publish_display_data raising must still hand off to the original."""
+
+    def _boom(*_a, **_kw):
+        raise OSError("ipub broken")
+
+    monkeypatch.setattr("IPython.display.publish_display_data", _boom)
+
+    ip = _FakeShell()
+    install(ip)
+    try:
+        raise ValueError("seen")
+    except BaseException as exc:
+        ip._showtraceback(type(exc), exc, ["stb"])
+
+    assert len(ip.original_calls) == 1
+
+
+def test_systemexit_is_not_swallowed(monkeypatch):
+    """SystemExit from payload path must propagate (not be caught)."""
+
+    def _exit(*_a, **_kw):
+        raise SystemExit(0)
+
+    monkeypatch.setattr(_traceback, "build_rich_payload", _exit)
+
+    ip = _FakeShell()
+    install(ip)
+    with pytest.raises(SystemExit):
+        try:
+            raise ValueError("x")
+        except BaseException as exc:
+            ip._showtraceback(type(exc), exc, [])
+
+
+def test_keyboardinterrupt_is_not_swallowed(monkeypatch):
+    def _int(*_a, **_kw):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(_traceback, "build_rich_payload", _int)
+
+    ip = _FakeShell()
+    install(ip)
+    with pytest.raises(KeyboardInterrupt):
+        try:
+            raise ValueError("x")
+        except BaseException as exc:
+            ip._showtraceback(type(exc), exc, [])
+
+
+def test_original_also_failing_does_not_reraise(monkeypatch):
+    """If BOTH our path AND the original path fail, we must still not
+    raise out to the user — there's nothing more we can usefully do."""
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("payload broke")
+
+    monkeypatch.setattr(_traceback, "build_rich_payload", _boom)
+
+    ip = SimpleNamespace()
+
+    def _bad_original(_self, _etype, _evalue, _stb):
+        raise OSError("original also broke")
+
+    import types as _t
+
+    ip._showtraceback = _t.MethodType(_bad_original, ip)
+
+    install(ip)
+    # Must not raise.
+    try:
+        raise ValueError("x")
+    except BaseException as exc:
+        ip._showtraceback(type(exc), exc, [])


### PR DESCRIPTION
## Summary

Hooks `ZMQInteractiveShell._showtraceback` in the launcher's bootstrap extension. When an exception escapes a cell, we build a structured payload (ename/evalue/frames with per-frame source windows + highlight markers) and publish one `display_data` carrying `application/vnd.nteract.traceback+json`. Default `output_type: "error"` emission is short-circuited — one rich output per exception, no duplicate.

Frontend renderer from PR #2138 picks it up directly via MIME priority. No per-cell helper; installing `nteract_kernel_launcher._bootstrap` is enough.

## Bulletproof wrapper

The emitter MUST NEVER prevent a user from seeing a traceback. `_safe_showtraceback`:

- Catches `BaseException`, not just `Exception`
- Re-raises `SystemExit` and `KeyboardInterrupt` (intentional control flow)
- Falls through to the original `_showtraceback` on any other failure — user sees plain ANSI if our path breaks
- Swallows if the original also fails (nothing more to usefully do; a meta-error would obscure the root exception)

## Leading-library-frame strip

IPython's `run_code` wrapper is outermost for every cell execution. Dropping it removes pure ceremony from every render. Intermediate library frames between user frames are kept (they carry real info when a user call raised inside a library). If every frame is library (e.g. import failure in a worker thread), all kept so we don't emit an empty stack.

## Tests (11 passing)

- payload shape: ename/evalue/frames/language/text
- highlight line detection
- install idempotency via `_nteract_installed` tag
- publish failure → fallback to original
- build_payload failure → fallback to original
- SystemExit propagates
- KeyboardInterrupt propagates
- original-also-fails → swallow (no meta-error)
- leading-library-strip happy path
- intermediate-library preservation
- all-library preservation

## Follow-ups (not this PR)

- **Rust-side ANSI parse on `.ipynb` load** (task #13). This PR covers live tracebacks; loaded-from-disk still rendered via `AnsiErrorOutput`.
- **Frame cap** (task #20). The renderer handles 3000-frame recursion via clustering; a kernel-side cap would keep payloads small.
- **Cell ID mapping** (task #24). Each frame's ipykernel temp file corresponds to a cell we know the id of at execute time. Stash the mapping, enrich frames, frontend can show `Cell [N]` / click-to-scroll.
- **SyntaxError frame suppression** (task #25). SyntaxError has no user frame — all `ast_parse` internals. Hide them; evalue carries the file:line already.

## Test plan

- [ ] `cargo xtask lint` clean
- [ ] `cargo test -p kernel-env --lib launcher` — 6 passing (includes the vendor tests that sweep the embedded file set)
- [ ] `pytest python/nteract-kernel-launcher/tests/test_traceback.py` — 11 passing
- [ ] Manual: restart kernel in a dev build, raise exception in a cell, confirm rich `TracebackOutput` render
- [ ] Manual: confirm IPython `run_code` frame is stripped (no library row above the `<module>` entry)
- [ ] Manual: verify `text` field (Copy button) round-trips the canonical `Traceback (most recent call last):` form