### PR TITLE
chore: bump all packages by patch version (v2.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ]
 }

--- a/.claude/plugins/nteract/.claude-plugin/plugin.json
+++ b/.claude/plugins/nteract/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nteract",
   "description": "Open, run, and edit nteract notebooks from Claude Code",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "automerge",
  "serde_json",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4138,7 +4138,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dirs",
  "libc",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "automerge",
  "automunge",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "kernel-env",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "automerge",
  "log",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -6935,7 +6935,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rmcp",
  "runtimed-client",
@@ -7009,7 +7009,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dirs",
  "hex",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7037,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "automerge",
  "automunge",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -7139,7 +7139,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7165,7 +7165,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "kernel-env",
  "log",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -7891,7 +7891,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11106,7 +11106,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/apps/notebook/src/wasm/runtimed-wasm/package.json
+++ b/apps/notebook/src/wasm/runtimed-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "runtimed-wasm",
   "type": "module",
   "description": "WASM bindings for runtimed notebook document operations, compiled from the same automerge crate as the daemon",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73a35c3bdc0c307fd5a9b35ef39fa563e5d3fcee3f42c68706e47951ed532fdd
-size 1734267
+oid sha256:37a585dfc78a4f825583fabe6804ffb48e3a25dac110935df0a02069d392feb6
+size 1733081

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.3.1"
+version = "2.3.2"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7870ef57c4f17a4e749e0298de21b9fab2605ad972e1fec88dca3397ea839b2f
+oid sha256:27d282e6cbed0505cc3e6cda023cd302b6c90362761c46af181dc85559f6f334
 size 5429841

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.3.1"
+version = "2.3.2"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.3.1"
+version = "2.3.2"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.3.1"
+version = "2.3.2"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository.workspace = true

--- a/crates/sift-wasm/pkg/package.json
+++ b/crates/sift-wasm/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "sift-wasm",
   "type": "module",
   "description": "WASM bindings for nteract-predicate — used by @nteract/sift",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7870ef57c4f17a4e749e0298de21b9fab2605ad972e1fec88dca3397ea839b2f
+oid sha256:27d282e6cbed0505cc3e6cda023cd302b6c90362761c46af181dc85559f6f334
 size 5429841

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/runtimed-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node.js bindings for the runtimed daemon client (napi-rs).",
   "private": true,
   "type": "module",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.0.3"
+version = "2.0.4"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.2.1"
+version = "0.2.2"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.3.1"
+version = "2.3.2"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.0.4"
+version = "0.0.5"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.3.1"
+version = "2.3.2"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Patch-bump every artifact in the repo so we can cut a stable release with the cancel-safe relay fix from #2182, the project-local LSP config from #2183, and the workspace-wide `cancel-unsafe-in-select` CI lint from #2184.

## What's bumped

- Tauri desktop app: `2.3.1 → 2.3.2`
- `runtimed` daemon, `runt` CLI, runtimed Python wheel, nteract Python wheel: `2.3.1 → 2.3.2`
- Workspace crates and internal-only path-deps: each by patch (e.g. `0.2.3 → 0.2.4`)
- Frontend packages and apps: each by patch
- Python packages: each by patch
- Claude/Codex plugin manifests + marketplace: `0.1.1 → 0.1.2`

`Cargo.lock` regenerated. `cargo xtask wasm` regenerated the WASM artifacts; the renderer-plugin JS/CSS bundles regenerated to byte-identical output.

## Verification

- `cargo check --workspace --exclude runtimed-py` clean
- `cargo xtask lint --fix` clean (Rust fmt, vp, ruff, ty)
- `cargo test -p runtimed --test tokio_select_cancel_safe` passes (the new CI lint is happy with the bumps)
- `cargo test -p runtimed --test tokio_mutex_lint` passes

## Test plan

- [ ] CI green
- [ ] After merge, tag `v2.3.2` on main to trigger the stable release pipeline
