### PR TITLE
fix(runtimed): surface typed error for missing conda env.yml env

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -405,6 +405,7 @@ export function useDaemonKernel({
     statusKey,
     lifecycle: runtimeState.kernel.lifecycle,
     errorReason: runtimeState.kernel.error_reason,
+    errorDetails: runtimeState.kernel.error_details,
     queueState,
     kernelInfo,
     envSyncState,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -180,6 +180,28 @@ fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::V
                     serde_json::json!(state.env.prewarmed_packages),
                 );
             }
+            // Error surface (#2157): when the kernel is in an error
+            // state, MCP clients get both the typed reason (stable
+            // for programmatic handling) and the human-readable
+            // details (for surfacing to the user).
+            if matches!(state.kernel.lifecycle, runtime_doc::RuntimeLifecycle::Error) {
+                if let Some(reason) = state
+                    .kernel
+                    .error_reason
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                {
+                    info.insert("error_reason".into(), serde_json::json!(reason));
+                }
+                if let Some(details) = state
+                    .kernel
+                    .error_details
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                {
+                    info.insert("error_details".into(), serde_json::json!(details));
+                }
+            }
         }
         Err(_) => {
             info.insert("kernel_status".into(), serde_json::json!("unknown"));

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -105,6 +105,16 @@ pub struct KernelState {
     /// deserializes as `Some("")`, indicating "scaffolded but unset").
     #[serde(default)]
     pub error_reason: Option<String>,
+    /// Free-form details accompanying an error, shown to the user via
+    /// the frontend banner and exposed to MCP tools. Carries specifics
+    /// that don't fit in the typed [`error_reason`] enum — e.g., the
+    /// name of a conda env declared in environment.yml that isn't
+    /// built on this machine, with a suggested remediation command.
+    ///
+    /// `None` when the CRDT field is absent; empty string indicates
+    /// "scaffolded but unset" (same convention as `error_reason`).
+    #[serde(default)]
+    pub error_details: Option<String>,
 }
 
 impl Default for KernelState {
@@ -118,6 +128,7 @@ impl Default for KernelState {
             runtime_agent_id: String::new(),
             lifecycle: RuntimeLifecycle::NotStarted,
             error_reason: None,
+            error_details: None,
         }
     }
 }
@@ -294,6 +305,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.activity");
         doc.put(&kernel, "error_reason", "")
             .expect("scaffold kernel.error_reason");
+        doc.put(&kernel, "error_details", "")
+            .expect("scaffold kernel.error_details");
 
         // queue/
         let queue = doc
@@ -380,6 +393,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.activity");
         doc.put(&kernel, "error_reason", "")
             .expect("scaffold kernel.error_reason");
+        doc.put(&kernel, "error_details", "")
+            .expect("scaffold kernel.error_details");
 
         let queue = doc
             .put_object(&ROOT, "queue", ObjType::Map)
@@ -836,10 +851,28 @@ impl RuntimeStateDoc {
         lifecycle: &RuntimeLifecycle,
         reason: Option<KernelErrorReason>,
     ) -> Result<(), RuntimeStateError> {
+        self.set_lifecycle_with_error_details(lifecycle, reason, None)
+    }
+
+    /// Like [`set_lifecycle_with_error`] but also writes a free-form
+    /// `error_details` string alongside the typed reason. Use for errors
+    /// where the user-facing banner needs specifics that don't fit in
+    /// [`KernelErrorReason`] — e.g., the name of a missing conda env.
+    ///
+    /// - `Some(details)` records the explanation (non-empty recommended).
+    /// - `None` clears `error_details` to `""`.
+    pub fn set_lifecycle_with_error_details(
+        &mut self,
+        lifecycle: &RuntimeLifecycle,
+        reason: Option<KernelErrorReason>,
+        details: Option<&str>,
+    ) -> Result<(), RuntimeStateError> {
         self.set_lifecycle(lifecycle)?;
         let kernel = self.scaffold_map("kernel")?;
         let reason_str = reason.map(|r| r.as_str()).unwrap_or("");
         self.doc.put(&kernel, "error_reason", reason_str)?;
+        let details_str = details.unwrap_or("");
+        self.doc.put(&kernel, "error_details", details_str)?;
         Ok(())
     }
 
