### PR TITLE
fix(notebook): remove osascript credential prompt on every upgrade

### DIFF
--- a/apps/notebook/upgrade/App.tsx
+++ b/apps/notebook/upgrade/App.tsx
@@ -2,11 +2,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
-import { AlertTriangle, Check, Circle, Loader2, Notebook } from "lucide-react";
+import { AlertTriangle, Check, Circle, Link2, Loader2, Notebook, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { NotebookStatus, UpgradeStep } from "./types";
+import type { CliMigrationInfo, NotebookStatus, UpgradeStep } from "./types";
 
 type Phase = "review" | "progress";
 
@@ -99,6 +99,126 @@ function StepRow({ step }: { step: StepInfo }) {
   );
 }
 
+function CliMigrationCard({
+  migration,
+  onComplete,
+}: {
+  migration: CliMigrationInfo;
+  onComplete: () => void;
+}) {
+  const [acting, setActing] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  const handleSymlink = useCallback(async () => {
+    setActing(true);
+    try {
+      await invoke("migrate_cli_to_symlink");
+      setResult({ ok: true, message: "Replaced with symlink. Future updates are automatic." });
+      onComplete();
+    } catch (e) {
+      const msg = String(e);
+      if (msg.includes("Cancelled")) {
+        setActing(false);
+        return;
+      }
+      setResult({ ok: false, message: msg });
+    } finally {
+      setActing(false);
+    }
+  }, [onComplete]);
+
+  const handleRemove = useCallback(async () => {
+    setActing(true);
+    try {
+      await invoke("remove_system_cli");
+      setResult({ ok: true, message: "Removed. The CLI is available at ~/.local/bin." });
+      onComplete();
+    } catch (e) {
+      const msg = String(e);
+      if (msg.includes("Cancelled")) {
+        setActing(false);
+        return;
+      }
+      setResult({ ok: false, message: msg });
+    } finally {
+      setActing(false);
+    }
+  }, [onComplete]);
+
+  const handleSkip = useCallback(() => {
+    setResult({
+      ok: true,
+      message:
+        "Skipped. You can remove it later with: sudo rm " +
+        migration.dir +
+        "/" +
+        migration.cli_name,
+    });
+    onComplete();
+  }, [migration, onComplete]);
+
+  if (result) {
+    return (
+      <div
+        className={cn(
+          "p-3 rounded-md border text-sm",
+          result.ok
+            ? "bg-muted/50 border-border text-muted-foreground"
+            : "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-800 dark:text-red-200",
+        )}
+      >
+        {result.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-900/10 space-y-3">
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium">
+          CLI at {migration.dir}/{migration.cli_name}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          A previous version copied the binary here. This requires admin credentials to update on
+          every upgrade. You can replace it with a symlink (auto-updates, one-time prompt), remove
+          it, or skip for now.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSymlink}
+          disabled={acting}
+          className="h-8 text-xs gap-1.5"
+        >
+          {acting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Link2 className="h-3 w-3" />}
+          Replace with symlink
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleRemove}
+          disabled={acting}
+          className="h-8 text-xs gap-1.5"
+        >
+          {acting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+          Remove
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleSkip}
+          disabled={acting}
+          className="h-8 text-xs text-muted-foreground"
+        >
+          Skip
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   const [phase, setPhase] = useState<Phase>("review");
   const [notebooks, setNotebooks] = useState<NotebookStatus[]>([]);
@@ -116,6 +236,9 @@ export default function App() {
     { id: "upgrading", label: "Upgrading daemon", status: "pending" },
     { id: "ready", label: "Ready to restart", status: "pending" },
   ]);
+
+  const [cliMigration, setCliMigration] = useState<CliMigrationInfo | null>(null);
+  const [cliMigrationDone, setCliMigrationDone] = useState(false);
 
   // Fetch notebook status on mount
   useEffect(() => {
@@ -177,6 +300,7 @@ export default function App() {
   const hasBusyKernels = notebooks.some((nb) => nb.kernel_status === "busy");
   const isReady = steps.every((s) => s.status === "completed");
   const hasFailed = steps.some((s) => s.status === "failed");
+  const showMigration = cliMigration !== null && isReady;
 
   const handleAbort = useCallback(async (windowLabel: string) => {
     setAbortingKernels((prev) => new Set(prev).add(windowLabel));
@@ -250,6 +374,18 @@ export default function App() {
       await invoke("run_upgrade");
     } catch (e) {
       setError(String(e));
+      return;
+    }
+
+    // Check for system-wide CLI that needs migration
+    try {
+      const migration = await invoke<CliMigrationInfo | null>("detect_cli_migration");
+      if (migration) {
+        setCliMigration(migration);
+      }
+    } catch (e) {
+      // Non-fatal, just skip the migration prompt
+      console.warn("CLI migration detection failed:", e);
     }
   }, []);
 
@@ -312,14 +448,22 @@ export default function App() {
           <>
             <div className="text-center space-y-2">
               <h1 className="text-2xl font-semibold tracking-tight">
-                {isReady ? "Update Complete" : hasFailed ? "Update Failed" : "Updating..."}
+                {isReady && !showMigration
+                  ? "Update Complete"
+                  : hasFailed
+                    ? "Update Failed"
+                    : showMigration
+                      ? "Update Complete"
+                      : "Updating..."}
               </h1>
               <p className="text-sm text-muted-foreground">
-                {isReady
+                {isReady && !showMigration
                   ? "Ready to restart with the new version"
                   : hasFailed
                     ? "Something went wrong"
-                    : "Please wait while we prepare the update"}
+                    : showMigration
+                      ? "One more thing before restarting"
+                      : "Please wait while we prepare the update"}
               </p>
             </div>
 
@@ -361,6 +505,13 @@ export default function App() {
               ))}
             </div>
 
+            {showMigration && !cliMigrationDone && (
+              <CliMigrationCard
+                migration={cliMigration}
+                onComplete={() => setCliMigrationDone(true)}
+              />
+            )}
+
             {error && (
               <div className="flex items-start gap-2 p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
                 <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
@@ -373,7 +524,12 @@ export default function App() {
                 Close
               </Button>
             ) : (
-              <Button onClick={handleRestart} disabled={!isReady} className="w-full" size="lg">
+              <Button
+                onClick={handleRestart}
+                disabled={!isReady || (showMigration && !cliMigrationDone)}
+                className="w-full"
+                size="lg"
+              >
                 {isReady ? "Restart Now" : "Preparing..."}
               </Button>
             )}

--- a/apps/notebook/upgrade/types.ts
+++ b/apps/notebook/upgrade/types.ts
@@ -13,3 +13,10 @@ export type UpgradeStep =
   | { step: "upgrading_daemon" }
   | { step: "ready" }
   | { step: "failed"; error: string };
+
+export interface CliMigrationInfo {
+  dir: string;
+  cli_name: string;
+  nb_name: string;
+  has_marker: boolean;
+}

--- a/apps/notebook/upgrade/types.ts
+++ b/apps/notebook/upgrade/types.ts
@@ -18,5 +18,4 @@ export interface CliMigrationInfo {
   dir: string;
   cli_name: string;
   nb_name: string;
-  has_marker: boolean;
 }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -397,32 +397,12 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
         } else {
             log::info!("[cli_install] CLI updated successfully");
         }
-
-        // Check system-wide install too. We can't silently refresh it (requires
-        // admin privileges), but we can log a warning so diagnostics catch it.
-        if is_cli_installed_system() {
-            let system_dir = PathBuf::from(SYSTEM_INSTALL_DIR);
-            let system_runt = system_dir.join(cli_command_name());
-            if let Some(bundled) = get_bundled_runt_path(app) {
-                let system_size = fs::metadata(&system_runt).map(|m| m.len()).unwrap_or(0);
-                let bundled_size = fs::metadata(&bundled).map(|m| m.len()).unwrap_or(0);
-                if system_size != bundled_size {
-                    log::warn!(
-                        "[cli_install] System-wide {} is stale (size {} vs bundled {}). \
-                         It will be updated on next in-app upgrade, or re-run Install CLI from the menu.",
-                        system_runt.display(),
-                        system_size,
-                        bundled_size
-                    );
-                }
-            }
-        }
     }
 }
 
 /// Check if the CLI is already installed (checks user-local, system-wide, and legacy locations).
 pub fn is_cli_installed() -> bool {
-    is_cli_installed_local() || is_cli_installed_system() || is_cli_installed_legacy()
+    is_cli_installed_local() || is_cli_installed_legacy()
 }
 
 /// Check if the CLI is installed to the user-local directory (`~/.local/bin`).
@@ -433,16 +413,10 @@ pub fn is_cli_installed_local() -> bool {
     dir.join(cli_name).exists() && dir.join(nb_name).exists()
 }
 
-/// Check if the CLI has a legacy install in `/usr/local/bin` (pre-system-wide era).
-/// Returns false if the system-wide marker is present (that's a managed install,
-/// not a legacy one).
+/// Check if the CLI has a legacy install in `/usr/local/bin`.
 pub fn is_cli_installed_legacy() -> bool {
     #[cfg(unix)]
     {
-        // If the system-wide marker exists, this is a managed install, not legacy
-        if is_cli_installed_system() {
-            return false;
-        }
         let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
         let cli_name = cli_command_name();
         let nb_name = cli_notebook_alias_name();
@@ -452,19 +426,6 @@ pub fn is_cli_installed_legacy() -> bool {
     {
         false
     }
-}
-
-/// Channel-specific marker file placed by system-wide install to distinguish
-/// our managed copy from binaries installed by other means (Homebrew, manual, etc.).
-fn system_install_marker() -> String {
-    format!(".nteract-managed-{}", cli_command_name())
-}
-
-/// Check if the CLI is installed system-wide by nteract (looks for our marker file).
-pub fn is_cli_installed_system() -> bool {
-    PathBuf::from(SYSTEM_INSTALL_DIR)
-        .join(system_install_marker())
-        .exists()
 }
 
 /// Install the CLI to `~/.local/bin` (no admin privileges needed).
@@ -499,271 +460,6 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-/// System-wide install directory.
-pub const SYSTEM_INSTALL_DIR: &str = if cfg!(unix) {
-    "/usr/local/bin"
-} else {
-    "C:\\Program Files\\nteract"
-};
-
-/// Install the CLI system-wide to `/usr/local/bin` (Unix) or `C:\Program Files\nteract`
-/// (Windows) using OS privilege escalation.
-/// Returns Ok(()) on success, Err with message on failure.
-pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
-    let bundled_runt = get_bundled_runt_path(app)
-        .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
-
-    let dir = PathBuf::from(SYSTEM_INSTALL_DIR);
-    // On Windows, executables need the .exe extension to be discoverable via PATH
-    let runt_name = if cfg!(windows) {
-        format!("{}.exe", cli_command_name())
-    } else {
-        cli_command_name().to_string()
-    };
-    let runt_dest = dir.join(runt_name);
-    let nb_dest = dir.join(cli_notebook_alias_name());
-
-    // Build the nb wrapper script content
-    let nb_script = format!(
-        "#!/bin/bash\n# {} - open notebooks faster than you can say {} notebook\nexec {} notebook \"$@\"\n",
-        cli_notebook_alias_name(),
-        cli_command_name(),
-        cli_command_name()
-    );
-
-    install_with_privilege_escalation(&bundled_runt, &runt_dest, &nb_dest, &nb_script)?;
-
-    log::info!(
-        "[cli_install] CLI installed system-wide: {} (copied from {})",
-        runt_dest.display(),
-        bundled_runt.display()
-    );
-
-    Ok(())
-}
-
-/// Install CLI commands to a privileged directory using OS-specific escalation.
-#[cfg(target_os = "macos")]
-fn install_with_privilege_escalation(
-    bundled_runt: &std::path::Path,
-    runt_dest: &std::path::Path,
-    nb_dest: &std::path::Path,
-    nb_script: &str,
-) -> Result<(), String> {
-    // Build the shell script that will run with admin privileges.
-    // We copy the binary (not symlink) so the install is durable even if the
-    // app bundle is moved, unmounted, or accessed by another user account.
-    let dir = shell_escape(
-        runt_dest
-            .parent()
-            .ok_or("Invalid install destination")?
-            .to_string_lossy()
-            .as_ref(),
-    );
-    let marker = shell_escape(
-        runt_dest
-            .parent()
-            .ok_or("Invalid install destination")?
-            .join(system_install_marker())
-            .to_string_lossy()
-            .as_ref(),
-    );
-    let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb} && touch {marker}",
-        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
-        runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
-        nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
-        nb_escaped = shell_escape(nb_script),
-    );
-
-    // Write the shell command to a secure temp file to avoid multiline string
-    // issues in AppleScript. Use a unique filename and restrict permissions to
-    // prevent TOCTOU attacks (another process replacing the script before osascript
-    // executes it with admin privileges).
-    let temp_script =
-        std::env::temp_dir().join(format!("nteract-cli-install-{}.sh", std::process::id()));
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o700)
-            .open(&temp_script)
-            .or_else(|_| {
-                // File might exist from a previous failed attempt
-                let _ = fs::remove_file(&temp_script);
-                fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .mode(0o700)
-                    .open(&temp_script)
-            })
-            .map_err(|e| format!("Failed to create install script: {}", e))?;
-        file.write_all(shell_cmd.as_bytes())
-            .map_err(|e| format!("Failed to write install script: {}", e))?;
-    }
-
-    let escaped_script_path = temp_script
-        .to_string_lossy()
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"");
-    let output = std::process::Command::new("osascript")
-        .arg("-e")
-        .arg(format!(
-            "do shell script \"sh '{escaped_script_path}'\" with administrator privileges"
-        ))
-        .output()
-        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
-
-    // Clean up temp script
-    let _ = fs::remove_file(&temp_script);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // User clicked "Cancel" in the authorization dialog
-        if stderr.contains("User canceled")
-            || stderr.contains("user canceled")
-            || stderr.contains("-128")
-        {
-            return Err("Installation cancelled.".to_string());
-        }
-        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
-    }
-
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn install_with_privilege_escalation(
-    bundled_runt: &std::path::Path,
-    runt_dest: &std::path::Path,
-    nb_dest: &std::path::Path,
-    nb_script: &str,
-) -> Result<(), String> {
-    let dir = shell_escape(
-        runt_dest
-            .parent()
-            .ok_or("Invalid install destination")?
-            .to_string_lossy()
-            .as_ref(),
-    );
-    let marker = shell_escape(
-        runt_dest
-            .parent()
-            .ok_or("Invalid install destination")?
-            .join(system_install_marker())
-            .to_string_lossy()
-            .as_ref(),
-    );
-    let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb} && touch {marker}",
-        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
-        runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
-        nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
-        nb_escaped = shell_escape(nb_script),
-    );
-
-    let output = std::process::Command::new("pkexec")
-        .arg("sh")
-        .arg("-c")
-        .arg(&shell_cmd)
-        .output()
-        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("dismissed") || stderr.contains("Not authorized") {
-            return Err("Installation cancelled.".to_string());
-        }
-        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
-    }
-
-    Ok(())
-}
-
-#[cfg(target_os = "windows")]
-fn install_with_privilege_escalation(
-    bundled_runt: &std::path::Path,
-    runt_dest: &std::path::Path,
-    nb_dest: &std::path::Path,
-    _nb_script: &str,
-) -> Result<(), String> {
-    // On Windows, use PowerShell's Start-Process with -Verb RunAs for UAC elevation.
-    // We copy the runt binary and create a .cmd wrapper for nb (since copying the
-    // binary would just give another runt instance, not a notebook shorthand).
-    // Use a temp file for error reporting since Start-Process -Verb RunAs doesn't
-    // propagate the inner process exit code.
-    let install_dir = runt_dest
-        .parent()
-        .ok_or("Invalid install destination")?
-        .to_string_lossy()
-        .replace('\'', "''");
-    let src = bundled_runt.to_string_lossy().replace('\'', "''");
-    let runt = runt_dest.to_string_lossy().replace('\'', "''");
-    // nb on Windows is a .cmd wrapper that calls runt notebook
-    let nb_cmd = nb_dest.with_extension("cmd");
-    let nb = nb_cmd.to_string_lossy().replace('\'', "''");
-    let cli_cmd = runt_workspace::cli_command_name();
-
-    let marker = system_install_marker().replace('\'', "''");
-
-    let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
-    let err_path = err_file.to_string_lossy().replace('\'', "''");
-
-    // The elevated script: create dir, copy runt, write nb.cmd wrapper, add to PATH,
-    // then broadcast WM_SETTINGCHANGE so new shells pick up the PATH change.
-    let ps_cmd = format!(
-        "$ErrorActionPreference='Stop'; try {{ \
-         New-Item -ItemType Directory -Force -Path '{install_dir}' | Out-Null; \
-         Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; \
-         Copy-Item '{src}' '{runt}'; \
-         Set-Content -Path '{nb}' -Value \"@echo off`r`n{cli_cmd} notebook %*\" -Encoding ASCII; \
-         New-Item -ItemType File -Force -Path '{install_dir}\\{marker}' | Out-Null; \
-         $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
-         if ($path -notlike '*{install_dir}*') {{ \
-           [Environment]::SetEnvironmentVariable('Path', '{install_dir};' + $path, 'Machine'); \
-           Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition '[DllImport(\"user32.dll\", SetLastError=true, CharSet=CharSet.Auto)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);'; \
-           $r = [UIntPtr]::Zero; \
-           [Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xFFFF, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$r) | Out-Null \
-         }}; \
-         Remove-Item -Force -ErrorAction SilentlyContinue '{err_path}' \
-         }} catch {{ $_.Exception.Message | Out-File '{err_path}' -Encoding utf8 }}"
-    );
-
-    let output = std::process::Command::new("powershell")
-        .args([
-            "-Command",
-            &format!(
-                "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-Command','{}'",
-                ps_cmd.replace('\'', "''")
-            ),
-        ])
-        .output()
-        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
-    }
-
-    // Check the error file written by the elevated script
-    if err_file.exists() {
-        let err_msg = fs::read_to_string(&err_file).unwrap_or_default();
-        let _ = fs::remove_file(&err_file);
-        if !err_msg.trim().is_empty() {
-            return Err(format!("Installation failed: {}", err_msg.trim()));
-        }
-    }
-
-    Ok(())
-}
-
-/// Escape a string for use inside a single-quoted shell argument.
-#[cfg(unix)]
-fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Warn if legacy /usr/local/bin has stale CLI copies that shadow ~/.local/bin.
@@ -927,6 +623,229 @@ fn ensure_shell_path(bin_dir: &std::path::Path) -> Result<(), String> {
         "[cli_install] Added ~/.local/bin to PATH in {}",
         rc_path.display()
     );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// System CLI migration (one-time, user-initiated during upgrade)
