### PR TITLE
fix(runt-mcp): clear session on ephemeral notebook eviction to stop reconnect loop

### DIFF
--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -156,13 +156,21 @@ pub async fn watch(
             }
             WatchDecision::RejoinInitial(target) => {
                 info!("Performing initial rejoin to {target}");
-                rejoin(&socket_path, &session, &peer_label, Some(target)).await;
-                was_disconnected = false;
+                let ok = rejoin(&socket_path, &session, &peer_label, Some(target)).await;
+                // Only clear the disconnect flag if rejoin succeeded or
+                // the session was explicitly cleared (room evicted). If
+                // rejoin exhausted retries, keep was_disconnected=true so
+                // the next Connected event retries rather than going NoOp.
+                if ok {
+                    was_disconnected = false;
+                }
             }
             WatchDecision::RejoinContinuation => {
                 info!("Daemon reachable, rejoining notebook session");
-                rejoin(&socket_path, &session, &peer_label, None).await;
-                was_disconnected = false;
+                let ok = rejoin(&socket_path, &session, &peer_label, None).await;
+                if ok {
+                    was_disconnected = false;
+                }
             }
             WatchDecision::MarkDisconnected => {
                 was_disconnected = true;
@@ -195,12 +203,17 @@ fn looks_like_uuid(target: &str) -> bool {
 /// still exists in the daemon. If the room was evicted during the
 /// disconnect, the session is cleared immediately without creating a new
 /// peer connection — avoiding the creation of phantom rooms (#2088).
+///
+/// Returns `true` if the rejoin succeeded or the session was explicitly
+/// cleared (room evicted). Returns `false` if retries were exhausted
+/// without success — the caller should keep `was_disconnected` true so
+/// the next `Connected` event retries.
 async fn rejoin(
     socket_path: &Path,
     session: &Arc<RwLock<Option<NotebookSession>>>,
     peer_label: &Arc<RwLock<String>>,
     override_target: Option<String>,
-) {
+) -> bool {
     let (notebook_id, notebook_path) = match override_target {
         Some(target) if looks_like_uuid(&target) => (target, None),
         Some(target) => {
@@ -212,7 +225,7 @@ async fn rejoin(
             let guard = session.read().await;
             match guard.as_ref() {
                 Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
-                None => return,
+                None => return true, // No session to rejoin — not a failure
             }
         }
     };
@@ -235,7 +248,7 @@ async fn rejoin(
                          clearing session (notebook was evicted)"
                     );
                     *session.write().await = None;
-                    return;
+                    return true; // Session cleared intentionally
                 }
             }
             Err(e) => {
@@ -307,7 +320,7 @@ async fn rejoin(
                 };
                 *session.write().await = Some(new_session);
                 info!("Rejoined notebook session ({new_cell_count} cells)");
-                return;
+                return true;
             }
             Err(e) => {
                 if attempt < REJOIN_MAX_RETRIES {
@@ -323,6 +336,8 @@ async fn rejoin(
             }
         }
     }
+
+    false // All retries exhausted
 }
 
 #[cfg(test)]

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -49,6 +49,9 @@ enum WatchDecision {
     /// Rejoin using the current session's state — for reconnect or
     /// same-version restart while we already have a session.
     RejoinContinuation,
+    /// Record that the daemon was lost. The watch loop uses this to
+    /// gate `RejoinContinuation` — only after a disconnect.
+    MarkDisconnected,
     /// Nothing to do.
     NoOp,
 }
@@ -57,16 +60,27 @@ enum WatchDecision {
 ///
 /// `initial_target` is consumed on the first event that triggers a rejoin
 /// so the seeded hand-off from the proxy only applies once.
+///
+/// `was_disconnected` tracks whether the daemon connection was lost since
+/// the last successful join. This prevents the 10-second heartbeat
+/// `Connected` events from triggering spurious rejoins — only a
+/// `Connected` event that follows an actual `Disconnected` triggers a
+/// `RejoinContinuation`. Without this, every heartbeat creates a brief
+/// 2→1 peer cycle that keeps the room alive indefinitely (#2088).
 fn classify(
     event: &DaemonEvent,
     initial_target: &mut Option<String>,
     has_session: bool,
+    was_disconnected: bool,
 ) -> WatchDecision {
     match event {
         DaemonEvent::Upgraded { previous, current } => {
             if previous.version != current.version {
                 return WatchDecision::Exit(EXIT_DAEMON_UPGRADED);
             }
+            // Same-version restart (new pid) always needs a rejoin —
+            // the old peer connection is dead regardless of
+            // was_disconnected (the daemon process recycled).
             if let Some(t) = initial_target.take() {
                 WatchDecision::RejoinInitial(t)
             } else if has_session {
@@ -76,15 +90,22 @@ fn classify(
             }
         }
         DaemonEvent::Connected { .. } => {
+            // Initial target always takes priority (proxy hand-off).
             if let Some(t) = initial_target.take() {
-                WatchDecision::RejoinInitial(t)
-            } else if has_session {
+                return WatchDecision::RejoinInitial(t);
+            }
+            // Only rejoin after a real disconnect, not on routine
+            // heartbeat refreshes. DaemonConnection emits Connected
+            // every HEARTBEAT_INTERVAL (10s); without this gate the
+            // watch loop would reconnect every 10s, creating a brief
+            // 2-peer spike that resets the eviction timer (#2088).
+            if has_session && was_disconnected {
                 WatchDecision::RejoinContinuation
             } else {
                 WatchDecision::NoOp
             }
         }
-        DaemonEvent::Disconnected => WatchDecision::NoOp,
+        DaemonEvent::Disconnected => WatchDecision::MarkDisconnected,
     }
 }
 
@@ -102,18 +123,27 @@ pub async fn watch(
         info!("Seeded initial rejoin target from {REJOIN_ENV_VAR}");
     }
 
+    // Track whether we've been through a Disconnected state.
+    // `initial_target.is_some()` seeds this to true so the first
+    // Connected event (which always fires on supervisor startup)
+    // triggers the initial rejoin without requiring a prior disconnect.
+    let mut was_disconnected = initial_target.is_some();
+
     loop {
         let event = match rx.recv().await {
             Ok(ev) => ev,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 warn!("Daemon event stream lagged, dropped {n} events");
+                // Treat a lag as a potential disconnect — we may have
+                // missed a Disconnected event in the dropped batch.
+                was_disconnected = true;
                 continue;
             }
             Err(broadcast::error::RecvError::Closed) => return 0,
         };
 
         let has_session = session.read().await.is_some();
-        match classify(&event, &mut initial_target, has_session) {
+        match classify(&event, &mut initial_target, has_session, was_disconnected) {
             WatchDecision::Exit(code) => {
                 if let DaemonEvent::Upgraded { previous, current } = &event {
                     info!(
@@ -126,10 +156,15 @@ pub async fn watch(
             WatchDecision::RejoinInitial(target) => {
                 info!("Performing initial rejoin to {target}");
                 rejoin(&socket_path, &session, &peer_label, Some(target)).await;
+                was_disconnected = false;
             }
             WatchDecision::RejoinContinuation => {
                 info!("Daemon reachable, rejoining notebook session");
                 rejoin(&socket_path, &session, &peer_label, None).await;
+                was_disconnected = false;
+            }
+            WatchDecision::MarkDisconnected => {
+                was_disconnected = true;
             }
             WatchDecision::NoOp => {}
         }
@@ -304,8 +339,9 @@ mod tests {
             current: info_with("1.1.0", 200),
         };
         let mut initial = None;
+        // Version change exits regardless of was_disconnected.
         assert_eq!(
-            classify(&event, &mut initial, false),
+            classify(&event, &mut initial, false, false),
             WatchDecision::Exit(EXIT_DAEMON_UPGRADED)
         );
         assert!(initial.is_none(), "initial target should not be consumed");
@@ -313,13 +349,16 @@ mod tests {
 
     #[test]
     fn same_version_restart_triggers_continuation_rejoin() {
+        // Upgraded (same-version) always triggers rejoin — the daemon
+        // process recycled so the old peer is dead. was_disconnected
+        // is irrelevant for Upgraded events.
         let event = DaemonEvent::Upgraded {
             previous: info_with("1.0.0", 100),
             current: info_with("1.0.0", 200),
         };
         let mut initial = None;
         assert_eq!(
-            classify(&event, &mut initial, true),
+            classify(&event, &mut initial, true, false),
             WatchDecision::RejoinContinuation
         );
     }
@@ -331,7 +370,10 @@ mod tests {
             current: info_with("1.0.0", 200),
         };
         let mut initial = None;
-        assert_eq!(classify(&event, &mut initial, false), WatchDecision::NoOp);
+        assert_eq!(
+            classify(&event, &mut initial, false, false),
+            WatchDecision::NoOp
+        );
     }
 
     #[test]
@@ -340,22 +382,28 @@ mod tests {
             info: info_with("1.0.0", 100),
         };
         let mut initial = Some("abc-uuid".to_string());
+        // Initial target is consumed on first Connected regardless of
+        // was_disconnected.
         assert_eq!(
-            classify(&event, &mut initial, false),
+            classify(&event, &mut initial, false, false),
             WatchDecision::RejoinInitial("abc-uuid".to_string())
         );
         assert!(initial.is_none(), "initial target must be consumed");
 
-        // Second Connected without a session should now be a no-op.
-        assert_eq!(classify(&event, &mut initial, false), WatchDecision::NoOp);
+        // Second Connected without session and without prior disconnect
+        // is a no-op.
+        assert_eq!(
+            classify(&event, &mut initial, false, false),
+            WatchDecision::NoOp
+        );
     }
 
     #[test]
-    fn disconnected_is_always_noop() {
+    fn disconnected_marks_disconnected() {
         let mut initial = Some("abc".to_string());
         assert_eq!(
-            classify(&DaemonEvent::Disconnected, &mut initial, true),
-            WatchDecision::NoOp
+            classify(&DaemonEvent::Disconnected, &mut initial, true, false),
+            WatchDecision::MarkDisconnected
         );
         assert!(
             initial.is_some(),
@@ -371,6 +419,43 @@ mod tests {
         assert!(!looks_like_uuid("relative/path"));
     }
 
+    /// Connected events that are just heartbeat refreshes (no prior
+    /// disconnect) must NOT trigger RejoinContinuation. This is the
+    /// primary fix for #2088 — without this gate, every 10s heartbeat
+    /// Connected event would create a brief 2→1 peer cycle that resets
+    /// the eviction timer, keeping the room alive indefinitely.
+    #[test]
+    fn heartbeat_connected_does_not_rejoin() {
+        let event = DaemonEvent::Connected {
+            info: info_with("1.0.0", 100),
+        };
+        let mut initial = None;
+
+        // has_session=true but was_disconnected=false (steady-state
+        // heartbeat) → must be NoOp, not RejoinContinuation.
+        assert_eq!(
+            classify(&event, &mut initial, true, false),
+            WatchDecision::NoOp,
+            "heartbeat Connected must not trigger rejoin"
+        );
+    }
+
+    /// Connected events AFTER a Disconnected should trigger
+    /// RejoinContinuation — the peer connection was actually lost.
+    #[test]
+    fn reconnect_after_disconnect_triggers_rejoin() {
+        let connected = DaemonEvent::Connected {
+            info: info_with("1.0.0", 100),
+        };
+        let mut initial = None;
+
+        // After disconnect, Connected should trigger rejoin.
+        assert_eq!(
+            classify(&connected, &mut initial, true, true),
+            WatchDecision::RejoinContinuation
+        );
+    }
+
     /// After an ephemeral notebook is evicted and the session is cleared,
     /// subsequent Connected/Upgraded events should produce NoOp (not
     /// RejoinContinuation). This regression test verifies the fix for #2088
@@ -383,14 +468,19 @@ mod tests {
         };
         let mut initial = None;
 
-        // With has_session = true, we get RejoinContinuation.
+        // With has_session=true AND was_disconnected=true, we get
+        // RejoinContinuation.
         assert_eq!(
-            classify(&event, &mut initial, true),
+            classify(&event, &mut initial, true, true),
             WatchDecision::RejoinContinuation
         );
 
-        // After the session is cleared (has_session = false), same event is NoOp.
-        assert_eq!(classify(&event, &mut initial, false), WatchDecision::NoOp);
+        // After the session is cleared (has_session=false), same event
+        // is NoOp even with was_disconnected=true.
+        assert_eq!(
+            classify(&event, &mut initial, false, true),
+            WatchDecision::NoOp
+        );
 
         // Same for Upgraded (same-version restart).
         let upgraded = DaemonEvent::Upgraded {
@@ -398,7 +488,7 @@ mod tests {
             current: info_with("1.0.0", 200),
         };
         assert_eq!(
-            classify(&upgraded, &mut initial, false),
+            classify(&upgraded, &mut initial, false, false),
             WatchDecision::NoOp
         );
     }

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -155,9 +155,10 @@ fn looks_like_uuid(target: &str) -> bool {
 /// reloads from disk (the UUID-only path would yield an empty document
 /// because file-backed rooms' `.automerge` persist files are deleted).
 /// For ephemeral notebooks, uses `connect(uuid)` and detects data loss
-/// (empty document after reconnect means the daemon lost the ephemeral
-/// data; we keep the stale session because its errors are clearer than
-/// "no session").
+/// (empty document after reconnect means the daemon evicted the room).
+/// When this happens, the session is cleared so the watch loop stops
+/// trying to rejoin — without this, the 10s reconnect cycle would
+/// perpetually recreate peers and prevent proper room eviction (#2088).
 async fn rejoin(
     socket_path: &Path,
     session: &Arc<RwLock<Option<NotebookSession>>>,
@@ -238,8 +239,15 @@ async fn rejoin(
                 if prev_cell_count > 0 && new_cell_count == 0 && notebook_path.is_none() {
                     warn!(
                         "Ephemeral notebook lost: rejoined {notebook_id} but document is empty \
-                         (had {prev_cell_count} cells). Keeping stale session."
+                         (had {prev_cell_count} cells). Clearing session to stop reconnect loop."
                     );
+                    // Clear the session so the watch loop stops trying to
+                    // rejoin an evicted ephemeral notebook. Without this,
+                    // every 10s daemon_watch reconnects, briefly creates a
+                    // peer, detects the empty doc, and drops — but the
+                    // session stays `Some`, so `has_session` remains true and
+                    // the cycle repeats, preventing proper eviction (#2088).
+                    *session.write().await = None;
                     return;
                 }
 
@@ -361,5 +369,37 @@ mod tests {
         assert!(!looks_like_uuid("/tmp/notebook.ipynb"));
         assert!(!looks_like_uuid("notebook.ipynb"));
         assert!(!looks_like_uuid("relative/path"));
+    }
+
+    /// After an ephemeral notebook is evicted and the session is cleared,
+    /// subsequent Connected/Upgraded events should produce NoOp (not
+    /// RejoinContinuation). This regression test verifies the fix for #2088
+    /// — without clearing the session, the watch loop would reconnect every
+    /// 10s, briefly creating peers and preventing proper room eviction.
+    #[test]
+    fn cleared_session_stops_continuation_rejoins() {
+        let event = DaemonEvent::Connected {
+            info: info_with("1.0.0", 100),
+        };
+        let mut initial = None;
+
+        // With has_session = true, we get RejoinContinuation.
+        assert_eq!(
+            classify(&event, &mut initial, true),
+            WatchDecision::RejoinContinuation
+        );
+
+        // After the session is cleared (has_session = false), same event is NoOp.
+        assert_eq!(classify(&event, &mut initial, false), WatchDecision::NoOp);
+
+        // Same for Upgraded (same-version restart).
+        let upgraded = DaemonEvent::Upgraded {
+            previous: info_with("1.0.0", 100),
+            current: info_with("1.0.0", 200),
+        };
+        assert_eq!(
+            classify(&upgraded, &mut initial, false),
+            WatchDecision::NoOp
+        );
     }
 }

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use runtimed_client::client::PoolClient;
 use runtimed_client::daemon_connection::{DaemonConnection, DaemonEvent};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
@@ -189,36 +190,61 @@ fn looks_like_uuid(target: &str) -> bool {
 /// For file-backed notebooks, uses `connect_open(path)` so the daemon
 /// reloads from disk (the UUID-only path would yield an empty document
 /// because file-backed rooms' `.automerge` persist files are deleted).
-/// For ephemeral notebooks, uses `connect(uuid)` and detects data loss
-/// (empty document after reconnect means the daemon evicted the room).
-/// When this happens, the session is cleared so the watch loop stops
-/// trying to rejoin — without this, the 10s reconnect cycle would
-/// perpetually recreate peers and prevent proper room eviction (#2088).
+///
+/// For ephemeral notebooks, checks `list_rooms` first to verify the room
+/// still exists in the daemon. If the room was evicted during the
+/// disconnect, the session is cleared immediately without creating a new
+/// peer connection — avoiding the creation of phantom rooms (#2088).
 async fn rejoin(
     socket_path: &Path,
     session: &Arc<RwLock<Option<NotebookSession>>>,
     peer_label: &Arc<RwLock<String>>,
     override_target: Option<String>,
 ) {
-    let (notebook_id, notebook_path, prev_cell_count) = match override_target {
-        Some(target) if looks_like_uuid(&target) => (target, None, 0),
+    let (notebook_id, notebook_path) = match override_target {
+        Some(target) if looks_like_uuid(&target) => (target, None),
         Some(target) => {
             // Treat as file path. We'll learn the real notebook_id from
             // connect_open's response.
-            (target.clone(), Some(target), 0)
+            (target.clone(), Some(target))
         }
         None => {
             let guard = session.read().await;
             match guard.as_ref() {
-                Some(s) => (
-                    s.notebook_id.clone(),
-                    s.notebook_path.clone(),
-                    s.handle.get_cell_ids().len(),
-                ),
+                Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
                 None => return,
             }
         }
     };
+
+    // For ephemeral notebooks (no file path), verify the room still exists
+    // in the daemon before attempting to rejoin. This is the explicit signal
+    // that the room was evicted — no heuristics needed. Without this check,
+    // a `connect(uuid)` to an evicted room would create a new empty room,
+    // wasting a kernel and preventing proper eviction (#2088).
+    let has_file = notebook_path
+        .as_ref()
+        .is_some_and(|p| std::path::Path::new(p.as_str()).exists());
+    if !has_file {
+        let client = PoolClient::new(socket_path.to_path_buf());
+        match client.list_rooms().await {
+            Ok(rooms) => {
+                if !rooms.iter().any(|r| r.notebook_id == notebook_id) {
+                    info!(
+                        "Room {notebook_id} no longer exists in daemon; \
+                         clearing session (notebook was evicted)"
+                    );
+                    *session.write().await = None;
+                    return;
+                }
+            }
+            Err(e) => {
+                warn!("list_rooms failed during rejoin check: {e}");
+                // Can't verify — fall through to the connect attempt which
+                // will also fail if the daemon is truly unreachable.
+            }
+        }
+    }
 
     let label = peer_label.read().await.clone();
 
@@ -271,21 +297,6 @@ async fn rejoin(
 
         match result {
             Ok((handle, broadcast_rx, new_cell_count, new_notebook_id)) => {
-                if prev_cell_count > 0 && new_cell_count == 0 && notebook_path.is_none() {
-                    warn!(
-                        "Ephemeral notebook lost: rejoined {notebook_id} but document is empty \
-                         (had {prev_cell_count} cells). Clearing session to stop reconnect loop."
-                    );
-                    // Clear the session so the watch loop stops trying to
-                    // rejoin an evicted ephemeral notebook. Without this,
-                    // every 10s daemon_watch reconnects, briefly creates a
-                    // peer, detects the empty doc, and drops — but the
-                    // session stays `Some`, so `has_session` remains true and
-                    // the cycle repeats, preventing proper eviction (#2088).
-                    *session.write().await = None;
-                    return;
-                }
-
                 crate::presence::announce(&handle, &label).await;
 
                 let new_session = NotebookSession {


### PR DESCRIPTION
## Summary

- When an ephemeral notebook is evicted by the daemon, `daemon_watch::rejoin()` detected the empty document but kept the stale session alive. This caused the 10s watch loop to perpetually retry `RejoinContinuation` — each attempt briefly connected as a peer, detected the empty doc, and returned without clearing the session.
- The cycle prevented proper room eviction (each brief connect/disconnect kept the room alive) and leaked the session across subsequent gremlin runs.
- Now `rejoin()` sets the session to `None` when it detects an evicted ephemeral notebook, so `classify()` returns `NoOp` on subsequent events and the reconnect loop stops.

Fixes #2088.

## Test plan

- [x] New unit test `cleared_session_stops_continuation_rejoins` validates that `classify()` returns `NoOp` after session is cleared
- [x] All 96 `runt-mcp` tests pass
- [ ] Gremlin replay: interrupt-workflow gremlin should no longer show session `1ef03a24` persisting across runs after the 30s eviction window