### PR TITLE
fix(runtimed): heal unsigned project-file-matching trust at room init

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -579,7 +579,57 @@ where
     }
 
     // 3. Set metadata (if present) and sync it
-    if let Some(meta) = metadata {
+    if let Some(mut meta) = metadata {
+        // #2150 reconciliation: if the parsed metadata has inline deps but
+        // no valid signature AND those deps exactly match a detected
+        // project file's deps, sign the snapshot in place before it lands
+        // in the doc. This keeps the doc's trust state consistent with
+        // room.trust_state (which room creation already promoted to
+        // Trusted via the same match condition) and stops
+        // check_and_update_trust_state from flipping it back to Untrusted
+        // after the first sync flush.
+        let needs_reconcile = matches!(
+            super::metadata::verify_trust_from_snapshot(&meta).status,
+            runt_trust::TrustStatus::Untrusted | runt_trust::TrustStatus::SignatureInvalid
+        );
+        if needs_reconcile {
+            // Build a TrustInfo-shaped view of the parsed meta so we can
+            // reuse the existing match helper. Only uv/conda deps are in
+            // scope for the trust check today (pixi bypasses trust, see
+            // #2151) so we only need to populate those.
+            let derived = runt_trust::TrustInfo {
+                status: runt_trust::TrustStatus::Untrusted,
+                uv_dependencies: meta
+                    .runt
+                    .uv
+                    .as_ref()
+                    .map(|u| u.dependencies.clone())
+                    .unwrap_or_default(),
+                conda_dependencies: meta
+                    .runt
+                    .conda
+                    .as_ref()
+                    .map(|c| c.dependencies.clone())
+                    .unwrap_or_default(),
+                conda_channels: vec![],
+            };
+            if super::metadata::project_file_deps_match_trust_info(path, &derived) {
+                match super::metadata::auto_sign_in_place(&mut meta) {
+                    Ok(()) => {
+                        info!(
+                            "[streaming-load] Signed project-file-matching metadata for {}",
+                            path.display()
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[streaming-load] Failed to auto-sign project-file-matching metadata: {}",
+                            e
+                        );
+                    }
+                }
+            }
+        }
         let encoded = {
             let mut doc = room.doc.write().await;
             if let Err(e) = doc.set_metadata_snapshot(&meta) {

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -611,7 +611,12 @@ where
                     .as_ref()
                     .map(|c| c.dependencies.clone())
                     .unwrap_or_default(),
-                conda_channels: vec![],
+                conda_channels: meta
+                    .runt
+                    .conda
+                    .as_ref()
+                    .map(|c| c.channels.clone())
+                    .unwrap_or_default(),
             };
             if super::metadata::project_file_deps_match_trust_info(path, &derived) {
                 match super::metadata::auto_sign_in_place(&mut meta) {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -898,6 +898,65 @@ pub(crate) async fn resolve_metadata_snapshot(
     None
 }
 
+/// Check whether a notebook's inline dependency list exactly matches a
+/// project file's dependency list (pyproject.toml / environment.yml /
+/// pixi.toml) in the notebook's own directory.
+///
+/// When this is true, the notebook's deps are an exact mirror of a file
+/// the user already has on disk. Signing them is safe because the trust
+/// surface ("these deps came from this machine") is already satisfied by
+/// file ownership. Used by #2150's room-init and streaming-load
+/// reconciliation to heal notebooks saved by pre-fix builds whose
+/// daemon-written deps never got a signature.
+///
+/// Returns `false` when no project file is found, when no kind matches
+/// the notebook's populated dep section, or when the lists differ.
+///
+/// Side-effect-free: does not read the notebook itself, does not touch
+/// the trust key, does not write anywhere. Callers decide what to do
+/// with the match.
+pub(crate) fn project_file_deps_match_trust_info(
+    notebook_path: &Path,
+    info: &runt_trust::TrustInfo,
+) -> bool {
+    let Some(parent) = notebook_path.parent() else {
+        return false;
+    };
+    let Some(detected) = crate::project_file::detect_project_file(parent) else {
+        return false;
+    };
+    // Order-insensitive compare: `extract_pyproject_deps` already sorts,
+    // but a hand-edited .ipynb may hold deps in any order. Sort both
+    // sides so the match is stable regardless of source ordering.
+    fn sorted(xs: &[String]) -> Vec<String> {
+        let mut v = xs.to_vec();
+        v.sort();
+        v
+    }
+    match detected.kind {
+        crate::project_file::ProjectFileKind::PyprojectToml => {
+            let Ok(content) = std::fs::read_to_string(&detected.path) else {
+                return false;
+            };
+            let project_deps = extract_pyproject_deps(&content);
+            !project_deps.is_empty() && sorted(&project_deps) == sorted(&info.uv_dependencies)
+        }
+        crate::project_file::ProjectFileKind::EnvironmentYml => {
+            let Ok(env_config) = crate::project_file::parse_environment_yml(&detected.path) else {
+                return false;
+            };
+            !env_config.dependencies.is_empty()
+                && sorted(&env_config.dependencies) == sorted(&info.conda_dependencies)
+        }
+        crate::project_file::ProjectFileKind::PixiToml => {
+            // Pixi deps currently bypass the HMAC check entirely
+            // (see #2151). Reconciliation is a no-op here until that
+            // lands — returning false keeps behavior unchanged.
+            false
+        }
+    }
+}
+
 /// Verify trust status of a notebook by reading its file from disk.
 /// Returns TrustState with the verification result.
 ///

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -945,8 +945,15 @@ pub(crate) fn project_file_deps_match_trust_info(
             let Ok(env_config) = crate::project_file::parse_environment_yml(&detected.path) else {
                 return false;
             };
+            // Channels are part of the signed trust payload (runt_trust
+            // extracts them into TrustInfo) and conda channel priority
+            // affects package resolution, so channel order matters.
+            // Compare exact, preserving order. A notebook with matching
+            // deps but different channels stays Untrusted — that's a
+            // real trust event, not a silent heal.
             !env_config.dependencies.is_empty()
                 && sorted(&env_config.dependencies) == sorted(&info.conda_dependencies)
+                && env_config.channels == info.conda_channels
         }
         crate::project_file::ProjectFileKind::PixiToml => {
             // Pixi deps currently bypass the HMAC check entirely
@@ -2418,19 +2425,22 @@ pub(crate) async fn auto_launch_kernel(
             crate::project_file::ProjectFileKind::EnvironmentYml => {
                 if let Ok(env_config) = crate::project_file::parse_environment_yml(&detected.path) {
                     let deps = env_config.dependencies;
+                    let channels = env_config.channels;
                     if !deps.is_empty() {
                         let mut doc = room.doc.write().await;
                         let mut changed = false;
                         doc.fork_and_merge(|fork| {
                             let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
                             let current_deps = snap.runt.conda.as_ref().map(|c| &c.dependencies);
+                            let current_channels = snap.runt.conda.as_ref().map(|c| &c.channels);
                             let deps_match = current_deps.is_some_and(|d| d == &deps);
+                            let channels_match = current_channels.is_some_and(|c| c == &channels);
                             let trust_ok = matches!(
                                 verify_trust_from_snapshot(&snap).status,
                                 runt_trust::TrustStatus::Trusted
                                     | runt_trust::TrustStatus::NoDependencies
                             );
-                            if !deps_match || !trust_ok {
+                            if !deps_match || !channels_match || !trust_ok {
                                 let conda = snap.runt.conda.get_or_insert_with(|| {
                                     notebook_doc::metadata::CondaInlineMetadata {
                                         dependencies: Vec::new(),
@@ -2439,6 +2449,12 @@ pub(crate) async fn auto_launch_kernel(
                                     }
                                 });
                                 conda.dependencies = deps;
+                                // Channels are part of the signed trust
+                                // payload. Mirror env.yml's channels
+                                // exactly so reconciliation on reopen
+                                // can verify the notebook's channel
+                                // list didn't drift from source.
+                                conda.channels = channels;
                                 if let Err(e) = auto_sign_in_place(&mut snap) {
                                     warn!(
                                         "[notebook-sync] Failed to auto-sign environment.yml bootstrap: {}",

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -342,7 +342,26 @@ impl NotebookRoom {
                     pending_launch: false,
                 },
             },
-            Some(p) => verify_trust_from_file(p),
+            Some(p) => {
+                let mut initial = verify_trust_from_file(p);
+                // #2150 reconciliation: if the .ipynb on disk has deps that
+                // exactly match a project file's deps (pyproject/env.yml),
+                // treat it as Trusted in memory so the auto-launch gate in
+                // peer.rs does not block. The signature lands in the doc
+                // via streaming_load's reconciliation pass, which fires
+                // before the first sync flush.
+                if matches!(initial.status, runt_trust::TrustStatus::Untrusted)
+                    && project_file_deps_match_trust_info(p, &initial.info)
+                {
+                    info!(
+                        "[notebook-sync] Reconciled project-file trust for {:?} (deps match; promoting Untrusted -> Trusted)",
+                        p
+                    );
+                    initial.status = runt_trust::TrustStatus::Trusted;
+                    initial.info.status = runt_trust::TrustStatus::Trusted;
+                }
+                initial
+            }
         };
         info!(
             "[notebook-sync] Trust status for {}: {:?}",
@@ -413,7 +432,16 @@ impl NotebookRoom {
                     pending_launch: false,
                 },
             },
-            Some(p) => verify_trust_from_file(p),
+            Some(p) => {
+                let mut initial = verify_trust_from_file(p);
+                if matches!(initial.status, runt_trust::TrustStatus::Untrusted)
+                    && project_file_deps_match_trust_info(p, &initial.info)
+                {
+                    initial.status = runt_trust::TrustStatus::Trusted;
+                    initial.info.status = runt_trust::TrustStatus::Trusted;
+                }
+                initial
+            }
         };
         let (state_changed_tx, _) = broadcast::channel(16);
         let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5379,6 +5379,99 @@ fn test_project_file_deps_match_trust_info_pyproject_mismatch() {
     assert!(!project_file_deps_match_trust_info(&nb_path, &info));
 }
 
+fn write_env_yml(dir: &std::path::Path, channels: &[&str], deps: &[&str]) {
+    let mut body = String::from("name: test\n");
+    if !channels.is_empty() {
+        body.push_str("channels:\n");
+        for c in channels {
+            body.push_str(&format!("  - {}\n", c));
+        }
+    }
+    body.push_str("dependencies:\n");
+    for d in deps {
+        body.push_str(&format!("  - {}\n", d));
+    }
+    std::fs::write(dir.join("environment.yml"), body).unwrap();
+}
+
+fn write_unsigned_ipynb_with_conda(path: &std::path::Path, deps: &[&str], channels: &[&str]) {
+    let deps_json = deps
+        .iter()
+        .map(|d| format!("\"{}\"", d))
+        .collect::<Vec<_>>()
+        .join(",");
+    let channels_json = channels
+        .iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = format!(
+        r#"{{
+  "cells": [],
+  "metadata": {{
+    "kernelspec": {{"name": "python3", "display_name": "Python 3", "language": "python"}},
+    "language_info": {{"name": "python"}},
+    "runt": {{
+      "schema_version": "1",
+      "conda": {{"dependencies": [{}], "channels": [{}]}}
+    }}
+  }},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}}"#,
+        deps_json, channels_json
+    );
+    std::fs::write(path, body).unwrap();
+}
+
+/// Codex P1 on #2158: env.yml match must also compare channels, not
+/// just deps. Without this, a notebook with matching deps but different
+/// inline channels would be auto-signed as Trusted, preserving an
+/// approved signature over channels that didn't come from the project
+/// file.
+#[test]
+fn test_project_file_deps_match_trust_info_envyml_channel_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_env_yml(tmp.path(), &["conda-forge"], &["pandas", "numpy"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    // Same deps, different channels — must not match.
+    write_unsigned_ipynb_with_conda(&nb_path, &["pandas", "numpy"], &["http://evil.example"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert_eq!(info.conda_dependencies, vec!["pandas", "numpy"]);
+    assert_eq!(info.conda_channels, vec!["http://evil.example"]);
+    assert!(
+        !project_file_deps_match_trust_info(&nb_path, &info),
+        "channel mismatch must block reconciliation even when deps match",
+    );
+}
+
+#[test]
+fn test_project_file_deps_match_trust_info_envyml_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_env_yml(tmp.path(), &["conda-forge", "bioconda"], &["pandas"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_conda(&nb_path, &["pandas"], &["conda-forge", "bioconda"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert!(project_file_deps_match_trust_info(&nb_path, &info));
+}
+
+#[test]
+fn test_project_file_deps_match_trust_info_envyml_channel_order() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_env_yml(tmp.path(), &["conda-forge", "bioconda"], &["pandas"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    // Same channels but reversed — channel priority matters, so reject.
+    write_unsigned_ipynb_with_conda(&nb_path, &["pandas"], &["bioconda", "conda-forge"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert!(
+        !project_file_deps_match_trust_info(&nb_path, &info),
+        "channel order affects conda resolution priority; reorderings must not auto-heal",
+    );
+}
+
 #[test]
 fn test_project_file_deps_match_trust_info_no_project_file() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5317,3 +5317,148 @@ dependencies:
         "pip block should be untouched:\n{updated}"
     );
 }
+
+// ── #2150: project-file trust reconciliation tests ─────────────────────
+
+fn write_pyproject_with_deps(dir: &std::path::Path, deps: &[&str]) {
+    let body = format!(
+        "[project]\nname = \"test\"\nversion = \"0.0.1\"\ndependencies = [{}]\n",
+        deps.iter()
+            .map(|d| format!("\"{}\"", d))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    std::fs::write(dir.join("pyproject.toml"), body).unwrap();
+}
+
+fn write_unsigned_ipynb_with_uv_deps(path: &std::path::Path, deps: &[&str]) {
+    let deps_json = deps
+        .iter()
+        .map(|d| format!("\"{}\"", d))
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = format!(
+        r#"{{
+  "cells": [],
+  "metadata": {{
+    "kernelspec": {{"name": "python3", "display_name": "Python 3", "language": "python"}},
+    "language_info": {{"name": "python"}},
+    "runt": {{
+      "schema_version": "1",
+      "uv": {{"dependencies": [{}]}}
+    }}
+  }},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}}"#,
+        deps_json
+    );
+    std::fs::write(path, body).unwrap();
+}
+
+#[test]
+fn test_project_file_deps_match_trust_info_pyproject_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas", "numpy"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_uv_deps(&nb_path, &["pandas", "numpy"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert_eq!(info.uv_dependencies, vec!["pandas", "numpy"]);
+    assert!(project_file_deps_match_trust_info(&nb_path, &info));
+}
+
+#[test]
+fn test_project_file_deps_match_trust_info_pyproject_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_uv_deps(&nb_path, &["pandas", "numpy"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert!(!project_file_deps_match_trust_info(&nb_path, &info));
+}
+
+#[test]
+fn test_project_file_deps_match_trust_info_no_project_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_uv_deps(&nb_path, &["pandas"]);
+
+    let info = verify_trust_from_file(&nb_path).info;
+    assert!(!project_file_deps_match_trust_info(&nb_path, &info));
+}
+
+/// Regression for #2150: a .ipynb on disk with deps that match a
+/// project file's but no signature (a notebook saved by the pre-fix
+/// build) must land on Trusted at room creation, so the auto-launch
+/// gate in peer.rs doesn't block.
+#[tokio::test]
+#[serial]
+async fn test_new_fresh_promotes_untrusted_when_project_file_deps_match() {
+    let key_tmp = tempfile::tempdir().unwrap();
+    let key_path = key_tmp.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas", "numpy"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_uv_deps(&nb_path, &["pandas", "numpy"]);
+
+    // Bare verify sees Untrusted — precondition.
+    assert_eq!(
+        verify_trust_from_file(&nb_path).status,
+        runt_trust::TrustStatus::Untrusted,
+    );
+
+    // Room creation runs reconciliation and should land on Trusted.
+    let blob_store = test_blob_store(&tmp);
+    let room = NotebookRoom::new_fresh(
+        uuid::Uuid::new_v4(),
+        Some(nb_path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+
+    let ts = room.trust_state.read().await;
+    assert_eq!(
+        ts.status,
+        runt_trust::TrustStatus::Trusted,
+        "room init should promote Untrusted -> Trusted when project-file deps match",
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}
+
+/// Counterpart: if deps differ, room init must leave trust Untrusted.
+#[tokio::test]
+#[serial]
+async fn test_new_fresh_leaves_untrusted_when_deps_differ() {
+    let key_tmp = tempfile::tempdir().unwrap();
+    let key_path = key_tmp.path().join("trust-key");
+    std::env::set_var("RUNT_TRUST_KEY_PATH", key_path.to_str().unwrap());
+
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas"]);
+    let nb_path = tmp.path().join("notebook.ipynb");
+    write_unsigned_ipynb_with_uv_deps(&nb_path, &["pandas", "numpy"]);
+
+    let blob_store = test_blob_store(&tmp);
+    let room = NotebookRoom::new_fresh(
+        uuid::Uuid::new_v4(),
+        Some(nb_path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+
+    let ts = room.trust_state.read().await;
+    assert_eq!(
+        ts.status,
+        runt_trust::TrustStatus::Untrusted,
+        "mismatched deps must not auto-promote",
+    );
+
+    std::env::remove_var("RUNT_TRUST_KEY_PATH");
+}

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2541,6 +2541,153 @@ class TestTrustApproval:
         assert info is not None
         assert info.needs_trust_approval is False
 
+    async def test_pyproject_trust_heal_at_room_init(self, client, tmp_path):
+        """A notebook saved by a pre-fix build has pyproject-matching deps
+        but no trust signature. On reopen, room-init reconciliation should
+        promote it to Trusted so `needs_trust_approval` is False and the
+        auto-launch gate does not block.
+
+        Regression for nteract/desktop#2150.
+        """
+        import json
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "0.0.1"\ndependencies = ["pandas", "numpy"]\n'
+        )
+
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "runt": {
+                            "schema_version": "1",
+                            "uv": {"dependencies": ["pandas", "numpy"]},
+                            # No trust_signature - simulates pre-fix daemon write
+                        }
+                    },
+                    "cells": [],
+                }
+            )
+        )
+
+        session = await client.open_notebook(str(nb_path))
+        info = await session.connection_info()
+        assert info is not None
+        assert info.needs_trust_approval is False, (
+            "pyproject-matching deps without a signature must heal at room init, "
+            "not block auto-launch"
+        )
+
+    async def test_pyproject_mismatch_stays_untrusted(self, client, tmp_path):
+        """If inline deps differ from pyproject.toml, reconciliation must
+        decline and the notebook stays Untrusted. This preserves real trust
+        events (novel deps arriving) instead of silently signing them.
+        """
+        import json
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "0.0.1"\ndependencies = ["pandas"]\n'
+        )
+
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "runt": {
+                            "schema_version": "1",
+                            "uv": {"dependencies": ["pandas", "malicious-pkg"]},
+                        }
+                    },
+                    "cells": [],
+                }
+            )
+        )
+
+        session = await client.open_notebook(str(nb_path))
+        info = await session.connection_info()
+        assert info is not None
+        assert info.needs_trust_approval is True
+
+    async def test_envyml_trust_heal_includes_channels(self, client, tmp_path):
+        """environment.yml reconciliation must match both deps and channels.
+        A notebook with matching deps AND matching channels heals.
+        """
+        import json
+
+        (tmp_path / "environment.yml").write_text(
+            "name: test-env\nchannels:\n  - conda-forge\ndependencies:\n  - pandas\n  - numpy\n"
+        )
+
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "runt": {
+                            "schema_version": "1",
+                            "conda": {
+                                "dependencies": ["pandas", "numpy"],
+                                "channels": ["conda-forge"],
+                            },
+                        }
+                    },
+                    "cells": [],
+                }
+            )
+        )
+
+        session = await client.open_notebook(str(nb_path))
+        info = await session.connection_info()
+        assert info is not None
+        assert info.needs_trust_approval is False
+
+    async def test_envyml_channel_mismatch_blocks_heal(self, client, tmp_path):
+        """Codex P1 on #2158: a notebook with matching conda deps but
+        different inline channels must stay Untrusted. Without this, a
+        notebook could smuggle an approved signature over channels that
+        didn't come from the project file.
+        """
+        import json
+
+        (tmp_path / "environment.yml").write_text(
+            "name: test-env\nchannels:\n  - conda-forge\ndependencies:\n  - pandas\n  - numpy\n"
+        )
+
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "runt": {
+                            "schema_version": "1",
+                            "conda": {
+                                "dependencies": ["pandas", "numpy"],
+                                "channels": ["http://evil.example"],
+                            },
+                        }
+                    },
+                    "cells": [],
+                }
+            )
+        )
+
+        session = await client.open_notebook(str(nb_path))
+        info = await session.connection_info()
+        assert info is not None
+        assert info.needs_trust_approval is True, (
+            "channel mismatch must block reconciliation even when deps match"
+        )
+
 
 # ============================================================================
 # Presence Tests


### PR DESCRIPTION
Closes #2150.

## Overview

Notebooks saved by pre-fix builds can have `metadata.runt.uv.dependencies` populated by the daemon's auto-launch bootstrap without a matching trust signature. On reopen, `verify_trust_from_file` returns `Untrusted`, and `peer.rs:444`'s auto-launch gate (Trusted | NoDependencies) blocks the kernel. The bootstrap fix in #2148 doesn't reach these notebooks because bootstrap runs downstream of the gate.

## Diagnosis

For a `.ipynb` with matching pyproject deps and no signature:

1. Room init: `verify_trust_from_file` → `Untrusted`. `trust_state.status = Untrusted`.
2. `peer.rs:444`: `should_auto_launch = matches!(status, Trusted | NoDependencies)` → false.
3. RuntimeStateDoc set to `awaiting_trust`. Banner stays. Kernel never launches.
4. Bootstrap in `auto_launch_kernel` (where #2148 signs) is never reached.

Confirmed with a dev-daemon E2E in the pre-fix build: log shows `Trust status: Untrusted` → `Kernel blocked on trust approval`, and bootstrap is never invoked.

## Fix

Added `project_file_deps_match_trust_info` in `notebook_sync_server/metadata.rs`. It walks the notebook's parent dir for `pyproject.toml` or `environment.yml`, extracts the project's deps, and compares against the .ipynb's inline deps (sorted, order-insensitive).

Wired in two places:

- **`room.rs::new_fresh` and `load_or_create`**: on Untrusted init, if deps match, promote `trust_state` to Trusted in memory so the auto-launch gate sees Trusted.
- **`load.rs::streaming_load_cells`**: before the parsed metadata lands in the doc, if it verifies as Untrusted and deps match, `auto_sign_in_place` signs it. Keeps the doc consistent with `room.trust_state` so `check_and_update_trust_state` doesn't flip back after the first sync flush.

Both paths reuse the same match helper.

## Design decision

Exact-match only. If the user added or removed a package relative to the project file, the deps differ, so reconciliation bails out and the banner stays. That preserves real trust events (novel deps arriving) while healing daemon self-writes.

Sorted comparison tolerates hand-edited notebooks where the order differs from `extract_pyproject_deps`'s sorted output.

## Pixi coverage

Pixi deps intentionally don't participate in reconciliation. They already bypass the HMAC check entirely (see #2151), so the match would be moot. Once #2151 lands and pixi joins the trust check, the pixi branch of the helper becomes a one-liner addition.

## Test plan

- [x] `cargo test -p runtimed --lib` - 442 passing
- [x] `cargo clippy -p runtimed --all-targets` - clean
- [x] Unit tests for `project_file_deps_match_trust_info`: pyproject match, pyproject mismatch, no project file.
- [x] `test_new_fresh_promotes_untrusted_when_project_file_deps_match` - room creation promotes trust.
- [x] `test_new_fresh_leaves_untrusted_when_deps_differ` - mismatched deps stay Untrusted.
- [x] Manual E2E: dev daemon rebuilt with the fix, handwrote a .ipynb with repo's pyproject deps and no signature, connected via MCP. Daemon log:
  ```
  [streaming-load] Signed project-file-matching metadata for .../prefix_saved.ipynb
  [notebook-sync] Auto-launch: using project file -> uv:pyproject
  Kernel started: studious-mouflon
  ```
  Pre-fix run against the same fixture showed `Trust status: Untrusted` → `Kernel blocked on trust approval`; kernel never started.
