### PR TITLE
perf(dx): supervisor stops rebuilding behind the user's back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` fo
 
 ### MCP Server
 
-`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload.
+`nteract-dev` proxies the Rust-native `runt mcp` server (direct Automerge access, no Python overhead). It auto-builds `runt` on startup. Source edits don't trigger rebuilds by default; use `up rebuild=true` to pick up changes to the daemon or Python bindings.
 
 `runt mcp` can also be run standalone (no proxy): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
 
@@ -363,13 +363,17 @@ When `nteract-dev` is active, agents also get the full nteract tool suite. **Use
 
 **Audit workflow example:** After modifying daemon or kernel code, use `connect_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
 
-### Hot reload
+### Rebuilding
 
-`nteract-dev` watches source directories and auto-restarts the child on changes:
-- **`crates/runt-mcp/src/`** → `cargo build -p runt` + restart (Rust MCP mode)
-- **`crates/runtimed-client/src/`** → `cargo build -p runt` + `maturin develop` + restart (shared code)
-- **`crates/runtimed-py/src/`, `crates/runtimed/src/`** → `maturin develop` + `cargo build` + restart
-- **`python/nteract/src/`, `python/runtimed/src/`** → child restart (Python mode) or background `maturin develop` (Rust mode)
+The supervisor does not watch source files. Rebuild on demand:
+
+- **Rust or Python bindings changed** → `up rebuild=true`. Rebuilds `runt` and runs `maturin develop`, then restarts the child.
+- **Only the MCP server itself changed** (`crates/runt-mcp/src/`) → `up rebuild=true` covers this too.
+- **Daemon source changed** → `up rebuild=true`, optionally with `daemon=true` to bounce the daemon as well.
+
+If you want the old always-on file watcher, set `NTERACT_DEV_WATCH=1` in the supervisor's environment. It's off by default because every source touch kicked `cargo build` + `maturin develop`, which churned sccache keys across the workspace and put the Rust cache-hit rate near zero during normal edits.
+
+`SKIP_MATURIN=1` (already set in `.mcp.json`) tells `up rebuild=true` to skip the maturin step. Pair it with `NTERACT_DEV_AUTOMATURIN=1` only if you want the startup-probe reintroduced; by default the supervisor starts without touching Python bindings.
 
 ### Tool availability
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2628,14 +2628,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
 
-        // Ensure maturin develop in background (non-blocking, dev workflow only).
-        // File watcher will re-run this when Rust bindings change.
-        let pr = project_root.clone();
-        tokio::task::spawn_blocking(move || {
-            if !ensure_maturin_develop(&pr) {
-                warn!("maturin develop failed — Python bindings may be stale");
-            }
-        });
+        // Python bindings are rebuilt on demand via `up rebuild=true`.
+        // Startup used to probe `import runtimed` and trigger `maturin
+        // develop` in the background; that fired on every session rejoin
+        // and churned sccache keys for the whole runtimed-py dependency
+        // graph. Now the supervisor starts clean and the user opts in
+        // explicitly. `SKIP_MATURIN=1` remains the escape hatch that
+        // also skips the `up rebuild=true` maturin step.
+        if std::env::var("SKIP_MATURIN").unwrap_or_default() != "1"
+            && std::env::var("NTERACT_DEV_AUTOMATURIN").unwrap_or_default() == "1"
+        {
+            let pr = project_root.clone();
+            tokio::task::spawn_blocking(move || {
+                if !ensure_maturin_develop(&pr) {
+                    warn!("maturin develop failed — Python bindings may be stale");
+                }
+            });
+        }
 
         // 2c: Create the MCP proxy and spawn the child
         let mut child_env = std::collections::HashMap::new();
@@ -2706,20 +2715,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             warn!("Failed to send resources/list_changed after init: {e}");
         }
 