+// ---------------------------------------------------------------------------
+
+/// Information about a system-wide CLI install that should be migrated.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SystemCliMigration {
+    pub dir: String,
+    pub cli_name: String,
+    pub nb_name: String,
+    pub has_marker: bool,
+}
+
+/// Detect a system-wide CLI install in `/usr/local/bin` that was placed by nteract.
+///
+/// Returns `Some` if at least the CLI binary exists at the legacy path. The
+/// presence of the `.nteract-managed-*` marker file confirms it was placed by
+/// the old system-wide installer, but we also detect unmarked legacy installs.
+#[cfg(unix)]
+pub fn detect_system_cli_migration() -> Option<SystemCliMigration> {
+    let dir = PathBuf::from(LEGACY_INSTALL_DIR);
+    let cli_name = cli_command_name();
+    let runt_path = dir.join(cli_name);
+
+    if !runt_path.exists() {
+        return None;
+    }
+
+    // Only consider it ours if it's a regular file (stale copy). Symlinks
+    // pointing into an nteract bundle are fine and don't need migration.
+    if runt_path.is_symlink() {
+        return None;
+    }
+
+    let nb_name = cli_notebook_alias_name();
+    let marker_name = format!(".nteract-managed-{}", cli_name);
+    let has_marker = dir.join(&marker_name).exists();
+
+    Some(SystemCliMigration {
+        dir: dir.to_string_lossy().to_string(),
+        cli_name: cli_name.to_string(),
+        nb_name: nb_name.to_string(),
+        has_marker,
+    })
+}
+
+#[cfg(not(unix))]
+pub fn detect_system_cli_migration() -> Option<SystemCliMigration> {
+    None
+}
+
+/// Replace the system-wide CLI copy with a symlink to the app bundle binary.
+/// Requires privilege escalation (one-time).
+#[cfg(target_os = "macos")]
+pub fn migrate_system_cli_to_symlink(app: &tauri::AppHandle) -> Result<(), String> {
+    let bundled_runt = get_bundled_runt_path(app)
+        .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
+
+    let dir = PathBuf::from(LEGACY_INSTALL_DIR);
+    let cli_name = cli_command_name();
+    let nb_name = cli_notebook_alias_name();
+    let marker_name = format!(".nteract-managed-{}", cli_name);
+
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} {marker} && ln -s {src} {runt}",
+        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
+        runt = shell_escape(dir.join(cli_name).to_string_lossy().as_ref()),
+        nb = shell_escape(dir.join(nb_name).to_string_lossy().as_ref()),
+        marker = shell_escape(dir.join(&marker_name).to_string_lossy().as_ref()),
+    );
+
+    escalate_shell_command(&shell_cmd)
+}
+
+/// Remove the system-wide CLI entirely. Requires privilege escalation.
+#[cfg(target_os = "macos")]
+pub fn remove_system_cli(app: &tauri::AppHandle) -> Result<(), String> {
+    let _ = app;
+    let dir = PathBuf::from(LEGACY_INSTALL_DIR);
+    let cli_name = cli_command_name();
+    let nb_name = cli_notebook_alias_name();
+    let marker_name = format!(".nteract-managed-{}", cli_name);
+
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} {marker}",
+        runt = shell_escape(dir.join(cli_name).to_string_lossy().as_ref()),
+        nb = shell_escape(dir.join(nb_name).to_string_lossy().as_ref()),
+        marker = shell_escape(dir.join(&marker_name).to_string_lossy().as_ref()),
+    );
+
+    escalate_shell_command(&shell_cmd)
+}
+
+/// Replace the system-wide CLI copy with a symlink to the app bundle binary.
+#[cfg(target_os = "linux")]
+pub fn migrate_system_cli_to_symlink(app: &tauri::AppHandle) -> Result<(), String> {
+    let bundled_runt = get_bundled_runt_path(app)
+        .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
+
+    let dir = PathBuf::from(LEGACY_INSTALL_DIR);
+    let cli_name = cli_command_name();
+    let nb_name = cli_notebook_alias_name();
+    let marker_name = format!(".nteract-managed-{}", cli_name);
+
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} {marker} && ln -s {src} {runt}",
+        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
+        runt = shell_escape(dir.join(cli_name).to_string_lossy().as_ref()),
+        nb = shell_escape(dir.join(nb_name).to_string_lossy().as_ref()),
+        marker = shell_escape(dir.join(&marker_name).to_string_lossy().as_ref()),
+    );
+
+    escalate_shell_command(&shell_cmd)
+}
+
+/// Remove the system-wide CLI entirely.
+#[cfg(target_os = "linux")]
+pub fn remove_system_cli(app: &tauri::AppHandle) -> Result<(), String> {
+    let _ = app;
+    let dir = PathBuf::from(LEGACY_INSTALL_DIR);
+    let cli_name = cli_command_name();
+    let nb_name = cli_notebook_alias_name();
+    let marker_name = format!(".nteract-managed-{}", cli_name);
+
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} {marker}",
+        runt = shell_escape(dir.join(cli_name).to_string_lossy().as_ref()),
+        nb = shell_escape(dir.join(nb_name).to_string_lossy().as_ref()),
+        marker = shell_escape(dir.join(&marker_name).to_string_lossy().as_ref()),
+    );
+
+    escalate_shell_command(&shell_cmd)
+}
+
+#[cfg(target_os = "windows")]
+pub fn migrate_system_cli_to_symlink(_app: &tauri::AppHandle) -> Result<(), String> {
+    Err("Symlink migration is not supported on Windows".to_string())
+}
+
+#[cfg(target_os = "windows")]
+pub fn remove_system_cli(_app: &tauri::AppHandle) -> Result<(), String> {
+    Err("System CLI removal is not supported on Windows".to_string())
+}
+
+/// Escape a string for use inside a single-quoted shell argument.
+#[cfg(unix)]
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Run a shell command with OS privilege escalation.
+#[cfg(target_os = "macos")]
+fn escalate_shell_command(shell_cmd: &str) -> Result<(), String> {
+    let temp_script =
+        std::env::temp_dir().join(format!("nteract-cli-migrate-{}.sh", std::process::id()));
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o700)
+            .open(&temp_script)
+            .or_else(|_| {
+                let _ = fs::remove_file(&temp_script);
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o700)
+                    .open(&temp_script)
+            })
+            .map_err(|e| format!("Failed to create migration script: {}", e))?;
+        file.write_all(shell_cmd.as_bytes())
+            .map_err(|e| format!("Failed to write migration script: {}", e))?;
+    }
+
+    let escaped_script_path = temp_script
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(format!(
+            "do shell script \"sh '{escaped_script_path}'\" with administrator privileges"
+        ))
+        .output()
+        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    let _ = fs::remove_file(&temp_script);
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("User canceled")
+            || stderr.contains("user canceled")
+            || stderr.contains("-128")
+        {
+            return Err("Cancelled.".to_string());
+        }
+        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn escalate_shell_command(shell_cmd: &str) -> Result<(), String> {
+    let output = std::process::Command::new("pkexec")
+        .arg("sh")
+        .arg("-c")
+        .arg(shell_cmd)
+        .output()
+        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("dismissed") || stderr.contains("Not authorized") {
+            return Err("Cancelled.".to_string());
+        }
+        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
     Ok(())
 }
 

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -636,39 +636,36 @@ pub struct SystemCliMigration {
     pub dir: String,
     pub cli_name: String,
     pub nb_name: String,
-    pub has_marker: bool,
 }
 
 /// Detect a system-wide CLI install in `/usr/local/bin` that was placed by nteract.
 ///
