### PR TITLE
fix(protocol): cancel-safe FramedReader actor for typed frames

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -751,6 +751,78 @@ pub async fn recv_typed_frame<R: AsyncRead + Unpin>(
     }
 }
 
+/// Cancel-safe wrapper around `recv_typed_frame`.
+///
+/// `recv_typed_frame` is built on `read_exact`, which is *not*
+/// cancel-safe — dropping the future mid-read silently consumes bytes
+/// from the underlying reader and the partial-read state is discarded.
+/// Putting `recv_typed_frame` directly inside a busy `tokio::select!`
+/// arm therefore desyncs the stream the moment another arm wins while
+/// a body read is in flight; the next iteration's length prefix is
+/// read from the middle of the previous payload.
+///
+/// `FramedReader` runs the read loop on a dedicated tokio task that
+/// owns the read half exclusively and publishes frames through a
+/// bounded mpsc channel. `FramedReader::recv()` is just an mpsc
+/// `recv()` — fully cancel-safe — so callers can place it in any
+/// `select!` without losing bytes.
+///
+/// On clean EOF the channel closes and `recv()` returns `None`.
+/// On a stream error the reader sends `Err(e)` once and then closes.
+pub struct FramedReader {
+    rx: tokio::sync::mpsc::Receiver<std::io::Result<TypedNotebookFrame>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl FramedReader {
+    /// Spawn a reader task that owns `reader`. `capacity` bounds the
+    /// in-flight frame queue so a slow consumer applies backpressure
+    /// to the source.
+    pub fn spawn<R>(mut reader: R, capacity: usize) -> Self
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        let handle = tokio::spawn(async move {
+            loop {
+                match recv_typed_frame(&mut reader).await {
+                    Ok(Some(frame)) => {
+                        if tx.send(Ok(frame)).await.is_err() {
+                            // Receiver dropped — caller is gone, stop reading.
+                            break;
+                        }
+                    }
+                    Ok(None) => break, // clean EOF, drop tx, channel closes
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        break;
+                    }
+                }
+            }
+        });
+        Self { rx, handle }
+    }
+
+    /// Cancel-safe receive of the next frame.
+    ///
+    /// Returns `Some(Ok(frame))` for each successful frame,
+    /// `Some(Err(_))` once on a stream error, and `None` once the
+    /// reader task has finished (clean EOF or post-error close).
+    pub async fn recv(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+        self.rx.recv().await
+    }
+}
+
+impl Drop for FramedReader {
+    fn drop(&mut self) {
+        // Closing the receiver lets the task observe a closed channel
+        // on its next send and exit cleanly. Abort is a backstop for
+        // the case where the task is parked on `read_exact` with no
+        // bytes ever arriving (e.g. half-closed socket).
+        self.handle.abort();
+    }
+}
+
 /// Send a length-prefixed frame.
 ///
 /// Returns an error if the payload exceeds `MAX_FRAME_SIZE` (100 MiB).
@@ -1617,5 +1689,110 @@ mod tests {
             Some(PackageManager::Conda)
         );
         assert_eq!(LaunchSpec::Concrete(EnvSource::Deno).auto_scope(), None);