@@ -2009,6 +2042,7 @@ impl RuntimeStateDoc {
                             None
                         }
                     });
+                let error_details = automunge::read_str_if_present(&self.doc, k, "error_details");
                 KernelState {
                     status: status.to_string(),
                     starting_phase: starting_phase.to_string(),
@@ -2018,6 +2052,7 @@ impl RuntimeStateDoc {
                     runtime_agent_id: self.read_str(k, "runtime_agent_id"),
                     lifecycle,
                     error_reason,
+                    error_details,
                 }
             })
             .unwrap_or_default();

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -55,18 +55,26 @@ pub enum KernelErrorReason {
     /// Pixi-managed environment is missing the `ipykernel` package.
     /// `NotebookToolbar` gates its "install ipykernel" prompt on this.
     MissingIpykernel,
+    /// environment.yml declares a conda env (by `name:` or `prefix:`) that
+    /// isn't built on this machine. Daemon sets this instead of silently
+    /// falling back to a pool env, so the frontend can tell the user what
+    /// to do (`conda env create -f environment.yml`). Accompanying
+    /// `error_details` carries the env name.
+    CondaEnvYmlMissing,
 }
 
 impl KernelErrorReason {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::MissingIpykernel => "missing_ipykernel",
+            Self::CondaEnvYmlMissing => "conda_env_yml_missing",
         }
     }
 
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "missing_ipykernel" => Some(Self::MissingIpykernel),
+            "conda_env_yml_missing" => Some(Self::CondaEnvYmlMissing),
             _ => None,
         }
     }

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -855,6 +855,10 @@ pub struct PyKernelState {
     /// CRDT key is absent (pre-migration doc); `Some("")` when the key is
     /// scaffolded but no reason has been recorded.
     pub error_reason: Option<String>,
+    /// Free-form details accompanying an error, shown to the user via
+    /// the frontend banner and surfaced to MCP tools. `None` when the
+    /// CRDT key is absent; `Some("")` when scaffolded but unset.
+    pub error_details: Option<String>,
     /// Kernel display name (e.g. "charming-toucan")
     pub name: String,
     /// Kernel language (e.g. "python", "typescript")
@@ -1065,6 +1069,7 @@ impl From<runtime_doc::RuntimeState> for PyRuntimeState {
                 lifecycle: lifecycle_variant,
                 activity,
                 error_reason: rs.kernel.error_reason,
+                error_details: rs.kernel.error_details,
                 name: rs.kernel.name,
                 language: rs.kernel.language,
                 env_source: rs.kernel.env_source,

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -916,13 +916,30 @@ pub(crate) fn missing_conda_env_yml_name(
     if detected.kind != crate::project_file::ProjectFileKind::EnvironmentYml {
         return None;
     }
-    if crate::project_file::resolve_conda_env_prefix(&detected.path).is_some() {
-        return None;
+    // `resolve_conda_env_prefix` returns the `prefix:` value verbatim
+    // without checking existence (it only validates via `find_named_conda_env`
+    // for the `name:` path). For an env declared with `prefix: /missing`
+    // we'd incorrectly conclude the env is built and skip the typed
+    // error. Verify the python binary exists before accepting the prefix.
+    if let Some(prefix) = crate::project_file::resolve_conda_env_prefix(&detected.path) {
+        if crate::project_file::conda_python_path(&prefix).exists() {
+            return None;
+        }
     }
-    crate::project_file::parse_environment_yml(&detected.path)
-        .ok()
-        .and_then(|c| c.name)
-        .or_else(|| Some(String::from("(unnamed)")))
+    // Declared but not built. Prefer the `name:` for display, fall back
+    // to the `prefix:` path, then to a placeholder if env.yml has
+    // neither (the kernel path's existing error handles the
+    // shape-broken case; we still want a useful banner).
+    let config = crate::project_file::parse_environment_yml(&detected.path).ok();
+    if let Some(ref c) = config {
+        if let Some(ref name) = c.name {
+            return Some(name.clone());
+        }
+        if let Some(ref prefix) = c.prefix {
+            return Some(prefix.display().to_string());
+        }
+    }
+    Some(String::from("(unnamed)"))
 }
 
 /// Check whether a notebook's inline dependency list exactly matches a

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -898,6 +898,33 @@ pub(crate) async fn resolve_metadata_snapshot(
     None
 }
 
+/// If the detected project file is an `environment.yml` whose declared
+/// conda env isn't built on this machine, return the declared env name.
+///
+/// The auto-launch path uses this to detect the miss upfront and set a
+/// specific error lifecycle (with `KernelErrorReason::CondaEnvYmlMissing`
+/// and human-readable details) instead of letting the runtime agent
+/// die with a generic "could not resolve conda environment prefix" and
+/// leaving the kernel stuck in `initializing` forever. Covers #2157.
+///
+/// Returns `None` when the project file isn't `environment.yml`, when
+/// the env is built and usable, or when env.yml has no `name:`/`prefix:`
+/// (the kernel path's existing error handles the shape-broken case).
+pub(crate) fn missing_conda_env_yml_name(
+    detected: &crate::project_file::DetectedProjectFile,
+) -> Option<String> {
+    if detected.kind != crate::project_file::ProjectFileKind::EnvironmentYml {
+        return None;
+    }
+    if crate::project_file::resolve_conda_env_prefix(&detected.path).is_some() {
+        return None;
+    }
+    crate::project_file::parse_environment_yml(&detected.path)
+        .ok()
+        .and_then(|c| c.name)
+        .or_else(|| Some(String::from("(unnamed)")))
+}
+
 /// Check whether a notebook's inline dependency list exactly matches a
 /// project file's dependency list (pyproject.toml / environment.yml /
 /// pixi.toml) in the notebook's own directory.
@@ -2475,6 +2502,35 @@ pub(crate) async fn auto_launch_kernel(
                     }
                 }
             }
+        }
+    }
+
+    // #2157: If the detected project file is an environment.yml whose
+    // declared conda env isn't built on this machine, surface a typed
+    // error instead of spawning a runtime agent that would die with
+    // "could not resolve conda environment prefix". Silent fallback to
+    // a pool env was rejected as user-hostile: env.yml users expect
+    // their declared deps to be installed, and a pool env lacks them.
+    // Writing Error + details gives the frontend enough to render a
+    // specific banner and MCP tools enough to report the miss.
+    if let Some(ref detected) = detected_project_file {
+        if let Some(env_name) = missing_conda_env_yml_name(detected) {
+            let yml_path = detected.path.display().to_string();
+            let details = format!(
+                "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
+                env_name, yml_path
+            );
+            warn!("[notebook-sync] {}", details);
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_lifecycle_with_error_details(
+                    &RuntimeLifecycle::Error,
+                    Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
+                    Some(&details),
+                )
+            }) {
+                warn!("[runtime-state] {}", e);
+            }
+            return;
         }
     }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5588,6 +5588,60 @@ fn test_missing_conda_env_yml_name_skips_non_envyml() {
     assert_eq!(missing_conda_env_yml_name(&detected), None);
 }
 
