### PR TITLE
fix(runt-mcp): validate MCP tool inputs to prevent silent bad state

### DIFF
--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -12,7 +12,7 @@ use notebook_protocol::protocol::NotebookRequest;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_bool, arg_str, arg_string_array, tool_error, tool_success};
+use super::{arg_bool, arg_str, arg_string_array, cell_not_found, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -185,10 +185,8 @@ pub async fn set_cell(
         .unwrap_or(30.0);
 
     let handle = require_handle!(server);
-
-    // Verify cell exists
-    if handle.get_cell(cell_id).is_none() {
-        return tool_error(&format!("Cell not found: {cell_id}"));
+    if let Some(err) = cell_not_found(&handle, cell_id) {
+        return err;
     }
 
     if source.is_none() && cell_type.is_none() {
@@ -248,20 +246,19 @@ pub async fn delete_cell(
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
 
     let handle = require_handle!(server);
+    if let Some(err) = cell_not_found(&handle, cell_id) {
+        return err;
+    }
 
     let peer_label = server.get_peer_label().await;
     crate::presence::emit_focus(&handle, cell_id, &peer_label).await;
 
-    let deleted = handle
+    handle
         .delete_cell(cell_id)
         .map_err(|e| McpError::internal_error(format!("Failed to delete cell: {e}"), None))?;
 
-    if deleted {
-        let result = serde_json::json!({ "cell_id": cell_id, "deleted": true });
-        tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
-    } else {
-        tool_error(&format!("Cell not found: {cell_id}"))
-    }
+    let result = serde_json::json!({ "cell_id": cell_id, "deleted": true });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
 
 /// Move a cell to a new position.
@@ -276,12 +273,9 @@ pub async fn move_cell(
 
     let after_cell_id = arg_str(request, "after_cell_id");
 
-    // Validate the cell being moved exists
-    if handle.get_cell(cell_id).is_none() {
-        return tool_error(&format!("Cell not found: {cell_id}"));
+    if let Some(err) = cell_not_found(&handle, cell_id) {
+        return err;
     }
-
-    // Validate the anchor cell exists (if specified)
     if let Some(anchor) = after_cell_id {
         if handle.get_cell(anchor).is_none() {
             return tool_error(&format!(

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -78,6 +78,10 @@ pub struct ClearOutputsParams {
 }
 
 /// Valid cell types per the nbformat spec.
+///
+/// TODO: promote to a shared `CellType` enum in `notebook-doc` so
+/// deserialization rejects invalid types at the boundary rather than
+/// requiring runtime checks in each consumer.
 const VALID_CELL_TYPES: &[&str] = &["code", "markdown", "raw"];
 
 /// Create a new cell, optionally executing it.

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -77,6 +77,9 @@ pub struct ClearOutputsParams {
     pub cell_ids: Option<Vec<String>>,
 }
 
+/// Valid cell types per the nbformat spec.
+const VALID_CELL_TYPES: &[&str] = &["code", "markdown", "raw"];
+
 /// Create a new cell, optionally executing it.
 pub async fn create_cell(
     server: &NteractMcp,
@@ -84,6 +87,13 @@ pub async fn create_cell(
 ) -> Result<CallToolResult, McpError> {
     let source = arg_str(request, "source").unwrap_or("");
     let cell_type = arg_str(request, "cell_type").unwrap_or("code");
+
+    if !VALID_CELL_TYPES.contains(&cell_type) {
+        return tool_error(&format!(
+            "Invalid cell_type: \"{cell_type}\". Must be one of: {}",
+            VALID_CELL_TYPES.join(", ")
+        ));
+    }
     let index = request
         .arguments
         .as_ref()
@@ -197,6 +207,12 @@ pub async fn set_cell(
         crate::presence::emit_cursor(&handle, cell_id, end_line, end_col, &peer_label).await;
     }
     if let Some(ct) = cell_type {
+        if !VALID_CELL_TYPES.contains(&ct) {
+            return tool_error(&format!(
+                "Invalid cell_type: \"{ct}\". Must be one of: {}",
+                VALID_CELL_TYPES.join(", ")
+            ));
+        }
         handle
             .set_cell_type(cell_id, ct)
             .map_err(|e| McpError::internal_error(format!("Failed to set cell type: {e}"), None))?;
@@ -255,6 +271,20 @@ pub async fn move_cell(
     let handle = require_handle!(server);
 
     let after_cell_id = arg_str(request, "after_cell_id");
+
+    // Validate the cell being moved exists
+    if handle.get_cell(cell_id).is_none() {
+        return tool_error(&format!("Cell not found: {cell_id}"));
+    }
+
+    // Validate the anchor cell exists (if specified)
+    if let Some(anchor) = after_cell_id {
+        if handle.get_cell(anchor).is_none() {
+            return tool_error(&format!(
+                "Anchor cell not found: {anchor}. Pass null/omit after_cell_id to move to the start."
+            ));
+        }
+    }
 
     handle
         .move_cell(cell_id, after_cell_id)

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -271,11 +271,7 @@ pub async fn move_cell(
 
     assert_cell_exists(&handle, cell_id)?;
     if let Some(anchor) = after_cell_id {
-        if handle.get_cell(anchor).is_none() {
-            return tool_error(&format!(
-                "Anchor cell not found: {anchor}. Pass null/omit after_cell_id to move to the start."
-            ));
-        }
+        assert_cell_exists(&handle, anchor)?;
     }
 
     handle

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -12,7 +12,7 @@ use notebook_protocol::protocol::NotebookRequest;
 use crate::execution;
 use crate::NteractMcp;
 
-use super::{arg_bool, arg_str, arg_string_array, cell_not_found, tool_error, tool_success};
+use super::{arg_bool, arg_str, arg_string_array, assert_cell_exists, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -185,9 +185,7 @@ pub async fn set_cell(
         .unwrap_or(30.0);
 
     let handle = require_handle!(server);
-    if let Some(err) = cell_not_found(&handle, cell_id) {
-        return err;
-    }
+    assert_cell_exists(&handle, cell_id)?;
 
     if source.is_none() && cell_type.is_none() {
         return tool_success(&format!(
@@ -246,9 +244,7 @@ pub async fn delete_cell(
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
 
     let handle = require_handle!(server);
-    if let Some(err) = cell_not_found(&handle, cell_id) {
-        return err;
-    }
+    assert_cell_exists(&handle, cell_id)?;
 
     let peer_label = server.get_peer_label().await;
     crate::presence::emit_focus(&handle, cell_id, &peer_label).await;
@@ -273,9 +269,7 @@ pub async fn move_cell(
 
     let after_cell_id = arg_str(request, "after_cell_id");
 
-    if let Some(err) = cell_not_found(&handle, cell_id) {
-        return err;
-    }
+    assert_cell_exists(&handle, cell_id)?;
     if let Some(anchor) = after_cell_id {
         if handle.get_cell(anchor).is_none() {
             return tool_error(&format!(

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -206,8 +206,9 @@ pub async fn add_dependency(
     let manager = detect_package_manager(&handle);
 
     for package in &packages {
-        add_dep_for_manager(&handle, package, &manager)
-            .map_err(|e| McpError::internal_error(e, None))?;
+        if let Err(e) = add_dep_for_manager(&handle, package, &manager) {
+            return tool_error(&e);
+        }
     }
     // For the response, use the first package as `package` for backward compat
     let package = packages.first().map(|s| s.as_str()).unwrap_or(raw_package);

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -189,6 +189,22 @@ pub async fn add_dependency(
     // Detect list-like strings agents sometimes pass and split them.
     let packages = parse_package_param(raw_package);
 
+    // Validate each package spec is non-empty and has a plausible format.
+    for pkg in &packages {
+        let name = pkg.trim();
+        if name.is_empty() {
+            return tool_error(
+                "Empty package name. Provide a valid package specifier (e.g. \"pandas>=2.0\").",
+            );
+        }
+        // Package names must start with a letter or digit (PEP 508 / conda).
+        if !name.chars().next().is_some_and(|c| c.is_alphanumeric()) {
+            return tool_error(&format!(
+                "Invalid package specifier: \"{name}\". Package names must start with a letter or digit."
+            ));
+        }
+    }
+
     let (handle, notebook_id) =
         {
             let guard = server.session.read().await;

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -145,9 +145,12 @@ pub(crate) fn add_dep_for_manager(
                 .add_pixi_dependency(package)
                 .map_err(|e| format!("Failed to add pixi dependency: {e}"))
         }
-        PackageManager::Uv | PackageManager::Unknown(_) => handle
-            .add_uv_dependency(package)
-            .map_err(|e| format!("Failed to add uv dependency: {e}")),
+        PackageManager::Uv | PackageManager::Unknown(_) => {
+            notebook_doc::metadata::validate_package_specifier(package)?;
+            handle
+                .add_uv_dependency(package)
+                .map_err(|e| format!("Failed to add uv dependency: {e}"))
+        }
     }
 }
 
@@ -188,22 +191,6 @@ pub async fn add_dependency(
 
     // Detect list-like strings agents sometimes pass and split them.
     let packages = parse_package_param(raw_package);
-
-    // Validate each package spec is non-empty and has a plausible format.
-    for pkg in &packages {
-        let name = pkg.trim();
-        if name.is_empty() {
-            return tool_error(
-                "Empty package name. Provide a valid package specifier (e.g. \"pandas>=2.0\").",
-            );
-        }
-        // Package names must start with a letter or digit (PEP 508 / conda).
-        if !name.chars().next().is_some_and(|c| c.is_alphanumeric()) {
-            return tool_error(&format!(
-                "Invalid package specifier: \"{name}\". Package names must start with a letter or digit."
-            ));
-        }
-    }
 
     let (handle, notebook_id) =
         {

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -11,7 +11,7 @@ use crate::execution;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_bool, arg_str, cell_not_found, tool_error, tool_success};
+use super::{arg_bool, arg_str, assert_cell_exists, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -52,9 +52,7 @@ pub async fn execute_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    if let Some(err) = cell_not_found(&handle, cell_id) {
-        return err;
-    }
+    assert_cell_exists(&handle, cell_id)?;
 
     let peer_label = server.get_peer_label().await;
     crate::presence::emit_focus(&handle, cell_id, &peer_label).await;

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -11,7 +11,7 @@ use crate::execution;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::{arg_bool, arg_str, tool_error, tool_success};
+use super::{arg_bool, arg_str, cell_not_found, tool_error, tool_success};
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -52,9 +52,8 @@ pub async fn execute_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    // Verify cell exists
-    if handle.get_cell(cell_id).is_none() {
-        return tool_error(&format!("Cell not found: {cell_id}"));
+    if let Some(err) = cell_not_found(&handle, cell_id) {
+        return err;
     }
 
     let peer_label = server.get_peer_label().await;

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -473,6 +473,24 @@ pub fn arg_string_array(request: &CallToolRequestParams, key: &str) -> Option<Ve
     Some(vec![])
 }
 
+/// Guard: return a `tool_error` if the cell does not exist in the notebook.
+///
+/// Call this early in any tool that takes a `cell_id` parameter so the agent
+/// gets a clear "Cell not found" message instead of a cryptic Automerge error
+/// or silent no-op.
+///
+/// Usage: `if let Some(err) = cell_not_found(&handle, cell_id) { return err; }`
+pub fn cell_not_found(
+    handle: &notebook_sync::handle::DocHandle,
+    cell_id: &str,
+) -> Option<Result<CallToolResult, McpError>> {
+    if handle.get_cell(cell_id).is_some() {
+        None
+    } else {
+        Some(tool_error(&format!("Cell not found: {cell_id}")))
+    }
+}
+
 /// Helper: create a text error result.
 pub fn tool_error(msg: &str) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::error(vec![Content::text(msg.to_string())]))

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -473,21 +473,24 @@ pub fn arg_string_array(request: &CallToolRequestParams, key: &str) -> Option<Ve
     Some(vec![])
 }
 
-/// Guard: return a `tool_error` if the cell does not exist in the notebook.
+/// Assert that a cell exists in the notebook, or return an `McpError`.
 ///
 /// Call this early in any tool that takes a `cell_id` parameter so the agent
 /// gets a clear "Cell not found" message instead of a cryptic Automerge error
 /// or silent no-op.
 ///
-/// Usage: `if let Some(err) = cell_not_found(&handle, cell_id) { return err; }`
-pub fn cell_not_found(
+/// Usage: `assert_cell_exists(&handle, cell_id)?;`
+pub fn assert_cell_exists(
     handle: &notebook_sync::handle::DocHandle,
     cell_id: &str,
-) -> Option<Result<CallToolResult, McpError>> {
+) -> Result<(), McpError> {
     if handle.get_cell(cell_id).is_some() {
-        None
+        Ok(())
     } else {
-        Some(tool_error(&format!("Cell not found: {cell_id}")))
+        Err(McpError::invalid_params(
+            format!("Cell not found: {cell_id}"),
+            None,
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

- Reject invalid `cell_type` values in `create_cell`/`set_cell` — only "code", "markdown", "raw" accepted per nbformat spec
- Validate both source cell and anchor cell exist in `move_cell` before attempting the move
- Reject empty and malformed package names in `add_dependency`

Found by gremlin stress testing (iteration 1).

## Test plan

- [x] All 101 `runt-mcp` unit tests pass
- [x] `cargo clippy -p runt-mcp -- -D warnings` clean