### PR TITLE
perf(dx): sccache for every cargo invocation + fix cargo runt alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
-runt = "run --package runt-cli --"
+runt = "run --package runt --"
 
 [env]
 TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }

--- a/.envrc
+++ b/.envrc
@@ -7,3 +7,14 @@ PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_DEV=1
+
+# Share sccache + non-incremental across every cargo invocation, not
+# just xtask paths. A direct `cargo check` or `cargo test` otherwise
+# bypasses sccache entirely and uses a different `CARGO_INCREMENTAL`
+# value than xtask, giving the same crate two cache key spaces. Both
+# gated on `has sccache` so contributors without sccache installed
+# still get a working cargo.
+if has sccache; then
+  export RUSTC_WRAPPER=sccache
+  export CARGO_INCREMENTAL=0
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,14 +35,23 @@ The `.envrc` file sets:
 - `PATH_add bin` — adds `bin/runt` wrapper to PATH (shadows system `runt`)
 - `export RUNTIMED_DEV=1` — enables per-worktree daemon isolation
 - `export RUNTIMED_WORKSPACE_PATH="$(pwd)"` — pins daemon to this worktree
+- `export RUSTC_WRAPPER=sccache` (if installed) — routes direct cargo through sccache
+- `export CARGO_INCREMENTAL=0` (if sccache installed) — matches xtask so both share cache keys
 
 **Verify it works:**
 ```bash
 cd /path/to/nteract/desktop
 echo $RUNTIMED_DEV              # Should print "1"
 echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path
+echo $RUSTC_WRAPPER             # Should print "sccache" when sccache is on PATH
 which runt                      # Should be repo/bin/runt (not /usr/local/bin/runt)
 ```
+
+**Install sccache:**
+```bash
+brew install sccache
+```
+Optional but strongly recommended. `cargo xtask` paths already wire sccache in; putting it in `.envrc` makes direct `cargo build` / `cargo check` / `cargo test` share the same cache instead of cold-compiling every crate.
 
 ### lld linker (macOS arm64)
 


### PR DESCRIPTION
Two small DX fixes.

## `cargo runt` alias

After #2206 renamed the `runt-cli` package to `runt`, the `cargo runt` alias in `.cargo/config.toml` kept pointing at the old name. Running `cargo runt` errored with `package(s) runt-cli not found`. Now points at `runt`.

## sccache for direct cargo calls

Only `cargo xtask` paths called `apply_sccache_env` today. Direct shell invocations (`cargo check`, `cargo test`, `cargo build`) skipped sccache entirely and used `CARGO_INCREMENTAL=1` while xtask forced it to 0. Same crate, two disjoint cache key spaces. Rust cache hit rates sat near 1% during normal editing as a result.

`.envrc` now exports when sccache is on PATH:

```bash
if has sccache; then
  export RUSTC_WRAPPER=sccache
  export CARGO_INCREMENTAL=0
fi
```

Contributors without sccache get a working cargo; everyone with sccache gets the cache for free, no matter how they invoke cargo.

`xtask::apply_sccache_env` stays as-is for CI and any path that invokes cargo outside the shell's direnv environment.

## Setup impact

Nothing breaks for existing contributors. If you have sccache, nothing changes except your hit rate goes up. If you don't, `brew install sccache` (documented in AGENTS.md) is optional but strongly suggested. No required setup step.
