### PR TITLE
chore: add .async-rust-lsp.toml for cancel-unsafe-in-select wrappers

### DIFF
--- a/.async-rust-lsp.toml
+++ b/.async-rust-lsp.toml
@@ -1,0 +1,13 @@
+# Project-local config for https://github.com/rgbkrk/async-rust-lsp
+#
+# These wrappers ultimately call `read_exact` / `write_all`, so they
+# inherit the same cancel-unsafety. The LSP rule can't follow function
+# bodies across files; listing them here teaches it to flag direct uses
+# inside `tokio::select!` arms — the exact pattern that produced the
+# `frame too large: 1818192238 bytes` desync fixed in PR #2182.
+
+[rules.cancel-unsafe-in-select]
+extra = [
+    "recv_typed_frame",
+    "send_typed_frame",
+]


### PR DESCRIPTION
## What

Drops a project-local config for [async-rust-lsp](https://github.com/rgbkrk/async-rust-lsp) so its `cancel-unsafe-in-select` rule catches our framed-protocol wrappers (`recv_typed_frame`, `send_typed_frame`).

## Why

PR #2182 fixed the relay desync caused by `recv_typed_frame` losing buffered bytes when its `select!` future was dropped mid-poll. The async-rust-lsp rule's default list catches direct uses of tokio's `read_exact` / `write_all`, but it can't follow function bodies across files — so wrappers like `recv_typed_frame` slip through.

Listing them in `.async-rust-lsp.toml` teaches the rule to flag the pre-fix pattern. End-to-end verified: the rule now fires on a synthetic replica of the relay arm `frame = connection::recv_typed_frame(&mut reader) => ...`, but produces zero diagnostics on the post-#2182 code in this repo.

## Test plan

- [ ] CI green (this is a config-only change; no Rust impact)
- [ ] Anyone running async-rust-lsp locally sees the rule's wrappers list reflected in editor diagnostics

Pairs with rgbkrk/async-rust-lsp#4 (the LSP-side PR adding config support).