### PR TITLE
fix(ci): move lld rustflag out of tracked .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,10 +5,6 @@ runt = "run --package runt --"
 [env]
 TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }
 
-# macOS arm64 developers link through LLVM's lld. Install with
-# `brew install lld` (provides ld64.lld). Apple's system ld also works;
-# switch to it by removing the rustflag locally. Intel and Linux targets
-# keep their platform defaults until we have measurements that justify
-# changing them.
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# Linker rustflags live in .envrc, gated on `has ld64.lld`. Hard-coding
+# `-fuse-ld=lld` here broke CI runners that don't ship lld, so the rule
+# moved to an env-scoped direnv export. See `.envrc`.

--- a/.envrc
+++ b/.envrc
@@ -18,3 +18,11 @@ if has sccache; then
   export RUSTC_WRAPPER=sccache
   export CARGO_INCREMENTAL=0
 fi
+
+# Link through LLVM lld on macOS arm64 when it's installed. Local dev
+# gets the faster linker; CI and contributors without lld fall back to
+# Apple's default ld. Scoped via CARGO_TARGET_<triple>_RUSTFLAGS so it
+# doesn't collide with a user-set RUSTFLAGS.
+if has ld64.lld; then
+  export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,13 +55,13 @@ Optional but strongly recommended. `cargo xtask` paths already wire sccache in; 
 
 ### lld linker (macOS arm64)
 
-`.cargo/config.toml` links macOS arm64 builds through LLVM's `lld`. Install it once:
+`.envrc` links macOS arm64 builds through LLVM's `lld` when it's installed. Without `lld` the build falls back to Apple's system `ld`. Install to cut incremental link time by roughly a third:
 
 ```bash
 brew install lld
 ```
 
-Without it, `cargo build` on arm64 Macs fails at link time. The rustflag is scoped to `aarch64-apple-darwin`; Intel and Linux use their platform defaults.
+The rustflag goes through direnv, not `.cargo/config.toml`, so CI runners and contributors without `lld` aren't forced to install it.
 
 ### MCP Server Configuration
 


### PR DESCRIPTION
CI has been failing on macos-latest runners with:

```
clang: error: invalid linker name in argument '-fuse-ld=lld'
```

`#2207` added `-C link-arg=-fuse-ld=lld` to `.cargo/config.toml` unconditionally for `aarch64-apple-darwin`. GitHub Actions runners don't ship lld; neither do most contributors who haven't run `brew install lld` yet. Any clone in that state fails at the first build-script link.

## Fix

Move the rustflag to `.envrc`, gated on `has ld64.lld`. Local developers with lld installed keep the 35%-faster incremental link from #2207. Everyone else falls back to Apple's default `ld`. CI gets Apple `ld` for free, no workflow changes needed.

Scoped via `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS` so it doesn't collide with a user-set `RUSTFLAGS`.

## Verify

```bash
# With lld installed + direnv active:
direnv exec . env | grep CARGO_TARGET_AARCH64
# → CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS=-C link-arg=-fuse-ld=lld

# Without lld:
# → (unset)
```
