### PR TITLE
feat(runtime-doc): scaffold ProjectContext on RuntimeStateDoc

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -48,6 +48,19 @@
 //!   trust/
 //!     status: Str          ("trusted" | "untrusted" | "signature_invalid" | "no_dependencies")
 //!     needs_approval: bool
+//!   project_context/         Map (daemon-observed project-file context)
+//!     state: Str              ("pending" | "not_found" | "detected" | "unreadable")
+//!     observed_at: Str        (ISO timestamp, "" when state == "pending")
+//!     kind: Str               ("pyproject_toml" | "pixi_toml" | "environment_yml"; "" unless state == "detected")
+//!     absolute_path: Str      ("" unless state == "detected")
+//!     relative_to_notebook: Str ("" unless state == "detected")
+//!     unreadable_path: Str    ("" unless state == "unreadable")
+//!     unreadable_reason: Str  ("" unless state == "unreadable")
+//!     parsed/                 Map (present when state == "detected")
+//!       dependencies: List[Str]
+//!       requires_python: Str|null
+//!       prerelease: Str|null
+//!       extras: Str           (JSON-encoded ProjectFileExtras)
 //!   display_index/          Map (keyed by display_id)
 //!     {display_id}: List[Str]  (entries: "execution_id\0output_id")
 //!   comms/                 Map (keyed by comm_id)
