### PR TITLE
perf(notebook): drop staticlib/cdylib crate-types from the desktop app

### DIFF
--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -12,7 +12,12 @@ workspace = true
 [lib]
 name = "notebook"
 path = "src/lib.rs"
-crate-type = ["lib", "staticlib", "cdylib"]
+# Desktop-only binary. The `notebook` bin is the single entry point;
+# the rlib exists so `main.rs` can call `notebook::run`. If a mobile
+# target (iOS/Android) is ever added, it needs `staticlib`/`cdylib`
+# under a target-cfg, not here. Unconditional mobile crate-types cost
+# a full extra linker pass per edit on every desktop build.
+crate-type = ["lib"]
 
 [[bin]]
 name = "notebook"


### PR DESCRIPTION
The `notebook` crate declared `crate-type = ["lib", "staticlib", "cdylib"]`, scaffolded by Tauri for mobile targets that load the app as a native library. The desktop app launches through the `notebook` bin, so those outputs are dead weight. Every incremental rebuild ran the linker three times over the same object code and produced an ~850 MB static archive that nothing opens.

Keeping just `lib` (so `main.rs` can call `notebook::run`) drops two linker passes and the large archive write per edit.

## Measured

Incremental `cargo build -p notebook` after touching `src/lib.rs`:

| | Wall | User CPU |
|---|------|----------|
| Before | 14.4s | 20.7s |
| After  | 8.8s  | 9.0s   |

38% faster wall-clock, more than 2× less CPU. Also frees ~858 MB of `target/debug/` every build.

## If mobile comes back

Add `staticlib` / `cdylib` under a target cfg, not unconditionally. The mobile hosts need them, the desktop build doesn't.
