### PR TITLE
feat(traceback): frame cap, SyntaxError layout, single-frame inline evalue

### DIFF
--- a/crates/runtimed/src/user_error.rs
+++ b/crates/runtimed/src/user_error.rs
@@ -51,6 +51,27 @@ pub struct RichFrame {
     pub library: bool,
 }
 
+/// Parse-error-only slot populated for `SyntaxError` /
+/// `IndentationError` / `TabError`. Carries the caret info the
+/// exception object exposes (`offset`, `text`, `msg`, and 3.11+
+/// `end_offset`/`end_lineno` for range underline) so the renderer
+/// can show the offending source line instead of a useless frame list.
+///
+/// `end_lineno` / `end_offset` of 0 means "absent" (the emitter
+/// normalizes CPython's `-1` sentinel to 0).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RichSyntax {
+    pub filename: String,
+    pub lineno: u32,
+    pub offset: u32,
+    #[serde(default)]
+    pub end_lineno: u32,
+    #[serde(default)]
+    pub end_offset: u32,
+    pub text: String,
+    pub msg: String,
+}
+
 /// The rich payload shape the frontend's `TracebackOutput` consumes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RichTraceback {
@@ -62,6 +83,10 @@ pub struct RichTraceback {
     /// Paste-ready plain text — the ANSI-stripped `traceback.format_exception`
     /// output. Frontend Copy button writes this verbatim.
     pub text: String,
+    /// Present for parse errors. When set, the renderer shows a
+    /// dedicated source-line + caret layout instead of a frame list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syntax: Option<RichSyntax>,
 }
 
 /// A user-code error, regardless of wire shape.
@@ -253,6 +278,7 @@ pub fn parse_ansi_traceback(
         frames,
         language: Some("python".to_string()),
         text,
+        syntax: None,
     })
 }
 
@@ -751,6 +777,7 @@ mod tests {
             frames: vec![],
             language: Some("python".into()),
             text: "Traceback (most recent call last):\n  File \"/tmp/x.py\", line 1, in <module>\n    1/0\nZeroDivisionError: division by zero".into(),
+            syntax: None,
         };
         let ue = UserErrorOutput::Rich(rt);
         let (ename, evalue, tb) = ue.to_classic();
@@ -953,6 +980,7 @@ mod tests {
             frames: vec![],
             language: Some("python".into()),
             text: "Traceback (most recent call last):\n  File \"/tmp/x.py\", line 1, in t\n    assert False, \"line one\\nline two\\nline three\"\nAssertionError: line one\nline two\nline three".into(),
+            syntax: None,
         };
         let (ename, evalue, tb) = UserErrorOutput::Rich(rt).to_classic();
         assert_eq!(ename, "AssertionError");
@@ -977,6 +1005,7 @@ mod tests {
             frames: vec![],
             language: Some("python".into()),
             text: "line1\nline2\n".into(),
+            syntax: None,
         };
         let (_, _, tb) = UserErrorOutput::Rich(rt).to_classic();
         // "line1\n" "line2\n" → ["line1", "line2"].

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -148,6 +148,17 @@ def _build_syntax_error_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, A
     filename = getattr(evalue, "filename", "") or ""
     lineno = getattr(evalue, "lineno", 0) or 0
     offset = getattr(evalue, "offset", 0) or 0