@@ -69,7 +82,10 @@ use automerge::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{KernelActivity, KernelErrorReason, RuntimeLifecycle, StreamOutputState};
+use crate::{
+    KernelActivity, KernelErrorReason, ProjectContext, ProjectFile, ProjectFileExtras,
+    ProjectFileKind, ProjectFileParsed, RuntimeLifecycle, StreamOutputState,
+};
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -354,6 +370,9 @@ impl RuntimeStateDoc {
         doc.put(&trust, "needs_approval", false)
             .expect("scaffold trust.needs_approval");
 
+        // project_context/ — daemon-observed project-file context
+        scaffold_project_context(&mut doc);
+
         // comms/ — keyed by comm_id, tracks widget state
         doc.put_object(&ROOT, "comms", ObjType::Map)
             .expect("scaffold comms");
@@ -441,6 +460,8 @@ impl RuntimeStateDoc {
             .expect("scaffold trust.status");
         doc.put(&trust, "needs_approval", false)
             .expect("scaffold trust.needs_approval");
+
+        scaffold_project_context(&mut doc);
 
         doc.put_object(&ROOT, "comms", ObjType::Map)
             .expect("scaffold comms");
@@ -1742,6 +1763,161 @@ impl RuntimeStateDoc {
         self.set_optional_str("path", path)
     }
 
+    // ── Project context ─────────────────────────────────────────────
+
+    /// Read the daemon-observed project context.
+    ///
+    /// Falls back to [`ProjectContext::Pending`] when the scaffolded map
+    /// is missing (e.g., a peer that did not run the scaffold) or when
+    /// the `state` tag is unparseable. Clients can treat `Pending` as
+    /// "we haven't heard yet" without distinguishing the two cases.
+    pub fn project_context(&self) -> ProjectContext {
+        let Some(pc) = self.get_map("project_context") else {
+            return ProjectContext::Pending;
+        };
+        let state = self.read_str(&pc, "state");
+        match state.as_str() {
+            "pending" | "" => ProjectContext::Pending,
+            "not_found" => ProjectContext::NotFound {
+                observed_at: self.read_str(&pc, "observed_at"),
+            },
+            "detected" => {
+                let kind = ProjectFileKind::parse(&self.read_str(&pc, "kind"))
+                    .unwrap_or(ProjectFileKind::PyprojectToml);
+                ProjectContext::Detected {
+                    project_file: ProjectFile {
+                        kind,
+                        absolute_path: self.read_str(&pc, "absolute_path"),
+                        relative_to_notebook: self.read_str(&pc, "relative_to_notebook"),
+                    },
+                    parsed: self.read_project_file_parsed(&pc),
+                    observed_at: self.read_str(&pc, "observed_at"),
+                }
+            }
+            "unreadable" => ProjectContext::Unreadable {
+                path: self.read_str(&pc, "unreadable_path"),
+                reason: self.read_str(&pc, "unreadable_reason"),
+                observed_at: self.read_str(&pc, "observed_at"),
+            },
+            _ => ProjectContext::Pending,
+        }
+    }
+
+    /// Write the daemon-observed project context.
+    ///
+    /// The daemon is the sole writer; no concurrent writers target this
+    /// key. All state fields are scalars except `parsed`, which we treat
+    /// as an atomic replace — the daemon writes the whole snapshot each
+    /// time it refreshes.
+    pub fn set_project_context(&mut self, ctx: &ProjectContext) -> Result<(), RuntimeStateError> {
+        let pc = self.scaffold_map("project_context")?;
+
+        self.doc.put(&pc, "state", ctx.variant_str())?;
+
+        // Clear every optional field, then fill per-variant. Keeps the
+        // scaffold shape stable regardless of which state we came from.
+        self.doc.put(&pc, "observed_at", "")?;
+        self.doc.put(&pc, "kind", "")?;
+        self.doc.put(&pc, "absolute_path", "")?;
+        self.doc.put(&pc, "relative_to_notebook", "")?;
+        self.doc.put(&pc, "unreadable_path", "")?;
+        self.doc.put(&pc, "unreadable_reason", "")?;
+        self.clear_project_file_parsed(&pc)?;
+
+        match ctx {
+            ProjectContext::Pending => {}
+            ProjectContext::NotFound { observed_at } => {
+                self.doc.put(&pc, "observed_at", observed_at.as_str())?;
+            }
+            ProjectContext::Detected {
+                project_file,
+                parsed,
+                observed_at,
+            } => {
+                self.doc.put(&pc, "observed_at", observed_at.as_str())?;
+                self.doc.put(&pc, "kind", project_file.kind.as_str())?;
+                self.doc
+                    .put(&pc, "absolute_path", project_file.absolute_path.as_str())?;
+                self.doc.put(
+                    &pc,
+                    "relative_to_notebook",
+                    project_file.relative_to_notebook.as_str(),
+                )?;
+                self.write_project_file_parsed(&pc, parsed)?;
+            }
+            ProjectContext::Unreadable {
+                path,
+                reason,
+                observed_at,
+            } => {
+                self.doc.put(&pc, "observed_at", observed_at.as_str())?;
+                self.doc.put(&pc, "unreadable_path", path.as_str())?;
+                self.doc.put(&pc, "unreadable_reason", reason.as_str())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_project_file_parsed(&self, pc: &automerge::ObjId) -> ProjectFileParsed {
+        let parsed_obj = match self.doc.get(pc, "parsed").ok().flatten() {
+            Some((Value::Object(ObjType::Map), id)) => id,
+            _ => return ProjectFileParsed::default(),
+        };
+        let dependencies = self.read_str_list(&parsed_obj, "dependencies");
+        let requires_python = self.read_opt_str(&parsed_obj, "requires_python");
+        let prerelease = self.read_opt_str(&parsed_obj, "prerelease");
+        let extras_json = self.read_str(&parsed_obj, "extras");
+        let extras = if extras_json.is_empty() {
+            ProjectFileExtras::None
+        } else {
+            serde_json::from_str(&extras_json).unwrap_or(ProjectFileExtras::None)
+        };
+        ProjectFileParsed {
+            dependencies,
+            requires_python,
+            prerelease,
+            extras,
+        }
+    }
+
+    fn write_project_file_parsed(
+        &mut self,
+        pc: &automerge::ObjId,
+        parsed: &ProjectFileParsed,
+    ) -> Result<(), RuntimeStateError> {
+        let obj = self.doc.put_object(pc, "parsed", ObjType::Map)?;
+        let deps_list = self.doc.put_object(&obj, "dependencies", ObjType::List)?;
+        for (i, dep) in parsed.dependencies.iter().enumerate() {
+            self.doc.insert(&deps_list, i, dep.as_str())?;
+        }
+        match parsed.requires_python.as_deref() {
+            Some(s) => self.doc.put(&obj, "requires_python", s)?,
+            None => self.doc.put(&obj, "requires_python", ScalarValue::Null)?,
+        }
+        match parsed.prerelease.as_deref() {
+            Some(s) => self.doc.put(&obj, "prerelease", s)?,
+            None => self.doc.put(&obj, "prerelease", ScalarValue::Null)?,
+        }
+        let extras_json = serde_json::to_string(&parsed.extras).unwrap_or_else(|_| "{}".into());
+        self.doc.put(&obj, "extras", extras_json.as_str())?;
+        Ok(())
+    }
+
+    fn clear_project_file_parsed(
+        &mut self,
+        pc: &automerge::ObjId,
+    ) -> Result<(), RuntimeStateError> {
+        // Replace the `parsed` child with a fresh empty map. Single-writer
+        // invariant on project_context means this put_object is safe.
+        let obj = self.doc.put_object(pc, "parsed", ObjType::Map)?;
+        self.doc.put_object(&obj, "dependencies", ObjType::List)?;
+        self.doc.put(&obj, "requires_python", ScalarValue::Null)?;
+        self.doc.put(&obj, "prerelease", ScalarValue::Null)?;
+        self.doc.put(&obj, "extras", "")?;
+        Ok(())
+    }
+
     fn set_optional_str(
         &mut self,
         key: &'static str,
@@ -2349,6 +2525,43 @@ impl RuntimeStateDoc {
             foreign_comms: Some(foreign_comms),
         })
     }
+}
+
+/// Scaffold the `project_context` map in a fresh doc.
+///
+/// All scalar fields start empty; `state` starts at `"pending"`. The
+/// daemon is the sole writer in production; clients rely on sync to
+/// populate the real values.
+#[allow(clippy::expect_used)]
+fn scaffold_project_context(doc: &mut AutoCommit) {
+    let pc = doc
+        .put_object(&ROOT, "project_context", ObjType::Map)
+        .expect("scaffold project_context");
+    doc.put(&pc, "state", "pending")
+        .expect("scaffold project_context.state");
+    doc.put(&pc, "observed_at", "")
+        .expect("scaffold project_context.observed_at");
+    doc.put(&pc, "kind", "")
+        .expect("scaffold project_context.kind");
+    doc.put(&pc, "absolute_path", "")
+        .expect("scaffold project_context.absolute_path");
+    doc.put(&pc, "relative_to_notebook", "")
+        .expect("scaffold project_context.relative_to_notebook");
+    doc.put(&pc, "unreadable_path", "")
+        .expect("scaffold project_context.unreadable_path");
+    doc.put(&pc, "unreadable_reason", "")
+        .expect("scaffold project_context.unreadable_reason");
+    let parsed = doc
+        .put_object(&pc, "parsed", ObjType::Map)
+        .expect("scaffold project_context.parsed");
+    doc.put_object(&parsed, "dependencies", ObjType::List)
+        .expect("scaffold project_context.parsed.dependencies");
+    doc.put(&parsed, "requires_python", ScalarValue::Null)
+        .expect("scaffold project_context.parsed.requires_python");
+    doc.put(&parsed, "prerelease", ScalarValue::Null)
+        .expect("scaffold project_context.parsed.prerelease");
+    doc.put(&parsed, "extras", "")
+        .expect("scaffold project_context.parsed.extras");
 }
 
 /// Result of [`RuntimeStateDoc::receive_sync_and_foreign_comms`].
@@ -5045,6 +5258,156 @@ mod tests {
         assert_eq!(
             doc.read_state().kernel.lifecycle,
             RuntimeLifecycle::Launching
+        );
+        Ok(())
+    }
+
+    // ── Project context ─────────────────────────────────────────────
+
+    #[test]
+    fn project_context_scaffolds_as_pending() {
+        let doc = RuntimeStateDoc::new();
+        assert_eq!(doc.project_context(), ProjectContext::Pending);
+    }
+
+    #[test]
+    fn project_context_new_with_actor_scaffolds_as_pending() {
+        let doc = RuntimeStateDoc::new_with_actor("test-actor");
+        assert_eq!(doc.project_context(), ProjectContext::Pending);
+    }
+
+    #[test]
+    fn project_context_new_empty_is_pending_without_scaffold() {
+        // new_empty() doesn't scaffold at all. Readers should treat the
+        // missing map as Pending rather than panicking.
+        let doc = RuntimeStateDoc::new_empty();
+        assert_eq!(doc.project_context(), ProjectContext::Pending);
+    }
+
+    #[test]
+    fn project_context_round_trips_not_found() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        let ctx = ProjectContext::NotFound {
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        doc.set_project_context(&ctx)?;
+        assert_eq!(doc.project_context(), ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn project_context_round_trips_detected_pyproject() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        let ctx = ProjectContext::Detected {
+            project_file: ProjectFile {
+                kind: ProjectFileKind::PyprojectToml,
+                absolute_path: "/abs/pyproject.toml".into(),
+                relative_to_notebook: "../pyproject.toml".into(),
+            },
+            parsed: ProjectFileParsed {
+                dependencies: vec!["pandas>=2.0".into(), "numpy".into()],
+                requires_python: Some(">=3.10".into()),
+                prerelease: None,
+                extras: ProjectFileExtras::None,
+            },
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        doc.set_project_context(&ctx)?;
+        assert_eq!(doc.project_context(), ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn project_context_round_trips_detected_pixi_with_extras() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        let ctx = ProjectContext::Detected {
+            project_file: ProjectFile {
+                kind: ProjectFileKind::PixiToml,
+                absolute_path: "/abs/pixi.toml".into(),
+                relative_to_notebook: "pixi.toml".into(),
+            },
+            parsed: ProjectFileParsed {
+                dependencies: vec!["python=3.11".into()],
+                requires_python: None,
+                prerelease: None,
+                extras: ProjectFileExtras::Pixi {
+                    channels: vec!["conda-forge".into()],
+                    pypi_dependencies: vec!["requests".into()],
+                },
+            },
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        doc.set_project_context(&ctx)?;
+        assert_eq!(doc.project_context(), ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn project_context_round_trips_detected_environment_yml_with_pip(
+    ) -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        let ctx = ProjectContext::Detected {
+            project_file: ProjectFile {
+                kind: ProjectFileKind::EnvironmentYml,
+                absolute_path: "/abs/environment.yml".into(),
+                relative_to_notebook: "../environment.yml".into(),
+            },
+            parsed: ProjectFileParsed {
+                dependencies: vec!["numpy".into(), "scipy".into()],
+                requires_python: None,
+                prerelease: None,
+                extras: ProjectFileExtras::EnvironmentYml {
+                    pip: vec!["httpx".into()],
+                },
+            },
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        doc.set_project_context(&ctx)?;
+        assert_eq!(doc.project_context(), ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn project_context_round_trips_unreadable() -> Result<(), RuntimeStateError> {
+        let mut doc = RuntimeStateDoc::new();
+        let ctx = ProjectContext::Unreadable {
+            path: "/abs/pyproject.toml".into(),
+            reason: "parse error at line 3".into(),
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        doc.set_project_context(&ctx)?;
+        assert_eq!(doc.project_context(), ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn project_context_transitions_clear_previous_fields() -> Result<(), RuntimeStateError> {
+        // Write Detected, then NotFound. The Detected-specific fields
+        // (kind, absolute_path, parsed.dependencies, ...) must all clear
+        // so the subsequent read doesn't show ghost data.
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_project_context(&ProjectContext::Detected {
+            project_file: ProjectFile {
+                kind: ProjectFileKind::PyprojectToml,
+                absolute_path: "/abs/pyproject.toml".into(),
+                relative_to_notebook: "../pyproject.toml".into(),
+            },
+            parsed: ProjectFileParsed {
+                dependencies: vec!["pandas".into()],
+                requires_python: Some(">=3.10".into()),
+                prerelease: None,
+                extras: ProjectFileExtras::None,
+            },
+            observed_at: "t0".into(),
+        })?;
+        doc.set_project_context(&ProjectContext::NotFound {
+            observed_at: "t1".into(),
+        })?;
+        assert_eq!(
+            doc.project_context(),
+            ProjectContext::NotFound {
+                observed_at: "t1".into(),
+            }
         );
         Ok(())
     }

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -6,6 +6,153 @@ pub struct StreamOutputState {
     pub blob_hash: String,
 }
 
+/// Project file the daemon picked for a notebook, identified by location
+/// and kind. The parsed contents live under [`ProjectFileParsed`], carried
+/// in the same [`ProjectContext::Detected`] state so every sync'd client
+/// sees the same snapshot without an IPC round trip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProjectFileKind {
+    PyprojectToml,
+    PixiToml,
+    EnvironmentYml,
+}
+
+impl ProjectFileKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PyprojectToml => "pyproject_toml",
+            Self::PixiToml => "pixi_toml",
+            Self::EnvironmentYml => "environment_yml",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pyproject_toml" => Some(Self::PyprojectToml),
+            "pixi_toml" => Some(Self::PixiToml),
+            "environment_yml" => Some(Self::EnvironmentYml),
+            _ => None,
+        }
+    }
+}
+
+/// Pointer to a project file on the daemon's disk.
+///
+/// `absolute_path` is the file itself (not its parent). `relative_to_notebook`
+/// is a display-friendly path that clients can render without re-walking
+/// the filesystem - e.g. `"../pyproject.toml"`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectFile {
+    pub kind: ProjectFileKind,
+    pub absolute_path: String,
+    pub relative_to_notebook: String,
+}
+
+/// Parsed snapshot the daemon took when it wrote a [`ProjectContext::Detected`]
+/// entry. Clients treat this as a time-stamped view: the file on disk can drift
+/// when the user edits it externally, and there is no round-trip RPC to refresh
+/// it synchronously. The daemon rewrites the snapshot on notebook open and on
+/// whatever future triggers we add (file watch, save-as).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ProjectFileParsed {
+    /// Declared dependencies, in the form the source file used
+    /// (e.g. `"pandas>=2.0"`, `"numpy"`, `"pip:requests"`).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    /// `requires-python` / Python constraint, when the file carries one.
+    #[serde(default)]
+    pub requires_python: Option<String>,
+    /// uv's `--prerelease` strategy, when configured.
+    #[serde(default)]
+    pub prerelease: Option<String>,
+    /// Kind-specific extras the three formats carry (conda channels,
+    /// environment.yml pip sub-list, pixi PyPI deps, ...).
+    #[serde(default)]
+    pub extras: ProjectFileExtras,
+}
+
+/// Kind-specific parsed fields that do not fit the common shape.
+///
+/// Kept as a tagged enum so each variant only names fields it actually owns,
+/// and adding a future kind (e.g. `conda-lock.yml`) is a closed-enum extension.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum ProjectFileExtras {
+    /// pyproject.toml has no kind-specific extras today.
+    #[default]
+    None,
+    /// pixi-specific fields parsed out of `pixi.toml`.
+    Pixi {
+        #[serde(default)]
+        channels: Vec<String>,
+        /// Dependencies under `[pypi-dependencies]`, kept separate from
+        /// conda-style entries under `dependencies`.
+        #[serde(default)]
+        pypi_dependencies: Vec<String>,
+    },
+    /// `environment.yml` carries a pip sub-list that is not a conda dep.
+    EnvironmentYml {
+        #[serde(default)]
+        pip: Vec<String>,
+    },
+}
+
+/// Daemon-observed project context for a notebook. Written by the daemon
+/// on notebook open and on any future refresh triggers we wire up. Clients
+/// read; the frontend in particular reads this in place of walking the
+/// filesystem itself.
+///
+/// Lifetime lines up with the enclosing [`RuntimeStateDoc`]: the field
+/// survives kernel death. It goes stale when the notebook file moves on
+/// disk, which the daemon does not currently re-walk for. The `observed_at`
+/// timestamp lets clients honestly surface "as of T" rather than imply
+/// live truth.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state")]
+pub enum ProjectContext {
+    /// Daemon has not walked yet. Initial state after notebook open and
+    /// the state clients see before the first daemon write arrives via sync.
+    #[default]
+    Pending,
+
+    /// Daemon walked, no project file in any parent directory.
+    NotFound {
+        /// When the daemon last confirmed "nothing here."
+        observed_at: String,
+    },
+
+    /// Daemon walked and found a project file. `parsed` is the snapshot
+    /// taken when this entry was written; `observed_at` is the truth
+    /// timestamp.
+    Detected {
+        project_file: ProjectFile,
+        parsed: ProjectFileParsed,
+        observed_at: String,
+    },
+
+    /// Daemon walked, a file was there, but parsing failed. Distinct
+    /// from `NotFound` so the UI can surface "your pyproject.toml is
+    /// malformed" instead of silently showing nothing.
+    Unreadable {
+        path: String,
+        reason: String,
+        observed_at: String,
+    },
+}
+
+impl ProjectContext {
+    /// Variant name as a static string. Written to the CRDT `state` key
+    /// and consumed by [`parse`](Self::parse) when reading.
+    pub fn variant_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::NotFound { .. } => "not_found",
+            Self::Detected { .. } => "detected",
+            Self::Unreadable { .. } => "unreadable",
+        }
+    }
+}
+
 /// Observable activity of a running kernel.
 ///
 /// Only meaningful when the runtime lifecycle is [`RuntimeLifecycle::Running`].
@@ -516,5 +663,124 @@ mod tests {
             resolve_lifecycle("Running", "Idle", "idle", ""),
             RuntimeLifecycle::Running(KernelActivity::Idle)
         );
+    }
+
+    // ── ProjectFileKind ─────────────────────────────────────────────
+
+    #[test]
+    fn project_file_kind_as_str_round_trips_through_parse() {
+        let kinds = [
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+        for k in kinds {
+            assert_eq!(ProjectFileKind::parse(k.as_str()), Some(k));
+        }
+    }
+
+    #[test]
+    fn project_file_kind_rejects_unknown_strings() {
+        assert_eq!(ProjectFileKind::parse(""), None);
+        assert_eq!(ProjectFileKind::parse("PyprojectToml"), None); // case sensitive
+        assert_eq!(ProjectFileKind::parse("bogus"), None);
+    }
+
+    // ── ProjectContext default / variant_str ────────────────────────
+
+    #[test]
+    fn project_context_default_is_pending() {
+        assert_eq!(ProjectContext::default(), ProjectContext::Pending);
+    }
+
+    #[test]
+    fn project_context_variant_str() {
+        assert_eq!(ProjectContext::Pending.variant_str(), "pending");
+        assert_eq!(
+            ProjectContext::NotFound {
+                observed_at: "t".into(),
+            }
+            .variant_str(),
+            "not_found"
+        );
+        assert_eq!(
+            ProjectContext::Detected {
+                project_file: ProjectFile {
+                    kind: ProjectFileKind::PyprojectToml,
+                    absolute_path: "/abs/pyproject.toml".into(),
+                    relative_to_notebook: "../pyproject.toml".into(),
+                },
+                parsed: ProjectFileParsed::default(),
+                observed_at: "t".into(),
+            }
+            .variant_str(),
+            "detected"
+        );
+        assert_eq!(
+            ProjectContext::Unreadable {
+                path: "/abs/pyproject.toml".into(),
+                reason: "parse error".into(),
+                observed_at: "t".into(),
+            }
+            .variant_str(),
+            "unreadable"
+        );
+    }
+
+    // ── ProjectContext serde round-trip ─────────────────────────────
+
+    #[test]
+    fn project_context_serde_tagged_round_trip() -> Result<(), serde_json::Error> {
+        let detected = ProjectContext::Detected {
+            project_file: ProjectFile {
+                kind: ProjectFileKind::PyprojectToml,
+                absolute_path: "/abs/pyproject.toml".into(),
+                relative_to_notebook: "../pyproject.toml".into(),
+            },
+            parsed: ProjectFileParsed {
+                dependencies: vec!["pandas>=2.0".into(), "numpy".into()],
+                requires_python: Some(">=3.10".into()),
+                prerelease: None,
+                extras: ProjectFileExtras::None,
+            },
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&detected)?;
+        assert!(json.contains(r#""state":"Detected""#));
+        let back: ProjectContext = serde_json::from_str(&json)?;
+        assert_eq!(back, detected);
+
+        let not_found = ProjectContext::NotFound {
+            observed_at: "2026-04-25T12:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&not_found)?;
+        assert!(json.contains(r#""state":"NotFound""#));
+        let back: ProjectContext = serde_json::from_str(&json)?;
+        assert_eq!(back, not_found);
+
+        let pending = ProjectContext::Pending;
+        let json = serde_json::to_string(&pending)?;
+        assert_eq!(json, r#"{"state":"Pending"}"#);
+        let back: ProjectContext = serde_json::from_str(&json)?;
+        assert_eq!(back, pending);
+
+        Ok(())
+    }
+
+    #[test]
+    fn project_file_extras_pixi_round_trip() -> Result<(), serde_json::Error> {
+        let extras = ProjectFileExtras::Pixi {
+            channels: vec!["conda-forge".into()],
+            pypi_dependencies: vec!["requests".into()],
+        };
+        let json = serde_json::to_string(&extras)?;
+        let back: ProjectFileExtras = serde_json::from_str(&json)?;
+        assert_eq!(back, extras);
+        Ok(())
+    }
+
+    #[test]
+    fn project_file_extras_default_is_none_variant() {
+        assert_eq!(ProjectFileExtras::default(), ProjectFileExtras::None);
     }
 }


### PR DESCRIPTION
First commit on #2208. Introduces the types and CRDT schema for daemon-observed project-file context. Nothing writes the field in production yet; that lands in the next PR.

## Schema additions on RuntimeStateDoc

```text
project_context/
  state: Str                     ("pending" | "not_found" | "detected" | "unreadable")
  observed_at: Str               (ISO timestamp, "" when pending)
  kind: Str                      ("pyproject_toml" | "pixi_toml" | "environment_yml"; "" unless detected)
  absolute_path: Str             ("" unless detected)
  relative_to_notebook: Str      ("" unless detected)
  unreadable_path: Str           ("" unless unreadable)
  unreadable_reason: Str         ("" unless unreadable)
  parsed/                        (present when detected)
    dependencies: List[Str]
    requires_python: Str|null
    prerelease: Str|null
    extras: Str                  (JSON-encoded ProjectFileExtras)
```

## Rust types

`runtime-doc` gains:

- `ProjectContext` enum (`Pending | NotFound | Detected | Unreadable`)
- `ProjectFileKind` enum (`PyprojectToml | PixiToml | EnvironmentYml`)
- `ProjectFile { kind, absolute_path, relative_to_notebook }`
- `ProjectFileParsed { dependencies, requires_python, prerelease, extras }`
- `ProjectFileExtras` tagged enum for kind-specific fields (`Pixi { channels, pypi_dependencies }`, `EnvironmentYml { pip }`, `None`)

`RuntimeStateDoc` picks up `project_context()` / `set_project_context()`.

## Design call: why RuntimeStateDoc

RuntimeStateDoc is the daemon-authoritative Automerge doc for a notebook. The daemon is the sole writer for nearly every field; comms are the known exception where the frontend also writes. NotebookDoc is authored by the frontend (cells, cell metadata, notebook metadata), so a daemon-written field does not belong there.

The word "runtime" in the doc name undersells what it carries. Trust, last-saved timestamp, env drift, notebook path, the captured env directory that survives kernel death - all daemon-observed notebook state. `project_context` is the same shape, so it sits alongside them.

When the kernel dies, `reset_starting_state` flips `kernel/lifecycle` to `NotStarted` and clears `prewarmed_packages`. Everything else persists. `project_context` survives kernel death for free.

## Design call: transitions clear previous fields

The setter zeroes every variant-specific field before writing the new state. A `Detected -> NotFound` flip has to leave `kind`, `absolute_path`, `parsed.dependencies` empty or the reader would pick up ghost data from the earlier state. The round-trip test `project_context_transitions_clear_previous_fields` locks this in.

## Design call: single writer

The daemon is the only writer. Scaffolding happens in `new()` and `new_with_actor()` where the daemon owns the doc. `new_empty()` - used by clients - does not scaffold; the reader returns `Pending` via an empty-doc fallback. Two peers calling `put_object` on the same key produce conflicting Automerge objects, and the "one peer creates, others receive via sync" invariant is in the high-risk architecture docs for exactly this reason.

## Behavioral coverage

- Fresh `new()` / `new_with_actor()` reads as `Pending`
- `new_empty()` (client-side) reads as `Pending` without scaffolding
- Round-trip each variant: `NotFound`, `Detected` (pyproject), `Detected` (pixi with channels + pypi deps), `Detected` (environment.yml with pip list), `Unreadable`
- `Detected -> NotFound` transition zeroes `kind`, `absolute_path`, and the `parsed` sub-map
- Unit tests in `types.rs` round-trip each type through serde and confirm `ProjectContext::default() == Pending`

## Not in this PR

- Daemon writes on notebook open (commit 2)
- App-side reads (post-regroup per #2208)
- Architecture-docs update to honestly describe RuntimeStateDoc ownership (follow-up)
