### PR TITLE
fix(runtimed): validate conda inline cache has all requested packages

### DIFF
--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -379,6 +379,11 @@ pub async fn check_uv_inline_cache(
 /// Check if a cached Conda inline environment already exists for the given deps.
 ///
 /// Returns `Some(PreparedEnv)` on cache hit, `None` on miss.
+///
+/// Beyond checking that the python binary exists, this also verifies that
+/// every requested package has a corresponding `conda-meta/` record.  A
+/// stale cache entry (e.g. created by a buggy build that dropped packages)
+/// is treated as a miss and removed so the next code path can rebuild it.
 pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<PreparedEnv> {
     let conda_deps = kernel_env::CondaDependencies {
         dependencies: deps.to_vec(),
@@ -400,14 +405,96 @@ pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<
     #[cfg(windows)]
     let python_path = env_path.join("Scripts").join("python.exe");
 
-    if python_path.exists() {
-        Some(PreparedEnv {
-            env_path,
-            python_path,
-        })
-    } else {
-        None
+    if !python_path.exists() {
+        return None;
     }
+
+    // Verify that every requested package is actually installed.  The
+    // python binary existing is necessary but not sufficient — a prior
+    // buggy build may have cached an env missing some packages (#2137).
+    if !deps.is_empty() {
+        let installed = conda_meta_package_names(&env_path);
+        for dep in deps {
+            let Some(bare) = bare_package_name(dep) else {
+                // Has a version specifier — extract the name portion for matching.
+                let name = dep
+                    .split(|c: char| {
+                        ['>', '<', '=', '!', '~', '[', ';', '@'].contains(&c) || c.is_whitespace()
+                    })
+                    .next()
+                    .unwrap_or("")
+                    .trim();
+                if name.is_empty() {
+                    continue;
+                }
+                if !installed.contains(&normalize_package_name(name)) {
+                    tracing::warn!(
+                        "[inline-env] Conda cache {:?} missing requested package {:?} — evicting stale cache",
+                        env_path, dep
+                    );
+                    let _ = std::fs::remove_dir_all(&env_path);
+                    return None;
+                }
+                continue;
+            };
+            if !installed.contains(&normalize_package_name(bare)) {
+                tracing::warn!(
+                    "[inline-env] Conda cache {:?} missing requested package {:?} — evicting stale cache",
+                    env_path, dep
+                );
+                let _ = std::fs::remove_dir_all(&env_path);
+                return None;
+            }
+        }
+    }
+
+    Some(PreparedEnv {
+        env_path,
+        python_path,
+    })
+}
+
+/// Read the `conda-meta/` directory and return a set of installed package
+/// names (normalized: lowercase, underscores replaced with hyphens).
+///
+/// Conda-meta filenames follow `{name}-{version}-{build}.json`.  We parse
+/// the name by splitting on `-` and taking the longest prefix whose next
+/// segment starts with a digit (the version).  This handles names with
+/// hyphens like `scikit-learn-1.4.0-py312_0.json`.
+fn conda_meta_package_names(env_path: &std::path::Path) -> HashSet<String> {
+    let meta_dir = env_path.join("conda-meta");
+    let mut names = HashSet::new();
+
+    let entries = match std::fs::read_dir(&meta_dir) {
+        Ok(e) => e,
+        Err(_) => return names,
+    };
+
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let fname = fname.to_string_lossy();
+        // Skip non-json and the `history` file
+        let Some(stem) = fname.strip_suffix(".json") else {
+            continue;
+        };
+
+        // Find the package name: take segments before the first segment
+        // that looks like a version number (starts with a digit).
+        let segments: Vec<&str> = stem.split('-').collect();
+        let mut name_end = 0;
+        for (i, seg) in segments.iter().enumerate() {
+            if i > 0 && seg.starts_with(|c: char| c.is_ascii_digit()) {
+                break;
+            }
+            name_end = i + 1;
+        }
+        if name_end > 0 {
+            let pkg_name = segments[..name_end].join("-");
+            names.insert(normalize_package_name(&pkg_name));
+        }
+    }
+
+    names
 }
 
 #[cfg(test)]
@@ -505,5 +592,64 @@ mod tests {
             compare_deps_to_pool(&deps, &pool),
             PoolDepRelation::Subset
         ));
+    }
+
+    #[test]
+    fn test_conda_meta_package_names_parses_filenames() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+
+        // Standard packages
+        std::fs::write(meta.join("numpy-2.4.3-py314h2b28147_0.json"), "{}").unwrap();
+        std::fs::write(meta.join("pandas-2.3.0-py314ha1ea8a9_0.json"), "{}").unwrap();
+        std::fs::write(meta.join("scipy-1.17.1-py314hf07bd8e_0.json"), "{}").unwrap();
+        // Hyphenated package name
+        std::fs::write(meta.join("scikit-learn-1.4.0-py312_0.json"), "{}").unwrap();
+        // Leading underscore
+        std::fs::write(meta.join("_openmp_mutex-4.5-20_gnu.json"), "{}").unwrap();
+        // history file (not a package)
+        std::fs::write(meta.join("history"), "").unwrap();
+
+        let names = conda_meta_package_names(dir.path());
+        assert!(names.contains("numpy"), "missing numpy: {:?}", names);
+        assert!(names.contains("pandas"), "missing pandas: {:?}", names);
+        assert!(names.contains("scipy"), "missing scipy: {:?}", names);
+        assert!(
+            names.contains("scikit-learn"),
+            "missing scikit-learn: {:?}",
+            names
+        );
+        assert!(
+            names.contains("-openmp-mutex"),
+            "missing _openmp_mutex: {:?}",
+            names
+        );
+        assert!(
+            !names.contains("history"),
+            "should not contain history: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_conda_cache_miss_on_missing_package() {
+        // This tests the package validation logic in check_conda_inline_cache
+        // indirectly through conda_meta_package_names.
+        let dir = tempfile::tempdir().unwrap();
+        let meta = dir.path().join("conda-meta");
+        std::fs::create_dir_all(&meta).unwrap();
+        std::fs::write(meta.join("numpy-2.4.3-py314h2b28147_0.json"), "{}").unwrap();
+        std::fs::write(meta.join("scipy-1.17.1-py314hf07bd8e_0.json"), "{}").unwrap();
+
+        let names = conda_meta_package_names(dir.path());
+        // pandas is NOT installed
+        assert!(names.contains("numpy"));
+        assert!(names.contains("scipy"));
+        assert!(!names.contains("pandas"), "pandas should not be present");
+        assert!(
+            !names.contains("matplotlib"),
+            "matplotlib should not be present"
+        );
     }
 }

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -283,6 +283,42 @@ fn bare_package_name(dep: &str) -> Option<&str> {
     Some(trimmed)
 }
 
