### PR TITLE
fix(notebook): gate cli_install tests module on unix to keep Windows clippy happy

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -846,7 +846,10 @@ fn escalate_shell_command(shell_cmd: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(test)]
+// All tests below exercise Unix-only shell-script symlink paths. On
+// Windows the module would be empty and `use super::*;` resolves to
+// nothing, tripping clippy's `unused-imports` on `-D warnings`.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Overview

Windows clippy job on main started failing with:

```
error: unused import: `super::*`
   --> crates\notebook\src\cli_install.rs:851:9
    |
851 |     use super::*;
    |         ^^^^^^^^
    = note: `-D unused-imports` implied by `-D warnings`
```

Every `#[test]` in `cli_install::tests` is `#[cfg(unix)]` — they exercise the Unix-side `nb` shell-script symlink logic. On Windows the module compiles under `#[cfg(test)]` but contains zero items after the per-test `cfg(unix)` gates filter everything out, leaving `use super::*;` dangling.

## Fix

Widen the module gate from `#[cfg(test)]` to `#[cfg(all(test, unix))]`. Unix behavior unchanged (all six tests still run); Windows drops the whole module and its unused import with it.

One-line change, no behavior impact.

## Test plan

- [x] `cargo xtask lint` clean locally (macOS).
- [ ] CI Windows clippy turns green.