### PR TITLE
fix(inline-env): route inline-dep notebooks with version specifiers through the pool

### DIFF
--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -4,7 +4,7 @@
 //! providing a [`BroadcastProgressHandler`] that forwards progress events
 //! to connected notebook clients via the broadcast channel.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -265,22 +265,26 @@ pub enum PoolDepRelation {
     Independent,
 }
 
-/// Strip a dependency string to its bare package name, discarding
-/// environment markers (`; python_version >= '3.10'`) and version
-/// specifiers (`>=`, `<`, `~=`, etc). Returns `None` only when the
-/// input is empty or produces an empty bare name.
+/// Split a dependency string into `(bare_name, constraint_tail)`.
 ///
-/// Used for matching deps by package identity across the inline-deps /
-/// pool-packages boundary. The caller gets a name it can `normalize`
-/// and look up; unsafe-for-pool-reuse constructs (exact pins, extras)
-/// are flagged separately by [`inline_dep_forbids_pool_reuse`].
-fn strip_to_bare(dep: &str) -> Option<&str> {
+/// The constraint tail is everything after the bare name with the
+/// environment marker (`; python_version >= '3.10'`) stripped and
+/// leading/trailing whitespace trimmed. Empty tail means the dep is
+/// bare (accepts any version). Returns `None` when the input is empty
+/// or produces an empty bare name.
+///
+/// Pool matching requires byte-equal tails (or an empty inline tail
+/// satisfied by any pool entry on the same bare). We DON'T attempt
+/// version-range solving — a notebook asking for `numpy<2` against
+/// a pool spec'd for `numpy>=2.2.6` would silently launch with the
+/// wrong version. Mismatched specs force Independent instead.
+fn split_bare_and_constraint(dep: &str) -> Option<(&str, &str)> {
     let trimmed = dep.trim();
     if trimmed.is_empty() {
         return None;
     }
-    // Environment marker first — `gremlin ; sys_platform == 'darwin'`
-    // contains `==` only inside the marker. We want the package name.
+    // Strip environment marker first — `gremlin ; sys_platform == 'darwin'`
+    // contains `==` inside the marker and is not a version pin.
     let before_marker = trimmed.split(';').next().unwrap_or(trimmed).trim();
     let cut_chars = ['>', '<', '=', '!', '~', '[', '@', ' ', '\t'];
     let cut = before_marker
@@ -288,28 +292,36 @@ fn strip_to_bare(dep: &str) -> Option<&str> {
         .unwrap_or(before_marker.len());
     let bare = before_marker[..cut].trim();
     if bare.is_empty() {
-        None
-    } else {
-        Some(bare)
+        return None;
     }
+    let tail = before_marker[cut..].trim();
+    Some((bare, tail))
+}
+
+/// Kept as a thin wrapper so existing tests on bare-name extraction
+/// stay meaningful. Returns `Some(name)` iff `split_bare_and_constraint`
+/// finds one.
+fn strip_to_bare(dep: &str) -> Option<&str> {
+    split_bare_and_constraint(dep).map(|(bare, _)| bare)
 }
 
 /// Check whether an inline dep must bypass pool reuse regardless of
-/// bare-name match.
+/// what the pool has.
 ///
-/// Two cases today:
-/// - Exact pin (`pkg==X.Y.Z`): pool env's version is settings-driven
-///   and may differ from the user's pin. Using a wrong-version pool
-///   env would silently break user code.
+/// Three constructs we refuse:
+/// - Exact pin (`pkg==X.Y.Z`): pool's installed version is driven by
+///   user settings and may differ. Running against a wrong-version
+///   pool env would silently break user code.
 /// - Extras (`pkg[feature]`): the extra pulls in transitive deps the
-///   pool may not have installed. Hard to verify from a spec string
-///   alone, so refuse.
+///   pool may not have installed. Can't verify from the spec string.
+/// - Direct reference (`pkg @ https://...`, `pkg @ git+...`): pool
+///   has the registry version, notebook asked for a specific source.
+///   Different sources, not interchangeable.
 fn inline_dep_forbids_pool_reuse(dep: &str) -> bool {
-    // Apply the same marker-strip before scanning for `==` so
-    // `gremlin ; sys_platform == 'darwin'` isn't mistaken for an exact
-    // pin on the gremlin package.
+    // Strip env marker first so `gremlin ; sys_platform == 'darwin'`
+    // isn't mistaken for an exact pin on the gremlin package.
     let before_marker = dep.split(';').next().unwrap_or(dep).trim();
-    before_marker.contains("==") || before_marker.contains('[')
+    before_marker.contains("==") || before_marker.contains('[') || before_marker.contains('@')
 }
 
 /// Extract the package name from a conda dependency specifier, stripping
@@ -355,26 +367,45 @@ fn normalize_package_name(name: &str) -> String {
 
 /// Compare inline deps against pool prewarmed packages.
 ///
-/// Matches by bare package name across both sides: environment markers
-/// and version specifiers are stripped from both `inline_deps` and
-/// `pool_packages` before comparison. This lets notebooks seeded from
-/// user settings (e.g. `numpy>=2.2.6`) route to a pool env built from
-/// the same settings (same specifier string) without being held up by
-/// the presence of the `>=`.
+/// Matching rule:
+/// - Bare name on both sides must be equal (after lowercase + `_`→`-`).
+/// - If the inline dep has no constraint tail, any pool entry on the
+///   same bare name covers it — the notebook accepts whatever version
+///   the pool has installed.
+/// - If the inline dep has a constraint tail, the pool must carry the
+///   *byte-equal* tail on the same bare name. This is the common case:
+///   a new notebook seeded from user settings and the pool env built
+///   from those same settings both carry `numpy>=2.2.6` verbatim.
 ///
-/// Returns [`PoolDepRelation::Independent`] when any dep pins an exact
-/// version (`pkg==X`) or declares extras (`pkg[feature]`) — pool reuse
-/// can't verify the pool env satisfies those constraints, so build from
-/// scratch instead.
+/// When bare names match but constraint tails differ
+/// (`inline: numpy<2`, `pool: numpy>=2.2.6`), we return
+/// [`PoolDepRelation::Independent`] — the pool has the wrong version
+/// range and reusing it would silently launch with a version the
+/// notebook didn't ask for. We don't attempt to solve version
+/// ranges; that's the package manager's job on a full build.
+///
+/// Forbidden constructs (exact pins, extras, direct references) also
+/// force Independent via [`inline_dep_forbids_pool_reuse`].
+///
+/// [`PoolDepRelation::Additive`] is reserved for the case where a dep
+/// is missing from the pool *entirely* (different bare name). The
+/// caller can install that missing dep on top of the pool env.
 pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) -> PoolDepRelation {
     if inline_deps.is_empty() {
         return PoolDepRelation::Subset;
     }
 
-    let pool_normalized: HashSet<String> = pool_packages
-        .iter()
-        .filter_map(|p| strip_to_bare(p).map(normalize_package_name))
-        .collect();
+    // Pool map: bare_name -> set of constraint tails observed on that
+    // name. A bare entry in the pool contributes "" to the set.
+    let mut pool_map: HashMap<String, HashSet<String>> = HashMap::new();
+    for p in pool_packages {
+        if let Some((bare, tail)) = split_bare_and_constraint(p) {
+            pool_map
+                .entry(normalize_package_name(bare))
+                .or_default()
+                .insert(tail.to_string());
+        }
+    }
 
     let mut delta = Vec::new();
 
@@ -382,14 +413,30 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
         if inline_dep_forbids_pool_reuse(dep) {
             return PoolDepRelation::Independent;
         }
-        let Some(bare) = strip_to_bare(dep) else {
+        let Some((bare, tail)) = split_bare_and_constraint(dep) else {
             // Empty / whitespace-only dep — nothing to match.
             continue;
         };
 
-        let normalized = normalize_package_name(bare);
-        if !pool_normalized.contains(&normalized) {
-            delta.push(dep.clone());
+        let key = normalize_package_name(bare);
+        match pool_map.get(&key) {
+            None => {
+                // Pool doesn't have this package at all — extras can
+                // be installed additively on top of the pool env.
+                delta.push(dep.clone());
+            }
+            Some(pool_tails) => {
+                if tail.is_empty() || pool_tails.contains(tail) {
+                    // Inline accepts any (no constraint), or the exact
+                    // constraint string is on the pool entry. Covered.
+                } else {
+                    // Pool has the package but with a different
+                    // constraint. Version-range overlap is possible
+                    // but not something we can verify cheaply — refuse
+                    // to reuse to avoid silent wrong-version launches.
+                    return PoolDepRelation::Independent;
+                }
+            }
         }
     }
 
@@ -776,12 +823,16 @@ mod tests {
     }
 
     #[test]
-    fn test_compare_additive_with_specifier_on_extra() {
-        // `pandas>=2.0` matches the pool's bare `pandas`. `torch` is
-        // not in pool — goes into the delta unchanged so the Additive
-        // path can install it at its original spec.
+    fn test_compare_additive_only_for_missing_bare_names() {
+        // Additive delta is reserved for deps whose bare name isn't in
+        // the pool at all. Constraint-mismatch on a matching bare name
+        // goes to Independent instead (no silent wrong-version reuse).
+        //
+        // Pool has bare `pandas` + missing `torch`, inline says
+        // `pandas` (bare, accepts any) + `torch` — only `torch` is
+        // delta; `pandas` bare-vs-bare covers.
         let pool = vec!["ipykernel".into(), "pandas".into()];
-        let deps = vec!["pandas>=2.0".into(), "torch".into()];
+        let deps = vec!["pandas".into(), "torch".into()];
         match compare_deps_to_pool(&deps, &pool) {
             PoolDepRelation::Additive { delta } => {
                 assert_eq!(delta, vec!["torch".to_string()]);
@@ -795,6 +846,71 @@ mod tests {
         // Extras pull in transitive deps the pool may not have.
         let pool = vec!["ipykernel".into(), "pandas".into()];
         let deps = vec!["pandas[parquet]".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_independent_on_constraint_mismatch() {
+        // Pool was built with `numpy>=2.2.6`. Notebook asks for
+        // `numpy<2`. Pool's installed numpy is 2.x-something; running
+        // user code against it would silently violate the `<2` bound.
+        // Must force fresh build.
+        let pool = vec!["ipykernel".into(), "numpy>=2.2.6".into()];
+        let deps = vec!["numpy<2".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_independent_on_space_separated_conda_constraint() {
+        // Conda-style `numpy 1.24.*` (space-separated version spec).
+        // Pool has bare `numpy`; inline wants `1.24.*`. Different
+        // constraint → Independent.
+        let pool = vec!["ipykernel".into(), "numpy".into()];
+        let deps = vec!["numpy 1.24.*".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_independent_on_direct_reference() {
+        // `pkg @ URL` is a direct reference to a specific source. Pool
+        // has registry-installed pkg; different source → refuse reuse.
+        let pool = vec!["ipykernel".into(), "pandas".into()];
+        let deps = vec!["pandas @ https://example.com/pandas.whl".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_bare_inline_covers_pool_constrained() {
+        // Inline dep is bare (accepts any version), pool has a
+        // constraint. Pool has *some* version of the package → covers.
+        let pool = vec!["ipykernel".into(), "numpy>=2.2.6".into()];
+        let deps = vec!["numpy".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_independent_inline_constrained_pool_bare() {
+        // Flip of the prior test: inline has a constraint, pool
+        // entry is bare (no constraint recorded). Pool's installed
+        // version may or may not satisfy the inline constraint —
+        // we can't tell without introspection, so refuse.
+        let pool = vec!["ipykernel".into(), "numpy".into()];
+        let deps = vec!["numpy>=2.2.6".into()];
         assert!(matches!(
             compare_deps_to_pool(&deps, &pool),
             PoolDepRelation::Independent

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -267,42 +267,49 @@ pub enum PoolDepRelation {
 
 /// Split a dependency string into `(bare_name, constraint_tail)`.
 ///
-/// The constraint tail is everything after the bare name with the
-/// environment marker (`; python_version >= '3.10'`) stripped and
-/// leading/trailing whitespace trimmed. Empty tail means the dep is
-/// bare (accepts any version). Returns `None` when the input is empty
-/// or produces an empty bare name.
+/// The constraint tail preserves everything after the bare name —
+/// version specifier, extras, AND any environment marker — with
+/// whitespace squeezed out so variants like `pkg>=1.0` and
+/// `pkg >= 1.0` normalize to the same tail. Empty tail means the
+/// dep is bare and unconditional (accepts any version, always
+/// installed). Returns `None` when the input is empty or produces
+/// an empty bare name.
 ///
-/// Pool matching requires byte-equal tails (or an empty inline tail
-/// satisfied by any pool entry on the same bare). We DON'T attempt
-/// version-range solving — a notebook asking for `numpy<2` against
-/// a pool spec'd for `numpy>=2.2.6` would silently launch with the
-/// wrong version. Mismatched specs force Independent instead.
-fn split_bare_and_constraint(dep: &str) -> Option<(&str, &str)> {
+/// Why the marker stays in the tail: pool `prewarmed_packages` is
+/// the install-spec list, not the actually-installed list. A spec
+/// like `gremlin ; sys_platform == 'darwin'` means gremlin is only
+/// present on Darwin pool envs. On other platforms the pool entry
+/// exists but gremlin isn't installed. Matching against the
+/// unconditional bare name would make a bare-`gremlin` inline dep
+/// hit a pool env that lacks the package. Keeping the marker in the
+/// tail forces a byte-equal match (or fall through to Independent).
+fn split_bare_and_constraint(dep: &str) -> Option<(&str, String)> {
     let trimmed = dep.trim();
     if trimmed.is_empty() {
         return None;
     }
-    // Strip environment marker first — `gremlin ; sys_platform == 'darwin'`
-    // contains `==` inside the marker and is not a version pin.
-    let before_marker = trimmed.split(';').next().unwrap_or(trimmed).trim();
-    let cut_chars = ['>', '<', '=', '!', '~', '[', '@', ' ', '\t'];
-    let cut = before_marker
+    // Cut at the first specifier, marker, or whitespace — whichever
+    // ends the bare name. The tail then carries everything from the
+    // first specifier through the end of the original string (marker
+    // included).
+    let cut_chars = ['>', '<', '=', '!', '~', '[', '@', ';', ' ', '\t'];
+    let cut = trimmed
         .find(|c: char| cut_chars.contains(&c))
-        .unwrap_or(before_marker.len());
-    let bare = before_marker[..cut].trim();
+        .unwrap_or(trimmed.len());
+    let bare = trimmed[..cut].trim();
     if bare.is_empty() {
         return None;
     }
-    let tail = before_marker[cut..].trim();
+    // Whitespace-normalize so `pkg>=1.0` and `pkg >= 1.0` compare
+    // equal. Strips internal whitespace too — `; sys_platform == 'x'`
+    // and `;sys_platform=='x'` both collapse to the same canonical
+    // form, which makes byte-equal comparison actually useful in
+    // practice.
+    let tail: String = trimmed[cut..]
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
     Some((bare, tail))
-}
-
-/// Kept as a thin wrapper so existing tests on bare-name extraction
-/// stay meaningful. Returns `Some(name)` iff `split_bare_and_constraint`
-/// finds one.
-fn strip_to_bare(dep: &str) -> Option<&str> {
-    split_bare_and_constraint(dep).map(|(bare, _)| bare)
 }
 
 /// Check whether an inline dep must bypass pool reuse regardless of
@@ -395,15 +402,17 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
         return PoolDepRelation::Subset;
     }
 
-    // Pool map: bare_name -> set of constraint tails observed on that
-    // name. A bare entry in the pool contributes "" to the set.
+    // Pool map: bare_name -> set of (normalized) constraint tails
+    // observed on that name. A bare unconditional pool entry
+    // contributes "" to the set; a marker-gated or version-spec'd
+    // entry contributes its canonical tail.
     let mut pool_map: HashMap<String, HashSet<String>> = HashMap::new();
     for p in pool_packages {
         if let Some((bare, tail)) = split_bare_and_constraint(p) {
             pool_map
                 .entry(normalize_package_name(bare))
                 .or_default()
-                .insert(tail.to_string());
+                .insert(tail);
         }
     }
 
@@ -421,21 +430,29 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
         let key = normalize_package_name(bare);
         match pool_map.get(&key) {
             None => {
-                // Pool doesn't have this package at all — extras can
-                // be installed additively on top of the pool env.
+                // Pool doesn't have this package at all — can be
+                // installed additively on top of the pool env.
                 delta.push(dep.clone());
             }
-            Some(pool_tails) => {
-                if tail.is_empty() || pool_tails.contains(tail) {
-                    // Inline accepts any (no constraint), or the exact
-                    // constraint string is on the pool entry. Covered.
-                } else {
-                    // Pool has the package but with a different
-                    // constraint. Version-range overlap is possible
-                    // but not something we can verify cheaply — refuse
-                    // to reuse to avoid silent wrong-version launches.
-                    return PoolDepRelation::Independent;
-                }
+            Some(pool_tails) if pool_tails.contains(&tail) => {
+                // Same canonical tail on both sides (including the
+                // unconditional-both case where tails are empty).
+                // Covered.
+            }
+            Some(_) => {
+                // Pool has the bare name but with a different
+                // constraint or marker. Three flavors all unsafe:
+                //  - Pool pinned to a range, inline wants a different
+                //    range (or bare) — can't verify pool's installed
+                //    version satisfies the request.
+                //  - Pool marker-gated, inline unconditional — pool
+                //    env may not actually have the package installed
+                //    on platforms where the marker evaluated false.
+                //  - Inline marker-gated, pool unconditional — same
+                //    risk in reverse; we don't evaluate markers here.
+                // Force Independent so the full-build path resolves
+                // everything from scratch.
+                return PoolDepRelation::Independent;
             }
         }
     }
@@ -605,38 +622,58 @@ fn conda_meta_package_names(env_path: &std::path::Path) -> HashSet<String> {
 mod tests {
     use super::*;
 
+    // Helper: take the bare name returned by split_bare_and_constraint.
+    fn bare_of(dep: &str) -> Option<String> {
+        split_bare_and_constraint(dep).map(|(b, _)| b.to_string())
+    }
+
+    // Helper: take the normalized tail returned by split_bare_and_constraint.
+    fn tail_of(dep: &str) -> Option<String> {
+        split_bare_and_constraint(dep).map(|(_, t)| t)
+    }
+
     #[test]
-    fn test_strip_to_bare() {
-        // Already-bare names pass through.
-        assert_eq!(strip_to_bare("pandas"), Some("pandas"));
-        assert_eq!(strip_to_bare("numpy"), Some("numpy"));
-        assert_eq!(strip_to_bare("  pandas  "), Some("pandas"));
-        assert_eq!(strip_to_bare(""), None);
+    fn test_split_bare_and_constraint_bare_names() {
+        assert_eq!(bare_of("pandas").as_deref(), Some("pandas"));
+        assert_eq!(bare_of("numpy").as_deref(), Some("numpy"));
+        assert_eq!(bare_of("  pandas  ").as_deref(), Some("pandas"));
+        assert_eq!(bare_of(""), None);
+        assert_eq!(tail_of("pandas").as_deref(), Some(""));
+    }
 
-        // Version specifiers get stripped to the bare name.
-        assert_eq!(strip_to_bare("pandas>=2.0"), Some("pandas"));
-        assert_eq!(strip_to_bare("pandas==2.0.0"), Some("pandas"));
-        assert_eq!(strip_to_bare("pandas<3"), Some("pandas"));
-        assert_eq!(strip_to_bare("pandas~=2.0"), Some("pandas"));
-        assert_eq!(strip_to_bare("pandas!=1.0"), Some("pandas"));
+    #[test]
+    fn test_split_bare_and_constraint_version_specifiers() {
+        // Version specifiers get split out as the tail — bare name
+        // stays clean.
+        assert_eq!(bare_of("pandas>=2.0").as_deref(), Some("pandas"));
+        assert_eq!(tail_of("pandas>=2.0").as_deref(), Some(">=2.0"));
+        assert_eq!(bare_of("pandas==2.0.0").as_deref(), Some("pandas"));
+        assert_eq!(tail_of("pandas==2.0.0").as_deref(), Some("==2.0.0"));
+        // Whitespace around the specifier normalizes away so
+        // `pkg>=1.0` and `pkg >= 1.0` compare equal.
+        assert_eq!(tail_of("pandas >= 2.0").as_deref(), Some(">=2.0"));
+    }
 
-        // Extras and direct URLs — bare name only, constraint info discarded.
-        assert_eq!(strip_to_bare("pandas[sql]"), Some("pandas"));
+    #[test]
+    fn test_split_bare_and_constraint_keeps_marker() {
+        // Markers are load-bearing: a pool entry with
+        // `pkg ; sys_platform == 'darwin'` only installs on Darwin, so
+        // the marker MUST survive into the tail. Comparison against
+        // bare-`pkg` must fail on platforms where the marker evaluated
+        // false (pool advertises the spec but package isn't installed).
         assert_eq!(
-            strip_to_bare("pandas @ https://example.com"),
-            Some("pandas")
-        );
-
-        // Environment markers — marker stripped first, bare name returned.
-        assert_eq!(
-            strip_to_bare("pandas ; python_version >= '3.8'"),
-            Some("pandas")
-        );
-        // `==` inside a marker (quoted comparison) mustn't corrupt the
-        // bare name — marker-first logic handles this.
-        assert_eq!(
-            strip_to_bare("gremlin ; sys_platform == 'darwin'"),
+            bare_of("gremlin ; sys_platform == 'darwin'").as_deref(),
             Some("gremlin")
+        );
+        // Canonical tail: whitespace stripped.
+        assert_eq!(
+            tail_of("gremlin ; sys_platform == 'darwin'").as_deref(),
+            Some(";sys_platform=='darwin'")
+        );
+        // Versioned + marker: tail carries both.
+        assert_eq!(
+            tail_of("pandas >= 2.0 ; python_version >= '3.10'").as_deref(),
+            Some(">=2.0;python_version>='3.10'")
         );
     }
 
@@ -892,11 +929,65 @@ mod tests {
     }
 
     #[test]
-    fn test_compare_subset_bare_inline_covers_pool_constrained() {
-        // Inline dep is bare (accepts any version), pool has a
-        // constraint. Pool has *some* version of the package → covers.
+    fn test_compare_independent_bare_inline_vs_pool_constrained() {
+        // Pool's `prewarmed_packages` is the install-spec list, not
+        // what's actually installed. A constrained pool entry might
+        // or might not have produced an installed package (marker
+        // evaluated false, resolver skipped it). So even a bare
+        // inline dep that would "accept any version" can't safely
+        // reuse a pool whose entry carries constraints — the package
+        // may not be installed at all.
         let pool = vec!["ipykernel".into(), "numpy>=2.2.6".into()];
         let deps = vec!["numpy".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_independent_marker_gated_pool_vs_bare_inline() {
+        // Codex-flagged regression: `gremlin ; sys_platform == 'darwin'`
+        // in the pool's install-spec list only produced an installed
+        // `gremlin` on Darwin pool envs. On Linux, the pool env carries
+        // the spec in `prewarmed_packages` but the package isn't there.
+        // A later bare-`gremlin` inline dep MUST NOT reuse that pool
+        // env, or the notebook launches with a missing import.
+        let pool = vec![
+            "ipykernel".into(),
+            "gremlin ; sys_platform == 'darwin'".into(),
+        ];
+        let deps = vec!["gremlin".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_marker_on_both_sides() {
+        // When the inline dep and pool spec carry the same marker
+        // verbatim (the common case: notebook seeded from settings and
+        // pool built from same settings), they canonicalize to the
+        // same tail and match.
+        let pool = vec![
+            "ipykernel".into(),
+            "gremlin ; sys_platform == 'darwin'".into(),
+        ];
+        let deps = vec!["gremlin ; sys_platform == 'darwin'".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_normalizes_internal_whitespace() {
+        // `pkg>=1.0` (no spaces) and `pkg >= 1.0` (spaces) produce
+        // the same canonical tail, so either form on one side
+        // matches the other.
+        let pool = vec!["ipykernel".into(), "numpy>=2.2.6".into()];
+        let deps = vec!["numpy >= 2.2.6".into()];
         assert!(matches!(
             compare_deps_to_pool(&deps, &pool),
             PoolDepRelation::Subset

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -265,22 +265,51 @@ pub enum PoolDepRelation {
     Independent,
 }
 
-/// Extract the bare package name from a dependency specifier.
+/// Strip a dependency string to its bare package name, discarding
+/// environment markers (`; python_version >= '3.10'`) and version
+/// specifiers (`>=`, `<`, `~=`, etc). Returns `None` only when the
+/// input is empty or produces an empty bare name.
 ///
-/// Returns `None` if the dep has a version constraint (anything beyond a bare name),
-/// since we can't guarantee the pool's installed version satisfies it.
-fn bare_package_name(dep: &str) -> Option<&str> {
+/// Used for matching deps by package identity across the inline-deps /
+/// pool-packages boundary. The caller gets a name it can `normalize`
+/// and look up; unsafe-for-pool-reuse constructs (exact pins, extras)
+/// are flagged separately by [`inline_dep_forbids_pool_reuse`].
+fn strip_to_bare(dep: &str) -> Option<&str> {
     let trimmed = dep.trim();
     if trimmed.is_empty() {
         return None;
     }
-    // If the dep contains any version specifier characters, it's not bare.
-    // This is conservative: "pandas>=2.0" → None, "pandas" → Some("pandas")
-    let specifier_chars = ['>', '<', '=', '!', '~', '[', ';', '@'];
-    if trimmed.contains(|c: char| specifier_chars.contains(&c) || c.is_whitespace()) {
-        return None;
+    // Environment marker first — `gremlin ; sys_platform == 'darwin'`
+    // contains `==` only inside the marker. We want the package name.
+    let before_marker = trimmed.split(';').next().unwrap_or(trimmed).trim();
+    let cut_chars = ['>', '<', '=', '!', '~', '[', '@', ' ', '\t'];
+    let cut = before_marker
+        .find(|c: char| cut_chars.contains(&c))
+        .unwrap_or(before_marker.len());
+    let bare = before_marker[..cut].trim();
+    if bare.is_empty() {
+        None
+    } else {
+        Some(bare)
     }
-    Some(trimmed)
+}
+
+/// Check whether an inline dep must bypass pool reuse regardless of
+/// bare-name match.
+///
+/// Two cases today:
+/// - Exact pin (`pkg==X.Y.Z`): pool env's version is settings-driven
+///   and may differ from the user's pin. Using a wrong-version pool
+///   env would silently break user code.
+/// - Extras (`pkg[feature]`): the extra pulls in transitive deps the
+///   pool may not have installed. Hard to verify from a spec string
+///   alone, so refuse.
+fn inline_dep_forbids_pool_reuse(dep: &str) -> bool {
+    // Apply the same marker-strip before scanning for `==` so
+    // `gremlin ; sys_platform == 'darwin'` isn't mistaken for an exact
+    // pin on the gremlin package.
+    let before_marker = dep.split(';').next().unwrap_or(dep).trim();
+    before_marker.contains("==") || before_marker.contains('[')
 }
 
 /// Extract the package name from a conda dependency specifier, stripping
@@ -326,9 +355,17 @@ fn normalize_package_name(name: &str) -> String {
 
 /// Compare inline deps against pool prewarmed packages.
 ///
-/// Conservative approach: only bare package names (no version specifiers)
-/// are eligible for pool reuse. If any dep has a version constraint,
-/// returns `Independent`.
+/// Matches by bare package name across both sides: environment markers
+/// and version specifiers are stripped from both `inline_deps` and
+/// `pool_packages` before comparison. This lets notebooks seeded from
+/// user settings (e.g. `numpy>=2.2.6`) route to a pool env built from
+/// the same settings (same specifier string) without being held up by
+/// the presence of the `>=`.
+///
+/// Returns [`PoolDepRelation::Independent`] when any dep pins an exact
+/// version (`pkg==X`) or declares extras (`pkg[feature]`) — pool reuse
+/// can't verify the pool env satisfies those constraints, so build from
+/// scratch instead.
 pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) -> PoolDepRelation {
     if inline_deps.is_empty() {
         return PoolDepRelation::Subset;
@@ -336,15 +373,18 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
 
     let pool_normalized: HashSet<String> = pool_packages
         .iter()
-        .map(|p| normalize_package_name(p))
+        .filter_map(|p| strip_to_bare(p).map(normalize_package_name))
         .collect();
 
     let mut delta = Vec::new();
 
     for dep in inline_deps {
-        let Some(bare) = bare_package_name(dep) else {
-            // Has a version specifier — can't guarantee pool compatibility
+        if inline_dep_forbids_pool_reuse(dep) {
             return PoolDepRelation::Independent;
+        }
+        let Some(bare) = strip_to_bare(dep) else {
+            // Empty / whitespace-only dep — nothing to match.
+            continue;
         };
 
         let normalized = normalize_package_name(bare);
@@ -519,23 +559,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bare_package_name() {
-        assert_eq!(bare_package_name("pandas"), Some("pandas"));
-        assert_eq!(bare_package_name("numpy"), Some("numpy"));
-        assert_eq!(bare_package_name("  pandas  "), Some("pandas"));
-        assert_eq!(bare_package_name(""), None);
+    fn test_strip_to_bare() {
+        // Already-bare names pass through.
+        assert_eq!(strip_to_bare("pandas"), Some("pandas"));
+        assert_eq!(strip_to_bare("numpy"), Some("numpy"));
+        assert_eq!(strip_to_bare("  pandas  "), Some("pandas"));
+        assert_eq!(strip_to_bare(""), None);
 
-        // Version specifiers → None
-        assert_eq!(bare_package_name("pandas>=2.0"), None);
-        assert_eq!(bare_package_name("pandas==2.0.0"), None);
-        assert_eq!(bare_package_name("pandas<3"), None);
-        assert_eq!(bare_package_name("pandas~=2.0"), None);
-        assert_eq!(bare_package_name("pandas!=1.0"), None);
+        // Version specifiers get stripped to the bare name.
+        assert_eq!(strip_to_bare("pandas>=2.0"), Some("pandas"));
+        assert_eq!(strip_to_bare("pandas==2.0.0"), Some("pandas"));
+        assert_eq!(strip_to_bare("pandas<3"), Some("pandas"));
+        assert_eq!(strip_to_bare("pandas~=2.0"), Some("pandas"));
+        assert_eq!(strip_to_bare("pandas!=1.0"), Some("pandas"));
 
-        // Extras / markers → None
-        assert_eq!(bare_package_name("pandas[sql]"), None);
-        assert_eq!(bare_package_name("pandas ; python_version >= '3.8'"), None);
-        assert_eq!(bare_package_name("pandas @ https://example.com"), None);
+        // Extras and direct URLs — bare name only, constraint info discarded.
+        assert_eq!(strip_to_bare("pandas[sql]"), Some("pandas"));
+        assert_eq!(
+            strip_to_bare("pandas @ https://example.com"),
+            Some("pandas")
+        );
+
+        // Environment markers — marker stripped first, bare name returned.
+        assert_eq!(
+            strip_to_bare("pandas ; python_version >= '3.8'"),
+            Some("pandas")
+        );
+        // `==` inside a marker (quoted comparison) mustn't corrupt the
+        // bare name — marker-first logic handles this.
+        assert_eq!(
+            strip_to_bare("gremlin ; sys_platform == 'darwin'"),
+            Some("gremlin")
+        );
+    }
+
+    #[test]
+    fn test_inline_dep_forbids_pool_reuse() {
+        // Exact pins and extras force Independent.
+        assert!(inline_dep_forbids_pool_reuse("pandas==2.0.0"));
+        assert!(inline_dep_forbids_pool_reuse("pandas[sql]"));
+        assert!(inline_dep_forbids_pool_reuse("pandas[sql]>=2.0"));
+
+        // Non-exact specifiers are safe for pool matching.
+        assert!(!inline_dep_forbids_pool_reuse("pandas"));
+        assert!(!inline_dep_forbids_pool_reuse("pandas>=2.0"));
+        assert!(!inline_dep_forbids_pool_reuse("pandas<3"));
+        assert!(!inline_dep_forbids_pool_reuse("pandas~=2.0"));
+
+        // `==` inside an environment marker is NOT a pin.
+        assert!(!inline_dep_forbids_pool_reuse(
+            "gremlin ; sys_platform == 'darwin'"
+        ));
     }
 
     #[test]
@@ -641,6 +715,89 @@ mod tests {
         assert!(matches!(
             compare_deps_to_pool(&deps, &pool),
             PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_with_version_specifiers() {
+        // Both sides carry version specifiers (pool list comes from
+        // `user_default_packages` verbatim, same with seeded inline deps).
+        // Match on bare name after stripping both.
+        let pool = vec![
+            "ipykernel".into(),
+            "numpy>=2.2.6".into(),
+            "pandas".into(),
+            "pyarrow>=14".into(),
+        ];
+        let deps = vec!["numpy>=2.2.6".into(), "pandas".into(), "pyarrow>=14".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_subset_matches_real_user_seeded_notebook() {
+        // Exact shape of a newly-created notebook seeded from the
+        // default rgbkrk user settings (9 UV deps, mix of bare +
+        // version-specifier + marker). Pool built from the same set
+        // plus the pool-essentials prefix.
+        let pool = vec![
+            "ipykernel".into(),
+            "ipywidgets".into(),
+            "anywidget".into(),
+            "nbformat".into(),
+            "uv".into(),
+            "dx".into(),
+            "gremlin ; sys_platform == 'darwin'".into(),
+            "narwhals>=1.0".into(),
+            "nteract".into(),
+            "nteract-kernel-launcher".into(),
+            "numpy>=2.2.6".into(),
+            "pandas".into(),
+            "polars".into(),
+            "pyarrow>=14".into(),
+        ];
+        let inline = vec![
+            "dx".into(),
+            "gremlin ; sys_platform == 'darwin'".into(),
+            "narwhals>=1.0".into(),
+            "nteract".into(),
+            "nteract-kernel-launcher".into(),
+            "numpy>=2.2.6".into(),
+            "pandas".into(),
+            "polars".into(),
+            "pyarrow>=14".into(),
+        ];
+        assert!(matches!(
+            compare_deps_to_pool(&inline, &pool),
+            PoolDepRelation::Subset
+        ));
+    }
+
+    #[test]
+    fn test_compare_additive_with_specifier_on_extra() {
+        // `pandas>=2.0` matches the pool's bare `pandas`. `torch` is
+        // not in pool — goes into the delta unchanged so the Additive
+        // path can install it at its original spec.
+        let pool = vec!["ipykernel".into(), "pandas".into()];
+        let deps = vec!["pandas>=2.0".into(), "torch".into()];
+        match compare_deps_to_pool(&deps, &pool) {
+            PoolDepRelation::Additive { delta } => {
+                assert_eq!(delta, vec!["torch".to_string()]);
+            }
+            other => panic!("expected Additive, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_compare_independent_on_extras() {
+        // Extras pull in transitive deps the pool may not have.
+        let pool = vec!["ipykernel".into(), "pandas".into()];
+        let deps = vec!["pandas[parquet]".into()];
+        assert!(matches!(
+            compare_deps_to_pool(&deps, &pool),
+            PoolDepRelation::Independent
         ));
     }
 


### PR DESCRIPTION
## Overview

Every new notebook gets 9 inline deps seeded from user settings (`dx`, `gremlin`, `narwhals>=1.0`, `nteract`, `nteract-kernel-launcher`, `numpy>=2.2.6`, `pandas`, `polars`, `pyarrow>=14`) so the notebook is reproducible on another machine. Pool envs are built from the same settings. Same specifier strings on both sides. Should match → use warm pool → fast kernel launch.

Instead: every notebook opened fresh paid a full cold-import of the entire data-science stack because `compare_deps_to_pool` rejected the whole list the moment it saw the first `>=`.

## Root cause

`crates/runtimed/src/inline_env.rs::compare_deps_to_pool` short-circuits to `Independent` if any inline dep has a specifier. `try_uv_pool_for_inline_deps` pre-checks this relation and bails to full ephemeral-env build before even taking a pool env.

`numpy>=2.2.6` on a seeded notebook → `Independent` → pool sidestepped → `uv run --with pandas --with polars --with numpy>=2.2.6 ...` → fresh ephemeral env every kernel launch → cold pandas import (~12s on my machine after a reboot).

Pool envs sat warm and unused.

## Design decision

Two strategies were on the table:

1. **Track resolved versions in `PooledEnv.prewarmed_packages`** and compare inline-dep specifiers against actual installed versions. Safe — knows the pool satisfies `numpy>=2.2.6` iff installed `numpy` ≥ 2.2.6. But it's a `PooledEnv` schema change that touches every pool construction site + serialization. Big scope.

2. **Strip specifiers on both sides, match by bare package name.** Pool packages carry specifier strings verbatim from `user_default_packages`, so a seeded-notebook `numpy>=2.2.6` and the pool's `numpy>=2.2.6` both strip to `numpy` and match. Small change, fits the "notebook-seeded-from-same-settings" common case cleanly.

Option 2. The safety story:

- Exact pins (`pkg==X.Y.Z`) and extras (`pkg[feature]`) still force `Independent`. Pins declare a specific-version requirement the pool can't verify; extras pull in transitive deps we can't check. Both skip the pool and build fresh.
- Non-pin specifiers (`>=`, `<=`, `~=`, `>`, `<`, `!=`) strip to bare and match. Pool was built from the same settings that seeded the notebook, so in the common case their installed versions satisfy each other's constraints. In the rare case of a stale settings-vs-notebook mismatch, the kernel just fails at user import — same as if the user had installed the wrong version manually.

Environment markers (`; sys_platform == 'darwin'`) get stripped before scanning for `==`, so the user default `gremlin ; sys_platform == 'darwin'` isn't mistaken for an exact version pin on `gremlin`.

## Behavioral coverage

| Inline dep | Before | After |
|-----------|--------|-------|
| `pandas` | Subset if in pool, Additive if not | same |
| `pandas>=2.0` | **Independent (always)** | **Subset if in pool** |
| `pandas==2.0.0` | Independent | Independent (unchanged) |
| `pandas[parquet]` | Independent | Independent (unchanged) |
| `gremlin ; sys_platform == 'darwin'` | **Independent (`==` in marker confused matcher)** | **Subset if in pool** |
| `[] (empty)` | Subset | Subset (unchanged) |

## End-to-end validation

Created a notebook via `create_notebook(dependencies=["pandas", "numpy", "polars"])` in a directory with no project file. Dev daemon log:

```
[notebook-sync] Inline UV deps are additive to pool env, delta: ["numpy"]
[uv] Syncing 1 dependencies to ".../runtimed-uv-a90a140e.../"
[uv] Synced dependencies from local cache (offline mode)
[notebook-sync] Installed 1 delta packages into pool env
[inline-env] claim_pool_env: renamed .../runtimed-uv-... -> .../inline-envs/a86e01c5... for inline-cache reuse
[jupyter-kernel] Starting Python kernel with cached inline env at .../inline-envs/a86e01c5.../bin/python
```

A second notebook with identical deps cache-hit directly:
```
[notebook-sync] UV inline cache hit at .../inline-envs/1d66d51c.../bin/python
```

Before this change, the same notebook would have logged `UV inline deps have version constraints, skipping pool reuse` and built a fresh ephemeral env.

## Test plan

- [x] `cargo test -p runtimed --lib inline_env::` — 16 passing (6 new cases)
- [x] `cargo test -p runtimed --lib` — 450 total passing
- [x] `cargo xtask lint --fix` clean
- [x] End-to-end: dev daemon with seeded notebook routes to Additive instead of Independent, installs delta into pool env
- [ ] Nightly regression check once this merges

## Context

Follow-up to the env-prewarm investigation — biggest win for initial-load latency on default-seeded notebooks. Separate concerns tracked elsewhere:

- Launcher-side warmup gap for `conda:env_yml` envs (no warmup runs at all)
- Warming `nteract_kernel_launcher` itself (PYTHONPATH path — ~50ms win)
- Altair/plotly deferred renderer flip (#15)

These can land independently.