### PR TITLE
fix(runtimed): mint UUIDs for ID-less cells so save/watch round-trips are stable

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(crate) struct ParsedIpynbCells {
     pub cells: Vec<CellSnapshot>,
     pub outputs_by_cell: HashMap<String, Vec<serde_json::Value>>,
+    pub attachments: HashMap<String, serde_json::Value>,
 }
 
 /// Parse cells from a Jupyter notebook JSON object.
@@ -13,9 +14,11 @@ pub(crate) struct ParsedIpynbCells {
 /// The source field can be either a string or an array of strings (lines).
 /// We normalize it to a single string.
 ///
-/// For older notebooks (pre-nbformat 4.5) that don't have cell IDs, we generate
-/// stable fallback IDs based on the cell index. This prevents data loss when
-/// merging changes from externally-generated notebooks.
+/// For older notebooks (pre-nbformat 4.5) without cell IDs we mint a fresh
+/// UUID per cell. The next save writes those UUIDs back, upgrading the file
+/// to nbformat 4.5. Positional `__external_cell_N` IDs were briefly used
+/// here and caused source/cell-type desync when the autosave-write-watch
+/// loop renumbered them by position — see issue and review notes.
 ///
 /// Positions are generated incrementally using fractional indexing.
 pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedIpynbCells> {
@@ -23,21 +26,18 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
 
     let cells_json = json.get("cells").and_then(|c| c.as_array())?;
 
-    // Generate positions incrementally
     let mut prev_position: Option<FractionalIndex> = None;
     let mut outputs_by_cell: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+    let mut attachments: HashMap<String, serde_json::Value> = HashMap::new();
 
     let parsed_cells = cells_json
         .iter()
-        .enumerate()
-        .map(|(index, cell)| {
-            // Use existing ID or generate a stable fallback based on index
-            // This handles older notebooks (pre-nbformat 4.5) without cell IDs
+        .map(|cell| {
             let id = cell
                 .get("id")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("__external_cell_{}", index));
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
             let cell_type = cell
                 .get("cell_type")
@@ -45,7 +45,6 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
                 .unwrap_or("code")
                 .to_string();
 
-            // Generate position incrementally (O(1) per cell, not O(n²))
             let position = match &prev_position {
                 None => FractionalIndex::default(),
                 Some(prev) => FractionalIndex::new_after(prev),
@@ -53,7 +52,6 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
             let position_str = position.to_string();
             prev_position = Some(position);
 
-            // Source can be a string or array of strings
             let source = match cell.get("source") {
                 Some(serde_json::Value::String(s)) => s.clone(),
                 Some(serde_json::Value::Array(arr)) => arr
@@ -64,15 +62,11 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
                 _ => String::new(),
             };
 
-            // Execution count: number or null
             let execution_count = match cell.get("execution_count") {
                 Some(serde_json::Value::Number(n)) => n.to_string(),
                 _ => "null".to_string(),
             };
 
-            // Outputs travel alongside the snapshot, not on it — they're
-            // destined for RuntimeStateDoc, keyed by execution_id, once the
-            // caller mints a synthetic execution for this cell.
             let outputs: Vec<serde_json::Value> = cell
                 .get("outputs")
                 .and_then(|v| v.as_array())
@@ -82,7 +76,12 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
                 outputs_by_cell.insert(id.clone(), outputs);
             }
 
-            // Cell metadata (preserves all fields, normalize to object)
+            if let Some(att) = cell.get("attachments") {
+                if att.is_object() {
+                    attachments.insert(id.clone(), att.clone());
+                }
+            }
+
             let metadata = match cell.get("metadata") {
                 Some(v) if v.is_object() => v.clone(),
                 _ => serde_json::json!({}),
@@ -103,37 +102,8 @@ pub(crate) fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<ParsedI
     Some(ParsedIpynbCells {
         cells: parsed_cells,
         outputs_by_cell,
+        attachments,
     })
-}
-
-/// Parse nbformat attachment payloads from a .ipynb JSON value.
-///
-/// Returns a map of `cell_id -> attachments JSON object` for any cell carrying attachments.
-pub(crate) fn parse_nbformat_attachments_from_ipynb(
-    json: &serde_json::Value,
-) -> HashMap<String, serde_json::Value> {
-    let Some(cells_json) = json.get("cells").and_then(|c| c.as_array()) else {
-        return HashMap::new();
-    };
-
-    cells_json
-        .iter()
-        .enumerate()
-        .filter_map(|(index, cell)| {
-            let id = cell
-                .get("id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("__external_cell_{}", index));
-
-            let attachments = cell.get("attachments")?;
-            if attachments.is_object() {
-                Some((id, attachments.clone()))
-            } else {
-                None
-            }
-        })
-        .collect()
 }
 
 /// Parse notebook metadata from a .ipynb JSON value.
@@ -190,8 +160,6 @@ pub(crate) struct ParsedStreamingNotebook {
     pub cells: Vec<StreamingCell>,
     pub metadata: Option<NotebookMetadataSnapshot>,
     pub attachments: NbformatAttachmentMap,
-    /// Original nbformat_minor from the file (0 if absent).
-    pub nbformat_minor: u32,
 }
 type StreamingLoadBatchEntry = (usize, StreamingCell, Vec<serde_json::Value>, ResolvedAssets);
 
@@ -274,13 +242,6 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
         NotebookMetadataSnapshot::from_metadata_value(&serde_meta)
     });
 
-    let nbformat_minor = jobj_get(obj, "nbformat_minor")
-        .and_then(|v| match v {
-            jiter::JsonValue::Int(n) => u32::try_from(*n).ok(),
-            _ => None,
-        })
-        .unwrap_or(0);
-
     let cells_arr = match jobj_get(obj, "cells") {
         Some(jiter::JsonValue::Array(arr)) => arr,
         Some(_) => return Err("'cells' is not an array".to_string()),
@@ -289,7 +250,6 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
                 cells: vec![],
                 metadata,
                 attachments: HashMap::new(),
-                nbformat_minor,
             })
         }
     };
@@ -299,7 +259,7 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
 
     let mut cells = Vec::with_capacity(cells_arr.len());
     let mut attachments = HashMap::new();
-    for (index, cell) in cells_arr.iter().enumerate() {
+    for cell in cells_arr.iter() {
         let cell_obj = match cell {
             jiter::JsonValue::Object(obj) => obj,
             _ => continue,
@@ -310,7 +270,7 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
                 jiter::JsonValue::Str(s) => Some(s.to_string()),
                 _ => None,
             })
-            .unwrap_or_else(|| format!("__external_cell_{}", index));
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         let cell_type = jobj_get(cell_obj, "cell_type")
             .and_then(|v| match v {
@@ -382,7 +342,6 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
         cells,
         metadata,
         attachments,
-        nbformat_minor,
     })
 }
 
@@ -484,9 +443,6 @@ where
         .map_err(|e| format!("Failed to read notebook: {}", e))?;
 
     let parsed = parse_notebook_jiter(&bytes)?;
-    room.persistence
-        .original_nbformat_minor
-        .store(parsed.nbformat_minor, Ordering::Relaxed);
     let cells = parsed.cells;
     let metadata = parsed.metadata;
     let nbformat_attachments = parsed.attachments;
@@ -734,9 +690,9 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc(
     let ParsedIpynbCells {
         cells,
         outputs_by_cell,
+        attachments: nbformat_attachments,
     } = parse_cells_from_ipynb(&json)
         .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
-    let nbformat_attachments = parse_nbformat_attachments_from_ipynb(&json);
 
     // Populate cells in the doc
     for (i, cell) in cells.iter().enumerate() {

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -27,7 +27,7 @@
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use automerge::sync;

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -148,17 +148,8 @@ pub(crate) async fn save_notebook_to_disk(
 
     let nbformat_attachments = room.nbformat_attachments_snapshot().await;
 
-    // Decide whether to emit cell IDs. Pre-4.5 notebooks had no cell IDs;
-    // writing synthetic `__external_cell_N` IDs would inject fields that
-    // were never in the original file.
-    let original_minor = room
-        .persistence
-        .original_nbformat_minor
-        .load(Ordering::Relaxed);
-    let should_write_cell_ids = original_minor >= 5 || original_minor == 0;
-
-    // Reconstruct cells as JSON
-    // Cell metadata now comes from the CellSnapshot (populated during load)
+    // Reconstruct cells as JSON. Cell IDs are always written — pre-4.5
+    // notebooks loaded without IDs got fresh UUIDs minted at parse time.
     let mut nb_cells = Vec::new();
     for cell in &cells {
         // Use metadata from the Automerge doc (populated during notebook load)
@@ -180,20 +171,12 @@ pub(crate) async fn save_notebook_to_disk(
             lines
         };
 
-        let mut cell_json = if should_write_cell_ids {
-            serde_json::json!({
-                "id": cell.id,
-                "cell_type": cell.cell_type,
-                "source": source_lines,
-                "metadata": cell_meta,
-            })
-        } else {
-            serde_json::json!({
-                "cell_type": cell.cell_type,
-                "source": source_lines,
-                "metadata": cell_meta,
-            })
-        };
+        let mut cell_json = serde_json::json!({
+            "id": cell.id,
+            "cell_type": cell.cell_type,
+            "source": source_lines,
+            "metadata": cell_meta,
+        });
 
         if cell.cell_type == "code" {
             // Resolve outputs from RuntimeStateDoc (keyed by execution_id)
@@ -234,19 +217,13 @@ pub(crate) async fn save_notebook_to_disk(
     }
 
     // Build the final notebook JSON.
-    // Preserve the original nbformat_minor for pre-4.5 notebooks rather
-    // than forcing an upgrade that would inject cell IDs into files that
-    // never had them.
+    // We always write cell IDs, so nbformat_minor is at least 5.
     let existing_minor = existing
         .as_ref()
         .and_then(|nb| nb.get("nbformat_minor"))
         .and_then(|v| v.as_u64())
         .unwrap_or(5);
-    let nbformat_minor = if should_write_cell_ids {
-        std::cmp::max(existing_minor, 5)
-    } else {
-        existing_minor
-    };
+    let nbformat_minor = std::cmp::max(existing_minor, 5);
 
     let cell_count = nb_cells.len();
     let notebook_json = serde_json::json!({
@@ -494,12 +471,6 @@ pub(crate) async fn clone_notebook_to_disk(
     // Generate fresh env_id for the cloned notebook
     let new_env_id = uuid::Uuid::new_v4().to_string();
 
-    let original_minor = room
-        .persistence
-        .original_nbformat_minor
-        .load(Ordering::Relaxed);
-    let should_write_cell_ids = original_minor >= 5 || original_minor == 0;
-
     // Build cells with cleared outputs and execution counts, but preserved metadata
     let mut nb_cells = Vec::new();
     for cell in &cells {
@@ -516,20 +487,12 @@ pub(crate) async fn clone_notebook_to_disk(
         // Use metadata from the Automerge doc (populated during notebook load)
         let cell_meta = cell.metadata.clone();
 
-        let mut cell_json = if should_write_cell_ids {
-            serde_json::json!({
-                "id": cell.id,
-                "cell_type": cell.cell_type,
-                "source": source_lines,
-                "metadata": cell_meta,
-            })
-        } else {
-            serde_json::json!({
-                "cell_type": cell.cell_type,
-                "source": source_lines,
-                "metadata": cell_meta,
-            })
-        };
+        let mut cell_json = serde_json::json!({
+            "id": cell.id,
+            "cell_type": cell.cell_type,
+            "source": source_lines,
+            "metadata": cell_meta,
+        });
 
         if cell.cell_type == "code" {
             // Clear outputs and execution_count for cloned notebook
@@ -567,11 +530,7 @@ pub(crate) async fn clone_notebook_to_disk(
         .and_then(|nb| nb.get("nbformat_minor"))
         .and_then(|v| v.as_u64())
         .unwrap_or(5);
-    let nbformat_minor = if should_write_cell_ids {
-        std::cmp::max(existing_minor, 5)
-    } else {
-        existing_minor
-    };
+    let nbformat_minor = std::cmp::max(existing_minor, 5);
 
     // Build the final notebook JSON
     let cell_count = nb_cells.len();
@@ -1117,24 +1076,12 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 }
                             };
 
-                            // Refresh original_nbformat_minor so the save
-                            // path reflects external upgrades (e.g. an editor
-                            // adding cell IDs and bumping to 4.5).
-                            if let Some(minor) = json
-                                .get("nbformat_minor")
-                                .and_then(|v| v.as_u64())
-                                .and_then(|n| u32::try_from(n).ok())
-                            {
-                                room.persistence
-                                    .original_nbformat_minor
-                                    .store(minor, Ordering::Relaxed);
-                            }
-
                             // Parse cells from the .ipynb
                             // None = parse failure (missing cells key), Some([]) = valid empty notebook
                             let ParsedIpynbCells {
                                 cells: external_cells,
                                 outputs_by_cell: external_outputs,
+                                attachments: external_attachments,
                             } = match parse_cells_from_ipynb(&json) {
                                 Some(parsed) => parsed,
                                 None => {
@@ -1145,7 +1092,6 @@ pub(crate) fn spawn_notebook_file_watcher(
                                     continue;
                                 }
                             };
-                            let external_attachments = parse_nbformat_attachments_from_ipynb(&json);
                             let external_metadata = parse_metadata_from_ipynb(&json);
 
                             // Check if kernel is running (to preserve outputs)

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -113,10 +113,6 @@ pub struct RoomPersistence {
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
-    /// Original nbformat_minor from the loaded .ipynb file (0 = unknown/new).
-    /// Used on save to decide whether to emit cell IDs (4.5+ requires them,
-    /// pre-4.5 files should not get synthetic IDs injected).
-    pub original_nbformat_minor: AtomicU32,
 }
 
 /// The debounced `.automerge` persist channels. See `spawn_persist_debouncer`.
@@ -142,7 +138,6 @@ impl RoomPersistence {
             watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
-            original_nbformat_minor: AtomicU32::new(0),
         }
     }
 
@@ -161,7 +156,6 @@ impl RoomPersistence {
             watcher_shutdown_tx: Mutex::new(None),
             nbformat_attachments: RwLock::new(HashMap::new()),
             is_loading: AtomicBool::new(false),
-            original_nbformat_minor: AtomicU32::new(0),
         }
     }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -820,6 +820,63 @@ async fn test_save_notebook_to_disk_enforces_nbformat_minor_5() {
     );
 }
 
+/// Round-trip a pre-4.5 notebook with no cell IDs through load+save and
+/// confirm every saved cell carries a stable ID. The earlier behavior
+/// minted positional `__external_cell_N` IDs that drifted across the
+/// autosave-write-watch loop, desyncing source from cell type. With real
+/// UUIDs, every save persists identifiers that survive any number of
+/// reloads.
+#[tokio::test]
+async fn test_save_persists_real_ids_for_legacy_notebook() {
+    use std::io::Write;
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "legacy.ipynb");
+
+    // Pre-4.5 notebook with cells that have no `id` field.
+    {
+        let mut f = std::fs::File::create(&notebook_path).unwrap();
+        writeln!(
+            f,
+            r##"{{
+                "nbformat": 4,
+                "nbformat_minor": 2,
+                "metadata": {{}},
+                "cells": [
+                    {{ "cell_type": "code", "source": "x = 1", "execution_count": null, "outputs": [] }},
+                    {{ "cell_type": "markdown", "source": "# Title", "metadata": {{}} }}
+                ]
+            }}"##
+        )
+        .unwrap();
+    }
+
+    let blob_store = room.blob_store.clone();
+    {
+        let mut doc = room.doc.write().await;
+        load_notebook_from_disk(&mut doc, &notebook_path, &blob_store)
+            .await
+            .unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let cells = saved.get("cells").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(cells.len(), 2);
+    for cell in cells {
+        let id = cell
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("every saved cell must carry an id");
+        assert!(
+            uuid::Uuid::parse_str(id).is_ok(),
+            "expected UUID, got {id:?}"
+        );
+    }
+    assert_eq!(saved.get("nbformat_minor"), Some(&serde_json::json!(5)));
+}
+
 #[tokio::test]
 async fn test_save_notebook_to_disk_with_outputs() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -1078,9 +1135,11 @@ fn test_parse_cells_from_ipynb_missing_ids() {
     let parsed = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
     let cells = &parsed.cells;
     assert_eq!(cells.len(), 2);
-    // Should generate fallback IDs based on index
-    assert_eq!(cells[0].id, "__external_cell_0");
-    assert_eq!(cells[1].id, "__external_cell_1");
+    // Should mint fresh UUIDs for ID-less cells so the next save writes
+    // stable identifiers rather than positional placeholders.
+    assert!(uuid::Uuid::parse_str(&cells[0].id).is_ok());
+    assert!(uuid::Uuid::parse_str(&cells[1].id).is_ok());
+    assert_ne!(cells[0].id, cells[1].id);
     assert_eq!(cells[0].source, "x = 1");
     assert_eq!(cells[1].source, "y = 2");
 }


### PR DESCRIPTION
## Diagnosis

`__external_cell_N` IDs are positional. Live repro from a session on a pre-4.5 notebook: open via MCP, send a batch of `delete_cell` and `set_cell` ops, autosave fires three seconds later, the file watcher fires on our own write, and cells 8-31 come back with markdown bodies in code cells (and vice versa). The cell-type-typed-as-code raises `SyntaxError: invalid decimal literal` because Python can't parse markdown.

The trace from `runtimed.log`:

1. MCP delete removes cells with IDs `__external_cell_5, 7, 8, ..., 13`.
2. Autosave (3s later) writes the post-delete state. Pre-fix, the on-disk file kept the IDs but a follow-on watcher reload re-keyed every cell's ID by position via `format!(\"__external_cell_{}\", index)`.
3. The watcher's `apply_ipynb_changes` matches by ID. In-memory cell `__external_cell_6` (originally content X6) now matches on-disk position 6 (content X14, originally cell `_14`) - and `apply_ipynb_changes` updates source by ID without touching cell type. Boom: source/type desync.

The `should_write_cell_ids` gate added in #2155 was a workaround for a different symptom (autosave injecting `__external_cell_N` placeholder names into pre-4.5 files). It made the underlying instability worse: skipping IDs on save meant the next watch reload regenerated them positionally, locking in the drift.

## Fix

Mint a UUID per cell that arrives without an ID. Always write `id` and `nbformat_minor >= 5` on save. The positional placeholder is gone end-to-end.

| | Pre-PR-533 | After PR #533 | After PR #2155 | This PR |
|---|---|---|---|---|
| Cells without IDs at load | left as-is | `__external_cell_{idx}` | same | UUID per cell |
| Save writes IDs | always | always | only if `original_minor >= 5` | always |
| `nbformat_minor` on save | always 5 | always 5 | preserves original | always >=5 |

Drops the `should_write_cell_ids` gate and the `original_nbformat_minor` field that fed it. Folds attachment parsing into `parse_cells_from_ipynb` so attachments and cells share one ID source (separate functions previously generated different UUIDs for the same positional cell on ID-less files, losing attachments).

Jiter streaming load is preserved - only the ID fallback line changed. Big notebooks still load near-instant.

## Files

- `load.rs` - UUID minting in `parse_cells_from_ipynb` and `parse_notebook_jiter`. Merged attachments into `ParsedIpynbCells`. Dropped dead `parse_nbformat_attachments_from_ipynb` and `nbformat_minor` field on `ParsedStreamingNotebook`.
- `persist.rs` - both save paths always emit \`id\`, watcher destructures attachments from the merged result, dropped the `original_nbformat_minor` refresh.
- `room.rs` / `mod.rs` - removed `original_nbformat_minor: AtomicU32`.
- `tests.rs` - `test_parse_cells_from_ipynb_missing_ids` asserts UUIDs; new `test_save_persists_real_ids_for_legacy_notebook` round-trips a pre-4.5 file through load+save and verifies every saved cell carries a UUID.

## Test plan

- [x] `cargo test -p runtimed --lib notebook_sync_server` (177 tests, including new round-trip)
- [x] `cargo test -p runtimed --lib` (465 tests)
- [x] `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- [x] `cargo xtask lint`
- [ ] Manual repro on the original notebook from the bug report (pre-4.5, MCP delete + set batches), confirm no source/type desync after autosave.