### PR TITLE
fix(settings): make raw frame reads cancel-safe

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -27,7 +27,7 @@
 //! - `0x03`: NotebookBroadcast (JSON)
 //! - `0x07`: SessionControl (JSON, server-originated)
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fmt;
 use std::str::FromStr;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -878,6 +878,56 @@ pub async fn recv_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result
     recv_frame_with_limit(reader, MAX_FRAME_SIZE).await
 }
 
+/// Cancel-safe wrapper around raw length-prefixed `recv_frame`.
+///
+/// Like `FramedReader` for typed notebook frames, this keeps the
+/// `read_exact` state inside a dedicated task so callers can wait for
+/// raw frames in `select!` or `timeout` without desynchronizing the
+/// underlying stream on cancellation.
+pub struct RawFrameReader {
+    rx: tokio::sync::mpsc::Receiver<std::io::Result<Vec<u8>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl RawFrameReader {
+    /// Spawn a reader task that owns `reader`. `capacity` bounds the
+    /// in-flight frame queue so slow consumers apply backpressure.
+    pub fn spawn<R>(mut reader: R, capacity: usize) -> Self
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+    {
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        let handle = tokio::spawn(async move {
+            loop {
+                match recv_frame(&mut reader).await {
+                    Ok(Some(frame)) => {
+                        if tx.send(Ok(frame)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        break;
+                    }
+                }
+            }
+        });
+        Self { rx, handle }
+    }
+
+    /// Cancel-safe receive of the next raw frame.
+    pub async fn recv(&mut self) -> Option<std::io::Result<Vec<u8>>> {
+        self.rx.recv().await
+    }
+}
+
+impl Drop for RawFrameReader {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// Receive a length-prefixed frame with the control/handshake size limit
 /// (64 KiB). Use this for handshake and JSON request/response traffic to
 /// prevent oversized frames from forcing large allocations.
@@ -1463,9 +1513,11 @@ mod tests {
                 .unwrap(),
             PackageManager::Conda
         );
-        assert!(PackageManager::Unknown("poetry".to_string())
-            .resolve()
-            .is_err());
+        assert!(
+            PackageManager::Unknown("poetry".to_string())
+                .resolve()
+                .is_err()
+        );
     }
 
     // -----------------------------------------------------------
@@ -1712,7 +1764,7 @@ mod tests {
     async fn framed_reader_does_not_desync_in_select_under_pressure() {
         use tokio::io::duplex;
         use tokio::sync::mpsc;
-        use tokio::time::{timeout, Duration};
+        use tokio::time::{Duration, timeout};
 
         // Tiny duplex buffer forces multi-poll reads, mirroring the real
         // socket pressure that triggered the production desync.
@@ -1794,5 +1846,51 @@ mod tests {
         let _ = pump_task.await;
         writer_task.await.expect("writer task panicked");
         assert_eq!(received, NUM_FRAMES as u64);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn raw_frame_reader_survives_timeout_during_partial_frame() {
+        use tokio::io::{AsyncWriteExt, duplex};
+        use tokio::time::{Duration, timeout};
+
+        let (server_side, client_side) = duplex(16);
+        let (_server_read, mut writer) = tokio::io::split(server_side);
+        let (reader, _client_write) = tokio::io::split(client_side);
+
+        let mut payload = vec![0u8; 1024];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = (i & 0xFF) as u8;
+        }
+        let expected = payload.clone();
+
+        let writer_task = tokio::spawn(async move {
+            let len = (payload.len() as u32).to_be_bytes();
+            writer.write_all(&len).await.expect("write length");
+            writer
+                .write_all(&payload[..32])
+                .await
+                .expect("write prefix");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            writer
+                .write_all(&payload[32..])
+                .await
+                .expect("write suffix");
+            writer.flush().await.expect("flush");
+        });
+
+        let mut framed = RawFrameReader::spawn(reader, 4);
+
+        timeout(Duration::from_millis(10), framed.recv())
+            .await
+            .expect_err("raw frame should not be complete yet");
+
+        let frame = timeout(Duration::from_secs(1), framed.recv())
+            .await
+            .expect("frame should arrive")
+            .expect("reader should stay open")
+            .expect("frame decode should succeed");
+        assert_eq!(frame, expected);
+
+        writer_task.await.expect("writer task panicked");
     }
 }

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -15,8 +15,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::connection::{self, Handshake};
 use crate::settings_doc::{
-    read_nested_list, split_comma_list, ColorTheme, CondaDefaults, PixiDefaults, SyncedSettings,
-    ThemeMode, UvDefaults,
+    ColorTheme, CondaDefaults, PixiDefaults, SyncedSettings, ThemeMode, UvDefaults,
+    read_nested_list, split_comma_list,
 };
 
 /// Error type for sync client operations.
@@ -39,10 +39,11 @@ pub enum SyncClientError {
 ///
 /// Holds a local Automerge document replica that stays in sync with the
 /// daemon's canonical copy via the Automerge sync protocol.
-pub struct SyncClient<S> {
+pub struct SyncClient<W> {
     doc: AutoCommit,
     peer_state: sync::State,
-    stream: S,
+    framed_reader: connection::RawFrameReader,
+    writer: tokio::io::WriteHalf<W>,
 }
 
 #[cfg(unix)]
@@ -106,13 +107,13 @@ impl SyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
     }
 }
 
-impl<S> SyncClient<S>
+impl<W> SyncClient<W>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    W: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     /// Initialize the client by sending the handshake and performing
     /// the initial sync exchange.
-    async fn init(mut stream: S) -> Result<Self, SyncClientError> {
+    async fn init(mut stream: W) -> Result<Self, SyncClientError> {
         // Send preamble (magic bytes + protocol version)
         connection::send_preamble(&mut stream)
             .await
@@ -125,34 +126,31 @@ where
 
         let mut doc = AutoCommit::new();
         let mut peer_state = sync::State::new();
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut framed_reader = connection::RawFrameReader::spawn(reader, 16);
 
         // The server sends first -- receive and apply
-        match connection::recv_frame(&mut stream).await? {
-            Some(data) => {
+        match recv_raw_frame(&mut framed_reader).await {
+            Ok(data) => {
                 let message = sync::Message::decode(&data)
                     .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
                 doc.sync()
                     .receive_sync_message(&mut peer_state, message)
                     .map_err(|e| SyncClientError::SyncError(format!("receive: {}", e)))?;
             }
-            None => return Err(SyncClientError::Disconnected),
+            Err(e) => return Err(e),
         }
 
         // Send our sync message back (to complete the handshake)
         if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-            connection::send_frame(&mut stream, &msg.encode()).await?;
+            connection::send_frame(&mut writer, &msg.encode()).await?;
         }
 
         // There might be more rounds needed -- keep going until no more messages
         loop {
             // Try to receive with a short timeout (the server may not have more to say)
-            match tokio::time::timeout(
-                Duration::from_millis(100),
-                connection::recv_frame(&mut stream),
-            )
-            .await
-            {
-                Ok(Ok(Some(data))) => {
+            match tokio::time::timeout(Duration::from_millis(100), framed_reader.recv()).await {
+                Ok(Some(Ok(data))) => {
                     let message = sync::Message::decode(&data)
                         .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
                     doc.sync()
@@ -160,11 +158,11 @@ where
                         .map_err(|e| SyncClientError::SyncError(format!("receive: {}", e)))?;
 
                     if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-                        connection::send_frame(&mut stream, &msg.encode()).await?;
+                        connection::send_frame(&mut writer, &msg.encode()).await?;
                     }
                 }
-                Ok(Ok(None)) => return Err(SyncClientError::Disconnected),
-                Ok(Err(e)) => return Err(SyncClientError::ConnectionFailed(e)),
+                Ok(Some(Err(e))) => return Err(SyncClientError::ConnectionFailed(e)),
+                Ok(None) => return Err(SyncClientError::Disconnected),
                 Err(_) => break, // Timeout -- initial sync is done
             }
         }
@@ -175,7 +173,8 @@ where
         Ok(Self {
             doc,
             peer_state,
-            stream,
+            framed_reader,
+            writer,
         })
     }
 
@@ -322,7 +321,7 @@ where
     /// Generate and send sync message to daemon.
     async fn sync_to_daemon(&mut self) -> Result<(), SyncClientError> {
         if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
-            connection::send_frame(&mut self.stream, &msg.encode()).await?;
+            connection::send_frame(&mut self.writer, &msg.encode()).await?;
         }
         Ok(())
     }
@@ -332,25 +331,31 @@ where
     /// Blocks until a sync message arrives, applies it, and returns the
     /// updated settings snapshot.
     pub async fn recv_changes(&mut self) -> Result<SyncedSettings, SyncClientError> {
-        match connection::recv_frame(&mut self.stream).await? {
-            Some(data) => {
-                let message = sync::Message::decode(&data)
-                    .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
-                self.doc
-                    .sync()
-                    .receive_sync_message(&mut self.peer_state, message)
-                    .map_err(|e| SyncClientError::SyncError(format!("receive: {}", e)))?;
+        let data = recv_raw_frame(&mut self.framed_reader).await?;
+        let message = sync::Message::decode(&data)
+            .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
+        self.doc
+            .sync()
+            .receive_sync_message(&mut self.peer_state, message)
+            .map_err(|e| SyncClientError::SyncError(format!("receive: {}", e)))?;
 
-                // Send ack if needed
-                if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
-                    connection::send_frame(&mut self.stream, &msg.encode()).await?;
-                }
-
-                Ok(self.get_all())
-            }
-            None => Err(SyncClientError::Disconnected),
+        // Send ack if needed
+        if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
+            connection::send_frame(&mut self.writer, &msg.encode()).await?;
         }
+
+        Ok(self.get_all())
     }
+}
+
+async fn recv_raw_frame(
+    framed_reader: &mut connection::RawFrameReader,
+) -> Result<Vec<u8>, SyncClientError> {
+    framed_reader
+        .recv()
+        .await
+        .ok_or(SyncClientError::Disconnected)?
+        .map_err(SyncClientError::ConnectionFailed)
 }
 
 /// Extract all settings from an Automerge document.

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use automerge::sync;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, RwLock};
+use tokio::sync::{RwLock, broadcast};
 use tracing::{info, warn};
 
 use crate::connection;
@@ -38,7 +38,7 @@ pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {
 /// 2. Watch loop: wait for changes (from other peers or from this client),
 ///    exchange sync messages to propagate
 pub async fn handle_settings_sync_connection<R, W>(
-    mut reader: R,
+    reader: R,
     mut writer: W,
     settings: Arc<RwLock<SettingsDoc>>,
     changed_tx: broadcast::Sender<()>,
@@ -47,7 +47,7 @@ pub async fn handle_settings_sync_connection<R, W>(
     json_path: PathBuf,
 ) -> anyhow::Result<()>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin,
 {
     let mut peer_state = sync::State::new();
@@ -65,12 +65,14 @@ where
         }
     }
 
+    let mut framed_reader = connection::RawFrameReader::spawn(reader, 16);
+
     // Phase 2: Exchange messages until sync is complete, then watch for changes
     loop {
         tokio::select! {
             // Incoming message from this client
-            result = connection::recv_frame(&mut reader) => {
-                match result? {
+            result = framed_reader.recv() => {
+                match result.transpose()? {
                     Some(data) => {
                         let message = sync::Message::decode(&data)
                             .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;


### PR DESCRIPTION
## Summary

- add a cancel-safe `RawFrameReader` for raw length-prefixed frames
- use it in settings sync server select loops instead of polling `recv_frame` directly
- split the settings sync client stream after handshake so initialization timeouts and `recv_changes()` receive through the raw frame actor

## Why

`recv_frame` uses `read_exact`, so cancelling it inside `select!` or `timeout` can discard partial frame bytes while keeping the stream alive. This applies the same actor-based fix as typed notebook frames to settings sync.

## Validation

- `cargo check -p runtimed-client -p runtimed`
- `cargo test -p notebook-protocol raw_frame_reader_survives_timeout_during_partial_frame -- --nocapture`
- `cargo test -p runtimed-client sync_client -- --nocapture`
- `cargo test -p runtimed test_settings_sync_via_unified_socket -- --nocapture`
- `git diff --check`