+/// Codex P2 on #2167: `prefix:` pointing at a non-existent path must
+/// be reported as missing so `auto_launch_kernel` surfaces the typed
+/// error instead of letting the runtime agent die with the generic
+/// resolver message. The reported name falls back to the prefix path
+/// when env.yml has no `name:`.
+#[test]
+fn test_missing_conda_env_yml_name_prefix_missing_reports_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing_prefix = tmp.path().join("definitely-does-not-exist");
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        format!(
+            "prefix: {}\ndependencies:\n  - python\n",
+            missing_prefix.display()
+        ),
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    let reported = missing_conda_env_yml_name(&detected).expect("prefix: missing should report");
+    assert!(
+        reported.contains("definitely-does-not-exist"),
+        "reported name should include the prefix path; got {reported:?}",
+    );
+}
+
+/// When env.yml has both `name:` and a non-existent `prefix:`, the
+/// name wins for display (shorter, more identifiable).
+#[test]
+fn test_missing_conda_env_yml_name_prefers_name_over_missing_prefix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing_prefix = tmp.path().join("definitely-does-not-exist");
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        format!(
+            "name: myenv\nprefix: {}\ndependencies:\n  - python\n",
+            missing_prefix.display()
+        ),
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(
+        missing_conda_env_yml_name(&detected).as_deref(),
+        Some("myenv"),
+    );
+}
+
 #[test]
 fn test_missing_conda_env_yml_name_prefix_with_python_is_not_missing() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5555,3 +5555,62 @@ async fn test_new_fresh_leaves_untrusted_when_deps_differ() {
 
     std::env::remove_var("RUNT_TRUST_KEY_PATH");
 }
