### PR TITLE
spec: notebook metadata extras round-trip

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fcc1b1e111390630a853ae3fd15bb28a74e0b103782c71aaa22e6c1e4901bac
-size 2504607
+oid sha256:08cb60406c46977c4c2e58293523a8dbf7d911e8c6c233f7246d7f7dad76fd5f
+size 2519855

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -380,6 +380,7 @@ impl NotebookDoc {
                 kernelspec,
                 language_info,
                 runt: runt.unwrap_or_default(),
+                extras: std::collections::BTreeMap::new(),
             });
         }
 
@@ -1951,6 +1952,7 @@ pub fn get_metadata_snapshot_from_doc(
             kernelspec,
             language_info,
             runt: runt.unwrap_or_default(),
+            extras: std::collections::BTreeMap::new(),
         });
     }
 
@@ -3351,12 +3353,15 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: Some(metadata::LanguageInfoSnapshot {
                 name: "python".to_string(),
                 version: Some("3.11.5".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3373,9 +3378,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3749,9 +3756,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3771,9 +3780,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3795,9 +3806,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3976,9 +3989,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
         doc.set_metadata_snapshot(&snapshot1).unwrap();
 
@@ -3988,12 +4003,15 @@ mod tests {
                 name: "deno".to_string(),
                 display_name: "Deno".to_string(),
                 language: Some("typescript".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: Some(metadata::LanguageInfoSnapshot {
                 name: "typescript".to_string(),
                 version: None,
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: metadata::RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
         doc.set_metadata_snapshot(&snapshot2).unwrap();
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -375,12 +375,14 @@ impl NotebookDoc {
         let runt = read_json_value(&self.doc, &meta_id, "runt")
             .and_then(|v| serde_json::from_value::<metadata::RuntMetadata>(v).ok());
 
-        if kernelspec.is_some() || language_info.is_some() || runt.is_some() {
+        let extras = scan_metadata_extras(&self.doc, &meta_id);
+
+        if kernelspec.is_some() || language_info.is_some() || runt.is_some() || !extras.is_empty() {
             return Some(metadata::NotebookMetadataSnapshot {
                 kernelspec,
                 language_info,
                 runt: runt.unwrap_or_default(),
-                extras: std::collections::BTreeMap::new(),
+                extras,
             });
         }
 
@@ -426,9 +428,28 @@ impl NotebookDoc {
             }
         }
 
-        let runt_v = serde_json::to_value(&snapshot.runt)
-            .map_err(|e| AutomergeError::InvalidObjId(format!("serialize runt: {}", e)))?;
-        update_json_at_key(&mut self.doc, &meta_id, "runt", &runt_v)?;
+        // Write runt only when non-empty so vanilla Jupyter notebooks
+        // round-trip without stamping a synthetic runt blob.
+        if snapshot.runt.is_empty() {
+            let _ = self.doc.delete(&meta_id, "runt");
+        } else {
+            let runt_v = serde_json::to_value(&snapshot.runt)
+                .map_err(|e| AutomergeError::InvalidObjId(format!("serialize runt: {}", e)))?;
+            update_json_at_key(&mut self.doc, &meta_id, "runt", &runt_v)?;
+        }
+
+        // Write extras. Each key becomes its own Automerge Map so
+        // concurrent edits to metadata.jupytext.* from two peers merge
+        // per-field. Guard against callers that stuff known top-level
+        // keys into extras — those would double-write at the same
+        // Automerge key.
+        for (key, value) in &snapshot.extras {
+            if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+                report_extras_collision(key);
+                continue;
+            }
+            update_json_at_key(&mut self.doc, &meta_id, key, value)?;
+        }
 
         Ok(())
     }
@@ -1877,6 +1898,71 @@ pub use automunge::{
     update_json_at_key,
 };
 
+/// Report a metadata-extras collision with a known typed key.
+///
+/// Called by `NotebookDoc::set_metadata_snapshot` when a caller stuffs
+/// a reserved key (`kernelspec`, `language_info`, `runt`) into the
+/// extras bag. Dropping the write is safe — the typed field carries
+/// the real value — but it indicates a caller bug that would otherwise
+/// silently cause an Automerge double-write at the same key. Error
+/// level so it surfaces on stable channels too.
+///
+/// Uses `log` under the `persistence` feature (daemon, native builds)
+/// and `eprintln!` otherwise (WASM, where a plain stderr message is
+/// the best we can do without pulling in a web-sys dep).
+fn report_extras_collision(key: &str) {
+    let msg = format!(
+        "[notebook-doc] metadata.extras collision: key {:?} is reserved for \
+         a typed field; dropping to avoid Automerge double-write. This \
+         indicates a caller bug in snapshot construction.",
+        key
+    );
+    #[cfg(feature = "persistence")]
+    log::error!("{}", msg);
+    #[cfg(not(feature = "persistence"))]
+    eprintln!("{}", msg);
+}
+
+/// Keys that live at `metadata.*` in the Automerge doc but must NOT be
+/// round-tripped as extras on the NotebookMetadataSnapshot:
+///
+/// - `kernelspec`, `language_info`, `runt`: modeled by typed fields.
+/// - `runtime`: an nteract-internal scalar (set by bootstrap,
+///   mutated by `set_metadata`) used for runtime-type detection.
+///   It's a schema artifact, not an nbformat key, so it must not
+///   surface on disk via the extras save path.
+/// - `ephemeral`: an nteract-internal scalar marking in-memory-only
+///   rooms.
+fn is_snapshot_reserved_metadata_key(key: &str) -> bool {
+    matches!(
+        key,
+        "kernelspec" | "language_info" | "runt" | "runtime" | "ephemeral"
+    )
+}
+
+/// Scan an Automerge metadata Map for top-level keys that aren't modeled
+/// by `NotebookMetadataSnapshot`'s typed fields.
+///
+/// Shared by `NotebookDoc::get_metadata_snapshot` and the free-function
+/// `get_metadata_snapshot_from_doc`. Both must behave identically —
+/// different behavior would mean the frontend sync snapshot and Python
+/// bindings disagree with the daemon's view of the same doc.
+fn scan_metadata_extras(
+    doc: &AutoCommit,
+    meta_id: &ObjId,
+) -> std::collections::BTreeMap<String, serde_json::Value> {
+    let mut extras = std::collections::BTreeMap::new();
+    for key in doc.keys(meta_id) {
+        if is_snapshot_reserved_metadata_key(&key) {
+            continue;
+        }
+        if let Some(value) = read_json_value(doc, meta_id, &key) {
+            extras.insert(key, value);
+        }
+    }
+    extras
+}
+
 /// Read cell metadata with native Automerge map support and legacy string fallback.
 ///
 /// Tries to read `metadata` as an `ObjType::Map` first (native storage),
@@ -1947,12 +2033,14 @@ pub fn get_metadata_snapshot_from_doc(
     let runt = read_json_value(doc, &meta_id, "runt")
         .and_then(|v| serde_json::from_value::<metadata::RuntMetadata>(v).ok());
 
-    if kernelspec.is_some() || language_info.is_some() || runt.is_some() {
+    let extras = scan_metadata_extras(doc, &meta_id);
+
+    if kernelspec.is_some() || language_info.is_some() || runt.is_some() || !extras.is_empty() {
         return Some(metadata::NotebookMetadataSnapshot {
             kernelspec,
             language_info,
             runt: runt.unwrap_or_default(),
-            extras: std::collections::BTreeMap::new(),
+            extras,
         });
     }
 
@@ -3387,10 +3475,15 @@ mod tests {
 
         doc.set_metadata_snapshot(&snapshot).unwrap();
 
-        // Native keys should exist
+        // kernelspec gets written. `runt` is empty (default) so the
+        // snapshot writer intentionally skips it to avoid stamping
+        // synthetic metadata on vanilla notebooks.
         let meta_id = doc.metadata_map_id().unwrap();
         assert!(doc.get_json_value(&meta_id, "kernelspec").is_some());
-        assert!(doc.get_json_value(&meta_id, "runt").is_some());
+        assert!(
+            doc.get_json_value(&meta_id, "runt").is_none(),
+            "empty runt must not be written to the doc"
+        );
 
         // Read back via native keys
         let read_back = doc.get_metadata_snapshot().unwrap();
@@ -4018,5 +4111,123 @@ mod tests {
         let read_back = doc.get_metadata_snapshot().unwrap();
         assert_eq!(read_back.kernelspec.as_ref().unwrap().name, "deno");
         assert_eq!(read_back.language_info.as_ref().unwrap().name, "typescript");
+    }
+
+    #[test]
+    fn set_metadata_snapshot_writes_extras_as_siblings() {
+        use crate::metadata::NotebookMetadataSnapshot;
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.extras.insert(
+            "jupytext".to_string(),
+            serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        );
+        snap.extras.insert(
+            "colab".to_string(),
+            serde_json::json!({"kernel": {"name": "python3"}}),
+        );
+        doc.set_metadata_snapshot(&snap).unwrap();
+
+        let round_tripped = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(round_tripped.extras.len(), 2);
+        assert_eq!(
+            round_tripped.extras.get("jupytext"),
+            Some(&serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}))
+        );
+        assert_eq!(
+            round_tripped.extras.get("colab"),
+            Some(&serde_json::json!({"kernel": {"name": "python3"}}))
+        );
+    }
+
+    #[test]
+    fn set_metadata_snapshot_drops_extras_colliding_with_kernelspec() {
+        use crate::metadata::{KernelspecSnapshot, NotebookMetadataSnapshot};
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.kernelspec = Some(KernelspecSnapshot {
+            name: "python3".to_string(),
+            display_name: "Python 3".to_string(),
+            language: Some("python".to_string()),
+            extras: Default::default(),
+        });
+        snap.extras
+            .insert("kernelspec".to_string(), serde_json::json!({"BAD": true}));
+
+        doc.set_metadata_snapshot(&snap).unwrap();
+
+        let round_tripped = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            round_tripped.kernelspec.as_ref().unwrap().name,
+            "python3",
+            "typed kernelspec must survive collision"
+        );
+        assert!(
+            !round_tripped.extras.contains_key("kernelspec"),
+            "collision-dropped key must not appear in extras"
+        );
+    }
+
+    #[test]
+    fn set_metadata_snapshot_drops_extras_colliding_with_language_info() {
+        use crate::metadata::{LanguageInfoSnapshot, NotebookMetadataSnapshot};
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.language_info = Some(LanguageInfoSnapshot {
+            name: "python".to_string(),
+            version: Some("3.11.5".to_string()),
+            extras: Default::default(),
+        });
+        snap.extras.insert(
+            "language_info".to_string(),
+            serde_json::json!({"BAD": true}),
+        );
+
+        doc.set_metadata_snapshot(&snap).unwrap();
+
+        let round_tripped = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(round_tripped.language_info.as_ref().unwrap().name, "python");
+        assert!(!round_tripped.extras.contains_key("language_info"));
+    }
+
+    #[test]
+    fn set_metadata_snapshot_drops_extras_colliding_with_runt() {
+        use crate::metadata::NotebookMetadataSnapshot;
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.runt.env_id = Some("real-env-id".to_string());
+        snap.extras
+            .insert("runt".to_string(), serde_json::json!({"env_id": "bogus"}));
+
+        doc.set_metadata_snapshot(&snap).unwrap();
+
+        let round_tripped = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            round_tripped.runt.env_id.as_deref(),
+            Some("real-env-id"),
+            "typed runt must win over colliding extras"
+        );
+        assert!(!round_tripped.extras.contains_key("runt"));
+    }
+
+    #[test]
+    fn get_metadata_snapshot_from_doc_reads_extras() {
+        use crate::metadata::NotebookMetadataSnapshot;
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.extras.insert(
+            "jupytext".to_string(),
+            serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        );
+        doc.set_metadata_snapshot(&snap).unwrap();
+
+        // Read via the free-function path (used by notebook-sync +
+        // Python bindings, not the &self method).
+        let round_tripped = crate::get_metadata_snapshot_from_doc(doc.doc())
+            .expect("free function should surface extras");
+        assert!(round_tripped.extras.contains_key("jupytext"));
     }
 }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -4145,13 +4145,15 @@ mod tests {
         use crate::metadata::{KernelspecSnapshot, NotebookMetadataSnapshot};
         let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
 
-        let mut snap = NotebookMetadataSnapshot::default();
-        snap.kernelspec = Some(KernelspecSnapshot {
-            name: "python3".to_string(),
-            display_name: "Python 3".to_string(),
-            language: Some("python".to_string()),
-            extras: Default::default(),
-        });
+        let mut snap = NotebookMetadataSnapshot {
+            kernelspec: Some(KernelspecSnapshot {
+                name: "python3".to_string(),
+                display_name: "Python 3".to_string(),
+                language: Some("python".to_string()),
+                extras: Default::default(),
+            }),
+            ..Default::default()
+        };
         snap.extras
             .insert("kernelspec".to_string(), serde_json::json!({"BAD": true}));
 
@@ -4174,12 +4176,14 @@ mod tests {
         use crate::metadata::{LanguageInfoSnapshot, NotebookMetadataSnapshot};
         let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
 
-        let mut snap = NotebookMetadataSnapshot::default();
-        snap.language_info = Some(LanguageInfoSnapshot {
-            name: "python".to_string(),
-            version: Some("3.11.5".to_string()),
-            extras: Default::default(),
-        });
+        let mut snap = NotebookMetadataSnapshot {
+            language_info: Some(LanguageInfoSnapshot {
+                name: "python".to_string(),
+                version: Some("3.11.5".to_string()),
+                extras: Default::default(),
+            }),
+            ..Default::default()
+        };
         snap.extras.insert(
             "language_info".to_string(),
             serde_json::json!({"BAD": true}),
@@ -4194,11 +4198,16 @@ mod tests {
 
     #[test]
     fn set_metadata_snapshot_drops_extras_colliding_with_runt() {
-        use crate::metadata::NotebookMetadataSnapshot;
+        use crate::metadata::{NotebookMetadataSnapshot, RuntMetadata};
         let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
 
-        let mut snap = NotebookMetadataSnapshot::default();
-        snap.runt.env_id = Some("real-env-id".to_string());
+        let mut snap = NotebookMetadataSnapshot {
+            runt: RuntMetadata {
+                env_id: Some("real-env-id".to_string()),
+                ..RuntMetadata::default()
+            },
+            ..Default::default()
+        };
         snap.extras
             .insert("runt".to_string(), serde_json::json!({"env_id": "bogus"}));
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -438,14 +438,40 @@ impl NotebookDoc {
             update_json_at_key(&mut self.doc, &meta_id, "runt", &runt_v)?;
         }
 
+        // Delete extras keys that were present in the doc but are absent
+        // from the incoming snapshot. This is the replacement semantic
+        // the file-watcher path needs: when a user deletes `jupytext`
+        // from the .ipynb, re-parses it, and pushes the new snapshot
+        // back, the old Automerge map must go. Without this, stale
+        // extras linger in the doc forever.
+        //
+        // Scan before writing so we don't delete keys we're about to
+        // re-add (a no-op) and so reserved keys (kernelspec,
+        // language_info, runt, runtime, ephemeral) never get touched.
+        let stale_keys: Vec<String> = self
+            .doc
+            .keys(&meta_id)
+            .filter(|k| !is_snapshot_reserved_metadata_key(k))
+            .filter(|k| !snapshot.extras.contains_key(k))
+            .collect();
+        for key in &stale_keys {
+            let _ = self.doc.delete(&meta_id, key.as_str());
+        }
+
         // Write extras. Each key becomes its own Automerge Map so
         // concurrent edits to metadata.jupytext.* from two peers merge
-        // per-field. Guard against callers that stuff known top-level
-        // keys into extras — those would double-write at the same
-        // Automerge key.
+        // per-field. Guard against callers that stuff known typed keys
+        // into extras — those would double-write at the same Automerge
+        // key. The `runtime`/`ephemeral` reserved scalars aren't in
+        // this guard because they're already skipped on the read path;
+        // if a caller did stash one in extras, silently dropping it in
+        // the stale-key filter below is preferable to an error log.
         for (key, value) in &snapshot.extras {
             if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
                 report_extras_collision(key);
+                continue;
+            }
+            if is_snapshot_reserved_metadata_key(key) {
                 continue;
             }
             update_json_at_key(&mut self.doc, &meta_id, key, value)?;
@@ -4220,6 +4246,90 @@ mod tests {
             "typed runt must win over colliding extras"
         );
         assert!(!round_tripped.extras.contains_key("runt"));
+    }
+
+    #[test]
+    fn set_metadata_snapshot_deletes_stale_extras_absent_from_replacement() {
+        use crate::metadata::NotebookMetadataSnapshot;
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        // Initial write: two unknown keys.
+        let mut first = NotebookMetadataSnapshot::default();
+        first
+            .extras
+            .insert("jupytext".to_string(), serde_json::json!({"formats": "py"}));
+        first.extras.insert(
+            "colab".to_string(),
+            serde_json::json!({"kernel": "python3"}),
+        );
+        doc.set_metadata_snapshot(&first).unwrap();
+
+        let after_first = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(after_first.extras.len(), 2);
+
+        // Replacement: only jupytext present. colab must be deleted,
+        // not quietly retained. This is the file-watcher-reload path —
+        // a user edits metadata on disk, we re-parse, and the daemon
+        // has to converge to the new shape.
+        let mut second = NotebookMetadataSnapshot::default();
+        second
+            .extras
+            .insert("jupytext".to_string(), serde_json::json!({"formats": "py"}));
+        doc.set_metadata_snapshot(&second).unwrap();
+
+        let after_second = doc.get_metadata_snapshot().unwrap();
+        assert!(after_second.extras.contains_key("jupytext"));
+        assert!(
+            !after_second.extras.contains_key("colab"),
+            "stale extras key must be deleted when absent from replacement"
+        );
+    }
+
+    #[test]
+    fn set_metadata_snapshot_preserves_runtime_and_ephemeral_scalars() {
+        use crate::metadata::NotebookMetadataSnapshot;
+        let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+        // Seed nteract-internal scalars directly on the metadata map —
+        // bootstrap writes `runtime` and rooms may carry `ephemeral`.
+        let meta_id = doc
+            .doc
+            .get(automerge::ROOT, "metadata")
+            .unwrap()
+            .and_then(|(v, id)| match v {
+                automerge::Value::Object(automerge::ObjType::Map) => Some(id),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                doc.doc
+                    .put_object(automerge::ROOT, "metadata", automerge::ObjType::Map)
+                    .unwrap()
+            });
+        doc.doc.put(&meta_id, "runtime", "python").unwrap();
+        doc.doc.put(&meta_id, "ephemeral", true).unwrap();
+
+        // Add an extras key, then replace with a snapshot that has NO
+        // extras. The runtime/ephemeral scalars must survive the
+        // stale-extras sweep — they're not nbformat keys and must not
+        // bleed into extras scans either.
+        let mut first = NotebookMetadataSnapshot::default();
+        first
+            .extras
+            .insert("jupytext".to_string(), serde_json::json!({"formats": "py"}));
+        doc.set_metadata_snapshot(&first).unwrap();
+
+        let empty = NotebookMetadataSnapshot::default();
+        doc.set_metadata_snapshot(&empty).unwrap();
+
+        // runtime and ephemeral scalars still on the doc.
+        let runtime_scalar = read_str(&doc.doc, meta_id.clone(), "runtime");
+        assert_eq!(runtime_scalar.as_deref(), Some("python"));
+        let ephemeral_present = doc.doc.get(&meta_id, "ephemeral").unwrap().is_some();
+        assert!(ephemeral_present);
+
+        // jupytext was deleted.
+        let after = doc.get_metadata_snapshot();
+        assert!(after.is_none() || !after.unwrap().extras.contains_key("jupytext"));
     }
 
     #[test]

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -151,9 +151,11 @@ pub struct DenoMetadata {
 
 /// Snapshot of notebook-level metadata for Automerge sync.
 ///
-/// Covers kernelspec + language_info + runt namespace — everything needed for
-/// kernel detection and environment resolution. Serialized as JSON and stored
-/// in the Automerge document under `metadata.notebook_metadata`.
+/// Three named fields (`kernelspec`, `language_info`, `runt`) plus a
+/// catch-all `extras` bag for unknown/third-party top-level keys
+/// (`jupytext`, `colab`, `vscode`, etc.). The flatten attribute means
+/// unknown keys at deserialize land in `extras` automatically; on
+/// serialize they emit at top level alongside the typed keys.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct NotebookMetadataSnapshot {
     /// Jupyter kernel specification (runtime type detection).
@@ -165,13 +167,28 @@ pub struct NotebookMetadataSnapshot {
     pub language_info: Option<LanguageInfoSnapshot>,
 
     /// Runt-specific metadata (dependencies, trust, environment config).
+    ///
+    /// Defaulted on deserialize so a notebook without `metadata.runt`
+    /// (i.e. every vanilla Jupyter notebook) deserializes cleanly.
+    /// Skipped on serialize when empty so we don't stamp a synthetic
+    /// `runt: { schema_version: "1" }` blob on every save of an
+    /// unrelated notebook.
+    #[serde(default, skip_serializing_if = "RuntMetadata::is_empty")]
     pub runt: RuntMetadata,
+
+    /// Catch-all for unknown/third-party top-level metadata keys.
+    /// See `RuntMetadata::extra` for the analogous pattern one level
+    /// deeper.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Kernelspec snapshot for Automerge sync.
 ///
-/// Mirrors the standard Jupyter `kernelspec` metadata fields.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Mirrors standard Jupyter `kernelspec` fields plus an `extras` bag
+/// so sub-keys we don't model (`env`, `interrupt_mode`, `metadata`)
+/// still round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct KernelspecSnapshot {
     /// Kernel name (e.g. `"python3"`, `"deno"`).
     pub name: String,
@@ -180,18 +197,28 @@ pub struct KernelspecSnapshot {
     /// Programming language (e.g. `"python"`, `"typescript"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+
+    /// Catch-all for unknown kernelspec sub-fields.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Language info snapshot for Automerge sync.
 ///
-/// Mirrors the standard Jupyter `language_info` metadata fields (subset).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Jupyter kernels populate many fields here after startup
+/// (`codemirror_mode`, `mimetype`, `file_extension`, `nbconvert_exporter`,
+/// `pygments_lexer`). Extras bag preserves them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct LanguageInfoSnapshot {
     /// Language name (e.g. `"python"`, `"typescript"`).
     pub name: String,
     /// Language version (e.g. `"3.11.5"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+
+    /// Catch-all for unknown language_info sub-fields.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 // ── Conversions to/from serde_json::Value ────────────────────────────
@@ -240,6 +267,7 @@ impl NotebookMetadataSnapshot {
             kernelspec,
             language_info,
             runt,
+            extras: std::collections::BTreeMap::new(),
         }
     }
 
@@ -826,10 +854,12 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: Some(LanguageInfoSnapshot {
                 name: "python".to_string(),
                 version: Some("3.11.5".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: RuntMetadata {
                 schema_version: "1".to_string(),
@@ -846,6 +876,7 @@ mod tests {
                 trust_timestamp: None,
                 extra: std::collections::BTreeMap::new(),
             },
+            extras: std::collections::BTreeMap::new(),
         };
 
         let json = serde_json::to_string(&snapshot).unwrap();
@@ -923,9 +954,11 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: Some("python".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: RuntMetadata::new_uv("env-1".to_string()),
+            extras: std::collections::BTreeMap::new(),
         };
 
         snapshot.merge_into_metadata_value(&mut metadata).unwrap();
@@ -1134,9 +1167,11 @@ mod tests {
                 name: name.to_string(),
                 display_name: name.to_string(),
                 language: language.map(String::from),
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: None,
             runt: RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         }
     }
 
@@ -1146,8 +1181,10 @@ mod tests {
             language_info: Some(LanguageInfoSnapshot {
                 name: name.to_string(),
                 version: None,
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         }
     }
 
@@ -1267,6 +1304,7 @@ mod tests {
                 name: "deno".to_string(),
                 display_name: "Deno".to_string(),
                 language: Some("typescript".to_string()),
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: RuntMetadata {
                 uv: Some(UvInlineMetadata {
@@ -1295,12 +1333,15 @@ mod tests {
                 name: "python3".to_string(),
                 display_name: "Python 3".to_string(),
                 language: None,
+                extras: std::collections::BTreeMap::new(),
             }),
             language_info: Some(LanguageInfoSnapshot {
                 name: "typescript".to_string(),
                 version: None,
+                extras: std::collections::BTreeMap::new(),
             }),
             runt: RuntMetadata::default(),
+            extras: std::collections::BTreeMap::new(),
         };
         assert_eq!(s.detect_runtime(), Some("python".to_string()));
     }
@@ -1651,5 +1692,114 @@ mod is_empty_tests {
         let mut runt = RuntMetadata::default();
         runt.schema_version = "2".to_string();
         assert!(!runt.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod snapshot_extras_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vanilla_snapshot_serializes_without_runt_key() {
+        let snap = NotebookMetadataSnapshot::default();
+        let v = serde_json::to_value(&snap).unwrap();
+        let obj = v.as_object().expect("snapshot serializes to object");
+        assert!(
+            !obj.contains_key("runt"),
+            "vanilla snapshot must not emit runt key, got: {v}"
+        );
+    }
+
+    #[test]
+    fn snapshot_with_runt_env_id_serializes_runt_key() {
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.runt.env_id = Some("abc".to_string());
+        let v = serde_json::to_value(&snap).unwrap();
+        assert!(v.as_object().unwrap().contains_key("runt"));
+    }
+
+    #[test]
+    fn snapshot_deserializes_when_runt_absent() {
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+        });
+        let snap: NotebookMetadataSnapshot = serde_json::from_value(v).unwrap();
+        assert!(snap.runt.is_empty());
+        assert_eq!(snap.kernelspec.as_ref().unwrap().name, "python3");
+    }
+
+    #[test]
+    fn extras_round_trip_at_top_level() {
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "jupytext": {"paired_paths": [["notebook.py", "py:percent"]]},
+            "colab": {"kernel": {"name": "python3"}},
+        });
+        let snap: NotebookMetadataSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(snap.extras.len(), 2);
+        assert!(snap.extras.contains_key("jupytext"));
+        assert!(snap.extras.contains_key("colab"));
+
+        let round_tripped = serde_json::to_value(&snap).unwrap();
+        assert_eq!(round_tripped["jupytext"], v["jupytext"]);
+        assert_eq!(round_tripped["colab"], v["colab"]);
+    }
+}
+
+#[cfg(test)]
+mod nested_extras_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn kernelspec_extras_round_trip() {
+        let v = json!({
+            "name": "python3",
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "env": {"PYTHONPATH": "/opt/extra"},
+            "interrupt_mode": "signal",
+            "metadata": {"debugger": true},
+        });
+        let ks: KernelspecSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(ks.extras.len(), 3);
+        assert!(ks.extras.contains_key("env"));
+        assert!(ks.extras.contains_key("interrupt_mode"));
+        assert!(ks.extras.contains_key("metadata"));
+
+        let out = serde_json::to_value(&ks).unwrap();
+        assert_eq!(out["env"], v["env"]);
+        assert_eq!(out["interrupt_mode"], v["interrupt_mode"]);
+        assert_eq!(out["metadata"], v["metadata"]);
+    }
+
+    #[test]
+    fn language_info_extras_round_trip() {
+        let v = json!({
+            "name": "python",
+            "version": "3.11.5",
+            "codemirror_mode": {"name": "ipython", "version": 3},
+            "mimetype": "text/x-python",
+            "file_extension": ".py",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+        });
+        let li: LanguageInfoSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(li.extras.len(), 5);
+        for key in [
+            "codemirror_mode",
+            "mimetype",
+            "file_extension",
+            "nbconvert_exporter",
+            "pygments_lexer",
+        ] {
+            assert!(li.extras.contains_key(key), "missing {key}");
+        }
+
+        let out = serde_json::to_value(&li).unwrap();
+        assert_eq!(out["codemirror_mode"], v["codemirror_mode"]);
+        assert_eq!(out["mimetype"], v["mimetype"]);
+        assert_eq!(out["pygments_lexer"], v["pygments_lexer"]);
     }
 }

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -1655,26 +1655,32 @@ mod is_empty_tests {
 
     #[test]
     fn runt_with_env_id_is_not_empty() {
-        let mut runt = RuntMetadata::default();
-        runt.env_id = Some("abc-123".to_string());
+        let runt = RuntMetadata {
+            env_id: Some("abc-123".to_string()),
+            ..RuntMetadata::default()
+        };
         assert!(!runt.is_empty());
     }
 
     #[test]
     fn runt_with_uv_is_not_empty() {
-        let mut runt = RuntMetadata::default();
-        runt.uv = Some(UvInlineMetadata {
-            dependencies: vec!["pandas".to_string()],
-            requires_python: None,
-            prerelease: None,
-        });
+        let runt = RuntMetadata {
+            uv: Some(UvInlineMetadata {
+                dependencies: vec!["pandas".to_string()],
+                requires_python: None,
+                prerelease: None,
+            }),
+            ..RuntMetadata::default()
+        };
         assert!(!runt.is_empty());
     }
 
     #[test]
     fn runt_with_trust_signature_is_not_empty() {
-        let mut runt = RuntMetadata::default();
-        runt.trust_signature = Some("hmac-sha256:deadbeef".to_string());
+        let runt = RuntMetadata {
+            trust_signature: Some("hmac-sha256:deadbeef".to_string()),
+            ..RuntMetadata::default()
+        };
         assert!(!runt.is_empty());
     }
 
@@ -1683,13 +1689,18 @@ mod is_empty_tests {
         let mut runt = RuntMetadata::default();
         runt.extra
             .insert("future_field".to_string(), serde_json::json!(42));
+        // Mutating a field through a mutable method (BTreeMap::insert)
+        // rather than reassigning via Default::default() — clippy is
+        // fine with this shape.
         assert!(!runt.is_empty());
     }
 
     #[test]
     fn runt_with_modified_schema_version_is_not_empty() {
-        let mut runt = RuntMetadata::default();
-        runt.schema_version = "2".to_string();
+        let runt = RuntMetadata {
+            schema_version: "2".to_string(),
+            ..RuntMetadata::default()
+        };
         assert!(!runt.is_empty());
     }
 }

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -229,46 +229,45 @@ impl NotebookMetadataSnapshot {
     ///
     /// Extracts `kernelspec`, `language_info`, and `runt` (with fallback to
     /// legacy `uv`/`conda` top-level keys).
+    /// Build a snapshot from raw notebook metadata JSON (from an `.ipynb`).
+    ///
+    /// Uses `serde_json::from_value::<Self>` so all three snapshot levels
+    /// (top, kernelspec, language_info) populate their `extras` bags in
+    /// one pass. `#[serde(default)]` on `runt` means vanilla Jupyter
+    /// notebooks (no `metadata.runt` key) deserialize cleanly.
+    ///
+    /// After the serde pass, runs one legacy fallback: if `runt.uv` or
+    /// `runt.conda` is unset but a top-level `uv` or `conda` exists (old
+    /// pre-`runt.*` notebooks), fold them into `runt` and remove from
+    /// extras so save doesn't emit them at both depths.
+    ///
+    /// Malformed input (serde_json::from_value fails for any reason)
+    /// produces a default snapshot. Today's per-field tolerance is
+    /// sacrificed for a cleaner single-call shape; malformed notebooks
+    /// are rare enough that silent partial success hides more bugs than
+    /// it saves data.
     pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
-        let kernelspec = metadata
-            .get("kernelspec")
-            .and_then(|v| serde_json::from_value::<KernelspecSnapshot>(v.clone()).ok());
+        let mut snapshot: NotebookMetadataSnapshot =
+            serde_json::from_value(metadata.clone()).unwrap_or_default();
 
-        let language_info = metadata
-            .get("language_info")
-            .and_then(|v| serde_json::from_value::<LanguageInfoSnapshot>(v.clone()).ok());
-
-        let runt = metadata
-            .get("runt")
-            .and_then(|v| serde_json::from_value::<RuntMetadata>(v.clone()).ok())
-            .unwrap_or_else(|| {
-                // Fallback: try legacy top-level uv/conda keys
-                let uv = metadata
-                    .get("uv")
-                    .and_then(|v| serde_json::from_value::<UvInlineMetadata>(v.clone()).ok());
-                let conda = metadata
-                    .get("conda")
-                    .and_then(|v| serde_json::from_value::<CondaInlineMetadata>(v.clone()).ok());
-
-                RuntMetadata {
-                    schema_version: "1".to_string(),
-                    env_id: None,
-                    uv,
-                    conda,
-                    pixi: None,
-                    deno: None,
-                    trust_signature: None,
-                    trust_timestamp: None,
-                    extra: std::collections::BTreeMap::new(),
-                }
-            });
-
-        NotebookMetadataSnapshot {
-            kernelspec,
-            language_info,
-            runt,
-            extras: std::collections::BTreeMap::new(),
+        // Legacy fallback: older notebooks stored uv/conda at the top
+        // level (not inside runt). Fold them into runt.* if typed runt
+        // didn't already carry them. Always strip from extras so save
+        // doesn't emit them at both depths.
+        let legacy_uv = snapshot.extras.remove("uv");
+        let legacy_conda = snapshot.extras.remove("conda");
+        if snapshot.runt.uv.is_none() {
+            if let Some(raw_uv) = legacy_uv {
+                snapshot.runt.uv = serde_json::from_value(raw_uv).ok();
+            }
         }
+        if snapshot.runt.conda.is_none() {
+            if let Some(raw_conda) = legacy_conda {
+                snapshot.runt.conda = serde_json::from_value(raw_conda).ok();
+            }
+        }
+
+        snapshot
     }
 
     /// Merge this snapshot into a mutable JSON object representing the full
@@ -1801,5 +1800,132 @@ mod nested_extras_tests {
         assert_eq!(out["codemirror_mode"], v["codemirror_mode"]);
         assert_eq!(out["mimetype"], v["mimetype"]);
         assert_eq!(out["pygments_lexer"], v["pygments_lexer"]);
+    }
+}
+
+#[cfg(test)]
+mod from_metadata_value_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vanilla_jupyter_notebook_deserializes() {
+        let v = json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3 (ipykernel)",
+                "language": "python",
+            },
+            "language_info": {
+                "name": "python",
+                "version": "3.11.5",
+            },
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.kernelspec.is_some());
+        assert!(snap.language_info.is_some());
+        assert!(snap.runt.is_empty());
+        assert!(snap.extras.is_empty());
+    }
+
+    #[test]
+    fn unknown_top_level_keys_become_extras() {
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+            "colab": {"kernel": {"name": "python3"}},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.extras.contains_key("jupytext"));
+        assert!(snap.extras.contains_key("colab"));
+        assert!(!snap.extras.contains_key("kernelspec"));
+    }
+
+    #[test]
+    fn legacy_top_level_uv_is_absorbed_into_runt() {
+        let v = json!({
+            "uv": {"dependencies": ["pandas"]},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.runt.uv.is_some());
+        assert_eq!(snap.runt.uv.as_ref().unwrap().dependencies, vec!["pandas"]);
+        assert!(
+            !snap.extras.contains_key("uv"),
+            "legacy uv must be folded into runt, not left in extras"
+        );
+    }
+
+    #[test]
+    fn legacy_top_level_conda_is_absorbed_into_runt() {
+        let v = json!({
+            "conda": {
+                "dependencies": ["numpy"],
+                "channels": ["conda-forge"],
+            },
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.runt.conda.is_some());
+        assert_eq!(
+            snap.runt.conda.as_ref().unwrap().dependencies,
+            vec!["numpy"]
+        );
+        assert!(!snap.extras.contains_key("conda"));
+    }
+
+    #[test]
+    fn runt_wins_when_both_typed_and_legacy_present() {
+        let v = json!({
+            "runt": {
+                "schema_version": "1",
+                "uv": {"dependencies": ["fresh"]},
+            },
+            "uv": {"dependencies": ["stale"]},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert_eq!(
+            snap.runt.uv.as_ref().unwrap().dependencies,
+            vec!["fresh"],
+            "runt.uv must win over legacy top-level uv"
+        );
+        assert!(!snap.extras.contains_key("uv"));
+    }
+
+    #[test]
+    fn full_round_trip_preserves_all_levels() {
+        let v = json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python",
+                "env": {"A": "1"},
+            },
+            "language_info": {
+                "name": "python",
+                "version": "3.11.5",
+                "codemirror_mode": {"name": "ipython", "version": 3},
+                "file_extension": ".py",
+            },
+            "runt": {
+                "schema_version": "1",
+                "uv": {"dependencies": ["pandas"]},
+            },
+            "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+            "vscode": {"extension": {"id": "ms-python.python"}},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        let out = serde_json::to_value(&snap).unwrap();
+
+        assert_eq!(out["kernelspec"]["env"], v["kernelspec"]["env"]);
+        assert_eq!(
+            out["language_info"]["codemirror_mode"],
+            v["language_info"]["codemirror_mode"]
+        );
+        assert_eq!(
+            out["language_info"]["file_extension"],
+            v["language_info"]["file_extension"]
+        );
+        assert_eq!(out["runt"]["uv"], v["runt"]["uv"]);
+        assert_eq!(out["jupytext"], v["jupytext"]);
+        assert_eq!(out["vscode"], v["vscode"]);
     }
 }

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -651,6 +651,24 @@ impl Default for RuntMetadata {
     }
 }
 
+impl RuntMetadata {
+    /// Returns true when this metadata carries no daemon-relevant state.
+    /// Used by `skip_serializing_if` so vanilla Jupyter notebooks don't
+    /// get a synthetic `runt: { schema_version: "1" }` stamped on first
+    /// save, which would churn git-tracked notebooks.
+    pub fn is_empty(&self) -> bool {
+        self.env_id.is_none()
+            && self.uv.is_none()
+            && self.conda.is_none()
+            && self.pixi.is_none()
+            && self.deno.is_none()
+            && self.trust_signature.is_none()
+            && self.trust_timestamp.is_none()
+            && self.extra.is_empty()
+            && self.schema_version == "1"
+    }
+}
+
 // ── Package name extraction ──────────────────────────────────────────
 
 /// Extract the base package name from a PEP 508 or conda dependency specifier.
@@ -1579,5 +1597,59 @@ mod tests {
         assert!(s.kernelspec.is_none());
         assert!(s.language_info.is_none());
         assert_eq!(s.runt.schema_version, "1");
+    }
+}
+
+#[cfg(test)]
+mod is_empty_tests {
+    use super::*;
+
+    #[test]
+    fn default_runt_is_empty() {
+        let runt = RuntMetadata::default();
+        assert!(
+            runt.is_empty(),
+            "freshly-defaulted RuntMetadata should be empty"
+        );
+    }
+
+    #[test]
+    fn runt_with_env_id_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.env_id = Some("abc-123".to_string());
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_uv_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.uv = Some(UvInlineMetadata {
+            dependencies: vec!["pandas".to_string()],
+            requires_python: None,
+            prerelease: None,
+        });
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_trust_signature_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.trust_signature = Some("hmac-sha256:deadbeef".to_string());
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_extra_key_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.extra
+            .insert("future_field".to_string(), serde_json::json!(42));
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_modified_schema_version_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.schema_version = "2".to_string();
+        assert!(!runt.is_empty());
     }
 }

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -340,9 +340,9 @@ mod tests {
                         name: "python3".into(),
                         display_name: "Python 3".into(),
                         language: Some("python".into()),
+                        extras: Default::default(),
                     }),
-                    language_info: None,
-                    runt: notebook_doc::metadata::RuntMetadata::default(),
+                    ..Default::default()
                 };
                 nd.set_metadata_snapshot(&snapshot).unwrap();
                 *doc = nd.into_inner();
@@ -536,9 +536,9 @@ mod tests {
                 name: "deno".into(),
                 display_name: "Deno".into(),
                 language: Some("typescript".into()),
+                extras: Default::default(),
             }),
-            language_info: None,
-            runt: notebook_doc::metadata::RuntMetadata::default(),
+            ..Default::default()
         };
 
         handle.set_metadata_snapshot(&snapshot).unwrap();
@@ -1152,9 +1152,9 @@ mod integration_tests {
                 name: "python3".into(),
                 display_name: "Python 3".into(),
                 language: Some("python".into()),
+                extras: Default::default(),
             }),
-            language_info: None,
-            runt: notebook_doc::metadata::RuntMetadata::default(),
+            ..Default::default()
         };
 
         handle

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -517,6 +517,10 @@ async fn get_raw_metadata_additional(
 
 /// Reconstruct an nbformat Metadata from a NotebookMetadataSnapshot.
 /// Used to bridge sync-handle metadata to extraction functions that expect nbformat types.
+///
+/// Carries `extras` at all three levels (top, kernelspec, language_info) into
+/// `additional` so unknown keys (jupytext, colab, vscode, etc.) survive the
+/// nbformat round-trip used by the pyproject/pixi import commands.
 fn metadata_from_snapshot(
     snapshot: &notebook_doc::metadata::NotebookMetadataSnapshot,
 ) -> nbformat::v4::Metadata {
@@ -528,7 +532,11 @@ fn metadata_from_snapshot(
                 name: ks.name.clone(),
                 display_name: ks.display_name.clone(),
                 language: ks.language.clone(),
-                additional: std::collections::HashMap::new(),
+                additional: ks
+                    .extras
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
             }),
         language_info: snapshot
             .language_info
@@ -537,14 +545,26 @@ fn metadata_from_snapshot(
                 name: li.name.clone(),
                 version: li.version.clone(),
                 codemirror_mode: None,
-                additional: std::collections::HashMap::new(),
+                additional: li
+                    .extras
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect(),
             }),
         authors: None,