-        // 2f: Start file watcher
-        let mut file_change_rx = start_file_watcher(&project_root).unwrap_or_else(|e| {
-            warn!("File watcher failed to start: {e}");
-            mpsc::channel(1).1
-        });
+        // 2f: Start file watcher (opt-in). Off by default. Watching the
+        // six source roots and kicking cargo + maturin on every edit
+        // invalidated sccache keys at a rate that showed up as ~2%
+        // Rust cache-hit rates during normal work. Explicit rebuilds
+        // via `up rebuild=true` keep the cache coherent, match the
+        // existing common flow, and don't surprise a session mid-edit.
+        if std::env::var("NTERACT_DEV_WATCH").unwrap_or_default() == "1" {
+            let mut file_change_rx = start_file_watcher(&project_root).unwrap_or_else(|e| {
+                warn!("File watcher failed to start: {e}");
+                mpsc::channel(1).1
+            });
 
-        // Run the file watcher loop in this task
-        let watcher_supervisor = Supervisor {
-            state: state_for_watcher,
-            child_ready: Arc::new(Notify::new()),
-        };
-        while let Some(change_kind) = file_change_rx.recv().await {
-            info!("File change detected: {change_kind:?}");
-            watcher_supervisor.handle_file_change(change_kind).await;
+            let watcher_supervisor = Supervisor {
+                state: state_for_watcher,
+                child_ready: Arc::new(Notify::new()),
+            };
+            while let Some(change_kind) = file_change_rx.recv().await {
+                info!("File change detected: {change_kind:?}");
+                watcher_supervisor.handle_file_change(change_kind).await;
+            }
+        } else {
+            info!(
+                "File watcher disabled. Set NTERACT_DEV_WATCH=1 to enable; \
+                 otherwise use `up rebuild=true` to rebuild on demand."
+            );
+            // Keep the reference so its Drop doesn't cancel any futures.
+            let _ = state_for_watcher;
         }
     });
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2717,16 +2717,19 @@ fn apply_sccache_env(command: &mut Command) {
     });
     if available {
         command.env("RUSTC_WRAPPER", "sccache");
-        // sccache cannot cache incremental builds — disable it so all
-        // crates are cacheable. Respect an explicit user override.
+        // sccache can't cache incremental builds. Disable it so every
+        // crate is cacheable. Respect an explicit user override.
         if env::var_os("CARGO_INCREMENTAL").is_none() {
             command.env("CARGO_INCREMENTAL", "0");
         }
-        // Default 10 GiB cache is too small when multiple worktrees share it.
-        // Override with SCCACHE_CACHE_SIZE for larger machines.
-        // Takes effect on next sccache-server start (`sccache --stop-server`).
+        // Cap the on-disk cache generously. Multiple worktrees, lld
+        // rustflag rotations, and maturin vs. workspace builds each
+        // occupy their own cache keys; 10 GiB evicts hot entries.
+        // An explicit user override wins. `sccache/config` on disk
+        // wins over this env var when sccache-server is already
+        // running; this is the floor for first-start setups.
         if env::var_os("SCCACHE_CACHE_SIZE").is_none() {
-            command.env("SCCACHE_CACHE_SIZE", "50G");
+            command.env("SCCACHE_CACHE_SIZE", "200G");
         }
     }
 }


### PR DESCRIPTION
The supervisor was doing a lot of unprompted build work. Two surfaces:

1. **File watcher.** Watched six source roots and kicked `cargo build -p runt` (plus `maturin develop` unless `SKIP_MATURIN=1`) on every edit.
2. **Startup probe.** Every supervisor spawn ran `uv run python -c 'import runtimed'` and ran maturin on failure. Not gated on `SKIP_MATURIN`. Every session rejoin paid for it.

Both paths churned sccache keys across the runtimed-py dependency graph for builds that had nothing to do with Python bindings. Normal sessions were seeing Rust cache-hit rates near 2% during active editing.

## New defaults

Both surfaces are opt-in now. `up rebuild=true` is the recommended way to rebuild; it was already the common flow.

| Path | Before | After |
|------|--------|-------|
| File watcher | On | Off by default. Set `NTERACT_DEV_WATCH=1` to restore. |
| Startup maturin probe | On, ungated | Off by default. Set `NTERACT_DEV_AUTOMATURIN=1` to restore. `SKIP_MATURIN=1` still overrides. |
| `up rebuild=true` | Works | Works, unchanged |
| `SCCACHE_CACHE_SIZE` first-start floor | 50G | 200G |

## Why raise the sccache floor

Multiple worktrees, rustflag rotations (e.g. lld vs. system ld), and maturin's target tree vs. the workspace's each occupy their own cache keys. 10G (sccache's default) and even 50G evict hot entries inside a long session. A user's `sccache/config` still wins when the server is already running; this is only the first-start floor for fresh setups.

## What the common flow looks like now

```
# Edit daemon / bindings / mcp server
up rebuild=true          # rebuilds and restarts child

# Only restart child without rebuild
up                       # idempotent
```

`down` / `status` / `logs` / `vite_logs` unchanged.

## Docs

AGENTS.md updated. The "Hot reload" section is now "Rebuilding", describing the explicit flow.