+
+// ── #2157: environment.yml declares unbuilt conda env ─────────────────
+
+#[test]
+fn test_missing_conda_env_yml_name_detects_unbuilt_named_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        "name: nteract-integration-probe-definitely-not-built-xyz\ndependencies:\n  - python\n",
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(
+        missing_conda_env_yml_name(&detected).as_deref(),
+        Some("nteract-integration-probe-definitely-not-built-xyz"),
+    );
+}
+
+#[test]
+fn test_missing_conda_env_yml_name_skips_non_envyml() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_pyproject_with_deps(tmp.path(), &["pandas"]);
+    let detected = crate::project_file::DetectedProjectFile {
+        path: tmp.path().join("pyproject.toml"),
+        kind: crate::project_file::ProjectFileKind::PyprojectToml,
+    };
+    assert_eq!(missing_conda_env_yml_name(&detected), None);
+}
+
+#[test]
+fn test_missing_conda_env_yml_name_prefix_with_python_is_not_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let prefix = tmp.path().join("fake-env");
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::write(prefix.join("bin").join("python"), "#!/bin/sh\nexit 0\n").unwrap();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::fs::create_dir_all(&prefix).unwrap();
+        std::fs::write(prefix.join("python.exe"), "").unwrap();
+    }
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        format!("prefix: {}\ndependencies:\n  - python\n", prefix.display()),
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(missing_conda_env_yml_name(&detected), None);
+}

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -23,15 +23,25 @@ export type KernelActivity = "Unknown" | "Idle" | "Busy";
  * [`KERNEL_ERROR_REASON`] constants instead of bare string literals when
  * gating UI on a specific cause.
  */
-export type KernelErrorReasonKey = "missing_ipykernel";
+export type KernelErrorReasonKey =
+  | "missing_ipykernel"
+  | "conda_env_yml_missing";
 
 /**
- * Typed error-reason strings. Mirrors
- * `KernelErrorReason::MissingIpykernel.as_str()` on the Rust side —
- * both ends use the same literal so the CRDT value is unambiguous.
+ * Typed error-reason strings. Mirrors `KernelErrorReason::as_str()` on
+ * the Rust side — both ends use the same literal so the CRDT value is
+ * unambiguous.
  */
 export const KERNEL_ERROR_REASON = {
   MISSING_IPYKERNEL: "missing_ipykernel",
+  /**
+   * environment.yml declares a conda env that isn't built on this
+   * machine. Daemon sets this instead of silently falling back to a
+   * pool env so the UI can render a specific "build your env" banner.
+   * `kernel.error_details` carries the declared env name and the
+   * remediation command.
+   */
+  CONDA_ENV_YML_MISSING: "conda_env_yml_missing",
 } as const satisfies Record<string, KernelErrorReasonKey>;
 
 /**
@@ -64,6 +74,14 @@ export interface KernelState {
    * unset. Most consumers can treat both as "no reason."
    */
   error_reason: string | null;
+  /**
+   * Free-form details accompanying an error, shown to the user via the
+   * banner. Carries specifics that don't fit in the typed
+   * `error_reason` enum — e.g., the name of a conda env declared in
+   * environment.yml that isn't built on this machine, with a suggested
+   * remediation command. `null`/empty when absent or unset.
+   */
+  error_details: string | null;
   name: string;
   language: string;
   env_source: string;