-        additional: std::collections::HashMap::new(),
+        additional: snapshot
+            .extras
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
     };
-    // Serialize runt back to additional
-    if let Ok(runt_value) = serde_json::to_value(&snapshot.runt) {
-        metadata.additional.insert("runt".to_string(), runt_value);
+    // Serialize runt back to additional when it carries real data. Vanilla
+    // Jupyter notebooks (no runt key on disk) must not gain a synthetic
+    // runt blob here, or the import commands would churn them.
+    if !snapshot.runt.is_empty() {
+        if let Ok(runt_value) = serde_json::to_value(&snapshot.runt) {
+            metadata.additional.insert("runt".to_string(), runt_value);
+        }
     }
     metadata
 }
@@ -567,7 +587,11 @@ fn snapshot_from_nbformat(
         name: ks.name.clone(),
         display_name: ks.display_name.clone(),
         language: ks.language.clone(),
-        extras: Default::default(),
+        extras: ks
+            .additional
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
     });
 
     let language_info = metadata
@@ -576,7 +600,11 @@ fn snapshot_from_nbformat(
         .map(|li| LanguageInfoSnapshot {
             name: li.name.clone(),
             version: li.version.clone(),
-            extras: Default::default(),
+            extras: li
+                .additional
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         });
 
     let convert_legacy_deno = |dd: crate::deno_env::DenoDependencies| DenoMetadata {
@@ -590,7 +618,13 @@ fn snapshot_from_nbformat(
         },
     };
 
+    // Track which top-level keys got absorbed into typed fields so we can
+    // strip them from extras. Otherwise `runt` (and the legacy `uv`/`conda`/
+    // `deno` fallbacks) would double-write at both depths on save.
+    let mut absorbed_keys: Vec<&str> = Vec::new();
+
     let runt = if let Some(runt_value) = metadata.additional.get("runt") {
+        absorbed_keys.push("runt");
         let mut runt_meta = serde_json::from_value::<RuntMetadata>(runt_value.clone())
             .unwrap_or_else(|_| RuntMetadata {
                 schema_version: "1".to_string(),
@@ -610,6 +644,7 @@ fn snapshot_from_nbformat(
                     serde_json::from_value::<crate::deno_env::DenoDependencies>(deno_value.clone())
                 {
                     runt_meta.deno = Some(convert_legacy_deno(dd));
+                    absorbed_keys.push("deno");
                 }
             }
         }
@@ -620,10 +655,16 @@ fn snapshot_from_nbformat(
             .additional
             .get("uv")
             .and_then(|v| serde_json::from_value::<UvInlineMetadata>(v.clone()).ok());
+        if uv.is_some() {
+            absorbed_keys.push("uv");
+        }
         let conda = metadata
             .additional
             .get("conda")
             .and_then(|v| serde_json::from_value::<CondaInlineMetadata>(v.clone()).ok());
+        if conda.is_some() {
+            absorbed_keys.push("conda");
+        }
         let deno = metadata
             .additional
             .get("deno")
@@ -631,7 +672,14 @@ fn snapshot_from_nbformat(
                 serde_json::from_value::<crate::deno_env::DenoDependencies>(v.clone()).ok()
             })
             .map(convert_legacy_deno);
+        if deno.is_some() {
+            absorbed_keys.push("deno");
+        }
 
+        // An empty RuntMetadata here means the nbformat had no runt-shaped
+        // data at all. is_empty() will return true and set_metadata_snapshot
+        // will skip the runt write on save, which is what vanilla Jupyter
+        // notebooks need to round-trip without a synthetic stamp.
         RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
@@ -645,11 +693,18 @@ fn snapshot_from_nbformat(
         }
     };
 
+    let extras = metadata
+        .additional
+        .iter()
+        .filter(|(k, _)| !absorbed_keys.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
     NotebookMetadataSnapshot {
         kernelspec,
         language_info,
         runt,
-        extras: std::collections::BTreeMap::new(),
+        extras,
     }
 }
 
@@ -1108,6 +1163,200 @@ mod tests {
     #[test]
     fn reopen_action_ignores_reopen_events_when_a_window_is_visible() {
         assert_eq!(reopen_action(true, 1), None);
+    }
+
+    mod bridge_helper_extras {
+        use super::super::{metadata_from_snapshot, snapshot_from_nbformat};
+        use notebook_doc::metadata::{
+            KernelspecSnapshot, LanguageInfoSnapshot, NotebookMetadataSnapshot, RuntMetadata,
+        };
+        use serde_json::json;
+
+        #[test]
+        fn metadata_from_snapshot_carries_all_three_extras_levels() {
+            let snapshot = NotebookMetadataSnapshot {
+                kernelspec: Some(KernelspecSnapshot {
+                    name: "python3".to_string(),
+                    display_name: "Python 3".to_string(),
+                    language: Some("python".to_string()),
+                    extras: [("env".to_string(), json!({"FOO": "bar"}))]
+                        .into_iter()
+                        .collect(),
+                }),
+                language_info: Some(LanguageInfoSnapshot {
+                    name: "python".to_string(),
+                    version: Some("3.11".to_string()),
+                    extras: [("mimetype".to_string(), json!("text/x-python"))]
+                        .into_iter()
+                        .collect(),
+                }),
+                runt: RuntMetadata::default(),
+                extras: [
+                    (
+                        "jupytext".to_string(),
+                        json!({"formats": "ipynb,py:percent"}),
+                    ),
+                    ("colab".to_string(), json!({"provenance": []})),
+                ]
+                .into_iter()
+                .collect(),
+            };
+
+            let meta = metadata_from_snapshot(&snapshot);
+
+            assert_eq!(
+                meta.additional.get("jupytext"),
+                Some(&json!({"formats": "ipynb,py:percent"}))
+            );
+            assert_eq!(
+                meta.additional.get("colab"),
+                Some(&json!({"provenance": []}))
+            );
+            assert_eq!(
+                meta.kernelspec.as_ref().unwrap().additional.get("env"),
+                Some(&json!({"FOO": "bar"}))
+            );
+            assert_eq!(
+                meta.language_info
+                    .as_ref()
+                    .unwrap()
+                    .additional
+                    .get("mimetype"),
+                Some(&json!("text/x-python"))
+            );
+            // Vanilla runt -> must not appear as a synthetic stamp.
+            assert!(meta.additional.get("runt").is_none());
+        }
+
+        #[test]
+        fn snapshot_from_nbformat_preserves_extras_and_strips_absorbed_keys() {
+            let mut additional = std::collections::HashMap::new();
+            additional.insert(
+                "jupytext".to_string(),
+                json!({"formats": "ipynb,py:percent"}),
+            );
+            additional.insert("vscode".to_string(), json!({"interpreter": "venv"}));
+            additional.insert(
+                "runt".to_string(),
+                json!({"schema_version": "1", "env_id": "uv-abc123"}),
+            );
+
+            let mut ks_additional = std::collections::HashMap::new();
+            ks_additional.insert("env".to_string(), json!({"FOO": "bar"}));
+            let mut li_additional = std::collections::HashMap::new();
+            li_additional.insert("mimetype".to_string(), json!("text/x-python"));
+
+            let metadata = nbformat::v4::Metadata {
+                kernelspec: Some(nbformat::v4::KernelSpec {
+                    name: "python3".to_string(),
+                    display_name: "Python 3".to_string(),
+                    language: Some("python".to_string()),
+                    additional: ks_additional,
+                }),
+                language_info: Some(nbformat::v4::LanguageInfo {
+                    name: "python".to_string(),
+                    version: Some("3.11".to_string()),
+                    codemirror_mode: None,
+                    additional: li_additional,
+                }),
+                authors: None,
+                additional,
+            };
+
+            let snapshot = snapshot_from_nbformat(&metadata);
+
+            assert_eq!(
+                snapshot.extras.get("jupytext"),
+                Some(&json!({"formats": "ipynb,py:percent"}))
+            );
+            assert_eq!(
+                snapshot.extras.get("vscode"),
+                Some(&json!({"interpreter": "venv"}))
+            );
+            // runt got absorbed into the typed field, must NOT leak into extras.
+            assert!(!snapshot.extras.contains_key("runt"));
+            assert_eq!(snapshot.runt.env_id.as_deref(), Some("uv-abc123"));
+
+            assert_eq!(
+                snapshot.kernelspec.as_ref().unwrap().extras.get("env"),
+                Some(&json!({"FOO": "bar"}))
+            );
+            assert_eq!(
+                snapshot
+                    .language_info
+                    .as_ref()
+                    .unwrap()
+                    .extras
+                    .get("mimetype"),
+                Some(&json!("text/x-python"))
+            );
+        }
+
+        #[test]
+        fn snapshot_from_nbformat_strips_legacy_uv_conda_deno_when_absorbed() {
+            let mut additional = std::collections::HashMap::new();
+            additional.insert("uv".to_string(), json!({"dependencies": ["pandas"]}));
+            additional.insert("conda".to_string(), json!({"channels": ["conda-forge"]}));
+            additional.insert("jupytext".to_string(), json!({"formats": "py"}));
+
+            let metadata = nbformat::v4::Metadata {
+                kernelspec: None,
+                language_info: None,
+                authors: None,
+                additional,
+            };
+
+            let snapshot = snapshot_from_nbformat(&metadata);
+
+            // Legacy uv/conda got folded into runt, must not also appear in extras.
+            assert!(!snapshot.extras.contains_key("uv"));
+            assert!(!snapshot.extras.contains_key("conda"));
+            assert!(snapshot.runt.uv.is_some());
+            assert!(snapshot.runt.conda.is_some());
+            // Unknown key survives.
+            assert_eq!(
+                snapshot.extras.get("jupytext"),
+                Some(&json!({"formats": "py"}))
+            );
+        }
+
+        #[test]
+        fn bridge_round_trip_preserves_unknown_keys_at_every_level() {
+            let original = NotebookMetadataSnapshot {
+                kernelspec: Some(KernelspecSnapshot {
+                    name: "python3".to_string(),
+                    display_name: "Python 3".to_string(),
+                    language: Some("python".to_string()),
+                    extras: [("env".to_string(), json!({"PATH": "/usr/bin"}))]
+                        .into_iter()
+                        .collect(),
+                }),
+                language_info: Some(LanguageInfoSnapshot {
+                    name: "python".to_string(),
+                    version: Some("3.11".to_string()),
+                    extras: [("file_extension".to_string(), json!(".py"))]
+                        .into_iter()
+                        .collect(),
+                }),
+                runt: RuntMetadata::default(),
+                extras: [("jupytext".to_string(), json!({"formats": "ipynb,py"}))]
+                    .into_iter()
+                    .collect(),
+            };
+
+            let meta = metadata_from_snapshot(&original);
+            let round_tripped = snapshot_from_nbformat(&meta);
+
+            assert_eq!(round_tripped.extras, original.extras);
+            assert_eq!(
+                round_tripped.kernelspec.as_ref().unwrap().extras,
+                original.kernelspec.as_ref().unwrap().extras
+            );
+            assert_eq!(
+                round_tripped.language_info.as_ref().unwrap().extras,
+                original.language_info.as_ref().unwrap().extras
+            );
+        }
     }
 }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1225,7 +1225,7 @@ mod tests {
                 Some(&json!("text/x-python"))
             );
             // Vanilla runt -> must not appear as a synthetic stamp.
-            assert!(meta.additional.get("runt").is_none());
+            assert!(!meta.additional.contains_key("runt"));
         }
 
         #[test]

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -551,21 +551,7 @@ fn metadata_from_snapshot(
 
 /// Helper to create a default empty NotebookMetadataSnapshot.
 fn default_metadata_snapshot() -> notebook_doc::metadata::NotebookMetadataSnapshot {
-    notebook_doc::metadata::NotebookMetadataSnapshot {
-        kernelspec: None,
-        language_info: None,
-        runt: notebook_doc::metadata::RuntMetadata {
-            schema_version: "1".to_string(),
-            env_id: None,
-            uv: None,
-            conda: None,
-            pixi: None,
-            deno: None,
-            trust_signature: None,
-            trust_timestamp: None,
-            extra: std::collections::BTreeMap::new(),
-        },
-    }
+    notebook_doc::metadata::NotebookMetadataSnapshot::default()
 }
 
 /// Convert nbformat metadata into a `NotebookMetadataSnapshot`.
@@ -581,6 +567,7 @@ fn snapshot_from_nbformat(
         name: ks.name.clone(),
         display_name: ks.display_name.clone(),
         language: ks.language.clone(),
+        extras: Default::default(),
     });
 
     let language_info = metadata
@@ -589,6 +576,7 @@ fn snapshot_from_nbformat(
         .map(|li| LanguageInfoSnapshot {
             name: li.name.clone(),
             version: li.version.clone(),
+            extras: Default::default(),
         });
 
     let convert_legacy_deno = |dd: crate::deno_env::DenoDependencies| DenoMetadata {
@@ -661,6 +649,7 @@ fn snapshot_from_nbformat(
         kernelspec,
         language_info,
         runt,
+        extras: std::collections::BTreeMap::new(),
     }
 }
 

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f019ad835cb3b09f329c6b6b9bd1b2933793403f31ec6cf0936ed5d6b35a7133
+oid sha256:5cd9a4f54d070fa80c82aa8da276a098eb3b375ee37d5a71fe926e602678a356
 size 6801448

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -687,6 +687,7 @@ impl AsyncSession {
                 name,
                 display_name,
                 language,
+                extras: Default::default(),
             });
             session_core::set_notebook_metadata(&state, &snapshot).await
         })

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -822,10 +822,12 @@ pub(crate) fn build_new_notebook_metadata(
                 name: "deno".to_string(),
                 display_name: "Deno".to_string(),
                 language: Some("typescript".to_string()),
+                extras: std::collections::BTreeMap::new(),
             },
             LanguageInfoSnapshot {
                 name: "typescript".to_string(),
                 version: None,
+                extras: std::collections::BTreeMap::new(),
             },
             RuntMetadata {
                 schema_version: "1".to_string(),
@@ -911,10 +913,12 @@ pub(crate) fn build_new_notebook_metadata(
                     name: "python3".to_string(),
                     display_name: "Python 3".to_string(),
                     language: Some("python".to_string()),
+                    extras: std::collections::BTreeMap::new(),
                 },
                 LanguageInfoSnapshot {
                     name: "python".to_string(),
                     version: None,
+                    extras: std::collections::BTreeMap::new(),
                 },
                 RuntMetadata {
                     schema_version: "1".to_string(),
@@ -935,6 +939,7 @@ pub(crate) fn build_new_notebook_metadata(
         kernelspec: Some(kernelspec),
         language_info: Some(language_info),
         runt,
+        extras: std::collections::BTreeMap::new(),
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -63,34 +63,24 @@ pub(crate) async fn save_notebook_to_disk(
         },
     };
 
-    // Read existing .ipynb as raw bytes (used for metadata preservation and
-    // content-hash guard to skip no-op writes).
+    // Read existing .ipynb as raw bytes. Used for two things: the
+    // content-hash guard further down (skip no-op writes), and the
+    // `nbformat_minor` floor (not carried in the doc today).
+    // We no longer read metadata from disk — the doc carries unknown
+    // top-level keys as extras, so everything round-trips through
+    // the snapshot.
     let existing_raw: Option<Vec<u8>> = match tokio::fs::read(&notebook_path).await {
         Ok(bytes) => Some(bytes),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
         Err(e) => {
             warn!(
                 "[notebook-sync] Failed to read existing notebook {:?}: {}, \
-                 will create new without preserving metadata",
+                 will create new",
                 notebook_path, e
             );
             None
         }
     };
-    let existing: Option<serde_json::Value> =
-        existing_raw
-            .as_ref()
-            .and_then(|bytes| match serde_json::from_slice(bytes) {
-                Ok(value) => Some(value),
-                Err(e) => {
-                    warn!(
-                        "[notebook-sync] Existing notebook at {:?} has invalid JSON ({}), \
-                     will overwrite without preserving metadata",
-                        notebook_path, e
-                    );
-                    None
-                }
-            });
 
     // Read cells, metadata, and per-cell execution_ids from the doc.
     let (cells, metadata_snapshot, cell_execution_ids) = {
@@ -152,19 +142,17 @@ pub(crate) async fn save_notebook_to_disk(
         resolved_outputs_by_cell.insert(cell.id.clone(), resolved);
     }
 
-    // Build metadata by merging synced snapshot onto existing
-    let mut metadata = existing
+    // Metadata comes entirely from the doc. No disk rescue; the
+    // snapshot carries unknown keys as extras.
+    let metadata = metadata_snapshot
         .as_ref()
-        .and_then(|nb| nb.get("metadata"))
-        .cloned()
-        .unwrap_or(serde_json::json!({}));
-
-    if let Some(ref snapshot) = metadata_snapshot {
-        snapshot.merge_into_metadata_value(&mut metadata).ok();
-    }
+        .map(|s| serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({})))
+        .unwrap_or_else(|| serde_json::json!({}));
 
     // We always write cell IDs, so nbformat_minor is at least 5.
-    let existing_minor = existing
+    let existing_minor = existing_raw
+        .as_ref()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
         .as_ref()
         .and_then(|nb| nb.get("nbformat_minor"))
         .and_then(|v| v.as_u64())

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -490,6 +490,7 @@ fn snapshot_with_uv(deps: Vec<String>) -> NotebookMetadataSnapshot {
             trust_timestamp: None,
             extra: std::collections::BTreeMap::new(),
         },
+        extras: std::collections::BTreeMap::new(),
     }
 }
 
