### PR TITLE
fix(runtimed): auto-sign project-file deps at bootstrap

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2281,7 +2281,16 @@ pub(crate) async fn auto_launch_kernel(
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
                             let current_deps = snap.runt.pixi.as_ref().map(|p| &p.dependencies);
-                            if current_deps.is_none_or(|d| d != &deps) {
+                            let deps_match = current_deps.is_some_and(|d| d == &deps);
+                            // Re-sign even when deps already match if the snapshot
+                            // isn't verifiably trusted — covers notebooks bootstrapped
+                            // by the pre-fix build (matching deps, no signature).
+                            let trust_ok = matches!(
+                                verify_trust_from_snapshot(&snap).status,
+                                runt_trust::TrustStatus::Trusted
+                                    | runt_trust::TrustStatus::NoDependencies
+                            );
+                            if !deps_match || !trust_ok {
                                 let pixi = snap.pixi_section_or_default();
                                 pixi.dependencies = deps;
                                 if let Err(e) = auto_sign_in_place(&mut snap) {
@@ -2314,7 +2323,13 @@ pub(crate) async fn auto_launch_kernel(
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
                             let current_deps = snap.runt.uv.as_ref().map(|u| &u.dependencies);
-                            if current_deps.is_none_or(|d| d != &deps) {
+                            let deps_match = current_deps.is_some_and(|d| d == &deps);
+                            let trust_ok = matches!(
+                                verify_trust_from_snapshot(&snap).status,
+                                runt_trust::TrustStatus::Trusted
+                                    | runt_trust::TrustStatus::NoDependencies
+                            );
+                            if !deps_match || !trust_ok {
                                 let uv = snap.runt.uv.get_or_insert_with(|| {
                                     notebook_doc::metadata::UvInlineMetadata {
                                         dependencies: Vec::new(),
@@ -2350,7 +2365,13 @@ pub(crate) async fn auto_launch_kernel(
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
                             let current_deps = snap.runt.conda.as_ref().map(|c| &c.dependencies);
-                            if current_deps.is_none_or(|d| d != &deps) {
+                            let deps_match = current_deps.is_some_and(|d| d == &deps);
+                            let trust_ok = matches!(
+                                verify_trust_from_snapshot(&snap).status,
+                                runt_trust::TrustStatus::Trusted
+                                    | runt_trust::TrustStatus::NoDependencies
+                            );
+                            if !deps_match || !trust_ok {
                                 let conda = snap.runt.conda.get_or_insert_with(|| {
                                     notebook_doc::metadata::CondaInlineMetadata {
                                         dependencies: Vec::new(),

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -816,6 +816,26 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
     }
 }
 
+/// Sign the snapshot's runt dependency metadata with the daemon's trust key
+/// and write the signature + timestamp back into the snapshot in place.
+///
+/// Does not persist the snapshot — the caller writes it back to the doc.
+/// Used by both `resign_trusted_snapshot` (re-sign a previously-Trusted
+/// notebook whose deps changed) and the project-file bootstrap path in
+/// `auto_launch_kernel` (auto-sign deps the daemon itself sourced from
+/// pyproject.toml / pixi.toml / environment.yml so the trust dialog
+/// doesn't fire on deps that came from a file the user already owns).
+pub(crate) fn auto_sign_in_place(snapshot: &mut NotebookMetadataSnapshot) -> Result<(), String> {
+    let runt_value = serde_json::to_value(&snapshot.runt)
+        .map_err(|e| format!("serialize runt metadata: {}", e))?;
+    let mut additional = std::collections::HashMap::new();
+    additional.insert("runt".to_string(), runt_value);
+    let signature = runt_trust::sign_notebook_dependencies(&additional)?;
+    snapshot.runt.trust_signature = Some(signature);
+    snapshot.runt.trust_timestamp = Some(chrono::Utc::now().to_rfc3339());
+    Ok(())
+}
+
 /// Re-sign the notebook's current metadata with the daemon's trust key and
 /// write the new signature back into the Automerge doc. Used when deps have
 /// changed on a previously-Trusted notebook, so the user doesn't have to
@@ -831,14 +851,7 @@ async fn resign_trusted_snapshot(room: &NotebookRoom) -> Result<bool, String> {
         return Ok(false);
     };
 
-    let runt_value = serde_json::to_value(&snapshot.runt)
-        .map_err(|e| format!("serialize runt metadata: {}", e))?;
-    let mut additional = std::collections::HashMap::new();
-    additional.insert("runt".to_string(), runt_value);
-    let signature = runt_trust::sign_notebook_dependencies(&additional)?;
-
-    snapshot.runt.trust_signature = Some(signature);
-    snapshot.runt.trust_timestamp = Some(chrono::Utc::now().to_rfc3339());
+    auto_sign_in_place(&mut snapshot)?;
 
     doc.fork_and_merge(|fork| {
         let _ = fork.set_metadata_snapshot(&snapshot);
@@ -2271,6 +2284,12 @@ pub(crate) async fn auto_launch_kernel(
                             if current_deps.is_none_or(|d| d != &deps) {
                                 let pixi = snap.pixi_section_or_default();
                                 pixi.dependencies = deps;
+                                if let Err(e) = auto_sign_in_place(&mut snap) {
+                                    warn!(
+                                        "[notebook-sync] Failed to auto-sign pixi.toml bootstrap: {}",
+                                        e
+                                    );
+                                }
                                 let _ = fork.set_metadata_snapshot(&snap);
                                 changed = true;
                             }
@@ -2304,6 +2323,12 @@ pub(crate) async fn auto_launch_kernel(
                                     }
                                 });
                                 uv.dependencies = deps;
+                                if let Err(e) = auto_sign_in_place(&mut snap) {
+                                    warn!(
+                                        "[notebook-sync] Failed to auto-sign pyproject.toml bootstrap: {}",
+                                        e
+                                    );
+                                }
                                 let _ = fork.set_metadata_snapshot(&snap);
                                 changed = true;
                             }
@@ -2334,6 +2359,12 @@ pub(crate) async fn auto_launch_kernel(
                                     }
                                 });
                                 conda.dependencies = deps;
+                                if let Err(e) = auto_sign_in_place(&mut snap) {
+                                    warn!(
+                                        "[notebook-sync] Failed to auto-sign environment.yml bootstrap: {}",
+                                        e
+                                    );
+                                }
                                 let _ = fork.set_metadata_snapshot(&snap);
                                 changed = true;
                             }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3572,6 +3572,50 @@ async fn test_auto_sign_in_place_pixi_writes_signature() {
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
 
+/// Regression for Codex P2: a notebook saved by the pre-fix build has
+/// pyproject deps already written into the CRDT but no trust signature.
+/// On reopen with the fix, the bootstrap must detect the untrusted state
+/// and sign even when deps match.
+#[tokio::test]
+#[serial]
+async fn test_bootstrap_re_signs_matching_but_unsigned_snapshot() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    // Pre-fix state: matching pyproject deps, no signature.
+    let mut snap = snapshot_with_uv(vec!["pandas".to_string(), "numpy".to_string()]);
+    assert!(snap.runt.trust_signature.is_none());
+    assert_eq!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::Untrusted,
+        "precondition: matching unsigned deps verify as Untrusted"
+    );
+
+    // Apply the bootstrap's new gate: when deps match but the snapshot
+    // doesn't verify as Trusted/NoDependencies, sign it.
+    let pyproject_deps = vec!["pandas".to_string(), "numpy".to_string()];
+    let current_deps = snap.runt.uv.as_ref().map(|u| u.dependencies.clone());
+    let deps_match = current_deps.as_ref().is_some_and(|d| d == &pyproject_deps);
+    let trust_ok = matches!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies,
+    );
+    assert!(deps_match);
+    assert!(!trust_ok);
+    if !deps_match || !trust_ok {
+        auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
+    }
+
+    assert_eq!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::Trusted,
+        "bootstrap must sign matching-but-unsigned snapshots, not skip them"
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
 /// Regression for the pyproject.toml trust-dialog flicker: simulate the
 /// auto-launch bootstrap end state (deps written + auto-signed) and drive
 /// it through `check_and_update_trust_state`. Trust must land on Trusted

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3490,6 +3490,132 @@ async fn test_check_and_update_trust_state_no_autoresign_when_not_previously_tru
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
 
+// ── auto_sign_in_place: regression coverage for project-file bootstrap ──
+//
+// The daemon's auto-launch path writes project-file deps (pyproject.toml,
+// pixi.toml, environment.yml) into `metadata.runt.{uv,conda,pixi}`. Before
+// this helper existed, those self-writes landed without a signature and
+// flipped the notebook to Untrusted — causing the trust dialog to fire
+// (and flicker on brand-new notebooks opened inside a project dir) for
+// deps the user already had on disk in a file they own.
+
+#[tokio::test]
+#[serial]
+async fn test_auto_sign_in_place_uv_yields_trusted() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let mut snap = snapshot_with_uv(vec!["pandas".to_string(), "numpy".to_string()]);
+    assert!(snap.runt.trust_signature.is_none());
+
+    auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
+
+    assert!(snap.runt.trust_signature.is_some());
+    assert!(snap.runt.trust_timestamp.is_some());
+    assert_eq!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::Trusted,
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_auto_sign_in_place_conda_yields_trusted() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let mut snap = snapshot_with_conda(vec!["scipy".to_string()]);
+    auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
+
+    assert_eq!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::Trusted,
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
+// Pixi deps currently bypass the HMAC trust check entirely —
+// `runt_trust::verify_notebook_trust` only short-circuits on uv+conda
+// emptiness and never looks at pixi, so a pixi-only snapshot always
+// returns NoDependencies regardless of signature state. Covering pixi
+// in `auto_sign_in_place` is still worth it (forward-compat for when
+// pixi joins the trust check), but the test asserts today's behavior.
+#[tokio::test]
+#[serial]
+async fn test_auto_sign_in_place_pixi_writes_signature() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let mut snap = snapshot_empty();
+    snap.runt.pixi = Some(notebook_doc::metadata::PixiInlineMetadata {
+        dependencies: vec!["pandas".to_string()],
+        pypi_dependencies: vec![],
+        channels: vec!["conda-forge".to_string()],
+        python: None,
+    });
+
+    auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
+
+    assert!(snap.runt.trust_signature.is_some());
+    assert!(snap.runt.trust_timestamp.is_some());
+    assert_eq!(
+        verify_trust_from_snapshot(&snap).status,
+        runt_trust::TrustStatus::NoDependencies,
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
+/// Regression for the pyproject.toml trust-dialog flicker: simulate the
+/// auto-launch bootstrap end state (deps written + auto-signed) and drive
+/// it through `check_and_update_trust_state`. Trust must land on Trusted
+/// without a needs-approval transition.
+#[tokio::test]
+#[serial]
+async fn test_pyproject_bootstrap_state_lands_trusted() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let key_path = temp_dir.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _path) = test_room_with_path(&tmp, "pyproject_bootstrap.ipynb");
+
+    // Brand-new room state the user would see: trust banner is shown for
+    // a pyproject-backed notebook the daemon is about to populate.
+    {
+        room.state
+            .with_doc(|sd| sd.set_trust("untrusted", true))
+            .unwrap();
+    }
+
+    // What the bootstrap block writes into the doc after the fix: deps
+    // from pyproject.toml plus an auto-signature covering them.
+    let mut snap = snapshot_with_uv(vec!["pandas".to_string(), "numpy".to_string()]);
+    auto_sign_in_place(&mut snap).expect("auto_sign_in_place");
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&snap).unwrap();
+    }
+
+    check_and_update_trust_state(&room).await;
+
+    let ts = room.trust_state.read().await;
+    assert_eq!(ts.status, runt_trust::TrustStatus::Trusted);
+    drop(ts);
+
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
+    assert_eq!(state.trust.status, "trusted");
+    assert!(!state.trust.needs_approval);
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
 // ── Per-agent oneshot channel tests ──────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Overview

The auto-launch path writes project-file deps (pyproject.toml / pixi.toml / environment.yml) into `metadata.runt.{uv,conda,pixi}` so UI and MCP tools can see what's installed. Those writes landed without a signature and flipped the notebook to `Untrusted`, firing the trust dialog for deps the user already had on disk in a file they own. On brand-new notebooks opened inside a project dir, this showed up as a trust banner flicker during auto-launch.

## Diagnosis

For a pyproject-backed notebook with no inline deps:

1. `.ipynb` on disk has empty `runt.uv.dependencies`. Room init's `verify_trust_from_file()` returns `NoDependencies`. No banner.
2. `auto_launch_kernel` detects `pyproject.toml`, reads `[project.dependencies]`, writes them into `runt.uv.dependencies` via `fork_and_merge`.
3. Doc sync flushes. `check_and_update_trust_state` re-verifies the fresh snapshot: deps are now non-empty, no matching signature → `Untrusted`.
4. `RuntimeStateDoc.trust.needs_approval` flips to `true`. Banner appears for deps the daemon itself just sourced from a local file.

## Fix

Add `auto_sign_in_place(snapshot)` alongside `resign_trusted_snapshot` in `notebook_sync_server/metadata.rs`. It signs the runt metadata in place and writes the signature + timestamp back into the snapshot. The three bootstrap closures call it right after writing deps, inside the same `fork_and_merge`. `resign_trusted_snapshot` refactored to use the helper so both paths share one signing implementation.

The bootstrap predicate fires on "deps differ OR snapshot doesn't verify as Trusted/NoDependencies" so a snapshot that reaches bootstrap with matching deps but a missing or invalid signature still gets signed. Defense-in-depth against external writes or stale signatures.

HMAC still protects against external editors changing the notebook's signed fields. What it no longer does is prompt for approval on deps the daemon itself wrote from a file the user owns.

## Design decision

Auto-sign at bootstrap instead of deleting the bootstrap. Deleting would lose the MCP/UI invariant that inline dep fields always reflect what's running. Introducing a parallel `metadata.runt.project_deps` surface cleanly separates HMAC-required from informational, but that's a schema change and consumer migration. Worth doing as a followup with `schema-update` label; this PR is a targeted bugfix.

## Scope limit

Bootstrap only runs when `auto_launch_kernel` runs, and auto-launch is gated on `Trusted | NoDependencies` at room creation (`peer.rs:444`). A notebook saved by the pre-fix build whose on-disk deps verify as `Untrusted` at room init never reaches bootstrap — the banner persists until the user clicks Trust once. Healing that path needs a project-file-reconciliation step upstream of the auto-launch gate. Tracked in #2150.

## Pixi coverage gap

`runt_trust::verify_notebook_trust` short-circuits on `uv_dependencies.is_empty() && conda_dependencies.is_empty()` and never looks at pixi. Pixi-only notebooks always return `NoDependencies` regardless of signature state. So the dialog wasn't firing for pixi bootstrap today - the `auto_sign_in_place` call in the pixi branch is forward-compat for when pixi joins the trust check. Worth filing as a separate issue.

## Test plan

- [x] `cargo test -p runtimed --lib` - 436 passing
- [x] `cargo clippy -p runtimed --all-targets` - clean
- [x] Three unit tests for `auto_sign_in_place` (uv, conda, pixi)
- [x] Regression test that simulates the bootstrap end state (deps + sign) and asserts `check_and_update_trust_state` lands on `Trusted` with `needs_approval=false`
- [x] Regression test for Codex P2: matching deps + missing signature path still signs
- [x] Manual E2E: dev daemon rebuilt with the fix, created a new notebook with working_dir in the repo root (pyproject.toml with 9 deps). Daemon log shows:
  ```
  Trust status for <id>: NoDependencies
  Bootstrapped pyproject.toml deps into CRDT
  Trust state changed via doc sync: NoDependencies -> Trusted
  ```
  Kernel auto-launched, cell executed cleanly in the uv:pyproject env. The pre-fix transition would have been `NoDependencies -> Untrusted` with banner/dialog.
