### PR TITLE
feat(protocol): offload Comm broadcast buffers through blob store

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -412,16 +412,44 @@ function AppContent() {
 
     // Custom comm messages (buttons, model.send()) are ephemeral events
     // delivered via broadcast, not CRDT state. Route to WidgetStore.
+    //
+    // Buffers ride as `BlobRef[]` ({ blob, size, media_type }). Fetch them
+    // from the daemon's blob HTTP server and hand the resolved
+    // ArrayBuffer[] to the existing widget-store contract. A follow-up
+    // moves the fetch into the iframe sandbox so widget binary stops
+    // materializing in the parent webview at all (matching the output
+    // bytes path).
     const customSub = engine.commBroadcasts$.subscribe((broadcast) => {
       const content = broadcast.content as Record<string, unknown> | undefined;
       const data = content?.data as Record<string, unknown> | undefined;
-      if (data?.method === "custom") {
-        const commId = content?.comm_id as string;
-        const inner = (data?.content as Record<string, unknown>) ?? {};
-        const buffers = (broadcast as { buffers?: number[][] }).buffers;
-        const arrayBuffers = buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
-        widgetStore.emitCustomMessage(commId, inner, arrayBuffers);
+      if (data?.method !== "custom") return;
+      const commId = content?.comm_id as string;
+      const inner = (data?.content as Record<string, unknown>) ?? {};
+      const refs = (broadcast as { buffers?: { blob: string; size: number }[] }).buffers ?? [];
+      if (refs.length === 0) {
+        widgetStore.emitCustomMessage(commId, inner, undefined);
+        return;
       }
+      const port = getBlobPort();
+      if (port === null) {
+        // Blob port not yet resolved — drop buffers, deliver content only.
+        // This is a rare race on first connect; comms after the first
+        // daemon:ready always have a port.
+        widgetStore.emitCustomMessage(commId, inner, undefined);
+        return;
+      }
+      Promise.all(
+        refs.map((ref) =>
+          fetch(`http://127.0.0.1:${port}/blob/${ref.blob}`).then((r) => r.arrayBuffer()),
+        ),
+      )
+        .then((arrayBuffers) => {
+          widgetStore.emitCustomMessage(commId, inner, arrayBuffers);
+        })
+        .catch((err) => {
+          logger.warn("[comm] failed to fetch widget buffers:", err);
+          widgetStore.emitCustomMessage(commId, inner, undefined);
+        });
     });
 
     return () => {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -425,7 +425,7 @@ function AppContent() {
       if (data?.method !== "custom") return;
       const commId = content?.comm_id as string;
       const inner = (data?.content as Record<string, unknown>) ?? {};
-      const refs = (broadcast as { buffers?: { blob: string; size: number }[] }).buffers ?? [];
+      const refs = broadcast.buffers ?? [];
       if (refs.length === 0) {
         widgetStore.emitCustomMessage(commId, inner, undefined);
         return;

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -387,10 +387,11 @@ struct FrameSizeLimits {
 /// - **NotebookResponse**: 64 MiB. `Response::DocBytes` returns a full
 ///   Automerge doc dump; `Response::NotebookState` carries
 ///   inspect-notebook output. Both can legitimately be large.
-/// - **NotebookBroadcast**: 16 MiB. `Comm.buffers` carries kernel-sourced
-///   widget buffer bytes and is the only path where kernel-controlled
-///   bytes still ride raw on a non-CRDT frame. Tightens further once
-///   that path moves through the blob store.
+/// - **NotebookBroadcast**: 16 MiB. `Comm.buffers` is now `Vec<BlobRef>`
+///   (kernel-side runtime agent puts buffers in the blob store before
+///   broadcasting). The cap stays loose in this revision pending a
+///   follow-up that drops it to 1 MiB along with the matching tightening
+///   on Request once `SendComm.buffers` is also offloaded.
 /// - **Presence**: 1 MiB. CBOR cursor + selection per peer.
 /// - **PoolStateSync**: 1 MiB. The pool doc is bounded.
 /// - **SessionControl**: 1 MiB. JSON readiness frames are tiny.

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -129,6 +129,24 @@ pub struct QueueEntry {
     pub execution_id: String,
 }
 
+/// Reference to a blob in the daemon's blob store.
+///
+/// Same JSON shape as the inline `ContentRef::Blob` variant used in output
+/// manifests: `{"blob": "<sha256>", "size": <bytes>, "media_type": "..."}`.
+/// Carried over the wire so consumers fetch the bytes from the blob HTTP
+/// server (`GET /blob/{hash}`) instead of receiving them inline.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlobRef {
+    pub blob: String,
+    pub size: u64,
+    #[serde(default = "default_buffer_media_type")]
+    pub media_type: String,
+}
+
+fn default_buffer_media_type() -> String {
+    "application/octet-stream".to_string()
+}
+
 /// Typed environment kind for sync operations.
 ///
 /// Replaces string-based env_type ("uv", "conda") with a discriminated union
@@ -596,9 +614,11 @@ pub enum NotebookBroadcast {
         msg_type: String,
         /// Message content (comm_id, data, target_name, etc.)
         content: serde_json::Value,
-        /// Binary buffers (base64-encoded when serialized to JSON)
+        /// Binary buffers, offloaded to the blob store. Consumers fetch the
+        /// bytes via the daemon's blob HTTP server. Empty for messages that
+        /// carry no buffers (most non-`comm_msg` types).
         #[serde(default)]
-        buffers: Vec<Vec<u8>>,
+        buffers: Vec<BlobRef>,
     },
 
     /// Environment progress update during kernel launch.

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -548,4 +548,31 @@ mod tests {
             _ => panic!("unexpected broadcast type"),
         }
     }
+
+    #[test]
+    fn test_notebook_broadcast_comm_with_buffer_refs() {
+        use notebook_protocol::protocol::BlobRef;
+        let broadcast = NotebookBroadcast::Comm {
+            msg_type: "comm_msg".into(),
+            content: serde_json::json!({"comm_id": "abc"}),
+            buffers: vec![BlobRef {
+                blob: "deadbeef".into(),
+                size: 42,
+                media_type: "application/octet-stream".into(),
+            }],
+        };
+        let json = serde_json::to_string(&broadcast).unwrap();
+        assert!(json.contains("deadbeef"));
+        assert!(json.contains("\"size\":42"));
+
+        let parsed: NotebookBroadcast = serde_json::from_str(&json).unwrap();
+        match parsed {
+            NotebookBroadcast::Comm { buffers, .. } => {
+                assert_eq!(buffers.len(), 1);
+                assert_eq!(buffers[0].blob, "deadbeef");
+                assert_eq!(buffers[0].size, 42);
+            }
+            _ => panic!("unexpected broadcast type"),
+        }
+    }
 }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1751,10 +1751,19 @@ impl KernelConnection for JupyterKernel {
                                     }
 
                                     if method != Some("update") {
+                                        let buffer_refs = if buffers.is_empty() {
+                                            Vec::new()
+                                        } else {
+                                            crate::output_prep::store_buffers_as_refs(
+                                                &buffers,
+                                                &blob_store,
+                                            )
+                                            .await
+                                        };
                                         let _ = broadcast_tx.send(NotebookBroadcast::Comm {
                                             msg_type: message.header.msg_type.clone(),
                                             content: content.clone(),
-                                            buffers: buffers.clone(),
+                                            buffers: buffer_refs,
                                         });
                                     }
                                 }

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 
 use crate::blob_store::BlobStore;
 use crate::output_store::{self, OutputManifest, DEFAULT_INLINE_THRESHOLD};
+use notebook_protocol::protocol::BlobRef;
 use runtime_doc::RuntimeStateDoc;
 
 /// Store widget buffers in the blob store and replace values in the state
@@ -82,6 +83,40 @@ pub(crate) async fn store_widget_buffers(
     }
 
     (modified, used_paths)
+}
+
+/// Store widget buffers in the blob store and return a parallel list of
+/// `BlobRef` entries, preserving order.
+///
+/// For the broadcast path (`NotebookBroadcast::Comm.buffers`), buffers ride
+/// alongside the message content rather than being embedded in a state dict
+/// at known paths. This helper is the simpler counterpart to
+/// `store_widget_buffers` for that use case.
+///
+/// Buffers that fail to store are skipped (logged at warn). The returned
+/// `Vec` is therefore at most as long as the input — frontends should not
+/// assume length-equality.
+pub(crate) async fn store_buffers_as_refs(
+    buffers: &[Vec<u8>],
+    blob_store: &BlobStore,
+) -> Vec<BlobRef> {
+    let mut refs = Vec::with_capacity(buffers.len());
+    for buf in buffers {
+        match blob_store.put(buf, "application/octet-stream").await {
+            Ok(hash) => refs.push(BlobRef {
+                blob: hash,
+                size: buf.len() as u64,
+                media_type: "application/octet-stream".to_string(),
+            }),
+            Err(e) => {
+                tracing::warn!(
+                    "[kernel-manager] Failed to store comm broadcast buffer: {}",
+                    e
+                );
+            }
+        }
+    }
+    refs
 }
 
 /// Navigate into a JSON value by key (object) or index (array).

--- a/packages/runtimed/src/broadcast-types.ts
+++ b/packages/runtimed/src/broadcast-types.ts
@@ -13,11 +13,26 @@
 
 // ── Broadcast interfaces ────────────────────────────────────────────
 
+/**
+ * Reference to a binary blob in the daemon's blob store. Mirrors the
+ * Rust `BlobRef` struct in `notebook-protocol`. Consumers fetch the
+ * bytes via `GET http://127.0.0.1:<blob_port>/blob/<hash>`.
+ */
+export interface BlobRef {
+  blob: string;
+  size: number;
+  media_type: string;
+}
+
 export interface CommBroadcast {
   event: "comm";
   msg_type: string;
   content: Record<string, unknown>;
-  buffers: number[][];
+  /**
+   * Widget binary buffers, offloaded to the blob store. Empty for
+   * messages that carry no buffers.
+   */
+  buffers: BlobRef[];
 }
 
 export interface EnvProgressBroadcast {


### PR DESCRIPTION
## Summary

Moves widget buffer bytes off the typed-frame wire (kernel → frontend direction). `NotebookBroadcast::Comm.buffers` becomes `Vec<BlobRef>` instead of `Vec<Vec<u8>>`. The runtime agent already has blob-store write access (it's how outputs work), so this needs zero new auth surface.

Closes an asymmetry that's been sitting in `jupyter_kernel.rs`: the same iopub handler already called `store_widget_buffers()` to offload buffers for the doc-state side at line 1727, then turned around and emitted the *same buffers raw* on the broadcast path at line 1754. Same bytes, two paths — one offloaded, one not. This PR uses the same blob-store pattern for both.

## Why this PR exists

Background from PRs #2191 / #2193: per-type frame caps with a 16 MiB Request cap, sized to fit `SendComm.buffers` after JSON's ~4× expansion of binary. The cap was honest but loose. The principled fix is to take the bytes off the channel — per-content offloading, not bigger caps.

`NotebookBroadcast::Comm.buffers` was the kernel-controlled side of the same problem: bytes flowing the *other* direction, also raw on the wire. Tightening Broadcast and Request caps both depend on offload work.

## Mechanics

| Piece | What changed |
|---|---|
| `BlobRef` struct (new) | `notebook-protocol`. Same JSON shape (`{blob, size, media_type}`) as the inline `ContentRef::Blob` used in output manifests. |
| `NotebookBroadcast::Comm.buffers` | `Vec<Vec<u8>>` → `Vec<BlobRef>` |
| `store_buffers_as_refs(buffers, blob_store)` (new) | `runtimed::output_prep`. Parallel-list counterpart to the existing in-place `store_widget_buffers`. Stores each buffer, returns a `Vec<BlobRef>`. Failed puts are logged + skipped. |
| `jupyter_kernel.rs:1754` | Calls `store_buffers_as_refs` before `broadcast_tx.send`. The two iopub-handler paths now offload buffers symmetrically. |
| `App.tsx` Comm broadcast handler | Reads `BlobRef[]` from the broadcast, fetches each via `http://127.0.0.1:<blob_port>/blob/<hash>`, hands resolved `ArrayBuffer[]` to the existing `widgetStore.emitCustomMessage` contract. |

## Cap stays at 16 MiB this PR

The `NotebookBroadcast` cap is unchanged (still 16 MiB). Tightening to 1 MiB lands once `SendComm.buffers` (the outbound direction) is also offloaded, since loosening Request to fit `SendComm` was the original reason for the matching loose Broadcast cap. Doing both at once keeps the cap-table consistent.

## Follow-ups

Tracked in `.context/plans/buffer-offload-and-blob-socket.md`:

1. **Iframe-side resolution.** Push the `BlobRef → ArrayBuffer` fetch into the iframe sandbox so widget binary stops materializing in the parent webview at all. Matches how output bytes already work — outputs travel as URLs to the iframe, the iframe fetches from the blob HTTP server. This PR keeps the parent fetch as a temporary bridge that preserves the existing `widgetStore.emitCustomMessage(commId, content, ArrayBuffer[])` contract.
2. **Outbound offload via `runtimed-blobs.sock`.** Frontend has no blob-store write path today; `SendComm.buffers` rides the typed wire. Adding a dedicated Unix socket for blob writes (separate from the typed-frame socket) eliminates the frame-mixing concern by physical channel separation, not just type-byte separation.
3. **Cap tightening.** Once both directions are offloaded, Request and Broadcast caps drop to 1 MiB.

## Test plan

- [x] `cargo build --workspace --exclude runtimed-py`
- [x] `cargo test -p notebook-protocol -p runtimed-client -p runtimed --lib --tests` (179 / 487 / 69 passing)
- [x] `pnpm test:run` (1048 frontend tests passing)
- [x] `cargo xtask lint --fix` clean
- [x] New: `protocol::tests::test_notebook_broadcast_comm_with_buffer_refs` — round-trips a `Comm` broadcast with a `BlobRef`, asserts hash and size land on the wire.
- [ ] Manual: open a notebook with a custom-message-driven widget (anywidget `model.send`), confirm buffers arrive intact end-to-end.

## Predecessors

- #2188 — drop dead broadcast variants
- #2190 — move path/last_saved to RuntimeStateDoc
- #2191 — per-type frame caps
- #2193 — bump Request cap to 16 MiB for SendComm widget buffers
- #2194 — drop dead Tauri dirty machinery