@@ -513,6 +514,7 @@ fn snapshot_with_conda(deps: Vec<String>) -> NotebookMetadataSnapshot {
             trust_timestamp: None,
             extra: std::collections::BTreeMap::new(),
         },
+        extras: std::collections::BTreeMap::new(),
     }
 }
 
@@ -532,6 +534,7 @@ fn snapshot_empty() -> NotebookMetadataSnapshot {
             trust_timestamp: None,
             extra: std::collections::BTreeMap::new(),
         },
+        extras: std::collections::BTreeMap::new(),
     }
 }
 
@@ -593,6 +596,7 @@ fn test_check_inline_deps_uv_priority() {
             trust_timestamp: None,
             extra: std::collections::BTreeMap::new(),
         },
+        extras: std::collections::BTreeMap::new(),
     };
     use notebook_protocol::connection::{EnvSource, PackageManager};
     assert_eq!(
@@ -627,6 +631,7 @@ fn test_check_inline_deps_deno() {
             trust_timestamp: None,
             extra: std::collections::BTreeMap::new(),
         },
+        extras: std::collections::BTreeMap::new(),
     };
     use notebook_protocol::connection::EnvSource;
     assert_eq!(check_inline_deps(&snapshot), Some(EnvSource::Deno));
@@ -741,10 +746,20 @@ async fn test_save_notebook_to_disk_preserves_unknown_metadata() {
         .unwrap();
     }
 
