### PR TITLE
fix(runtimed): fall back to conda pool when env.yml declared env is missing

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -898,6 +898,35 @@ pub(crate) async fn resolve_metadata_snapshot(
     None
 }
 
+/// If the detected project file is an `environment.yml` whose declared
+/// conda env isn't built on this machine, return the declared env name
+/// so the caller can fall back to a pool env instead of hard-failing in
+/// the runtime agent.
+///
+/// Used by the auto-launch path: `conda:env_yml` otherwise tries to
+/// resolve the named env and errors with "could not resolve conda
+/// environment prefix" when the env doesn't exist. The kernel hangs in
+/// "initializing" forever. With this check we can detect the miss
+/// upfront and route the launch through the conda pool.
+///
+/// Returns `None` when the project file isn't `environment.yml`, when
+/// the env is built and usable, or when env.yml has no `name:`/`prefix:`
+/// field (in which case the existing error path handles it).
+pub(crate) fn missing_conda_env_yml_name(
+    detected: &crate::project_file::DetectedProjectFile,
+) -> Option<String> {
+    if detected.kind != crate::project_file::ProjectFileKind::EnvironmentYml {
+        return None;
+    }
+    if crate::project_file::resolve_conda_env_prefix(&detected.path).is_some() {
+        return None;
+    }
+    crate::project_file::parse_environment_yml(&detected.path)
+        .ok()
+        .and_then(|c| c.name)
+        .or_else(|| Some(String::from("(unnamed)")))
+}
+
 /// Check whether a notebook's inline dependency list exactly matches a
 /// project file's dependency list (pyproject.toml / environment.yml /
 /// pixi.toml) in the notebook's own directory.
