### PR TITLE
fix(runtimed): sort .ipynb keys + strip output_id on save

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -2,19 +2,60 @@ use serde::Serialize;
 
 use super::*;
 
+/// Recursively rebuild every `Value::Object` with its keys in sorted order.
+///
+/// Python `nbformat.write` emits `.ipynb` files via `json.dumps(sort_keys=True)`.
+/// Our daemon save path used to leave keys in insertion order (serde_json here
+/// runs with `preserve_order` via the workspace's feature set), which produced
+/// diffs against Jupyter-written files on every save. Applying the sort
+/// ourselves before the pretty-printer matches Jupyter byte-for-byte at every
+/// depth.
+fn sort_value_keys(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<(String, serde_json::Value)> = map.into_iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            let mut sorted = serde_json::Map::new();
+            for (k, v) in entries {
+                sorted.insert(k, sort_value_keys(v));
+            }
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(sort_value_keys).collect())
+        }
+        other => other,
+    }
+}
+
 /// Serialize a notebook JSON value with 1-space indent and trailing newline,
-/// matching the nbformat/Jupyter convention.
+/// matching the nbformat/Jupyter convention. Keys are sorted alphabetically
+/// at every depth.
 fn serialize_notebook_json(value: &serde_json::Value) -> Result<String, String> {
+    let sorted = sort_value_keys(value.clone());
     let mut buf = Vec::new();
     let formatter = serde_json::ser::PrettyFormatter::with_indent(b" ");
     let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
-    value
+    sorted
         .serialize(&mut ser)
         .map_err(|e| format!("Failed to serialize notebook: {e}"))?;
     let mut content =
         String::from_utf8(buf).map_err(|e| format!("Invalid UTF-8 in notebook: {e}"))?;
     content.push('\n');
     Ok(content)
+}
+
+/// Drop the daemon's runtime-only `output_id` field from a resolved output
+/// `Value` before it hits disk. `output_id` is a UUID minted per kernel
+/// execution used to address outputs in the in-memory index and to keep
+/// React keys stable. It is not part of the nbformat spec, and persisting
+/// it produces churn on every re-execution (fresh UUIDs per run) plus a
+/// round-trip surprise (the daemon re-mints IDs on load when missing, so
+/// the on-disk values are authoritative only until the next save).
+fn strip_runtime_only_output_fields(output: &mut serde_json::Value) {
+    if let Some(obj) = output.as_object_mut() {
+        obj.remove("output_id");
+    }
 }
 
 #[derive(Debug)]