-    // Add a cell and save
+    // Load from disk first (populates doc with extras + runt). Then
+    // edit + save. The doc is the source of truth for metadata; the
+    // save path no longer reads the on-disk file to rescue unknown
+    // keys, so they must be in the doc.
     {
         let mut doc = room.doc.write().await;
-        doc.add_cell(0, "cell1", "code").unwrap();
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+        doc.add_cell(1, "cell1", "code").unwrap();
         doc.update_source("cell1", "x = 1").unwrap();
     }
 
@@ -755,7 +770,7 @@ async fn test_save_notebook_to_disk_preserves_unknown_metadata() {
     let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
     let metadata = saved.get("metadata").unwrap();
 
-    // custom_extension should be preserved
+    // custom_extension should be preserved (via top-level extras)
     assert!(
         metadata.get("custom_extension").is_some(),
         "custom_extension should be preserved"
@@ -765,18 +780,19 @@ async fn test_save_notebook_to_disk_preserves_unknown_metadata() {
         Some(&serde_json::json!("value"))
     );
 
-    // jupyter should be preserved
+    // jupyter should be preserved (via top-level extras)
     assert!(
         metadata.get("jupyter").is_some(),
         "jupyter metadata should be preserved"
     );
 
-    // trust_signature in runt should be preserved (deep-merge)
+    // trust_signature in runt should be preserved (the typed runt
+    // field round-trips trust_signature explicitly).
     let runt = metadata.get("runt").unwrap();
     assert_eq!(
         runt.get("trust_signature"),
         Some(&serde_json::json!("abc123")),
-        "trust_signature should be preserved via deep-merge"
+        "trust_signature should be preserved"
     );
 }
 
@@ -3396,8 +3412,16 @@ async fn test_check_and_update_trust_state_no_deps() {
             .unwrap();
     }
 
-    // Write an empty metadata snapshot (no dependencies).
-    let snapshot = snapshot_empty();
+    // Write a minimal snapshot with a kernelspec so get_metadata_snapshot
+    // returns Some (post-refactor: empty runt alone produces a None
+    // snapshot because no keys get written to the doc).
+    let mut snapshot = snapshot_empty();
+    snapshot.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+        name: "python3".to_string(),
+        display_name: "Python 3".to_string(),
+        language: Some("python".to_string()),
+        extras: std::collections::BTreeMap::new(),
+    });
     {
         let mut doc = room.doc.write().await;
         doc.set_metadata_snapshot(&snapshot).unwrap();
@@ -3476,8 +3500,16 @@ async fn test_check_and_update_trust_state_idempotent() {
             .unwrap();
     }
 
-    // Write an empty metadata snapshot to trigger Untrusted → NoDependencies.
-    let snapshot = snapshot_empty();
+    // Write a minimal snapshot with a kernelspec so get_metadata_snapshot
+    // returns Some (post-refactor: empty runt alone produces a None
+    // snapshot because no keys get written to the doc).
+    let mut snapshot = snapshot_empty();
+    snapshot.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+        name: "python3".to_string(),
+        display_name: "Python 3".to_string(),
+        language: Some("python".to_string()),
+        extras: std::collections::BTreeMap::new(),
+    });
     {
         let mut doc = room.doc.write().await;
         doc.set_metadata_snapshot(&snapshot).unwrap();

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6069,3 +6069,99 @@ async fn test_clone_as_ephemeral_rejects_invalid_uuid() {
         other => panic!("Expected Error, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn test_save_round_trips_unknown_top_level_metadata() {
+    // Regression test for Codex F3 on PR #2192: unknown top-level
+    // metadata keys (jupytext, colab, etc.) must survive save.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "with-jupytext.ipynb");
+
+    std::fs::write(
+        &notebook_path,
+        r#"{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+  "language_info": {"name": "python", "version": "3.11.5"},
+  "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+  "colab": {"kernel": {"name": "python3"}}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"#,
+    )
+    .unwrap();
+
+    {
+        let mut doc = room.doc.write().await;
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let written = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+    assert_eq!(
+        nb["metadata"]["jupytext"],
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        "jupytext key must survive save round-trip"
+    );
+    assert_eq!(
+        nb["metadata"]["colab"],
+        serde_json::json!({"kernel": {"name": "python3"}}),
+        "colab key must survive save round-trip"
+    );
+}
+
+#[tokio::test]
+async fn test_save_does_not_stamp_synthetic_runt_on_vanilla_notebook() {
+    // Vanilla Jupyter notebook: no metadata.runt. Save must NOT add
+    // `runt: { schema_version: "1" }` — that would churn every
+    // git-tracked Jupyter notebook the user opens.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "vanilla.ipynb");
+
+    std::fs::write(
+        &notebook_path,
+        r#"{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+  "language_info": {"name": "python", "version": "3.11.5"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"#,
+    )
+    .unwrap();
+
+    {
+        let mut doc = room.doc.write().await;
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let written = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+    assert!(
+        !nb["metadata"].as_object().unwrap().contains_key("runt"),
+        "vanilla notebook save must not stamp metadata.runt, got: {}",
+        nb["metadata"]
+    );
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6165,3 +6165,87 @@ async fn test_save_does_not_stamp_synthetic_runt_on_vanilla_notebook() {
         nb["metadata"]
     );
 }
+
+#[tokio::test]
+async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
+    // Codex F3 on PR #2192: clone must preserve unknown top-level
+    // metadata keys from source (jupytext, colab, vscode, etc.).
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+
+    let source_uuid = Uuid::new_v4();
+    let source_room = get_or_create_room(
+        &rooms,
+        &path_index,
+        source_uuid,
+        Some(tmp.path().join("source.ipynb")),
+        &docs_dir,
+        blob_store.clone(),
+        false,
+    )
+    .await;
+
+    // Seed source doc with kernelspec (so snapshot is Some) plus
+    // unknown extras.
+    {
+        let mut doc = source_room.doc.write().await;
+        let mut snap = snapshot_empty();
+        snap.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+            name: "python3".to_string(),
+            display_name: "Python 3".to_string(),
+            language: Some("python".to_string()),
+            extras: std::collections::BTreeMap::new(),
+        });
+        snap.extras.insert(
+            "jupytext".to_string(),
+            serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        );
+        snap.extras.insert(
+            "vscode".to_string(),
+            serde_json::json!({"extension": {"id": "ms-python.python"}}),
+        );
+        doc.set_metadata_snapshot(&snap).unwrap();
+    }
+
+    let response = crate::requests::clone_notebook::handle_inner(
+        &rooms,
+        &path_index,
+        &docs_dir,
+        blob_store.clone(),
+        source_uuid.to_string(),
+    )
+    .await;
+
+    let clone_id = match response {
+        NotebookResponse::NotebookCloned { notebook_id, .. } => notebook_id,
+        other => panic!("Expected NotebookCloned, got {other:?}"),
+    };
+    let clone_uuid = Uuid::parse_str(&clone_id).unwrap();
+    let clone_room = rooms
+        .lock()
+        .await
+        .get(&clone_uuid)
+        .cloned()
+        .expect("clone room should be registered");
+
+    let clone_snap = clone_room
+        .doc
+        .read()
+        .await
+        .get_metadata_snapshot()
+        .expect("clone has metadata");
+    assert!(
+        clone_snap.extras.contains_key("jupytext"),
+        "jupytext must survive clone; extras: {:?}",
+        clone_snap.extras.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        clone_snap.extras.contains_key("vscode"),
+        "vscode must survive clone; extras: {:?}",
+        clone_snap.extras.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        clone_snap.extras["jupytext"],
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]})
+    );
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6249,3 +6249,81 @@ async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
         serde_json::json!({"paired_paths": [["x.py", "py:percent"]]})
     );
 }
+
+#[tokio::test]
+async fn test_file_watcher_replacement_drops_stale_top_level_metadata() {
+    // Codex P2#2 on PR #2198: the file-watcher path calls
+    // set_metadata_snapshot with whatever the new on-disk file
+    // parsed to. When a user deletes an unknown top-level key (say,
+    // `colab`) from the .ipynb, the daemon must converge — not keep
+    // the stale Automerge map around forever. Simulate the reload by
+    // parsing two different on-disk states and applying each.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "watcher-reload.ipynb");
+
+    // First state: both jupytext and colab present.
+    std::fs::write(
+        &notebook_path,
+        r#"{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+  "language_info": {"name": "python", "version": "3.11.5"},
+  "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+  "colab": {"kernel": {"name": "python3"}}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"#,
+    )
+    .unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+    }
+
+    let first = {
+        let doc = room.doc.read().await;
+        doc.get_metadata_snapshot().unwrap()
+    };
+    assert!(first.extras.contains_key("jupytext"));
+    assert!(first.extras.contains_key("colab"));
+
+    // Second state: colab removed, jupytext kept. This mirrors the
+    // watcher path exactly: parse_metadata_from_ipynb + set_metadata_snapshot.
+    let new_json = serde_json::json!({
+        "cells": [],
+        "metadata": {
+            "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+            "language_info": {"name": "python", "version": "3.11.5"},
+            "jupytext": {"paired_paths": [["x.py", "py:percent"]]}
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5
+    });
+    let new_meta = crate::notebook_sync_server::parse_metadata_from_ipynb(&new_json).unwrap();
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&new_meta).unwrap();
+    }
+
+    let after = {
+        let doc = room.doc.read().await;
+        doc.get_metadata_snapshot().unwrap()
+    };
+    assert!(
+        after.extras.contains_key("jupytext"),
+        "jupytext must still be present after replace"
+    );
+    assert!(
+        !after.extras.contains_key("colab"),
+        "colab must be deleted from doc after replacement snapshot omits it; extras={:?}",
+        after.extras.keys().collect::<Vec<_>>()
+    );
+}

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f019ad835cb3b09f329c6b6b9bd1b2933793403f31ec6cf0936ed5d6b35a7133
+oid sha256:5cd9a4f54d070fa80c82aa8da276a098eb3b375ee37d5a71fe926e602678a356
 size 6801448