+    }
+
+    /// `recv_typed_frame` is built on `read_exact`, which is NOT cancel-
+    /// safe: dropping the future mid-read silently discards bytes
+    /// already pulled off the underlying reader.
+    ///
+    /// This test exercises the exact misuse pattern that desynced the
+    /// runtime-agent ↔ daemon channel under heavy stream output: a peer
+    /// loop puts `recv_typed_frame` in a `tokio::select!` arm next to a
+    /// high-frequency cancel-safe arm. When the cancel-safe arm wins
+    /// while a body read is in flight, the next iteration's
+    /// `recv_typed_frame` reads its 4-byte length prefix from the middle
+    /// of the previous payload and flags `frame too large` (production
+    /// repros saw 0x20202020 from indented kernel stdout and 0x6C6C6F6E
+    /// from "...loaded kernel_..." text).
+    ///
+    /// `FramedReader` is the structural fix: a dedicated reader task
+    /// owns the read half and publishes frames through an mpsc, whose
+    /// `recv()` is cancel-safe.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn framed_reader_does_not_desync_in_select_under_pressure() {
+        use tokio::io::duplex;
+        use tokio::sync::mpsc;
+        use tokio::time::{timeout, Duration};
+
+        // Tiny duplex buffer forces multi-poll reads, mirroring the real
+        // socket pressure that triggered the production desync.
+        let (server_side, client_side) = duplex(64);
+        let (_server_read, mut writer) = tokio::io::split(server_side);
+        let (reader, _client_write) = tokio::io::split(client_side);
+
+        const NUM_FRAMES: usize = 32;
+        const PAYLOAD_SIZE: usize = 4096;
+
+        let writer_task = tokio::spawn(async move {
+            for i in 0u64..NUM_FRAMES as u64 {
+                let mut payload = vec![0u8; PAYLOAD_SIZE];
+                payload[..8].copy_from_slice(&i.to_be_bytes());
+                for (j, b) in payload[8..].iter_mut().enumerate() {
+                    *b = (j & 0xFF) as u8;
+                }
+                send_typed_frame(&mut writer, NotebookFrameType::AutomergeSync, &payload)
+                    .await
+                    .expect("writer should not fail");
+            }
+        });
+
+        // Always-ready cancel-safe interrupter, simulating the real
+        // daemon pressure (state_changed_rx fires per kernel output).
+        let (interrupter_tx, mut interrupter_rx) = mpsc::unbounded_channel::<()>();
+        let pump_token = interrupter_tx.clone();
+        let pump_task = tokio::spawn(async move {
+            loop {
+                if pump_token.send(()).is_err() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let mut framed = FramedReader::spawn(reader, 16);
+
+        let mut received = 0u64;
+        let receive_loop = async {
+            while received < NUM_FRAMES as u64 {
+                tokio::select! {
+                    biased;
+                    Some(_) = interrupter_rx.recv() => {
+                        while interrupter_rx.try_recv().is_ok() {}
+                    }
+                    maybe = framed.recv() => {
+                        let frame = maybe
+                            .expect("channel should not close before NUM_FRAMES delivered")
+                            .expect("frame decode should not error mid-stream");
+                        assert_eq!(frame.frame_type, NotebookFrameType::AutomergeSync);
+                        assert_eq!(frame.payload.len(), PAYLOAD_SIZE);
+                        let seq = u64::from_be_bytes(frame.payload[..8].try_into().unwrap());
+                        assert_eq!(
+                            seq, received,
+                            "frame sequence desynced (expected {}, got {})",
+                            received, seq,
+                        );
+                        for (j, b) in frame.payload[8..].iter().enumerate() {
+                            assert_eq!(
+                                *b,
+                                (j & 0xFF) as u8,
+                                "payload corruption at offset {} of frame {}",
+                                j + 8,
+                                received,
+                            );
+                        }
+                        received += 1;
+                    }
+                }
+            }
+        };
+
+        timeout(Duration::from_secs(10), receive_loop)
+            .await
+            .expect("receive loop should complete within 10s");
+
+        pump_task.abort();
+        let _ = pump_task.await;
+        writer_task.await.expect("writer task panicked");
+        assert_eq!(received, NUM_FRAMES as u64);
     }
 }

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -73,10 +73,9 @@ struct PendingEntry {
 /// handles are dropped (command channel closes).
 pub async fn run<R, W>(mut config: RelayTaskConfig, reader: R, writer: W)
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin,
 {
-    let mut reader = tokio::io::BufReader::new(reader);
     let mut writer = tokio::io::BufWriter::new(writer);
 
     let notebook_id = &config.notebook_id;
@@ -84,10 +83,20 @@ where
 
     info!("[relay] Started for {}", notebook_id);
 
+    // Hand the read half to a dedicated FramedReader actor so the busy
+    // `select!` below stays cancel-safe. `recv_typed_frame`'s internal
+    // `read_exact` calls drop bytes when the future is cancelled
+    // mid-read — production logs captured this as
+    // `frame too large: 1818192238 bytes` (mid-payload text from a
+    // streaming kernel output reinterpreted as a length prefix).
+    // BufReader stays for syscall coalescing inside the actor task.
+    let buffered = tokio::io::BufReader::new(reader);
+    let mut framed_reader = connection::FramedReader::spawn(buffered, 16);
+
     loop {
         enum SelectResult {
             Command(Option<RelayCommand>),
-            Frame(std::io::Result<Option<connection::TypedNotebookFrame>>),
+            Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
         }
 
         let select_result = tokio::select! {
@@ -95,7 +104,7 @@ where
             // Prioritize incoming daemon frames (sync, broadcast, presence,
             // responses) over outgoing commands. Keeping frames flowing
             // prevents head divergence; commands can wait a tick.
-            frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
+            frame = framed_reader.recv() => SelectResult::Frame(frame),
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
         };
 
@@ -154,17 +163,17 @@ where
                 }
             },
 
-            SelectResult::Frame(Ok(Some(frame))) => {
+            SelectResult::Frame(Some(Ok(frame))) => {
                 route_incoming_frame(&frame, &mut pending, &config.frame_tx);
             }
 
-            SelectResult::Frame(Ok(None)) => {
-                info!("[relay] Daemon closed connection for {}", notebook_id);
+            SelectResult::Frame(Some(Err(e))) => {
+                warn!("[relay] Read error for {}: {}", notebook_id, e);
                 break;
             }
 
-            SelectResult::Frame(Err(e)) => {
-                warn!("[relay] Read error for {}: {}", notebook_id, e);
+            SelectResult::Frame(None) => {
+                info!("[relay] Daemon closed connection for {}", notebook_id);
                 break;
             }
         }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -153,10 +153,17 @@ struct SyncFrameContext<'a> {
 /// It is NEVER held across `.await` points (socket I/O).
 pub async fn run<R, W>(mut config: SyncTaskConfig, reader: R, writer: W)
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin,
 {
-    let mut reader = tokio::io::BufReader::new(reader);
+    // Hand the read half to a dedicated FramedReader actor so the
+    // busy `select!` (and the `timeout(.., recv)` ack pattern) below
+    // stay cancel-safe. `recv_typed_frame`'s internal `read_exact`
+    // drops bytes mid-read whenever its future is cancelled — the
+    // exact failure mode that desyncs the wire under stream-output
+    // pressure.
+    let buffered = tokio::io::BufReader::new(reader);
+    let mut framed_reader = connection::FramedReader::spawn(buffered, 16);
     let mut writer = tokio::io::BufWriter::new(writer);
 
     let notebook_id = {
@@ -181,7 +188,7 @@ where
         enum SelectResult {
             Changed,
             Command(Option<SyncCommand>),
-            Frame(std::io::Result<Option<connection::TypedNotebookFrame>>),
+            Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
         }
 
         let select_result = tokio::select! {
@@ -200,8 +207,8 @@ where
             // Protocol command (request/response, confirm_sync, etc.)
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
 
-            // Incoming frame from daemon
-            frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
+            // Incoming frame from daemon (cancel-safe: actor owns read_exact)
+            frame = framed_reader.recv() => SelectResult::Frame(frame),
         };
 
         match select_result {
@@ -233,13 +240,8 @@ where
                 }
 
                 // Wait briefly for an ack from the daemon (like sync_to_daemon)
-                match tokio::time::timeout(
-                    Duration::from_millis(500),
-                    connection::recv_typed_frame(&mut reader),
-                )
-                .await
-                {
-                    Ok(Ok(Some(frame))) => {
+                match tokio::time::timeout(Duration::from_millis(500), framed_reader.recv()).await {
+                    Ok(Some(Ok(frame))) => {
                         SyncFrameContext {
                             doc: &config.doc,
                             snapshot_tx: &config.snapshot_tx,
@@ -251,11 +253,11 @@ where
                         .handle_incoming_frame(&frame, &mut writer)
                         .await;
                     }
-                    Ok(Ok(None)) => {
+                    Ok(None) => {
                         info!("[notebook-sync] Connection closed for {}", notebook_id);
                         break;
                     }
-                    Ok(Err(e)) => {
+                    Ok(Some(Err(e))) => {
                         warn!("[notebook-sync] Socket error for {}: {}", notebook_id, e);
                         break;
                     }
@@ -283,7 +285,7 @@ where
                         broadcast_tx: req_broadcast_tx,
                     } => {
                         let result = send_request_impl(
-                            &mut reader,
+                            &mut framed_reader,
                             &mut writer,
                             req_broadcast_tx.as_ref(),
                             &request,
@@ -302,7 +304,7 @@ where
 
                     SyncCommand::ConfirmSync { reply } => {
                         let result = confirm_sync_impl(
-                            &mut reader,
+                            &mut framed_reader,
                             &mut writer,
                             &mut SyncFrameContext {
                                 doc: &config.doc,
@@ -319,7 +321,7 @@ where
 
                     SyncCommand::ConfirmStateSync { reply } => {
                         let result = confirm_state_sync_impl(
-                            &mut reader,
+                            &mut framed_reader,
                             &mut writer,
                             &mut SyncFrameContext {
                                 doc: &config.doc,
@@ -349,7 +351,7 @@ where
 
             // ─── Incoming frame from daemon ────────────────────────────────
             SelectResult::Frame(frame_result) => match frame_result {
-                Ok(Some(frame)) => {
+                Some(Ok(frame)) => {
                     SyncFrameContext {
                         doc: &config.doc,
                         snapshot_tx: &config.snapshot_tx,
@@ -361,14 +363,14 @@ where
                     .handle_incoming_frame(&frame, &mut writer)
                     .await;
                 }
-                Ok(None) => {
+                None => {
                     info!(
                         "[notebook-sync] Disconnected from daemon for {}, loop_count={}",
                         notebook_id, loop_count
                     );
                     break;
                 }
-                Err(e) => {
+                Some(Err(e)) => {
                     warn!(
                         "[notebook-sync] Socket error for {}: {}, loop_count={}",
                         notebook_id, e, loop_count
@@ -661,8 +663,8 @@ impl SyncFrameContext<'_> {
 ///
 /// While waiting, also processes AutomergeSync and Broadcast frames that arrive
 /// interleaved with the response.
-async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    reader: &mut R,
+async fn send_request_impl<W: AsyncWrite + Unpin>(
+    framed: &mut connection::FramedReader,
     writer: &mut W,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
@@ -685,7 +687,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     // Wait for a Response frame, processing other frames that arrive meanwhile
     let result = tokio::time::timeout(
         Duration::from_secs(timeout_secs),
-        wait_for_response(reader, writer, req_broadcast_tx, ctx),
+        wait_for_response(framed, writer, req_broadcast_tx, ctx),
     )
     .await;
 
@@ -697,17 +699,18 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 }
 
 /// Wait for a Response frame from the daemon, processing other frames.
-async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    reader: &mut R,
+async fn wait_for_response<W: AsyncWrite + Unpin>(
+    framed: &mut connection::FramedReader,
     writer: &mut W,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     ctx: &mut SyncFrameContext<'_>,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
-        let frame = connection::recv_typed_frame(reader)
+        let frame = framed
+            .recv()
             .await
-            .map_err(SyncError::Io)?
-            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
+            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?
+            .map_err(SyncError::Io)?;
 
         match frame.frame_type {
             NotebookFrameType::Response => {
@@ -808,8 +811,8 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 ///
 /// Performs sync rounds until our local heads are in the peer's shared_heads,
 /// or until we've done 5 rounds (best-effort).
-async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    reader: &mut R,
+async fn confirm_sync_impl<W: AsyncWrite + Unpin>(
+    framed: &mut connection::FramedReader,
     writer: &mut W,
     ctx: &mut SyncFrameContext<'_>,
 ) -> Result<(), SyncError> {
@@ -840,21 +843,16 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         }
 
         // Wait for response
-        match tokio::time::timeout(
-            Duration::from_millis(2000),
-            connection::recv_typed_frame(reader),
-        )
-        .await
-        {
-            Ok(Ok(Some(frame))) => {
+        match tokio::time::timeout(Duration::from_millis(2000), framed.recv()).await {
+            Ok(Some(Ok(frame))) => {
                 ctx.handle_incoming_frame(&frame, writer).await;
             }
-            Ok(Ok(None)) => {
+            Ok(None) => {
                 return Err(SyncError::Protocol(
                     "Connection closed during confirm_sync".into(),
                 ));
             }
-            Ok(Err(e)) => {
+            Ok(Some(Err(e))) => {
                 return Err(SyncError::Io(e));
             }
             Err(_) => {
@@ -880,8 +878,8 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 /// The client never writes to the state doc, so there is no convergence
 /// to negotiate. We send our current heads (so the daemon can reply with
 /// anything we're missing) and then drain frames with a short timeout.
-async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
-    reader: &mut R,
+async fn confirm_state_sync_impl<W: AsyncWrite + Unpin>(
+    framed: &mut connection::FramedReader,
     writer: &mut W,
     ctx: &mut SyncFrameContext<'_>,
 ) -> Result<(), SyncError> {
@@ -898,21 +896,16 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
     // Drain up to 10 frames with a 200ms per-frame timeout.
     for _ in 0..10 {
-        match tokio::time::timeout(
-            Duration::from_millis(200),
-            connection::recv_typed_frame(reader),
-        )
-        .await
-        {
-            Ok(Ok(Some(frame))) => {
+        match tokio::time::timeout(Duration::from_millis(200), framed.recv()).await {
+            Ok(Some(Ok(frame))) => {
                 ctx.handle_incoming_frame(&frame, writer).await;
             }
-            Ok(Ok(None)) => {
+            Ok(None) => {
                 return Err(SyncError::Protocol(
                     "Connection closed during state sync flush".into(),
                 ));
             }
-            Ok(Err(e)) => {
+            Ok(Some(Err(e))) => {
                 return Err(SyncError::Io(e));
             }
             Err(_) => break, // timeout — done draining

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1862,7 +1862,7 @@ impl Daemon {
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
-        S: AsyncRead + AsyncWrite + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
             send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,
@@ -2215,7 +2215,7 @@ impl Daemon {
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
-        S: AsyncRead + AsyncWrite + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
             send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -26,17 +26,23 @@ use runtime_doc::RuntimeLifecycle;
 /// 3. Fires `runtime_agent_connected` to unblock LaunchKernel
 /// 4. Enters a sync loop relaying frames bidirectionally
 pub async fn handle_runtime_agent_sync_connection<R, W>(
-    mut reader: R,
+    reader: R,
     mut writer: W,
     room: Arc<NotebookRoom>,
     notebook_id: String,
     runtime_agent_id: String,
 ) where
-    R: tokio::io::AsyncRead + Unpin + Send,
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send,
 {
-    use notebook_protocol::connection::{recv_typed_frame, send_typed_frame, NotebookFrameType};
+    use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
     use notebook_protocol::protocol::RuntimeAgentResponse;
+
+    // Frames are received on a dedicated task so the busy `select!`
+    // below stays cancel-safe — `recv_typed_frame`'s internal
+    // `read_exact` calls would otherwise drop bytes mid-read whenever
+    // another arm wins, desyncing the runtime-agent ↔ daemon stream.
+    let mut framed_reader = FramedReader::spawn(reader, 16);
 
     info!(
         "[notebook-sync] Runtime agent sync connection: notebook={} runtime_agent={}",
@@ -139,73 +145,72 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
 
     loop {
         tokio::select! {
-            // Frames from runtime agent
-            frame = recv_typed_frame(&mut reader) => {
-                match frame {
-                    Ok(Some(typed_frame)) => {
-                        match typed_frame.frame_type {
-                            NotebookFrameType::AutomergeSync => {
-                                if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
-                                    let mut doc = room.doc.write().await;
-                                    if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
-                                        let _ = room.broadcasts.changed_tx.send(());
-                                    }
-                                    // Send sync reply
-                                    if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
-                                        let encoded = reply.encode();
-                                        let _ = send_typed_frame(
-                                            &mut writer,
-                                            NotebookFrameType::AutomergeSync,
-                                            &encoded,
-                                        ).await;
-                                    }
-                                }
-                            }
-                            NotebookFrameType::RuntimeStateSync => {
-                                if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
-                                    let reply_encoded = room.state.with_doc(|sd| {
-                                        if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                            &mut state_sync_state, msg,
-                                        ) {
-                                            if changed {
-                                                // Notification handled by with_doc heads check
-                                            }
-                                        }
-                                        Ok(sd.generate_sync_message(&mut state_sync_state)
-                                            .map(|reply| reply.encode()))
-                                    }).ok().flatten();
-                                    if let Some(encoded) = reply_encoded {
-                                        let _ = send_typed_frame(
-                                            &mut writer,
-                                            NotebookFrameType::RuntimeStateSync,
-                                            &encoded,
-                                        ).await;
-                                    }
-                                }
-                            }
-                            NotebookFrameType::Response => {
-                                if let Ok(envelope) = serde_json::from_slice::<
-                                    notebook_protocol::protocol::RuntimeAgentResponseEnvelope,
-                                >(&typed_frame.payload) {
-                                    if let Some(reply) = pending_replies.remove(&envelope.id) {
-                                        let _ = reply.send(envelope.response);
-                                    } else {
-                                        debug!("[notebook-sync] Agent response for unknown id: {}", envelope.id);
-                                    }
-                                }
-                            }
-                            _ => {
-                                debug!("[notebook-sync] Agent sent unexpected frame type: {:?}", typed_frame.frame_type);
-                            }
-                        }
+            // Frames from runtime agent (cancel-safe via FramedReader actor)
+            maybe_frame = framed_reader.recv() => {
+                let typed_frame = match maybe_frame {
+                    Some(Ok(frame)) => frame,
+                    Some(Err(e)) => {
+                        info!("[notebook-sync] Agent disconnected: {}", e);
+                        break;
                     }
-                    Ok(None) => {
+                    None => {
                         info!("[notebook-sync] Agent disconnected (EOF)");
                         break;
                     }
-                    Err(e) => {
-                        info!("[notebook-sync] Agent disconnected: {}", e);
-                        break;
+                };
+                match typed_frame.frame_type {
+                    NotebookFrameType::AutomergeSync => {
+                        if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                            let mut doc = room.doc.write().await;
+                            if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
+                                let _ = room.broadcasts.changed_tx.send(());
+                            }
+                            // Send sync reply
+                            if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
+                                let encoded = reply.encode();
+                                let _ = send_typed_frame(
+                                    &mut writer,
+                                    NotebookFrameType::AutomergeSync,
+                                    &encoded,
+                                ).await;
+                            }
+                        }
+                    }
+                    NotebookFrameType::RuntimeStateSync => {
+                        if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                            let reply_encoded = room.state.with_doc(|sd| {
+                                if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                    &mut state_sync_state, msg,
+                                ) {
+                                    if changed {
+                                        // Notification handled by with_doc heads check
+                                    }
+                                }
+                                Ok(sd.generate_sync_message(&mut state_sync_state)
+                                    .map(|reply| reply.encode()))
+                            }).ok().flatten();
+                            if let Some(encoded) = reply_encoded {
+                                let _ = send_typed_frame(
+                                    &mut writer,
+                                    NotebookFrameType::RuntimeStateSync,
+                                    &encoded,
+                                ).await;
+                            }
+                        }
+                    }
+                    NotebookFrameType::Response => {
+                        if let Ok(envelope) = serde_json::from_slice::<
+                            notebook_protocol::protocol::RuntimeAgentResponseEnvelope,
+                        >(&typed_frame.payload) {
+                            if let Some(reply) = pending_replies.remove(&envelope.id) {
+                                let _ = reply.send(envelope.response);
+                            } else {
+                                debug!("[notebook-sync] Agent response for unknown id: {}", envelope.id);
+                            }
+                        }
+                    }
+                    _ => {
+                        debug!("[notebook-sync] Agent sent unexpected frame type: {:?}", typed_frame.frame_type);
                     }
                 }
             }
@@ -326,7 +331,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
 /// is already communicated in the NotebookConnectionInfo response.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
-    mut reader: R,
+    reader: R,
     mut writer: W,
     room: Arc<NotebookRoom>,
     rooms: NotebookRooms,
@@ -346,7 +351,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin,
 {
     // Set working_dir on the room if provided (for untitled notebook project detection)
@@ -545,7 +550,7 @@ where
     let peer_id = uuid::Uuid::new_v4().to_string();
 
     let result = run_sync_loop_v2(
-        &mut reader,
+        reader,
         &mut writer,
         &room,
         rooms.clone(),
@@ -1126,9 +1131,13 @@ where
 ///
 /// Handles both Automerge sync messages and NotebookRequest messages.
 /// This protocol supports daemon-owned kernel execution (Phase 8).
+///
+/// Takes `reader` by value because the post-streaming-load main loop
+/// hands it to a `FramedReader` actor; from that point the read half
+/// belongs to the dedicated reader task, not this select loop.
 #[allow(clippy::too_many_arguments)]
 async fn run_sync_loop_v2<R, W>(
-    reader: &mut R,
+    mut reader: R,
     writer: &mut W,
     room: &Arc<NotebookRoom>,
     _rooms: NotebookRooms,
@@ -1139,7 +1148,7 @@ async fn run_sync_loop_v2<R, W>(
     client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin,
 {
     // Subscribe before sending bootstrap traffic so any writes that land
@@ -1234,7 +1243,8 @@ where
     // frontend can observe progressive notebook-doc updates.
     if let Some(load_path) = needs_load {
         if room.try_start_loading() {
-            match streaming_load_cells(reader, writer, room, load_path, &mut peer_state).await {
+            match streaming_load_cells(&mut reader, writer, room, load_path, &mut peer_state).await
+            {
                 Ok(count) => {
                     room.finish_loading();
                     info!(
@@ -1356,14 +1366,24 @@ where
     let mut prune_interval = tokio::time::interval(prune_period);
     prune_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    // Hand the reader off to a dedicated FramedReader actor before
+    // entering the busy `select!` below. `recv_typed_frame`'s internal
+    // `read_exact` calls are NOT cancel-safe — putting them directly
+    // in a `select!` arm desyncs the framed stream the moment another
+    // arm wins mid-payload (see issue + production diagnostics).
+    let mut framed_reader = connection::FramedReader::spawn(reader, 16);
+
     // Phase 2: Exchange messages until sync is complete, then watch for changes
     loop {
         tokio::select! {
-            // Incoming message from this client
-            result = connection::recv_typed_frame(reader) => {
-                match result? {
-                    Some(frame) => {
-                        match frame.frame_type {
+            // Incoming message from this client (cancel-safe via FramedReader actor)
+            maybe_frame = framed_reader.recv() => {
+                let frame = match maybe_frame {
+                    Some(Ok(frame)) => frame,
+                    Some(Err(e)) => return Err(e.into()),
+                    None => return Ok(()), // clean EOF
+                };
+                match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 // Handle Automerge sync message
                                 let message = sync::Message::decode(&frame.payload)
@@ -1762,12 +1782,6 @@ where
                                 );
                             }
                         }
-                    }
-                    None => {
-                        // Client disconnected
-                        return Ok(());
-                    }
-                }
             }
 
             // Another peer changed the document — push update to this client

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -35,8 +35,7 @@ use std::sync::Arc;
 
 use notebook_doc::presence::PresenceState;
 use notebook_protocol::connection::{
-    recv_typed_frame, send_json_frame, send_preamble, send_typed_frame, Handshake,
-    NotebookFrameType,
+    send_json_frame, send_preamble, send_typed_frame, FramedReader, Handshake, NotebookFrameType,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use runtime_doc::RuntimeStateHandle;
@@ -75,10 +74,17 @@ pub async fn run_runtime_agent(
 
     // -- 1. Connect to daemon socket ----------------------------------------
 
-    let (mut reader, mut writer) =
+    let (reader, mut writer) =
         connect_and_handshake(&socket_path, &notebook_id, &runtime_agent_id, &blob_root).await?;
 
     info!("[runtime-agent] Connected to daemon, handshake sent");
+
+    // Hand the read half to a dedicated FramedReader actor so the busy
+    // `select!` below stays cancel-safe — `recv_typed_frame`'s
+    // `read_exact` calls would otherwise drop bytes mid-read whenever
+    // another arm wins, producing the runtime-agent ↔ daemon desync
+    // captured in production logs as `frame too large: 538976288 bytes`.
+    let mut framed_reader = FramedReader::spawn(reader, 16);
 
     // -- 2. Bootstrap RuntimeStateDoc ---------------------------------------
 
@@ -120,10 +126,10 @@ pub async fn run_runtime_agent(
 
     loop {
         tokio::select! {
-            // Read frames from daemon socket
-            frame = recv_typed_frame(&mut reader) => {
-                match frame {
-                    Ok(Some(typed_frame)) => {
+            // Read frames from daemon socket (cancel-safe via FramedReader actor)
+            maybe_frame = framed_reader.recv() => {
+                match maybe_frame {
+                    Some(Ok(typed_frame)) => {
                         match typed_frame.frame_type {
                             // RuntimeAgentRequest: envelope with correlation ID.
                             // Commands (fire-and-forget) get no response.
@@ -303,11 +309,7 @@ pub async fn run_runtime_agent(
                             }
                         }
                     }
-                    Ok(None) => {
-                        info!("[runtime-agent] Daemon disconnected (EOF)");
-                        break;
-                    }
-                    Err(e) => {
+                    Some(Err(e)) => {
                         // A framing error here means one of two things:
                         //   - the daemon half-closed the sync stream (clean),
                         //     which we treat as a disconnect,
@@ -325,6 +327,9 @@ pub async fn run_runtime_agent(
                              (kernel stays running)",
                             e
                         );
+                        // Drop the old framed reader before reconnecting so
+                        // its background task exits cleanly.
+                        drop(framed_reader);
                         match reconnect_with_backoff(
                             &socket_path,
                             &notebook_id,
@@ -334,7 +339,7 @@ pub async fn run_runtime_agent(
                         .await
                         {
                             Ok((new_reader, new_writer)) => {
-                                reader = new_reader;
+                                framed_reader = FramedReader::spawn(new_reader, 16);
                                 writer = new_writer;
                                 // The daemon creates a fresh sync state for
                                 // each connection; match that or the doc
@@ -355,6 +360,10 @@ pub async fn run_runtime_agent(
                                 break;
                             }
                         }
+                    }
+                    None => {
+                        info!("[runtime-agent] Daemon disconnected (EOF)");
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Diagnosis

`recv_typed_frame` is built on `read_exact`, which is not cancel-safe. When a `tokio::select!` arm loses a race mid-payload, the partial read is dropped and the next call reads the remaining bytes as a fresh length prefix. The wire desyncs.

Production caught this twice in one session running a llama-cpp notebook (~54KB of streaming Metal-init stdout):

- frontend relay: `frame too large: 1818192238 bytes` (`0x6C6C6F6E` = `"llon"`)
- daemon-side runtime-agent socket: `frame too large: 538976288 bytes` (`0x20202020` = four spaces)

The runtime-agent socket dies, the runtime agent gets SIGKILLed, and the frontend's ErrorBoundary surfaces ``null pointer passed to rust`` from the now-stale WASM doc.

## The fix

`FramedReader`. A dedicated tokio task owns the read half and pushes parsed frames over a bounded mpsc. Consumers call `framed.recv()`, which is `mpsc::Receiver::recv` and therefore cancel-safe in any `select!`. The `read_exact` calls now live in a task that is never cancelled mid-frame.

```rust
let buffered = tokio::io::BufReader::new(reader);
let mut framed = connection::FramedReader::spawn(buffered, 16);

loop {
    tokio::select! {
        // ...other arms...
        frame = framed.recv() => { /* cancel-safe */ }
    }
}
```

## Sites migrated

| File | Path |
|------|------|
| `crates/notebook-protocol/src/connection.rs` | actor definition + regression test |
| `crates/notebook-sync/src/relay_task.rs` | frontend relay (the path that hit the production crash) |
| `crates/notebook-sync/src/sync_task.rs` | Python client run loop + 4 helpers (`send_request_impl`, `wait_for_response`, `confirm_sync_impl`, `confirm_state_sync_impl`) |
| `crates/runtimed/src/runtime_agent.rs` | runtime-agent reader, including reconnect path |
| `crates/runtimed/src/notebook_sync_server/peer.rs` | both `handle_notebook_sync_connection` and `handle_runtime_agent_sync_connection` |
| `crates/runtimed/src/daemon.rs` | `Send + 'static` bound propagation on `S` |

## Regression test

`framed_reader_does_not_desync_in_select_under_pressure` floods small frames against a busy `select!` and asserts none are lost or corrupted. The same test against pre-fix code fails with `frame too large: 943274555 bytes`.

## Verification

- `cargo build --workspace --exclude runtimed-py` — clean
- `cargo test -p notebook-protocol` — 65 passed (incl. new test)
- `cargo test -p runtimed --lib` — 466 passed
- `cargo xtask lint --fix` — clean

## Test plan

- [ ] CI green
- [ ] Reload the llama-cpp notebook that triggered the original crash; confirm no `frame too large` warnings in daemon or relay logs and no ErrorBoundary trip
- [ ] Smoke: kernel launch, cell execute, dependency sync, autosave round-trip