@@ -2493,11 +2522,30 @@ pub(crate) async fn auto_launch_kernel(
                 // Project file wins because inline deps get promoted to the
                 // project file at sync/launch time (project is source of truth).
                 let env_source: EnvSource = if let Some(ref proj) = project_source {
-                    info!(
-                        "[notebook-sync] Auto-launch: using project file -> {}",
-                        proj.as_str()
-                    );
-                    proj.clone()
+                    // If the project file is an environment.yml whose
+                    // declared conda env isn't built on this machine,
+                    // fall back to the conda pool instead of letting
+                    // `conda:env_yml` fail downstream in the runtime
+                    // agent. Without this, the kernel hangs in
+                    // `initializing` forever (#2157).
+                    if let Some(missing_name) = detected_project_file
+                        .as_ref()
+                        .and_then(missing_conda_env_yml_name)
+                    {
+                        let fallback = EnvSource::Prewarmed(PackageManager::Conda);
+                        warn!(
+                            "[notebook-sync] conda:env_yml declared env '{}' not built on this machine; falling back to {}",
+                            missing_name,
+                            fallback.as_str()
+                        );
+                        fallback
+                    } else {
+                        info!(
+                            "[notebook-sync] Auto-launch: using project file -> {}",
+                            proj.as_str()
+                        );
+                        proj.clone()
+                    }
                 } else if let Some(ref source) = inline_source {
                     // Skip Deno inline source for Python notebooks (kernelspec takes priority)
                     if !matches!(source, EnvSource::Deno) {
@@ -2566,11 +2614,24 @@ pub(crate) async fn auto_launch_kernel(
                     // Default to Python
                     // Priority: project file > inline deps > prewarmed
                     let env_source: EnvSource = if let Some(ref source) = project_source {
-                        info!(
-                            "[notebook-sync] Auto-launch: using project file -> {}",
-                            source.as_str()
-                        );
-                        source.clone()
+                        if let Some(missing_name) = detected_project_file
+                            .as_ref()
+                            .and_then(missing_conda_env_yml_name)
+                        {
+                            let fallback = EnvSource::Prewarmed(PackageManager::Conda);
+                            warn!(
+                                "[notebook-sync] conda:env_yml declared env '{}' not built on this machine; falling back to {}",
+                                missing_name,
+                                fallback.as_str()
+                            );
+                            fallback
+                        } else {
+                            info!(
+                                "[notebook-sync] Auto-launch: using project file -> {}",
+                                source.as_str()
+                            );
+                            source.clone()
+                        }
                     } else if let Some(ref source) = inline_source {
                         info!(
                             "[notebook-sync] Auto-launch: found inline deps -> {}",

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5482,6 +5482,75 @@ fn test_project_file_deps_match_trust_info_no_project_file() {
     assert!(!project_file_deps_match_trust_info(&nb_path, &info));
 }
 
+// ── #2157: conda:env_yml fallback when declared env is missing ─────────
+
+/// When the env.yml declares a conda env that isn't built on the test
+/// machine, `missing_conda_env_yml_name` returns the declared name so
+/// the auto-launch path can fall back to the conda pool instead of
+/// hard-failing in the runtime agent.
+#[test]
+fn test_missing_conda_env_yml_name_detects_unbuilt_named_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        "name: nteract-integration-probe-definitely-not-built-xyz\ndependencies:\n  - python\n",
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(
+        missing_conda_env_yml_name(&detected).as_deref(),
+        Some("nteract-integration-probe-definitely-not-built-xyz"),
+    );
+}
+
+/// `missing_conda_env_yml_name` is an env.yml-specific check — pyproject
+/// and pixi project files never report as "missing" through this helper.
+#[test]
+fn test_missing_conda_env_yml_name_skips_non_envyml() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas"]);
+    let detected = crate::project_file::DetectedProjectFile {
+        path: tmp.path().join("pyproject.toml"),
+        kind: crate::project_file::ProjectFileKind::PyprojectToml,
+    };
+    assert_eq!(missing_conda_env_yml_name(&detected), None);
+}
+
+/// env.yml with a `prefix:` pointing at a real directory is "built"
+/// (python exists). Helper returns None so the normal conda:env_yml
+/// path runs.
+#[test]
+fn test_missing_conda_env_yml_name_prefix_with_python_is_not_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Fabricate a fake conda env layout: prefix/bin/python exists.
+    let prefix = tmp.path().join("fake-env");
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::write(prefix.join("bin").join("python"), "#!/bin/sh\nexit 0\n").unwrap();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::fs::create_dir_all(&prefix).unwrap();
+        std::fs::write(prefix.join("python.exe"), "").unwrap();
+    }
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        format!("prefix: {}\ndependencies:\n  - python\n", prefix.display()),
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(missing_conda_env_yml_name(&detected), None);
+}
+
 /// Regression for #2150: a .ipynb on disk with deps that match a
 /// project file's but no signature (a notebook saved by the pre-fix
 /// build) must land on Trusted at room creation, so the auto-launch


### PR DESCRIPTION
Closes #2157.

## Overview

A notebook next to an `environment.yml` declaring a conda env that isn't built on the user's machine sent the runtime agent down the `conda:env_yml` path, which tried to resolve the named env via `find_named_conda_env`, got `None`, and returned `Err("conda:env_yml could not resolve conda environment prefix")`. The agent died, the kernel stayed in `initializing` forever, and nothing in the daemon's default log level explained why.

## Diagnosis

From the user-feedback writeup on 2026-04-24:

```
LaunchKernel: type=python source=conda:env_yml
WARN Agent kernel launch failed:
  Failed to launch kernel: conda:env_yml could not resolve conda environment prefix
Runtime agent exited with status: signal: 9 (SIGKILL)
```

The failure was hard-coded in `jupyter_kernel.rs:375-377`. Nothing in the orchestrator caught it. `reset_starting_state` was called but no recovery was attempted.

## Fix

Added `missing_conda_env_yml_name` in `notebook_sync_server/metadata.rs`. Given a detected `environment.yml`, it returns the declared env name when the env isn't built. Uses the same resolver (`resolve_conda_env_prefix` → `find_named_conda_env`) the kernel path uses, so detection agrees with what the kernel would see.

Wired into both `env_source` decision sites in `auto_launch_kernel`. When the check fires, the log warns with the declared name and env_source becomes `Prewarmed(Conda)` instead of `EnvYml`. The runtime agent launches against a pool conda env; the notebook is usable.

## Scope limit

The env.yml's deps are bootstrapped into the CRDT by #2148's path but **do not auto-sync into the claimed pool env on fallback**. Imports from those deps (`import pandas`) fail until the user adds the deps through the UI or the sync banner. Tracking separately; the scope of this PR is "kernel no longer stuck forever," not full parity with a built env.

The per-feedback-document proper UX is a consent prompt at open time ("this repo declares environment.yml, ~5min + ~2GB to build; build now or use pool?"). That's a product design + frontend change, distinct from this daemon-side unblock. Worth a followup issue.

## Test plan

- [x] `cargo test -p runtimed --lib` — 448 passing (+3)
- [x] `cargo clippy -p runtimed --all-targets` — clean
- [x] Three unit tests for `missing_conda_env_yml_name`: detects unbuilt named env, skips non-env.yml project files, treats `prefix:` pointing at a real env as not missing.
- [x] Manual E2E: dev daemon rebuilt, notebook next to `environment.yml` naming `nteract-definitely-not-built-env-xyz`. Daemon log:
  ```
  Auto-launch: detected project file ".../environment.yml" -> conda:env_yml
  Bootstrapped environment.yml deps into CRDT
  WARN conda:env_yml declared env 'nteract-definitely-not-built-env-xyz' not built on this machine; falling back to conda:prewarmed
  ...
  LaunchKernel: type=python source=conda:prewarmed
  Starting Python kernel from env at ".../conda-envs/10a83a7be15ee9ac/bin/python"
  Auto-launch via runtime agent succeeded: python kernel with conda:prewarmed environment
  ```
  Cell executed (basic `print` works). `import pandas` fails — tracked as the scope limit above.
