### PR TITLE
fix(mcp): raise blob-spill preview caps and add get_cell full_output opt-in

### DIFF
--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -176,6 +176,14 @@
         "cell_id": {
           "description": "The cell ID to retrieve.",
           "type": "string"
+        },
+        "full_output": {
+          "default": null,
+          "description": "Return the unabridged output text for any stream or error that was\nspilled to the blob store. When false (the default), outputs past the\ndaemon's preview cap render as a head + tail + elision marker +\nblob URL. Pass `true` only when the agent truly needs the full\ntext — the response can grow large and will consume context budget.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -125,14 +125,17 @@ pub async fn execute_and_wait(
     };
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
+    // Execute paths (and `and_run` variants) always use preview mode —
+    // agents that need unabridged output should call `get_cell(full_output=true)`
+    // afterwards rather than paying for it on every run.
+    let ctx = output_resolver::ResolveCtx {
+        blob_base_url: blob_base_url.as_deref(),
+        blob_store_path: blob_store_path.as_deref(),
+        comms: comms.as_ref(),
+        ..Default::default()
+    };
     let outputs = if !output_manifests.is_empty() {
-        output_resolver::resolve_cell_outputs_for_llm(
-            &output_manifests,
-            blob_base_url,
-            blob_store_path,
-            comms.as_ref(),
-        )
-        .await
+        output_resolver::resolve_cell_outputs_for_llm(&output_manifests, ctx).await
     } else {
         // Outputs live in RuntimeStateDoc keyed by execution_id. Fetch via
         // the explicit lookup — CellSnapshot no longer carries them.
@@ -140,13 +143,7 @@ pub async fn execute_and_wait(
         if raw_outputs.is_empty() {
             Vec::new()
         } else {
-            output_resolver::resolve_cell_outputs_for_llm(
-                &raw_outputs,
-                blob_base_url,
-                blob_store_path,
-                comms.as_ref(),
-            )
-            .await
+            output_resolver::resolve_cell_outputs_for_llm(&raw_outputs, ctx).await
         }
     };
 

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -17,6 +17,13 @@ use super::{arg_bool, arg_str, tool_error, tool_success};
 pub struct GetCellParams {
     /// The cell ID to retrieve.
     pub cell_id: String,
+    /// Return the unabridged output text for any stream or error that was
+    /// spilled to the blob store. When false (the default), outputs past the
+    /// daemon's preview cap render as a head + tail + elision marker +
+    /// blob URL. Pass `true` only when the agent truly needs the full
+    /// text — the response can grow large and will consume context budget.
+    #[serde(default)]
+    pub full_output: Option<bool>,
 }
 
 #[allow(dead_code)]
@@ -50,6 +57,7 @@ pub async fn get_cell(
 ) -> Result<CallToolResult, McpError> {
     let cell_id = arg_str(request, "cell_id")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+    let full_output = arg_bool(request, "full_output").unwrap_or(false);
 
     let handle = require_handle!(server);
 
@@ -75,13 +83,22 @@ pub async fn get_cell(
         raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
     }
 
-    // Resolve outputs (with widget state synthesis)
+    // Resolve outputs (with widget state synthesis). `get_cell` is the
+    // only tool that honors `full_output=true`; all other paths hardcode
+    // preview mode to protect the agent's context budget.
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = output_resolver::resolve_cell_outputs_for_llm(
         &raw_outputs,
-        &server.blob_base_url,
-        &server.blob_store_path,
-        comms.as_ref(),
+        output_resolver::ResolveCtx {
+            blob_base_url: server.blob_base_url.as_deref(),
+            blob_store_path: server.blob_store_path.as_deref(),
+            comms: comms.as_ref(),
+            length: if full_output {
+                output_resolver::OutputLength::Full
+            } else {
+                output_resolver::OutputLength::Preview
+            },
+        },
     )
     .await;
 
@@ -176,11 +193,16 @@ pub async fn get_all_cells(
 
                 // Resolve outputs through the output resolver so that
                 // text/llm+plain is synthesized and viz specs are summarized.
+                // `get_all_cells` never fetches full blob text — a batch of
+                // cells could blow context even with one large output.
                 let resolved = output_resolver::resolve_cell_outputs_for_llm(
                     raw_outputs,
-                    &server.blob_base_url,
-                    &server.blob_store_path,
-                    comms.as_ref(),
+                    output_resolver::ResolveCtx {
+                        blob_base_url: server.blob_base_url.as_deref(),
+                        blob_store_path: server.blob_store_path.as_deref(),
+                        comms: comms.as_ref(),
+                        ..Default::default()
+                    },
                 )
                 .await;
                 let output_texts: Vec<String> = resolved
@@ -216,9 +238,12 @@ pub async fn get_all_cells(
                 let raw_outputs = outputs_by_cell.get(&cell.id).unwrap_or(&empty_outputs);
                 let outputs = output_resolver::resolve_cell_outputs_for_llm(
                     raw_outputs,
-                    &server.blob_base_url,
-                    &server.blob_store_path,
-                    comms.as_ref(),
+                    output_resolver::ResolveCtx {
+                        blob_base_url: server.blob_base_url.as_deref(),
+                        blob_store_path: server.blob_store_path.as_deref(),
+                        comms: comms.as_ref(),
+                        ..Default::default()
+                    },
                 )
                 .await;
                 let header = formatting::format_cell_header(&cell.id, &cell.cell_type, ec, status);
@@ -260,9 +285,12 @@ pub async fn get_all_cells(
                 if include_outputs && !raw_outputs.is_empty() {
                     let outputs = output_resolver::resolve_cell_outputs_for_llm(
                         raw_outputs,
-                        &server.blob_base_url,
-                        &server.blob_store_path,
-                        comms.as_ref(),
+                        output_resolver::ResolveCtx {
+                            blob_base_url: server.blob_base_url.as_deref(),
+                            blob_store_path: server.blob_store_path.as_deref(),
+                            comms: comms.as_ref(),
+                            ..Default::default()
+                        },
                     )
                     .await;
                     let output_text = formatting::format_outputs_text(&outputs);

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -203,11 +203,15 @@ pub async fn run_all_cells(
         // Resolve outputs from the execution's output manifests.
         let output_manifests = &exec.outputs;
         let outputs = if !output_manifests.is_empty() {
+            // Batch execute path — always preview mode. No per-cell opt-out.
             runtimed_client::output_resolver::resolve_cell_outputs_for_llm(
                 output_manifests,
-                &server.blob_base_url,
-                &server.blob_store_path,
-                comms,
+                runtimed_client::output_resolver::ResolveCtx {
+                    blob_base_url: server.blob_base_url.as_deref(),
+                    blob_store_path: server.blob_store_path.as_deref(),
+                    comms,
+                    ..Default::default()
+                },
             )
             .await
         } else {

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -18,6 +18,39 @@ use crate::resolved_output::{DataValue, Output};
 
 pub use notebook_doc::mime::{mime_kind, MimeKind};
 
+/// Whether to render blob-spilled streams/errors as the head+tail preview
+/// or fetch the full blob text.
+///
+/// Default is `Preview`. `Full` is opt-in and only honored by the
+/// `get_cell(full_output=true)` path — batch reads and execution paths
+/// always use `Preview` so they don't silently blow LLM context.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OutputLength {
+    #[default]
+    Preview,
+    Full,
+}
+
+/// Context for resolving output manifests.
+///
+/// Groups the blob-store location, widget-state lookup, and preview/full
+/// mode so call sites don't accumulate a tail of `None, None, None, false`
+/// args. Use [`ResolveCtx::default()`] for the common "preview, no blob
+/// base, no comms" case.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResolveCtx<'a> {
+    /// Base URL for the daemon's blob HTTP server
+    /// (`http://127.0.0.1:<port>`). `None` when fetching from disk.
+    pub blob_base_url: Option<&'a str>,
+    /// On-disk blob store root, when reading blobs directly.
+    pub blob_store_path: Option<&'a std::path::Path>,
+    /// Widget state for comm-view synthesis on display_data outputs.
+    pub comms: Option<&'a HashMap<String, CommDocEntry>>,
+    /// Whether to render the blob-preview marker (default) or fetch the
+    /// full blob text. See [`OutputLength`].
+    pub length: OutputLength,
+}
+
 /// MIME type for Jupyter widget view references.
 const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
 
@@ -553,15 +586,11 @@ pub async fn resolve_cell_outputs(
 /// is resolved; everything else is described from manifest metadata.
 pub async fn resolve_cell_outputs_for_llm(
     raw_outputs: &[serde_json::Value],
-    blob_base_url: &Option<String>,
-    blob_store_path: &Option<PathBuf>,
-    comms: Option<&HashMap<String, CommDocEntry>>,
+    ctx: ResolveCtx<'_>,
 ) -> Vec<Output> {
     let mut outputs = Vec::with_capacity(raw_outputs.len());
     for manifest in raw_outputs {
-        if let Some(output) =
-            resolve_output_for_llm(manifest, blob_base_url, blob_store_path, comms).await
-        {
+        if let Some(output) = resolve_output_for_llm(manifest, ctx).await {
             outputs.push(output);
         }
     }
@@ -575,36 +604,46 @@ pub async fn resolve_cell_outputs_for_llm(
 /// only fetches the highest-priority text MIME type.
 pub async fn resolve_output_for_llm(
     manifest: &serde_json::Value,
-    blob_base_url: &Option<String>,
-    blob_store_path: &Option<PathBuf>,
-    comms: Option<&HashMap<String, CommDocEntry>>,
+    ctx: ResolveCtx<'_>,
 ) -> Option<Output> {
     let output_type = manifest.get("output_type")?.as_str()?;
+    // Bridge ctx -> the internal helper signatures without touching them.
+    // Allocations are cheap (single Option<String> / PathBuf clone) and
+    // only paid when a caller actually provides these fields.
+    let blob_base_url = ctx.blob_base_url.map(String::from);
+    let blob_store_path = ctx.blob_store_path.map(|p| p.to_path_buf());
 
     match output_type {
         // Stream and error are text-only — resolve as normal.
         "stream" => {
             let name = manifest.get("name")?.as_str()?;
             let text_ref = manifest.get("text")?;
-            // Fast path: Blob + preview → render without fetching.
-            if let Some(blob_hash) = text_ref.get("blob").and_then(|v| v.as_str()) {
-                if let Some(preview) = manifest.get("llm_preview") {
-                    let text = render_stream_preview(preview, blob_hash, blob_base_url);
-                    return Some(Output::stream(name, &text));
+            // Fast path: Blob + preview → render without fetching. Used
+            // for `OutputLength::Preview` (the default). `Full` skips this
+            // and drops through to `resolve_text_ref`, which fetches the
+            // full blob — the escape hatch for `get_cell(full_output=true)`.
+            if ctx.length == OutputLength::Preview {
+                if let Some(blob_hash) = text_ref.get("blob").and_then(|v| v.as_str()) {
+                    if let Some(preview) = manifest.get("llm_preview") {
+                        let text = render_stream_preview(preview, blob_hash, &blob_base_url);
+                        return Some(Output::stream(name, &text));
+                    }
                 }
             }
-            let text = resolve_text_ref(text_ref, blob_base_url, blob_store_path).await?;
+            let text = resolve_text_ref(text_ref, &blob_base_url, &blob_store_path).await?;
             Some(Output::stream(name, &text))
         }
         "error" => {
             let ename = manifest.get("ename")?.as_str()?.to_string();
             let evalue = manifest.get("evalue")?.as_str()?.to_string();
             let traceback_val = manifest.get("traceback")?;
-            // Fast path: Blob + preview → render without fetching.
-            if let Some(blob_hash) = traceback_val.get("blob").and_then(|v| v.as_str()) {
-                if let Some(preview) = manifest.get("llm_preview") {
-                    let tb = render_error_preview(preview, blob_hash, blob_base_url);
-                    return Some(Output::error(&ename, &evalue, tb));
+            // Same preview/full opt-out as the stream case above.
+            if ctx.length == OutputLength::Preview {
+                if let Some(blob_hash) = traceback_val.get("blob").and_then(|v| v.as_str()) {
+                    if let Some(preview) = manifest.get("llm_preview") {
+                        let tb = render_error_preview(preview, blob_hash, &blob_base_url);
+                        return Some(Output::error(&ename, &evalue, tb));
+                    }
                 }
             }
             let traceback = if let Some(arr) = traceback_val.as_array() {
@@ -613,14 +652,20 @@ pub async fn resolve_output_for_llm(
                     .collect()
             } else {
                 let tb_str =
-                    resolve_text_ref(traceback_val, blob_base_url, blob_store_path).await?;
+                    resolve_text_ref(traceback_val, &blob_base_url, &blob_store_path).await?;
                 serde_json::from_str::<Vec<String>>(&tb_str).ok()?
             };
             Some(Output::error(&ename, &evalue, traceback))
         }
         "display_data" | "execute_result" => {
-            resolve_display_for_llm(output_type, manifest, blob_base_url, blob_store_path, comms)
-                .await
+            resolve_display_for_llm(
+                output_type,
+                manifest,
+                &blob_base_url,
+                &blob_store_path,
+                ctx.comms,
+            )
+            .await
         }
         _ => None,
     }
@@ -1603,7 +1648,7 @@ mod tests {
             "text/plain": inline_ref("hello world"),
             "image/png": blob_ref("abc123", 50_000),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1622,7 +1667,7 @@ mod tests {
             "text/latex": inline_ref("$E=mc^2$"),
             "text/plain": inline_ref("E=mc^2"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1642,7 +1687,7 @@ mod tests {
             "text/plain": inline_ref("raw repr"),
             "image/png": blob_ref("img123", 100_000),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1662,7 +1707,7 @@ mod tests {
         let manifest = make_display_manifest(json!({
             "text/plain": inline_ref(&large_text),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1688,7 +1733,7 @@ mod tests {
         let manifest = make_display_manifest(json!({
             "text/plain": inline_ref(&text),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1707,7 +1752,15 @@ mod tests {
             "image/svg+xml": blob_ref("svg456", 12_000),
         }));
         let blob_base = Some("http://localhost:9999".to_string());
-        let Some(output) = resolve_output_for_llm(&manifest, &blob_base, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                blob_base_url: blob_base.as_deref(),
+                ..Default::default()
+            },
+        )
+        .await
+        else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1736,7 +1789,7 @@ mod tests {
             "application/vnd.vegalite.v5+json": inline_ref(r#"{"mark":"point","encoding":{"x":{"field":"Horsepower","type":"quantitative"},"y":{"field":"Miles_per_Gallon","type":"quantitative"}}}"#),
             "text/plain": inline_ref("alt.Chart(...)"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1758,7 +1811,7 @@ mod tests {
             "application/vnd.plotly.v1+json": inline_ref(r#"{"data":[{"type":"bar","x":["A","B"],"y":[1,2]}],"layout":{"title":"Test"}}"#),
             "text/plain": inline_ref("Figure()"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1778,7 +1831,7 @@ mod tests {
             "application/geo+json": inline_ref(r#"{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"name":"origin"}}]}"#),
             "text/plain": inline_ref("<GeoJSON object>"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1799,7 +1852,7 @@ mod tests {
             "text/html": inline_ref("<b>bold</b>"),
             "text/plain": inline_ref("bold"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1823,7 +1876,7 @@ mod tests {
             "text/plain": inline_ref("IntSlider(value=42)"),
         }));
         // No comms passed → widget synthesis can't look up state
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1840,7 +1893,7 @@ mod tests {
     #[tokio::test]
     async fn llm_empty_data_map() {
         let manifest = make_display_manifest(json!({}));
-        let output = resolve_output_for_llm(&manifest, &None, &None, None).await;
+        let output = resolve_output_for_llm(&manifest, ResolveCtx::default()).await;
         // Empty data map still produces an output, just with empty data
         let Some(output) = output else {
             panic!("should produce output");
@@ -1858,7 +1911,7 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hello from stdout"),
         });
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         assert_eq!(output.output_type, "stream");
@@ -1873,7 +1926,7 @@ mod tests {
             "evalue": "bad value",
             "traceback": ["line 1", "line 2"],
         });
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         assert_eq!(output.output_type, "error");
@@ -1887,7 +1940,7 @@ mod tests {
     #[tokio::test]
     async fn llm_execute_result_has_execution_count() {
         let manifest = make_execute_result_manifest(json!({"text/plain": inline_ref("42")}), 5);
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         assert_eq!(output.output_type, "execute_result");
@@ -1901,7 +1954,7 @@ mod tests {
             "text/latex": blob_ref("latex_hash", 5000),
             "text/plain": inline_ref("fallback plain"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1922,7 +1975,15 @@ mod tests {
             "text/html": blob_ref("html_hash", 8_000),
         }));
         let blob_base = Some("http://localhost:9999".to_string());
-        let Some(output) = resolve_output_for_llm(&manifest, &blob_base, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                blob_base_url: blob_base.as_deref(),
+                ..Default::default()
+            },
+        )
+        .await
+        else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1952,7 +2013,7 @@ mod tests {
             "application/vnd.apache.parquet": blob_ref("pq_hash_123", 10_000),
             "text/llm+plain": inline_ref("DataFrame (polars): 3 rows × 2 columns\nColumns:\n  - id: Int64\n  - name: String"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -1982,7 +2043,7 @@ mod tests {
             "application/vnd.vegalite.v5+json": inline_ref(r#"{"mark": "bar"}"#),
             "text/llm+plain": inline_ref("Custom author summary: sales by region"),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(data) = output.data else {
@@ -2003,7 +2064,7 @@ mod tests {
         let manifest = make_display_manifest(json!({
             "application/vnd.apache.parquet": blob_ref("pq_hash_456", 10_000),
         }));
-        let Some(output) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         // Without blob store access, the synthesizer can't read bytes and
@@ -2031,7 +2092,7 @@ mod tests {
                 "image/png": blob_ref("fig_png", 80_000),
             })),
         ];
-        let outputs = resolve_cell_outputs_for_llm(&manifests, &None, &None, None).await;
+        let outputs = resolve_cell_outputs_for_llm(&manifests, ResolveCtx::default()).await;
         assert_eq!(outputs.len(), 2);
         assert_eq!(outputs[0].output_type, "stream");
         assert_eq!(outputs[1].output_type, "display_data");
@@ -2060,9 +2121,10 @@ mod tests {
         });
         let Some(out) = resolve_output_for_llm(
             &manifest,
-            &Some("http://localhost:9999".to_string()),
-            &None,
-            None,
+            ResolveCtx {
+                blob_base_url: Some("http://localhost:9999"),
+                ..Default::default()
+            },
         )
         .await
         else {
@@ -2091,7 +2153,7 @@ mod tests {
                 "total_lines": 10u64,
             },
         });
-        let Some(out) = resolve_output_for_llm(&manifest, &None, &None, None).await else {
+        let Some(out) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
             panic!("resolve should succeed");
         };
         let Some(text) = out.text else {
@@ -2118,9 +2180,10 @@ mod tests {
         });
         let Some(out) = resolve_output_for_llm(
             &manifest,
-            &Some("http://localhost:9999".to_string()),
-            &None,
-            None,
+            ResolveCtx {
+                blob_base_url: Some("http://localhost:9999"),
+                ..Default::default()
+            },
         )
         .await
         else {
@@ -2157,7 +2220,14 @@ mod tests {
             "name": "stdout",
             "text": {"blob": hash, "size": 18},
         });
-        let Some(out) = resolve_output_for_llm(&manifest, &None, &Some(store_path), None).await
+        let Some(out) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                blob_store_path: Some(&store_path),
+                ..Default::default()
+            },
+        )
+        .await
         else {
             panic!("resolve should succeed");
         };

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -235,9 +235,17 @@ pub struct DisplayDataManifest {
 }
 
 /// Maximum head/tail size per side in bytes.
-const PREVIEW_BYTE_CAP: usize = 1024;
+// Size/line caps for the head+tail preview we stamp on blob-spilled
+// manifests. Sized so typical cell outputs (df.head, model.summary,
+// short training logs) fit entirely under the cap — when the cap is
+// tight, agents reading `get_cell`/`execute_cell` responses get a
+// head/tail/elision marker instead of real output, and many agents
+// don't follow the blob URL. Genuine multi-MB dumps (full training
+// runs, scraped pages) still spill. Callers that need the full blob
+// content can request it explicitly via `get_cell(full_output=true)`.
+const PREVIEW_BYTE_CAP: usize = 8 * 1024;
 /// Maximum head/tail size per side in lines.
-const PREVIEW_LINE_CAP: usize = 40;
+const PREVIEW_LINE_CAP: usize = 200;
 
 /// LLM-friendly summary of a spilled stream text blob. Populated at
 /// manifest-creation time so readers never need to fetch the blob just
@@ -1180,27 +1188,31 @@ mod tests {
 
     #[test]
     fn stream_preview_long_text_has_head_and_tail() {
-        let text = (0..200)
+        // Enough lines to force head+tail+elided past the line cap.
+        let total = PREVIEW_LINE_CAP * 4;
+        let text = (0..total)
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
             .join("\n");
         let p = StreamPreview::from_text(&text);
         assert!(p.head.starts_with("line 0\n"));
-        assert!(p.tail.ends_with("line 199"));
-        assert!(p.head.len() <= 1024);
-        assert!(p.head.lines().count() <= 40);
-        assert!(p.tail.len() <= 1024);
-        assert!(p.tail.lines().count() <= 40);
+        assert!(p.tail.ends_with(&format!("line {}", total - 1)));
+        assert!(p.head.len() <= PREVIEW_BYTE_CAP);
+        assert!(p.head.lines().count() <= PREVIEW_LINE_CAP);
+        assert!(p.tail.len() <= PREVIEW_BYTE_CAP);
+        assert!(p.tail.lines().count() <= PREVIEW_LINE_CAP);
         assert_eq!(p.total_bytes, text.len() as u64);
-        assert_eq!(p.total_lines, 200);
+        assert_eq!(p.total_lines, total as u64);
     }
 
     #[test]
     fn stream_preview_caps_head_at_byte_limit_mid_line() {
-        let text = "x".repeat(10_000);
+        // Force one line longer than the byte cap.
+        let total_bytes = PREVIEW_BYTE_CAP * 4;
+        let text = "x".repeat(total_bytes);
         let p = StreamPreview::from_text(&text);
-        assert!(p.head.len() <= 1024);
-        assert_eq!(p.total_bytes, 10_000);
+        assert!(p.head.len() <= PREVIEW_BYTE_CAP);
+        assert_eq!(p.total_bytes, total_bytes as u64);
     }
 
     #[test]
@@ -1233,13 +1245,14 @@ mod tests {
 
     #[test]
     fn stream_preview_caps_tail_on_long_single_line() {
-        // A single multi-KB line should cap the tail too. The tail walks
-        // forward to the next char boundary, so allow a small overrun on
-        // the advertised byte cap (≤ 3 bytes of slack for UTF-8).
-        let text = "y".repeat(10_000);
+        // A single multi-byte-cap line should cap the tail too. The tail
+        // walks forward to the next char boundary, so allow a small
+        // overrun on the advertised byte cap (≤ 3 bytes of slack for UTF-8).
+        let total_bytes = PREVIEW_BYTE_CAP * 4;
+        let text = "y".repeat(total_bytes);
         let p = StreamPreview::from_text(&text);
-        assert_eq!(p.total_bytes, 10_000);
-        assert!(p.tail.len() <= 1024 + 3);
+        assert_eq!(p.total_bytes, total_bytes as u64);
+        assert!(p.tail.len() <= PREVIEW_BYTE_CAP + 3);
         // Head plus tail together should still sample both ends of the stream.
         assert!(p.head.starts_with('y'));
     }
@@ -1251,20 +1264,22 @@ mod tests {
         // iterated forward from `lines.len() - line_cap` and broke on the
         // byte cap, which silently dropped the newest lines.
         //
-        // Build 100 lines of 60 bytes each. The last 40 lines sum to 2400
-        // bytes, well over the 1 KiB cap. The tail should contain the very
-        // last line ("line 99") even though it had to drop earlier ones to
-        // stay within the cap.
-        let text: String = (0..100)
-            .map(|i| format!("{}line {i}\n", "x".repeat(50)))
+        // Build `line_cap * 2` lines each wide enough that the tail window
+        // exceeds the byte cap. The tail should contain the very last line
+        // even though it had to drop earlier ones to stay within the cap.
+        let line_width = (PREVIEW_BYTE_CAP / PREVIEW_LINE_CAP) + 10;
+        let total_lines = PREVIEW_LINE_CAP * 2;
+        let text: String = (0..total_lines)
+            .map(|i| format!("{}line {i}\n", "x".repeat(line_width)))
             .collect();
         let p = StreamPreview::from_text(&text);
+        let last = format!("line {}", total_lines - 1);
         assert!(
-            p.tail.contains("line 99"),
+            p.tail.contains(&last),
             "tail should contain the final line; got: {:?}",
             p.tail
         );
-        assert!(p.tail.len() <= 1024 + 3);
+        assert!(p.tail.len() <= PREVIEW_BYTE_CAP + 3);
     }
 
     #[test]
@@ -1299,13 +1314,14 @@ mod tests {
         // Three-byte code point repeated past the cap — must not panic and
         // must produce valid UTF-8. Allow a few bytes of slack because
         // safe_byte_slice rounds to char boundaries.
-        let text = "日".repeat(1_000); // 3 bytes each = 3_000 bytes
+        let char_count = PREVIEW_BYTE_CAP * 2; // each char = 3 bytes, so well past the cap
+        let text = "日".repeat(char_count);
         let p = StreamPreview::from_text(&text);
-        assert_eq!(p.total_bytes, 3_000);
+        assert_eq!(p.total_bytes, (char_count * 3) as u64);
         assert!(p.head.chars().all(|c| c == '日'));
         assert!(p.tail.chars().all(|c| c == '日'));
-        assert!(p.head.len() <= 1024 + 3);
-        assert!(p.tail.len() <= 1024 + 3);
+        assert!(p.head.len() <= PREVIEW_BYTE_CAP + 3);
+        assert!(p.tail.len() <= PREVIEW_BYTE_CAP + 3);
     }
 
     #[tokio::test]

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1901,9 +1901,11 @@ async fn stream_blob_spill_is_renderable_by_llm_resolver() {
 
     let outputs = resolve_cell_outputs_for_llm(
         &[manifest_json],
-        &Some("http://127.0.0.1:1234".to_string()),
-        &Some(dir.path().to_path_buf()),
-        None,
+        runtimed_client::output_resolver::ResolveCtx {
+            blob_base_url: Some("http://127.0.0.1:1234"),
+            blob_store_path: Some(dir.path()),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -1941,9 +1943,11 @@ async fn error_blob_spill_is_renderable_by_llm_resolver() {
 
     let outputs = resolve_cell_outputs_for_llm(
         &[manifest_json],
-        &Some("http://127.0.0.1:1234".to_string()),
-        &Some(dir.path().to_path_buf()),
-        None,
+        runtimed_client::output_resolver::ResolveCtx {
+            blob_base_url: Some("http://127.0.0.1:1234"),
+            blob_store_path: Some(dir.path()),
+            ..Default::default()
+        },
     )
     .await;
 


### PR DESCRIPTION
## Overview

MCP agents saw their cell outputs collapsed mid-session. A cell printing more than 40 lines or 1 KB got spilled to the blob store, and every subsequent `execute_cell` / `get_cell` rendered a head+tail preview + elision marker + blob URL instead of the actual text. Agents typically don't follow the blob URL, so reads that used to work against short cells silently truncated as the session accumulated output.

Two-part fix: raise the caps so typical outputs stay inline, and give agents an explicit opt-in for the unabridged blob text.

## What changed

**Caps bumped** in `crates/runtimed/src/output_store.rs`:

| | Before | After |
|-|-|-|
| `PREVIEW_BYTE_CAP` | 1 KB | 8 KB |
| `PREVIEW_LINE_CAP` | 40 | 200 |

The old ceiling was tight enough that routine outputs (`df.head()`, `model.summary()`, verbose training logs) spilled. 8 KB / 200 lines fits the common case — truly huge dumps still spill.

**`get_cell(full_output=true)`** opt-in. When true, skips the preview fast path and fetches the full blob.

Scoped narrow on purpose:

| Tool | full_output honored? |
|------|----------------------|
| `get_cell` | yes (new) |
| `get_all_cells` | no — batch read, full across many cells = context blowup |
| `execute_cell` | no — pay only when you ask for it |
| `create_cell` / `set_cell` / `replace_match` / `replace_regex` with `and_run=true` | no — same reasoning as `execute_cell` |

The rule: an agent that just ran a cell requests full output explicitly if it needs it, instead of paying for it on every `and_run` round-trip.

## Signature cleanup

The internal resolver grew a fifth positional arg: `(manifest, &Option<String>, &Option<PathBuf>, Option<&HashMap>, bool)`. Windows-syscall territory. Introducing:

```rust
pub struct ResolveCtx<'a> {
    pub blob_base_url:   Option<&'a str>,
    pub blob_store_path: Option<&'a Path>,
    pub comms:           Option<&'a HashMap<String, CommDocEntry>>,
    pub length:          OutputLength,   // Preview | Full (default: Preview)
}

pub enum OutputLength { Preview, Full }
```

All callers updated. Tests that don't care about blob fields use `ResolveCtx::default()`. The one explicit `OutputLength::Full` call site lives in `get_cell` alongside the `full_output` param read.

## End-to-end verification

Cell prints 500 lines (19.5 KB) — spills to blob.

```
execute_cell (always preview)  →  head(200) + marker + tail(200) = 401 lines
get_cell                        →  head(200) + marker + tail(200) = 401 lines
get_cell(full_output=true)      →  500 lines, no marker
```

Verified against the dev daemon via raw MCP JSON-RPC (`cargo build -p runtimed && runt mcp`).

## Test plan

- [x] `cargo test -p runtimed --lib output_store::` — 55/55 (5 tests updated to reference `PREVIEW_BYTE_CAP` / `PREVIEW_LINE_CAP` instead of magic numbers so future tuning doesn't keep breaking them)
- [x] `cargo test -p runtimed-client --lib` — existing 179 pass
- [x] `cargo test -p runt-mcp --lib` — pass
- [x] `cargo xtask lint --fix` clean
- [x] `cargo clippy -p runtimed -p runtimed-client -p runt-mcp` clean
- [x] `cargo xtask sync-tool-cache` regenerated (`full_output` added to `get_cell` schema, integrated in `tool-cache.json` and both `.mcpb` manifests)
- [x] End-to-end verified: spill → preview render → full render