--- a/docs/superpowers/plans/2026-04-25-metadata-extras.md
+++ b/docs/superpowers/plans/2026-04-25-metadata-extras.md
@@ -1,0 +1,1336 @@
+# Notebook Metadata Extras Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Automerge `NotebookDoc` carry all top-level notebook metadata keys (including unknown third-party keys like `jupytext`, `colab`, `vscode`) so clone and save preserve them without reading the on-disk `.ipynb` at save time.
+
+**Architecture:** Add `extras: BTreeMap<String, Value>` with `#[serde(flatten)]` to `NotebookMetadataSnapshot`, `KernelspecSnapshot`, `LanguageInfoSnapshot`. `RuntMetadata` gets `is_empty()` + `#[serde(default, skip_serializing_if = "RuntMetadata::is_empty")]` so vanilla Jupyter notebooks round-trip without a synthetic `runt` stamp. `NotebookDoc::set_metadata_snapshot` guards against extras keys that collide with typed field names, logs `error!` on collision. `get_metadata_snapshot` and the free-function `get_metadata_snapshot_from_doc` both get a scan loop that collects unknown keys; they share the same helper. `persist.rs` stops reading the existing `.ipynb` for metadata (keeps reading it for the content-hash guard).
+
+**Tech Stack:** Rust, `serde` + `serde_json`, `automerge`, `tokio`, `tracing`.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-metadata-extras.md`
+
+---
+
+## File structure
+
+| File | Role in this plan |
+|---|---|
+| `crates/notebook-doc/src/metadata.rs` | Struct definitions (`NotebookMetadataSnapshot`, `KernelspecSnapshot`, `LanguageInfoSnapshot`, `RuntMetadata`), `from_metadata_value`, `merge_into_metadata_value`, `RuntMetadata::is_empty`. Unit tests for the extras serde contract. |
+| `crates/notebook-doc/src/lib.rs` | `NotebookDoc::set_metadata_snapshot` (collision guard + extras write), `NotebookDoc::get_metadata_snapshot` (scan), free-function `get_metadata_snapshot_from_doc` (same scan, shared helper). Unit tests for the doc-level round-trip. |
+| `crates/runtimed/src/notebook_sync_server/persist.rs` | Drop the metadata-rescue read of the existing `.ipynb`. Keep `existing_raw` for the content-hash guard. Integration test added in `tests.rs`. |
+| `crates/runtimed/src/notebook_sync_server/tests.rs` | Integration tests: save round-trips unknown top-level keys; clone carries unknown keys to the clone doc. |
+
+---
+
+## Task 1: `RuntMetadata::is_empty` and `skip_serializing_if`
+
+**Files:**
+- Modify: `crates/notebook-doc/src/metadata.rs` (RuntMetadata definition around line 26; Default impl around line 638)
+
+- [ ] **Step 1: Write the failing test for `is_empty`**
+
+Append to the unit-test module at the bottom of `crates/notebook-doc/src/metadata.rs` (find `#[cfg(test)] mod tests` — if there is none, add one):
+
+```rust
+#[cfg(test)]
+mod is_empty_tests {
+    use super::*;
+
+    #[test]
+    fn default_runt_is_empty() {
+        let runt = RuntMetadata::default();
+        assert!(runt.is_empty(), "freshly-defaulted RuntMetadata should be empty");
+    }
+
+    #[test]
+    fn runt_with_env_id_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.env_id = Some("abc-123".to_string());
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_uv_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.uv = Some(UvInlineMetadata {
+            dependencies: vec!["pandas".to_string()],
+            requires_python: None,
+            prerelease: None,
+        });
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_trust_signature_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.trust_signature = Some("hmac-sha256:deadbeef".to_string());
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_extra_key_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.extra.insert("future_field".to_string(), serde_json::json!(42));
+        assert!(!runt.is_empty());
+    }
+
+    #[test]
+    fn runt_with_modified_schema_version_is_not_empty() {
+        let mut runt = RuntMetadata::default();
+        runt.schema_version = "2".to_string();
+        assert!(!runt.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p notebook-doc --lib is_empty_tests 2>&1 | tail -10`
+Expected: FAIL with "no method named `is_empty` found for struct `RuntMetadata`".
+
+- [ ] **Step 3: Implement `is_empty`**
+
+Add after the existing `impl Default for RuntMetadata` block (around line 652 in the current file):
+
+```rust
+impl RuntMetadata {
+    /// Returns true when this metadata carries no daemon-relevant state.
+    /// Used by `skip_serializing_if` so vanilla Jupyter notebooks don't
+    /// get a synthetic `runt: { schema_version: "1" }` stamped on first
+    /// save, which would churn git-tracked notebooks.
+    pub fn is_empty(&self) -> bool {
+        self.env_id.is_none()
+            && self.uv.is_none()
+            && self.conda.is_none()
+            && self.pixi.is_none()
+            && self.deno.is_none()
+            && self.trust_signature.is_none()
+            && self.trust_timestamp.is_none()
+            && self.extra.is_empty()
+            && self.schema_version == "1"
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p notebook-doc --lib is_empty_tests 2>&1 | tail -10`
+Expected: PASS, 6 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/notebook-doc/src/metadata.rs
+git commit -m "feat(notebook-doc): RuntMetadata::is_empty"
+```
+
+---
+
+## Task 2: Extras field on `NotebookMetadataSnapshot`, with `#[serde(default, skip_serializing_if = "RuntMetadata::is_empty")]` on runt
+
+**Files:**
+- Modify: `crates/notebook-doc/src/metadata.rs` (NotebookMetadataSnapshot definition, currently around line 157)
+
+- [ ] **Step 1: Write the failing tests for the struct shape**
+
+Append to `crates/notebook-doc/src/metadata.rs`:
+
+```rust
+#[cfg(test)]
+mod snapshot_extras_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vanilla_snapshot_serializes_without_runt_key() {
+        // A NotebookMetadataSnapshot with an empty default RuntMetadata
+        // must NOT emit a `runt` key when serialized. This is the
+        // "no synthetic runt stamp on vanilla notebooks" invariant.
+        let snap = NotebookMetadataSnapshot::default();
+        let v = serde_json::to_value(&snap).unwrap();
+        let obj = v.as_object().expect("snapshot serializes to object");
+        assert!(
+            !obj.contains_key("runt"),
+            "vanilla snapshot must not emit runt key, got: {v}"
+        );
+    }
+
+    #[test]
+    fn snapshot_with_runt_env_id_serializes_runt_key() {
+        let mut snap = NotebookMetadataSnapshot::default();
+        snap.runt.env_id = Some("abc".to_string());
+        let v = serde_json::to_value(&snap).unwrap();
+        assert!(v.as_object().unwrap().contains_key("runt"));
+    }
+
+    #[test]
+    fn snapshot_deserializes_when_runt_absent() {
+        // Vanilla Jupyter notebooks have no runt key. Must not fail.
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+        });
+        let snap: NotebookMetadataSnapshot = serde_json::from_value(v).unwrap();
+        assert!(snap.runt.is_empty());
+        assert_eq!(snap.kernelspec.as_ref().unwrap().name, "python3");
+    }
+
+    #[test]
+    fn extras_round_trip_at_top_level() {
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "jupytext": {"paired_paths": [["notebook.py", "py:percent"]]},
+            "colab": {"kernel": {"name": "python3"}},
+        });
+        let snap: NotebookMetadataSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(snap.extras.len(), 2);
+        assert!(snap.extras.contains_key("jupytext"));
+        assert!(snap.extras.contains_key("colab"));
+
+        let round_tripped = serde_json::to_value(&snap).unwrap();
+        assert_eq!(round_tripped["jupytext"], v["jupytext"]);
+        assert_eq!(round_tripped["colab"], v["colab"]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p notebook-doc --lib snapshot_extras_tests 2>&1 | tail -10`
+Expected: FAIL on all four tests (field `extras` not found, runt key still emitted, etc).
+
+- [ ] **Step 3: Rewrite `NotebookMetadataSnapshot`**
+
+Replace the existing struct definition (currently around lines 155-170 in `crates/notebook-doc/src/metadata.rs`) with:
+
+```rust
+/// Typed snapshot of notebook-level metadata for Automerge sync.
+///
+/// Three named fields (`kernelspec`, `language_info`, `runt`) plus a
+/// catch-all `extras` bag for unknown/third-party top-level keys
+/// (`jupytext`, `colab`, `vscode`, etc.). The flatten attribute means
+/// unknown keys at deserialize land in `extras` automatically; on
+/// serialize they emit at top level alongside the typed keys.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct NotebookMetadataSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernelspec: Option<KernelspecSnapshot>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_info: Option<LanguageInfoSnapshot>,
+
+    /// Runt-namespace metadata. Defaulted on deserialize so a notebook
+    /// without `metadata.runt` (i.e. every vanilla Jupyter notebook)
+    /// deserializes cleanly. Skipped on serialize when empty so we
+    /// don't stamp a synthetic `runt: { schema_version: "1" }` blob
+    /// on every save of an unrelated notebook.
+    #[serde(default, skip_serializing_if = "RuntMetadata::is_empty")]
+    pub runt: RuntMetadata,
+
+    /// Catch-all for unknown/third-party top-level metadata keys.
+    /// See `RuntMetadata::extra` for the analogous pattern one level
+    /// deeper.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p notebook-doc --lib snapshot_extras_tests 2>&1 | tail -10`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run the full notebook-doc test suite to catch other breakage**
+
+Run: `cargo test -p notebook-doc 2>&1 | tail -15`
+Expected: all pre-existing tests still pass. If any fail with "extras field" mismatches, update them in-place to use `Default::default()` for the new field.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-doc/src/metadata.rs
+git commit -m "feat(notebook-doc): NotebookMetadataSnapshot carries extras, skips empty runt"
+```
+
+---
+
+## Task 3: Extras fields on `KernelspecSnapshot` and `LanguageInfoSnapshot`
+
+**Files:**
+- Modify: `crates/notebook-doc/src/metadata.rs` (KernelspecSnapshot around line 174, LanguageInfoSnapshot around line 188)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `crates/notebook-doc/src/metadata.rs`:
+
+```rust
+#[cfg(test)]
+mod nested_extras_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn kernelspec_extras_round_trip() {
+        // Standard Jupyter kernelspec often carries env, interrupt_mode,
+        // metadata. These must survive load → save.
+        let v = json!({
+            "name": "python3",
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "env": {"PYTHONPATH": "/opt/extra"},
+            "interrupt_mode": "signal",
+            "metadata": {"debugger": true},
+        });
+        let ks: KernelspecSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(ks.extras.len(), 3);
+        assert!(ks.extras.contains_key("env"));
+        assert!(ks.extras.contains_key("interrupt_mode"));
+        assert!(ks.extras.contains_key("metadata"));
+
+        let out = serde_json::to_value(&ks).unwrap();
+        assert_eq!(out["env"], v["env"]);
+        assert_eq!(out["interrupt_mode"], v["interrupt_mode"]);
+        assert_eq!(out["metadata"], v["metadata"]);
+    }
+
+    #[test]
+    fn language_info_extras_round_trip() {
+        // Jupyter kernels populate many fields after startup. All must
+        // survive round-trip or save churns them on every notebook.
+        let v = json!({
+            "name": "python",
+            "version": "3.11.5",
+            "codemirror_mode": {"name": "ipython", "version": 3},
+            "mimetype": "text/x-python",
+            "file_extension": ".py",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+        });
+        let li: LanguageInfoSnapshot = serde_json::from_value(v.clone()).unwrap();
+        assert_eq!(li.extras.len(), 5);
+        for key in ["codemirror_mode", "mimetype", "file_extension",
+                    "nbconvert_exporter", "pygments_lexer"] {
+            assert!(li.extras.contains_key(key), "missing {key}");
+        }
+
+        let out = serde_json::to_value(&li).unwrap();
+        assert_eq!(out["codemirror_mode"], v["codemirror_mode"]);
+        assert_eq!(out["mimetype"], v["mimetype"]);
+        assert_eq!(out["pygments_lexer"], v["pygments_lexer"]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p notebook-doc --lib nested_extras_tests 2>&1 | tail -10`
+Expected: FAIL (extras field not found).
+
+- [ ] **Step 3: Rewrite `KernelspecSnapshot` and `LanguageInfoSnapshot`**
+
+Replace the existing `KernelspecSnapshot` definition (around lines 173-183):
+
+```rust
+/// Kernelspec snapshot for Automerge sync.
+///
+/// Mirrors standard Jupyter `kernelspec` fields plus an `extras` bag
+/// so sub-keys we don't model (`env`, `interrupt_mode`, `metadata`)
+/// still round-trip.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct KernelspecSnapshot {
+    pub name: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    /// Catch-all for unknown kernelspec sub-fields.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+Replace the existing `LanguageInfoSnapshot` definition (around lines 188-195):
+
+```rust
+/// Language info snapshot for Automerge sync.
+///
+/// Jupyter kernels populate many fields here after startup
+/// (`codemirror_mode`, `mimetype`, `file_extension`, `nbconvert_exporter`,
+/// `pygments_lexer`). Extras bag preserves them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct LanguageInfoSnapshot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Catch-all for unknown language_info sub-fields.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p notebook-doc --lib nested_extras_tests 2>&1 | tail -10`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Run the full notebook-doc test suite**
+
+Run: `cargo test -p notebook-doc 2>&1 | tail -15`
+Expected: all pass. Any pre-existing construction sites for `KernelspecSnapshot { name, display_name, language }` now need `..Default::default()` — fix them if compilation complains.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-doc/src/metadata.rs
+git commit -m "feat(notebook-doc): KernelspecSnapshot + LanguageInfoSnapshot carry extras"
+```
+
+---
+
+## Task 4: Rewrite `from_metadata_value` to use serde
+
+**Files:**
+- Modify: `crates/notebook-doc/src/metadata.rs` (from_metadata_value around line 205)
+
+- [ ] **Step 1: Write failing tests for the new behavior**
+
+Append to `crates/notebook-doc/src/metadata.rs`:
+
+```rust
+#[cfg(test)]
+mod from_metadata_value_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vanilla_jupyter_notebook_deserializes() {
+        // Vanilla Jupyter notebook: kernelspec + language_info, no runt.
+        // Must deserialize cleanly with an empty default RuntMetadata.
+        let v = json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3 (ipykernel)",
+                "language": "python",
+            },
+            "language_info": {
+                "name": "python",
+                "version": "3.11.5",
+            },
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.kernelspec.is_some());
+        assert!(snap.language_info.is_some());
+        assert!(snap.runt.is_empty());
+        assert!(snap.extras.is_empty());
+    }
+
+    #[test]
+    fn unknown_top_level_keys_become_extras() {
+        let v = json!({
+            "kernelspec": {"name": "python3", "display_name": "Python 3"},
+            "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+            "colab": {"kernel": {"name": "python3"}},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.extras.contains_key("jupytext"));
+        assert!(snap.extras.contains_key("colab"));
+        assert!(!snap.extras.contains_key("kernelspec"));
+    }
+
+    #[test]
+    fn legacy_top_level_uv_is_absorbed_into_runt() {
+        // Legacy notebooks had metadata.uv at top level.
+        // from_metadata_value must fold it into runt.uv so the save
+        // path emits it at the new path, not both.
+        let v = json!({
+            "uv": {"dependencies": ["pandas"]},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.runt.uv.is_some());
+        assert_eq!(snap.runt.uv.as_ref().unwrap().dependencies, vec!["pandas"]);
+        assert!(!snap.extras.contains_key("uv"),
+            "legacy uv must be folded into runt, not left in extras");
+    }
+
+    #[test]
+    fn legacy_top_level_conda_is_absorbed_into_runt() {
+        let v = json!({
+            "conda": {
+                "dependencies": ["numpy"],
+                "channels": ["conda-forge"],
+            },
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert!(snap.runt.conda.is_some());
+        assert_eq!(snap.runt.conda.as_ref().unwrap().dependencies, vec!["numpy"]);
+        assert!(!snap.extras.contains_key("conda"));
+    }
+
+    #[test]
+    fn runt_wins_when_both_typed_and_legacy_present() {
+        // Typed runt.uv wins over legacy top-level uv.
+        let v = json!({
+            "runt": {
+                "schema_version": "1",
+                "uv": {"dependencies": ["fresh"]},
+            },
+            "uv": {"dependencies": ["stale"]},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        assert_eq!(
+            snap.runt.uv.as_ref().unwrap().dependencies,
+            vec!["fresh"],
+            "runt.uv must win over legacy top-level uv"
+        );
+        assert!(!snap.extras.contains_key("uv"));
+    }
+
+    #[test]
+    fn full_round_trip_preserves_all_levels() {
+        // Top-level extras, kernelspec extras, language_info extras,
+        // and runt all present; every key must survive load → save.
+        let v = json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python",
+                "env": {"A": "1"},
+            },
+            "language_info": {
+                "name": "python",
+                "version": "3.11.5",
+                "codemirror_mode": {"name": "ipython", "version": 3},
+                "file_extension": ".py",
+            },
+            "runt": {
+                "schema_version": "1",
+                "uv": {"dependencies": ["pandas"]},
+            },
+            "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+            "vscode": {"extension": {"id": "ms-python.python"}},
+        });
+        let snap = NotebookMetadataSnapshot::from_metadata_value(&v);
+        let out = serde_json::to_value(&snap).unwrap();
+
+        assert_eq!(out["kernelspec"]["env"], v["kernelspec"]["env"]);
+        assert_eq!(
+            out["language_info"]["codemirror_mode"],
+            v["language_info"]["codemirror_mode"]
+        );
+        assert_eq!(
+            out["language_info"]["file_extension"],
+            v["language_info"]["file_extension"]
+        );
+        assert_eq!(out["runt"]["uv"], v["runt"]["uv"]);
+        assert_eq!(out["jupytext"], v["jupytext"]);
+        assert_eq!(out["vscode"], v["vscode"]);
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p notebook-doc --lib from_metadata_value_tests 2>&1 | tail -20`
+Expected: several FAIL. The existing `from_metadata_value` doesn't populate extras.
+
+- [ ] **Step 3: Rewrite `from_metadata_value`**
+
+Replace the existing implementation (currently around lines 205-244) with:
+
+```rust
+/// Build a snapshot from raw notebook metadata JSON (from an .ipynb).
+///
+/// Uses `serde_json::from_value::<Self>` so all three snapshot levels
+/// (top, kernelspec, language_info) populate their `extras` bags in
+/// one pass. `#[serde(default)]` on `runt` means vanilla Jupyter
+/// notebooks (no `metadata.runt` key) deserialize cleanly.
+///
+/// After the serde pass, runs one legacy fallback: if `runt.uv` or
+/// `runt.conda` is unset but a top-level `uv` or `conda` exists (old
+/// pre-`runt.*` notebooks), fold them into `runt` and remove from
+/// extras so save doesn't emit them at both depths.
+pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
+    let mut snapshot: NotebookMetadataSnapshot =
+        serde_json::from_value(metadata.clone()).unwrap_or_default();
+
+    if snapshot.runt.uv.is_none() {
+        if let Some(raw_uv) = snapshot.extras.remove("uv") {
+            snapshot.runt.uv = serde_json::from_value(raw_uv).ok();
+        }
+    }
+    if snapshot.runt.conda.is_none() {
+        if let Some(raw_conda) = snapshot.extras.remove("conda") {
+            snapshot.runt.conda = serde_json::from_value(raw_conda).ok();
+        }
+    }
+
+    snapshot
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `cargo test -p notebook-doc --lib from_metadata_value_tests 2>&1 | tail -15`
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Run the full notebook-doc suite to catch regressions**
+
+Run: `cargo test -p notebook-doc 2>&1 | tail -15`
+Expected: all pass. Pre-existing `from_metadata_value` tests may still pass because the behavior contract for known keys hasn't changed. If any fail, inspect: the only behavior change from today is "malformed field nukes whole snapshot" vs. today's "per-field tolerance." Acceptable per spec; update test expectations if needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-doc/src/metadata.rs
+git commit -m "feat(notebook-doc): from_metadata_value uses serde flatten for extras"
+```
+
+---
+
+## Task 5: Collision guard and extras write in `NotebookDoc::set_metadata_snapshot`
+
+**Files:**
+- Modify: `crates/notebook-doc/src/lib.rs` (set_metadata_snapshot around line 393)
+
+- [ ] **Step 1: Write failing tests**
+
+Find or create a test module in `crates/notebook-doc/src/lib.rs`. Use an existing `#[cfg(test)] mod tests` block (there's one already) and append:
+
+```rust
+#[test]
+fn set_metadata_snapshot_writes_extras_as_siblings() {
+    use crate::metadata::NotebookMetadataSnapshot;
+    let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.extras.insert(
+        "jupytext".to_string(),
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+    );
+    snap.extras.insert(
+        "colab".to_string(),
+        serde_json::json!({"kernel": {"name": "python3"}}),
+    );
+    doc.set_metadata_snapshot(&snap).unwrap();
+
+    let round_tripped = doc.get_metadata_snapshot().unwrap();
+    assert_eq!(round_tripped.extras.len(), 2);
+    assert_eq!(
+        round_tripped.extras.get("jupytext"),
+        Some(&serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}))
+    );
+    assert_eq!(
+        round_tripped.extras.get("colab"),
+        Some(&serde_json::json!({"kernel": {"name": "python3"}}))
+    );
+}
+
+#[test]
+fn set_metadata_snapshot_drops_extras_colliding_with_kernelspec() {
+    use crate::metadata::{KernelspecSnapshot, NotebookMetadataSnapshot};
+    let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.kernelspec = Some(KernelspecSnapshot {
+        name: "python3".to_string(),
+        display_name: "Python 3".to_string(),
+        language: Some("python".to_string()),
+        extras: Default::default(),
+    });
+    // Caller bug: sneaking "kernelspec" into extras would double-write.
+    // Guard must drop the extras entry and leave the typed kernelspec
+    // intact.
+    snap.extras.insert(
+        "kernelspec".to_string(),
+        serde_json::json!({"BAD": true}),
+    );
+
+    doc.set_metadata_snapshot(&snap).unwrap();
+
+    let round_tripped = doc.get_metadata_snapshot().unwrap();
+    assert_eq!(
+        round_tripped.kernelspec.as_ref().unwrap().name,
+        "python3",
+        "typed kernelspec must survive collision; extras must be dropped"
+    );
+    assert!(
+        !round_tripped.extras.contains_key("kernelspec"),
+        "collision-dropped key must not appear in extras on read"
+    );
+}
+
+#[test]
+fn set_metadata_snapshot_drops_extras_colliding_with_language_info() {
+    use crate::metadata::{LanguageInfoSnapshot, NotebookMetadataSnapshot};
+    let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.language_info = Some(LanguageInfoSnapshot {
+        name: "python".to_string(),
+        version: Some("3.11.5".to_string()),
+        extras: Default::default(),
+    });
+    snap.extras.insert(
+        "language_info".to_string(),
+        serde_json::json!({"BAD": true}),
+    );
+
+    doc.set_metadata_snapshot(&snap).unwrap();
+
+    let round_tripped = doc.get_metadata_snapshot().unwrap();
+    assert_eq!(
+        round_tripped.language_info.as_ref().unwrap().name,
+        "python"
+    );
+    assert!(!round_tripped.extras.contains_key("language_info"));
+}
+
+#[test]
+fn set_metadata_snapshot_drops_extras_colliding_with_runt() {
+    use crate::metadata::NotebookMetadataSnapshot;
+    let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.runt.env_id = Some("real-env-id".to_string());
+    snap.extras.insert(
+        "runt".to_string(),
+        serde_json::json!({"env_id": "bogus"}),
+    );
+
+    doc.set_metadata_snapshot(&snap).unwrap();
+
+    let round_tripped = doc.get_metadata_snapshot().unwrap();
+    assert_eq!(
+        round_tripped.runt.env_id.as_deref(),
+        Some("real-env-id"),
+        "typed runt must win over colliding extras"
+    );
+    assert!(!round_tripped.extras.contains_key("runt"));
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cargo test -p notebook-doc --lib set_metadata_snapshot_ 2>&1 | tail -15`
+Expected: all FAIL. `set_metadata_snapshot` doesn't write extras yet, and `get_metadata_snapshot` doesn't read them.
+
+- [ ] **Step 3: Update `NotebookDoc::set_metadata_snapshot`**
+
+Locate the current implementation (around line 393 in `crates/notebook-doc/src/lib.rs`). Add the extras loop after the existing `update_json_at_key(&mut self.doc, &meta_id, "runt", &runt_v)?;` line. The full method now looks like:
+
+```rust
+pub fn set_metadata_snapshot(
+    &mut self,
+    snapshot: &metadata::NotebookMetadataSnapshot,
+) -> Result<(), AutomergeError> {
+    let meta_id = match self.metadata_map_id() {
+        Some(id) => id,
+        None => self
+            .doc
+            .put_object(automerge::ROOT, "metadata", ObjType::Map)?,
+    };
+
+    match &snapshot.kernelspec {
+        Some(ks) => {
+            let v = serde_json::to_value(ks).map_err(|e| {
+                AutomergeError::InvalidObjId(format!("serialize kernelspec: {}", e))
+            })?;
+            update_json_at_key(&mut self.doc, &meta_id, "kernelspec", &v)?;
+        }
+        None => {
+            let _ = self.doc.delete(&meta_id, "kernelspec");
+        }
+    }
+
+    match &snapshot.language_info {
+        Some(li) => {
+            let v = serde_json::to_value(li).map_err(|e| {
+                AutomergeError::InvalidObjId(format!("serialize language_info: {}", e))
+            })?;
+            update_json_at_key(&mut self.doc, &meta_id, "language_info", &v)?;
+        }
+        None => {
+            let _ = self.doc.delete(&meta_id, "language_info");
+        }
+    }
+
+    // Write runt only when non-empty so vanilla Jupyter notebooks
+    // round-trip without stamping a synthetic runt blob.
+    if snapshot.runt.is_empty() {
+        let _ = self.doc.delete(&meta_id, "runt");
+    } else {
+        let runt_v = serde_json::to_value(&snapshot.runt)
+            .map_err(|e| AutomergeError::InvalidObjId(format!("serialize runt: {}", e)))?;
+        update_json_at_key(&mut self.doc, &meta_id, "runt", &runt_v)?;
+    }
+
+    // Write extras. Each key becomes its own Automerge Map so concurrent
+    // edits to metadata.jupytext.* from two peers merge per-field.
+    // Guard against callers that stuff known top-level keys into
+    // extras — those would double-write at the same Automerge key.
+    for (key, value) in &snapshot.extras {
+        if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+            tracing::error!(
+                "[notebook-doc] metadata.extras collision: key {:?} \
+                 is reserved for a typed field; dropping to avoid \
+                 Automerge double-write. This indicates a caller bug \
+                 in snapshot construction.",
+                key
+            );
+            continue;
+        }
+        update_json_at_key(&mut self.doc, &meta_id, key, value)?;
+    }
+
+    Ok(())
+}
+```
+
+Note that the runt-empty branch now calls `delete` — this is the other half of the "no stamping" behavior: if a user clears all runt content, we remove the key from the doc entirely.
+
+- [ ] **Step 4: Run tests (expect 2 of 4 still failing)**
+
+Run: `cargo test -p notebook-doc --lib set_metadata_snapshot_ 2>&1 | tail -15`
+Expected: the "collision drops" tests pass; the "writes extras as siblings" test still FAILS until `get_metadata_snapshot` is taught to scan (Task 6).
+
+If any test fails for the wrong reason (e.g. a type mismatch), fix before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/notebook-doc/src/lib.rs
+git commit -m "feat(notebook-doc): set_metadata_snapshot writes extras + collision guard"
+```
+
+---
+
+## Task 6: Shared extras-scan helper; wire both `get_metadata_snapshot` paths
+
+**Files:**
+- Modify: `crates/notebook-doc/src/lib.rs` (`NotebookDoc::get_metadata_snapshot` around line 368; free-function `get_metadata_snapshot_from_doc` around line 1930)
+
+- [ ] **Step 1: Add a private helper for the scan**
+
+Insert this function in `crates/notebook-doc/src/lib.rs`, near the existing `fn read_cell_metadata` (around line 1883):
+
+```rust
+/// Scan an Automerge metadata Map for top-level keys that aren't
+/// modeled by `NotebookMetadataSnapshot`'s typed fields.
+///
+/// Shared by `NotebookDoc::get_metadata_snapshot` and the free-function
+/// `get_metadata_snapshot_from_doc`. Both must behave identically —
+/// different behavior would mean the frontend sync snapshot and
+/// Python bindings disagree with the daemon's view of the same doc.
+fn scan_metadata_extras(
+    doc: &AutoCommit,
+    meta_id: &ObjId,
+) -> std::collections::BTreeMap<String, serde_json::Value> {
+    let mut extras = std::collections::BTreeMap::new();
+    for key in doc.keys(meta_id) {
+        if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+            continue;
+        }
+        if let Some(value) = read_json_value(doc, meta_id, &key) {
+            extras.insert(key, value);
+        }
+    }
+    extras
+}
+```
+
+- [ ] **Step 2: Update `NotebookDoc::get_metadata_snapshot`**
+
+Replace the current body (around lines 368-387 in `crates/notebook-doc/src/lib.rs`):
+
+```rust
+pub fn get_metadata_snapshot(&self) -> Option<metadata::NotebookMetadataSnapshot> {
+    let meta_id = self.metadata_map_id()?;
+
+    let kernelspec = read_json_value(&self.doc, &meta_id, "kernelspec")
+        .and_then(|v| serde_json::from_value::<metadata::KernelspecSnapshot>(v).ok());
+    let language_info = read_json_value(&self.doc, &meta_id, "language_info")
+        .and_then(|v| serde_json::from_value::<metadata::LanguageInfoSnapshot>(v).ok());
+    let runt = read_json_value(&self.doc, &meta_id, "runt")
+        .and_then(|v| serde_json::from_value::<metadata::RuntMetadata>(v).ok());
+
+    let extras = scan_metadata_extras(&self.doc, &meta_id);
+
+    if kernelspec.is_some()
+        || language_info.is_some()
+        || runt.is_some()
+        || !extras.is_empty()
+    {
+        return Some(metadata::NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt: runt.unwrap_or_default(),
+            extras,
+        });
+    }
+
+    None
+}
+```
+
+- [ ] **Step 3: Update the free-function `get_metadata_snapshot_from_doc`**
+
+Replace the current body (around lines 1930-1958 in `crates/notebook-doc/src/lib.rs`):
+
+```rust
+pub fn get_metadata_snapshot_from_doc(
+    doc: &AutoCommit,
+) -> Option<metadata::NotebookMetadataSnapshot> {
+    let meta_id = doc
+        .get(automerge::ROOT, "metadata")
+        .ok()
+        .flatten()
+        .and_then(|(value, id)| match value {
+            automerge::Value::Object(ObjType::Map) => Some(id),
+            _ => None,
+        })?;
+
+    let kernelspec = read_json_value(doc, &meta_id, "kernelspec")
+        .and_then(|v| serde_json::from_value::<metadata::KernelspecSnapshot>(v).ok());
+    let language_info = read_json_value(doc, &meta_id, "language_info")
+        .and_then(|v| serde_json::from_value::<metadata::LanguageInfoSnapshot>(v).ok());
+    let runt = read_json_value(doc, &meta_id, "runt")
+        .and_then(|v| serde_json::from_value::<metadata::RuntMetadata>(v).ok());
+
+    let extras = scan_metadata_extras(doc, &meta_id);
+
+    if kernelspec.is_some()
+        || language_info.is_some()
+        || runt.is_some()
+        || !extras.is_empty()
+    {
+        return Some(metadata::NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt: runt.unwrap_or_default(),
+            extras,
+        });
+    }
+
+    None
+}
+```
+
+- [ ] **Step 4: Add a test for the free-function path**
+
+Append to the `#[cfg(test)] mod tests` block in `crates/notebook-doc/src/lib.rs`:
+
+```rust
+#[test]
+fn get_metadata_snapshot_from_doc_reads_extras() {
+    use crate::metadata::NotebookMetadataSnapshot;
+    let mut doc = NotebookDoc::new_with_actor("test-nb", "test");
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.extras.insert(
+        "jupytext".to_string(),
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+    );
+    doc.set_metadata_snapshot(&snap).unwrap();
+
+    // Read via the free-function path (used by notebook-sync +
+    // Python bindings, not the &self method).
+    let round_tripped = crate::get_metadata_snapshot_from_doc(doc.doc())
+        .expect("free function should surface extras");
+    assert!(round_tripped.extras.contains_key("jupytext"));
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p notebook-doc --lib 2>&1 | tail -20`
+Expected: all pass. The earlier-failing `set_metadata_snapshot_writes_extras_as_siblings` from Task 5 also passes now.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/notebook-doc/src/lib.rs
+git commit -m "feat(notebook-doc): extras scan on both get_metadata_snapshot paths"
+```
+
+---
+
+## Task 7: Drop the metadata-rescue read in `persist.rs`
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/persist.rs` (the metadata-build block around lines 66-165)
+
+- [ ] **Step 1: Rewrite the metadata-prep block**
+
+In `save_notebook_to_disk`, replace the block from "Read existing .ipynb as raw bytes" through "Build metadata by merging synced snapshot onto existing" / "snapshot.merge_into_metadata_value" with the simpler version:
+
+```rust
+    // Read existing .ipynb as raw bytes. Used for two things: the
+    // content-hash guard further down (skip no-op writes), and the
+    // `nbformat_minor` floor (we don't carry that in the doc today).
+    // We no longer read metadata from disk — the doc carries unknown
+    // top-level keys as extras, so everything round-trips through
+    // the snapshot.
+    let existing_raw: Option<Vec<u8>> = match tokio::fs::read(&notebook_path).await {
+        Ok(bytes) => Some(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            warn!(
+                "[notebook-sync] Failed to read existing notebook {:?}: {}, \
+                 will create new",
+                notebook_path, e
+            );
+            None
+        }
+    };
+```
+
+Delete the `let existing: Option<serde_json::Value> = ...` parse (around lines 80-93) and everything from "Build metadata by merging synced snapshot onto existing" through the `snapshot.merge_into_metadata_value` call. Replace with:
+
+```rust
+    // nbformat_minor: pull from existing file if present, floor at 5.
+    let existing_minor = existing_raw
+        .as_ref()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
+        .and_then(|nb| nb.get("nbformat_minor").and_then(|v| v.as_u64()))
+        .unwrap_or(5) as i32;
+    let nbformat_minor = std::cmp::max(existing_minor, 5);
+
+    // Metadata comes entirely from the doc. No disk rescue; the
+    // snapshot carries unknown keys as extras.
+    let metadata = metadata_snapshot
+        .as_ref()
+        .map(|s| serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({})))
+        .unwrap_or_else(|| serde_json::json!({}));
+```
+
+- [ ] **Step 2: Run persist unit tests to confirm compile + behavior**
+
+Run: `cargo test -p runtimed --lib notebook_sync_server::persist 2>&1 | tail -10`
+Expected: compiles. If there are failures, read carefully — most likely they're about the `existing` binding no longer existing. Update the affected test code.
+
+- [ ] **Step 3: Run the full runtimed sync-server suite**
+
+Run: `cargo test -p runtimed --lib notebook_sync_server 2>&1 | tail -10`
+Expected: pass or a small number of test failures related to pre-existing expectations about metadata preservation that are now handled differently (through the doc, not via disk rescue).
+
+If any failures, they likely come from tests that constructed a `NotebookRoom` without going through the load path, so the doc lacks metadata the tests then expected to see after save. Inspect + fix the test to set the expected metadata on the doc via `set_metadata_snapshot` before saving.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/persist.rs
+git commit -m "refactor(runtimed): persist.rs stops reading existing .ipynb for metadata"
+```
+
+---
+
+## Task 8: Integration test — save round-trips unknown metadata
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/tests.rs` (append a new `#[tokio::test]`)
+
+- [ ] **Step 1: Append the test**
+
+Add to the bottom of `crates/runtimed/src/notebook_sync_server/tests.rs`:
+
+```rust
+#[tokio::test]
+async fn test_save_round_trips_unknown_top_level_metadata() {
+    // Regression test for Codex F3 on PR #2192: unknown top-level
+    // metadata keys (jupytext, colab, etc.) must survive save.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "with-jupytext.ipynb");
+
+    // Write an .ipynb with unknown metadata keys, then load it through
+    // the normal load path so the doc carries extras.
+    std::fs::write(
+        &notebook_path,
+        r#"{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+  "language_info": {"name": "python", "version": "3.11.5"},
+  "jupytext": {"paired_paths": [["x.py", "py:percent"]]},
+  "colab": {"kernel": {"name": "python3"}}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"#,
+    )
+    .unwrap();
+
+    // Seed the room's doc from the file via the normal load path.
+    {
+        let mut doc = room.doc.write().await;
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Save, then re-read the file.
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let written = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+    assert_eq!(
+        nb["metadata"]["jupytext"],
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        "jupytext key must survive save round-trip"
+    );
+    assert_eq!(
+        nb["metadata"]["colab"],
+        serde_json::json!({"kernel": {"name": "python3"}}),
+        "colab key must survive save round-trip"
+    );
+}
+
+#[tokio::test]
+async fn test_save_does_not_stamp_synthetic_runt_on_vanilla_notebook() {
+    // Vanilla Jupyter notebook: no metadata.runt. Save must NOT add
+    // `runt: { schema_version: "1" }` — that would churn every
+    // git-tracked Jupyter notebook the user opens.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "vanilla.ipynb");
+
+    std::fs::write(
+        &notebook_path,
+        r#"{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+  "language_info": {"name": "python", "version": "3.11.5"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"#,
+    )
+    .unwrap();
+
+    {
+        let mut doc = room.doc.write().await;
+        crate::notebook_sync_server::load_notebook_from_disk(
+            &mut doc,
+            &notebook_path,
+            &room.blob_store,
+        )
+        .await
+        .unwrap();
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let written = std::fs::read_to_string(&notebook_path).unwrap();
+    let nb: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+    assert!(
+        !nb["metadata"].as_object().unwrap().contains_key("runt"),
+        "vanilla notebook save must not stamp metadata.runt, got: {}",
+        nb["metadata"]
+    );
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `cargo test -p runtimed --lib test_save_round_trips_unknown_top_level_metadata test_save_does_not_stamp_synthetic_runt_on_vanilla_notebook 2>&1 | tail -15`
+
+Note: cargo test accepts multiple filters. If the above doesn't match, run them one at a time.
+
+Expected: both tests pass.
+
+- [ ] **Step 3: Full suite**
+
+Run: `cargo test -p runtimed --lib notebook_sync_server 2>&1 | tail -10`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/tests.rs
+git commit -m "test(runtimed): save round-trips unknown metadata + no vanilla runt stamp"
+```
+
+---
+
+## Task 9: Integration test — clone carries unknown metadata to the clone doc
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/tests.rs` (extend the existing clone test or add a sibling)
+
+- [ ] **Step 1: Append a new clone test**
+
+Add to the bottom of `crates/runtimed/src/notebook_sync_server/tests.rs`:
+
+```rust
+#[tokio::test]
+async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
+    // Codex F3 on PR #2192: clone must preserve unknown top-level
+    // metadata keys from source (jupytext, colab, vscode, etc.).
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+
+    let source_uuid = Uuid::new_v4();
+    let source_room = get_or_create_room(
+        &rooms,
+        &path_index,
+        source_uuid,
+        Some(tmp.path().join("source.ipynb")),
+        &docs_dir,
+        blob_store.clone(),
+        false,
+    )
+    .await;
+
+    // Seed source doc with kernelspec (required for snapshot to be
+    // Some) plus unknown extras.
+    {
+        let mut doc = source_room.doc.write().await;
+        let mut snap = snapshot_empty();
+        snap.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+            name: "python3".to_string(),
+            display_name: "Python 3".to_string(),
+            language: Some("python".to_string()),
+            extras: Default::default(),
+        });
+        snap.extras.insert(
+            "jupytext".to_string(),
+            serde_json::json!({"paired_paths": [["x.py", "py:percent"]]}),
+        );
+        snap.extras.insert(
+            "vscode".to_string(),
+            serde_json::json!({"extension": {"id": "ms-python.python"}}),
+        );
+        doc.set_metadata_snapshot(&snap).unwrap();
+    }
+
+    let response = crate::requests::clone_notebook::handle_inner(
+        &rooms,
+        &path_index,
+        &docs_dir,
+        blob_store.clone(),
+        source_uuid.to_string(),
+    )
+    .await;
+
+    let clone_id = match response {
+        NotebookResponse::NotebookCloned { notebook_id, .. } => notebook_id,
+        other => panic!("Expected NotebookCloned, got {other:?}"),
+    };
+    let clone_uuid = Uuid::parse_str(&clone_id).unwrap();
+    let clone_room = rooms
+        .lock()
+        .await
+        .get(&clone_uuid)
+        .cloned()
+        .expect("clone room should be registered");
+
+    let clone_snap = clone_room
+        .doc
+        .read()
+        .await
+        .get_metadata_snapshot()
+        .expect("clone has metadata");
+    assert!(
+        clone_snap.extras.contains_key("jupytext"),
+        "jupytext must survive clone; extras: {:?}",
+        clone_snap.extras.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        clone_snap.extras.contains_key("vscode"),
+        "vscode must survive clone; extras: {:?}",
+        clone_snap.extras.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        clone_snap.extras["jupytext"],
+        serde_json::json!({"paired_paths": [["x.py", "py:percent"]]})
+    );
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cargo test -p runtimed --lib test_clone_as_ephemeral_carries_unknown_metadata_extras 2>&1 | tail -10`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/tests.rs
+git commit -m "test(runtimed): clone carries unknown metadata extras"
+```
+
+---
+
+## Task 10: Final sweep, lint, and PR-ready verification
+
+**Files:** none new
+
+- [ ] **Step 1: Sweep for any remaining `merge_into_metadata_value` callers**
+
+Run: `grep -rn "merge_into_metadata_value" crates/ 2>&1 | grep -v target`
+Expected: only the definition in `crates/notebook-doc/src/metadata.rs` and the unit test at line ~913. If there are other prod callers, revisit Task 7 — the persist path should be the only consumer.
+
+If the unit test at line 913 remains and still calls the function, leave it. The function is still valid public API even if no prod code uses it (callers outside this repo may depend on it via the crate).
+
+- [ ] **Step 2: Clippy + fmt**
+
+Run: `cargo clippy -p notebook-doc -p runtimed --tests -- -D warnings 2>&1 | tail -5`
+Expected: clean.
+
+Run: `cargo fmt --check -p notebook-doc -p runtimed 2>&1 | tail -3`
+Expected: no output (clean).
+
+- [ ] **Step 3: Workspace build**
+
+Run: `cargo check --workspace 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 4: Full impacted-crate test suites**
+
+```bash
+cargo test -p notebook-doc 2>&1 | tail -10
+cargo test -p runtimed --lib notebook_sync_server 2>&1 | tail -5
+cargo test -p notebook-sync 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Manual QA checklist (human)**
+
+- [ ] Open a notebook that has `metadata.jupytext` on disk (any jupytext-paired notebook works). Confirm the daemon loads it. Edit a cell; wait for autosave. Re-read the file. `metadata.jupytext` must still be present and unchanged.
+- [ ] Open a vanilla Jupyter notebook with no `metadata.runt`. Edit and save. Re-read the file. `metadata.runt` must NOT have been added.
+- [ ] Open the same jupytext notebook, Clone it. Save the clone to a new path. `metadata.jupytext` must appear in the new file too.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- Extras on NotebookMetadataSnapshot: Task 2.
+- Extras on KernelspecSnapshot + LanguageInfoSnapshot: Task 3.
+- RuntMetadata::is_empty + skip_serializing_if: Tasks 1 + 2.
+- from_metadata_value rewrite (serde + default, legacy fallback): Task 4.
+- NotebookDoc::set_metadata_snapshot (collision guard + extras write + runt-empty delete): Task 5.
+- NotebookDoc::get_metadata_snapshot scan: Task 6.
+- Free-function get_metadata_snapshot_from_doc scan (Codex P2): Task 6 (shared helper).
+- persist.rs drops existing-file metadata read: Task 7.
+- Tests pinning vanilla-no-runt-stamp invariant: Tasks 2 + 8.
+- Tests pinning notebook-sync free-function path: Task 6.
+- Clone carries unknown metadata: Task 9.
+
+All spec items have a task.
+
+**Type consistency:**
+- `NotebookMetadataSnapshot.extras: BTreeMap<String, Value>` — same shape across Task 2 (definition), Task 4 (populated in `from_metadata_value`), Task 5 (iterated in `set_metadata_snapshot`), Task 6 (populated in scan).
+- `scan_metadata_extras` signature: `(doc: &AutoCommit, meta_id: &ObjId) -> BTreeMap<String, Value>`. Used identically by both get-snapshot paths in Task 6.
+- `RuntMetadata::is_empty`: free method on `RuntMetadata`, no args, returns `bool`. Task 1 defines; Task 2 uses in `skip_serializing_if`; Task 5 uses in `set_metadata_snapshot` to choose between write and delete.
+
+No inconsistencies.
+
+**Placeholder check:** All steps have concrete code. No "similar to" references; repeated blocks are repeated verbatim. No TODO/TBD.
+
+One flagged implementation-time concern in Task 7 Step 3: pre-existing tests in `notebook_sync_server` may fail if they constructed rooms without going through load and depended on disk rescue for metadata. The plan says "inspect + fix the test." If many tests need fixing, that's a signal we missed something. Batch-review those together rather than forcing the test update one-by-one.