-/// Returns `Some` if at least the CLI binary exists at the legacy path. The
-/// presence of the `.nteract-managed-*` marker file confirms it was placed by
-/// the old system-wide installer, but we also detect unmarked legacy installs.
+/// Only returns `Some` when the `.nteract-managed-*` marker file is present.
+/// Without that marker the binary could belong to Homebrew, a manual install,
+/// or another tool, and we must not touch it with elevated privileges.
 #[cfg(unix)]
 pub fn detect_system_cli_migration() -> Option<SystemCliMigration> {
     let dir = PathBuf::from(LEGACY_INSTALL_DIR);
     let cli_name = cli_command_name();
-    let runt_path = dir.join(cli_name);
+    let marker_name = format!(".nteract-managed-{}", cli_name);
 
-    if !runt_path.exists() {
+    if !dir.join(&marker_name).exists() {
         return None;
     }
 
-    // Only consider it ours if it's a regular file (stale copy). Symlinks
-    // pointing into an nteract bundle are fine and don't need migration.
-    if runt_path.is_symlink() {
+    let runt_path = dir.join(cli_name);
+
+    // Symlinks pointing into an nteract bundle are fine and don't need migration.
+    if !runt_path.exists() || runt_path.is_symlink() {
         return None;
     }
 
     let nb_name = cli_notebook_alias_name();
-    let marker_name = format!(".nteract-managed-{}", cli_name);
-    let has_marker = dir.join(&marker_name).exists();
 
     Some(SystemCliMigration {
         dir: dir.to_string_lossy().to_string(),
         cli_name: cli_name.to_string(),
         nb_name: nb_name.to_string(),
-        has_marker,
     })
 }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1443,23 +1443,32 @@ async fn run_upgrade(
             Err(e) => log::warn!("[upgrade] Local CLI re-install failed (non-fatal): {}", e),
         }
     }
-    // System-wide installs are copies (not symlinks), so they need updating too.
-    if cli_install::is_cli_installed_system() {
-        match cli_install::install_cli_system(&app) {
-            Ok(()) => log::info!("[upgrade] System-wide CLI re-installed successfully"),
-            Err(e) => log::warn!(
-                "[upgrade] System-wide CLI re-install failed (non-fatal): {}",
-                e
-            ),
-        }
-    }
-
     // Step 6: Signal ready
     app.emit("upgrade:progress", UpgradeProgress::Ready)
         .map_err(|e| e.to_string())?;
 
     log::info!("[upgrade] Upgrade complete, ready for restart");
     Ok(())
+}
+
+/// Check if there is a system-wide CLI install that should be migrated.
+#[tauri::command]
+fn detect_cli_migration() -> Option<cli_install::SystemCliMigration> {
+    cli_install::detect_system_cli_migration()
+}
+
+/// Replace the system-wide CLI copy at `/usr/local/bin` with a symlink to the
+/// app bundle. Requires one-time privilege escalation.
+#[tauri::command]
+fn migrate_cli_to_symlink(app: tauri::AppHandle) -> Result<(), String> {
+    cli_install::migrate_system_cli_to_symlink(&app)
+}
+
+/// Remove the system-wide CLI from `/usr/local/bin` entirely.
+/// Requires one-time privilege escalation.
+#[tauri::command]
+fn remove_system_cli(app: tauri::AppHandle) -> Result<(), String> {
+    cli_install::remove_system_cli(&app)
 }
 
 /// Ensure the daemon is running using Tauri's sidecar API.
