### PR TITLE
refactor: rename runt-cli package to runt

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -35,7 +35,7 @@ Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` t
 
 ## MCP Server
 
-`nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
+`nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
 
 ## System daemon CLI (`runt` / `runt-nightly`)
 

--- a/.claude/skills/build-system/SKILL.md
+++ b/.claude/skills/build-system/SKILL.md
@@ -11,7 +11,7 @@ For commands and dev workflows, see `CLAUDE.md` → "Build System" and run `carg
 
 Three phases:
 
-1. **Single Rust compilation** — `cargo build -p runtimed -p runt-cli -p mcp-supervisor -p notebook` in one invocation (workspace feature unification happens once, so the final tauri step doesn't recompile). Sidecars (`runtimed`, `runt`) are copied to `crates/notebook/binaries/` for Tauri bundling.
+1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p mcp-supervisor -p notebook` in one invocation (workspace feature unification happens once, so the final tauri step doesn't recompile). Sidecars (`runtimed`, `runt`) are copied to `crates/notebook/binaries/` for Tauri bundling.
 
 2. **Frontend + Python bindings in parallel** — `pnpm build` (TypeScript + Vite) and `maturin develop` (Python `.so`) run concurrently. Both must finish before phase 3.
 
@@ -37,7 +37,7 @@ Shared:
 
 App binaries:
 - `notebook` (Tauri) → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runt-trust`, `runt-workspace`
-- `runt-cli` → `runtimed-client`, `notebook-doc`, `runt-workspace`, `kernel-env`, `runt-mcp`
+- `runt` → `runtimed-client`, `notebook-doc`, `runt-workspace`, `kernel-env`, `runt-mcp`
 - `runtimed` → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `kernel-launch`, `kernel-env`, `runt-trust`, `runt-workspace`
 - `runtimed-py` → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `kernel-env`, `notebook-sync`, `runt-workspace`
 - `runtimed-wasm` → `notebook-doc`

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -119,7 +119,7 @@ Schema changes don't require a protocol bump — wire format for sync frames sta
 
 Python wheels always built (macOS arm64, Linux x64, Windows x64) and published. `continue-on-error: true` on PyPI step handles duplicate version conflicts.
 
-Desktop version: `{runt-cli version}-{suffix}.{timestamp}` stamped into `tauri.conf.json` and `Cargo.toml` at build time (not committed).
+Desktop version: `{runt version}-{suffix}.{timestamp}` stamped into `tauri.conf.json` and `Cargo.toml` at build time (not committed).
 
 ### Trusted Publishing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -481,7 +481,7 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -167,7 +167,7 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
 
           mkdir -p crates/notebook/binaries target/release/binaries
@@ -183,7 +183,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           $target = (rustc --print host-tuple).Trim()
 
           New-Item -ItemType Directory -Force crates/notebook/binaries | Out-Null

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -123,7 +123,7 @@ jobs:
         run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
 
       - name: Build for Linux x64
-        run: cargo build --release --target x86_64-unknown-linux-gnu -p runt-cli
+        run: cargo build --release --target x86_64-unknown-linux-gnu -p runt
 
       - name: Rename binaries
         run: |
@@ -183,10 +183,10 @@ jobs:
         run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
 
       - name: Build for macOS ARM64
-        run: cargo build --release --target aarch64-apple-darwin -p runt-cli
+        run: cargo build --release --target aarch64-apple-darwin -p runt
 
       - name: Build for macOS x64
-        run: cargo build --release --target x86_64-apple-darwin -p runt-cli
+        run: cargo build --release --target x86_64-apple-darwin -p runt
 
       - name: Rename binaries
         run: |
@@ -302,7 +302,7 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
@@ -475,7 +475,7 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release --target x86_64-apple-darwin -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release --target x86_64-apple-darwin -p runtimed -p runt -p nteract-mcp
           TARGET="x86_64-apple-darwin"
           mkdir -p crates/notebook/binaries
           cp target/x86_64-apple-darwin/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
@@ -629,7 +629,7 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
@@ -760,7 +760,7 @@ jobs:
 
       - name: Build external binaries
         run: |
-          cargo build --release -p runtimed -p runt-cli -p nteract-mcp
+          cargo build --release -p runtimed -p runt -p nteract-mcp
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` fo
 
 ### MCP Server
 
-`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload.
+`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload.
 
 `runt mcp` can also be run standalone (no proxy): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
 
@@ -356,8 +356,8 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 ### Hot reload
 
 `nteract-dev` watches source directories and auto-restarts the child on changes:
-- **`crates/runt-mcp/src/`** → `cargo build -p runt-cli` + restart (Rust MCP mode)
-- **`crates/runtimed-client/src/`** → `cargo build -p runt-cli` + `maturin develop` + restart (shared code)
+- **`crates/runt-mcp/src/`** → `cargo build -p runt` + restart (Rust MCP mode)
+- **`crates/runtimed-client/src/`** → `cargo build -p runt` + `maturin develop` + restart (shared code)
 - **`crates/runtimed-py/src/`, `crates/runtimed/src/`** → `maturin develop` + `cargo build` + restart
 - **`python/nteract/src/`, `python/runtimed/src/`** → child restart (Python mode) or background `maturin develop` (Rust mode)
 
@@ -381,7 +381,7 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 | `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723, MIME classification |
 | `notebook-protocol` | Wire types — requests, responses, broadcasts |
 | `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
-| `runt-cli` | CLI (`runt` binary) — daemon management, kernel control, notebook launching, MCP server |
+| `runt` | CLI (`runt` binary) — daemon management, kernel control, notebook launching, MCP server |
 | `runt-mcp` | Rust-native MCP server — 26 tools for notebook interaction via `runt mcp` |
 | `runt-mcp-proxy` | Resilient proxy for `runt mcp` — child supervision, restart-with-retry, session tracking |
 | `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6934,7 +6934,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "runt-cli"
+name = "runt"
 version = "2.3.2"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ strip = "debuginfo"
 lto = true
 codegen-units = 1
 # Keep unwinding so catch_unwind guards work in release — both runtimed
-# (spawn_supervised task recovery) and runt-cli (automerge sync panic
+# (spawn_supervised task recovery) and runt (automerge sync panic
 # recovery, automerge/automerge#1187). The binary size cost is ~2-5%
 # but prevents silent process death on shared notebooks.
 panic = "unwind"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ macOS builds are signed and notarized. Windows builds are not code signed.
 
 ### Crate publishing
 
-`runt-cli`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, and `xtask` are **not published to crates.io** (`publish = false`).
+`runt`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, and `xtask` are **not published to crates.io** (`publish = false`).
 
 ## Python Packages (runtimed, nteract)
 

--- a/bin/runt
+++ b/bin/runt
@@ -14,7 +14,7 @@ BINARY="$REPO_ROOT/target/debug/runt"
 
 if [ ! -f "$BINARY" ]; then
     echo "runt not built yet — building..." >&2
-    cargo build --manifest-path "$REPO_ROOT/Cargo.toml" -p runt-cli
+    cargo build --manifest-path "$REPO_ROOT/Cargo.toml" -p runt
 fi
 
 exec "$BINARY" "$@"

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -21,7 +21,7 @@ graph TD
         ND["notebook-doc<br/><i>shared Automerge doc ops</i>"]
         RTC["runtimed-client<br/><i>shared client/runtime helpers</i>"]
         RD["runtimed (lib + bin)<br/><i>daemon</i>"]
-        RC["runt-cli (bin: runt)<br/><i>CLI</i>"]
+        RC["runt (bin: runt)<br/><i>CLI</i>"]
         NB["notebook (Tauri app)<br/><i>main app</i>"]
         XT["xtask<br/><i>build orchestrator</i>"]
         RWASM["runtimed-wasm<br/><i>WASM notebook doc ops</i>"]
@@ -76,7 +76,7 @@ here is what happens under the hood:
 ```mermaid
 graph LR
     A["1. pnpm install"] --> M["2. Build MCP widget HTML<br/>crates/runt-mcp/assets/_output.html"]
-    M --> R["3. cargo build<br/>-p runtimed -p runt-cli -p mcp-supervisor -p notebook"]
+    M --> R["3. cargo build<br/>-p runtimed -p runt -p mcp-supervisor -p notebook"]
     R --> E["4. Copy sidecar binaries<br/>for Tauri bundling"]
     E --> P["5. In parallel:<br/>uv sync + maturin develop<br/>and pnpm frontend build"]
     P --> F["6. cargo tauri build<br/>or debug link step"]
@@ -93,7 +93,7 @@ Shows only the Cargo `path` dependencies between workspace members:
 graph BT
     RD["runtimed"]
     RTC["runtimed-client"]
-    RC["runt-cli"]
+    RC["runt"]
     NB["notebook"]
     ND["notebook-doc"]
     NP["notebook-protocol"]

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -326,7 +326,7 @@ cargo xtask run-mcp
 
 This:
 1. Starts the dev daemon if not running
-2. Builds `runt-cli` and spawns `runt mcp` as a child process
+2. Builds `runt` and spawns `runt mcp` as a child process
 3. Proxies all tool calls + adds the dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
 4. Watches source files and hot-reloads on changes
 
@@ -387,8 +387,8 @@ These tools are always available, even when the child `runt mcp` is down:
 `python/nteract/src/`, `python/runtimed/src/`, `crates/runtimed-py/src/`, and
 `crates/runtimed/src/`:
 
-- **`crates/runt-mcp/src/`** → `cargo build -p runt-cli`, then child restart
-- **`crates/runtimed-client/src/`** → `cargo build -p runt-cli` + `maturin develop`, then child restart
+- **`crates/runt-mcp/src/`** → `cargo build -p runt`, then child restart
+- **`crates/runtimed-client/src/`** → `cargo build -p runt` + `maturin develop`, then child restart
 - **Python changes** → child restarts automatically
 - **Daemon / bindings Rust changes** → `maturin develop` runs first, then child restarts
 - **Behavior changes** take effect immediately on the next tool call

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -9,7 +9,7 @@ The repo keeps a shared semver source version across its release inputs, but CI 
 | Artifact | Where | Version source |
 |---|---|---|
 | nteract desktop app | GitHub Releases | `crates/notebook/tauri.conf.json` |
-| `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` (package name `runt-cli`) |
+| `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` |
 | `runtimed` daemon | Bundled in app + Python wheel | `crates/runtimed/Cargo.toml` |
 | `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
 | `nteract` Python package | PyPI | `python/nteract/pyproject.toml` |
@@ -142,7 +142,7 @@ The reusable `release-common.yml` accepts inputs from the nightly/stable callers
 
 Python wheels are always built (macOS arm64, Linux x64, Windows x64) and always published. `continue-on-error: true` on the PyPI step handles duplicate version conflicts (e.g., re-running a workflow).
 
-Desktop version is computed as `{runt-cli version}-{suffix}.{timestamp}` where suffix is `nightly` or `stable`. This is stamped into `tauri.conf.json` and `Cargo.toml` at build time — not committed.
+Desktop version is computed as `{runt version}-{suffix}.{timestamp}` where suffix is `nightly` or `stable`. This is stamped into `tauri.conf.json` and `Cargo.toml` at build time — not committed.
 
 ### Trusted Publishing
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -9,9 +9,9 @@ The runtime daemon manages prewarmed Python environments, notebook document sync
 | Install nightly from source (Linux/headless) | `cargo xtask install-nightly` |
 | Run daemon | `cargo run -p runtimed` |
 | Run with debug logs | `RUST_LOG=debug cargo run -p runtimed` |
-| Check status | `cargo run -p runt-cli -- daemon status` |
-| Ping daemon | `cargo run -p runt-cli -- daemon ping` |
-| View logs | `cargo run -p runt-cli -- daemon logs -f` |
+| Check status | `cargo run -p runt -- daemon status` |
+| Ping daemon | `cargo run -p runt -- daemon ping` |
+| View logs | `cargo run -p runt -- daemon logs -f` |
 | Run tests | `cargo test -p runtimed` |
 
 ## Why It Exists
@@ -107,7 +107,7 @@ It refuses by default on macOS (the desktop app manages its own daemon via SMApp
 Verify the running version with:
 
 ```bash
-cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
+cargo run -p runt -- daemon status --json | jq -r '.daemon_info.version'
 ```
 
 For per-worktree daemon development (no system install involved), use `cargo xtask dev-daemon` instead — it runs the daemon out of the worktree with per-worktree socket isolation and no service files.
@@ -293,25 +293,25 @@ The `runt` CLI has daemon subcommands for testing and service management:
 
 ```bash
 # Service management
-cargo run -p runt-cli -- daemon status        # Show service + pool statistics
-cargo run -p runt-cli -- daemon status --json # JSON output
-cargo run -p runt-cli -- daemon start         # Start the daemon service
-cargo run -p runt-cli -- daemon stop          # Stop the daemon service
-cargo run -p runt-cli -- daemon restart       # Restart the daemon service
-cargo run -p runt-cli -- daemon logs -f       # Tail daemon logs
-cargo run -p runt-cli -- daemon flush         # Flush pool and rebuild environments
+cargo run -p runt -- daemon status        # Show service + pool statistics
+cargo run -p runt -- daemon status --json # JSON output
+cargo run -p runt -- daemon start         # Start the daemon service
+cargo run -p runt -- daemon stop          # Stop the daemon service
+cargo run -p runt -- daemon restart       # Restart the daemon service
+cargo run -p runt -- daemon logs -f       # Tail daemon logs
+cargo run -p runt -- daemon flush         # Flush pool and rebuild environments
 
 # Debug/health checks
-cargo run -p runt-cli -- daemon ping          # Check daemon is responding
-cargo run -p runt-cli -- daemon shutdown      # Shutdown daemon via IPC
+cargo run -p runt -- daemon ping          # Check daemon is responding
+cargo run -p runt -- daemon shutdown      # Shutdown daemon via IPC
 ```
 
-**Note:** In Conductor workspaces, use `./target/debug/runt` instead of `cargo run -p runt-cli --` for faster iteration. The debug binary connects to the worktree daemon automatically.
+**Note:** In Conductor workspaces, use `./target/debug/runt` instead of `cargo run -p runt --` for faster iteration. The debug binary connects to the worktree daemon automatically.
 
 ```bash
 # Kernel and notebook inspection
-cargo run -p runt-cli -- ps                   # List all kernels (connection-file + daemon)
-cargo run -p runt-cli -- notebooks            # List open notebooks with kernel info
+cargo run -p runt -- ps                   # List all kernels (connection-file + daemon)
+cargo run -p runt -- notebooks            # List open notebooks with kernel info
 ```
 
 ## Python Bindings (runtimed-py)

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -126,7 +126,7 @@ ASSERT stderr contains "error: unrecognized subcommand"
 
 TEST "version matches regex"
 RUN runt --version
-ASSERT stdout matches /runt-cli \d+\.\d+\.\d+/
+ASSERT stdout matches /runt \d+\.\d+\.\d+/
 ```
 
 **Available assertions:**

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -317,7 +317,7 @@ fn binary_fingerprint(project_root: &Path, name: &str) -> BinaryFingerprint {
 }
 
 /// Snapshot both binaries `up rebuild=true` touches: the daemon
-/// (`runtimed`) and the MCP child host (`runt`, via `runt-cli`).
+/// (`runtimed`) and the MCP child host (`runt`).
 /// Returns a tuple of fingerprints; `None` in either slot means the
 /// binary didn't exist at snapshot time.
 fn managed_binary_fingerprints(project_root: &Path) -> (BinaryFingerprint, BinaryFingerprint) {
@@ -343,13 +343,13 @@ fn fingerprint_changed(before: &BinaryFingerprint, after: &BinaryFingerprint) ->
 ///
 /// Returns `true` on success, `false` on failure.
 fn run_cargo_build_daemon(project_root: &Path) -> bool {
-    info!("Building daemon + CLI (cargo build -p runtimed -p runt-cli)...");
+    info!("Building daemon + CLI (cargo build -p runtimed -p runt)...");
     let mut cmd = std::process::Command::new("cargo");
     cmd.arg("build")
         .arg("-p")
         .arg("runtimed")
         .arg("-p")
-        .arg("runt-cli")
+        .arg("runt")
         .current_dir(project_root)
         .stdout(Stdio::null())
         .stderr(Stdio::inherit());
@@ -375,7 +375,7 @@ fn run_cargo_build_daemon(project_root: &Path) -> bool {
 /// Build the runt CLI binary (which includes runt-mcp).
 /// Respects release mode so the built binary matches what cargo_binary() resolves.
 fn build_runt_cli(project_root: &Path) -> bool {
-    let mut args = vec!["build", "-p", "runt-cli"];
+    let mut args = vec!["build", "-p", "runt"];
     if use_release_binaries() {
         args.push("--release");
     }
@@ -388,11 +388,11 @@ fn build_runt_cli(project_root: &Path) -> bool {
 
     match status {
         Ok(s) if s.success() => {
-            info!("cargo build -p runt-cli succeeded");
+            info!("cargo build -p runt succeeded");
             true
         }
         Ok(s) => {
-            error!("cargo build -p runt-cli failed with {s}");
+            error!("cargo build -p runt failed with {s}");
             false
         }
         Err(e) => {
@@ -948,9 +948,9 @@ impl Supervisor {
 
         match kind {
             ChangeKind::RustMcpChanged => {
-                info!("Rust MCP files changed, building runt-cli...");
+                info!("Rust MCP files changed, building runt...");
                 if !build_runt_cli(&project_root) {
-                    error!("cargo build -p runt-cli failed, keeping current child");
+                    error!("cargo build -p runt failed, keeping current child");
                     return;
                 }
                 if !skip_maturin {
@@ -962,7 +962,7 @@ impl Supervisor {
             }
             ChangeKind::RustChanged => {
                 info!(
-                    "Rust binding files changed, building runt-cli{}...",
+                    "Rust binding files changed, building runt{}...",
                     if skip_maturin {
                         ""
                     } else {
@@ -970,7 +970,7 @@ impl Supervisor {
                     }
                 );
                 if !build_runt_cli(&project_root) {
-                    error!("cargo build -p runt-cli failed, keeping current child");
+                    error!("cargo build -p runt failed, keeping current child");
                     return;
                 }
                 if !skip_maturin && !run_maturin_develop(&project_root) {
@@ -1140,9 +1140,9 @@ impl Supervisor {
         //
         // Snapshot *both* managed binaries before cargo build.
         // `run_cargo_build_daemon` actually compiles `runtimed` AND
-        // `runt-cli` (the MCP child host) in one invocation; they can
+        // `runt` (the MCP child host) in one invocation; they can
         // change independently on the same rebuild call — editing
-        // `crates/runt-mcp/src/**` relinks runt-cli while leaving
+        // `crates/runt-mcp/src/**` relinks runt while leaving
         // runtimed untouched. We gate daemon restart on the runtimed
         // fingerprint and child restart on the runt fingerprint, so a
         // rebuild that updates only one triggers only the restart it
@@ -1167,9 +1167,9 @@ impl Supervisor {
             child_changed_by_rebuild = fingerprint_changed(&child_before, &child_after);
             report.push(
                 match (daemon_changed_by_rebuild, child_changed_by_rebuild) {
-                    (true, true) => "rebuild: daemon + runt-cli binaries built".into(),
-                    (true, false) => "rebuild: daemon binary built (runt-cli fresh)".into(),
-                    (false, true) => "rebuild: runt-cli binary built (daemon fresh)".into(),
+                    (true, true) => "rebuild: daemon + runt binaries built".into(),
+                    (true, false) => "rebuild: daemon binary built (runt fresh)".into(),
+                    (false, true) => "rebuild: runt binary built (daemon fresh)".into(),
                     (false, false) => "rebuild: no binary changes (cargo fresh)".into(),
                 },
             );
@@ -1282,9 +1282,9 @@ impl Supervisor {
         // Restart the MCP child when any of:
         //  - child isn't running (can't skip),
         //  - daemon restarted (need fresh child tied to new daemon),
-        //  - runt-cli binary changed (the child IS runt-cli; stale
-        //    bytes otherwise — matches the file-watcher's existing
-        //    rule for `crates/runt-mcp/src/**` changes).
+        //  - runt binary changed (the child IS runt; stale bytes
+        //    otherwise — matches the file-watcher's existing rule for
+        //    `crates/runt-mcp/src/**` changes).
         let child_healthy = {
             let state = self.state.read().await;
             if let Some(ref proxy) = state.proxy {
@@ -1306,7 +1306,7 @@ impl Supervisor {
             match self.restart_child().await {
                 Ok(()) => {
                     let reason = if child_changed_by_rebuild && !needs_daemon_restart {
-                        "child: restarted (runt-cli binary changed)"
+                        "child: restarted (runt binary changed)"
                     } else {
                         "child: restarted"
                     };
@@ -1817,7 +1817,7 @@ impl ServerHandler for Supervisor {
                     state.project_root.clone()
                 };
 
-                // 1. Rebuild daemon binary and CLI (cargo build -p runtimed -p runt-cli)
+                // 1. Rebuild daemon binary and CLI (cargo build -p runtimed -p runt)
                 if !run_cargo_build_daemon(&project_root) {
                     return Ok(CallToolResult::success(vec![Content::text(
                         "cargo build -p runtimed failed — check the supervisor logs for details",
@@ -2013,7 +2013,7 @@ impl ServerHandler for Supervisor {
                     }
                     return Ok(CallToolResult::success(vec![Content::text(format!(
                         "Cannot switch to {mode} mode — missing binaries:\n  {}\n\
-                         Build them first with: cargo build {}-p runtimed -p runt-cli",
+                         Build them first with: cargo build {}-p runtimed -p runt",
                         missing.join("\n  "),
                         profile_flag
                     ))]));
@@ -2273,7 +2273,7 @@ fn classify_change(path: &Path, project_root: &Path) -> Option<ChangeKind> {
         return Some(ChangeKind::RustChanged);
     }
 
-    // Rust MCP server files only (needs cargo build -p runt-cli, no maturin)
+    // Rust MCP server files only (needs cargo build -p runt, no maturin)
     if rel_str.starts_with("crates/runt-mcp/src/") && rel_str.ends_with(".rs") {
         return Some(ChangeKind::RustMcpChanged);
     }
@@ -2562,7 +2562,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let pr = project_root.clone();
                 let build_ok = tokio::task::spawn_blocking(move || {
                     std::process::Command::new("cargo")
-                        .args(["build", "-p", "runt-cli"])
+                        .args(["build", "-p", "runt"])
                         .current_dir(&pr)
                         .status()
                         .map(|s| s.success())
@@ -2617,7 +2617,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await
                 .unwrap_or(false);
             if !build_ok {
-                error!("Failed to build runt-cli — MCP server will not work");
+                error!("Failed to build runt — MCP server will not work");
                 child_ready.notify_waiters();
                 return;
             }

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "runt-cli"
+name = "runt"
 version = "2.3.2"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
@@ -9,10 +9,6 @@ publish = false
 
 [lints]
 workspace = true
-
-[[bin]]
-name = "runt"
-path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/runt/tests/cli.hone
+++ b/crates/runt/tests/cli.hone
@@ -14,7 +14,7 @@ ASSERT stdout contains "Usage: runt [COMMAND]"
 TEST "version flag displays version"
 RUN runt --version
 ASSERT exit_code == 0
-ASSERT stdout matches /runt-cli \d+\.\d+\.\d+/
+ASSERT stdout matches /runt \d+\.\d+\.\d+/
 
 TEST "invalid command fails"
 RUN runt invalid_command

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -807,7 +807,7 @@ fn cmd_build(rust_only: bool) {
             "-p",
             "runtimed",
             "-p",
-            "runt-cli",
+            "runt",
             "-p",
             "nteract-mcp",
             "-p",
@@ -1779,7 +1779,7 @@ fn cmd_mcp(print_config: bool, release: bool) {
     if release {
         println!("Building runtimed (release) for supervisor...");
         run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
-        run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
+        run_cmd("cargo", &["build", "--release", "-p", "runt"]);
     }
 
     if print_config {
@@ -1848,9 +1848,9 @@ fn cmd_mcp(print_config: bool, release: bool) {
 fn cmd_mcp_inspector() {
     require_pnpm();
 
-    // Build runt-cli so it's ready when the inspector spawns it
+    // Build runt so it's ready when the inspector spawns it
     println!("Building runt CLI...");
-    run_cmd("cargo", &["build", "-p", "runt-cli"]);
+    run_cmd("cargo", &["build", "-p", "runt"]);
 
     ensure_pnpm_install();
 
@@ -1921,7 +1921,7 @@ fn cmd_dev_mcp(print_config: bool) {
     // Step 1: Build the runt CLI so we can query daemon status
     if !Path::new(dev_runt_cli_binary()).exists() {
         println!("Building runt CLI...");
-        run_cmd("cargo", &["build", "-p", "runt-cli"]);
+        run_cmd("cargo", &["build", "-p", "runt"]);
     }
 
     // Step 2: Resolve the socket path from the dev daemon
@@ -1935,7 +1935,7 @@ fn cmd_dev_mcp(print_config: bool) {
 
         let output = command.output().unwrap_or_else(|e| {
             eprintln!("Failed to run runt daemon status: {e}");
-            eprintln!("Build the CLI first: cargo build -p runt-cli");
+            eprintln!("Build the CLI first: cargo build -p runt");
             exit(1);
         });
 
@@ -2457,7 +2457,7 @@ fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
 /// If `release` is false, builds in debug mode (faster for development).
 fn build_runtimed_daemon(release: bool) {
     build_external_binary("runtimed", "runtimed", release);
-    build_external_binary("runt-cli", "runt", release);
+    build_external_binary("runt", "runt", release);
     build_external_binary("nteract-mcp", "nteract-mcp", release);
 }
 
@@ -3008,8 +3008,8 @@ fn cmd_sync_tool_cache(check: bool) {
     let manifest_nightly = Path::new("mcpb/manifest.nightly.json");
     let manifest_stable = Path::new("mcpb/manifest.stable.json");
 
-    eprintln!("Building runt-cli (release)...");
-    run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
+    eprintln!("Building runt (release)...");
+    run_cmd("cargo", &["build", "--release", "-p", "runt"]);
 
     eprintln!("Dumping tool list from runt mcp...");
     let runt_bin = Path::new("target/release/runt");

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
             export TAURI_ENV_DEBUG=false
 
             # Build sidecar binaries (Tauri checks for these during notebook compilation)
-            cargo build --release -p runtimed -p runt-cli
+            cargo build --release -p runtimed -p runt
 
             TARGET=$(rustc --print host-tuple)
             mkdir -p crates/notebook/binaries

--- a/scripts/install-nightly
+++ b/scripts/install-nightly
@@ -31,9 +31,9 @@ SERVICE_UNIT="$SERVICE_NAME.service"
 
 echo "=== install-nightly ==="
 
-echo "Building runtimed, runt-cli, nteract-mcp (release, channel=nightly)..."
+echo "Building runtimed, runt, nteract-mcp (release, channel=nightly)..."
 RUNT_BUILD_CHANNEL=nightly cargo build --release \
-  -p runtimed -p runt-cli -p nteract-mcp
+  -p runtimed -p runt -p nteract-mcp
 
 mkdir -p "$INSTALL_DIR" "$SERVICE_DIR"
 


### PR DESCRIPTION
The crate was named `runt-cli` but ships a binary named `runt`, and users invoke it as `runt` / `runt-nightly`. The `-cli` suffix added noise to `cargo build -p runt-cli` and made `runt --version` print `runt-cli 2.3.2` instead of `runt 2.3.2`. This renames the package to match the tool.

## What changed

- `crates/runt/Cargo.toml`: `name = "runt-cli"` → `name = "runt"`. Dropped the redundant `[[bin]]` block since the default binary name now matches the package.
- Every `cargo build -p runt-cli` / `cargo run -p runt-cli` call updated: `crates/xtask/src/main.rs`, `crates/mcp-supervisor/src/main.rs`, `bin/runt`, `scripts/install-nightly`, `flake.nix`.
- Docs updated to match: `AGENTS.md` (hot-reload section, workspace crate row, MCP server section), `RELEASING.md`, `contributing/{runtimed,development,build-dependencies,releasing,testing}.md`, `.claude/rules/mcp-servers.md`, `.claude/skills/{build-system,releasing}/SKILL.md`.
- Hone CLI test and its mirror in `contributing/testing.md` now expect the new `runt X.Y.Z` version prefix.

## Not changed

- Directory stays at `crates/runt/`.
- Binary name stays `runt` (Cargo defaults to the package name now that the explicit `[[bin]]` block is gone).
- `publish = false` still holds.
- Historical `docs/superpowers/**` plans are left alone so the historical record remains accurate.

## Verification

- `cargo build -p runt`, `cargo build -p runtimed -p runt -p mcp-supervisor` succeed.
- `./target/debug/runt --version` prints `runt 2.3.2+c89c222+dirty`.
- `cargo test -p runt` - 5 passing.
- `cargo test -p mcp-supervisor` - 14 passing (including the `managed_binary_fingerprints_tracks_daemon_and_runt_independently` test).
- `cargo xtask lint` passes (Rust fmt + clippy, TS, Python).
- `rg 'runt-cli'` on the tree returns only historical `docs/superpowers/` specs.
