### PR TITLE
fix(runtimed): ghost-output prevention + MCP input validation

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -468,10 +468,28 @@ impl DocHandle {
     ///
     /// Reads the cell's `execution_id` from the notebook doc, then looks up
     /// outputs in the RuntimeStateDoc — providing a transparent facade.
+    ///
+    /// Ghost-output guard (#2086): if the execution's captured source doesn't
+    /// match the cell's current source, the execution_id is stale (source was
+    /// edited after execution was queued). Returns `None` in that case so
+    /// callers never see outputs from a different version of the code.
     pub fn get_cell_outputs(&self, cell_id: &str) -> Option<Vec<serde_json::Value>> {
         let state = self.doc.lock().ok()?;
         // Read execution_id from the raw Automerge doc
         let eid = read_execution_id(&state.doc, cell_id)?;
+
+        // Ghost-output guard: verify the execution's captured source matches
+        // the cell's current source. If they differ, the user edited the cell
+        // after this execution was queued — return no outputs.
+        if let Some(exec) = state.state_doc.get_execution(&eid) {
+            if let Some(ref captured_source) = exec.source {
+                let current_source = read_cell_source(&state.doc, cell_id).unwrap_or_default();
+                if captured_source != &current_source {
+                    return None;
+                }
+            }
+        }
+
         let outputs = state.state_doc.get_outputs(&eid);
         if outputs.is_empty() {
             None
@@ -829,4 +847,12 @@ fn read_execution_id(doc: &AutoCommit, cell_id: &str) -> Option<String> {
         },
         _ => None,
     }
+}
+
+/// Read cell source text directly from a raw AutoCommit document.
+fn read_cell_source(doc: &AutoCommit, cell_id: &str) -> Option<String> {
+    let (_, cells_id) = doc.get(&automerge::ROOT, "cells").ok().flatten()?;
+    let (_, cell_obj) = doc.get(&cells_id, cell_id).ok().flatten()?;
+    let (_, source_id) = doc.get(&cell_obj, "source").ok().flatten()?;
+    doc.text(&source_id).ok()
 }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -77,6 +77,9 @@ pub struct ClearOutputsParams {
     pub cell_ids: Option<Vec<String>>,
 }
 
+/// Valid cell types per the nbformat spec.
+const VALID_CELL_TYPES: &[&str] = &["code", "markdown", "raw"];
+
 /// Create a new cell, optionally executing it.
 pub async fn create_cell(
     server: &NteractMcp,
@@ -84,6 +87,13 @@ pub async fn create_cell(
 ) -> Result<CallToolResult, McpError> {
     let source = arg_str(request, "source").unwrap_or("");
     let cell_type = arg_str(request, "cell_type").unwrap_or("code");
+
+    if !VALID_CELL_TYPES.contains(&cell_type) {
+        return tool_error(&format!(
+            "Invalid cell_type: \"{cell_type}\". Must be one of: {}",
+            VALID_CELL_TYPES.join(", ")
+        ));
+    }
     let index = request
         .arguments
         .as_ref()
@@ -197,6 +207,12 @@ pub async fn set_cell(
         crate::presence::emit_cursor(&handle, cell_id, end_line, end_col, &peer_label).await;
     }
     if let Some(ct) = cell_type {
+        if !VALID_CELL_TYPES.contains(&ct) {
+            return tool_error(&format!(
+                "Invalid cell_type: \"{ct}\". Must be one of: {}",
+                VALID_CELL_TYPES.join(", ")
+            ));
+        }
         handle
             .set_cell_type(cell_id, ct)
             .map_err(|e| McpError::internal_error(format!("Failed to set cell type: {e}"), None))?;
@@ -255,6 +271,20 @@ pub async fn move_cell(
     let handle = require_handle!(server);
 
     let after_cell_id = arg_str(request, "after_cell_id");
+
+    // Validate the cell being moved exists
+    if handle.get_cell(cell_id).is_none() {
+        return tool_error(&format!("Cell not found: {cell_id}"));
+    }
+
+    // Validate the anchor cell exists (if specified)
+    if let Some(anchor) = after_cell_id {
+        if handle.get_cell(anchor).is_none() {
+            return tool_error(&format!(
+                "Anchor cell not found: {anchor}. Pass null/omit after_cell_id to move to the start."
+            ));
+        }
+    }
 
     handle
         .move_cell(cell_id, after_cell_id)

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -189,6 +189,22 @@ pub async fn add_dependency(
     // Detect list-like strings agents sometimes pass and split them.
     let packages = parse_package_param(raw_package);
 
+    // Validate each package spec is non-empty and has a plausible format.
+    for pkg in &packages {
+        let name = pkg.trim();
+        if name.is_empty() {
+            return tool_error(
+                "Empty package name. Provide a valid package specifier (e.g. \"pandas>=2.0\").",
+            );
+        }
+        // Package names must start with a letter or digit (PEP 508 / conda).
+        if !name.chars().next().is_some_and(|c| c.is_alphanumeric()) {
+            return tool_error(&format!(
+                "Invalid package specifier: \"{name}\". Package names must start with a letter or digit."
+            ));
+        }
+    }
+
     let (handle, notebook_id) =
         {
             let guard = server.session.read().await;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -767,6 +767,24 @@ impl NotebookHandle {
         let Some(eid) = self.doc.get_execution_id(cell_id) else {
             return Vec::new();
         };
+
+        // Ghost-output guard (#2086): if the execution's captured source
+        // doesn't match the cell's current source, the user edited the cell
+        // after this execution was queued. Return empty to avoid showing
+        // stale output from a different version of the code.
+        if let Some(exec) = self.state_doc.get_execution(&eid) {
+            if let Some(ref captured) = exec.source {
+                let current = self
+                    .doc
+                    .get_cell(cell_id)
+                    .map(|c| c.source)
+                    .unwrap_or_default();
+                if captured != &current {
+                    return Vec::new();
+                }
+            }
+        }
+
         self.state_doc
             .get_outputs(&eid)
             .into_iter()

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -45,7 +45,7 @@ use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
 use crate::paths::notebook_doc_filename;
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
-use notebook_doc::diff::diff_metadata_touched;
+use notebook_doc::diff::{diff_cells, diff_metadata_touched};
 use notebook_doc::presence::{self, PresenceState};
 use runtime_doc::RuntimeStateDoc;
 

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1423,15 +1423,16 @@ where
 
                                     // Ghost-output prevention (#2086): if a peer
                                     // edited cell source while an execution was
-                                    // in-flight, clear the execution_id pointer so
-                                    // the stale output won't be associated with the
-                                    // cell. The old execution's output remains in
-                                    // RuntimeStateDoc but the cell no longer points
-                                    // to it.
+                                    // in-flight OR already completed, clear the
+                                    // execution_id pointer so stale output won't
+                                    // be associated with the cell.
                                     //
-                                    // Also mark executions as failed for cells that
-                                    // were deleted — the kernel still runs the code
-                                    // but the cell no longer exists to display it.
+                                    // We compare the cell's current source against
+                                    // the captured source stored in the execution
+                                    // entry. This catches both the wide window
+                                    // (execution still running when source changes)
+                                    // and the tight window (execution already done
+                                    // by the time the sync frame arrives).
                                     if heads_before != heads_after {
                                         let changeset = diff_cells(
                                             doc.doc_mut(),
@@ -1441,18 +1442,28 @@ where
                                         for changed in &changeset.changed {
                                             if changed.fields.source {
                                                 if let Some(eid) = doc.get_execution_id(&changed.cell_id) {
-                                                    let is_active = room
+                                                    let source_mismatch = room
                                                         .state
                                                         .read(|sd| {
                                                             sd.get_execution(&eid).is_some_and(|exec| {
-                                                                exec.status == "queued" || exec.status == "running"
-                                                            })
+                                                                match &exec.source {
+                                                                    Some(captured) => {
+                                                                        let current = doc.get_cell(&changed.cell_id)
+                                                                            .map(|c| c.source)
+                                                                            .unwrap_or_default();
+                                                                        captured != &current
+                                                                    }
+                                                                    // No captured source — legacy execution,
+                                                                    // clear to be safe.
+                                                                    None => true,
+                                                                }
+                                                                })
                                                         })
                                                         .unwrap_or(false);
-                                                    if is_active {
+                                                    if source_mismatch {
                                                         debug!(
                                                             "[notebook-sync] Clearing stale execution_id {} for cell {} \
-                                                             (source edited while execution in-flight)",
+                                                             (source changed since execution was queued)",
                                                             eid, changed.cell_id
                                                         );
                                                         let _ = doc.set_execution_id(&changed.cell_id, None);

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1421,6 +1421,47 @@ where
                                         &heads_after,
                                     );
 
+                                    // Ghost-output prevention (#2086): if a peer
+                                    // edited cell source while an execution was
+                                    // in-flight, clear the execution_id pointer so
+                                    // the stale output won't be associated with the
+                                    // cell. The old execution's output remains in
+                                    // RuntimeStateDoc but the cell no longer points
+                                    // to it.
+                                    //
+                                    // Also mark executions as failed for cells that
+                                    // were deleted — the kernel still runs the code
+                                    // but the cell no longer exists to display it.
+                                    if heads_before != heads_after {
+                                        let changeset = diff_cells(
+                                            doc.doc_mut(),
+                                            &heads_before,
+                                            &heads_after,
+                                        );
+                                        for changed in &changeset.changed {
+                                            if changed.fields.source {
+                                                if let Some(eid) = doc.get_execution_id(&changed.cell_id) {
+                                                    let is_active = room
+                                                        .state
+                                                        .read(|sd| {
+                                                            sd.get_execution(&eid).is_some_and(|exec| {
+                                                                exec.status == "queued" || exec.status == "running"
+                                                            })
+                                                        })
+                                                        .unwrap_or(false);
+                                                    if is_active {
+                                                        debug!(
+                                                            "[notebook-sync] Clearing stale execution_id {} for cell {} \
+                                                             (source edited while execution in-flight)",
+                                                            eid, changed.cell_id
+                                                        );
+                                                        let _ = doc.set_execution_id(&changed.cell_id, None);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
                                     let bytes = doc.save();
 
                                     // Notify other peers in this room

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -95,7 +95,15 @@ pub(crate) async fn save_notebook_to_disk(
         (cells, metadata_snapshot, eids)
     };
 
+    // Build cell_id → current_source map for ghost-output guard.
+    let cell_sources: HashMap<String, String> = cells
+        .iter()
+        .map(|c| (c.id.clone(), c.source.clone()))
+        .collect();
+
     // Read outputs and execution_count from RuntimeStateDoc keyed by execution_id.
+    // Ghost-output guard (#2086): skip outputs when the execution's captured
+    // source doesn't match the cell's current source (source edited since execution).
     let (cell_outputs, cell_execution_counts): (
         HashMap<String, Vec<serde_json::Value>>,
         HashMap<String, Option<i64>>,
@@ -106,11 +114,19 @@ pub(crate) async fn save_notebook_to_disk(
             let mut ec_map = HashMap::new();
             for (cell_id, eid) in &cell_execution_ids {
                 if let Some(eid) = eid.as_ref() {
-                    let outputs = sd.get_outputs(eid);
-                    if !outputs.is_empty() {
-                        outputs_map.insert(cell_id.clone(), outputs);
-                    }
                     if let Some(exec) = sd.get_execution(eid) {
+                        // Ghost-output guard: skip stale executions
+                        if let Some(ref captured) = exec.source {
+                            let current =
+                                cell_sources.get(cell_id).map(|s| s.as_str()).unwrap_or("");
+                            if captured != current {
+                                continue;
+                            }
+                        }
+                        let outputs = sd.get_outputs(eid);
+                        if !outputs.is_empty() {
+                            outputs_map.insert(cell_id.clone(), outputs);
+                        }
                         ec_map.insert(cell_id.clone(), exec.execution_count);
                     }
                 }


### PR DESCRIPTION
## Summary

- **Ghost-output prevention (#2086):** Three-layer defense against stale execution outputs appearing on cells whose source was edited after execution was queued. Compares execution's captured source against cell's current source instead of relying on execution status timing.
  - Daemon sync handler clears stale `execution_id` pointers on source change
  - Read path (`get_cell_outputs`) verifies source match before returning outputs
  - Save path skips stale execution outputs when writing `.ipynb`
- **MCP input validation:** Rejects invalid `cell_type` values, validates `move_cell` anchor existence, rejects empty/malformed package names in `add_dependency`

## Test plan

- [x] `cargo clippy -p runtimed -p runt-mcp -p notebook-sync -p runtimed-wasm -- -D warnings` clean
- [x] `cargo test -p runtimed -p notebook-sync -p runt-mcp -p runtime-doc` passing (465/466 runtimed, 101/101 runt-mcp; 1 pre-existing flaky test)
- [x] Nightly installed and verified: `2.3.2+d941e2a`
- [ ] Gremlin replay: ghost-output wide + tight window scenarios
- [ ] Gremlin replay: breaker Test 4 (sleep(10) + set_cell race)