### PR TITLE
feat(runtimed): wire UserErrorOutput through runtime state + manifest

### DIFF
--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -240,6 +240,57 @@ describe("resolveManifestSync", () => {
     expect(resolveManifestSync(manifest, blobPort)).toBeNull();
   });
 
+  it("resolves error manifest with inline rich sibling", () => {
+    // Launcher-emitted rich payload: small enough to live inline on the
+    // manifest. Sync resolve should attach the parsed payload to the output.
+    const richPayload = { ename: "KeyError", evalue: "'x'", frames: [], text: "KeyError: 'x'" };
+    const manifest: OutputManifest = {
+      output_type: "error",
+      ename: "KeyError",
+      evalue: "'x'",
+      traceback: { inline: JSON.stringify(["KeyError: 'x'"]) },
+      rich: { inline: JSON.stringify(richPayload) },
+    };
+    const output = resolveManifestSync(manifest, blobPort);
+    expect(output).not.toBeNull();
+    if (output && output.output_type === "error") {
+      expect(output.rich).toEqual(richPayload);
+    }
+  });
+
+  it("defers sync resolution when rich is blob-backed", () => {
+    // Classic traceback is inline (would normally be sync-resolvable),
+    // but the rich sibling exceeds the 1KB threshold and lives in a blob.
+    // Without deferring, callers would accept the sync result as final
+    // and the rich payload would never be fetched — rich tracebacks of
+    // any size would downgrade to ANSI rendering.
+    const manifest: OutputManifest = {
+      output_type: "error",
+      ename: "ZeroDivisionError",
+      evalue: "division by zero",
+      traceback: { inline: JSON.stringify(["ZeroDivisionError: division by zero"]) },
+      rich: { blob: "richblob", size: 4096 },
+    };
+    expect(resolveManifestSync(manifest, blobPort)).toBeNull();
+  });
+
+  it("omits rich field when absent on the manifest", () => {
+    // Classic path with no rich sibling (e.g. vanilla ipykernel_launcher
+    // whose ANSI traceback didn't parse into frames). rich stays
+    // undefined so OutputArea falls through to AnsiErrorOutput.
+    const manifest: OutputManifest = {
+      output_type: "error",
+      ename: "ValueError",
+      evalue: "bad",
+      traceback: { inline: JSON.stringify(["ValueError: bad"]) },
+    };
+    const output = resolveManifestSync(manifest, blobPort);
+    expect(output).not.toBeNull();
+    if (output && output.output_type === "error") {
+      expect(output.rich).toBeUndefined();
+    }
+  });
+
   it("auto-parses JSON MIME types in sync resolution", () => {
     const manifest: OutputManifest = {
       output_type: "execute_result",

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -61,6 +61,17 @@ export type OutputManifest =
       ename: string;
       evalue: string;
       traceback: ContentRef;
+      /**
+       * Optional rich-traceback sibling. Carries the structured payload
+       * the frontend's `TracebackOutput` renders (ename, evalue, frames
+       * with source context, highlight markers). Present when the
+       * kernel emitted rich via `application/vnd.nteract.traceback+json`
+       * OR the daemon synthesized one from an ANSI traceback at load.
+       *
+       * In-memory only — `.ipynb` save strips the sibling so files stay
+       * nbformat-clean (see `resolve_manifest` in `output_store.rs`).
+       */
+      rich?: ContentRef;
     });
 
 /**
@@ -268,19 +279,53 @@ export async function resolveManifest(
       };
     }
     case "error": {
-      const tracebackJson = await resolveContentRef(
-        manifest.traceback,
-        blobPort,
-      );
+      const tracebackJson = await resolveContentRef(manifest.traceback, blobPort);
       const traceback = JSON.parse(tracebackJson) as string[];
+      const rich = await resolveRich(manifest.rich, blobPort);
       return {
         output_id,
         output_type: "error",
         ename: manifest.ename,
         evalue: manifest.evalue,
         traceback,
+        rich,
       };
     }
+  }
+}
+
+/**
+ * Resolve the optional rich-traceback ContentRef into the parsed payload.
+ *
+ * Returns `undefined` when the manifest has no sibling OR the resolve
+ * returned malformed JSON. The caller (OutputArea) treats `undefined`
+ * as "fall back to AnsiErrorOutput", so a bad payload never blocks
+ * rendering — we just lose the rich upgrade.
+ */
+async function resolveRich(
+  ref: ContentRef | undefined,
+  blobPort: number,
+): Promise<Record<string, unknown> | undefined> {
+  if (!ref) return undefined;
+  try {
+    const json = await resolveContentRef(ref, blobPort);
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveRichSync(
+  ref: ContentRef | undefined,
+  blobPort: number,
+): Record<string, unknown> | undefined {
+  if (!ref) return undefined;
+  try {
+    const json = resolveContentRefSync(ref, blobPort);
+    if (json === null) return undefined;
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return undefined;
   }
 }
 
@@ -336,12 +381,14 @@ export function resolveManifestSync(
       const tracebackJson = resolveContentRefSync(manifest.traceback, blobPort);
       if (tracebackJson === null) return null;
       const traceback = JSON.parse(tracebackJson) as string[];
+      const rich = resolveRichSync(manifest.rich, blobPort);
       return {
         output_id,
         output_type: "error",
         ename: manifest.ename,
         evalue: manifest.evalue,
         traceback,
+        rich,
       };
     }
   }

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -297,10 +297,10 @@ export async function resolveManifest(
 /**
  * Resolve the optional rich-traceback ContentRef into the parsed payload.
  *
- * Returns `undefined` when the manifest has no sibling OR the resolve
- * returned malformed JSON. The caller (OutputArea) treats `undefined`
- * as "fall back to AnsiErrorOutput", so a bad payload never blocks
- * rendering — we just lose the rich upgrade.
+ * Returns `undefined` when the manifest has no sibling OR the JSON
+ * parse fails. The caller (OutputArea) treats `undefined` as "fall
+ * back to AnsiErrorOutput", so a malformed payload never blocks
+ * rendering — we just lose the rich upgrade for that one output.
  */
 async function resolveRich(
   ref: ContentRef | undefined,
@@ -315,17 +315,32 @@ async function resolveRich(
   }
 }
 
+/**
+ * Sync counterpart. Three-state to distinguish "no sibling" (caller
+ * finishes resolution) from "sibling exists but blob-backed" (caller
+ * must return null so the async path picks it up):
+ *
+ * - `"absent"`   → no sibling on the manifest, output is complete
+ * - `"async"`    → sibling present but needs a blob fetch
+ * - `{...}`      → resolved payload (or empty object for a malformed
+ *                  blob — async-retrying a parse failure would loop)
+ */
+type RichSyncResult = "absent" | "async" | Record<string, unknown>;
+
 function resolveRichSync(
   ref: ContentRef | undefined,
   blobPort: number,
-): Record<string, unknown> | undefined {
-  if (!ref) return undefined;
+): RichSyncResult {
+  if (!ref) return "absent";
+  const json = resolveContentRefSync(ref, blobPort);
+  if (json === null) return "async";
   try {
-    const json = resolveContentRefSync(ref, blobPort);
-    if (json === null) return undefined;
     return JSON.parse(json) as Record<string, unknown>;
   } catch {
-    return undefined;
+    // Resolved bytes parsed as non-JSON — TracebackOutput's fallback
+    // will render the raw object view. Async would just fail the same
+    // parse.
+    return {};
   }
 }
 
@@ -381,7 +396,12 @@ export function resolveManifestSync(
       const tracebackJson = resolveContentRefSync(manifest.traceback, blobPort);
       if (tracebackJson === null) return null;
       const traceback = JSON.parse(tracebackJson) as string[];
-      const rich = resolveRichSync(manifest.rich, blobPort);
+      const richResult = resolveRichSync(manifest.rich, blobPort);
+      // If the rich sibling exists but needs a blob fetch, defer the
+      // whole output to the async path. Otherwise callers treat this
+      // as fully resolved and never upgrade to rich rendering.
+      if (richResult === "async") return null;
+      const rich = richResult === "absent" ? undefined : richResult;
       return {
         output_id,
         output_type: "error",

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -64,6 +64,14 @@ export type JupyterOutput =
       ename: string;
       evalue: string;
       traceback: string[];
+      /**
+       * Optional rich-traceback sibling payload (see
+       * `src/components/cell/jupyter-output.ts` for the canonical doc).
+       * Present when the kernel emitted rich via
+       * `application/vnd.nteract.traceback+json` OR the daemon
+       * synthesized one from the ANSI traceback at `.ipynb` load.
+       */
+      rich?: unknown;
     });
 
 export interface KernelspecInfo {

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -19,6 +19,20 @@ fn main() {
     // rerun-if-changed above, cargo won't use its default behavior).
     println!("cargo:rerun-if-changed=build.rs");
 
+    // Re-run whenever the current HEAD moves so the embedded git hash
+    // reflects the tree actually being compiled. Without this, a `git
+    // checkout` or merge leaves cargo happy to reuse a stale OUT_DIR
+    // whose `git_hash.txt` points at a previous commit — the daemon
+    // then mis-reports its version (e.g. 7583085 after landing bf42cea)
+    // and anyone reading the status thinks the binary is out of date.
+    //
+    // `.git/HEAD` covers branch switches. `.git/refs/heads/<branch>`
+    // covers new commits on the current branch; we tell cargo to watch
+    // the packed-refs file too for the common "refs compacted" case.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+    println!("cargo:rerun-if-changed=../../.git/packed-refs");
+
     write_git_hash();
 }
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1150,7 +1150,7 @@ impl KernelConnection for JupyterKernel {
                                         continue;
                                     }
 
-                                    if let Some(_cid) = cell_id {
+                                    if let Some(cid) = cell_id.as_ref() {
                                         let _output_type = match &message.content {
                                             JupyterMessageContent::DisplayData(_) => "display_data",
                                             JupyterMessageContent::ExecuteResult(_) => {
@@ -1211,6 +1211,28 @@ impl KernelConnection for JupyterKernel {
                                             if let Err(e) = state_for_iopub.merge(&mut fork) {
                                                 warn!("[runtime-state] merge: {}", e);
                                             }
+                                        }
+
+                                        // Rich-traceback detection. A display_data or
+                                        // execute_result carrying TRACEBACK_MIME IS an error
+                                        // semantically — the launcher short-circuits
+                                        // `_showtraceback` and emits rich display_data instead
+                                        // of classic ErrorOutput. Without this, the runtime
+                                        // never flips `execution_had_error`, and
+                                        // `Execution.result().success` comes back true for
+                                        // failed cells. Route through the same CellError
+                                        // command the classic arm uses.
+                                        if matches!(
+                                            crate::user_error::UserErrorOutput::from_iopub(
+                                                &message.content
+                                            ),
+                                            Some(crate::user_error::UserErrorOutput::Rich(_))
+                                        ) {
+                                            let _ =
+                                                iopub_cmd_tx.try_send(QueueCommand::CellError {
+                                                    cell_id: cid.clone(),
+                                                    execution_id: eid,
+                                                });
                                         }
                                     }
                                 }

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -467,6 +467,13 @@ pub enum OutputManifest {
         traceback: ContentRef,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         llm_preview: Option<ErrorPreview>,
+        /// Rich traceback sibling — the structured payload the frontend's
+        /// `TracebackOutput` renders. Present when this error arrived
+        /// with [`user_error::TRACEBACK_MIME`] from the launcher, OR was
+        /// synthesized on load via the ANSI parser. In-memory only; not
+        /// serialized to `.ipynb` (see `resolve_manifest`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rich: Option<ContentRef>,
     },
 }
 
@@ -531,6 +538,35 @@ pub async fn create_manifest(
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
 
+    // Rich-MIME promotion. A display_data or execute_result carrying
+    // `application/vnd.nteract.traceback+json` IS an error — the
+    // launcher short-circuits `_showtraceback` to emit it this way. Keep
+    // the CRDT shape aligned with the nbformat semantic by building an
+    // `OutputManifest::Error` directly, with the rich payload carried
+    // as a sibling `ContentRef`. On save, `resolve_manifest` emits the
+    // classic nbformat shape and drops the sibling — .ipynb stays
+    // standards-clean.
+    if matches!(output_type, "display_data" | "execute_result") {
+        if let Some(ue) = crate::user_error::UserErrorOutput::from_nbformat(output) {
+            let (ename, evalue, traceback_strings) = ue.to_classic();
+            let rich_payload = match &ue {
+                crate::user_error::UserErrorOutput::Rich(rt) => Some(rt.clone()),
+                _ => None,
+            };
+            let manifest = build_error_manifest(
+                existing_output_id,
+                ename,
+                evalue,
+                traceback_strings,
+                rich_payload,
+                blob_store,
+                threshold,
+            )
+            .await?;
+            return Ok(manifest);
+        }
+    }
+
     let manifest = match output_type {
         "display_data" => {
             let data = convert_data_bundle(output.get("data"), blob_store, threshold).await?;
@@ -584,38 +620,50 @@ pub async fn create_manifest(
             }
         }
         "error" => {
-            let ename = output
-                .get("ename")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let evalue = output
-                .get("evalue")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let traceback_value = output
-                .get("traceback")
-                .cloned()
-                .unwrap_or(Value::Array(vec![]));
-            let traceback_json = serde_json::to_string(&traceback_value)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            let traceback =
-                ContentRef::from_data(&traceback_json, "application/json", blob_store, threshold)
-                    .await?;
-            let llm_preview = match &traceback {
-                ContentRef::Blob { .. } => {
-                    Some(ErrorPreview::from_traceback_value(&traceback_value))
+            // Go through UserErrorOutput so we can synthesize a rich
+            // sibling from the ANSI traceback when loading classic
+            // `.ipynb` error outputs. Missing ename/evalue fall through
+            // as empty strings (matches the previous behavior).
+            let ue = crate::user_error::UserErrorOutput::from_nbformat(output);
+            let (ename, evalue, traceback_strings, rich_payload) = match ue {
+                Some(u) => {
+                    let rich = u.to_rich();
+                    let (e, v, tb) = u.to_classic();
+                    (e, v, tb, rich)
                 }
-                ContentRef::Inline { .. } => None,
+                None => (
+                    output
+                        .get("ename")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    output
+                        .get("evalue")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    output
+                        .get("traceback")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    None,
+                ),
             };
-            OutputManifest::Error {
-                output_id: existing_output_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+            build_error_manifest(
+                existing_output_id,
                 ename,
                 evalue,
-                traceback,
-                llm_preview,
-            }
+                traceback_strings,
+                rich_payload,
+                blob_store,
+                threshold,
+            )
+            .await?
         }
         _ => {
             return Err(io::Error::new(
@@ -626,6 +674,64 @@ pub async fn create_manifest(
     };
 
     Ok(manifest)
+}
+
+/// Build an `OutputManifest::Error` from the canonical fields.
+///
+/// Used by `create_manifest` for both the classic error branch and the
+/// rich-MIME-promoted display_data/execute_result case. Centralizes:
+/// - the traceback-as-JSON-array ContentRef encoding,
+/// - llm_preview synthesis for blob'd tracebacks, and
+/// - the optional rich sibling encoding.
+async fn build_error_manifest(
+    existing_output_id: Option<String>,
+    ename: String,
+    evalue: String,
+    traceback_strings: Vec<String>,
+    rich_payload: Option<crate::user_error::RichTraceback>,
+    blob_store: &BlobStore,
+    threshold: usize,
+) -> io::Result<OutputManifest> {
+    let traceback_value = Value::Array(
+        traceback_strings
+            .iter()
+            .map(|s| Value::String(s.clone()))
+            .collect(),
+    );
+    let traceback_json = serde_json::to_string(&traceback_value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let traceback =
+        ContentRef::from_data(&traceback_json, "application/json", blob_store, threshold).await?;
+    let llm_preview = match &traceback {
+        ContentRef::Blob { .. } => Some(ErrorPreview::from_traceback_value(&traceback_value)),
+        ContentRef::Inline { .. } => None,
+    };
+
+    let rich = match rich_payload {
+        Some(rt) => {
+            let rich_json = serde_json::to_string(&rt)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Some(
+                ContentRef::from_data(
+                    &rich_json,
+                    crate::user_error::TRACEBACK_MIME,
+                    blob_store,
+                    threshold,
+                )
+                .await?,
+            )
+        }
+        None => None,
+    };
+
+    Ok(OutputManifest::Error {
+        output_id: existing_output_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+        ename,
+        evalue,
+        traceback,
+        llm_preview,
+        rich,
+    })
 }
 
 /// Write ref-MIME buffers to the blob store before the manifest is built.
@@ -1497,6 +1603,130 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(manifest, OutputManifest::Error { ename, .. } if ename == "ValueError"));
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_error_from_ipynb_synthesizes_rich_sibling() {
+        // A .ipynb-loaded classic error whose traceback carries recognizable
+        // frames should build an Error manifest WITH a `rich` sibling,
+        // synthesized via the ANSI parser. Lets loaded-from-disk notebooks
+        // render rich without per-cell parsing on the frontend.
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "error",
+            "ename": "ZeroDivisionError",
+            "evalue": "division by zero",
+            "traceback": [
+                "Traceback (most recent call last):",
+                "  File \"/tmp/foo.py\", line 10, in main",
+                "    return divide(1, 0)",
+                "  File \"/tmp/foo.py\", line 4, in divide",
+                "    return a / b",
+                "ZeroDivisionError: division by zero",
+            ],
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::Error { rich, .. } = manifest else {
+            panic!("expected Error manifest");
+        };
+        assert!(rich.is_some(), "rich sibling should be synthesized");
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_error_no_frames_no_rich_sibling() {
+        // If the ANSI parser can't recover any frames, we skip the rich
+        // sibling rather than emit a header-only payload.
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "bad",
+            "traceback": ["just some noise", "ValueError: bad"],
+        });
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::Error { rich, .. } = manifest else {
+            panic!("expected Error manifest");
+        };
+        assert!(rich.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_display_data_with_mime_promotes_to_error() {
+        // Launcher emits display_data carrying TRACEBACK_MIME. The manifest
+        // created here must be OutputManifest::Error with the rich sibling
+        // carrying the payload, and classic fields populated from
+        // `to_classic()` projection. On save, .ipynb will emit output_type:
+        // "error" with the recovered traceback[].
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let payload = serde_json::json!({
+            "ename": "KeyError",
+            "evalue": "'missing'",
+            "frames": [{"filename": "/tmp/x.py", "lineno": 2, "name": "f"}],
+            "text": "Traceback (most recent call last):\n  File \"/tmp/x.py\", line 2, in f\n    user[\"missing\"]\nKeyError: 'missing'",
+        });
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": { crate::user_error::TRACEBACK_MIME: payload },
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::Error {
+            ename,
+            evalue,
+            rich,
+            ..
+        } = manifest
+        else {
+            panic!("expected Error manifest (promoted from display_data)");
+        };
+        assert_eq!(ename, "KeyError");
+        assert_eq!(evalue, "'missing'");
+        assert!(rich.is_some(), "rich sibling should survive promotion");
+    }
+
+    #[tokio::test]
+    async fn test_error_manifest_resolves_back_to_classic_ipynb_shape() {
+        // End-to-end: the save path (`resolve_manifest`) strips the rich
+        // sibling so .ipynb stays standards-clean. Even a promoted
+        // display_data becomes output_type="error" on disk.
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let payload = serde_json::json!({
+            "ename": "KeyError",
+            "evalue": "'missing'",
+            "frames": [],
+            "text": "Traceback (most recent call last):\n  File \"/tmp/x.py\", line 1, in <module>\n    user[\"missing\"]\nKeyError: 'missing'",
+        });
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": { crate::user_error::TRACEBACK_MIME: payload },
+        });
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["output_type"], "error");
+        assert_eq!(resolved["ename"], "KeyError");
+        assert_eq!(resolved["evalue"], "'missing'");
+        assert!(resolved["traceback"].is_array());
+        assert!(
+            resolved.get("rich").is_none(),
+            "rich sibling must not leak to .ipynb"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/user_error.rs
+++ b/crates/runtimed/src/user_error.rs
@@ -79,6 +79,30 @@ pub enum UserErrorOutput {
 }
 
 impl UserErrorOutput {
+    /// Read an IOPub `JupyterMessageContent` and recognize a user error.
+    ///
+    /// Returns:
+    /// - `Classic` for `ErrorOutput { ename, evalue, traceback }`
+    /// - `Rich`    for `DisplayData` / `ExecuteResult` whose `data`
+    ///             contains [`TRACEBACK_MIME`]
+    /// - `None`    otherwise
+    ///
+    /// This is the runtime agent's single entry point for deciding
+    /// "did user code raise?" — both wire shapes route through it.
+    pub fn from_iopub(content: &jupyter_protocol::JupyterMessageContent) -> Option<Self> {
+        use jupyter_protocol::JupyterMessageContent as J;
+        match content {
+            J::ErrorOutput(err) => Some(UserErrorOutput::Classic {
+                ename: err.ename.clone(),
+                evalue: err.evalue.clone(),
+                traceback: err.traceback.clone(),
+            }),
+            J::DisplayData(dd) => media_rich(&dd.data).map(UserErrorOutput::Rich),
+            J::ExecuteResult(er) => media_rich(&er.data).map(UserErrorOutput::Rich),
+            _ => None,
+        }
+    }
+
     /// Read an nbformat-shaped output value and recognize a user error.
     ///
     /// Returns:
@@ -167,6 +191,23 @@ fn rich_from_value(raw: &serde_json::Value) -> Option<RichTraceback> {
         serde_json::Value::String(s) => serde_json::from_str(s).ok(),
         other => serde_json::from_value(other.clone()).ok(),
     }
+}
+
+/// Scan a `Media` bundle for our traceback MIME and decode the payload.
+///
+/// The `MediaType::Other((mime, value))` arm is where custom MIMEs land
+/// on the Rust side after jupyter-protocol deserializes IOPub JSON.
+/// We accept both object and stringified-JSON payload shapes (mirrors
+/// the nbformat path — some publish routes stringify vnd.* MIMEs).
+fn media_rich(data: &jupyter_protocol::Media) -> Option<RichTraceback> {
+    for mt in &data.content {
+        if let jupyter_protocol::MediaType::Other((mime, value)) = mt {
+            if mime == TRACEBACK_MIME {
+                return rich_from_value(value);
+            }
+        }
+    }
+    None
 }
 
 // ─── ANSI traceback parser ────────────────────────────────────────────────
@@ -491,6 +532,132 @@ fn build_paste_text(stripped: &str, ename: &str, evalue: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ── UserErrorOutput::from_iopub ──────────────────────────────────
+
+    fn rich_payload() -> serde_json::Value {
+        json!({
+            "ename": "KeyError",
+            "evalue": "'x'",
+            "frames": [{"filename": "/tmp/x.py", "lineno": 1, "name": "f"}],
+            "text": "KeyError: 'x'",
+        })
+    }
+
+    #[test]
+    fn from_iopub_error_output_is_classic() {
+        let content =
+            jupyter_protocol::JupyterMessageContent::ErrorOutput(jupyter_protocol::ErrorOutput {
+                ename: "ZeroDivisionError".into(),
+                evalue: "division by zero".into(),
+                traceback: vec!["line1".into(), "line2".into()],
+            });
+        let ue = UserErrorOutput::from_iopub(&content).unwrap();
+        match ue {
+            UserErrorOutput::Classic {
+                ename,
+                evalue,
+                traceback,
+            } => {
+                assert_eq!(ename, "ZeroDivisionError");
+                assert_eq!(evalue, "division by zero");
+                assert_eq!(traceback.len(), 2);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn from_iopub_display_data_with_mime_is_rich() {
+        let data = jupyter_protocol::Media {
+            content: vec![jupyter_protocol::MediaType::Other((
+                TRACEBACK_MIME.to_string(),
+                rich_payload(),
+            ))],
+        };
+        let content =
+            jupyter_protocol::JupyterMessageContent::DisplayData(jupyter_protocol::DisplayData {
+                data,
+                metadata: Default::default(),
+                transient: None,
+            });
+        let ue = UserErrorOutput::from_iopub(&content).unwrap();
+        match ue {
+            UserErrorOutput::Rich(rt) => {
+                assert_eq!(rt.ename, "KeyError");
+                assert_eq!(rt.evalue, "'x'");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn from_iopub_execute_result_with_mime_is_rich() {
+        // Some emitters use execute_result for last-expression errors.
+        let data = jupyter_protocol::Media {
+            content: vec![jupyter_protocol::MediaType::Other((
+                TRACEBACK_MIME.to_string(),
+                rich_payload(),
+            ))],
+        };
+        let content = jupyter_protocol::JupyterMessageContent::ExecuteResult(
+            jupyter_protocol::ExecuteResult {
+                execution_count: jupyter_protocol::ExecutionCount::new(1),
+                data,
+                metadata: Default::default(),
+                transient: None,
+            },
+        );
+        let ue = UserErrorOutput::from_iopub(&content).unwrap();
+        assert!(matches!(ue, UserErrorOutput::Rich(_)));
+    }
+
+    #[test]
+    fn from_iopub_display_data_without_mime_is_none() {
+        let data = jupyter_protocol::Media {
+            content: vec![jupyter_protocol::MediaType::Plain("plain text".into())],
+        };
+        let content =
+            jupyter_protocol::JupyterMessageContent::DisplayData(jupyter_protocol::DisplayData {
+                data,
+                metadata: Default::default(),
+                transient: None,
+            });
+        assert!(UserErrorOutput::from_iopub(&content).is_none());
+    }
+
+    #[test]
+    fn from_iopub_stringified_mime_payload_is_rich() {
+        // Mirror the nbformat stringified case: the value can be a JSON string.
+        let as_str = serde_json::to_string(&rich_payload()).unwrap();
+        let data = jupyter_protocol::Media {
+            content: vec![jupyter_protocol::MediaType::Other((
+                TRACEBACK_MIME.to_string(),
+                serde_json::Value::String(as_str),
+            ))],
+        };
+        let content =
+            jupyter_protocol::JupyterMessageContent::DisplayData(jupyter_protocol::DisplayData {
+                data,
+                metadata: Default::default(),
+                transient: None,
+            });
+        assert!(matches!(
+            UserErrorOutput::from_iopub(&content).unwrap(),
+            UserErrorOutput::Rich(_)
+        ));
+    }
+
+    #[test]
+    fn from_iopub_unrelated_messages_are_none() {
+        let content = jupyter_protocol::JupyterMessageContent::StreamContent(
+            jupyter_protocol::StreamContent {
+                name: jupyter_protocol::Stdio::Stdout,
+                text: "hi\n".into(),
+            },
+        );
+        assert!(UserErrorOutput::from_iopub(&content).is_none());
+    }
 
     // ── UserErrorOutput::from_nbformat ───────────────────────────────
 

--- a/crates/runtimed/src/user_error.rs
+++ b/crates/runtimed/src/user_error.rs
@@ -83,9 +83,9 @@ impl UserErrorOutput {
     ///
     /// Returns:
     /// - `Classic` for `ErrorOutput { ename, evalue, traceback }`
-    /// - `Rich`    for `DisplayData` / `ExecuteResult` whose `data`
-    ///             contains [`TRACEBACK_MIME`]
-    /// - `None`    otherwise
+    /// - `Rich` for `DisplayData` / `ExecuteResult` whose `data` contains
+    ///   [`TRACEBACK_MIME`]
+    /// - `None` otherwise
     ///
     /// This is the runtime agent's single entry point for deciding
     /// "did user code raise?" — both wire shapes route through it.

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -10,6 +10,7 @@ import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
+import { TracebackOutput } from "@/components/outputs/traceback-output";
 import { useWidgetStore } from "@/components/widgets/widget-store-context";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -201,6 +202,14 @@ function renderOutput(
       );
 
     case "error":
+      // Rich sibling is set by the daemon when either the kernel
+      // emitted `application/vnd.nteract.traceback+json` (launcher path)
+      // or the Rust-side ANSI parser synthesized one at `.ipynb` load.
+      // When absent, fall back to the plain ANSI render — the classic
+      // path still works for vanilla ipykernel_launcher.
+      if (output.rich != null && typeof output.rich === "object") {
+        return <TracebackOutput key={key} data={output.rich} />;
+      }
       return (
         <AnsiErrorOutput
           key={key}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -426,19 +426,37 @@ export function OutputArea({
           outputIndex: index,
         });
       } else if (output.output_type === "error") {
-        batch.push({
-          mimeType: "text/plain",
-          data: output.traceback.join("\n"),
-          metadata: {
-            isError: true,
-            ename: output.ename,
-            evalue: output.evalue,
-            traceback: output.traceback,
-          },
-          outputId,
-          cellId,
-          outputIndex: index,
-        });
+        // Prefer the rich payload when present so mixed cells (HTML +
+        // raise, plotly + raise, widget + raise) don't downgrade to
+        // plain ANSI just because a sibling output forced iframe
+        // isolation. The iframe's OutputRenderer routes the rich MIME
+        // through TracebackOutput; without this branch we'd send
+        // text/plain and the iframe's AnsiErrorOutput fallback would
+        // win, losing the rich upgrade.
+        if (output.rich != null && typeof output.rich === "object") {
+          batch.push({
+            mimeType: "application/vnd.nteract.traceback+json",
+            data: output.rich,
+            metadata: { isError: true },
+            outputId,
+            cellId,
+            outputIndex: index,
+          });
+        } else {
+          batch.push({
+            mimeType: "text/plain",
+            data: output.traceback.join("\n"),
+            metadata: {
+              isError: true,
+              ename: output.ename,
+              evalue: output.evalue,
+              traceback: output.traceback,
+            },
+            outputId,
+            cellId,
+            outputIndex: index,
+          });
+        }
       }
     });
 

--- a/src/components/cell/jupyter-output.ts
+++ b/src/components/cell/jupyter-output.ts
@@ -32,4 +32,17 @@ export type JupyterOutput =
       ename: string;
       evalue: string;
       traceback: string[];
+      /**
+       * Optional rich-traceback sibling payload. Carries the structured
+       * traceback shape `TracebackOutput` expects (ename, evalue,
+       * frames with source context, highlight markers). Present when:
+       *
+       * - the kernel emitted rich via `application/vnd.nteract.traceback+json`
+       *   (nteract-kernel-launcher path), OR
+       * - the daemon synthesized one from the ANSI traceback at
+       *   `.ipynb` load via the Rust-side parser.
+       *
+       * When absent, the output renders via plain `AnsiErrorOutput`.
+       */
+      rich?: unknown;
     });

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -36,6 +36,7 @@ import { ImageOutput } from "@/components/outputs/image-output";
 import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { PdfOutput } from "@/components/outputs/pdf-output";
+import { TracebackOutput } from "@/components/outputs/traceback-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -392,7 +393,15 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
     );
   }
 
-  // Handle error output
+  // Rich traceback MIME — take precedence over the text/plain error
+  // fallback so cells that mix rich outputs with errors (e.g., display
+  // HTML then raise) still get the rich render inside the iframe.
+  if (mimeType === "application/vnd.nteract.traceback+json") {
+    return <TracebackOutput data={data} />;
+  }
+
+  // Handle error output (classic ANSI path — fallback when no rich
+  // sibling was available to promote above).
   if (mimeType === "text/plain" && metadata?.isError) {
     return (
       <AnsiErrorOutput


### PR DESCRIPTION
Follow-up to #2142. Wires `UserErrorOutput` through runtime state, manifest creation, save, load, and frontend rendering so a "user code raised" event has one consistent shape regardless of wire format.

## Overview

**IOPub classification.** `UserErrorOutput::from_iopub` is the single entry point the runtime agent consults to decide "did user code raise?" It recognizes both `JupyterMessageContent::ErrorOutput` (classic ANSI-string form from vanilla `ipykernel_launcher`) and `DisplayData` / `ExecuteResult` whose Media carries `application/vnd.nteract.traceback+json` (rich form from `nteract-kernel-launcher`).

**Runtime state (Codex P1 on #2141).** The launcher short-circuits IPython's `_showtraceback` and emits rich display_data in place of classic `ErrorOutput`. Without this fix the runtime agent missed the error, `execution_had_error` stayed false, and `Execution.result().success` lied for failed cells. The cell-path IOPub dispatcher now consults `from_iopub` on every display_data / execute_result and queues `QueueCommand::CellError` when classified as Rich. The classic arm is untouched.

**Manifest creation.** Centralized in `build_error_manifest`. Both branches produce `OutputManifest::Error` with an optional `rich: Option<ContentRef>` sibling:

- `display_data` / `execute_result` with the rich MIME → Error manifest carrying the kernel's own structured payload.
- Classic `output_type: "error"` → Error manifest; the ANSI parser synthesizes a rich sibling when frames can be recovered. Loaded-from-disk notebooks pick up rich rendering for free.

**Save path.** `resolve_manifest` already matched `Error { .., rich: _, .. }`, so the sibling is dropped when writing `.ipynb`. Files on disk stay standards-compliant: `{output_type, ename, evalue, traceback[]}`, no custom fields, no rich leakage. A round-trip test asserts this invariant.

**Frontend routing.** `OutputManifest` TS type gains `rich?: ContentRef`. `resolveManifest` / `resolveManifestSync` resolve the sibling via inline/blob and attach it to the `JupyterOutput`. The sync path is three-state (`absent` / `async` / resolved) so blob-backed rich payloads defer to async rather than silently downgrade. `OutputArea.renderOutput` routes to `TracebackOutput` when `output.rich` is present, else falls back to `AnsiErrorOutput`. The iframe batch path (triggered when any sibling output forces isolation) sends the rich MIME through so HTML/plotly/widget + raise combos stay rich instead of downgrading to plain ANSI.

## Design decision: rich-traceback synthesis is always-on

No feature-flag gate on the synthesis itself. `bootstrap_dx` gates the launcher Python that runs inside the kernel. That's where the scariest surface area lives (custom IPython hooks, bootstrap extension, new emission path). The daemon-side ANSI → rich conversion is the mitigation, not the risk: a pure function over already-emitted wire bytes, never writes custom fields to disk, falls back cleanly to `AnsiErrorOutput` when the parser returns `None`. Gating synthesis behind the same flag would add plumbing for no safety benefit.

## Behavioral coverage

| Source | Outcome |
|---|---|
| Launcher (`bootstrap_dx` ON) emits rich display_data | `OutputManifest::Error` + rich sibling (kernel's payload) → `TracebackOutput` |
| Vanilla `ipykernel_launcher` emits classic `ErrorOutput` with parseable ANSI | `OutputManifest::Error` + synthesized rich sibling → `TracebackOutput` |
| Kernel with non-IPython traceback, no recognizable frame headers | `OutputManifest::Error`, `rich: None` → `AnsiErrorOutput` fallback |
| `.ipynb` on disk | Standard `{output_type, ename, evalue, traceback[]}`. No custom fields |
| Any of the above inside a cell that also emits iframe-isolated output | Same outcome, preserved through iframe batch path |

## Incidental: daemon git hash drift

`crates/runtimed/build.rs` only had `cargo:rerun-if-changed=build.rs`, so cargo reused a cached `git_hash.txt` across branch switches and new commits. The embedded hash drifted from whatever tree was being compiled. Added rerun directives for `.git/HEAD`, `.git/index`, and `.git/packed-refs` so the hash tracks HEAD movement. Daemon now correctly reports `2.3.0+<short-sha>+dirty`.