### PR TITLE
fix(protocol): bump Request cap to 16 MiB for SendComm widget buffers

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -375,9 +375,15 @@ struct FrameSizeLimits {
 ///   Initial sync of a notebook with many cells / lots of accumulated
 ///   ephemeral state can be many MB; outputs are blob-offloaded but
 ///   the doc itself can still be large.
-/// - **NotebookRequest**: 1 MiB. Every variant is small (cell IDs,
-///   metadata snapshots, completion requests). `SendComm` slider
-///   values are bytes, not megabytes. Headroom for SetMetadataSnapshot.
+/// - **NotebookRequest**: 16 MiB. Most variants are tiny (cell IDs,
+///   metadata snapshots, completion requests) — they sit well under the
+///   256 KiB warn so growth on them still surfaces. The cap exists for
+///   one outlier: `SendComm` carries the same comm envelope shape as
+///   `NotebookBroadcast::Comm`, including custom-message buffers from
+///   `model.send(content, callbacks, buffers)`. JSON-encoding `Vec<Vec<u8>>`
+///   inflates binary by ~4×, so a 256 KiB widget buffer becomes ~1 MiB
+///   on the wire. Tightens once `SendComm.buffers` and
+///   `NotebookBroadcast::Comm.buffers` both move through the blob store.
 /// - **NotebookResponse**: 64 MiB. `Response::DocBytes` returns a full
 ///   Automerge doc dump; `Response::NotebookState` carries
 ///   inspect-notebook output. Both can legitimately be large.
@@ -396,7 +402,7 @@ fn frame_size_limits(type_byte: u8) -> FrameSizeLimits {
             warn: 16 * MIB,
         },
         frame_types::REQUEST => FrameSizeLimits {
-            cap: MIB,
+            cap: 16 * MIB,
             warn: 256 * KIB,
         },
         frame_types::RESPONSE => FrameSizeLimits {
@@ -1366,8 +1372,9 @@ mod tests {
 
     #[tokio::test]
     async fn typed_frame_rejects_oversized_request() {
-        // Requests carry small JSON envelopes. A multi-MiB length header
-        // on the Request channel is parser confusion or corruption.
+        // The Request cap rejects payloads that exceed the channel's
+        // legitimate worst case (today: a SendComm envelope with widget
+        // buffers that JSON-expand from binary).
         let cap = frame_size_limits(notebook_doc::frame_types::REQUEST).cap;
         let body_len: u32 = (cap as u32) + 1;
         let total_len: u32 = body_len + 1;
@@ -1377,6 +1384,27 @@ mod tests {
         let mut cursor = std::io::Cursor::new(buf);
         let err = recv_typed_frame(&mut cursor).await.unwrap_err();
         assert!(err.to_string().contains("too large for type 0x01"));
+    }
+
+    #[tokio::test]
+    async fn typed_frame_allows_sendcomm_with_widget_buffers() {
+        // Custom comm messages from `model.send(content, callbacks, buffers)`
+        // ride `NotebookRequest::SendComm`. JSON-encoding `Vec<Vec<u8>>`
+        // expands binary by ~4×, so a 256 KiB widget buffer becomes
+        // ~1 MiB on the wire. The Request cap must accommodate this.
+        // 4 MiB simulates a buffer roughly equivalent to a 1 MiB binary
+        // payload after JSON expansion — a realistic moderate-size
+        // custom widget message.
+        let big_payload = vec![0x42u8; 4 * 1024 * 1024];
+        let mut buf = Vec::new();
+        send_typed_frame(&mut buf, NotebookFrameType::Request, &big_payload)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::Request);
+        assert_eq!(frame.payload.len(), big_payload.len());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #2191. Bumps the `NotebookRequest` cap from 1 MiB → 16 MiB.

Codex caught the regression on the merged PR: `NotebookRequest::SendComm` carries widget buffers from anywidget's `model.send(content, callbacks, buffers)`. JSON-encoding `Vec<Vec<u8>>` expands binary by ~4×, so a 256 KiB widget buffer becomes ~1 MiB on the wire. The 1 MiB cap clipped moderate custom-message payloads.

## Why this cap

Request and Broadcast carry the same comm-envelope shape with the same buffer-expansion problem (`SendComm` outbound, `Comm` broadcast inbound). Capping them symmetrically at 16 MiB is honest. Other Request variants — `ExecuteCell`, `LaunchKernel`, `SaveNotebook`, etc. — are tiny and sit well below the 256 KiB warn threshold, so growth on those surfaces in logs even though the cap is loose.

## Cap table after this PR

| Type | Cap | Warn |
|------|-----|------|
| `0x00` AutomergeSync | 64 MiB | 16 MiB |
| `0x01` NotebookRequest | **16 MiB** ⬆ | 256 KiB |
| `0x02` NotebookResponse | 64 MiB | 16 MiB |
| `0x03` NotebookBroadcast | 16 MiB | 4 MiB |
| `0x04` Presence | 1 MiB | 256 KiB |
| `0x05` RuntimeStateSync | 64 MiB | 16 MiB |
| `0x06` PoolStateSync | 1 MiB | 256 KiB |
| `0x07` SessionControl | 1 MiB | 256 KiB |

## Future tightening

The principled fix — push `SendComm.buffers` through the blob store before the request, mirroring the kernel-side path that already does this for output buffers — lets both Request and Broadcast tighten back toward 1 MiB. Filed as a follow-up; generalizes the existing "Comm-broadcast blob offload" item to cover both directions.

## Test plan

- [ ] CI green
- [ ] `cargo test -p notebook-protocol --lib` passes (69 tests, was 68)
- New: `typed_frame_allows_sendcomm_with_widget_buffers` — round-trips a 4 MiB Request payload to pin the contract.
- Updated: `typed_frame_rejects_oversized_request` — comment now reflects the actual reason for the cap.

## Predecessor

#2191 (per-type frame caps).
