### PR TITLE
perf(mcp-supervisor): slim compile graph, track daemon version via child handshake

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,13 +1,5 @@
 approval_policy = "never"
 sandbox_mode = "workspace-write"
-[mcp_servers.nteract-dev]
-command = "cargo"
-args = ["run", "-p", "mcp-supervisor"]
-cwd = "."
-startup_timeout_sec = 120
-
-[mcp_servers.nteract-dev.env]
-RUNTIMED_DEV = "1"
 
 [sandbox_workspace_write]
 network_access = true

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "nteract-dev": {
-      "command": "./target/debug/mcp-supervisor",
-      "args": [],
+      "command": "cargo",
+      "args": ["run", "-p", "mcp-supervisor"],
       "env": {
         "RUNTIMED_DEV": "1",
         "SKIP_MATURIN": "1"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "nteract-dev": {
-      "command": "cargo",
-      "args": ["run", "-p", "mcp-supervisor"],
+      "command": "./target/debug/mcp-supervisor",
+      "args": [],
       "env": {
         "RUNTIMED_DEV": "1",
         "SKIP_MATURIN": "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 **Three MCP servers** should be configured:
 
 1. **nteract-dev** (development, per-worktree daemon)
-   - Command: `cargo xtask run-mcp` (builds and runs the local `mcp-supervisor` binary)
+   - Command: `cargo run -p mcp-supervisor` (used by `.mcp.json`). Build cost is small now that the supervisor no longer links `runtimed-client` — first run after `cargo clean` takes a few seconds, warm runs are instant.
    - Working directory: `/path/to/nteract/desktop`
    - Env vars: Inherits from shell (direnv provides RUNTIMED_DEV, RUNTIMED_WORKSPACE_PATH)
    - Socket: `~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock`
@@ -86,7 +86,7 @@ which runt                      # Should be repo/bin/runt (not /usr/local/bin/ru
 
 If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (provided by `nteract-dev`), **prefer those over manual terminal commands**. `nteract-dev` manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
-**Claude Code has nteract-dev locally** — the local dev environment connects Claude Code to the repo-local `nteract-dev` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose these tools, use the manual `cargo xtask` commands below.
+**Claude Code has nteract-dev locally** — `.mcp.json` launches `cargo run -p mcp-supervisor` on session start. If your current environment does not expose these tools, use the manual `cargo xtask` commands below.
 
 | Instead of… | Use… |
 |-------------|------|
@@ -314,7 +314,7 @@ cargo xtask run-mcp --print-config
 
 Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
 
-For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same server using the `nteract-dev` entry name. The Codex config sets `cwd = "."` so GUI-launched sessions still start the supervisor from the repo root, and bumps the startup timeout because the first `cargo run -p mcp-supervisor` can take longer than the default while it builds.
+`.mcp.json` launches `cargo run -p mcp-supervisor`. The supervisor's compile graph is small — it no longer links `runtimed-client`, because the proxy now learns the daemon version from the child's MCP handshake instead of opening its own daemon socket. Cold builds take a few seconds, warm rebuilds are near-instant.
 
 ### MCP Server
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6997,7 +6997,6 @@ name = "runt-mcp-proxy"
 version = "0.1.4"
 dependencies = [
  "rmcp",
- "runtimed-client",
  "schemars 1.2.1",
  "serde",
  "serde_json",

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2663,7 +2663,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 child_env,
                 server_name: "nteract-dev".to_string(),
                 cache_dir: Some(project_root.join(".context")),
-                daemon_socket_path: None,
                 monitor_poll_interval_ms: 500,
             },
             tool_list_changed_tx,

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -163,16 +163,6 @@ async fn main() -> ExitCode {
     }
     info!("Validated {binary_name} is available");
 
-    // Resolve the daemon socket path for version tracking. The proxy
-    // spawns a long-lived `DaemonConnection` against this socket and
-    // uses its cached `DaemonInfo` to detect daemon upgrades.
-    let build_channel = if channel == "nightly" {
-        runt_workspace::BuildChannel::Nightly
-    } else {
-        runt_workspace::BuildChannel::Stable
-    };
-    let daemon_socket_path = Some(runt_workspace::socket_path_for_channel(build_channel));
-
     // Build child environment
     let mut child_env = HashMap::new();
     child_env.insert("NTERACT_CHANNEL".to_string(), channel.clone());
@@ -181,6 +171,11 @@ async fn main() -> ExitCode {
     // on every child restart. This is the core upgrade mechanism: the user
     // upgrades the nteract app (new runt binary), and the proxy picks it up
     // without needing to reinstall the MCPB extension.
+    //
+    // Daemon version tracking now flows through the child's MCP handshake
+    // (`runt mcp` stamps the daemon version into `ServerInfo.title`), so the
+    // proxy no longer opens its own daemon socket — that used to drag the
+    // full runtimed-client compile graph into every MCP process.
     let channel_for_resolve = channel.clone();
     let config = ProxyConfig {
         resolve_child_command: Box::new(move || {
@@ -196,7 +191,6 @@ async fn main() -> ExitCode {
             let _ = std::fs::create_dir_all(&dir);
             dir
         }),
-        daemon_socket_path,
         monitor_poll_interval_ms: 500,
     };
 

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -13,7 +13,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
-runtimed-client = { path = "../runtimed-client" }
 tracing = "0.1"
 uuid = { workspace = true }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -29,6 +29,26 @@ use crate::version::ReconnectionEvent;
 /// target. Must match `runt_mcp::daemon_watch::REJOIN_ENV_VAR`.
 const REJOIN_ENV_VAR: &str = "NTERACT_MCP_REJOIN_NOTEBOOK";
 
+/// Extract the daemon version from a freshly-initialized child's MCP
+/// `ServerInfo`. `runt mcp` stamps the daemon version into
+/// `server_info.title` as `"nteract (daemon X.Y.Z)"` during its startup
+/// handshake. Returning `None` is expected whenever the daemon wasn't
+/// reachable when the child started — the proxy degrades to a generic
+/// "child restarted" reconnection banner in that case.
+fn extract_daemon_version(client: &child::RunningChild) -> Option<String> {
+    let title = client.peer_info()?.server_info.title.as_deref()?;
+    // Title format: "nteract (daemon X.Y.Z)".
+    let open = title.find("(daemon ")?;
+    let close = title.rfind(')')?;
+    let inner = title.get(open + "(daemon ".len()..close)?;
+    let v = inner.trim();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v.to_string())
+    }
+}
+
 /// Configuration for the MCP proxy.
 pub struct ProxyConfig {
     /// Resolver that returns the path to the child binary.
@@ -44,18 +64,6 @@ pub struct ProxyConfig {
     pub server_name: String,
     /// Directory for tool cache (optional, enables optimistic tool serving).
     pub cache_dir: Option<PathBuf>,
-    /// Daemon socket path (optional, enables version tracking via a
-    /// long-lived [`DaemonConnection`]).
-    ///
-    /// When set, the proxy spawns a `DaemonConnection` supervisor in
-    /// [`McpProxy::new`]. The supervisor keeps a cached `DaemonInfo`
-    /// and emits `Upgraded` events when the daemon restarts with a
-    /// new pid/version. Replaces the old `daemon_info_path` field that
-    /// polled `daemon.json` on a timer.
-    ///
-    /// Defaults to `None` in tests and builds that don't need daemon-
-    /// version tracking.
-    pub daemon_socket_path: Option<PathBuf>,
     /// Child monitor polling interval in milliseconds (default: 500ms).
     /// Lower values detect child exit faster but use more CPU.
     pub monitor_poll_interval_ms: u64,
@@ -102,10 +110,6 @@ pub struct McpProxy {
     pub exit_signal: Arc<Notify>,
     /// Flag to prevent concurrent restarts (monitor + tool call racing).
     restart_in_progress: Arc<Mutex<bool>>,
-    /// Long-lived connection to the daemon for version tracking.
-    /// `None` when `ProxyConfig.daemon_socket_path` was `None` (tests
-    /// and minimal-mode builds).
-    daemon_connection: Option<Arc<runtimed_client::daemon_connection::DaemonConnection>>,
 }
 
 impl McpProxy {
@@ -122,21 +126,6 @@ impl McpProxy {
             info!("Loaded {} cached child tools", cached.len());
         }
 
-        // Spawn a long-lived daemon connection for version tracking.
-        // Replaces the old pattern of reading daemon.json on a timer.
-        // `None` is valid for tests and minimal-mode builds.
-        let daemon_connection = config.daemon_socket_path.as_ref().map(|p| {
-            Arc::new(runtimed_client::daemon_connection::DaemonConnection::spawn(
-                p.clone(),
-            ))
-        });
-
-        // Initial version: None at startup. The first version becomes
-        // known when the daemon connection fires its first `Connected`
-        // event, which the tool-list-handler and restart-detector pick
-        // up via state inspection.
-        let daemon_version: Option<String> = None;
-
         Self {
             state: Arc::new(RwLock::new(ProxyState {
                 child_client: None,
@@ -146,7 +135,7 @@ impl McpProxy {
                 last_notebook_id: None,
                 upstream_name: "unknown".to_string(),
                 upstream_title: None,
-                last_daemon_version: daemon_version,
+                last_daemon_version: None,
                 reconnection_message: None,
                 tool_list_changed_tx,
                 should_exit: false,
@@ -157,7 +146,6 @@ impl McpProxy {
             child_ready: Arc::new(Notify::new()),
             exit_signal: Arc::new(Notify::new()),
             restart_in_progress: Arc::new(Mutex::new(false)),
-            daemon_connection,
         }
     }
 
@@ -195,6 +183,12 @@ impl McpProxy {
         )
         .await?;
 
+        // Read the daemon version out of the child's ServerInfo.title
+        // before we move the client into state. `runt mcp` stamps the
+        // daemon version there during its startup handshake (see
+        // crates/runt-mcp/src/lib.rs::get_info).
+        let daemon_version = extract_daemon_version(&client);
+
         let mut state = self.state.write().await;
         state.child_client = Some(client);
         state.child_spawn_time = Some(Instant::now());
@@ -202,13 +196,7 @@ impl McpProxy {
         // Refresh tool cache from the new child
         self.refresh_tool_cache_locked(&mut state).await;
 
-        // Record current daemon version via the long-lived connection.
-        // `last_known_info` is non-blocking; if the connection hasn't
-        // finished its first handshake yet, version stays None and the
-        // next restart path will pick it up.
-        if let Some(ref conn) = self.daemon_connection {
-            state.last_daemon_version = conn.last_known_info().await.map(|i| i.version);
-        }
+        state.last_daemon_version = daemon_version;
 
         drop(state);
 
@@ -326,6 +314,10 @@ impl McpProxy {
         .await
         {
             Ok(client) => {
+                // Read new daemon version from the restarted child's
+                // ServerInfo.title before moving the client into state.
+                let new_version = extract_daemon_version(&client);
+
                 let mut state = self.state.write().await;
                 state.child_client = Some(client);
                 state.restart_count += 1;
@@ -360,14 +352,11 @@ impl McpProxy {
                     }
                 }
 
-                // Detect version change via the long-lived daemon
-                // connection. The supervisor task keeps `last_known_info`
-                // fresh via its heartbeat, so this read is a local cache
-                // hit — no socket I/O on the restart hot path.
-                let new_version = match self.daemon_connection.as_ref() {
-                    Some(conn) => conn.last_known_info().await.map(|i| i.version),
-                    None => None,
-                };
+                // The new child told us the daemon version it saw on its
+                // startup handshake. Compare it with what the previous
+                // child reported to detect a daemon upgrade across the
+                // restart. If either side is unknown we degrade to the
+                // generic ChildRestart banner below.
                 state.last_daemon_version = new_version.clone();
 
                 // Session rejoin is now the child's responsibility
@@ -954,7 +943,6 @@ mod tests {
             child_env: HashMap::new(),
             server_name: "test-proxy".to_string(),
             cache_dir: None,
-            daemon_socket_path: None,
             monitor_poll_interval_ms: 500,
         }
     }
@@ -966,7 +954,6 @@ mod tests {
             child_env: HashMap::new(),
             server_name: "test-proxy".to_string(),
             cache_dir: Some(dir.to_path_buf()),
-            daemon_socket_path: None,
             monitor_poll_interval_ms: 500,
         }
     }
@@ -1370,7 +1357,6 @@ mod tests {
             child_env: env,
             server_name: "nteract".to_string(),
             cache_dir: None,
-            daemon_socket_path: None,
             monitor_poll_interval_ms: 500,
         };
 
@@ -1381,31 +1367,43 @@ mod tests {
     // ── Version tracking at creation ──────────────────────────────────
 
     #[tokio::test]
-    async fn proxy_has_no_version_when_no_socket_path() {
+    async fn proxy_starts_with_no_daemon_version() {
+        // No child has handed us a ServerInfo yet, so we don't know the
+        // daemon version. Populated on init_child / restart_child from
+        // the child's MCP handshake.
         let proxy = McpProxy::new(test_config(), None);
         let state = proxy.state.read().await;
         assert!(state.last_daemon_version.is_none());
     }
 
-    #[tokio::test]
-    async fn proxy_has_no_version_when_socket_absent() {
-        // With a socket path that points nowhere, the DaemonConnection
-        // supervisor stays in Reconnecting state — last_known_info is
-        // None until a real daemon appears, which is the expected
-        // startup behavior.
-        let config = ProxyConfig {
-            resolve_child_command: Box::new(|| Ok(PathBuf::from("/nonexistent/runt"))),
-            child_args: vec!["mcp".to_string()],
-            child_env: HashMap::new(),
-            server_name: "test".to_string(),
-            cache_dir: None,
-            daemon_socket_path: Some(PathBuf::from("/nonexistent/runtimed.sock")),
-            monitor_poll_interval_ms: 500,
-        };
+    // ── extract_daemon_version title parsing ──────────────────────────
 
-        let proxy = McpProxy::new(config, None);
-        let state = proxy.state.read().await;
-        assert!(state.last_daemon_version.is_none());
+    #[test]
+    fn parse_daemon_version_from_title() {
+        assert_eq!(
+            parse_daemon_version_in_title("nteract (daemon 2.3.2)"),
+            Some("2.3.2")
+        );
+        assert_eq!(
+            parse_daemon_version_in_title("nteract (daemon 2.3.2+abc1234)"),
+            Some("2.3.2+abc1234")
+        );
+        assert_eq!(parse_daemon_version_in_title("nteract"), None);
+        assert_eq!(parse_daemon_version_in_title("nteract (daemon )"), None);
+    }
+
+    /// Pure version of `extract_daemon_version` without the RunningChild
+    /// wrapper, for unit testing the title parser.
+    fn parse_daemon_version_in_title(title: &str) -> Option<&str> {
+        let open = title.find("(daemon ")?;
+        let close = title.rfind(')')?;
+        let inner = title.get(open + "(daemon ".len()..close)?;
+        let v = inner.trim();
+        if v.is_empty() {
+            None
+        } else {
+            Some(v)
+        }
     }
 
     // ── Restart metrics ───────────────────────────────────────────────

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -44,6 +44,12 @@ pub struct NteractMcp {
     peer_label: Arc<RwLock<String>>,
     /// When true, the `show_notebook` tool is not registered (headless environments).
     no_show: bool,
+    /// Daemon version, if it was reachable during startup. Surfaced to the
+    /// parent proxy via `ServerInfo.server_info.title` so the proxy can
+    /// detect daemon upgrades across child restarts without holding its
+    /// own `DaemonConnection` (which would drag the runtimed-client
+    /// compile graph into `mcp-supervisor`).
+    daemon_version: Option<String>,
 }
 
 impl NteractMcp {
@@ -60,6 +66,7 @@ impl NteractMcp {
             session: Arc::new(RwLock::new(None)),
             peer_label: Arc::new(RwLock::new("Inkwell".to_string())),
             no_show: false,
+            daemon_version: None,
         }
     }
 
@@ -72,6 +79,13 @@ impl NteractMcp {
         let mut server = Self::new(socket_path, blob_base_url, blob_store_path);
         server.no_show = true;
         server
+    }
+
+    /// Set the daemon version to report in `ServerInfo.server_info.title`.
+    /// Called by the `runt mcp` binary after a best-effort daemon query.
+    pub fn with_daemon_version(mut self, version: Option<String>) -> Self {
+        self.daemon_version = version;
+        self
     }
 
     /// Get the peer label for notebook connections.
@@ -100,6 +114,15 @@ impl ServerHandler for NteractMcp {
             serde_json::from_value(serde_json::json!({})).unwrap(),
         );
 
+        // Stamp the daemon version into `server_info.title` so the parent
+        // proxy can detect daemon upgrades across child restarts by diffing
+        // `peer_info()` before vs after. The proxy doesn't need its own
+        // DaemonConnection — the child already has one.
+        let mut impl_info = Implementation::new("nteract", env!("CARGO_PKG_VERSION"));
+        if let Some(ref v) = self.daemon_version {
+            impl_info.title = Some(format!("nteract (daemon {v})"));
+        }
+
         ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_tools()
@@ -107,7 +130,7 @@ impl ServerHandler for NteractMcp {
                 .enable_extensions_with(extensions)
                 .build(),
         )
-        .with_server_info(Implementation::new("nteract", env!("CARGO_PKG_VERSION")))
+        .with_server_info(impl_info)
         .with_instructions(
             "nteract MCP server for Jupyter notebooks. \
              Each connection has one active notebook session. \

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -809,12 +809,27 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
 
+    // Best-effort daemon-version query with a short timeout. The value is
+    // stamped into `ServerInfo.server_info.title` so the parent proxy can
+    // detect daemon upgrades across child restarts. If the daemon isn't up
+    // yet (common at launch), we skip it — the proxy will degrade to a
+    // "child restarted" message, which is accurate.
+    let daemon_version = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        runtimed_client::singleton::query_daemon_info(socket_path.clone()),
+    )
+    .await
+    .ok()
+    .flatten()
+    .map(|info| info.version);
+
     use rmcp::service::ServiceExt;
     let server = if no_show {
         runt_mcp::NteractMcp::new_no_show(socket_path.clone(), blob_base_url, blob_store_path)
     } else {
         runt_mcp::NteractMcp::new(socket_path.clone(), blob_base_url, blob_store_path)
-    };
+    }
+    .with_daemon_version(daemon_version);
 
     // Grab shared state handles before serving (serve consumes the server)
     let session = server.session().clone();


### PR DESCRIPTION
Claude Code starts every session by executing `.mcp.json`, which ran `cargo run -p mcp-supervisor`. That took seconds even warm, because the supervisor pulled in `runt-mcp-proxy`, which linked `runtimed-client`, which dragged rattler and the rest of the daemon graph. Roughly 750 crates to rebuild staleness-checks on every session start.

Most of that existed to support one field: `last_daemon_version`, used to print `"Daemon upgraded (X → Y)"` on reconnection banners. The proxy held its own `DaemonConnection` in parallel with the child's — `runt mcp` already speaks to the daemon.

## What changed

- `runt mcp` does a 500ms best-effort `query_daemon_info` at startup and stamps the result into `ServerInfo.server_info.title` as `"nteract (daemon X.Y.Z)"`.
- `runt-mcp-proxy` reads that title out of `peer_info()` after each `spawn_child` and caches it. Diffing before vs after a restart drives the same `DaemonUpgrade` / `ChildRestart` banner logic as before.
- `ProxyConfig.daemon_socket_path` is gone. The proxy no longer opens a daemon socket of its own.
- `runt-mcp-proxy` drops its `runtimed-client` dependency. One line in `Cargo.toml`, whole transitive graph gone.

`nteract-mcp` (the shipped MCPB sidecar) inherits the same simplification — one fewer socket connection and one fewer long-lived supervisor task per MCP session.

## Result

- Cold build of `mcp-supervisor` after `cargo clean -p mcp-supervisor -p runt-mcp-proxy`: **3.8s** (from tens of seconds).
- Warm build: **0.15s**.
- `.mcp.json` stays on `cargo run -p mcp-supervisor` because there's no longer a reason to work around it.

## daemon.json

Closes #1812. The proxy was the last non-Tauri-webview `daemon.json` consumer worth removing. The upgrade window in shipped Tauri builds still reads it, and we can't retro-patch those, so the producer stays. The rule going forward: new code talks to the socket, not the file.

## Other cleanup

- Dropped the duplicate `nteract-dev` MCP entry from `.codex/config.toml`.
- `AGENTS.md` updated to reflect the smaller compile graph.
