### PR TITLE
feat(runt-mcp): enrich session drop errors with cause and notebook_id

### DIFF
--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -25,7 +25,7 @@ use runtimed_client::daemon_connection::{DaemonConnection, DaemonEvent};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
-use crate::session::NotebookSession;
+use crate::session::{NotebookSession, SessionDropInfo, SessionDropReason};
 
 /// Exit code when the daemon has been upgraded and the MCP server should
 /// restart. EX_TEMPFAIL (sysexits.h) — "temporary failure; try again."
@@ -121,6 +121,7 @@ pub async fn watch(
     socket_path: PathBuf,
     session: Arc<RwLock<Option<NotebookSession>>>,
     peer_label: Arc<RwLock<String>>,
+    last_session_drop: Arc<RwLock<Option<SessionDropInfo>>>,
 ) -> i32 {
     let mut rx = daemon_conn.subscribe();
     let mut initial_target: Option<String> = std::env::var(REJOIN_ENV_VAR).ok();
@@ -171,7 +172,14 @@ pub async fn watch(
             }
             WatchDecision::RejoinInitial(target) => {
                 info!("Performing initial rejoin to {target}");
-                let ok = rejoin(&socket_path, &session, &peer_label, Some(target)).await;
+                let ok = rejoin(
+                    &socket_path,
+                    &session,
+                    &peer_label,
+                    &last_session_drop,
+                    Some(target),
+                )
+                .await;
                 // Only clear the disconnect flag and consume the initial
                 // target if rejoin succeeded or the session was explicitly
                 // cleared (room evicted). If rejoin exhausted retries,
@@ -184,7 +192,14 @@ pub async fn watch(
             }
             WatchDecision::RejoinContinuation => {
                 info!("Daemon reachable, rejoining notebook session");
-                let ok = rejoin(&socket_path, &session, &peer_label, None).await;
+                let ok = rejoin(
+                    &socket_path,
+                    &session,
+                    &peer_label,
+                    &last_session_drop,
+                    None,
+                )
+                .await;
                 if ok {
                     was_disconnected = false;
                 }
@@ -229,6 +244,7 @@ async fn rejoin(
     socket_path: &Path,
     session: &Arc<RwLock<Option<NotebookSession>>>,
     peer_label: &Arc<RwLock<String>>,
+    last_session_drop: &Arc<RwLock<Option<SessionDropInfo>>>,
     override_target: Option<String>,
 ) -> bool {
     let (notebook_id, notebook_path) = match override_target {
@@ -264,6 +280,11 @@ async fn rejoin(
                         "Room {notebook_id} no longer exists in daemon; \
                          clearing session (notebook was evicted)"
                     );
+                    *last_session_drop.write().await = Some(SessionDropInfo {
+                        reason: SessionDropReason::Evicted,
+                        notebook_id: notebook_id.clone(),
+                        notebook_path: notebook_path.clone(),
+                    });
                     *session.write().await = None;
                     return true; // Session cleared intentionally
                 }

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -370,6 +370,14 @@ async fn rejoin(
                     tokio::time::sleep(REJOIN_RETRY_DELAY).await;
                 } else {
                     warn!("Rejoin exhausted retries: {e}");
+                    // Record the drop so no_session_error can surface the
+                    // notebook_id and reconnect hint to the agent.
+                    *last_session_drop.write().await = Some(SessionDropInfo {
+                        reason: SessionDropReason::Disconnected,
+                        notebook_id: notebook_id.clone(),
+                        notebook_path: notebook_path.clone(),
+                    });
+                    *session.write().await = None;
                 }
             }
         }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -30,7 +30,7 @@ mod session;
 mod structured;
 pub mod tools;
 
-use session::NotebookSession;
+use session::{NotebookSession, SessionDropInfo};
 
 /// The nteract MCP server.
 pub struct NteractMcp {
@@ -38,6 +38,10 @@ pub struct NteractMcp {
     blob_base_url: Option<String>,
     blob_store_path: Option<PathBuf>,
     session: Arc<RwLock<Option<NotebookSession>>>,
+    /// Context from the most recently dropped session — allows error messages
+    /// to tell agents *why* the session was lost and *which notebook_id* to
+    /// reconnect to, instead of the generic "No active notebook session".
+    last_session_drop: Arc<RwLock<Option<SessionDropInfo>>>,
     /// The MCP client's display name, sniffed from the initialize handshake.
     /// Used as the peer label in notebook sessions so the notebook app shows
     /// "Claude Desktop" or "Claude Code" instead of the default "Inkwell".
@@ -64,6 +68,7 @@ impl NteractMcp {
             blob_base_url,
             blob_store_path,
             session: Arc::new(RwLock::new(None)),
+            last_session_drop: Arc::new(RwLock::new(None)),
             peer_label: Arc::new(RwLock::new("Inkwell".to_string())),
             no_show: false,
             daemon_version: None,
@@ -101,6 +106,11 @@ impl NteractMcp {
     /// Get the shared peer label (for the daemon watcher).
     pub fn peer_label_shared(&self) -> &Arc<RwLock<String>> {
         &self.peer_label
+    }
+
+    /// Get the shared session drop info (for the daemon watcher).
+    pub fn last_session_drop(&self) -> &Arc<RwLock<Option<SessionDropInfo>>> {
+        &self.last_session_drop
     }
 }
 

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -16,3 +16,35 @@ pub struct NotebookSession {
     /// Broadcast receiver for daemon events (execution done, outputs, etc.)
     pub broadcast_rx: BroadcastReceiver,
 }
+
+/// Why the session was dropped. Recorded when the session transitions from
+/// `Some` → `None` so the "no active session" error can tell agents *why*
+/// and *how to recover* instead of a generic message.
+#[derive(Debug, Clone)]
+pub enum SessionDropReason {
+    /// Room was evicted by the daemon (idle timeout).
+    Evicted,
+    /// Agent switched to a different notebook (normal, not an error).
+    Switched,
+    /// Daemon connection was lost and rejoin failed.
+    Disconnected,
+}
+
+impl std::fmt::Display for SessionDropReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Evicted => write!(f, "notebook was evicted (idle timeout)"),
+            Self::Switched => write!(f, "switched to a different notebook"),
+            Self::Disconnected => write!(f, "daemon connection lost"),
+        }
+    }
+}
+
+/// Context from the most recently dropped session — enough for the error
+/// message to tell the agent what happened and how to recover.
+#[derive(Debug, Clone)]
+pub struct SessionDropInfo {
+    pub reason: SessionDropReason,
+    pub notebook_id: String,
+    pub notebook_path: Option<String>,
+}

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -192,16 +192,16 @@ pub async fn add_dependency(
     // Detect list-like strings agents sometimes pass and split them.
     let packages = parse_package_param(raw_package);
 
-    let (handle, notebook_id) =
-        {
-            let guard = server.session.read().await;
-            match guard.as_ref() {
-                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-                None => return tool_error(
-                    "No active notebook session. Call connect_notebook or create_notebook first.",
-                ),
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                drop(guard);
+                return super::no_session_error(server).await;
             }
-        };
+        }
+    };
 
     let manager = detect_package_manager(&handle);
 

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -34,16 +34,16 @@ pub async fn restart_kernel(
     server: &NteractMcp,
     _request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let (handle, notebook_id) =
-        {
-            let guard = server.session.read().await;
-            match guard.as_ref() {
-                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-                None => return tool_error(
-                    "No active notebook session. Call connect_notebook or create_notebook first.",
-                ),
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                drop(guard);
+                return super::no_session_error(server).await;
             }
-        };
+        }
+    };
 
     // Capture kernel_type from the *current* RuntimeState before shutdown.
     // After a daemon restart the fresh RuntimeStateDoc has kernel.name = "",

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -11,15 +11,18 @@ use crate::NteractMcp;
 
 /// Acquire the active session's `DocHandle`, or early-return a "no session" tool error.
 /// Clones the handle and drops the session read-lock so other tools aren't blocked.
