### PR TITLE
docs(settings): rewrite bootstrap_dx feature flag copy

### DIFF
--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -87,9 +87,8 @@ export function isKnownPythonEnv(value: string): value is "uv" | "conda" | "pixi
  */
 export const FEATURE_FLAG_METADATA = {
   bootstrap_dx: {
-    label: "nteract/dx DataFrame rendering",
-    description:
-      "Install nteract-kernel-launcher + dx into UV kernels and enable rich DataFrame rendering via dx.install(). Requires restarting any running kernels.",
+    label: "Rich DataFrames and Exceptions",
+    description: "Enable the nteract kernel launcher into Python runtimes.",
   },
 } as const satisfies Record<string, { label: string; description: string }>;
 


### PR DESCRIPTION
## Overview

Feature flag card in Settings → Feature Flags currently reads:

> **nteract/dx DataFrame rendering**
> Install nteract-kernel-launcher + dx into UV kernels and enable rich DataFrame rendering via dx.install(). Requires restarting any running kernels.

That's implementation framing — two product names, an internal function call, and an operational caveat. None of it helps a user decide whether to flip the toggle. It also now undersells what the flag does: the launcher ships rich traceback rendering alongside DataFrame formatting.

New copy:

> **Rich DataFrames and Exceptions**
> Enable the nteract kernel launcher into Python runtimes.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [ ] Visual check in Settings panel post-merge