+/// Extract the package name from a conda dependency specifier, stripping
+/// channel qualifiers (`conda-forge::numpy`) and version constraints
+/// (`numpy>=1.24`).  Returns the bare, untrimmed name suitable for
+/// [`normalize_package_name`].
+///
+/// Examples:
+/// - `"numpy"` → `Some("numpy")`
+/// - `"numpy>=1.24"` → `Some("numpy")`
+/// - `"conda-forge::numpy>=1.24"` → `Some("numpy")`
+/// - `"conda-forge::numpy"` → `Some("numpy")`
+/// - `""` → `None`
+fn extract_conda_package_name(dep: &str) -> Option<&str> {
+    let trimmed = dep.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Strip channel qualifier (e.g. "conda-forge::numpy" → "numpy")
+    let after_channel = match trimmed.find("::") {
+        Some(pos) => &trimmed[pos + 2..],
+        None => trimmed,
+    };
+    // Strip version/specifier suffix
+    let specifier_chars = ['>', '<', '=', '!', '~', '[', ';', '@'];
+    let name = match after_channel.find(|c: char| specifier_chars.contains(&c) || c.is_whitespace())
+    {
+        Some(pos) => &after_channel[..pos],
+        None => after_channel,
+    };
+    let name = name.trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// Normalize a package name for comparison: lowercase, replace `_` with `-`.
 fn normalize_package_name(name: &str) -> String {
     name.to_lowercase().replace('_', "-")
@@ -415,29 +451,10 @@ pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<
     if !deps.is_empty() {
         let installed = conda_meta_package_names(&env_path);
         for dep in deps {
-            let Some(bare) = bare_package_name(dep) else {
-                // Has a version specifier — extract the name portion for matching.
-                let name = dep
-                    .split(|c: char| {
-                        ['>', '<', '=', '!', '~', '[', ';', '@'].contains(&c) || c.is_whitespace()
-                    })
-                    .next()
-                    .unwrap_or("")
-                    .trim();
-                if name.is_empty() {
-                    continue;
-                }
-                if !installed.contains(&normalize_package_name(name)) {
-                    tracing::warn!(
-                        "[inline-env] Conda cache {:?} missing requested package {:?} — evicting stale cache",
-                        env_path, dep
-                    );
-                    let _ = std::fs::remove_dir_all(&env_path);
-                    return None;
-                }
+            let Some(name) = extract_conda_package_name(dep) else {
                 continue;
             };
-            if !installed.contains(&normalize_package_name(bare)) {
+            if !installed.contains(&normalize_package_name(name)) {
                 tracing::warn!(
                     "[inline-env] Conda cache {:?} missing requested package {:?} — evicting stale cache",
                     env_path, dep
@@ -519,6 +536,39 @@ mod tests {
         assert_eq!(bare_package_name("pandas[sql]"), None);
         assert_eq!(bare_package_name("pandas ; python_version >= '3.8'"), None);
         assert_eq!(bare_package_name("pandas @ https://example.com"), None);
+    }
+
+    #[test]
+    fn test_extract_conda_package_name() {
+        // Bare names
+        assert_eq!(extract_conda_package_name("numpy"), Some("numpy"));
+        assert_eq!(extract_conda_package_name("pandas"), Some("pandas"));
+        assert_eq!(extract_conda_package_name("  scipy  "), Some("scipy"));
+        assert_eq!(extract_conda_package_name(""), None);
+
+        // Version specifiers
+        assert_eq!(extract_conda_package_name("numpy>=1.24"), Some("numpy"));
+        assert_eq!(extract_conda_package_name("pandas==2.0.0"), Some("pandas"));
+        assert_eq!(extract_conda_package_name("pandas<3"), Some("pandas"));
+        assert_eq!(extract_conda_package_name("pandas~=2.0"), Some("pandas"));
+
+        // Channel qualifiers
+        assert_eq!(
+            extract_conda_package_name("conda-forge::numpy"),
+            Some("numpy")
+        );
+        assert_eq!(
+            extract_conda_package_name("conda-forge::numpy>=1.24"),
+            Some("numpy")
+        );
+        assert_eq!(extract_conda_package_name("defaults::scipy"), Some("scipy"));
+
+        // Extras / markers
+        assert_eq!(extract_conda_package_name("pandas[sql]"), Some("pandas"));
+        assert_eq!(
+            extract_conda_package_name("pandas ; python_version >= '3.8'"),
+            Some("pandas")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `check_conda_inline_cache` now reads `conda-meta/` records and verifies every requested dependency is actually installed, not just that a python binary exists
- Stale cache entries (from the pre-#2137 buggy pool-reuse path that dropped packages) are automatically evicted on mismatch, allowing the fixed rebuild logic to run
- Adds `conda_meta_package_names` helper that parses conda-meta filenames to extract installed package names with proper normalization

## Context

PR #2137 fixed the pool-reuse Additive branch to pass all deps to the conda solver. However, replay showed the fix was bypassed because the stale inline cache (`~/.cache/runt/inline-envs/1cefbe865d12f777`) — created by the buggy pre-fix daemon — served an environment missing pandas and matplotlib. The cache check only verified `bin/python` existed, so the broken env was returned as a cache hit before the fixed pool-reuse code path was ever reached.

## Test plan

- [x] Unit tests for `conda_meta_package_names` filename parsing (hyphenated names, underscore normalization, non-JSON files)
- [x] Unit test verifying missing packages are detected
- [x] All 402 runtimed lib tests pass
- [ ] Gremlin replay: `add_dependency("scipy", after="restart")` on conda inline notebook with [pandas, numpy, matplotlib] should produce a working env with all 4 packages