--- a/docs/superpowers/specs/2026-04-25-metadata-extras.md
+++ b/docs/superpowers/specs/2026-04-25-metadata-extras.md
@@ -1,0 +1,404 @@
+# Notebook metadata extras: make the Automerge doc authoritative for all top-level metadata keys
+
+## Problem
+
+`NotebookMetadataSnapshot` carries three typed fields: `kernelspec`, `language_info`, `runt`. Every other top-level notebook metadata key (`jupytext`, `colab`, `vscode`, and whatever else a third-party tool stamps in there) is silently discarded when a `.ipynb` loads.
+
+Today the loss is papered over on the save path by reading the existing `.ipynb` from disk and merging the typed snapshot onto it, so known-file-backed notebooks appear to round-trip unknown keys. Two places that breaks:
+
+1. **Clone.** An ephemeral clone has no on-disk file to rescue from. On first Save-As, unknown source keys vanish because the save path sees no existing file to merge with. This is what Codex flagged as F3 on PR #2192.
+2. **The layering rule.** `architecture.md` says the Automerge doc is the source of truth for notebook state. Reading metadata off disk at save time violates that, and the fact that it works at all is load-bearing accident.
+
+## Goal
+
+Make the Automerge `NotebookDoc` carry all top-level metadata keys, typed or not. Clone then copies the doc; save writes the doc; external edits merge into the doc. No disk rescue.
+
+## Scope
+
+### In scope
+
+- `NotebookMetadataSnapshot` gains an `extras: BTreeMap<String, serde_json::Value>` field with `#[serde(flatten)]` so unknown top-level keys round-trip via serde.
+- `KernelspecSnapshot` gains an `extras: BTreeMap<String, serde_json::Value>` field, matching how `RuntMetadata.extra` already catches unknown sub-keys. Standard Jupyter kernelspec fields like `env`, `interrupt_mode`, `metadata` currently vanish.
+- `LanguageInfoSnapshot` gains the same. Standard Jupyter `language_info` fields (`codemirror_mode`, `mimetype`, `file_extension`, `nbconvert_exporter`, `pygments_lexer`) currently vanish. The existing comment on `merge_into_metadata_value` in metadata.rs already flags this ("preserve fields we don't track, like codemirror_mode").
+- `NotebookDoc::set_metadata_snapshot` writes extras as siblings of `kernelspec`/`language_info`/`runt` under the `metadata` Automerge Map, each as its own JSON value (one `update_json_at_key` per entry).
+- `NotebookDoc::get_metadata_snapshot` reads the three typed keys, then enumerates the rest of the `metadata` Map and collects them into `extras`.
+- `NotebookDoc::set_metadata_snapshot` guards against the caller inserting a known-key collision (`kernelspec`, `language_info`, `runt`) into top-level `extras`: logs an `error!` with the colliding key and drops it before writing.
+- `save_notebook_to_disk` stops reading the existing `.ipynb` to recover metadata. The snapshot round-trip carries everything.
+- `clone_notebook::seed_clone_from_source` benefits automatically since it copies the typed snapshot.
+- Unit + integration tests covering: unknown top-level keys round-trip, unknown kernelspec/language_info sub-keys round-trip, clone preserves extras, collision guard drops known top-level keys and logs.
+
+### Out of scope
+
+- Migrating docs that are currently loaded in a running daemon. They lack extras until the next fresh load from disk. Accepted one-time loss: the `.ipynb` on disk still has them until that first save-after-upgrade. Documented, not patched.
+- Changing `parse_metadata_from_ipynb`'s signature or callers. The function already takes a `Value`; the snapshot builder change propagates automatically.
+- Touching per-cell metadata. Cells already handle arbitrary keys via `CellSnapshot.metadata: serde_json::Value`.
+- Output metadata. Separate path (`OutputManifest::metadata: HashMap<String, Value>`), unrelated.
+- Anything about the `runt.*` keys. `RuntMetadata.extra` already handles unknowns inside `runt`.
+
+## Architecture
+
+### Data flow
+
+```
+Load (.ipynb on disk)
+  ↓
+parse_metadata_from_ipynb(value)
+  ↓
+NotebookMetadataSnapshot {
+    kernelspec, language_info, runt,
+    extras: BTreeMap { "jupytext": ..., "colab": ..., ... },
+}
+  ↓
+doc.set_metadata_snapshot(&snapshot)
+  ↓
+Automerge metadata Map {
+    kernelspec: Map, language_info: Map, runt: Map,
+    jupytext: Map, colab: Map, ...
+}
+  ↓
+Sync to peers (frontend + other daemon clients)
+  ↓
+doc.get_metadata_snapshot() (at save time)
+  ↓
+NotebookMetadataSnapshot (same shape)
+  ↓
+nbformat_convert::build_v4_notebook → typed v4::Notebook
+  ↓
+nbformat::serialize_notebook → .ipynb on disk
+```
+
+### Why siblings at `metadata` root, not nested under an `_extras` key
+
+- Matches the `.ipynb` on-disk shape exactly. No lift/flatten layer at serialize time.
+- Matches the pattern `RuntMetadata.extra` already uses one level down.
+- Gives each extra its own Automerge Map, so concurrent edits to `metadata.jupytext.paired_paths` from two peers merge per-field instead of stomping at the `_extras` root.
+
+### Why the save path stops reading `existing`
+
+Before: `metadata = read_existing_ipynb().metadata; snapshot.merge_into(&mut metadata); write(&metadata)`.
+After: `metadata = serde_json::to_value(&snapshot)?; write(&metadata)`.
+
+The doc is now complete. Re-reading the file means treating disk as authoritative, which contradicts "daemon as source of truth" and hid the original bug.
+
+### Collision guard
+
+`set_metadata_snapshot` iterates `snapshot.extras`. For each `(key, value)`:
+
+```rust
+if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+    tracing::error!(
+        "[notebook-doc] metadata.extras collision: key {:?} is reserved for typed field; dropping to avoid Automerge double-write. This indicates a caller bug.",
+        key
+    );
+    continue;
+}
+```
+
+`error!` (not `warn!`) because silent data loss is a correctness issue and per `.claude/rules/logging.md` it should be visible on stable channels (which use `warn` default filter).
+
+## Components
+
+### `crates/notebook-doc/src/metadata.rs`
+
+**`NotebookMetadataSnapshot`** gains an extras field:
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct NotebookMetadataSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernelspec: Option<KernelspecSnapshot>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_info: Option<LanguageInfoSnapshot>,
+
+    pub runt: RuntMetadata,
+
+    /// Catch-all for unknown/third-party top-level metadata keys
+    /// (e.g. `jupytext`, `colab`, `vscode`). Preserves fields we don't
+    /// model through load → doc → save round-trips. Excludes the typed
+    /// keys above; `set_metadata_snapshot` guards against collisions.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+**`KernelspecSnapshot`** gains an extras field for unknown kernelspec sub-keys:
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct KernelspecSnapshot {
+    pub name: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    /// Unknown kernelspec sub-fields (e.g. `env`, `interrupt_mode`,
+    /// `metadata`) that Jupyter clients write but we don't model. Round-
+    /// tripped verbatim so notebooks stay portable.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+**`LanguageInfoSnapshot`** gains the same:
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct LanguageInfoSnapshot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Unknown language_info sub-fields (e.g. `codemirror_mode`,
+    /// `mimetype`, `file_extension`, `nbconvert_exporter`,
+    /// `pygments_lexer`). Jupyter clients populate these after kernel
+    /// startup; without this, they vanished on every save.
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+Both `KernelspecSnapshot` and `LanguageInfoSnapshot` gain `Default` as a side-effect of `BTreeMap: Default`. That lines up with other recently-added `Default`s on the nbformat side.
+
+**`from_metadata_value`** switches from manual per-field extraction to `serde_json::from_value::<Self>(value.clone())` once the new flattened extras fields are in place. That's where the flatten payoff lands — serde does the "known fields go to typed slots, unknowns go to extras" dispatch automatically for all three levels at once.
+
+The legacy `uv`/`conda` fallback becomes a one-line post-processing step: if the resulting `runt.uv` / `runt.conda` is `None` and the incoming value had top-level `uv` / `conda`, fold them into `runt`. Explicitly strip them from `extras` after, otherwise they'd serialize twice on save (once inside `runt`, once as a top-level sibling).
+
+```rust
+pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
+    // Serde handles kernelspec / language_info / runt as typed fields
+    // with their own extras, and drops everything else into top-level
+    // extras. A malformed input just produces a default snapshot.
+    let mut snapshot: Self = serde_json::from_value(metadata.clone())
+        .unwrap_or_default();
+
+    // Legacy fallback: if runt.uv / runt.conda weren't populated,
+    // try the legacy top-level paths.
+    if snapshot.runt.uv.is_none() {
+        if let Some(raw_uv) = snapshot.extras.remove("uv") {
+            snapshot.runt.uv = serde_json::from_value(raw_uv).ok();
+        }
+    }
+    if snapshot.runt.conda.is_none() {
+        if let Some(raw_conda) = snapshot.extras.remove("conda") {
+            snapshot.runt.conda = serde_json::from_value(raw_conda).ok();
+        }
+    }
+
+    snapshot
+}
+```
+
+One real behavioral change to name: **partial-failure tolerance.**
+
+Today's manual code extracts each field via `.get("kernelspec").and_then(from_value::<KernelspecSnapshot>).ok()`, so a malformed `kernelspec` doesn't prevent `language_info` or `runt` from being captured. With `serde_json::from_value::<Self>(..).unwrap_or_default()`, a malformed value anywhere inside the metadata object triggers the `unwrap_or_default()` and we lose everything.
+
+Two mitigations worth considering:
+
+1. **Manual per-field deserialize plus an extras pass at the end.** Keeps today's per-field tolerance. Loses the "one serde call does it all" clarity.
+2. **Trust serde.** The only way `from_value` fails here is malformed input JSON, which means a corrupted or non-Jupyter `.ipynb`. The rest of the load path already assumes valid JSON. Losing a few metadata fields on a truly malformed notebook is acceptable.
+
+I'd go with option 2 and note it in a comment. If this bites in practice we can add the per-field tolerance back, but it's premature optimization for a failure mode that hasn't been reported.
+
+If user disagrees: fall back to option 1 during implementation, keeping today's `.and_then(..)` per-field pattern for the three typed fields and adding a separate extras scan over the raw `metadata` object (filtering out the known keys explicitly).
+
+**`merge_into_metadata_value`** needs to also write extras. Currently it sets only the three typed keys on the target value. After the change, it iterates `extras` and sets each one via direct `obj.insert`. Callers today (if any remain) that relied on merging with a pre-populated target continue to work — extras just fill in more siblings.
+
+### `crates/notebook-doc/src/lib.rs`
+
+**`NotebookDoc::set_metadata_snapshot`** gets the collision guard and an extras loop:
+
+```rust
+pub fn set_metadata_snapshot(
+    &mut self,
+    snapshot: &metadata::NotebookMetadataSnapshot,
+) -> Result<(), AutomergeError> {
+    let meta_id = /* unchanged setup */;
+
+    // Known typed keys unchanged
+    // ... kernelspec, language_info, runt ...
+
+    // Write extras. Each key gets its own Automerge Map so concurrent
+    // edits merge per-field. Guard against callers that stuff known
+    // keys into extras — those would produce duplicate writes and
+    // Automerge conflicts at the same key.
+    for (key, value) in &snapshot.extras {
+        if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+            tracing::error!(
+                "[notebook-doc] metadata.extras collision: key {:?} \
+                 is reserved for typed field; dropping. This indicates \
+                 a caller bug in snapshot construction.",
+                key
+            );
+            continue;
+        }
+        update_json_at_key(&mut self.doc, &meta_id, key, value)?;
+    }
+
+    Ok(())
+}
+```
+
+**`NotebookDoc::get_metadata_snapshot`** gets the scanning loop for extras:
+
+```rust
+pub fn get_metadata_snapshot(&self) -> Option<metadata::NotebookMetadataSnapshot> {
+    let meta_id = self.metadata_map_id()?;
+
+    let kernelspec = /* unchanged */;
+    let language_info = /* unchanged */;
+    let runt = /* unchanged */;
+
+    // Scan the metadata map for keys we don't model.
+    let mut extras = std::collections::BTreeMap::new();
+    for key in self.doc.keys(&meta_id) {
+        if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+            continue;
+        }
+        if let Some(value) = read_json_value(&self.doc, &meta_id, &key) {
+            extras.insert(key, value);
+        }
+    }
+
+    if kernelspec.is_some() || language_info.is_some() || runt.is_some()
+        || !extras.is_empty() {
+        return Some(metadata::NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt: runt.unwrap_or_default(),
+            extras,
+        });
+    }
+    None
+}
+```
+
+### `crates/runtimed/src/notebook_sync_server/persist.rs`
+
+Drop the existing-file read. The full rewrite of the metadata prep is about 20 lines less than today's code:
+
+```rust
+// Build metadata from the doc snapshot. The doc carries unknown top-
+// level keys as sibling extras under NotebookMetadataSnapshot.extras,
+// so there's nothing left to recover from disk.
+let metadata = metadata_snapshot
+    .as_ref()
+    .map(|s| serde_json::to_value(s).unwrap_or(serde_json::json!({})))
+    .unwrap_or(serde_json::json!({}));
+
+// nbformat_minor: still pull from existing file for the 4.5 floor, or
+// default to 5. This isn't carried in the doc schema today.
+let existing_minor = tokio::fs::read(&notebook_path)
+    .await
+    .ok()
+    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+    .and_then(|nb| nb.get("nbformat_minor").and_then(|v| v.as_u64()))
+    .unwrap_or(5) as i32;
+let nbformat_minor = std::cmp::max(existing_minor, 5);
+```
+
+The `existing_raw` / `existing` bindings and the JSON re-parse for metadata purposes go away. `existing` is still checked for the content-hash guard; we keep that part (content-hash is a different concern — "would this write be a no-op" is still true).
+
+Actually — on re-read, the content-hash guard uses `existing_raw.as_slice() == content_with_newline.as_bytes()` which needs `existing_raw`. So the `existing_raw` read stays for the no-op-skip case. What we drop is the `existing` parse to recover metadata. Cleaner structure:
+
+```rust
+let existing_raw: Option<Vec<u8>> = /* unchanged read for hash guard */;
+
+// nbformat_minor floor — separate concern, just needs the numeric field.
+let existing_minor = existing_raw
+    .as_ref()
+    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
+    .and_then(|nb| nb.get("nbformat_minor").and_then(|v| v.as_u64()))
+    .unwrap_or(5) as i32;
+let nbformat_minor = std::cmp::max(existing_minor, 5);
+
+// Metadata comes entirely from the doc.
+let metadata = metadata_snapshot
+    .as_ref()
+    .map(|s| serde_json::to_value(s).unwrap_or(serde_json::json!({})))
+    .unwrap_or(serde_json::json!({}));
+```
+
+The hash guard block further down stays as-is. The `merge_into_metadata_value` call goes away.
+
+### `crates/runtimed/src/requests/clone_notebook.rs`
+
+No change required. `seed_clone_from_source` already does `doc.get_metadata_snapshot()` → mutate `env_id` / leave `trust_*` → `set_metadata_snapshot`. Once the snapshot carries extras, they flow through unchanged.
+
+## Data flow
+
+```
+                                    ┌────────────────────────────┐
+(load)  .ipynb on disk  ──────────▶ │ parse_metadata_from_ipynb   │
+                                    │   (now populates extras)    │
+                                    └────────────┬────────────────┘
+                                                 ▼
+                                    NotebookMetadataSnapshot
+                                      { kernelspec, language_info,
+                                        runt, extras }
+                                                 │
+                         ┌───────────────────────┴────────────────┐
+                         ▼                                        ▼
+            doc.set_metadata_snapshot                serde round-trip for clone
+                         │                                        │
+                         ▼                                        ▼
+            Automerge metadata Map:                   clone's doc gets the same
+              kernelspec, language_info, runt,        snapshot (extras included)
+              jupytext, colab, vscode, ...
+                         │
+                         │ (sync to peers via Automerge)
+                         ▼
+                  Frontend + MCP server
+                         │
+                         │ (at save time)
+                         ▼
+            doc.get_metadata_snapshot()
+              (scans all top-level keys, returns
+               typed + extras)
+                         │
+                         ▼
+(save)  serialize to .ipynb  ◀──── build_v4_notebook(snapshot_value, ...)
+```
+
+## Error handling
+
+- **Serialization failure in extras.** `serde_json::to_value(&snapshot)` can fail only if a `Value` somewhere is numerically NaN or similar. Treat it the same as any other save failure — `Err` propagates up through `set_metadata_snapshot` → save path. In practice unreachable.
+- **Collision on write.** `set_metadata_snapshot` logs `error!` and drops. Save proceeds with the typed key intact.
+- **Extras key invalid as Automerge map name.** Automerge map keys are arbitrary UTF-8 strings; any valid JSON key is valid. Nothing to guard.
+
+## Testing
+
+### Unit (`crates/notebook-doc/src/metadata.rs`)
+
+- `from_metadata_value_collects_unknown_top_level_keys` — input has `jupytext`, `colab`; assert both land in `extras`.
+- `from_metadata_value_skips_known_top_level_keys` — input has `kernelspec`, `language_info`, `runt`; assert none leak into top-level `extras`.
+- `from_metadata_value_skips_legacy_uv_conda` — legacy top-level `uv`/`conda` keys are absorbed into `runt` by existing fallback; assert they don't *also* appear in top-level `extras`.
+- `kernelspec_extras_round_trip` — input kernelspec has `{name, display_name, language, env: {...}, interrupt_mode}`; deserialize → serialize → assert `env` and `interrupt_mode` survive in `kernelspec.extras`.
+- `language_info_extras_round_trip` — input language_info has `{name, version, codemirror_mode: {...}, mimetype, file_extension, nbconvert_exporter, pygments_lexer}`; assert all five unknown fields land in `language_info.extras` and round-trip.
+- Full-metadata round-trip: `from_metadata_value(v)` → `serde_json::to_value(snapshot)` preserves all keys at all three levels (top-level extras + kernelspec extras + language_info extras).
+
+### Unit (`crates/notebook-doc/src/lib.rs`)
+
+- `set_get_metadata_snapshot_round_trips_extras` — set a snapshot with `extras: {"jupytext": {...}, "colab": {...}}`; get back equal snapshot.
+- `set_metadata_snapshot_drops_extras_collision_with_kernelspec` — insert `"kernelspec"` into extras; assert log emits (captured via a test-mode layer or just assert the doc's `kernelspec` Map was not overwritten); typed `kernelspec` stays intact.
+- `get_metadata_snapshot_returns_none_when_empty` — unchanged baseline test.
+
+### Integration (`crates/runtimed/src/notebook_sync_server/tests.rs`)
+
+- `test_save_preserves_unknown_top_level_metadata` — create file-backed room with an `.ipynb` containing `metadata.jupytext`; let load populate the doc; save; re-read `.ipynb`; assert `metadata.jupytext` unchanged.
+- `test_clone_as_ephemeral_carries_unknown_metadata_to_clone` — extend the existing clone test: source has `metadata.jupytext`; assert clone doc's snapshot has the same value in extras.
+
+## Migration
+
+Docs currently loaded in a running daemon have no extras in their Automerge doc. On upgrade:
+
+- File-backed rooms: the on-disk `.ipynb` still has unknown keys until the first save after upgrade. If the user saves before reopening, the keys vanish because the doc doesn't have them and (after this change) we no longer read the existing file to recover.
+- Untitled rooms: if any had unknown keys synthesized in memory (unlikely; the load path never put them there), they'd be lost. Not a real case.
+
+Accepted. Documented in the PR body. The rationale: the keys are still on disk in the one place they live, a force-reload (close and reopen) pulls them back in, and the alternative (one-shot migration code) adds maintenance burden for a one-time concern.
+
+## Rollout
+
+- Single PR, atomic. No feature flag. Behavior change is additive (extras now preserved; typed fields unchanged).
+- No protocol or wire format change. `NotebookMetadataSnapshot` serializes the same way with or without the extras flatten; the serde flatten just means unknown fields that would previously be dropped now land in a named field.
+- No downstream schema migrations.

--- a/docs/superpowers/specs/2026-04-25-metadata-extras.md
+++ b/docs/superpowers/specs/2026-04-25-metadata-extras.md
@@ -22,6 +22,7 @@ Make the Automerge `NotebookDoc` carry all top-level metadata keys, typed or not
 - `LanguageInfoSnapshot` gains the same. Standard Jupyter `language_info` fields (`codemirror_mode`, `mimetype`, `file_extension`, `nbconvert_exporter`, `pygments_lexer`) currently vanish. The existing comment on `merge_into_metadata_value` in metadata.rs already flags this ("preserve fields we don't track, like codemirror_mode").
 - `NotebookDoc::set_metadata_snapshot` writes extras as siblings of `kernelspec`/`language_info`/`runt` under the `metadata` Automerge Map, each as its own JSON value (one `update_json_at_key` per entry).
 - `NotebookDoc::get_metadata_snapshot` reads the three typed keys, then enumerates the rest of the `metadata` Map and collects them into `extras`.
+- `get_metadata_snapshot_from_doc` (the free-function variant in `crates/notebook-doc/src/lib.rs` used by `NotebookSnapshot::from_doc` in notebook-sync and `DocHandle::get_notebook_metadata`) gets the same scan. Without this, the Python bindings and frontend sync snapshot keep dropping extras even after the `&self` method is fixed.
 - `NotebookDoc::set_metadata_snapshot` guards against the caller inserting a known-key collision (`kernelspec`, `language_info`, `runt`) into top-level `extras`: logs an `error!` with the colliding key and drops it before writing.
 - `save_notebook_to_disk` stops reading the existing `.ipynb` to recover metadata. The snapshot round-trip carries everything.
 - `clone_notebook::seed_clone_from_source` benefits automatically since it copies the typed snapshot.
@@ -160,20 +161,68 @@ pub struct LanguageInfoSnapshot {
 
 Both `KernelspecSnapshot` and `LanguageInfoSnapshot` gain `Default` as a side-effect of `BTreeMap: Default`. That lines up with other recently-added `Default`s on the nbformat side.
 
-**`from_metadata_value`** switches from manual per-field extraction to `serde_json::from_value::<Self>(value.clone())` once the new flattened extras fields are in place. That's where the flatten payoff lands — serde does the "known fields go to typed slots, unknowns go to extras" dispatch automatically for all three levels at once.
+**`NotebookMetadataSnapshot.runt`** gets `#[serde(default)]` and `#[serde(skip_serializing_if = "RuntMetadata::is_empty")]` so vanilla Jupyter notebooks (no `metadata.runt` key) deserialize cleanly *and* round-trip without the daemon stamping a `runt: { schema_version: "1" }` blob into every notebook on first save.
 
-The legacy `uv`/`conda` fallback becomes a one-line post-processing step: if the resulting `runt.uv` / `runt.conda` is `None` and the incoming value had top-level `uv` / `conda`, fold them into `runt`. Explicitly strip them from `extras` after, otherwise they'd serialize twice on save (once inside `runt`, once as a top-level sibling).
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct NotebookMetadataSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernelspec: Option<KernelspecSnapshot>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_info: Option<LanguageInfoSnapshot>,
+
+    #[serde(default, skip_serializing_if = "RuntMetadata::is_empty")]
+    pub runt: RuntMetadata,
+
+    #[serde(default, flatten)]
+    pub extras: std::collections::BTreeMap<String, serde_json::Value>,
+}
+```
+
+**`RuntMetadata::is_empty`** is a small helper that returns true when every field is at its default:
+
+```rust
+impl RuntMetadata {
+    /// Returns true when this metadata carries no daemon-relevant state.
+    /// Used by `skip_serializing_if` so vanilla Jupyter notebooks don't
+    /// get a synthetic `runt: { schema_version: "1" }` stamped on first
+    /// save, which would churn git-tracked notebooks.
+    pub fn is_empty(&self) -> bool {
+        self.env_id.is_none()
+            && self.uv.is_none()
+            && self.conda.is_none()
+            && self.pixi.is_none()
+            && self.deno.is_none()
+            && self.trust_signature.is_none()
+            && self.trust_timestamp.is_none()
+            && self.extra.is_empty()
+            && self.schema_version == default_schema_version()
+    }
+}
+
+fn default_schema_version() -> String {
+    "1".to_string()
+}
+```
+
+`schema_version` was already defaulting to `"1"` via `Default`; this just names the default so `is_empty` can check against it.
+
+**`from_metadata_value`** becomes a single `serde_json::from_value` call plus a legacy `uv`/`conda` fallback:
 
 ```rust
 pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
     // Serde handles kernelspec / language_info / runt as typed fields
-    // with their own extras, and drops everything else into top-level
-    // extras. A malformed input just produces a default snapshot.
+    // with their own sub-extras, and drops everything else into
+    // top-level extras. `#[serde(default)]` on `runt` means a notebook
+    // without it (the common case for Jupyter-written files) still
+    // deserializes cleanly.
     let mut snapshot: Self = serde_json::from_value(metadata.clone())
         .unwrap_or_default();
 
     // Legacy fallback: if runt.uv / runt.conda weren't populated,
-    // try the legacy top-level paths.
+    // try the top-level keys. Strip from extras so save doesn't
+    // emit them at both depths.
     if snapshot.runt.uv.is_none() {
         if let Some(raw_uv) = snapshot.extras.remove("uv") {
             snapshot.runt.uv = serde_json::from_value(raw_uv).ok();
@@ -189,18 +238,10 @@ pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
 }
 ```
 
-One real behavioral change to name: **partial-failure tolerance.**
-
-Today's manual code extracts each field via `.get("kernelspec").and_then(from_value::<KernelspecSnapshot>).ok()`, so a malformed `kernelspec` doesn't prevent `language_info` or `runt` from being captured. With `serde_json::from_value::<Self>(..).unwrap_or_default()`, a malformed value anywhere inside the metadata object triggers the `unwrap_or_default()` and we lose everything.
-
-Two mitigations worth considering:
-
-1. **Manual per-field deserialize plus an extras pass at the end.** Keeps today's per-field tolerance. Loses the "one serde call does it all" clarity.
-2. **Trust serde.** The only way `from_value` fails here is malformed input JSON, which means a corrupted or non-Jupyter `.ipynb`. The rest of the load path already assumes valid JSON. Losing a few metadata fields on a truly malformed notebook is acceptable.
-
-I'd go with option 2 and note it in a comment. If this bites in practice we can add the per-field tolerance back, but it's premature optimization for a failure mode that hasn't been reported.
-
-If user disagrees: fall back to option 1 during implementation, keeping today's `.and_then(..)` per-field pattern for the three typed fields and adding a separate extras scan over the raw `metadata` object (filtering out the known keys explicitly).
+Behavioral notes:
+- Missing `runt` (vanilla Jupyter notebook) deserializes to an `is_empty()` `RuntMetadata`, which `skip_serializing_if` drops on save. No daemon stamp on unrelated notebooks.
+- `runt` present and non-empty: round-trips unchanged.
+- Malformed field anywhere in the metadata object (e.g. `kernelspec: 42`) fails the whole `from_value` call and `unwrap_or_default()` fires, producing an empty snapshot. This is a behavior change from today's per-field tolerance; judged acceptable because the "one malformed field, siblings intact" failure mode is rare and has never been reported, while the cleaner single-call path is easier to audit and maintain.
 
 **`merge_into_metadata_value`** needs to also write extras. Currently it sets only the three typed keys on the target value. After the change, it iterates `extras` and sets each one via direct `obj.insert`. Callers today (if any remain) that relied on merging with a pre-populated target continue to work — extras just fill in more siblings.
 
@@ -272,6 +313,43 @@ pub fn get_metadata_snapshot(&self) -> Option<metadata::NotebookMetadataSnapshot
     None
 }
 ```
+
+**`get_metadata_snapshot_from_doc`** (the free-function variant at `crates/notebook-doc/src/lib.rs:1930`, callable from anywhere holding an `&AutoCommit`) gets the same scan. `NotebookSnapshot::from_doc` in notebook-sync routes through it, and the Python-binding `DocHandle::get_notebook_metadata` pulls its value from a `NotebookSnapshot`. If this function skips the extras scan while the `&self` method does it, daemon save/clone preserves extras but Python and the frontend sync snapshot silently drop them (Codex P2 review on PR #2198).
+
+```rust
+pub fn get_metadata_snapshot_from_doc(
+    doc: &AutoCommit,
+) -> Option<metadata::NotebookMetadataSnapshot> {
+    let meta_id = /* unchanged: locate the metadata Map */;
+
+    let kernelspec = /* unchanged */;
+    let language_info = /* unchanged */;
+    let runt = /* unchanged */;
+
+    let mut extras = std::collections::BTreeMap::new();
+    for key in doc.keys(&meta_id) {
+        if matches!(key.as_str(), "kernelspec" | "language_info" | "runt") {
+            continue;
+        }
+        if let Some(value) = read_json_value(doc, &meta_id, &key) {
+            extras.insert(key, value);
+        }
+    }
+
+    if kernelspec.is_some() || language_info.is_some() || runt.is_some()
+        || !extras.is_empty() {
+        return Some(metadata::NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt: runt.unwrap_or_default(),
+            extras,
+        });
+    }
+    None
+}
+```
+
+Consider factoring the shared scan into a small helper (`fn scan_metadata_extras(doc: &AutoCommit, meta_id: &ObjId) -> BTreeMap<...>`) so the method and the free function stay in sync. Decide at implementation time based on how clean the call sites end up.
 
 ### `crates/runtimed/src/notebook_sync_server/persist.rs`
 
@@ -379,9 +457,11 @@ No change required. `seed_clone_from_source` already does `doc.get_metadata_snap
 
 ### Unit (`crates/notebook-doc/src/lib.rs`)
 
-- `set_get_metadata_snapshot_round_trips_extras` — set a snapshot with `extras: {"jupytext": {...}, "colab": {...}}`; get back equal snapshot.
+- `set_get_metadata_snapshot_round_trips_extras` — set a snapshot with `extras: {"jupytext": {...}, "colab": {...}}`; get back equal snapshot via `NotebookDoc::get_metadata_snapshot`.
+- `get_metadata_snapshot_from_doc_reads_extras` — set a snapshot via `NotebookDoc::set_metadata_snapshot`; read back via the free-function `get_metadata_snapshot_from_doc`; assert extras land in the returned snapshot. Guards the notebook-sync / Python-bindings path.
 - `set_metadata_snapshot_drops_extras_collision_with_kernelspec` — insert `"kernelspec"` into extras; assert log emits (captured via a test-mode layer or just assert the doc's `kernelspec` Map was not overwritten); typed `kernelspec` stays intact.
 - `get_metadata_snapshot_returns_none_when_empty` — unchanged baseline test.
+- `vanilla_notebook_save_does_not_stamp_runt` — build a snapshot with `RuntMetadata::default()` (what a vanilla Jupyter notebook produces after `from_metadata_value`); `serde_json::to_value(&snapshot)` must NOT contain a `runt` key. This pins the no-stamp behavior so a future `#[serde(skip_serializing_if)]` removal gets caught.
 
 ### Integration (`crates/runtimed/src/notebook_sync_server/tests.rs`)
 


### PR DESCRIPTION
Make the Automerge `NotebookDoc` carry **all** top-level notebook metadata keys, including unknown/third-party keys (`jupytext`, `colab`, `vscode`, etc.). Before this PR, `NotebookMetadataSnapshot` only modeled `kernelspec` / `language_info` / `runt`; every other top-level key was dropped on load and then rescued on save by re-reading the on-disk `.ipynb`. That broke clone (no on-disk file to rescue from, Codex F3 on #2192) and violated the "daemon as source of truth" rule.

Spec: [`docs/superpowers/specs/2026-04-25-metadata-extras.md`](docs/superpowers/specs/2026-04-25-metadata-extras.md)
Plan: [`docs/superpowers/plans/2026-04-25-metadata-extras.md`](docs/superpowers/plans/2026-04-25-metadata-extras.md)

## Summary

1. Added `#[serde(flatten)]` `extras: BTreeMap<String, Value>` to `NotebookMetadataSnapshot`, `KernelspecSnapshot`, and `LanguageInfoSnapshot`. Unknown keys round-trip at all three levels automatically.
2. `RuntMetadata::is_empty()` + `#[serde(default, skip_serializing_if)]` on the `runt` field. Vanilla Jupyter notebooks (no `metadata.runt` key) deserialize cleanly and round-trip through save without stamping a synthetic `runt: { schema_version: "1" }` blob. That would have churned every git-tracked Jupyter notebook the user ever opened.
3. `NotebookDoc::set_metadata_snapshot` writes extras as siblings of `kernelspec`/`language_info`/`runt`, guards against extras keys that collide with typed field names (drops with an `error!`-level log that surfaces on stable channels), **and deletes stale extras that aren't in the replacement snapshot**. The last part matters for the file-watcher reload path: editing `colab` out of an `.ipynb` on disk now converges in the doc instead of leaving a ghost key that would be rewritten on the next save.
4. `NotebookDoc::get_metadata_snapshot` and the free-function `get_metadata_snapshot_from_doc` both get a shared scan loop (`scan_metadata_extras`). The free-function variant is used by `NotebookSnapshot::from_doc` in notebook-sync and `DocHandle::get_notebook_metadata` in the Python bindings.
5. The nbformat bridge helpers `metadata_from_snapshot` / `snapshot_from_nbformat` in `crates/notebook/` carry `extras` at all three levels (top, kernelspec, language_info). These sit on the hot path for the pyproject/pixi dep-import commands, which flip daemon snapshots into nbformat and back. Before, the bridge silently dropped unknown keys on the round-trip. The reverse direction also strips absorbed keys (`runt`, and legacy `uv`/`conda`/`deno` when runt is absent) from extras so save doesn't double-write at both depths.
6. `persist.rs` stops reading the existing `.ipynb` for metadata. The doc is the source of truth now. `existing_raw` stays for the content-hash guard and the `nbformat_minor` floor.

## Why two small behavior changes are safe

**Malformed metadata becomes all-or-nothing.** Today's `from_metadata_value` extracts each typed field independently, so a malformed `kernelspec` leaves siblings intact. The new version uses a single `serde_json::from_value::<Self>` + `unwrap_or_default()`, so one bad field clears the whole snapshot. Tradeoff accepted: the "one field malformed, siblings intact" scenario is rare, and silent partial success hides data corruption rather than surfacing it.

**Docs currently loaded in a running daemon have no extras.** A room opened before this ships has empty extras in its in-memory Automerge state. First save after upgrade therefore loses unknown keys for still-open rooms. Recovery: close + reopen the notebook; the new load path pulls extras back in. Keys never leave disk in the interim.

## Tests

- **notebook-doc** (293 passing, 21 new across 4 test modules):
  - `is_empty_tests` (6): RuntMetadata::is_empty covers env_id, uv, trust_signature, extra, schema_version, default cases.
  - `snapshot_extras_tests` (4): vanilla notebook has no `runt` in serialized form, runt appears when env_id is set, vanilla deserializes without a runt key, top-level extras round-trip.
  - `nested_extras_tests` (2): kernelspec and language_info sub-extras round-trip Jupyter-standard sub-fields (`env`, `interrupt_mode`, `metadata`, `codemirror_mode`, `mimetype`, `file_extension`, `nbconvert_exporter`, `pygments_lexer`).
  - `from_metadata_value_tests` (6): vanilla Jupyter, unknown-keys-become-extras, legacy `uv`/`conda` absorbed into runt (stripped from extras to prevent double-write), `runt` wins when both present, full round-trip across all three levels.
  - `set_metadata_snapshot_*` (7): extras written as siblings, 3 collision cases drop extras and preserve typed fields, `get_metadata_snapshot_from_doc_reads_extras` pins the notebook-sync / Python free-function path, **`set_metadata_snapshot_deletes_stale_extras_absent_from_replacement` pins the watcher-reload deletion contract**, and **`set_metadata_snapshot_preserves_runtime_and_ephemeral_scalars` pins that nteract-internal scalars don't get swept by the stale-extras scan**.

- **notebook crate** (4 new bridge-helper tests):
  - `metadata_from_snapshot_carries_all_three_extras_levels`: snapshot extras make it into nbformat `additional` at top, kernelspec, and language_info.
  - `snapshot_from_nbformat_preserves_extras_and_strips_absorbed_keys`: unknown keys surface in extras, typed `runt` is absorbed.
  - `snapshot_from_nbformat_strips_legacy_uv_conda_deno_when_absorbed`: legacy pre-`runt.*` notebooks don't double-write.
  - `bridge_round_trip_preserves_unknown_keys_at_every_level`: full symmetry check.

- **runtimed** (202 sync_server tests passing, 4 new):
  - `test_save_round_trips_unknown_top_level_metadata`: jupytext + colab keys survive load then save.
  - `test_save_does_not_stamp_synthetic_runt_on_vanilla_notebook`: vanilla Jupyter notebook save does NOT gain a `metadata.runt` blob. Git-churn fix.
  - `test_clone_as_ephemeral_carries_unknown_metadata_extras`: Codex F3 regression test - clone carries jupytext + vscode keys through to the clone doc.
  - **`test_file_watcher_replacement_drops_stale_top_level_metadata`**: mirrors the watcher path exactly. Load a notebook with `jupytext` + `colab`, then apply a replacement snapshot without `colab`. Assert `colab` is deleted from the doc.

## Workspace-wide impact

Adding `extras` to three public structs required `..Default::default()` spread (or explicit `extras: Default::default()`) at every construction site. Touched: `crates/notebook-doc`, `crates/runtimed`, `crates/notebook`, `crates/notebook-sync`, `crates/runtimed-py`. No breaking API changes. All existing fields and method signatures stable.

## Test plan

- [x] `cargo test -p notebook-doc` (293 passing)
- [x] `cargo test -p notebook --lib` (new bridge tests pass)
- [x] `cargo test -p runtimed --lib notebook_sync_server` (202 passing, 1 ignored)
- [x] `cargo clippy -p notebook-doc -p notebook -p runtimed --tests -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual QA: open a jupytext-paired notebook, edit a cell, save. `metadata.jupytext` must survive unchanged on disk. Open a vanilla Jupyter notebook, save. `metadata.runt` must NOT appear. Clone a jupytext notebook and Save-As. `metadata.jupytext` must be in the new file. Delete `colab` from an open notebook's on-disk file, wait for the file watcher, save. `metadata.colab` must be gone from the saved file.

## Follow-up

Not covered: one-shot migration to back-fill extras for rooms already loaded before this ships. Acceptable. Close+reopen recovers the keys from disk, and the in-memory window is small.
