### PR TITLE
fix(test): wrap raw AsyncSession in Notebook for runtime access

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2660,6 +2660,7 @@ class TestTrustApproval:
         import json
 
         from runtimed import KERNEL_ERROR_REASON
+        from runtimed._notebook import Notebook
 
         (tmp_path / "environment.yml").write_text(
             "name: nteract-integration-probe-unbuilt-env-xyz\n"
@@ -2685,7 +2686,8 @@ class TestTrustApproval:
             )
         )
 
-        notebook = await client.open_notebook(str(nb_path))
+        session = await client.open_notebook(str(nb_path))
+        notebook = Notebook(session)
 
         # Poll briefly for the daemon to detect the miss and write the
         # error lifecycle. Auto-launch runs in a spawned task, so the


### PR DESCRIPTION
The `test_envyml_missing_env_surfaces_error_state` integration test was calling `.runtime.kernel` on a raw `AsyncSession`. The `client` fixture returns a `NativeAsyncClient` whose `open_notebook()` yields `AsyncSession` directly. The `.runtime` property lives on the `Notebook` wrapper class, not `AsyncSession`, so the test hit an `AttributeError`.

Wraps the returned session in `Notebook(session)` so `.runtime.kernel` resolves correctly.

## Verification

- [ ] `test_envyml_missing_env_surfaces_error_state` passes in CI
- [ ] No regressions in `TestTrustApproval` suite

_PR submitted by @rgbkrk's agent, Quill_