@@ -183,7 +224,8 @@ pub(crate) async fn save_notebook_to_disk(
             let mut resolved_outputs = Vec::new();
             if let Some(outputs) = cell_outputs.get(&cell.id) {
                 for output in outputs {
-                    let output_value = resolve_cell_output(output, &room.blob_store).await;
+                    let mut output_value = resolve_cell_output(output, &room.blob_store).await;
+                    strip_runtime_only_output_fields(&mut output_value);
                     resolved_outputs.push(output_value);
                 }
             }
@@ -227,10 +269,10 @@ pub(crate) async fn save_notebook_to_disk(
 
     let cell_count = nb_cells.len();
     let notebook_json = serde_json::json!({
+        "cells": nb_cells,
+        "metadata": metadata,
         "nbformat": 4,
         "nbformat_minor": nbformat_minor,
-        "metadata": metadata,
-        "cells": nb_cells,
     });
 
     let content_with_newline =
@@ -535,10 +577,10 @@ pub(crate) async fn clone_notebook_to_disk(
     // Build the final notebook JSON
     let cell_count = nb_cells.len();
     let notebook_json = serde_json::json!({
+        "cells": nb_cells,
+        "metadata": metadata,
         "nbformat": 4,
         "nbformat_minor": nbformat_minor,
-        "metadata": metadata,
-        "cells": nb_cells,
     });
 
     let content_with_newline =
@@ -1170,4 +1212,124 @@ pub(crate) fn spawn_notebook_file_watcher(
     });
 
     shutdown_tx
+}
+
+#[cfg(test)]
+mod serialize_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn top_level_keys(v: &serde_json::Value) -> Vec<&str> {
+        v.as_object()
+            .expect("expected object")
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    #[test]
+    fn sort_value_keys_orders_top_level() {
+        let sorted = sort_value_keys(json!({
+            "zebra": 1,
+            "apple": 2,
+            "mango": 3,
+        }));
+        assert_eq!(top_level_keys(&sorted), vec!["apple", "mango", "zebra"]);
+    }
+
+    #[test]
+    fn sort_value_keys_recurses_into_objects_and_arrays() {
+        let sorted = sort_value_keys(json!({
+            "cells": [
+                { "zebra": 1, "apple": 2 },
+                { "mango": 3, "banana": 4 },
+            ]
+        }));
+        let cells = sorted.get("cells").unwrap().as_array().unwrap();
+        assert_eq!(top_level_keys(&cells[0]), vec!["apple", "zebra"]);
+        assert_eq!(top_level_keys(&cells[1]), vec!["banana", "mango"]);
+    }
+
+    #[test]
+    fn sort_value_keys_preserves_array_element_order() {
+        let sorted = sort_value_keys(json!({
+            "list": [3, 1, 2],
+        }));
+        let list = sorted.get("list").unwrap().as_array().unwrap();
+        let values: Vec<i64> = list.iter().map(|v| v.as_i64().unwrap()).collect();
+        assert_eq!(values, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn serialize_notebook_json_emits_sorted_keys_and_trailing_newline() {
+        let nb = json!({
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "cells": [
+                {
+                    "id": "cell-1",
+                    "cell_type": "code",
+                    "source": ["x = 1\n"],
+                    "outputs": [],
+                    "execution_count": 1,
+                    "metadata": {}
+                }
+            ],
+            "metadata": {}
+        });
+        let out = serialize_notebook_json(&nb).expect("serialize");
+
+        // Trailing newline
+        assert!(out.ends_with('\n'), "missing trailing newline");
+
+        // Top-level order: cells, metadata, nbformat, nbformat_minor
+        let cells_pos = out.find("\"cells\"").expect("cells key");
+        let metadata_pos = out.find("\"metadata\"").expect("metadata key");
+        let nbformat_pos = out.find("\"nbformat\"").expect("nbformat key");
+        let minor_pos = out.find("\"nbformat_minor\"").expect("nbformat_minor key");
+        assert!(cells_pos < metadata_pos, "cells must come before metadata");
+        assert!(
+            metadata_pos < nbformat_pos,
+            "metadata must come before nbformat"
+        );
+        assert!(
+            nbformat_pos < minor_pos,
+            "nbformat must come before nbformat_minor"
+        );
+
+        // Cell keys alphabetical: cell_type, execution_count, id, metadata, outputs, source
+        let ct = out.find("\"cell_type\"").unwrap();
+        let ec = out.find("\"execution_count\"").unwrap();
+        let id = out.find("\"id\"").unwrap();
+        let src = out.find("\"source\"").unwrap();
+        assert!(ct < ec && ec < id && id < src, "cell keys not alphabetical");
+    }
+
+    #[test]
+    fn strip_runtime_only_output_fields_removes_output_id() {
+        let mut out = json!({
+            "output_type": "stream",
+            "output_id": "abc-123",
+            "name": "stdout",
+            "text": "hello\n"
+        });
+        strip_runtime_only_output_fields(&mut out);
+        assert!(out.get("output_id").is_none());
+        assert_eq!(out.get("output_type").unwrap(), "stream");
+        assert_eq!(out.get("name").unwrap(), "stdout");
+    }
+
+    #[test]
+    fn strip_runtime_only_output_fields_is_noop_on_non_object() {
+        let mut s = json!("a string");
+        strip_runtime_only_output_fields(&mut s);
+        assert_eq!(s, json!("a string"));
+    }
+
+    #[test]
+    fn strip_runtime_only_output_fields_ok_when_absent() {
+        let mut out = json!({ "output_type": "stream", "name": "stdout" });
+        strip_runtime_only_output_fields(&mut out);
+        assert_eq!(out, json!({ "output_type": "stream", "name": "stdout" }));
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -922,6 +922,83 @@ async fn test_save_notebook_to_disk_with_outputs() {
     } else {
         panic!("Expected code cell");
     }
+
+    // Runtime-only output_id must not hit disk. Check the raw bytes, since
+    // the typed `nbformat::v4::Output` would silently drop unknown fields.
+    assert!(
+        !content.contains("output_id"),
+        "saved notebook should not contain runtime-only output_id field, got:\n{content}"
+    );
+}
+
+/// Saves should produce byte-identical output twice in a row for the same
+/// state, and top-level + cell keys should be alphabetically sorted. This is
+/// the git-diff churn fix: a no-op save produces the same bytes, and edits
+/// produce minimal, stable diffs because key order is deterministic.
+#[tokio::test]
+async fn test_save_notebook_to_disk_produces_sorted_stable_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "stable.ipynb");
+
+    let eid = "exec-stable-1";
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-alpha", "code").unwrap();
+        doc.update_source("cell-alpha", "x = 1").unwrap();
+        doc.set_execution_id("cell-alpha", Some(eid)).unwrap();
+        doc.add_cell(1, "cell-beta", "markdown").unwrap();
+        doc.update_source("cell-beta", "# heading").unwrap();
+    }
+    room.state
+        .with_doc(|sd| {
+            let output = serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": ["ok\n"],
+                "output_id": "runtime-only-uuid",
+            });
+            sd.create_execution(eid, "cell-alpha")?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_outputs(eid, &[output])?;
+            sd.set_execution_done(eid, true)?;
+            Ok(())
+        })
+        .unwrap();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+    let first = std::fs::read_to_string(&notebook_path).unwrap();
+
+    // Second save against unchanged state must produce identical bytes.
+    save_notebook_to_disk(&room, None).await.unwrap();
+    let second = std::fs::read_to_string(&notebook_path).unwrap();
+    assert_eq!(first, second, "consecutive saves must be byte-identical");
+
+    // Top-level key order: cells, metadata, nbformat, nbformat_minor.
+    let cells_pos = first.find("\"cells\"").expect("cells key present");
+    let metadata_pos = first.find("\"metadata\"").expect("metadata key present");
+    let nbformat_pos = first.find("\"nbformat\"").expect("nbformat key present");
+    let minor_pos = first
+        .find("\"nbformat_minor\"")
+        .expect("nbformat_minor key present");
+    assert!(
+        cells_pos < metadata_pos && metadata_pos < nbformat_pos && nbformat_pos < minor_pos,
+        "top-level keys not alphabetical in:\n{first}"
+    );
+
+    // Code cell keys: cell_type, execution_count, id, metadata, outputs, source.
+    let code_start = first.find("\"cell_type\": \"code\"").expect("code cell");
+    let slice = &first[code_start..];
+    let ct = slice.find("\"cell_type\"").unwrap();
+    let ec = slice.find("\"execution_count\"").unwrap();
+    let id = slice.find("\"id\"").unwrap();
+    let src = slice.find("\"source\"").unwrap();
+    assert!(ct < ec && ec < id && id < src, "code cell keys not sorted");
+
+    // Runtime-only output_id must not hit disk.
+    assert!(
+        !first.contains("output_id"),
+        "output_id leaked to disk:\n{first}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Two bugs in `notebook_sync_server/persist.rs` that together turned a one-line notebook edit into 478 modified lines in [ds-modules/Small_Models_SP26](https://github.com/ds-modules/Small_Models_SP26):

### 1. Key order was struct-declaration order, not alphabetical

Python `nbformat.write` emits `.ipynb` files via `json.dumps(sort_keys=True)`. Our daemon built the JSON with a `serde_json::json!{...}` that listed `nbformat`, `nbformat_minor`, `metadata`, `cells` in that order, and `serde_json` in this workspace runs with `preserve_order` so nothing re-sorted. Every save rewrote the top of the file.

Fix: add `sort_value_keys`, a recursive walker that rebuilds each `Value::Object` with sorted keys, and apply it in `serialize_notebook_json` before the existing `PrettyFormatter` + trailing-newline pass. Works regardless of the `preserve_order` feature flag.

### 2. `output_id` was leaking to disk on every save

`output_id` is a daemon runtime UUID minted per kernel execution. Its jobs are (a) addressing outputs in the in-memory output index and (b) giving the frontend stable React keys so streaming appends don't flicker. It's not part of nbformat. `resolve_manifest` included it in its return value (used everywhere, including the save path), so every re-execution wrote fresh UUIDs to disk — visible as churn across the whole outputs block in git.

Fix: `strip_runtime_only_output_fields` removes `output_id` from each output `Value` after `resolve_cell_output` and before it lands in the cell's JSON. `resolve_manifest` is unchanged (in-memory users still get the UUID). `load.rs` already mints fresh UUIDs when loading outputs without `output_id`, so round-tripping just re-UUIDs on each open — the daemon was already written to tolerate this case.

## Behavioral notes

- **One-time reformat on first post-change save.** Existing notebooks in user working copies will rewrite to sorted-keys + no-output_id on first edit. After that, churn goes to zero. Same rollout shape as prettier/black.
- **File watcher is safe.** `SELF_WRITE_SKIP_WINDOW_MS` still protects against self-write echoes.
- **Autosave is safe during load.** `is_loading` gate in `spawn_autosave_debouncer` (persist.rs:867) already prevents load-time doc mutations from queueing a save.
- **Content-hash guard still works.** `save_notebook_to_disk` (persist.rs:241) compares serialized output against on-disk bytes to skip no-op writes.

## Tests

- **`sort_value_keys_*`** — 3 unit tests on the tree walker (top-level, nested, arrays).
- **`serialize_notebook_json_emits_sorted_keys_and_trailing_newline`** — the whole emit path.
- **`strip_runtime_only_output_fields_*`** — 3 tests covering present, absent, non-object.
- **`test_save_notebook_to_disk_with_outputs`** — existing test gets one extra assertion that `output_id` isn't in saved bytes.
- **`test_save_notebook_to_disk_produces_sorted_stable_output`** — new integration test: round-trips a code+markdown notebook with an explicit runtime-only `output_id`, asserts byte-identical consecutive saves, alphabetical top-level + per-cell keys, and no `output_id` on disk.

All 184 pre-existing `notebook_sync_server` tests still pass. 10 new assertions across 8 new test functions.

## Not in this PR

- **nbformat crate dep bump to 2.1.0 / route through `nbformat::serialize_notebook`.** Explored; the crate's typed `v4::Output` API is the wrong abstraction for daemon save because our outputs are already pre-resolved nbformat-shaped JSON produced by `resolve_manifest`, not `jupyter_protocol::media::Media`. Converting back through the typed enum would round-trip every output through type inference and lose fields. The `sort_value_keys` pattern is identical to the one shipped in [runtimed/runtimed#298](https://github.com/runtimed/runtimed/pull/298); if we later want one source of truth, we can `pub` that helper and import it, but duplicating ~15 lines is cheaper than introducing a typed-conversion layer.
- **Clone rework.** `clone_notebook_to_disk` also hand-rolls JSON but Save-As-Copy's design is getting rethought anyway — tracked separately as a follow-up to create an ephemeral (no-disk) clone seeded from the current doc.
- **Binary MIME split direction fix.** Upstream in `jupyter-protocol`'s media serializer, binary payloads (`image/png`, etc.) get split into multi-line lists while modern Python `nbformat.write` emits single strings. Separate follow-up, decided direction pending.

## Test plan

- [x] `cargo test -p runtimed --lib notebook_sync_server` (184 passing, +10 new)
- [x] `cargo clippy -p runtimed --tests -- -D warnings`
- [x] `cargo fmt -p runtimed --check`