@@ -144,6 +162,7 @@ export const DEFAULT_RUNTIME_STATE: RuntimeState = {
   kernel: {
     lifecycle: { lifecycle: "NotStarted" },
     error_reason: null,
+    error_details: null,
     name: "",
     language: "",
     env_source: "",

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -23,9 +23,7 @@ export type KernelActivity = "Unknown" | "Idle" | "Busy";
  * [`KERNEL_ERROR_REASON`] constants instead of bare string literals when
  * gating UI on a specific cause.
  */
-export type KernelErrorReasonKey =
-  | "missing_ipykernel"
-  | "conda_env_yml_missing";
+export type KernelErrorReasonKey = "missing_ipykernel" | "conda_env_yml_missing";
 
 /**
  * Typed error-reason strings. Mirrors `KernelErrorReason::as_str()` on

--- a/python/runtimed/src/runtimed/_constants.py
+++ b/python/runtimed/src/runtimed/_constants.py
@@ -19,10 +19,10 @@ from typing import Final, Literal
 
 # ── Kernel error reasons ────────────────────────────────────────────
 
-#: Pixi-managed environment is missing the ``ipykernel`` package.
-#: Matches ``KernelErrorReason::MissingIpykernel.as_str()`` on the Rust
-#: side and ``KERNEL_ERROR_REASON.MISSING_IPYKERNEL`` in TypeScript.
-KernelErrorReasonKey = Literal["missing_ipykernel"]
+#: Typed error-reason strings on ``kernel.error_reason``. Mirrors
+#: ``KernelErrorReason::as_str()`` in the Rust ``runtime_doc`` crate and
+#: ``KERNEL_ERROR_REASON`` in the TypeScript ``@runtimed`` package.
+KernelErrorReasonKey = Literal["missing_ipykernel", "conda_env_yml_missing"]
 
 
 class KERNEL_ERROR_REASON:
@@ -35,6 +35,12 @@ class KERNEL_ERROR_REASON:
     """
 
     MISSING_IPYKERNEL: Final[KernelErrorReasonKey] = "missing_ipykernel"
+    #: environment.yml declares a conda env that isn't built on this
+    #: machine. Daemon sets this instead of silently falling back to a
+    #: pool env so the frontend can render a specific "build your env"
+    #: banner and MCP tools can report the miss. ``kernel.error_details``
+    #: carries the declared env name and remediation command.
+    CONDA_ENV_YML_MISSING: Final[KernelErrorReasonKey] = "conda_env_yml_missing"
 
 
 # ── Kernel status strings (legacy `kernel.status` vocabulary) ───────

--- a/python/runtimed/src/runtimed/_internals.pyi
+++ b/python/runtimed/src/runtimed/_internals.pyi
@@ -281,6 +281,13 @@ class KernelState:
         CRDT key is absent; empty string when scaffolded but unset."""
         ...
     @property
+    def error_details(self) -> str | None:
+        """Free-form error details accompanying error_reason. None when
+        the CRDT key is absent; empty string when scaffolded but unset.
+        Carries specifics that don't fit the typed reason enum — e.g.,
+        the name of a missing conda env plus a remediation command."""
+        ...
+    @property
     def name(self) -> str:
         """Kernel display name (e.g. "charming-toucan")."""
         ...

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2649,6 +2649,73 @@ class TestTrustApproval:
         assert info is not None
         assert info.needs_trust_approval is False
 
+    async def test_envyml_missing_env_surfaces_error_state(self, client, tmp_path):
+        """#2157: when environment.yml declares a conda env that isn't built
+        on this machine, the daemon must set RuntimeStateDoc lifecycle to
+        Error with a typed reason and descriptive details — NOT silently
+        fall back to a pool env, and NOT leave the kernel stuck in
+        `initializing` forever.
+        """
+        import asyncio
+        import json
+
+        from runtimed import KERNEL_ERROR_REASON
+
+        (tmp_path / "environment.yml").write_text(
+            "name: nteract-integration-probe-unbuilt-env-xyz\n"
+            "channels:\n  - conda-forge\n"
+            "dependencies:\n  - pandas\n"
+        )
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "kernelspec": {
+                            "name": "python3",
+                            "display_name": "Python 3",
+                            "language": "python",
+                        },
+                        "runt": {"schema_version": "1"},
+                    },
+                    "cells": [],
+                }
+            )
+        )
+
+        notebook = await client.open_notebook(str(nb_path))
+
+        # Poll briefly for the daemon to detect the miss and write the
+        # error lifecycle. Auto-launch runs in a spawned task, so the
+        # state might lag the open_notebook response.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        kernel_state = None
+        while asyncio.get_event_loop().time() < deadline:
+            kernel_state = notebook.runtime.kernel
+            lifecycle = kernel_state.lifecycle
+            # RuntimeLifecycle serializes as {"lifecycle": "Error"} or the
+            # typed enum depending on binding — match both shapes.
+            if getattr(lifecycle, "lifecycle", None) == "Error" or str(lifecycle) == "Error":
+                break
+            await asyncio.sleep(0.1)
+
+        assert kernel_state is not None
+        lifecycle = kernel_state.lifecycle
+        lifecycle_tag = getattr(lifecycle, "lifecycle", None) or str(lifecycle)
+        assert lifecycle_tag == "Error", (
+            f"expected lifecycle=Error after env.yml miss; got {lifecycle_tag!r}"
+        )
+        assert kernel_state.error_reason == KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING
+        details = kernel_state.error_details or ""
+        assert "nteract-integration-probe-unbuilt-env-xyz" in details, (
+            f"error_details should name the declared env; got {details!r}"
+        )
+        assert "conda env create -f" in details, (
+            f"error_details should suggest the remediation; got {details!r}"
+        )
+
     async def test_envyml_channel_mismatch_blocks_heal(self, client, tmp_path):
         """Codex P1 on #2158: a notebook with matching conda deps but
         different inline channels must stay Untrusted. Without this, a


### PR DESCRIPTION
Closes #2157.

## Overview

When `environment.yml` next to a notebook declares a conda env that isn't built on the user's machine, the runtime agent hit `"could not resolve conda environment prefix"` and died. The kernel stayed in `initializing` forever, nothing in the default log level or RuntimeStateDoc explained why, and neither the frontend banner nor MCP tools had any reason to surface.

## Rejected bandaid

An earlier draft (closed as #2163) silently fell back to a conda pool env. Got rejected: the user declares specific deps in env.yml; a pool env doesn't have them; imports fail; notebook looks broken. "Silently wrong" is worse than "visibly broken."

## Fix

Surface a **typed error state with specific details** that lands on the CRDT and flows to every reader.

**runtime-doc:**
- New `KernelErrorReason::CondaEnvYmlMissing` variant (`"conda_env_yml_missing"`).
- New `kernel.error_details` CRDT field — free-form string for specifics that don't fit the typed reason enum. Here it carries the declared env name + remediation command.
- New `set_lifecycle_with_error_details` setter.

**runtimed:**
- `missing_conda_env_yml_name` helper detects the miss using the same resolver the runtime agent uses.
- `auto_launch_kernel` checks before spawning the runtime agent. On miss, sets lifecycle = Error with the reason + details, returns. No wasted agent spawn, no stuck-forever.

**Wire consistency:**
- Python `runtimed._constants.KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING`.
- TypeScript `KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING` in `@runtimed`.
- `KernelState.error_details: string | null` on the TS side.
- `PyKernelState.error_details: Optional[str]` on the Python side.

**MCP surface:**
- `runt-mcp`'s `read_runtime_info` exposes both `error_reason` and `error_details` when lifecycle is Error. Verified E2E via `connect_notebook`:
  ```json
  {
    "kernel_status": "error",
    "error_reason": "conda_env_yml_missing",
    "error_details": "environment.yml declares conda env '...', which is not built on this machine. Run: conda env create -f ..."
  }
  ```

## Out of scope (follow-ups)

- **Frontend banner** rendering this error specifically. The CRDT fields are there and the TS types are updated; the banner component (`NotebookToolbar`) can light up on `error_reason === KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING` in a follow-up PR.
- **Consent prompt UX** ("build env now?"): the product design direction from the feedback writeup. Distinct lifecycle state. v2.4+.
- **Auto-sync env.yml deps into pool env** (#2164): different approach to the same user goal. Not blocking this PR.

## Test plan

- [x] `cargo test -p runtime-doc --lib` — 134 passing
- [x] `cargo test -p runtimed --lib` — 448 passing (+3 for `missing_conda_env_yml_name`)
- [x] `cargo clippy --workspace --exclude runtimed-py` — clean
- [x] runtimed-py integration test `test_envyml_missing_env_surfaces_error_state` (polls RuntimeStateDoc for lifecycle=Error, asserts reason + details)
- [x] Manual E2E: dev daemon rebuilt, notebook next to env.yml naming `nteract-integration-probe-unbuilt-env-xyz`. Daemon log fires the warn with remediation command. No runtime agent spawn. `connect_notebook` returns error_reason + error_details as above.