+///
+/// When the session was previously active but dropped, the error includes
+/// the *reason* (evicted, disconnected, switched) and the *notebook_id*
+/// so agents can recover in one turn via `connect_notebook`.
 macro_rules! require_handle {
     ($server:expr) => {{
         let guard = $server.session.read().await;
         match guard.as_ref() {
             Some(s) => s.handle.clone(),
             None => {
-                return $crate::tools::tool_error(
-                    "No active notebook session. Call connect_notebook or create_notebook first.",
-                )
+                drop(guard);
+                return $crate::tools::no_session_error($server).await;
             }
         }
     }};
@@ -471,6 +474,33 @@ pub fn arg_string_array(request: &CallToolRequestParams, key: &str) -> Option<Ve
     // Present but wrong type (number, bool, object, etc.)
     tracing::warn!("[mcp] Array param '{key}' has unexpected type: {}", val);
     Some(vec![])
+}
+
+/// Build a context-rich "no active session" error.
+///
+/// If we have drop context (from a previous session), the error message
+/// includes *why* the session was lost and *which notebook_id* to reconnect
+/// to — enabling agents to recover in one turn instead of wasting turns on
+/// `list_active_notebooks`.
+pub async fn no_session_error(server: &crate::NteractMcp) -> Result<CallToolResult, McpError> {
+    let drop_info = server.last_session_drop.read().await;
+    match drop_info.as_ref() {
+        Some(info) => {
+            let mut msg = format!("No active notebook session ({}). ", info.reason);
+            msg.push_str(&format!(
+                "Reconnect with: connect_notebook(notebook_id=\"{}\")",
+                info.notebook_id
+            ));
+            if let Some(ref path) = info.notebook_path {
+                msg.push_str(&format!(" — file: {path}"));
+            }
+            tool_error(&msg)
+        }
+        None => tool_error(
+            "No active notebook session. \
+             Call connect_notebook or create_notebook first.",
+        ),
+    }
 }
 
 /// Assert that a cell exists in the notebook, or return an `McpError`.

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use runtimed_client::client::PoolClient;
 
 use crate::formatting;
