### PR TITLE
spike: runt-store + libSQL/Turso evaluation (not for merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -113,6 +113,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -400,7 +406,7 @@ dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -595,7 +601,7 @@ dependencies = [
  "itertools 0.14.0",
  "leb128",
  "rand 0.9.4",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "sha2 0.11.0",
  "smol_str",
@@ -707,6 +713,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
 dependencies = [
  "scoped-tls",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1057,6 +1086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1197,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1454,6 +1503,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1939,7 +2022,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "unicode-width",
 ]
@@ -1966,7 +2049,7 @@ dependencies = [
  "dprint-core",
  "dprint-core-macros",
  "percent-encoding",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
 ]
 
@@ -1979,7 +2062,7 @@ dependencies = [
  "allocator-api2",
  "bumpalo",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2943,7 +3026,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -3067,7 +3150,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "triomphe",
 ]
@@ -3852,6 +3935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,6 +4091,47 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsql"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.1",
+ "bytes",
+ "futures",
+ "libsql-sys",
+ "parking_lot",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "glob",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4206,6 +4336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,7 +4411,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tokio",
@@ -4429,6 +4565,16 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -4442,7 +4588,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -5233,6 +5379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pep440_rs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5257,7 +5409,7 @@ dependencies = [
  "once_cell",
  "pep440_rs",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
@@ -5573,6 +5725,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5632,7 +5812,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -6215,7 +6395,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-regex",
  "memmap2",
- "nom",
+ "nom 8.0.0",
  "nom-language",
  "purl",
  "rattler_digest",
@@ -6496,7 +6676,7 @@ checksum = "8c3d2a564b41942dd87e441e4c68a31e4be517915daf5d20fe4b36cd3f4a7c5e"
 dependencies = [
  "archspec",
  "libloading 0.9.0",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "plist",
  "rattler_conda_types",
@@ -7007,6 +7187,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "runt-store"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "dashmap 6.1.0",
+ "dirs",
+ "libsql",
+ "parking_lot",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "runt-trust"
 version = "0.2.2"
 dependencies = [
@@ -7241,6 +7438,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7547,7 +7750,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -8250,7 +8453,7 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "siphasher 0.3.11",
  "swc_atoms",
@@ -8272,7 +8475,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "phf 0.11.3",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "string_enum",
  "swc_atoms",
@@ -8290,7 +8493,7 @@ dependencies = [
  "bitflags 2.11.1",
  "either",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "seq-macro",
  "serde",
  "smallvec",
@@ -8313,7 +8516,7 @@ dependencies = [
  "either",
  "num-bigint",
  "phf 0.11.3",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "seq-macro",
  "serde",
  "smartstring",
@@ -9135,6 +9338,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10289,6 +10502,18 @@ dependencies = [
 
 [[package]]
 name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
@@ -11137,11 +11362,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.48",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/mcp-supervisor",
     "crates/runt-mcp",
     "crates/runt-mcp-proxy",
+    "crates/runt-store",
     "crates/nteract-mcp",
     "crates/repr-llm",
     "crates/nteract-predicate",

--- a/crates/runt-store/Cargo.toml
+++ b/crates/runt-store/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "runt-store"
+version = "0.0.1"
+edition.workspace = true
+description = "Daemon local data store (spike: libSQL/Turso-backed trust allowlist + room for history/search/completion caches)"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+dashmap = "6"
+dirs = "6"
+# libsql core only — no replication, no remote, no sync, no TLS. This
+# is the embedded SQLite-fork path; the remote/replication features
+# would drag in hyper + tower + tonic which belong on a cloud-sync
+# future, not the daemon's local store.
+libsql = { version = "0.9", default-features = false, features = ["core"] }
+parking_lot = "0.12"
+serde = { workspace = true }
+thiserror = "2"
+tokio = { workspace = true, features = ["sync", "fs", "rt"] }
+tracing = "0.1"
+
+[dev-dependencies]
+criterion = { version = "0.7", features = ["async_tokio"] }
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "trust_allowlist"
+harness = false

--- a/crates/runt-store/benches/trust_allowlist.rs
+++ b/crates/runt-store/benches/trust_allowlist.rs
@@ -1,0 +1,121 @@
+//! libSQL-backed trust allowlist benchmarks.
+//!
+//! Same shape as the Lance spike's benches (PR #2176) — any divergence
+//! in numbers is a real backend difference.
+//!
+//! Run with:
+//!   cargo bench -p runt-store --bench trust_allowlist
+
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use runt_store::{PackageManager, TrustAllowlist};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+fn seed_names(prefix: &str, count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("{prefix}-pkg-{i:05}")).collect()
+}
+
+async fn open_seeded(tmp: &TempDir, count: usize) -> TrustAllowlist {
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    let names = seed_names("seed", count);
+    store.add(PackageManager::Uv, &names).await.unwrap();
+    store
+}
+
+fn bench_cold_load(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("cold_load");
+    for &count in &[100usize, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_function(format!("rows={count}"), |b| {
+            b.iter_custom(|iters| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let tmp = TempDir::new().unwrap();
+                    rt.block_on(async {
+                        let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+                        let names = seed_names("cold", count);
+                        store.add(PackageManager::Uv, &names).await.unwrap();
+                        drop(store);
+                    });
+                    let start = Instant::now();
+                    rt.block_on(async {
+                        let _ = TrustAllowlist::open(tmp.path()).await.unwrap();
+                    });
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_contains(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let store = rt.block_on(open_seeded(&tmp, 1_000));
+
+    let mut group = c.benchmark_group("contains");
+    group.bench_function("hit", |b| {
+        b.iter(|| store.contains(PackageManager::Uv, "seed-pkg-00500"));
+    });
+    group.bench_function("miss", |b| {
+        b.iter(|| store.contains(PackageManager::Uv, "this-will-never-match"));
+    });
+    group.finish();
+}
+
+fn bench_novel(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let store = rt.block_on(open_seeded(&tmp, 1_000));
+
+    let candidates: Vec<String> = (0..18)
+        .map(|i| format!("seed-pkg-{i:05}"))
+        .chain((0..2).map(|i| format!("brand-new-pkg-{i}")))
+        .collect();
+
+    c.bench_function("novel_20_vs_1000", |b| {
+        b.iter(|| {
+            let refs = candidates
+                .iter()
+                .map(|s| (PackageManager::Uv, s.as_str()))
+                .collect::<Vec<_>>();
+            let _ = store.novel(refs);
+        });
+    });
+}
+
+fn bench_add_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("add_single");
+    group.sample_size(30);
+    group.bench_function("append_one", |b| {
+        b.iter_custom(|iters| {
+            let mut total = std::time::Duration::ZERO;
+            for i in 0..iters {
+                let tmp = TempDir::new().unwrap();
+                let store = rt.block_on(TrustAllowlist::open(tmp.path())).unwrap();
+                let name = format!("one-off-{i}");
+                let start = Instant::now();
+                rt.block_on(store.add(PackageManager::Uv, &[name.clone()]))
+                    .unwrap();
+                total += start.elapsed();
+            }
+            total
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cold_load,
+    bench_contains,
+    bench_novel,
+    bench_add_single
+);
+criterion_main!(benches);

--- a/crates/runt-store/src/lib.rs
+++ b/crates/runt-store/src/lib.rs
@@ -1,0 +1,35 @@
+//! `runt-store` — daemon local data store (Turso/libSQL spike).
+//!
+//! # What this is
+//!
+//! Mirror of the LanceDB spike (PR #2176) using libSQL core only.
+//! Same `TrustAllowlist` facade, same 9 integration tests, same
+//! benchmark harness. Apples-to-apples comparison for the "what
+//! should own daemon-side accumulated state?" decision.
+//!
+//! See PR #2176 for the LanceDB numbers and the broader workload
+//! analysis (parquet/sift, Arrow IPC, indexed search, history cache).
+//!
+//! # Speed model
+//!
+//! Same in-memory-first pattern as the Lance spike:
+//!
+//! - Reads on the hot path never touch disk. The whole table is
+//!   materialized into a `HashSet` at `open()` time, and `contains()`
+//!   is a pure `HashSet` lookup.
+//! - Writes update the set and append to the DB in the same call.
+//!
+//! libSQL gives us WAL + synchronous=NORMAL out of the box, which is
+//! effectively what we'd want for an "append decisions, rarely remove"
+//! workload.
+//!
+//! # On disk
+//!
+//! Default root is `dirs::data_local_dir()/runt/store/`. One database
+//! file: `allowlist.db`. No per-channel split.
+
+pub mod paths;
+pub mod trust_allowlist;
+
+pub use paths::{default_store_dir, store_dir_for};
+pub use trust_allowlist::{PackageManager, TrustAllowlist, TrustAllowlistError, TrustedPackage};

--- a/crates/runt-store/src/paths.rs
+++ b/crates/runt-store/src/paths.rs
@@ -1,0 +1,23 @@
+//! Store directory resolution.
+//!
+//! `data_local_dir` on purpose — the allowlist is user decision
+//! history, not cached data. Losing it breaks the UX contract.
+//!
+//! macOS: `~/Library/Application Support/runt/store/`
+//! Linux: `~/.local/share/runt/store/`
+//! Windows: `%LOCALAPPDATA%\runt\store\`
+
+use std::path::PathBuf;
+
+/// Default store directory, shared between stable and nightly channels
+/// so the user's trust decisions carry across both (same convention as
+/// the HMAC trust key in `runt-trust`).
+pub fn default_store_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join("runt").join("store"))
+}
+
+/// Explicit store directory under a caller-provided root. Used by
+/// tests and benchmarks to isolate stores per process under `tempdir`.
+pub fn store_dir_for(root: impl Into<PathBuf>) -> PathBuf {
+    root.into().join("runt").join("store")
+}

--- a/crates/runt-store/src/trust_allowlist.rs
+++ b/crates/runt-store/src/trust_allowlist.rs
@@ -1,0 +1,285 @@
+//! Trust allowlist: the set of `(package_manager, package_name)` pairs
+//! the user has already approved for auto-launch.
+//!
+//! # Storage model
+//!
+//! Durability via libSQL (Turso fork of SQLite). One table:
+//!
+//! ```sql
+//! CREATE TABLE trust_allowlist (
+//!   manager   TEXT NOT NULL,
+//!   name      TEXT NOT NULL,
+//!   added_at  INTEGER NOT NULL,
+//!   PRIMARY KEY (manager, name)
+//! ) WITHOUT ROWID;
+//! ```
+//!
+//! `WITHOUT ROWID` keeps the B-tree keyed by the natural identifier,
+//! which is what we want for both lookup and upsert. `added_at` is
+//! Unix seconds.
+//!
+//! # Hot path
+//!
+//! All rows are loaded into an in-memory `HashSet` at `open()` time.
+//! `contains()` is a pure set lookup — no disk I/O, no `.await`. The
+//! set is the authoritative view inside the running daemon; libSQL is
+//! the durability layer and source of truth on cold start.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use libsql::{params, Builder};
+use parking_lot::RwLock;
+use thiserror::Error;
+
+const DB_FILE: &str = "allowlist.db";
+
+/// Package manager subset the trust surface covers today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PackageManager {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+impl PackageManager {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PackageManager::Uv => "uv",
+            PackageManager::Conda => "conda",
+            PackageManager::Pixi => "pixi",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "uv" => Some(PackageManager::Uv),
+            "conda" => Some(PackageManager::Conda),
+            "pixi" => Some(PackageManager::Pixi),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedPackage {
+    pub manager: PackageManager,
+    pub name: String,
+    pub added_at: i64,
+}
+
+#[derive(Debug, Error)]
+pub enum TrustAllowlistError {
+    #[error("libsql error: {0}")]
+    LibSql(#[from] libsql::Error),
+    #[error("store directory unavailable")]
+    NoStoreDir,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("system clock before unix epoch: {0}")]
+    Clock(#[from] std::time::SystemTimeError),
+}
+
+/// In-memory view of the allowlist backed by a libSQL database on disk.
+#[derive(Clone)]
+pub struct TrustAllowlist {
+    entries: Arc<RwLock<HashSet<(PackageManager, String)>>>,
+    db: Arc<libsql::Database>,
+}
+
+impl TrustAllowlist {
+    /// Open (or create) the allowlist at `store_dir`. Creates the
+    /// directory + database file if missing, applies the schema, and
+    /// loads every row into the in-memory set.
+    pub async fn open(store_dir: &Path) -> Result<Self, TrustAllowlistError> {
+        tokio::fs::create_dir_all(store_dir).await?;
+        let db_path = store_dir.join(DB_FILE);
+        let db = Builder::new_local(&db_path).build().await?;
+        let conn = db.connect()?;
+
+        // Pragmas tuned for a local, single-process store: WAL so
+        // readers and writers don't block each other, NORMAL sync
+        // (WAL is already durable on checkpoint, full FSYNC is
+        // overkill for accumulated user decisions), foreign_keys off
+        // (nothing references us).
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\n\
+             PRAGMA synchronous=NORMAL;\n\
+             PRAGMA foreign_keys=OFF;",
+        )
+        .await?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trust_allowlist (\n\
+               manager  TEXT NOT NULL,\n\
+               name     TEXT NOT NULL,\n\
+               added_at INTEGER NOT NULL,\n\
+               PRIMARY KEY (manager, name)\n\
+             ) WITHOUT ROWID;",
+        )
+        .await?;
+
+        let mut entries = HashSet::new();
+        let mut rows = conn
+            .query("SELECT manager, name FROM trust_allowlist", ())
+            .await?;
+        while let Some(row) = rows.next().await? {
+            let manager: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            if let Some(manager) = PackageManager::parse(&manager) {
+                entries.insert((manager, name));
+            }
+        }
+
+        Ok(Self {
+            entries: Arc::new(RwLock::new(entries)),
+            db: Arc::new(db),
+        })
+    }
+
+    /// Hot path: does the `(manager, name)` pair live in the allowlist?
+    /// Pure in-memory lookup — no disk I/O, no `.await`.
+    pub fn contains(&self, manager: PackageManager, name: &str) -> bool {
+        self.entries.read().contains(&(manager, name.to_string()))
+    }
+
+    /// Return candidates that are NOT already on the allowlist. Used
+    /// by the dialog's partial-coverage UI.
+    pub fn novel<'a, I>(&self, candidates: I) -> Vec<(PackageManager, String)>
+    where
+        I: IntoIterator<Item = (PackageManager, &'a str)>,
+    {
+        let guard = self.entries.read();
+        candidates
+            .into_iter()
+            .filter(|(manager, name)| !guard.contains(&(*manager, name.to_string())))
+            .map(|(manager, name)| (manager, name.to_string()))
+            .collect()
+    }
+
+    /// Append a batch of packages to the allowlist. Already-present
+    /// entries are skipped via the in-memory dedup; DB upserts use
+    /// `OR IGNORE` as defense-in-depth.
+    pub async fn add(
+        &self,
+        manager: PackageManager,
+        names: &[String],
+    ) -> Result<(), TrustAllowlistError> {
+        if names.is_empty() {
+            return Ok(());
+        }
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_secs() as i64;
+
+        let fresh: Vec<String> = {
+            let mut guard = self.entries.write();
+            names
+                .iter()
+                .filter_map(|n| {
+                    if guard.insert((manager, n.clone())) {
+                        Some(n.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+        if fresh.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.db.connect()?;
+        // Use a transaction so the batch append is atomic. With
+        // WAL + synchronous=NORMAL this remains cheap (one fsync at
+        // commit) but guarantees either all-or-nothing on crash.
+        conn.execute("BEGIN IMMEDIATE", ()).await?;
+        for name in &fresh {
+            conn.execute(
+                "INSERT OR IGNORE INTO trust_allowlist (manager, name, added_at) VALUES (?1, ?2, ?3)",
+                params![manager.as_str().to_string(), name.clone(), now],
+            )
+            .await?;
+        }
+        conn.execute("COMMIT", ()).await?;
+        Ok(())
+    }
+
+    /// Remove a single entry. No-op when it's not present.
+    pub async fn remove(
+        &self,
+        manager: PackageManager,
+        name: &str,
+    ) -> Result<(), TrustAllowlistError> {
+        let removed = {
+            let mut guard = self.entries.write();
+            guard.remove(&(manager, name.to_string()))
+        };
+        if !removed {
+            return Ok(());
+        }
+        let conn = self.db.connect()?;
+        conn.execute(
+            "DELETE FROM trust_allowlist WHERE manager = ?1 AND name = ?2",
+            params![manager.as_str().to_string(), name.to_string()],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Snapshot names for a given manager (sorted).
+    pub fn list(&self, manager: PackageManager) -> Vec<String> {
+        let guard = self.entries.read();
+        let mut out: Vec<String> = guard
+            .iter()
+            .filter(|(m, _)| *m == manager)
+            .map(|(_, n)| n.clone())
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Snapshot with timestamps. Heavier than `list` — reads from the DB.
+    pub async fn list_all(&self) -> Result<Vec<TrustedPackage>, TrustAllowlistError> {
+        let conn = self.db.connect()?;
+        let mut rows = conn
+            .query(
+                "SELECT manager, name, added_at FROM trust_allowlist ORDER BY manager, name",
+                (),
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let manager: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let added_at: i64 = row.get(2)?;
+            if let Some(manager) = PackageManager::parse(&manager) {
+                out.push(TrustedPackage {
+                    manager,
+                    name,
+                    added_at,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Drop all entries. Used by tests and by an eventual "forget"
+    /// action in the UI.
+    pub async fn clear(&self) -> Result<(), TrustAllowlistError> {
+        self.entries.write().clear();
+        let conn = self.db.connect()?;
+        conn.execute("DELETE FROM trust_allowlist", ()).await?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().is_empty()
+    }
+}

--- a/crates/runt-store/tests/trust_allowlist.rs
+++ b/crates/runt-store/tests/trust_allowlist.rs
@@ -1,0 +1,162 @@
+//! Integration tests for `TrustAllowlist` (libSQL backend).
+//!
+//! Identical shape to the Lance spike's tests so the two can be
+//! compared directly. Any divergence is a real semantic difference
+//! between the backends, not a test-harness artifact.
+
+use runt_store::{PackageManager, TrustAllowlist};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn fresh_store_is_empty() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert!(store.is_empty());
+    assert!(!store.contains(PackageManager::Uv, "pandas"));
+}
+
+#[tokio::test]
+async fn add_then_contains() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    assert!(store.contains(PackageManager::Uv, "pandas"));
+    assert!(store.contains(PackageManager::Uv, "numpy"));
+    assert!(!store.contains(PackageManager::Conda, "pandas"));
+}
+
+#[tokio::test]
+async fn add_is_idempotent_in_memory() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(store.len(), 1);
+}
+
+#[tokio::test]
+async fn novel_returns_uncovered_only() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    let novel = store.novel([
+        (PackageManager::Uv, "pandas"),
+        (PackageManager::Uv, "numpy"),
+        (PackageManager::Uv, "polars"),
+    ]);
+    assert_eq!(novel, vec![(PackageManager::Uv, "polars".to_string())]);
+}
+
+#[tokio::test]
+async fn reopen_restores_entries() {
+    let tmp = TempDir::new().unwrap();
+    {
+        let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+        store
+            .add(
+                PackageManager::Conda,
+                &["scipy".to_string(), "matplotlib".to_string()],
+            )
+            .await
+            .unwrap();
+    }
+    // Drop and reopen — verifies WAL + on-disk state.
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert_eq!(store.len(), 2);
+    assert!(store.contains(PackageManager::Conda, "scipy"));
+    assert!(store.contains(PackageManager::Conda, "matplotlib"));
+}
+
+#[tokio::test]
+async fn remove_drops_single_entry() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store.remove(PackageManager::Uv, "pandas").await.unwrap();
+    assert!(!store.contains(PackageManager::Uv, "pandas"));
+    assert!(store.contains(PackageManager::Uv, "numpy"));
+
+    store
+        .remove(PackageManager::Uv, "never-existed")
+        .await
+        .unwrap();
+    assert_eq!(store.len(), 1);
+}
+
+#[tokio::test]
+async fn list_filters_by_manager() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store
+        .add(PackageManager::Conda, &["scipy".to_string()])
+        .await
+        .unwrap();
+
+    let uv = store.list(PackageManager::Uv);
+    assert_eq!(uv, vec!["numpy".to_string(), "pandas".to_string()]);
+    let conda = store.list(PackageManager::Conda);
+    assert_eq!(conda, vec!["scipy".to_string()]);
+}
+
+#[tokio::test]
+async fn list_all_round_trips_timestamps() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    let all = store.list_all().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].name, "pandas");
+    assert!(all[0].added_at > 0);
+}
+
+#[tokio::test]
+async fn clear_empties_both_views() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store.clear().await.unwrap();
+    assert!(store.is_empty());
+    drop(store);
+    let reopened = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert!(reopened.is_empty());
+}


### PR DESCRIPTION
**Not for merge.** Companion artifact to #2176. Closing after review so the branch stays reachable for reference.

## What this spike is

Mirror of the LanceDB spike (#2176) swapping the durability layer for libSQL (Turso's SQLite fork). Same `TrustAllowlist` facade, same 9 integration tests, same criterion benchmark harness, same binary-size measurement methodology. Direct apples-to-apples numbers for the "what should own daemon-side accumulated state?" decision.

## What libSQL actually is

SQLite fork maintained by the Turso team. Same file format, same SQL, same semantics. Adds:

- Native vector types (`F32_BLOB`, `vector_distance_cos`, `vector_top_k`) — brute force today, ANN on the roadmap.
- FTS5 built in (comes with SQLite).
- Optional remote replication / edge sync via Turso cloud (opt-in via features, not pulled in here).
- Pure-Rust embedded client `libsql` with async API.

Config here: `features = ["core"]` — disables `replication`, `remote`, `sync`, `tls`. What remains is the embedded DB only.

## Speed

Identical bench harness to #2176. Numbers from the same machine (macOS arm64):

| Metric | Lance | libSQL | Winner |
|---|---|---|---|
| `contains()` hit | 82 ns | **60 ns** | libSQL (−27%) |
| `contains()` miss | 95 ns | **60 ns** | libSQL (−37%) |
| `novel(20 vs 1k)` | 1.62 µs | **1.29 µs** | libSQL (−20%) |
| `cold_load` 100 rows | 642 µs | **429 µs** | libSQL (−33%) |
| `cold_load` 1k rows | 889 µs | 888 µs | tie |
| `cold_load` 10k rows | **2.6 ms** | 4.47 ms | Lance (libSQL +72%) |
| `add()` + fsync | 1.35 ms | **497 µs** | libSQL (−63%) |

The `contains` delta is noise — both implementations are pure `HashSet` lookups once the in-memory set is warm. The meaningful deltas are cold_load (SQLite's single-file BTree beats Lance's Arrow/DataFusion stack at small sizes) and `add` (libSQL's WAL commit beats Lance's fragment write). Lance pulls ahead at 10k rows where its columnar scan amortizes better, but that regime is not a realistic allowlist shape.

9/9 integration tests pass in ~20ms (Lance: 40ms).

## Binary size

Same methodology as #2176 — add `runt-store` as a runtime dep to `runtimed`, force linkage via a `pub` probe gated behind an env var so LLVM can't prune it.

| Binary | Baseline | With `runt-store` linked | Delta |
|---|---|---|---|
| `runtimed` | 24 MB | **25 MB** | **+1 MB (+4%)** |
| `runt-cli` | 9.3 MB | 9.3 MB | **0** |

Compare to Lance's **+25 MB (+106%)** on `runtimed`.

libSQL is the SQLite fork statically linked — a single self-contained C library via `libsql-ffi`. Lance is a full query engine (DataFusion) + columnar format + index infra. The capability gap justifies the weight if and only if we need those capabilities.

## What each backend gives us for our workloads

Summarizing the analysis from #2176:

| Workload | libSQL | Lance |
|---|---|---|
| Trust allowlist | ✓ trivial SQL | ✓ overkill |
| IPython history FTS | ✓ FTS5 | ✓ inverted index |
| Cell/output FTS | ✓ FTS5 | ✓ inverted + ngram |
| Vector over cells | ~ brute force; ANN coming | ✓ mature HNSW/IVF |
| Parquet / sift consolidation | ✗ keeps parquet separate | ✓ native Lance format |
| Arrow IPC streaming | ✗ serialization boundary | ✓ no format boundary |
| Binary cost | +1 MB | +25 MB |
| Ops / schema migration | classic SQLite, well understood | evolving |
| Cloud sync (future) | ✓ Turso edge (opt-in) | ✗ |

## Recommendation

**Ship #2132 on libSQL.** For the immediate workload (trust allowlist + near-term history cache + text search over cells/outputs), libSQL's capabilities are sufficient and the cost is 25× cheaper. Picking libSQL now doesn't forclose Lance later — `runt-store` is a facade; if vector search or parquet consolidation becomes important we can add Lance as a second backend or migrate.

Keeping the branch so anyone can `cargo bench -p runt-store` to reproduce. Branch name is `spike/runt-store-turso` because "libSQL" isn't a verb; "Turso" is what people actually call this stack.

## Next steps (not in this PR)

1. **Commit to libSQL as the daemon's local store.** If you agree, close this + #2176, file a tracking issue for the first real landing: `runt-store` wired into `runtimed` with the `TrustAllowlist` used by `auto_launch_kernel`.
2. **Implement #2132 on top** — ~200 line follow-up PR. Filter inline deps through the allowlist before bootstrap, auto-sign when fully covered, highlight novel packages in the dialog.
3. **Land FTS5 over cell source text** as a sibling table once #2132 ships. Low risk, high leverage for "find the cell where I did X."
4. **Benchmark libSQL vector at real scale** before committing to it for semantic search — the spike only measured the allowlist workload, not a 100k-embedding retrieve.

## What lives on this branch

- `crates/runt-store/` — facade + `TrustAllowlist` + `paths` module.
- `benches/trust_allowlist.rs` — criterion benchmarks used for the numbers above.
- `tests/trust_allowlist.rs` — 9 integration tests, all green.
- No wiring into `runtimed`. Only the workspace `Cargo.toml` adds the crate.

Binary-size probe (the `runt-store` dep + `trust_allowlist_probe` module) was added temporarily for the measurement, then stripped so this branch stays focused. To reproduce the size number, run `cargo build --release -p runtimed -p runt-cli` on this branch (baseline) and on a branch that adds `runt-store = { path = "../runt-store" }` to `runtimed`'s Cargo.toml with a `pub` function calling into it.