+    # `end_lineno` / `end_offset` exist on 3.11+ SyntaxError. When the
+    # parser knows the end of the offending token, we can underline a
+    # range (e.g. `^^^^`) instead of a single caret — Python's own
+    # traceback format does this since 3.11.
+    # `-1` is a documented sentinel meaning "unknown" (see cpython
+    # Objects/exceptions.c); normalize to 0 so the renderer can treat
+    # 0 as "absent".
+    end_lineno_raw = getattr(evalue, "end_lineno", None)
+    end_offset_raw = getattr(evalue, "end_offset", None)
+    end_lineno = end_lineno_raw if isinstance(end_lineno_raw, int) and end_lineno_raw > 0 else 0
+    end_offset = end_offset_raw if isinstance(end_offset_raw, int) and end_offset_raw > 0 else 0
     text = getattr(evalue, "text", "") or ""
     msg = getattr(evalue, "msg", None) or str(evalue)
     return {
@@ -160,6 +171,8 @@ def _build_syntax_error_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, A
             "filename": filename,
             "lineno": lineno,
             "offset": offset,
+            "end_lineno": end_lineno,
+            "end_offset": end_offset,
             "text": text.rstrip("\n"),
             "msg": msg,
         },

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -43,6 +43,15 @@ _LIBRARY_PATH_MARKERS = (
 _CONTEXT_BEFORE = 2
 _CONTEXT_AFTER = 2
 
+# Head + tail frames kept when a traceback is longer than head + tail.
+# A RecursionError is 1000 frames; without a cap the payload balloons
+# for no information gain (the frontend already clusters duplicates,
+# but distinct-but-deep stacks still blow up). Head preserves the
+# outermost (user-visible entry) frames; tail preserves the innermost
+# (raise-site) frames. Between them, a sentinel records the count.
+_MAX_HEAD_FRAMES = 5
+_MAX_TAIL_FRAMES = 5
+
 
 # ─── Payload construction ───────────────────────────────────────────────────
 
@@ -70,6 +79,30 @@ def _source_window(filename: str, lineno: int) -> list[dict[str, Any]]:
     return out
 
 
+def _clip_frames(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep head + tail; summarize the middle with a sentinel frame.
+
+    No-op when the stack fits under the cap. Otherwise returns the head,
+    a sentinel row describing how many frames were elided, then the
+    tail. The sentinel is marked ``library: True`` so the frontend's
+    dimming/collapse rules match its "this is noise" semantic.
+    """
+    total = len(frames)
+    if total <= _MAX_HEAD_FRAMES + _MAX_TAIL_FRAMES:
+        return frames
+    head = frames[:_MAX_HEAD_FRAMES]
+    tail = frames[-_MAX_TAIL_FRAMES:]
+    omitted = total - len(head) - len(tail)
+    sentinel: dict[str, Any] = {
+        "filename": "",
+        "lineno": 0,
+        "name": f"… {omitted} frames omitted …",
+        "lines": [],
+        "library": True,
+    }
+    return head + [sentinel] + tail
+
+
 def _strip_leading_library_frames(frames: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop library frames above the first user frame.
 
@@ -93,12 +126,58 @@ def _strip_leading_library_frames(frames: list[dict[str, Any]]) -> list[dict[str
     return frames
 
 
+def _build_syntax_error_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
+    """Special-case payload for `SyntaxError` and friends.
+
+    Parse errors never have a user-code frame — IPython raises from
+    inside ``ast_parse`` before any cell bytecode runs, so the traceback
+    is all internals and pure noise from the user's perspective.
+
+    The useful information lives on the exception object itself:
+    ``offset``, ``text``, ``msg``, ``lineno``. We emit a payload with
+    empty ``frames`` and an additional ``syntax`` slot carrying the
+    caret location, so the renderer can show something like:
+
+        SyntaxError: invalid syntax
+          | This is not valid syntax
+          |     ^
+
+    Applies to ``SyntaxError``, ``IndentationError``, ``TabError`` —
+    they all share the same attribute surface.
+    """
+    filename = getattr(evalue, "filename", "") or ""
+    lineno = getattr(evalue, "lineno", 0) or 0
+    offset = getattr(evalue, "offset", 0) or 0
+    text = getattr(evalue, "text", "") or ""
+    msg = getattr(evalue, "msg", None) or str(evalue)
+    return {
+        "ename": etype.__name__ if isinstance(etype, type) else str(etype),
+        "evalue": str(evalue),
+        "frames": [],
+        "language": "python",
+        "text": "".join(_pytraceback.format_exception(etype, evalue, tb)),
+        "syntax": {
+            "filename": filename,
+            "lineno": lineno,
+            "offset": offset,
+            "text": text.rstrip("\n"),
+            "msg": msg,
+        },
+    }
+
+
 def build_rich_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
     """Structure an exception into the rich traceback payload.
 
     Assumes the caller protects against exceptions from this function —
     see `_safe_showtraceback` below.
     """
+    # Parse errors take a dedicated code path — their traceback carries
+    # no user-code frame, but the exception object has the caret info
+    # (offset, text) we want to render.
+    if isinstance(evalue, SyntaxError):
+        return _build_syntax_error_payload(etype, evalue, tb)
+
     raw_frames = []
     for f in _pytraceback.extract_tb(tb):
         # `FrameSummary.lineno` is typed as `int | None`; treat missing
@@ -114,7 +193,7 @@ def build_rich_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
                 "library": _is_library_frame(f.filename),
             }
         )
-    frames = _strip_leading_library_frames(raw_frames)
+    frames = _clip_frames(_strip_leading_library_frames(raw_frames))
     text = "".join(_pytraceback.format_exception(etype, evalue, tb))
     ename = etype.__name__ if isinstance(etype, type) else str(etype)
     return {

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -106,6 +106,106 @@ def test_strip_leading_library_frames_keeps_everything_when_all_library():
     assert out == raw
 
 
+# ─── frame cap (#20) ───────────────────────────────────────────────────────
+
+
+def _mk_frames(n: int) -> list[dict]:
+    return [
+        {
+            "filename": f"/tmp/f{i}.py",
+            "lineno": i + 1,
+            "name": f"f{i}",
+            "lines": [],
+            "library": False,
+        }
+        for i in range(n)
+    ]
+
+
+def test_clip_frames_noop_under_cap():
+    # 10 total (head=5 + tail=5) is the boundary — no clipping.
+    frames = _mk_frames(10)
+    out = _traceback._clip_frames(frames)
+    assert out == frames
+
+
+def test_clip_frames_inserts_sentinel_when_over_cap():
+    frames = _mk_frames(25)
+    out = _traceback._clip_frames(frames)
+    # head (5) + sentinel (1) + tail (5) = 11
+    assert len(out) == 11
+    assert out[:5] == frames[:5]
+    assert out[-5:] == frames[-5:]
+    sentinel = out[5]
+    assert sentinel["library"] is True
+    assert "15 frames omitted" in sentinel["name"]
+    assert sentinel["filename"] == ""
+
+
+def test_build_payload_clips_huge_recursion():
+    # RecursionError-ish: a ton of user-frames.
+    def recurse(n):
+        if n == 0:
+            raise RuntimeError("bottom")
+        return recurse(n - 1)
+
+    try:
+        recurse(200)
+    except RuntimeError as exc:
+        payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+
+    # With cap = head(5) + tail(5) + sentinel, frames should be <= 11.
+    assert len(payload["frames"]) <= 11
+    # Sentinel is present somewhere in the middle.
+    assert any("frames omitted" in f["name"] for f in payload["frames"])
+
+
+# ─── SyntaxError special-case (#25) ────────────────────────────────────────
+
+
+def _capture_syntax_error() -> SyntaxError:
+    try:
+        compile("def oops(\n", "<test>", "exec")
+    except SyntaxError as exc:
+        return exc
+    raise AssertionError("compile should have raised")
+
+
+def test_syntax_error_emits_syntax_slot_and_no_frames():
+    exc = _capture_syntax_error()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    assert payload["ename"] == "SyntaxError"
+    # The whole point: no user-frame noise.
+    assert payload["frames"] == []
+    # Syntax slot carries the caret info.
+    syntax = payload.get("syntax")
+    assert syntax is not None
+    assert syntax["filename"] == "<test>"
+    assert syntax["lineno"] == 1
+    assert syntax["offset"] >= 1
+    assert "oops" in syntax["text"]
+    assert syntax["msg"]
+
+
+def test_syntax_error_text_still_present_for_copy_button():
+    # The `text` field (what the Copy button writes) must still round-trip
+    # the canonical "Traceback ..." output so pasting to an LLM works.
+    exc = _capture_syntax_error()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    assert "SyntaxError" in payload["text"]
+
+
+def test_indentation_error_takes_syntax_path():
+    # IndentationError subclasses SyntaxError; same treatment.
+    try:
+        compile("def x():\npass\n", "<test>", "exec")
+    except IndentationError as exc:
+        payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+        assert payload["ename"] == "IndentationError"
+        assert payload["frames"] == []
+        assert payload.get("syntax") is not None
+
+
 # ─── install: wrapping + idempotency ───────────────────────────────────────
 
 

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -185,6 +185,12 @@ def test_syntax_error_emits_syntax_slot_and_no_frames():
     assert syntax["offset"] >= 1
     assert "oops" in syntax["text"]
     assert syntax["msg"]
+    # end_lineno / end_offset are always present (0 means "absent"),
+    # and when the parser populates them, end_offset >= offset.
+    assert isinstance(syntax["end_lineno"], int)
+    assert isinstance(syntax["end_offset"], int)
+    if syntax["end_offset"] > 0:
+        assert syntax["end_offset"] >= syntax["offset"]
 
 
 def test_syntax_error_text_still_present_for_copy_button():

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -43,6 +43,21 @@ interface Frame {
   library?: boolean;
 }
 
+/**
+ * Parse-error-only info, populated when the exception is a
+ * `SyntaxError` / `IndentationError` / `TabError`. These don't have
+ * user-code frames (IPython raises from `ast_parse` before any cell
+ * bytecode runs), so we dedicate a slot to what actually helps:
+ * the offending source line and a caret at `offset`.
+ */
+interface SyntaxInfo {
+  filename: string;
+  lineno: number;
+  offset: number;
+  text: string;
+  msg: string;
+}
+
 interface TracebackPayload {
   /** Exception class name, e.g. "ValueError". */
   ename: string;
@@ -64,6 +79,12 @@ interface TracebackPayload {
   text?: string;
   /** Raw traceback strings, for cases where we couldn't parse. */
   raw?: string[];
+  /**
+   * Present for `SyntaxError` / `IndentationError` / `TabError`.
+   * When set, the renderer shows a dedicated parse-error layout
+   * (source line + caret) instead of a frame list.
+   */
+  syntax?: SyntaxInfo;
 }
 
 interface Props {
@@ -126,6 +147,13 @@ export function TracebackOutput({ data, className }: Props) {
     return !c.frame.library;
   };
 
+  // Single-frame polish: when there's exactly one user frame named
+  // `<module>` (cell top-level), inline the evalue next to the ename
+  // in the header and skip the chevron row. Most real cell errors are
+  // this shape; the ceremonial per-frame row is just noise.
+  const collapseSingleFrame =
+    clusters.length === 1 && clusters[0].frame.name === "<module>" && !clusters[0].frame.library;
+
   return (
     <div
       data-slot="traceback"
@@ -135,18 +163,31 @@ export function TracebackOutput({ data, className }: Props) {
         className,
       )}
     >
-      <Header ename={payload.ename} evalue={payload.evalue} payload={payload} />
-      {clusters.length > 0 && (
-        <ol className="divide-y divide-destructive/15">
-          {clusters.map((cluster, i) => (
-            <FrameRow
-              key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
-              cluster={cluster}
-              defaultOpen={shouldOpen(cluster, i)}
-              language={language}
-            />
-          ))}
-        </ol>
+      <Header
+        ename={payload.ename}
+        evalue={payload.evalue}
+        payload={payload}
+        inlineEvalue={collapseSingleFrame || Boolean(payload.syntax)}
+      />
+      {payload.syntax ? (
+        <SyntaxErrorBlock syntax={payload.syntax} language={language} />
+      ) : collapseSingleFrame && clusters[0].frame.lines && clusters[0].frame.lines.length > 0 ? (
+        <div className="px-3 pb-2">
+          <SourceBlock lines={clusters[0].frame.lines} language={language} />
+        </div>
+      ) : (
+        clusters.length > 0 && (
+          <ol className="divide-y divide-destructive/15">
+            {clusters.map((cluster, i) => (
+              <FrameRow
+                key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
+                cluster={cluster}
+                defaultOpen={shouldOpen(cluster, i)}
+                language={language}
+              />
+            ))}
+          </ol>
+        )
       )}
     </div>
   );
@@ -158,11 +199,22 @@ function Header({
   ename,
   evalue,
   payload,
+  inlineEvalue,
 }: {
   ename: string;
   evalue: string;
   payload: TracebackPayload;
+  /**
+   * When true, render `ename: evalue` on a single line (for the
+   * single-frame and SyntaxError cases where the two-line header
+   * is unnecessary ceremony).
+   */
+  inlineEvalue?: boolean;
 }) {
+  // Multi-line evalues (pytest AssertionError, chained SQL errors)
+  // never inline cleanly — fall through to the two-line layout even
+  // when the caller asked for inline.
+  const canInline = inlineEvalue && evalue && !evalue.includes("\n");
   return (
     <div className="flex items-start gap-2 px-3 py-2 font-mono">
       <OctagonAlert
@@ -171,13 +223,82 @@ function Header({
         strokeWidth={2.5}
       />
       <div className="min-w-0 flex-1">
-        <div className="font-semibold text-destructive">{ename}</div>
-        {evalue && (
-          <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">{evalue}</div>
+        {canInline ? (
+          <div>
+            <span className="font-semibold text-destructive">{ename}</span>
+            <span className="text-destructive/80">: </span>
+            <span className="whitespace-pre-wrap break-words text-foreground/85">{evalue}</span>
+          </div>
+        ) : (
+          <>
+            <div className="font-semibold text-destructive">{ename}</div>
+            {evalue && (
+              <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">
+                {evalue}
+              </div>
+            )}
+          </>
         )}
       </div>
       <CopyButton payload={payload} />
     </div>
+  );
+}
+
+/**
+ * Parse-error layout. Shows the offending source line with a caret at
+ * the `offset` column. No frame list (SyntaxError doesn't have one
+ * that'd be useful). If `text` is empty (older Python versions don't
+ * always populate it), we show just the header.
+ */
+function SyntaxErrorBlock({ syntax, language }: { syntax: SyntaxInfo; language: string }) {
+  const isDark = useDarkMode();
+  const rawTheme = useColorTheme();
+  const colorTheme = rawTheme === "cream" ? "cream" : "classic";
+
+  if (!syntax.text) {
+    return null;
+  }
+
+  // `offset` is 1-based (CPython convention). Clamp to the line length
+  // so caret padding never blows past the content.
+  const caretCol = Math.max(1, Math.min(syntax.offset || 1, syntax.text.length + 1));
+  const caretPadding = " ".repeat(caretCol - 1);
+
+  const gutterWidth = String(syntax.lineno || 1).length;
+
+  return (
+    <pre
+      className={cn(
+        "mx-3 mb-2 overflow-x-auto rounded border border-destructive/15 bg-muted/40",
+        "px-2 py-1.5 leading-5",
+      )}
+      style={{ fontFamily: CM_FONT_FAMILY, fontSize: "13px" }}
+    >
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 border-l-2 border-destructive bg-destructive/10 pl-1.5">
+        <span
+          className="select-none text-right font-semibold tabular-nums text-destructive"
+          style={{ minWidth: `${gutterWidth}ch` }}
+        >
+          ▸{String(syntax.lineno || 1).padStart(gutterWidth, " ")}
+        </span>
+        <code className="whitespace-pre">
+          {highlight(syntax.text, language, isDark, colorTheme)}
+        </code>
+      </div>
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 border-l-2 border-transparent pl-1.5">
+        <span
+          className="select-none text-right tabular-nums text-muted-foreground/50"
+          style={{ minWidth: `${gutterWidth}ch` }}
+        >
+          {" ".repeat(gutterWidth + 1)}
+        </span>
+        <code className="whitespace-pre text-destructive">
+          {caretPadding}
+          <span aria-hidden="true">^</span>
+        </code>
+      </div>
+    </pre>
   );
 }
 
@@ -363,7 +484,20 @@ function toPayload(data: unknown): TracebackPayload | null {
     language: typeof o.language === "string" ? o.language : undefined,
     text: typeof o.text === "string" ? o.text : undefined,
     raw: Array.isArray(o.raw) ? (o.raw as string[]) : undefined,
+    syntax: isSyntaxInfo(o.syntax) ? o.syntax : undefined,
   };
+}
+
+function isSyntaxInfo(v: unknown): v is SyntaxInfo {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.filename === "string" &&
+    typeof s.lineno === "number" &&
+    typeof s.offset === "number" &&
+    typeof s.text === "string" &&
+    typeof s.msg === "string"
+  );
 }
 
 function safeStringify(x: unknown): string {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -54,6 +54,14 @@ interface SyntaxInfo {
   filename: string;
   lineno: number;
   offset: number;
+  /**
+   * End of the offending token (Python 3.11+). 0 means "absent" — the
+   * renderer falls back to a single-column caret. When set, we underline
+   * the `[offset, end_offset)` range so multi-char errors read at a
+   * glance. Matches CPython's own traceback format since 3.11.
+   */
+  end_lineno?: number;
+  end_offset?: number;
   text: string;
   msg: string;
 }
@@ -148,11 +156,17 @@ export function TracebackOutput({ data, className }: Props) {
   };
 
   // Single-frame polish: when there's exactly one user frame named
-  // `<module>` (cell top-level), inline the evalue next to the ename
-  // in the header and skip the chevron row. Most real cell errors are
-  // this shape; the ceremonial per-frame row is just noise.
+  // `<module>` (cell top-level), skip the chevron row and render the
+  // source block directly. Most real cell errors are this shape; the
+  // ceremonial per-frame row is just noise.
   const collapseSingleFrame =
     clusters.length === 1 && clusters[0].frame.name === "<module>" && !clusters[0].frame.library;
+
+  // Inline `ename: evalue` on one line when the evalue fits. Multi-line
+  // evalues (pytest diffs, chained SQL errors) fall through to the
+  // two-line layout. Independent of frame count — a short evalue next
+  // to the ename reads better whether we show frames below or not.
+  const inlineEvalue = Boolean(payload.evalue) && !payload.evalue.includes("\n");
 
   return (
     <div
@@ -165,9 +179,13 @@ export function TracebackOutput({ data, className }: Props) {
     >
       <Header
         ename={payload.ename}
-        evalue={payload.evalue}
+        // For parse errors, prefer `syntax.msg` ("invalid syntax") over
+        // `str(evalue)` ("invalid syntax (<tmpfile>, line 1)"). IPython
+        // stringifies SyntaxError with a temp-file tail that's noise
+        // for cell users — the caret block shows location already.
+        evalue={payload.syntax?.msg || payload.evalue}
         payload={payload}
-        inlineEvalue={collapseSingleFrame || Boolean(payload.syntax)}
+        inlineEvalue={inlineEvalue || Boolean(payload.syntax?.msg)}
       />
       {payload.syntax ? (
         <SyntaxErrorBlock syntax={payload.syntax} language={language} />
@@ -211,10 +229,10 @@ function Header({
    */
   inlineEvalue?: boolean;
 }) {
-  // Multi-line evalues (pytest AssertionError, chained SQL errors)
-  // never inline cleanly — fall through to the two-line layout even
-  // when the caller asked for inline.
-  const canInline = inlineEvalue && evalue && !evalue.includes("\n");
+  // Caller already decides whether inlining is appropriate (short,
+  // single-line evalues). Trust that here so the two layouts don't
+  // disagree on edge cases.
+  const canInline = inlineEvalue && Boolean(evalue);
   return (
     <div className="flex items-start gap-2 px-3 py-2 font-mono">
       <OctagonAlert
@@ -261,9 +279,18 @@ function SyntaxErrorBlock({ syntax, language }: { syntax: SyntaxInfo; language: 
   }
 
   // `offset` is 1-based (CPython convention). Clamp to the line length
-  // so caret padding never blows past the content.
-  const caretCol = Math.max(1, Math.min(syntax.offset || 1, syntax.text.length + 1));
-  const caretPadding = " ".repeat(caretCol - 1);
+  // so the underline never runs past the content.
+  const lineLen = syntax.text.length;
+  const startCol = Math.max(1, Math.min(syntax.offset || 1, lineLen + 1));
+  // When `end_offset` is known AND on the same line AND past `offset`,
+  // underline the whole range. Otherwise fall back to a single caret
+  // at `startCol`.
+  const sameLine = !syntax.end_lineno || syntax.end_lineno === syntax.lineno;
+  const endColRaw = syntax.end_offset ?? 0;
+  const endCol = sameLine && endColRaw > startCol ? Math.min(endColRaw, lineLen + 1) : startCol + 1;
+  const underlineLen = Math.max(1, endCol - startCol);
+  const underlinePadding = " ".repeat(startCol - 1);
+  const underline = "^".repeat(underlineLen);
 
   const gutterWidth = String(syntax.lineno || 1).length;
 
@@ -293,9 +320,9 @@ function SyntaxErrorBlock({ syntax, language }: { syntax: SyntaxInfo; language: 
         >
           {" ".repeat(gutterWidth + 1)}
         </span>
-        <code className="whitespace-pre text-destructive">
-          {caretPadding}
-          <span aria-hidden="true">^</span>
+        <code className="whitespace-pre font-semibold text-destructive">
+          {underlinePadding}
+          <span aria-hidden="true">{underline}</span>
         </code>
       </div>
     </pre>
@@ -498,6 +525,7 @@ function isSyntaxInfo(v: unknown): v is SyntaxInfo {
     typeof s.text === "string" &&
     typeof s.msg === "string"
   );
+  // end_lineno / end_offset are optional — we don't require them.
 }
 
 function safeStringify(x: unknown): string {


### PR DESCRIPTION
Three polish items for the rich traceback renderer. Bundled because they touch the same kernel/daemon/frontend pipeline and each change is small enough that splitting would be churn.

## Frame cap

A RecursionError traceback is ~1000 frames. The frontend already clusters consecutive duplicates into a single `× N` row, but distinct-but-deep stacks (mutually recursive, alternating call sites) slip through and blow up the payload.

Launcher now keeps 5 head + 5 tail frames and summarizes the middle with a sentinel row:

```json
{ "filename": "", "lineno": 0, "name": "… 990 frames omitted …", "library": true, "lines": [] }
```

`library: true` means existing dim-on-library rules handle it for free — no frontend changes.

## SyntaxError layout

Parse errors have no user-code frame. IPython raises from inside `ast_parse` before any cell bytecode runs, so the traceback is entirely internals. Before this PR the renderer walked those frames.

`build_rich_payload` detects `SyntaxError` (and subclasses `IndentationError`, `TabError`, `_IncompleteInputError`) and emits a payload with empty `frames` plus a `syntax` slot carrying everything CPython gives us:

```python
{
  "ename": "SyntaxError",
  "evalue": "invalid syntax (<tmpfile>, line 1)",
  "frames": [],
  "syntax": {
    "filename": "<tmpfile>",
    "lineno": 1, "offset": 7,
    "end_lineno": 1, "end_offset": 8,
    "text": "def x(:",
    "msg": "invalid syntax"
  },
  "text": "…canonical Traceback…",
}
```

`syntax` round-trips through the daemon via a new `RichSyntax` struct in `crates/runtimed/src/user_error.rs`. Without that, serde deserializes into a struct that has no such field and silently drops it on reserialization — the single invisible bug that made the first iteration of the frontend look broken.

Frontend renders the offending source line and draws:

- `^^^^` range underline when `end_offset > offset` and on the same line (matches CPython's 3.11+ format)
- single `^` caret otherwise

Header shows `syntax.msg` ("invalid syntax") instead of `str(evalue)` ("invalid syntax (<tmpfile>, line 1)"). The `(<tmpfile>, line 1)` tail is an ipykernel scratch-path artifact — noise for cell users, and location is already in the caret block.

CPython uses `-1` as the "unknown" sentinel for `end_lineno`/`end_offset`. Emitter normalizes to 0 so the renderer treats 0 as "absent" without special-casing negatives.

## Inline evalue

When `evalue` fits on one line, inline `ename: evalue` on the header. Multi-line evalues (AssertionError diffs, chained SQL errors) fall through to the two-line layout — inlining a multi-line value looks broken.

Independent of frame count. Before this PR a RuntimeError with a 6-frame stack showed `RuntimeError\nbottom`; now it reads `RuntimeError: bottom` even with frames rendered below.

## Behavioral coverage

| Input | Before | After |
|-------|--------|-------|
| RecursionError (1000 frames) | 1000-row `<ol>` | 5 head + sentinel + 5 tail |
| `def x(:` (real SyntaxError) | Frame list of IPython wrappers | Source line + `^^` range underline |
| `def oops(\n` (`_IncompleteInputError`) | Frame list of IPython wrappers | Source line + `^` caret (no `end_offset`) |
| `raise ValueError('x')` at cell top | Header + chevron row + source | Inline header + source |
| `RuntimeError` with 6 frames | `RuntimeError\nbottom` two-line | `RuntimeError: bottom` one-line, frames below |
| `AssertionError` with multi-line diff | Two-line header + frame row | Unchanged (multi-line falls through) |

## Test plan

- [x] `pytest python/nteract-kernel-launcher/tests/test_traceback.py` — 17/17 (7 new cases)
- [x] `cargo test -p runtimed --lib user_error` — 26/26 (existing tests pass with `syntax: None` backfill)
- [x] `pnpm test src/components/outputs` — 89/89
- [x] `cargo xtask lint` clean
- [x] Visual verification in dev daemon: SyntaxError caret + range underline, RuntimeError inline, clipped recursion sentinel