### PR TITLE
fix(output_store): promote blob-ref MIME on DisplayHandle.update()

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1247,10 +1247,30 @@ impl KernelConnection for JupyterKernel {
                                             }
                                         };
 
+                                        let data_value =
+                                            serde_json::to_value(&update.data).unwrap_or_default();
+
+                                        // Preflight ZMQ buffers keyed by blob-ref MIME into
+                                        // the blob store — mirror the initial-display path.
+                                        // Without this, `DisplayHandle.update(df2)` carries
+                                        // buffers the kernel still holds but the daemon never
+                                        // persists, and the blob-ref promotion downstream
+                                        // would drop the entry on `BlobStore::exists` miss.
+                                        let iopub_buffers: Vec<Vec<u8>> =
+                                            message.buffers.iter().map(|b| b.to_vec()).collect();
+                                        let preflight_wrapper =
+                                            serde_json::json!({ "data": data_value });
+                                        crate::output_store::preflight_ref_buffers(
+                                            &preflight_wrapper,
+                                            &iopub_buffers,
+                                            &blob_store,
+                                        )
+                                        .await;
+
                                         let updated = update_output_by_display_id_with_manifests(
                                             &mut fork,
                                             display_id,
-                                            &serde_json::to_value(&update.data).unwrap_or_default(),
+                                            &data_value,
                                             &update.metadata,
                                             &blob_store,
                                         )

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -840,14 +840,19 @@ pub async fn update_manifest_display_data(
         return Ok(None);
     }
 
