### PR TITLE
spike: runt-store + pure-Rust turso evaluation (not for merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -113,6 +113,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -400,7 +406,7 @@ dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -595,7 +601,7 @@ dependencies = [
  "itertools 0.14.0",
  "leb128",
  "rand 0.9.4",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "sha2 0.11.0",
  "smol_str",
@@ -707,6 +713,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
 dependencies = [
  "scoped-tls",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1057,6 +1086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1197,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1454,6 +1503,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1939,7 +2022,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "unicode-width",
 ]
@@ -1966,7 +2049,7 @@ dependencies = [
  "dprint-core",
  "dprint-core-macros",
  "percent-encoding",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
 ]
 
@@ -1979,7 +2062,7 @@ dependencies = [
  "allocator-api2",
  "bumpalo",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2943,7 +3026,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -3067,7 +3150,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "triomphe",
 ]
@@ -3852,6 +3935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4002,6 +4091,47 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsql"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.1",
+ "bytes",
+ "futures",
+ "libsql-sys",
+ "parking_lot",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "glob",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4206,6 +4336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,7 +4411,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tokio",
@@ -4429,6 +4565,16 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -4442,7 +4588,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -5233,6 +5379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pep440_rs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5257,7 +5409,7 @@ dependencies = [
  "once_cell",
  "pep440_rs",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
@@ -5573,6 +5725,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5632,7 +5812,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -6215,7 +6395,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-regex",
  "memmap2",
- "nom",
+ "nom 8.0.0",
  "nom-language",
  "purl",
  "rattler_digest",
@@ -6496,7 +6676,7 @@ checksum = "8c3d2a564b41942dd87e441e4c68a31e4be517915daf5d20fe4b36cd3f4a7c5e"
 dependencies = [
  "archspec",
  "libloading 0.9.0",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "plist",
  "rattler_conda_types",
@@ -7007,6 +7187,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "runt-store"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "dashmap 6.1.0",
+ "dirs",
+ "libsql",
+ "parking_lot",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "runt-trust"
 version = "0.2.2"
 dependencies = [
@@ -7241,6 +7438,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7547,7 +7750,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -8250,7 +8453,7 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "siphasher 0.3.11",
  "swc_atoms",
@@ -8272,7 +8475,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "phf 0.11.3",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "string_enum",
  "swc_atoms",
@@ -8290,7 +8493,7 @@ dependencies = [
  "bitflags 2.11.1",
  "either",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "seq-macro",
  "serde",
  "smallvec",
@@ -8313,7 +8516,7 @@ dependencies = [
  "either",
  "num-bigint",
  "phf 0.11.3",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "seq-macro",
  "serde",
  "smartstring",
@@ -9135,6 +9338,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10289,6 +10502,18 @@ dependencies = [
 
 [[package]]
 name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
@@ -11137,11 +11362,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.48",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aegis"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +75,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -62,7 +107,7 @@ dependencies = [
  "rustix-openpty",
  "serde",
  "signal-hook",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
  "windows-sys 0.59.0",
 ]
@@ -101,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -171,6 +216,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "linkme",
+ "once_cell",
+ "rand 0.8.6",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -384,6 +454,12 @@ dependencies = [
  "regex",
  "regex-syntax",
 ]
+
+[[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "ast_node"
@@ -716,18 +792,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.66.1"
+name = "bigdecimal"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -859,6 +948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +975,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "built"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -933,6 +1040,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1138,6 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1324,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -1497,6 +1634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1672,6 +1829,15 @@ name = "ctor-proc-macro"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ctutils"
@@ -1782,7 +1948,7 @@ dependencies = [
  "swc_eq_ignore_macros",
  "text_lines",
  "thiserror 2.0.18",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
 ]
 
@@ -2024,7 +2190,7 @@ dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
  "serde",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2192,10 +2358,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter 1.0.1",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -2236,6 +2421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2446,18 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.4",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -2709,6 +2912,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,7 +2958,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2780,6 +3013,16 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3026,7 +3269,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3553,10 +3796,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -4082,6 +4354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,44 +4375,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsql"
-version = "0.9.30"
+name = "linkme"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
 dependencies = [
- "async-trait",
- "bitflags 2.11.1",
- "bytes",
- "futures",
- "libsql-sys",
- "parking_lot",
- "thiserror 1.0.69",
- "tracing",
+ "linkme-impl",
 ]
 
 [[package]]
-name = "libsql-ffi"
-version = "0.9.30"
+name = "linkme-impl"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "glob",
-]
-
-[[package]]
-name = "libsql-sys"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
-dependencies = [
- "bytes",
- "libsql-ffi",
- "once_cell",
- "tracing",
- "zerocopy 0.7.35",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4168,6 +4428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4317,6 +4590,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5156,6 +5460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,6 +5561,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pack1"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e7cd9bd638dc2c831519a0caa1c006cab771a92b1303403a8322773c5b72d6"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,7 +5608,7 @@ checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5341,7 +5666,7 @@ dependencies = [
  "seq-macro",
  "snap",
  "thrift",
- "twox-hash",
+ "twox-hash 1.6.3",
  "zstd",
 ]
 
@@ -5379,12 +5704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pep440_rs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,7 +5711,7 @@ checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
 dependencies = [
  "once_cell",
  "serde",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unscanny",
  "version-ranges",
 ]
@@ -5413,7 +5732,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 1.0.69",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
  "urlencoding",
  "version-ranges",
@@ -5786,6 +6105,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,7 +6143,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5952,6 +6283,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6174,7 +6528,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -6291,12 +6645,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -6411,7 +6783,7 @@ dependencies = [
  "serde_yaml",
  "simd-json",
  "smallvec",
- "strum",
+ "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -6616,7 +6988,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "simple_spawn_blocking",
- "strum",
+ "strum 0.28.0",
  "superslice",
  "tempfile",
  "thiserror 2.0.18",
@@ -7092,6 +7464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7194,13 +7576,13 @@ dependencies = [
  "criterion",
  "dashmap 6.1.0",
  "dirs",
- "libsql",
  "parking_lot",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "turso",
 ]
 
 [[package]]
@@ -7457,6 +7839,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
  "semver",
 ]
 
@@ -8092,6 +8484,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_pcg 0.3.1",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "sift-wasm"
 version = "0.1.2"
 dependencies = [
@@ -8180,6 +8592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8254,6 +8675,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "softaes"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
 
 [[package]]
 name = "softbuffer"
@@ -8396,11 +8823,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8460,7 +8909,7 @@ dependencies = [
  "swc_eq_ignore_macros",
  "swc_visit",
  "tracing",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
 ]
 
@@ -9215,7 +9664,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -9815,6 +10264,190 @@ dependencies = [
 ]
 
 [[package]]
+name = "turso"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faba49ac70e21ea35cc963341485f3d17822f2cf433f42152a182117da21d29f"
+dependencies = [
+ "mimalloc",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fac73a12b91b569f4671d63d65912876c11e6312597c996dac40494f9f9b39"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "antithesis_sdk",
+ "arc-swap",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "branches",
+ "built",
+ "bumpalo",
+ "bytemuck",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-skiplist",
+ "either",
+ "fallible-iterator",
+ "fastbloom",
+ "hex",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading 0.8.9",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "paste",
+ "polling",
+ "rand 0.9.4",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash 2.1.2",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd7410a02a3a4cebd48a5bc0db74940d1157dc9c05ad42d48ee5156dd31edd1"
+dependencies = [
+ "chrono",
+ "getrandom 0.3.4",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c846c30c3cb085884a8bbaba7760bdcc406ff2176cbde1e51d41b6057171fd4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8402ba98c236e3e6d6ed6a43557a9a0b3a682f86a37fcafe02b659b9e6c06b82"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "miette",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b68fee8a6d8515fa6be08ad998d34eba0ac4a8e81dae4b9d0041e21ca01e22"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b90fe1bcada9dda8b8e20900f744bdd52f641cccc179f1507e83f8f2ec0b1dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a94f0d86e6823f63fc52040eb33131ce7fb9cebdb7329a5231443d846e0195a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "genawaiter",
+ "http",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49fb6c54aaa988f333505a9023fe4985725995b1575eb1557105fa4ac13ea6d"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9822,6 +10455,15 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -9847,6 +10489,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -9924,6 +10575,12 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -9933,6 +10590,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -11362,32 +12029,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/mcp-supervisor",
     "crates/runt-mcp",
     "crates/runt-mcp-proxy",
+    "crates/runt-store",
     "crates/nteract-mcp",
     "crates/repr-llm",
     "crates/nteract-predicate",

--- a/crates/runt-store/Cargo.toml
+++ b/crates/runt-store/Cargo.toml
@@ -2,7 +2,7 @@
 name = "runt-store"
 version = "0.0.1"
 edition.workspace = true
-description = "Daemon local data store (spike: libSQL/Turso-backed trust allowlist + room for history/search/completion caches)"
+description = "Daemon local data store (spike: pure-Rust Turso-backed trust allowlist + room for history/search/completion caches)"
 repository.workspace = true
 license.workspace = true
 
@@ -10,11 +10,10 @@ license.workspace = true
 anyhow = { workspace = true }
 dashmap = "6"
 dirs = "6"
-# libsql core only — no replication, no remote, no sync, no TLS. This
-# is the embedded SQLite-fork path; the remote/replication features
-# would drag in hyper + tower + tonic which belong on a cloud-sync
-# future, not the daemon's local store.
-libsql = { version = "0.9", default-features = false, features = ["core"] }
+# Pure-Rust Turso. No C toolchain for cross-compilation, no FFI.
+# `mimalloc` is the default and worth keeping for SQLite-comparable
+# alloc perf. `sync` (cloud replication) is intentionally left off.
+turso = "0.5"
 parking_lot = "0.12"
 serde = { workspace = true }
 thiserror = "2"

--- a/crates/runt-store/Cargo.toml
+++ b/crates/runt-store/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "runt-store"
+version = "0.0.1"
+edition.workspace = true
+description = "Daemon local data store (spike: libSQL/Turso-backed trust allowlist + room for history/search/completion caches)"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+dashmap = "6"
+dirs = "6"
+# libsql core only — no replication, no remote, no sync, no TLS. This
+# is the embedded SQLite-fork path; the remote/replication features
+# would drag in hyper + tower + tonic which belong on a cloud-sync
+# future, not the daemon's local store.
+libsql = { version = "0.9", default-features = false, features = ["core"] }
+parking_lot = "0.12"
+serde = { workspace = true }
+thiserror = "2"
+tokio = { workspace = true, features = ["sync", "fs", "rt"] }
+tracing = "0.1"
+
+[dev-dependencies]
+criterion = { version = "0.7", features = ["async_tokio"] }
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "trust_allowlist"
+harness = false

--- a/crates/runt-store/benches/trust_allowlist.rs
+++ b/crates/runt-store/benches/trust_allowlist.rs
@@ -1,0 +1,121 @@
+//! libSQL-backed trust allowlist benchmarks.
+//!
+//! Same shape as the Lance spike's benches (PR #2176) — any divergence
+//! in numbers is a real backend difference.
+//!
+//! Run with:
+//!   cargo bench -p runt-store --bench trust_allowlist
+
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use runt_store::{PackageManager, TrustAllowlist};
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+fn seed_names(prefix: &str, count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("{prefix}-pkg-{i:05}")).collect()
+}
+
+async fn open_seeded(tmp: &TempDir, count: usize) -> TrustAllowlist {
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    let names = seed_names("seed", count);
+    store.add(PackageManager::Uv, &names).await.unwrap();
+    store
+}
+
+fn bench_cold_load(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("cold_load");
+    for &count in &[100usize, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_function(format!("rows={count}"), |b| {
+            b.iter_custom(|iters| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let tmp = TempDir::new().unwrap();
+                    rt.block_on(async {
+                        let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+                        let names = seed_names("cold", count);
+                        store.add(PackageManager::Uv, &names).await.unwrap();
+                        drop(store);
+                    });
+                    let start = Instant::now();
+                    rt.block_on(async {
+                        let _ = TrustAllowlist::open(tmp.path()).await.unwrap();
+                    });
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_contains(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let store = rt.block_on(open_seeded(&tmp, 1_000));
+
+    let mut group = c.benchmark_group("contains");
+    group.bench_function("hit", |b| {
+        b.iter(|| store.contains(PackageManager::Uv, "seed-pkg-00500"));
+    });
+    group.bench_function("miss", |b| {
+        b.iter(|| store.contains(PackageManager::Uv, "this-will-never-match"));
+    });
+    group.finish();
+}
+
+fn bench_novel(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let store = rt.block_on(open_seeded(&tmp, 1_000));
+
+    let candidates: Vec<String> = (0..18)
+        .map(|i| format!("seed-pkg-{i:05}"))
+        .chain((0..2).map(|i| format!("brand-new-pkg-{i}")))
+        .collect();
+
+    c.bench_function("novel_20_vs_1000", |b| {
+        b.iter(|| {
+            let refs = candidates
+                .iter()
+                .map(|s| (PackageManager::Uv, s.as_str()))
+                .collect::<Vec<_>>();
+            let _ = store.novel(refs);
+        });
+    });
+}
+
+fn bench_add_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("add_single");
+    group.sample_size(30);
+    group.bench_function("append_one", |b| {
+        b.iter_custom(|iters| {
+            let mut total = std::time::Duration::ZERO;
+            for i in 0..iters {
+                let tmp = TempDir::new().unwrap();
+                let store = rt.block_on(TrustAllowlist::open(tmp.path())).unwrap();
+                let name = format!("one-off-{i}");
+                let start = Instant::now();
+                rt.block_on(store.add(PackageManager::Uv, &[name.clone()]))
+                    .unwrap();
+                total += start.elapsed();
+            }
+            total
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cold_load,
+    bench_contains,
+    bench_novel,
+    bench_add_single
+);
+criterion_main!(benches);

--- a/crates/runt-store/src/lib.rs
+++ b/crates/runt-store/src/lib.rs
@@ -1,27 +1,31 @@
-//! `runt-store` — daemon local data store (Turso/libSQL spike).
+//! `runt-store` — daemon local data store (pure-Rust `turso` spike).
 //!
 //! # What this is
 //!
-//! Mirror of the LanceDB spike (PR #2176) using libSQL core only.
-//! Same `TrustAllowlist` facade, same 9 integration tests, same
-//! benchmark harness. Apples-to-apples comparison for the "what
-//! should own daemon-side accumulated state?" decision.
+//! Third backend in the daemon-store evaluation after Lance (#2176)
+//! and libSQL (#2178). This one uses the `turso` crate — the Turso
+//! team's ground-up, pure-Rust rewrite of the SQLite engine.
 //!
-//! See PR #2176 for the LanceDB numbers and the broader workload
-//! analysis (parquet/sift, Arrow IPC, indexed search, history cache).
+//! Same `TrustAllowlist` facade, same 9 integration tests, same
+//! criterion harness. Apples-to-apples numbers.
+//!
+//! # Why pure Rust matters
+//!
+//! libSQL ships the SQLite C source via `libsql-ffi` + `cc`. That's
+//! fine for macOS/Linux dev boxes but adds a C toolchain dependency
+//! for every target, and complicates Windows cross-compilation. The
+//! `turso` crate is 100% Rust — no `cc`, no `bindgen`, no C sources.
+//! Worth paying some perf to keep the daemon's build story clean,
+//! *if* the pure-Rust version is close enough.
 //!
 //! # Speed model
 //!
-//! Same in-memory-first pattern as the Lance spike:
+//! Same in-memory-first pattern:
 //!
 //! - Reads on the hot path never touch disk. The whole table is
-//!   materialized into a `HashSet` at `open()` time, and `contains()`
+//!   materialized into a `HashSet` at `open()` time, `contains()`
 //!   is a pure `HashSet` lookup.
 //! - Writes update the set and append to the DB in the same call.
-//!
-//! libSQL gives us WAL + synchronous=NORMAL out of the box, which is
-//! effectively what we'd want for an "append decisions, rarely remove"
-//! workload.
 //!
 //! # On disk
 //!

--- a/crates/runt-store/src/lib.rs
+++ b/crates/runt-store/src/lib.rs
@@ -1,0 +1,35 @@
+//! `runt-store` — daemon local data store (Turso/libSQL spike).
+//!
+//! # What this is
+//!
+//! Mirror of the LanceDB spike (PR #2176) using libSQL core only.
+//! Same `TrustAllowlist` facade, same 9 integration tests, same
+//! benchmark harness. Apples-to-apples comparison for the "what
+//! should own daemon-side accumulated state?" decision.
+//!
+//! See PR #2176 for the LanceDB numbers and the broader workload
+//! analysis (parquet/sift, Arrow IPC, indexed search, history cache).
+//!
+//! # Speed model
+//!
+//! Same in-memory-first pattern as the Lance spike:
+//!
+//! - Reads on the hot path never touch disk. The whole table is
+//!   materialized into a `HashSet` at `open()` time, and `contains()`
+//!   is a pure `HashSet` lookup.
+//! - Writes update the set and append to the DB in the same call.
+//!
+//! libSQL gives us WAL + synchronous=NORMAL out of the box, which is
+//! effectively what we'd want for an "append decisions, rarely remove"
+//! workload.
+//!
+//! # On disk
+//!
+//! Default root is `dirs::data_local_dir()/runt/store/`. One database
+//! file: `allowlist.db`. No per-channel split.
+
+pub mod paths;
+pub mod trust_allowlist;
+
+pub use paths::{default_store_dir, store_dir_for};
+pub use trust_allowlist::{PackageManager, TrustAllowlist, TrustAllowlistError, TrustedPackage};

--- a/crates/runt-store/src/paths.rs
+++ b/crates/runt-store/src/paths.rs
@@ -1,0 +1,23 @@
+//! Store directory resolution.
+//!
+//! `data_local_dir` on purpose — the allowlist is user decision
+//! history, not cached data. Losing it breaks the UX contract.
+//!
+//! macOS: `~/Library/Application Support/runt/store/`
+//! Linux: `~/.local/share/runt/store/`
+//! Windows: `%LOCALAPPDATA%\runt\store\`
+
+use std::path::PathBuf;
+
+/// Default store directory, shared between stable and nightly channels
+/// so the user's trust decisions carry across both (same convention as
+/// the HMAC trust key in `runt-trust`).
+pub fn default_store_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join("runt").join("store"))
+}
+
+/// Explicit store directory under a caller-provided root. Used by
+/// tests and benchmarks to isolate stores per process under `tempdir`.
+pub fn store_dir_for(root: impl Into<PathBuf>) -> PathBuf {
+    root.into().join("runt").join("store")
+}

--- a/crates/runt-store/src/trust_allowlist.rs
+++ b/crates/runt-store/src/trust_allowlist.rs
@@ -3,7 +3,9 @@
 //!
 //! # Storage model
 //!
-//! Durability via libSQL (Turso fork of SQLite). One table:
+//! Durability via the `turso` crate — the Turso team's ground-up
+//! pure-Rust rewrite of the SQLite engine, SQLite-compatible on the
+//! wire + file format. One table:
 //!
 //! ```sql
 //! CREATE TABLE trust_allowlist (
@@ -11,18 +13,20 @@
 //!   name      TEXT NOT NULL,
 //!   added_at  INTEGER NOT NULL,
 //!   PRIMARY KEY (manager, name)
-//! ) WITHOUT ROWID;
+//! );
 //! ```
 //!
-//! `WITHOUT ROWID` keeps the B-tree keyed by the natural identifier,
-//! which is what we want for both lookup and upsert. `added_at` is
-//! Unix seconds.
+//! `added_at` is Unix seconds. (Note: `turso` 0.5 does not yet parse
+//! `WITHOUT ROWID`, so the primary key goes on a normal b-tree over
+//! rowid. Functionally identical for our lookup pattern, since we
+//! always hit the `(manager, name)` index. Reintroduce once turso
+//! catches up to SQLite's full DDL.)
 //!
 //! # Hot path
 //!
 //! All rows are loaded into an in-memory `HashSet` at `open()` time.
 //! `contains()` is a pure set lookup — no disk I/O, no `.await`. The
-//! set is the authoritative view inside the running daemon; libSQL is
+//! set is the authoritative view inside the running daemon; turso is
 //! the durability layer and source of truth on cold start.
 
 use std::collections::HashSet;
@@ -30,9 +34,9 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use libsql::{params, Builder};
 use parking_lot::RwLock;
 use thiserror::Error;
+use turso::{params, Builder};
 
 const DB_FILE: &str = "allowlist.db";
 
@@ -72,8 +76,8 @@ pub struct TrustedPackage {
 
 #[derive(Debug, Error)]
 pub enum TrustAllowlistError {
-    #[error("libsql error: {0}")]
-    LibSql(#[from] libsql::Error),
+    #[error("turso error: {0}")]
+    Turso(#[from] turso::Error),
     #[error("store directory unavailable")]
     NoStoreDir,
     #[error("io error: {0}")]
@@ -82,11 +86,11 @@ pub enum TrustAllowlistError {
     Clock(#[from] std::time::SystemTimeError),
 }
 
-/// In-memory view of the allowlist backed by a libSQL database on disk.
+/// In-memory view of the allowlist backed by a turso database on disk.
 #[derive(Clone)]
 pub struct TrustAllowlist {
     entries: Arc<RwLock<HashSet<(PackageManager, String)>>>,
-    db: Arc<libsql::Database>,
+    db: Arc<turso::Database>,
 }
 
 impl TrustAllowlist {
@@ -96,28 +100,25 @@ impl TrustAllowlist {
     pub async fn open(store_dir: &Path) -> Result<Self, TrustAllowlistError> {
         tokio::fs::create_dir_all(store_dir).await?;
         let db_path = store_dir.join(DB_FILE);
-        let db = Builder::new_local(&db_path).build().await?;
+        let db_path_str = db_path
+            .to_str()
+            .ok_or(TrustAllowlistError::NoStoreDir)?
+            .to_string();
+        let db = Builder::new_local(&db_path_str).build().await?;
         let conn = db.connect()?;
 
-        // Pragmas tuned for a local, single-process store: WAL so
-        // readers and writers don't block each other, NORMAL sync
-        // (WAL is already durable on checkpoint, full FSYNC is
-        // overkill for accumulated user decisions), foreign_keys off
-        // (nothing references us).
-        conn.execute_batch(
-            "PRAGMA journal_mode=WAL;\n\
-             PRAGMA synchronous=NORMAL;\n\
-             PRAGMA foreign_keys=OFF;",
-        )
-        .await?;
+        // turso 0.5 uses WAL by default and doesn't expose a
+        // `PRAGMA journal_mode` yet — it's the engine's built-in
+        // durability mode. No pragma batch needed.
 
-        conn.execute_batch(
+        conn.execute(
             "CREATE TABLE IF NOT EXISTS trust_allowlist (\n\
                manager  TEXT NOT NULL,\n\
                name     TEXT NOT NULL,\n\
                added_at INTEGER NOT NULL,\n\
                PRIMARY KEY (manager, name)\n\
-             ) WITHOUT ROWID;",
+             )",
+            (),
         )
         .await?;
 
@@ -191,19 +192,19 @@ impl TrustAllowlist {
             return Ok(());
         }
 
-        let conn = self.db.connect()?;
-        // Use a transaction so the batch append is atomic. With
-        // WAL + synchronous=NORMAL this remains cheap (one fsync at
-        // commit) but guarantees either all-or-nothing on crash.
-        conn.execute("BEGIN IMMEDIATE", ()).await?;
+        let mut conn = self.db.connect()?;
+        // Batch the appends in a single transaction so the write is
+        // atomic — either all rows land or none do. turso uses WAL
+        // internally so the per-commit cost is one fsync.
+        let tx = conn.transaction().await?;
         for name in &fresh {
-            conn.execute(
+            tx.execute(
                 "INSERT OR IGNORE INTO trust_allowlist (manager, name, added_at) VALUES (?1, ?2, ?3)",
                 params![manager.as_str().to_string(), name.clone(), now],
             )
             .await?;
         }
-        conn.execute("COMMIT", ()).await?;
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/runt-store/src/trust_allowlist.rs
+++ b/crates/runt-store/src/trust_allowlist.rs
@@ -1,0 +1,285 @@
+//! Trust allowlist: the set of `(package_manager, package_name)` pairs
+//! the user has already approved for auto-launch.
+//!
+//! # Storage model
+//!
+//! Durability via libSQL (Turso fork of SQLite). One table:
+//!
+//! ```sql
+//! CREATE TABLE trust_allowlist (
+//!   manager   TEXT NOT NULL,
+//!   name      TEXT NOT NULL,
+//!   added_at  INTEGER NOT NULL,
+//!   PRIMARY KEY (manager, name)
+//! ) WITHOUT ROWID;
+//! ```
+//!
+//! `WITHOUT ROWID` keeps the B-tree keyed by the natural identifier,
+//! which is what we want for both lookup and upsert. `added_at` is
+//! Unix seconds.
+//!
+//! # Hot path
+//!
+//! All rows are loaded into an in-memory `HashSet` at `open()` time.
+//! `contains()` is a pure set lookup — no disk I/O, no `.await`. The
+//! set is the authoritative view inside the running daemon; libSQL is
+//! the durability layer and source of truth on cold start.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use libsql::{params, Builder};
+use parking_lot::RwLock;
+use thiserror::Error;
+
+const DB_FILE: &str = "allowlist.db";
+
+/// Package manager subset the trust surface covers today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PackageManager {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+impl PackageManager {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PackageManager::Uv => "uv",
+            PackageManager::Conda => "conda",
+            PackageManager::Pixi => "pixi",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "uv" => Some(PackageManager::Uv),
+            "conda" => Some(PackageManager::Conda),
+            "pixi" => Some(PackageManager::Pixi),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedPackage {
+    pub manager: PackageManager,
+    pub name: String,
+    pub added_at: i64,
+}
+
+#[derive(Debug, Error)]
+pub enum TrustAllowlistError {
+    #[error("libsql error: {0}")]
+    LibSql(#[from] libsql::Error),
+    #[error("store directory unavailable")]
+    NoStoreDir,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("system clock before unix epoch: {0}")]
+    Clock(#[from] std::time::SystemTimeError),
+}
+
+/// In-memory view of the allowlist backed by a libSQL database on disk.
+#[derive(Clone)]
+pub struct TrustAllowlist {
+    entries: Arc<RwLock<HashSet<(PackageManager, String)>>>,
+    db: Arc<libsql::Database>,
+}
+
+impl TrustAllowlist {
+    /// Open (or create) the allowlist at `store_dir`. Creates the
+    /// directory + database file if missing, applies the schema, and
+    /// loads every row into the in-memory set.
+    pub async fn open(store_dir: &Path) -> Result<Self, TrustAllowlistError> {
+        tokio::fs::create_dir_all(store_dir).await?;
+        let db_path = store_dir.join(DB_FILE);
+        let db = Builder::new_local(&db_path).build().await?;
+        let conn = db.connect()?;
+
+        // Pragmas tuned for a local, single-process store: WAL so
+        // readers and writers don't block each other, NORMAL sync
+        // (WAL is already durable on checkpoint, full FSYNC is
+        // overkill for accumulated user decisions), foreign_keys off
+        // (nothing references us).
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\n\
+             PRAGMA synchronous=NORMAL;\n\
+             PRAGMA foreign_keys=OFF;",
+        )
+        .await?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trust_allowlist (\n\
+               manager  TEXT NOT NULL,\n\
+               name     TEXT NOT NULL,\n\
+               added_at INTEGER NOT NULL,\n\
+               PRIMARY KEY (manager, name)\n\
+             ) WITHOUT ROWID;",
+        )
+        .await?;
+
+        let mut entries = HashSet::new();
+        let mut rows = conn
+            .query("SELECT manager, name FROM trust_allowlist", ())
+            .await?;
+        while let Some(row) = rows.next().await? {
+            let manager: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            if let Some(manager) = PackageManager::parse(&manager) {
+                entries.insert((manager, name));
+            }
+        }
+
+        Ok(Self {
+            entries: Arc::new(RwLock::new(entries)),
+            db: Arc::new(db),
+        })
+    }
+
+    /// Hot path: does the `(manager, name)` pair live in the allowlist?
+    /// Pure in-memory lookup — no disk I/O, no `.await`.
+    pub fn contains(&self, manager: PackageManager, name: &str) -> bool {
+        self.entries.read().contains(&(manager, name.to_string()))
+    }
+
+    /// Return candidates that are NOT already on the allowlist. Used
+    /// by the dialog's partial-coverage UI.
+    pub fn novel<'a, I>(&self, candidates: I) -> Vec<(PackageManager, String)>
+    where
+        I: IntoIterator<Item = (PackageManager, &'a str)>,
+    {
+        let guard = self.entries.read();
+        candidates
+            .into_iter()
+            .filter(|(manager, name)| !guard.contains(&(*manager, name.to_string())))
+            .map(|(manager, name)| (manager, name.to_string()))
+            .collect()
+    }
+
+    /// Append a batch of packages to the allowlist. Already-present
+    /// entries are skipped via the in-memory dedup; DB upserts use
+    /// `OR IGNORE` as defense-in-depth.
+    pub async fn add(
+        &self,
+        manager: PackageManager,
+        names: &[String],
+    ) -> Result<(), TrustAllowlistError> {
+        if names.is_empty() {
+            return Ok(());
+        }
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_secs() as i64;
+
+        let fresh: Vec<String> = {
+            let mut guard = self.entries.write();
+            names
+                .iter()
+                .filter_map(|n| {
+                    if guard.insert((manager, n.clone())) {
+                        Some(n.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+        if fresh.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.db.connect()?;
+        // Use a transaction so the batch append is atomic. With
+        // WAL + synchronous=NORMAL this remains cheap (one fsync at
+        // commit) but guarantees either all-or-nothing on crash.
+        conn.execute("BEGIN IMMEDIATE", ()).await?;
+        for name in &fresh {
+            conn.execute(
+                "INSERT OR IGNORE INTO trust_allowlist (manager, name, added_at) VALUES (?1, ?2, ?3)",
+                params![manager.as_str().to_string(), name.clone(), now],
+            )
+            .await?;
+        }
+        conn.execute("COMMIT", ()).await?;
+        Ok(())
+    }
+
+    /// Remove a single entry. No-op when it's not present.
+    pub async fn remove(
+        &self,
+        manager: PackageManager,
+        name: &str,
+    ) -> Result<(), TrustAllowlistError> {
+        let removed = {
+            let mut guard = self.entries.write();
+            guard.remove(&(manager, name.to_string()))
+        };
+        if !removed {
+            return Ok(());
+        }
+        let conn = self.db.connect()?;
+        conn.execute(
+            "DELETE FROM trust_allowlist WHERE manager = ?1 AND name = ?2",
+            params![manager.as_str().to_string(), name.to_string()],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Snapshot names for a given manager (sorted).
+    pub fn list(&self, manager: PackageManager) -> Vec<String> {
+        let guard = self.entries.read();
+        let mut out: Vec<String> = guard
+            .iter()
+            .filter(|(m, _)| *m == manager)
+            .map(|(_, n)| n.clone())
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Snapshot with timestamps. Heavier than `list` — reads from the DB.
+    pub async fn list_all(&self) -> Result<Vec<TrustedPackage>, TrustAllowlistError> {
+        let conn = self.db.connect()?;
+        let mut rows = conn
+            .query(
+                "SELECT manager, name, added_at FROM trust_allowlist ORDER BY manager, name",
+                (),
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let manager: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let added_at: i64 = row.get(2)?;
+            if let Some(manager) = PackageManager::parse(&manager) {
+                out.push(TrustedPackage {
+                    manager,
+                    name,
+                    added_at,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Drop all entries. Used by tests and by an eventual "forget"
+    /// action in the UI.
+    pub async fn clear(&self) -> Result<(), TrustAllowlistError> {
+        self.entries.write().clear();
+        let conn = self.db.connect()?;
+        conn.execute("DELETE FROM trust_allowlist", ()).await?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().is_empty()
+    }
+}

--- a/crates/runt-store/tests/trust_allowlist.rs
+++ b/crates/runt-store/tests/trust_allowlist.rs
@@ -1,0 +1,162 @@
+//! Integration tests for `TrustAllowlist` (libSQL backend).
+//!
+//! Identical shape to the Lance spike's tests so the two can be
+//! compared directly. Any divergence is a real semantic difference
+//! between the backends, not a test-harness artifact.
+
+use runt_store::{PackageManager, TrustAllowlist};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn fresh_store_is_empty() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert!(store.is_empty());
+    assert!(!store.contains(PackageManager::Uv, "pandas"));
+}
+
+#[tokio::test]
+async fn add_then_contains() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    assert!(store.contains(PackageManager::Uv, "pandas"));
+    assert!(store.contains(PackageManager::Uv, "numpy"));
+    assert!(!store.contains(PackageManager::Conda, "pandas"));
+}
+
+#[tokio::test]
+async fn add_is_idempotent_in_memory() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(store.len(), 1);
+}
+
+#[tokio::test]
+async fn novel_returns_uncovered_only() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    let novel = store.novel([
+        (PackageManager::Uv, "pandas"),
+        (PackageManager::Uv, "numpy"),
+        (PackageManager::Uv, "polars"),
+    ]);
+    assert_eq!(novel, vec![(PackageManager::Uv, "polars".to_string())]);
+}
+
+#[tokio::test]
+async fn reopen_restores_entries() {
+    let tmp = TempDir::new().unwrap();
+    {
+        let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+        store
+            .add(
+                PackageManager::Conda,
+                &["scipy".to_string(), "matplotlib".to_string()],
+            )
+            .await
+            .unwrap();
+    }
+    // Drop and reopen — verifies WAL + on-disk state.
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert_eq!(store.len(), 2);
+    assert!(store.contains(PackageManager::Conda, "scipy"));
+    assert!(store.contains(PackageManager::Conda, "matplotlib"));
+}
+
+#[tokio::test]
+async fn remove_drops_single_entry() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store.remove(PackageManager::Uv, "pandas").await.unwrap();
+    assert!(!store.contains(PackageManager::Uv, "pandas"));
+    assert!(store.contains(PackageManager::Uv, "numpy"));
+
+    store
+        .remove(PackageManager::Uv, "never-existed")
+        .await
+        .unwrap();
+    assert_eq!(store.len(), 1);
+}
+
+#[tokio::test]
+async fn list_filters_by_manager() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store
+        .add(PackageManager::Conda, &["scipy".to_string()])
+        .await
+        .unwrap();
+
+    let uv = store.list(PackageManager::Uv);
+    assert_eq!(uv, vec!["numpy".to_string(), "pandas".to_string()]);
+    let conda = store.list(PackageManager::Conda);
+    assert_eq!(conda, vec!["scipy".to_string()]);
+}
+
+#[tokio::test]
+async fn list_all_round_trips_timestamps() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(PackageManager::Uv, &["pandas".to_string()])
+        .await
+        .unwrap();
+    let all = store.list_all().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].name, "pandas");
+    assert!(all[0].added_at > 0);
+}
+
+#[tokio::test]
+async fn clear_empties_both_views() {
+    let tmp = TempDir::new().unwrap();
+    let store = TrustAllowlist::open(tmp.path()).await.unwrap();
+    store
+        .add(
+            PackageManager::Uv,
+            &["pandas".to_string(), "numpy".to_string()],
+        )
+        .await
+        .unwrap();
+    store.clear().await.unwrap();
+    assert!(store.is_empty());
+    drop(store);
+    let reopened = TrustAllowlist::open(tmp.path()).await.unwrap();
+    assert!(reopened.is_empty());
+}


### PR DESCRIPTION
**Not for merge.** Third backend artifact after #2176 (Lance) and #2178 (libSQL). Closing after review; branch stays reachable.

## What this spike is

`runt-store` with the `turso` crate (0.5.3) as durability — the Turso team's ground-up, pure-Rust rewrite of the SQLite engine. Same `TrustAllowlist` facade, same 9 integration tests, same criterion harness, same binary-size measurement methodology.

## Why look at this

libSQL (#2178) is SQLite with Rust wrappers — still a C library underneath (`libsql-ffi`, `libsql-sys`, cc, bindgen). The `turso` crate is 100% Rust — no C toolchain, no bindgen. That's a supply-chain and cross-compilation win if the performance and maturity are close enough.

## API swap diff

Minimal — the `turso` crate is API-compatible with libsql by design:

- `libsql` → `turso` imports.
- `Builder::new_local(&Path)` → `new_local(&str)` (had to `.to_str()` the path).
- Explicit `BEGIN IMMEDIATE`/`COMMIT` via `execute` → `conn.transaction()` + `tx.commit()`.
- Dropped `WITHOUT ROWID` from the schema — turso 0.5's parser doesn't accept it yet. Same semantics for our workload (primary-key lookup either way), but flagging the maturity gap.

Integration tests: 9/9 pass in ~20ms.

## Numbers

All from the same macOS arm64 machine. See #2176 and #2178 for the baselines in context.

| Metric | Lance | libSQL | **Turso (Rust)** |
|---|---|---|---|
| Binary delta (runtimed) | +25 MB | +1 MB | **+4 MB** |
| `contains()` hit | 82 ns | 60 ns | **56 ns** |
| `contains()` miss | 95 ns | 60 ns | **56 ns** |
| `novel(20 vs 1k)` | 1.62 µs | 1.29 µs | **1.20 µs** |
| `cold_load` 100 rows | 642 µs | 429 µs | **285 µs** |
| `cold_load` 1k rows | 889 µs | 888 µs | 891 µs |
| `cold_load` 10k rows | **2.6 ms** | 4.47 ms | 6.15 ms |
| `add()` + commit | 1.35 ms | 497 µs | **98 µs** ⚠ |
| Tests | 9/9 | 9/9 | 9/9 |

## The suspicious `add()` number

Turso at 98 µs vs libSQL at 497 µs is a 5× delta on single-row commit. SQLite with WAL + `synchronous=NORMAL` (libSQL's default) does one `fsync` per commit, which is the minimum for durability. 98 µs is suspicious for that on this hardware.

Likely explanations:
- Turso 0.5 may not be issuing `fsync` on commit by default.
- Turso's `PRAGMA synchronous` handling may differ — the codebase has the pragma in its internal benchmarks but default behavior isn't clear from a quick read.
- macOS-specific: libsql uses `F_FULLFSYNC` for real durability; turso's `io/unix.rs` has `FullFsync` as a `FileSyncType` variant but may not invoke it on every commit.

Bottom line: we **shouldn't** trust the write-perf number until durability semantics are verified. A "fast write" that doesn't hit disk isn't a real comparison to libSQL's "slow write" that does.

## Ergonomics

- **Build time**: fresh workspace build with `turso` in runt-store took ~85s. libSQL was slightly faster because it reuses its C compile cache across rebuilds. First build from scratch is a wash.
- **No C toolchain**: actually delivers on the promise. No `cc`, no `bindgen`, no SQLite C sources. Dep graph is all Rust crates.
- **Single-file compile**: `cargo build` works on any platform Rust supports without host C prerequisites.

## Maturity gap

- 0.5 pre-1.0. Breaking changes are on the table.
- Parser doesn't accept `WITHOUT ROWID` (minor, workaround trivial).
- FTS5 story is unclear from the surface API — `turso_core` has fts5 module references but I didn't verify at query level.
- Unverified durability story (see above).
- No experience at scale in production embedded contexts (that I know of).

## Recommendation

**libSQL today, turso on the roadmap.**

libSQL wins where it counts right now:
- Stable SQLite semantics.
- Verified fsync on commit.
- FTS5 definitely works.
- +1 MB vs +4 MB.

But the `runt-store` facade is backend-agnostic. When turso reaches 1.0 with:
- Verified durability matching libSQL / stock SQLite.
- Full SQL surface including `WITHOUT ROWID` (minor) and FTS5 (matters).
- A track record of embedded use.

...the swap is a pure dep change. No call-site churn.

## What lives on this branch

- `crates/runt-store/` — facade + `TrustAllowlist` + `paths` module, now backed by turso.
- `benches/trust_allowlist.rs` — same criterion harness.
- `tests/trust_allowlist.rs` — same 9 integration tests.
- No wiring into `runtimed`. Only the workspace `Cargo.toml` adds the crate.

## Decision

Three spikes, same facade. Picking libSQL as the path forward. Next step is promoting one of the spike branches to a real PR that wires `runt-store` into `runtimed` and uses it for #2132.
