### PR TITLE
fix(mcp-supervisor): adopt live Vite, don't sweep-and-respawn

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -639,10 +639,10 @@ impl Supervisor {
     /// Start the Vite dev server for hot-reload frontend development.
     async fn start_vite(&self) -> Result<u16, String> {
         // Phase 1: Check existing process and extract state (hold lock briefly)
-        let (project_root, needs_start) = {
+        let project_root = {
             let mut state = self.state.write().await;
 
-            // Already running?
+            // Already running under our management?
             if let Some(proc) = state.managed.get_mut("vite") {
                 if proc.is_alive() {
                     return proc
@@ -653,13 +653,9 @@ impl Supervisor {
                 state.managed.remove("vite");
             }
 
-            (state.project_root.clone(), true)
+            state.project_root.clone()
             // Lock dropped here
         };
-
-        if !needs_start {
-            unreachable!();
-        }
 
         // Phase 2: Derive port and run pnpm install without holding the lock
         let port = std::env::var("RUNTIMED_VITE_PORT")
@@ -667,6 +663,19 @@ impl Supervisor {
             .or_else(|| std::env::var("CONDUCTOR_PORT").ok())
             .and_then(|p| p.parse::<u16>().ok())
             .unwrap_or_else(|| runt_workspace::vite_port_for_workspace(&project_root));
+
+        // Phase 2.5: If the port is already live, adopt it instead of
+        // trying to spawn our own. Common case: a prior `up vite=true`
+        // timed out and killed the pnpm parent, but pnpm's grandchildren
+        // (node/vite-plus) survived and are now serving. We shouldn't
+        // kill a working server just because it isn't in our managed
+        // map — the sweep phase already runs before us, so by this point
+        // anything live on this port is either our own orphan (adopt it)
+        // or something we deliberately decided not to sweep.
+        if vite_port_is_live(port).await {
+            info!("[supervisor] Vite already serving on port {port}; adopting");
+            return Ok(port);
+        }
 
         // Ensure pnpm install is in sync with the lockfile. Previously this
         // only ran when node_modules was completely missing, which missed
@@ -972,6 +981,15 @@ impl Supervisor {
     #[cfg(unix)]
     async fn sweep_zombie_vites(&self, port: u16) -> Vec<u32> {
         {
+            // If the port is actively serving, don't sweep. Could be a
+            // working Vite from a previous session (our orphan, or a
+            // user-started one). `start_vite` will adopt it at phase 2.5.
+            // Without this check we kill-and-respawn on every `up`,
+            // which creates the orphan we're trying to avoid.
+            if vite_port_is_live(port).await {
+                return Vec::new();
+            }
+
             let managed_pid: Option<u32> = {
                 let mut state = self.state.write().await;
                 let proc = state.managed.get_mut("vite");
@@ -1998,13 +2016,36 @@ impl ServerHandler for Supervisor {
 
 /// Read the last N lines of a log file (caps at 64KB to avoid huge reads).
 /// Maximum time to wait for Vite to start accepting connections.
-const VITE_READY_TIMEOUT: Duration = Duration::from_secs(20);
+///
+/// Cold-start budget. A fresh Vite with `buildAllRendererPlugins` doing
+/// markdown/plotly/vega/leaflet/sift IIFE builds takes 30-50s on this
+/// machine. The previous 20s budget triggered on every cold start and
+/// the supervisor's kill-on-timeout then orphaned pnpm's grandchildren,
+/// which would bind the port ~30s later and survive into the next `up`
+/// call as a zombie.
+const VITE_READY_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// After first successful TCP connect, wait this long to see whether
 /// Vite crashes on its initial build. The renderer-plugin build phase
 /// is an async promise — Vite prints "Local: http://…" *before* the
 /// build resolves, so a port-bind alone isn't proof of health.
 const VITE_POST_CONNECT_STABILIZE: Duration = Duration::from_millis(1500);
+
+/// Quick probe to decide whether something is already listening on the
+/// Vite port. Non-strict — a successful TCP connect means "we should
+/// adopt this port rather than trying to spawn our own Vite". The
+/// risk of adopting a non-Vite server on a project-specific port
+/// `vite_port_for_workspace(&root)` is low in dev contexts.
+async fn vite_port_is_live(port: u16) -> bool {
+    let addr = format!("127.0.0.1:{port}");
+    tokio::time::timeout(
+        Duration::from_millis(400),
+        tokio::net::TcpStream::connect(&addr),
+    )
+    .await
+    .map(|r| r.is_ok())
+    .unwrap_or(false)
+}
 
 /// Wait for a freshly-spawned Vite child to be actually serving, or
 /// return a specific failure. Polls two signals in a loop:


### PR DESCRIPTION
`up vite=true` reported `vite: FAILED — did not accept connections within 20s` on every dev session even though Vite was actually serving. Traced to a kill-respawn loop:

1. First `up vite=true` spawns `pnpm dev`. The 20s timeout triggers on cold start because `buildAllRendererPlugins` (markdown, plotly, vega, leaflet, sift IIFE builds) takes 30-50s on first run.
2. Supervisor kills the pnpm child. But pnpm's grandchildren (node, vite-plus) aren't in pnpm's process group — they survive.
3. ~30s later, the orphan grandchildren finish building and bind port 9075.
4. Next `up` runs the sweep, lsof-finds the orphan, SIGTERMs it for being non-managed. Spawns a new pnpm. Same timeout. Same orphan. Cycle forever.

## Fix

Two cooperating probes:

- **`sweep_zombie_vites`** TCP-probes the port first. If something is already serving, it's either our orphan or user-started — either way, don't sweep.
- **`start_vite`** adds a phase 2.5 probe after port derivation. If the port is already live, adopt and return success without spawning a child.

The two compose: sweep decides whether to clear the port, `start_vite` decides whether to adopt what's there. Orphans get adopted as soon as they become ready, instead of killed in an endless cycle.

Also raises `VITE_READY_TIMEOUT` from 20s to 60s for cold-start budget. Even with adoption fixing the immediate UX, a genuine cold first-build still needs room to finish before the supervisor gives up on a child it just spawned.

## Follow-up

Full process-group cleanup on kill (so grandchildren don't orphan in the first place) — separate fix. On unix, `CommandExt::process_group(0)` plus `kill(-pgid)` does it cleanly. Would let us drop the adoption path for the "supervisor killed its own vite" case, though adoption still helps when a user started Vite outside the supervisor.

## Test plan

- [ ] `cargo test -p mcp-supervisor --tests` passes (9/9)
- [ ] `cargo clippy -p mcp-supervisor --all-targets -- -D warnings` clean
- [ ] `cargo xtask lint` clean
- [ ] Manual: `up vite=true` on a session with an orphan Vite → reports success and adopts. (Requires MCP reconnect to pick up the new supervisor binary.)
- [ ] Manual: `up vite=true` on a fresh project with nothing on 9075 → spawns Vite, waits up to 60s, reports success.