-    // Create updated manifest with new data (preserves output_id)
+    // Create updated manifest with new data (preserves output_id). Use
+    // the same `convert_data_bundle` the initial-display path uses so
+    // blob-ref MIME entries get promoted to their wrapped content type.
+    // Previously this went through a duplicate helper that skipped the
+    // promotion, which left rich payloads (e.g. dx parquet) rendered as
+    // raw JSON refs after `DisplayHandle.update()`.
     match manifest {
         OutputManifest::DisplayData {
             output_id,
             transient,
             ..
         } => {
-            let data = convert_value_to_content_refs(new_data, blob_store, threshold).await?;
+            let data = convert_data_bundle(Some(new_data), blob_store, threshold).await?;
             let metadata = new_metadata.clone().into_iter().collect();
             let updated = OutputManifest::DisplayData {
                 output_id: output_id.clone(),
@@ -863,7 +868,7 @@ pub async fn update_manifest_display_data(
             transient,
             ..
         } => {
-            let data = convert_value_to_content_refs(new_data, blob_store, threshold).await?;
+            let data = convert_data_bundle(Some(new_data), blob_store, threshold).await?;
             let metadata = new_metadata.clone().into_iter().collect();
             let updated = OutputManifest::ExecuteResult {
                 output_id: output_id.clone(),
@@ -876,37 +881,6 @@ pub async fn update_manifest_display_data(
         }
         _ => Ok(None),
     }
-}
-
-/// Convert a data Value (MIME bundle) to ContentRef map.
-async fn convert_value_to_content_refs(
-    data: &Value,
-    blob_store: &BlobStore,
-    threshold: usize,
-) -> io::Result<HashMap<String, ContentRef>> {
-    let mut result = HashMap::new();
-    if let Value::Object(map) = data {
-        for (mime_type, value) in map {
-            let content_ref = if is_binary_mime(mime_type) {
-                // Binary MIME type: base64-decode → store raw bytes in blob.
-                let base64_str = value_to_string(value);
-                let raw_bytes = base64::engine::general_purpose::STANDARD
-                    .decode(&base64_str)
-                    .map_err(|e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("base64 decode failed for {}: {}", mime_type, e),
-                        )
-                    })?;
-                ContentRef::from_binary(&raw_bytes, mime_type, blob_store).await?
-            } else {
-                let content_str = value_to_string(value);
-                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?
-            };
-            result.insert(mime_type.clone(), content_ref);
-        }
-    }
-    Ok(result)
 }
 
 /// Resolve a manifest back to a full Jupyter output JSON value.
@@ -2096,6 +2070,81 @@ mod tests {
         .await
         .unwrap();
         assert!(not_updated.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_manifest_promotes_blob_ref_mime() {
+        // Regression for task #14: `DisplayHandle.update()` previously went
+        // through a duplicate data-bundle converter that didn't promote
+        // `application/vnd.nteract.blob-ref+json` entries to their wrapped
+        // content type. dx parquet outputs stayed as raw ref JSON after
+        // update; only the initial display path promoted.
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Seed the blob store with a payload and get its hash (mimics the
+        // kernel-side `nteract.dx.blob` upload that happens before the
+        // display_data message lands).
+        let payload_bytes = b"fake-parquet-bytes-for-the-test";
+        let hash = store
+            .put(payload_bytes, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        // Initial display_data: a blob-ref entry wrapping parquet.
+        let initial = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.nteract.blob-ref+json": {
+                    "hash": hash,
+                    "content_type": "application/vnd.apache.parquet",
+                    "size": payload_bytes.len(),
+                }
+            },
+            "metadata": {},
+            "transient": { "display_id": "my-df" }
+        });
+        let manifest = create_manifest(&initial, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        // An update comes in with a new blob-ref pointing at the same hash
+        // (it would be a fresh hash in practice, but reuse for simplicity).
+        let new_data = serde_json::json!({
+            "application/vnd.nteract.blob-ref+json": {
+                "hash": hash,
+                "content_type": "application/vnd.apache.parquet",
+                "size": payload_bytes.len(),
+            }
+        });
+
+        let updated = update_manifest_display_data(
+            &manifest,
+            "my-df",
+            &new_data,
+            &serde_json::Map::new(),
+            &store,
+            DEFAULT_INLINE_THRESHOLD,
+        )
+        .await
+        .unwrap()
+        .expect("update should produce a manifest");
+
+        // After update, the manifest's data map MUST contain the wrapped
+        // content-type, not the raw blob-ref MIME. This is the fix: before
+        // this change, the update path stored the ref MIME as-is.
+        let OutputManifest::DisplayData { data, .. } = updated else {
+            panic!("expected DisplayData variant");
+        };
+        assert!(
+            data.contains_key("application/vnd.apache.parquet"),
+            "update must promote blob-ref to wrapped content type; got keys: {:?}",
+            data.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !data.contains_key("application/vnd.nteract.blob-ref+json"),
+            "raw blob-ref MIME must not appear in promoted manifest"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`DisplayHandle.update(df2)` delivered buffers correctly but the output manifest kept the raw `application/vnd.nteract.blob-ref+json` entry instead of the wrapped content type (e.g. `application/vnd.apache.parquet`). Rich payloads rendered as raw JSON refs after update; only the initial display path promoted to the resolved blob URL.

Caught during yesterday's manual QA: initial `display(df)` rendered via sift; `h.update(df2)` on a DisplayHandle dropped back to the JSON-tree fallback.

## Root cause

Two asymmetries between the initial-display and update paths:

1. `update_manifest_display_data` routed through its own `convert_value_to_content_refs` helper that skipped the `BLOB_REF_MIME` promotion branch. The initial path uses `convert_data_bundle` which has an explicit branch that turns a blob-ref entry into a `ContentRef` at the wrapped content_type.
2. The `UpdateDisplayData` IOPub arm dropped `message.buffers`. Initial display runs `preflight_ref_buffers` before manifest creation so the ZMQ buffer bytes land in the blob store under the declared hash; without it the declared hash misses `BlobStore::exists` during promotion and the ref gets dropped.

## Fix

- Deleted the duplicate `convert_value_to_content_refs` helper. `update_manifest_display_data` now delegates to `convert_data_bundle` — one path, one set of promotion rules.
- Added `preflight_ref_buffers` to the `UpdateDisplayData` IOPub arm with the same wrapper shape (`{"data": ...}`) the initial path uses.

## Test

`test_update_manifest_promotes_blob_ref_mime`: seed the blob store with fake parquet bytes, build an initial `display_data` manifest with a blob-ref wrapping the parquet, call `update_manifest_display_data` with a fresh blob-ref, assert the resulting manifest's data map contains `application/vnd.apache.parquet` and NOT the raw blob-ref MIME.

## Test plan

- [ ] `cargo test -p runtimed --lib output_store::` passes
- [ ] `cargo test -p runtimed --lib` passes (432 tests)
- [ ] `cargo xtask lint` clean
- [ ] Manual: run the `DisplayHandle` update cell from yesterday's notebook, confirm the sift table renders after `h.update(df2)` instead of the raw JSON tree