### PR TITLE
fix(notebook): show_notebook displays correct title for path-resolved rooms

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -590,6 +590,10 @@ pub struct NotebookConnectionInfo {
     /// Whether this notebook is ephemeral (in-memory only, no persistence).
     #[serde(default)]
     pub ephemeral: bool,
+    /// On-disk path when the room is file-backed. Populated by `CreateNotebook`
+    /// when `notebook_id_hint` resolves to a room that already has a path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notebook_path: Option<String>,
 }
 
 /// Frame types for notebook sync connections.
@@ -1069,6 +1073,7 @@ mod tests {
             needs_trust_approval: false,
             error: None,
             ephemeral: false,
+            notebook_path: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
@@ -1086,6 +1091,7 @@ mod tests {
             needs_trust_approval: false,
             error: None,
             ephemeral: false,
+            notebook_path: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
@@ -1101,6 +1107,7 @@ mod tests {
             needs_trust_approval: true,
             error: None,
             ephemeral: false,
+            notebook_path: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""needs_trust_approval":true"#));
@@ -1115,9 +1122,30 @@ mod tests {
             needs_trust_approval: false,
             error: Some("File not found".into()),
             ephemeral: false,
+            notebook_path: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""error":"File not found""#));
+
+        // With notebook_path
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: false,
+            notebook_path: Some("/home/user/notebook.ipynb".into()),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));
+
+        // Backward compat: deserialize without notebook_path
+        let old_json = r#"{"protocol":"v2","notebook_id":"abc","cell_count":1,"needs_trust_approval":false,"ephemeral":false}"#;
+        let info: NotebookConnectionInfo = serde_json::from_str(old_json).unwrap();
+        assert!(info.notebook_path.is_none());
     }
 
     #[tokio::test]

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -742,9 +742,7 @@ async fn initialize_notebook_sync_create(
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
         ephemeral: info.ephemeral,
-        // Create mode has no on-disk path. If the room was created from a
-        // restored untitled-session snapshot it still has no file backing.
-        notebook_path: None,
+        notebook_path: info.notebook_path.clone(),
         runtime: Some(runtime),
     };
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -645,7 +645,7 @@ async fn initialize_notebook_sync_open(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
-    let path_for_payload = path.to_string_lossy().to_string();
+    let caller_path = path.to_string_lossy().to_string();
     let result = notebook_sync::connect::connect_open_relay(socket_path, path, frame_tx)
         .await
         .map_err(|e| format!("sync connect (open): {}", e))?;
@@ -668,7 +668,7 @@ async fn initialize_notebook_sync_open(
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
         ephemeral: info.ephemeral,
-        notebook_path: Some(path_for_payload),
+        notebook_path: info.notebook_path.or(Some(caller_path)),
         runtime: None,
     };
 

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -648,13 +648,13 @@ pub async fn show_notebook(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    // Resolve notebook_id from param or current session
-    let target = match arg_str(request, "notebook_id") {
-        Some(id) => id.to_string(),
+    // Resolve notebook_id (and optional path) from param or current session
+    let (target, session_path) = match arg_str(request, "notebook_id") {
+        Some(id) => (id.to_string(), None),
         None => {
             let session = server.session.read().await;
             match session.as_ref() {
-                Some(s) => s.notebook_id.clone(),
+                Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
                 None => {
                     return tool_error(
                         "No notebook_id provided and no active session. \
@@ -672,19 +672,16 @@ pub async fn show_notebook(
         .list_rooms()
         .await
         .map_err(|e| McpError::internal_error(format!("Failed to list notebooks: {e}"), None))?;
-    if !rooms.iter().any(|r| r.notebook_id == target) {
+    let room = rooms.iter().find(|r| r.notebook_id == target);
+    if room.is_none() {
         return tool_error(&format!(
             "Notebook '{}' is not currently running. \
              Use list_active_notebooks() to see active notebooks.",
             target
         ));
     }
-
-    let is_ephemeral = rooms
-        .iter()
-        .find(|r| r.notebook_id == target)
-        .map(|r| r.ephemeral)
-        .unwrap_or(false);
+    let room = room.unwrap();
+    let is_ephemeral = room.ephemeral;
 
     if !has_display() {
         let mut result = serde_json::json!({
@@ -700,11 +697,18 @@ pub async fn show_notebook(
         return tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default());
     }
 
-    // Launch the app using the binary's build channel.
-    // NOTE: If RUNTIMED_SOCKET_PATH points at a different channel's daemon,
-    // this may open the wrong app. That's a known dev-only edge case.
-    let is_file_backed = std::path::Path::new(&target).is_absolute();
-    if is_file_backed {
+    // Resolve the on-disk path: prefer room path (authoritative), then session
+    // path, then fall back to the target string if it looks like a file path.
+    let resolved_path = room
+        .notebook_path
+        .as_deref()
+        .or(session_path.as_deref())
+        .filter(|p| std::path::Path::new(p).is_absolute());
+
+    if let Some(path) = resolved_path {
+        runt_workspace::open_notebook_app(Some(std::path::Path::new(path)), &[])
+            .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
+    } else if std::path::Path::new(&target).is_absolute() {
         runt_workspace::open_notebook_app(Some(std::path::Path::new(&target)), &[])
             .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
     } else {

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -672,15 +672,13 @@ pub async fn show_notebook(
         .list_rooms()
         .await
         .map_err(|e| McpError::internal_error(format!("Failed to list notebooks: {e}"), None))?;
-    let room = rooms.iter().find(|r| r.notebook_id == target);
-    if room.is_none() {
+    let Some(room) = rooms.iter().find(|r| r.notebook_id == target) else {
         return tool_error(&format!(
             "Notebook '{}' is not currently running. \
              Use list_active_notebooks() to see active notebooks.",
             target
         ));
-    }
-    let room = room.unwrap();
+    };
     let is_ephemeral = room.ephemeral;
 
     if !has_display() {

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -200,6 +200,8 @@ pub struct RoomInfo {
     pub kernel_status: Option<String>,
     #[serde(default)]
     pub ephemeral: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notebook_path: Option<String>,
 }
 
 /// Blob channel request.

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -727,6 +727,8 @@ pub struct NotebookConnectionInfo {
     pub needs_trust_approval: bool,
     /// Whether this notebook is ephemeral (in-memory only, no persistence).
     pub ephemeral: bool,
+    /// On-disk path when the notebook is file-backed.
+    pub notebook_path: Option<String>,
 }
 
 #[pymethods]
@@ -751,6 +753,7 @@ impl NotebookConnectionInfo {
             cell_count: info.cell_count,
             needs_trust_approval: info.needs_trust_approval,
             ephemeral: info.ephemeral,
+            notebook_path: info.notebook_path,
         }
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1910,6 +1910,7 @@ impl Daemon {
                 needs_trust_approval: false,
                 error: Some(error),
                 ephemeral: false,
+                notebook_path: None,
             };
             send_json_frame(writer, &response).await?;
             Ok(())
@@ -2168,6 +2169,7 @@ impl Daemon {
             needs_trust_approval,
             error: None,
             ephemeral: false,
+            notebook_path: Some(path.clone()),
         };
         send_json_frame(&mut writer, &response).await?;
 
@@ -2306,6 +2308,7 @@ impl Daemon {
                 needs_trust_approval: false,
                 error: Some(format!("Failed to create notebook: {}", e)),
                 ephemeral: false,
+                notebook_path: None,
             };
             send_json_frame(&mut writer, &response).await?;
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
@@ -2322,6 +2325,13 @@ impl Daemon {
         } else {
             (connection::PROTOCOL_V2, 2)
         };
+        let notebook_path = room
+            .identity
+            .path
+            .read()
+            .await
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
         let response = NotebookConnectionInfo {
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),
@@ -2331,6 +2341,7 @@ impl Daemon {
             needs_trust_approval: false,
             error: None,
             ephemeral,
+            notebook_path,
         };
         send_json_frame(&mut writer, &response).await?;
 
@@ -2860,6 +2871,14 @@ impl Daemon {
                         .map(|(kt, es, st)| (Some(kt), Some(es), Some(st)))
                         .unwrap_or((None, None, None));
 
+                    let notebook_path = room
+                        .identity
+                        .path
+                        .read()
+                        .await
+                        .as_ref()
+                        .map(|p| p.to_string_lossy().to_string());
+
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
                         active_peers: room
@@ -2878,6 +2897,7 @@ impl Daemon {
                             .identity
                             .is_ephemeral
                             .load(std::sync::atomic::Ordering::Relaxed),
+                        notebook_path,
                     });
                 }
                 Response::RoomsList { rooms: room_infos }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2169,7 +2169,7 @@ impl Daemon {
             needs_trust_approval,
             error: None,
             ephemeral: false,
-            notebook_path: Some(path.clone()),
+            notebook_path: Some(notebook_id.clone()),
         };
         send_json_frame(&mut writer, &response).await?;
 


### PR DESCRIPTION
## Overview

`show_notebook` displayed "Untitled.ipynb" in the title bar for notebooks originally opened by path through MCP. The tool read `session.notebook_id` (a UUID) and used `Path::new(&uuid).is_absolute()` to decide how to launch the app. UUIDs aren't absolute paths, so the app always opened with `--notebook-id`, triggering `OpenMode::Create` with a hardcoded "Untitled.ipynb" title.

## What changed

Three layers of fix, from the MCP tool down to the wire protocol:

1. **`show_notebook` path resolution** (`runt-mcp/tools/session.rs`). Reads `notebook_path` from the session and from `RoomInfo`. When a path is available, opens the app by file path instead of UUID.

2. **`RoomInfo` gains `notebook_path`** (`runtimed-client/protocol.rs`, `runtimed/daemon.rs`). The `ListRooms` handler reads `room.identity.path` and includes it in the response. Also makes `list_active_notebooks` more useful for all MCP consumers.

3. **`NotebookConnectionInfo` gains `notebook_path`** (`notebook-protocol/connection.rs`, `runtimed/daemon.rs`, `notebook/lib.rs`, `runtimed-py/output.rs`). When `CreateNotebook` resolves via `notebook_id_hint` to a room that already has a path, the wire response carries it. The Tauri app uses this for `DaemonReadyPayload` instead of hardcoded `None`. The new field is `Option` with `serde(default)` for backward compatibility.

## Verification

- [ ] Open a notebook by path via MCP `connect_notebook(path=...)`, then call `show_notebook`. Title bar should show the notebook filename, not "Untitled.ipynb".
- [ ] `list_active_notebooks` shows `notebook_path` for file-backed rooms.
- [ ] Opening a new untitled notebook still shows "Untitled.ipynb" in the title bar.

Closes #2156

_PR submitted by @rgbkrk's agent, Quill_