@@ -4212,6 +4221,9 @@ pub fn run(
             get_upgrade_notebook_status,
             abort_kernel_for_upgrade,
             run_upgrade,
+            detect_cli_migration,
+            migrate_cli_to_symlink,
+            remove_system_cli,
             // pyproject.toml discovery
             detect_pyproject,
             get_pyproject_dependencies,
@@ -4748,28 +4760,9 @@ pub fn run(
                 crate::menu::MENU_INSTALL_CLI => {
                     let app_handle = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        // Show confirmation dialog — this requires admin privileges
-                        let install_dir = crate::cli_install::SYSTEM_INSTALL_DIR;
-                        let confirmed =
-                            tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                .message(format!(
-                                    "This will install the CLI commands to {install_dir}, which requires administrator privileges.",
-                                ))
-                                .title("Install CLI?")
-                                .kind(tauri_plugin_dialog::MessageDialogKind::Info)
-                                .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                                    "Install".to_string(),
-                                    "Cancel".to_string(),
-                                ))
-                                .blocking_show();
-
-                        if !confirmed {
-                            return;
-                        }
-
                         let result = tauri::async_runtime::spawn_blocking({
                             let app_handle = app_handle.clone();
-                            move || crate::cli_install::install_cli_system(&app_handle)
+                            move || crate::cli_install::install_cli(&app_handle)
                         })
                         .await;
 
@@ -4779,7 +4772,7 @@ pub fn run(
                                 let cli_cmd = runt_workspace::cli_command_name();
                                 let nb_cmd = runt_workspace::cli_notebook_alias_name();
                                 let success_message = format!(
-                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to {install_dir}.\n\nOpen a new terminal and run: {cli_cmd} --help"
+                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to ~/.local/bin.\n\nOpen a new terminal and run: {cli_cmd} --help"
                                 );
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
                                     .message(success_message)
@@ -4789,13 +4782,11 @@ pub fn run(
                             }
                             Ok(Err(e)) => {
                                 log::error!("[cli_install] CLI installation failed: {}", e);
-                                if e != "Installation cancelled." {
-                                    let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                        .message(format!("Failed to install CLI: {}", e))
-                                        .title("Installation Failed")
-                                        .kind(tauri_plugin_dialog::MessageDialogKind::Error)
-                                        .blocking_show();
-                                }
+                                let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
+                                    .message(format!("Failed to install CLI: {}", e))
+                                    .title("Installation Failed")
+                                    .kind(tauri_plugin_dialog::MessageDialogKind::Error)
+                                    .blocking_show();
                             }
                             Err(e) => {
                                 log::error!("[cli_install] CLI install task panicked: {}", e);

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -66,7 +66,7 @@ pub fn about_menu_label() -> String {
 
 pub fn install_cli_menu_label() -> String {
     format!(
-        "Install '{}' Command in PATH...",
+        "Install '{}' Command in PATH",
         runt_workspace::cli_command_name()
     )
 }


### PR DESCRIPTION
## Overview

The system-wide CLI install (`/usr/local/bin`) copied the `runt` binary on every app upgrade, triggering a macOS admin credential dialog (`osascript`) each time. The local install (`~/.local/bin` symlink) already auto-tracks the app bundle with zero privilege escalation, making the system-wide path redundant and annoying.

This PR deletes the automatic system-wide install and adds a one-time migration step in the upgrade UI for existing users who have a stale copy in `/usr/local/bin`.

## What changed

**Removed** (~265 lines of privilege escalation code):
- `install_cli_system`, `install_with_privilege_escalation` (macOS/Linux/Windows), `is_cli_installed_system`, `system_install_marker`, `SYSTEM_INSTALL_DIR`
- The upgrade flow no longer silently calls `install_cli_system` at step 5
- The "Install CLI" menu item no longer triggers system-wide install with admin confirmation

**Added** - migration helpers and upgrade UI:
- `detect_system_cli_migration` checks if `/usr/local/bin/runt` is a stale binary copy (not a symlink)
- `migrate_system_cli_to_symlink` and `remove_system_cli` are one-time privileged actions
- Three new Tauri commands (`detect_cli_migration`, `migrate_cli_to_symlink`, `remove_system_cli`)
- `CliMigrationCard` component in the upgrade window with three choices:
  - **Replace with symlink** (auto-updates going forward, one last admin prompt)
  - **Remove** (user relies on `~/.local/bin`)
  - **Skip** (stale copy stays, shown the manual `sudo rm` command)

**Changed**:
- "Install 'runt' Command in PATH" menu item now runs the local `~/.local/bin` install directly (no admin dialog)
- Removed trailing "..." from menu label (no dialog before action)

<!-- Screenshots of the migration card in the upgrade window go here -->

## Verification

- [ ] Upgrade with an existing `/usr/local/bin/runt` binary copy. Migration card appears with all three options.
- [ ] "Replace with symlink" prompts for admin once, then `/usr/local/bin/runt` is a symlink to the app bundle.
- [ ] "Remove" prompts for admin once, then `/usr/local/bin/runt` is gone.
- [ ] "Skip" dismisses the card and shows the manual removal command.
- [ ] Upgrade without `/usr/local/bin/runt`. No migration card, straight to "Ready to restart."
- [ ] Menu > "Install 'runt' Command in PATH" installs to `~/.local/bin` with no admin prompt.

_PR submitted by @rgbkrk's agent, Quill_