### PR TITLE
fix(notebook): project-file Tauri commands fall back to working_dir

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -386,6 +386,67 @@ fn working_dir_for_window(
     Ok(registry.get(window.label())?.working_dir.clone())
 }
 
+/// Resolve a filesystem anchor for project-file searches (pyproject.toml,
+/// environment.yml, pixi.toml, deno.json).
+///
+/// - If the notebook is file-backed, returns its path as-is. Walkers take
+///   `.parent()` when they see a file.
+/// - Otherwise, if the window's context carries a `working_dir`, returns
+///   `{working_dir}/{UNTITLED_ANCHOR}` — a synthetic path that makes the
+///   downstream helpers behave the same way they do for file-backed
+///   notebooks. See `UNTITLED_ANCHOR` for why.
+/// - Otherwise, returns `None`.
+///
+/// Root-level working_dirs (`/`, `C:\`) don't need special handling: each
+/// `find_*` walker terminates at the filesystem root via its own
+/// `match current.parent()` arm, same as the daemon-side
+/// `find_nearest_project_file`.
+///
+/// Untitled notebooks (including ephemeral clones) inherit a `working_dir`
+/// at create/fork time, so this fallback keeps the UI's project-file
+/// detection working between Clone and the first Save-As.
+fn project_search_path_for_window(
+    window: &tauri::Window,
+    registry: &WindowNotebookRegistry,
+) -> Result<Option<PathBuf>, String> {
+    let path_lock = path_for_window(window, registry)?;
+    let notebook_path = path_lock.lock().map_err(|e| e.to_string())?.clone();
+    let working_dir = working_dir_for_window(window, registry)?;
+    Ok(resolve_project_search_path(notebook_path, working_dir))
+}
+
+/// Synthetic filename appended to an untitled notebook's `working_dir`.
+///
+/// The downstream `find_*` walkers and `create_*_info` helpers both take
+/// a `notebook_path` parameter. Walkers look at `.parent()` when they see
+/// a file, so passing the directory directly works. But the `create_*_info`
+/// helpers compute `relative_path` via
+/// `pathdiff::diff_paths(&config.path, notebook_path.parent().unwrap_or(notebook_path))`
+/// — if we passed the directory directly, `.parent()` would climb one
+/// level too high and relative paths would include an extra segment.
+///
+/// Joining this sentinel onto the directory makes `.parent()` resolve
+/// back to the directory, so both walker and info-helper behave as if
+/// the notebook were a real file at this synthetic path. The string is
+/// never written to disk or shown to users.
+///
+/// Cleaner long-term: change `create_*_info` to take an anchor directory
+/// directly. Left as a follow-up to keep this patch small.
+const UNTITLED_ANCHOR: &str = ".__untitled__.ipynb";
+
+/// Pure helper used by `project_search_path_for_window`. Factored out so
+/// the fallback logic can be unit-tested without constructing a
+/// `tauri::Window`.
+fn resolve_project_search_path(
+    notebook_path: Option<PathBuf>,
+    working_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(p) = notebook_path {
+        return Some(p);
+    }
+    working_dir.map(|d| d.join(UNTITLED_ANCHOR))
+}
+
 fn notebook_id_for_window(
     window: &tauri::Window,
     registry: &WindowNotebookRegistry,
@@ -974,8 +1035,47 @@ async fn setup_sync_receivers(
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_commit_hash, next_available_sample_path, reopen_action, ReopenAction};
+    use super::{
+        extract_commit_hash, next_available_sample_path, reopen_action,
+        resolve_project_search_path, ReopenAction, UNTITLED_ANCHOR,
+    };
+    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    #[test]
+    fn resolve_project_search_path_prefers_notebook_path() {
+        let nb = PathBuf::from("/tmp/foo/bar.ipynb");
+        let wd = PathBuf::from("/tmp/other");
+        assert_eq!(
+            resolve_project_search_path(Some(nb.clone()), Some(wd)),
+            Some(nb)
+        );
+    }
+
+    #[test]
+    fn resolve_project_search_path_falls_back_to_working_dir() {
+        let wd = PathBuf::from("/tmp/proj");
+        let result = resolve_project_search_path(None, Some(wd.clone()));
+        assert_eq!(result, Some(wd.join(UNTITLED_ANCHOR)));
+        // `.parent()` of the synthetic path lines up with working_dir so
+        // walkers start in the right place and relative_path stays sane.
+        assert_eq!(result.unwrap().parent(), Some(wd.as_path()));
+    }
+
+    #[test]
+    fn resolve_project_search_path_returns_none_when_both_missing() {
+        assert_eq!(resolve_project_search_path(None, None), None);
+    }
+
+    #[test]
+    fn resolve_project_search_path_accepts_root_working_dir() {
+        // Root-level working_dirs are fine: the `find_*` walkers
+        // terminate at the filesystem root on their own, so we don't
+        // need a special guard here.
+        let root = PathBuf::from("/");
+        let result = resolve_project_search_path(None, Some(root.clone()));
+        assert_eq!(result, Some(root.join(UNTITLED_ANCHOR)));
+    }
 
     #[test]
     fn extract_commit_hash_returns_sha_without_dirty_suffix() {
@@ -2969,14 +3069,10 @@ async fn detect_pyproject(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<pyproject::PyProjectInfo>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    // Need a notebook path to search from
-    let Some(notebook_path) = notebook_path else {
+    // Use the notebook path if file-backed, else fall back to the window's
+    // working_dir so ephemeral clones and other untitled notebooks still
+    // resolve project files.
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 
@@ -3015,13 +3111,7 @@ async fn get_pyproject_dependencies(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<PyProjectDepsJson>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    let Some(notebook_path) = notebook_path else {
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 
@@ -3056,15 +3146,10 @@ async fn import_pyproject_dependencies(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<(), String> {
-    let path = path_for_window(&window, registry.inner())?;
     let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
 
-    let Some(notebook_path) = notebook_path else {
-        return Err("No notebook path set".to_string());
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
+        return Err("No notebook path or working directory set".to_string());
     };
 
     let Some(pyproject_path) = pyproject::find_pyproject(&notebook_path) else {
@@ -3168,14 +3253,7 @@ async fn detect_pixi_toml(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<pixi::PixiInfo>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    // Need a notebook path to search from
-    let Some(notebook_path) = notebook_path else {
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 
@@ -3206,14 +3284,7 @@ async fn detect_environment_yml(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<environment_yml::EnvironmentYmlInfo>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    // Need a notebook path to search from
-    let Some(notebook_path) = notebook_path else {
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 
@@ -3252,13 +3323,7 @@ async fn get_environment_yml_dependencies(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<EnvironmentYmlDepsJson>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    let Some(notebook_path) = notebook_path else {
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 
@@ -3293,15 +3358,10 @@ async fn import_pixi_dependencies(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<(), String> {
-    let path = path_for_window(&window, registry.inner())?;
     let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
 
-    let Some(notebook_path) = notebook_path else {
-        return Err("No notebook path set".to_string());
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
+        return Err("No notebook path or working directory set".to_string());
     };
 
     let Some(pixi_path) = pixi::find_pixi_toml(&notebook_path) else {
@@ -3342,13 +3402,7 @@ async fn detect_deno_config(
     window: tauri::Window,
     registry: tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<Option<deno_env::DenoConfigInfo>, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_path = {
-        let path = path.lock().map_err(|e| e.to_string())?;
-        path.clone()
-    };
-
-    let Some(notebook_path) = notebook_path else {
+    let Some(notebook_path) = project_search_path_for_window(&window, registry.inner())? else {
         return Ok(None);
     };
 


### PR DESCRIPTION
## Why

After the ephemeral-clone landing (#2192), untitled notebooks — clones fresh from `CloneAsEphemeral`, plus any other newly-created untitled — had no `.ipynb` path. The daemon-side auto-launch resolved project files fine via `room.identity.working_dir` and `find_nearest_project_file`, but the **UI** dependency banners stayed blank. Every Tauri project-file detection command short-circuited to `None` because it only looked at `path_for_window`.

Codex flagged this as F2 on the #2192 review: `detect_pyproject`, `get_pyproject_dependencies`, `import_pyproject_dependencies`, `detect_pixi_toml`, `detect_environment_yml`, `get_environment_yml_dependencies`, `import_pixi_dependencies`, and `detect_deno_config` all shared the same pattern.

## What changed

Added a shared helper `project_search_path_for_window` (with a pure-logic inner `resolve_project_search_path`) that:

1. Returns the notebook path if it's file-backed.
2. Falls back to `{working_dir}/{UNTITLED_ANCHOR}` — a synthetic filename joined onto the window's working_dir so both the `find_*` walkers and the `create_*_info` helpers do the right thing without changing their signatures.
3. Returns `None` only when both path and working_dir are absent.

Rewrote the 8 Tauri commands listed above to use it.

## Why the synthetic `UNTITLED_ANCHOR` filename

The downstream helpers:

- `find_pyproject`, `find_pixi_toml`, `find_environment_yml`, `find_deno_config`: take a path, use `.parent()` when it's a file, use the path directly when it's a directory. A bare directory works fine here.
- `create_pyproject_info`, `create_pixi_info`, `create_environment_yml_info`, `create_deno_config_info`: compute `relative_path = pathdiff::diff_paths(&config.path, notebook_path.parent().unwrap_or(notebook_path))`. If we passed a directory directly, `.parent()` would climb one level too high and the relative path would include an extra segment.

Joining `UNTITLED_ANCHOR` onto the directory makes `.parent()` resolve back to the directory itself, so both helper families behave as if the notebook were a real file at the synthetic path. The filename never touches disk; it's only fed into pure-function helpers.

Cleaner long-term: change `create_*_info` to take an anchor directory directly. Flagged inline. Out of scope for this fix.

## Why no root-suspicion guard

Initial draft rejected root working_dirs and fell back to `~/notebooks`. Turned out unnecessary:

- `find_pyproject`, `find_pixi_toml`, `find_environment_yml`, `find_deno_config`, and the daemon-side `find_nearest_project_file` all have `match current.parent() { Some(p) if p != current => ..., _ => return None }` at the bottom of their walk loop.
- A `/` working_dir produces: check root for the file → not present → terminate. No escape past filesystem root, no false positives.

Comment in the helper calls this out so the guard doesn't get re-added later.

## Tests

4 unit tests on `resolve_project_search_path`:

- `prefers_notebook_path` — when both present, path wins
- `falls_back_to_working_dir` — when only working_dir, synthetic path with `.parent()` equal to working_dir
- `returns_none_when_both_missing` — full None passthrough
- `accepts_root_working_dir` — `/` is fine, produces `/{UNTITLED_ANCHOR}`

## Test plan

- [x] `cargo test -p notebook --lib resolve_project_search_path` (4 passing)
- [x] `cargo clippy -p notebook --tests -- -D warnings`
- [x] `cargo check -p notebook`
- [ ] Manual QA: clone a notebook that sits in a directory with `pyproject.toml`; confirm the clone window shows the pyproject dependency banner without needing Save-As first.

## Out of scope

- **F3** — unknown top-level metadata preservation on clone. Tracked separately.
- Refactor `create_*_info` helpers to take an anchor directory instead of a notebook path (removes the `UNTITLED_ANCHOR` hack).
