### PR TITLE
fix(runtimed): copy resolved_assets on ephemeral clone

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5859,6 +5859,16 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
         doc.update_source("code-1", "x = 1").unwrap();
         doc.add_cell(1, "md-1", "markdown").unwrap();
         doc.update_source("md-1", "# hello").unwrap();
+        // Seed resolved_assets on the markdown cell so we can verify the
+        // clone carries them through (markdown cells render via
+        // `cell.resolvedAssets` — asset ref -> blob hash — and an empty
+        // map would break inline images).
+        let mut assets = HashMap::new();
+        assets.insert(
+            "attachment:image.png".to_string(),
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        );
+        doc.set_cell_resolved_assets("md-1", &assets).unwrap();
         // Stamp source metadata: env_id + trust signature + timestamp.
         let mut snap = snapshot_empty();
         snap.runt.env_id = Some("source-env-id".to_string());
@@ -5954,11 +5964,26 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
         Some("2026-04-25T00:00:00Z")
     );
 
-    // Attachments copied.
+    // Attachments copied (nbformat cache, used by save path).
     let clone_attachments = clone_room.nbformat_attachments_snapshot().await;
     assert_eq!(
         clone_attachments.get("md-1"),
         Some(&serde_json::json!({"image.png": {"image/png": "base64data"}}))
+    );
+
+    // resolved_assets copied on the markdown cell (CRDT-level asset map,
+    // used by frontend rendering of cell.resolvedAssets).
+    let clone_md_assets = clone_room
+        .doc
+        .read()
+        .await
+        .get_cell_resolved_assets("md-1")
+        .expect("markdown cell should carry resolved_assets map");
+    assert_eq!(
+        clone_md_assets
+            .get("attachment:image.png")
+            .map(String::as_str),
+        Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
     );
 }
 

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -146,6 +146,17 @@ async fn seed_clone_from_source(
                     &cell.metadata,
                 )
                 .map_err(|e| format!("add_cell_full({}): {e}", cell.id))?;
+
+            // `add_cell_full` seeds an empty `resolved_assets` map. Markdown
+            // cells render via `cell.resolvedAssets` (attachment ref -> blob
+            // hash), so without this copy, inline images in cloned markdown
+            // cells would break until a save+reload rebuilt the map from
+            // the attachment cache.
+            if !cell.resolved_assets.is_empty() {
+                clone_doc
+                    .set_cell_resolved_assets(&cell.id, &cell.resolved_assets)
+                    .map_err(|e| format!("set_cell_resolved_assets({}): {e}", cell.id))?;
+            }
         }
 
         // Apply metadata with a fresh env_id. Trust signature + timestamp


### PR DESCRIPTION
Codex review on #2192 caught a real bug in the ephemeral clone handler: `add_cell_full` always creates an empty `resolved_assets` map. Markdown cells render through `cell.resolvedAssets` (attachment ref → blob hash), so inline images in cloned markdown cells broke until a save + reload rebuilt the map from the `nbformat_attachments` cache.

## Fix

In `crates/runtimed/src/requests/clone_notebook.rs` (`seed_clone_from_source`), after the `add_cell_full` call for each cell, copy the source cell's `resolved_assets` via `set_cell_resolved_assets`. Only fires when the source actually has resolved assets, so non-markdown cells and unresolved markdown take the no-op branch.

## Test

Extended `test_clone_as_ephemeral_forks_cells_and_clears_outputs` to seed `resolved_assets` on the source markdown cell and assert the clone carries them through via `clone_doc.get_cell_resolved_assets`. Confirmed the test fails without the fix (stashed the handler change, re-ran: the assertion on `clone_md_assets.get("attachment:image.png")` fails with `None`, just like the original bug).

## Follow-ups from the same Codex review

- **F2** — `detect_pyproject` / `get_pyproject_dependencies` / `detect_pixi_toml` / `detect_environment_yml` in `crates/notebook/src/lib.rs` use `path_for_window` only; they're blind for untitled notebooks (including ephemeral clones). The daemon-side auto-launch works fine because the room has `working_dir` — it's the Tauri-side UI commands that need a fallback. Being handled in a separate Tauri-cleanup branch.
- **F3** — the old `clone_notebook_to_disk` preserved unknown top-level metadata keys (jupytext config, colab metadata, etc.) by merging with the existing source `.ipynb`. The new flow only round-trips `kernelspec` + `language_info` + `runt.*` via `NotebookMetadataSnapshot`; unknown keys vanish on clone. Tracked for a follow-up PR.

## Test plan

- [x] `cargo test -p runtimed --lib test_clone_as_ephemeral` (3 passing, including the extended happy-path test)
- [x] Confirmed the test fails without the fix (negative check)
- [x] `cargo clippy -p runtimed --tests -- -D warnings`
- [x] `cargo fmt --check`
