### PR TITLE
chore: add anywidget to root pyproject deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyarrow>=14",
     "numpy>=2.2.6",
     "narwhals>=1.0",
+    "anywidget>=0.9.21",
 ]
 
 [build-system]


### PR DESCRIPTION
Adds `anywidget>=0.9.21` to root `pyproject.toml`. Used by ad-hoc widget exploration in notebook scratch sessions and by the comm-broadcast offload PR's verification flow. Lives in the same UV workspace as the other Python deps.