-use crate::session::NotebookSession;
+use crate::session::{NotebookSession, SessionDropInfo, SessionDropReason};
 use crate::NteractMcp;
 
 /// Read the current session's notebook_id (if any) before replacing it.
@@ -61,6 +61,12 @@ async fn disconnect_previous_session(server: &NteractMcp, new_notebook_id: Optio
             "[mcp] Disconnecting previous session {} before notebook switch",
             old.notebook_id
         );
+        // Record the drop so "no session" errors can point agents back.
+        *server.last_session_drop.write().await = Some(SessionDropInfo {
+            reason: SessionDropReason::Switched,
+            notebook_id: old.notebook_id.clone(),
+            notebook_path: old.notebook_path.clone(),
+        });
         // Drop the old session — channels close, sync task shuts down,
         // daemon peer count decrements, eviction timer starts.
         // Kernel lifecycle is the daemon's responsibility.
@@ -592,16 +598,16 @@ pub async fn save_notebook(
     let path = arg_str(request, "path").map(resolve_path);
 
     // Need both handle and the notebook_id from the session.
-    let (handle, notebook_id) =
-        {
-            let guard = server.session.read().await;
-            match guard.as_ref() {
-                Some(s) => (s.handle.clone(), s.notebook_id.clone()),
-                None => return tool_error(
-                    "No active notebook session. Call connect_notebook or create_notebook first.",
-                ),
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                drop(guard);
+                return super::no_session_error(server).await;
             }
-        };
+        }
+    };
 
     // The daemon decides whether a path is required (untitled rooms with
     // no existing path field return SaveError with a clear message). We no

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -684,11 +684,7 @@ pub async fn show_notebook(
             match session.as_ref() {
                 Some(s) => (s.notebook_id.clone(), s.notebook_path.clone()),
                 None => {
-                    return tool_error(
-                        "No notebook_id provided and no active session. \
-                         Use list_active_notebooks() to find a notebook_id, \
-                         or connect to one first.",
-                    )
+                    return super::no_session_error(server).await;
                 }
             }
         }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -834,6 +834,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     // Grab shared state handles before serving (serve consumes the server)
     let session = server.session().clone();
     let peer_label = server.peer_label_shared().clone();
+    let last_session_drop = server.last_session_drop().clone();
 
     let transport = rmcp::transport::io::stdio();
     let handle = server.serve(transport).await?;
@@ -851,7 +852,14 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     );
     let watch_socket = socket_path;
     let watch_handle = tokio::spawn(async move {
-        runt_mcp::daemon_watch::watch(daemon_conn, watch_socket, session, peer_label).await
+        runt_mcp::daemon_watch::watch(
+            daemon_conn,
+            watch_socket,
+            session,
+            peer_label,
+            last_session_drop,
+        )
+        .await
     });
 
     tokio::spawn(async {


### PR DESCRIPTION
## Summary

- AX baseline finding: agents waste 3-10 turns recovering from session drops because "No active notebook session" gives no context about *why* the session was lost or *which notebook to reconnect to*. The refiner lost 23% of its turn budget on reconnection cycles.
- Now records the drop reason (eviction, notebook switch, daemon disconnect) and the last notebook_id when a session transitions from Some → None.
- Error messages now include actionable recovery instructions: `"No active notebook session (notebook was evicted). Reconnect with: connect_notebook(notebook_id="abc123") — file: /path/to/nb.ipynb"`

## Test plan

- [ ] `cargo test -p runt-mcp` — 101 tests pass
- [ ] `cargo clippy -p runt-mcp -p runt -- -D warnings` — clean
- [ ] Verify eviction path: connect to notebook, let it idle-evict, call any tool → error includes "evicted" + notebook_id
- [ ] Verify switch path: connect to notebook A, connect to notebook B, call tool → drop info references notebook A
- [ ] Verify fresh start: launch MCP server, call tool without connecting → generic "Call connect_notebook or create_notebook first"