### PR TITLE
fix(runtimed): inject launcher PYTHONPATH for conda:env_yml spawn

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -364,6 +364,18 @@ impl KernelConnection for JupyterKernel {
                                 cmd.arg(&connection_file_path);
                                 cmd.stdout(Stdio::null());
                                 cmd.stderr(Stdio::piped());
+                                if bootstrap_dx {
+                                    // The env belongs to the user (created from
+                                    // their environment.yml). Writing launcher
+                                    // files into a shared conda env is a
+                                    // permissions / cleanup hazard, so inject
+                                    // the daemon-side launcher via PYTHONPATH —
+                                    // same pattern as `uv run` and `pixi exec`.
+                                    // Without this, `-m nteract_kernel_launcher`
+                                    // fails immediately with ModuleNotFoundError.
+                                    let dir = crate::launcher_cache::launcher_cache_dir().await?;
+                                    cmd.env("PYTHONPATH", &dir);
+                                }
                                 cmd
                             } else {
                                 return Err(anyhow::anyhow!(


### PR DESCRIPTION
## Overview

`conda:env_yml` kernel spawn with `bootstrap_dx=true` crashes at exit 1 with `ModuleNotFoundError: No module named 'nteract_kernel_launcher'`. The launcher is vendored into every pool env (UV / conda-inline / pixi-pool) at creation time, but `conda:env_yml` uses the user's existing conda env — which the daemon deliberately doesn't touch (permissions, shared env, cleanup hazard).

`uv run` and `pixi exec` already solve this: they inject the daemon-side launcher cache dir via `PYTHONPATH` instead of vendoring. This PR applies the same pattern to `conda:env_yml`.

## Design decision

Three options were on the table:

1. **Vendor into the user's conda env.** Simple but mutates shared state. A second machine with the same `small_models_sp26` env would see mysterious nteract files in site-packages. Cleanup on uninstall is an open question. No.
2. **PYTHONPATH injection.** Daemon materializes the launcher once per daemon lifetime at a stable cache path (`~/Library/Caches/runt-nightly/.../launcher/`). Child python process gets `PYTHONPATH=<that path>` and resolves `-m nteract_kernel_launcher` without any env-side writes. This is what `uv run` and `pixi exec` do.
3. **Fall back to `ipykernel_launcher` when we can't vendor.** Loses bootstrap_dx features silently. Worse UX than fixing the plumbing.

Option 2 is the right scope.

## Repro

Exact argv the daemon spawns:

```
$ /opt/homebrew/Caskroom/miniforge/base/envs/small_models_sp26/bin/python \
    -Xfrozen_modules=off -m nteract_kernel_launcher -f /tmp/bogus.json
/opt/homebrew/Caskroom/miniforge/base/envs/small_models_sp26/bin/python: No module named nteract_kernel_launcher
  (exit 1)
```

With `PYTHONPATH` pointing at the daemon cache:

```
$ PYTHONPATH=~/Library/Caches/runt-nightly/.../launcher \
    /opt/homebrew/Caskroom/miniforge/base/envs/small_models_sp26/bin/python \
    -Xfrozen_modules=off -c "import nteract_kernel_launcher"
  (exit 0)
```

## End-to-end test

Dev daemon with the fix, minimal `environment.yml` referencing `small_models_sp26`, open a notebook from that directory. Auto-launch hits the `conda:env_yml` path, kernel starts, cell executes:

```
python:   /opt/homebrew/Caskroom/miniforge/base/envs/small_models_sp26/bin/python
launcher: ~/Library/Caches/runt-nightly/.../launcher/nteract_kernel_launcher/__init__.py
```

## Context

Addresses the launcher half of bug #4 from the 2026-04-24 session report (`2-Beginner_NBs/2-1-LlamaCpp_SmallLM_Demo.ipynb` on a repo with `environment.yml`). The session was on a nightly that predated PR #2154 (stderr capture on kernel early exit, merged in 18a1f494), so the underlying cause was obscured behind "exit status: 1" in the daemon log. #2154 is already in main — a future recurrence of this class would surface the `ModuleNotFoundError` directly in the diagnostics.

The other three bugs from the session report (whole-file churn on open, Untitled.ipynb title after show_notebook, conda:env_yml env-resolution silent fail) are separate issues / PRs.

## Test plan

- [x] `cargo build -p runtimed` clean
- [x] `cargo xtask lint` clean
- [x] Manual repro confirmed exit-1 without fix
- [x] End-to-end kernel spawn in `conda:env_yml` env succeeds with fix
- [ ] Nightly regression check once this merges