### PR TITLE
ci(runtimed): lint cancel-unsafe-in-select across all workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,13 +457,14 @@ checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
 name = "async-rust-lsp"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38bd32e1e07fef4e4fd210444cf5d5123407c0a1dc35be064af367c3318edfe"
+checksum = "79cfc076dad6403ecdbe15a362cecac5fa0e49e91c57e941d4aceecbf5dc4781"
 dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml 0.8.2",
  "tower-lsp",
  "tracing",
  "tracing-appender",

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -116,4 +116,4 @@ nbformat = "2.0.0"
 serial_test = "3"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }
 notebook-sync = { path = "../notebook-sync" }
-async-rust-lsp = "0.2"
+async-rust-lsp = "0.3"

--- a/crates/runtimed/tests/tokio_select_cancel_safe.rs
+++ b/crates/runtimed/tests/tokio_select_cancel_safe.rs
@@ -1,0 +1,120 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! CI lint: ensure no cancel-unsafe tokio I/O futures appear in the
+//! future-expression position of `tokio::select!` arms across any
+//! workspace crate.
+//!
+//! Cancel-unsafe futures (`read_exact`, `write_all`, `read_line`, …)
+//! discard buffered bytes when dropped. When a sibling arm wins the
+//! `select!` race, the losing future is dropped — the next read starts
+//! in the wrong place and length-prefixed protocols silently desync.
+//! See PR #2182 for the relay desync fix and rgbkrk/async-rust-lsp#4
+//! for the rule.
+//!
+//! Project-local wrappers (e.g. `recv_typed_frame` that delegates to
+//! `read_exact`) are listed in `.async-rust-lsp.toml` at the workspace
+//! root and added to the rule's blocklist via the extras config.
+//!
+//! Scope: every `crates/<name>/src/` tree, walked recursively. New
+//! workspace members are picked up automatically.
+
+use async_rust_lsp::config::Config;
+use async_rust_lsp::rules::cancel_unsafe_in_select::check_cancel_unsafe_in_select_with;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn workspace_has_no_cancel_unsafe_in_select() {
+    let workspace_root = workspace_root();
+    let crates_dir = workspace_root.join("crates");
+
+    // Load project-local extras from .async-rust-lsp.toml at the
+    // workspace root. If the file is absent or malformed, this falls
+    // back to defaults (built-in tokio-primitives only).
+    let (config, _) = Config::discover_from(&workspace_root);
+    let extras = &config.rules.cancel_unsafe_in_select.extra;
+
+    let mut violations: Vec<String> = Vec::new();
+    let mut file_count: usize = 0;
+
+    for entry in std::fs::read_dir(&crates_dir)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", crates_dir.display()))
+    {
+        let crate_dir = match entry {
+            Ok(e) => e.path(),
+            Err(_) => continue,
+        };
+        if !crate_dir.is_dir() {
+            continue;
+        }
+        let src_dir = crate_dir.join("src");
+        if !src_dir.is_dir() {
+            continue;
+        }
+
+        walk_rs_files(&src_dir, &mut |path| {
+            file_count += 1;
+            let source = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+            for d in check_cancel_unsafe_in_select_with(&source, extras) {
+                let rel = path.strip_prefix(&workspace_root).unwrap_or(path);
+                let first_line = d.message.lines().next().unwrap_or(d.message.as_str());
+                violations.push(format!(
+                    "  {}:{}: {}",
+                    rel.display(),
+                    d.range.start.line + 1,
+                    first_line
+                ));
+            }
+        });
+    }
+
+    assert!(
+        file_count > 0,
+        "no .rs files scanned under {}",
+        crates_dir.display()
+    );
+
+    if !violations.is_empty() {
+        let mut msg = format!(
+            "Found {} cancel-unsafe future(s) in tokio::select! arms across {} files:\n\n",
+            violations.len(),
+            file_count
+        );
+        for v in &violations {
+            msg.push_str(v);
+            msg.push('\n');
+        }
+        msg.push_str(
+            "\nFix: move the call into a dedicated reader/writer task that forwards parsed \
+             messages over an mpsc channel; then `select!` on `channel.recv()`, which is \
+             cancel-safe. See nteract/desktop#2182 for the FramedReader actor pattern.\n",
+        );
+        panic!("{msg}");
+    }
+}
+
+/// Walk up two parents from `crates/runtimed` to the workspace root.
+fn workspace_root() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(Path::to_path_buf)
+        .unwrap_or(manifest)
+}
+
+fn walk_rs_files(dir: &Path, cb: &mut dyn FnMut(&Path)) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_rs_files(&path, cb);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            cb(&path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a CI lint test (`crates/runtimed/tests/tokio_select_cancel_safe.rs`) that runs the `cancel-unsafe-in-select` rule from [`async-rust-lsp` 0.3.1](https://github.com/rgbkrk/async-rust-lsp) across every workspace crate and panics on any violation. Bumps the dep from `0.2` to `0.3` to pick up the new rule and the `Config` discovery API.

The test pairs with the `.async-rust-lsp.toml` config that landed in #2183 and the `FramedReader` actor fix in #2182.

## Why

PR #2182 fixed a relay desync caused by `recv_typed_frame` being dropped mid-poll inside a `tokio::select!` arm. The fix ships, but the antipattern is easy to reintroduce: a future built on `read_exact` / `write_all` discards buffered bytes when dropped, silently desyncing length-prefixed wire protocols. The rule catches the antipattern at CI time. Local editors with the LSP installed already get the same diagnostics in real time.

## Scope

Every `crates/<name>/src/` tree, walked recursively. New workspace members are picked up automatically — no allowlist to maintain. 193 `.rs` files scanned in ~0.37s on this branch.

The default rule list catches direct uses of tokio's `read_exact`, `read_to_end`, `read_to_string`, `read_buf`, `read_line`, `read_until`, `write_all`, `write_buf`, `write_all_buf`. Project-local wrappers (`recv_typed_frame`, `send_typed_frame`) come from `.async-rust-lsp.toml` extras.

## Result

Zero violations across the workspace today. The lint serves as a regression guard going forward.

## Test plan

- [ ] CI green (the new test runs as part of `cargo test -p runtimed`)
- [ ] Locally: `cargo test -p runtimed --test tokio_select_cancel_safe` passes
- [ ] As a sanity check, temporarily replace `framed_reader.recv()` in `crates/notebook-sync/src/relay_task.rs` with `connection::recv_typed_frame(&mut reader)` and confirm the test fails with that line cited
