### PR TITLE
perf(build): link macOS arm64 through lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,11 @@ runt = "run --package runt-cli --"
 
 [env]
 TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }
+
+# macOS arm64 developers link through LLVM's lld. Install with
+# `brew install lld` (provides ld64.lld). Apple's system ld also works;
+# switch to it by removing the rustflag locally. Intel and Linux targets
+# keep their platform defaults until we have measurements that justify
+# changing them.
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,16 @@ echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path
 which runt                      # Should be repo/bin/runt (not /usr/local/bin/runt)
 ```
 
+### lld linker (macOS arm64)
+
+`.cargo/config.toml` links macOS arm64 builds through LLVM's `lld`. Install it once:
+
+```bash
+brew install lld
+```
+
+Without it, `cargo build` on arm64 Macs fails at link time. The rustflag is scoped to `aarch64-apple-darwin`; Intel and Linux use their platform defaults.
+
 ### MCP Server Configuration
 
 **Three MCP servers** should be configured:


### PR DESCRIPTION
macOS arm64 developers link through LLVM's `lld`. Apple's system `ld` still works and can be selected locally by removing the rustflag.

## Measured

Incremental `cargo build -p notebook` after touching `src/lib.rs`:

| Linker | Wall |
|--------|------|
| Apple `ld` | 9.08s |
| `lld` | 5.94s |

35% faster per edit on the Tauri app crate, which re-links on any Rust change in the app shell. Full `cargo xtask build-app` completes cleanly, producing an ad-hoc-signed `nteract.app` with all four sidecars in place.

## Scope

Scoped to `aarch64-apple-darwin` only. Intel Macs and Linux keep their platform defaults until we have measurements to justify a change.

## Setup

Requires `brew install lld`. AGENTS.md notes the dependency. Without it, `cargo build` on arm64 Macs fails at link time.

## Follow-up

`.cargo/` is gitignored but `.cargo/config.toml` is tracked (it predates the ignore rule). Adding anything else under `.cargo/` needs `git add -f`. Worth a separate cleanup - probably narrowing the rule to `/target` inside `.cargo/` rather than the whole directory.
