### PR TITLE
fix(runt-mcp): surface fast auto-launch errors in create_notebook response

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -138,6 +138,33 @@ async fn collect_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serd
             }
         }
     }
+
+    // When the kernel is "starting", poll briefly to catch fast error
+    // transitions. The daemon's auto-launch sets Resolving synchronously,
+    // then runs checks (e.g. missing_conda_env_yml_name) that may flip
+    // to Error within milliseconds. Without this, create_notebook returns
+    // kernel_status "starting" and the agent never learns about the error
+    // unless it polls again. 10 × 50ms = 500ms ceiling — long enough for
+    // filesystem-only checks, short enough to not delay legitimate builds.
+    let status = info
+        .get("kernel_status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if status == "starting" {
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let updated = read_runtime_info(handle);
+            let new_status = updated
+                .get("kernel_status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if new_status != "starting" {
+                info = updated;
+                break;
+            }
+        }
+    }
+
     info
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `create_notebook(conda, working_dir)` with a missing named conda env returned `kernel_status: "starting"` instead of `"error"` with `error_reason: "conda_env_yml_missing"`.
- **Root cause**: The daemon sets `Resolving` (legacy `"starting"`) synchronously *before* spawning `auto_launch_kernel` in the background. `collect_runtime_info()` saw `"starting"` and returned immediately — it only polled when the status was `"not_started"`. Fast error checks like `missing_conda_env_yml_name` (pure filesystem, sub-100ms) fired in the background task but their `Error` lifecycle never reached the MCP response.
- **Fix**: Add a second poll stage in `collect_runtime_info`: when `kernel_status` is `"starting"`, poll 10×50ms (500ms ceiling) watching for transitions away from `"starting"`. This catches filesystem-only error checks without delaying legitimate env builds that stay in `"starting"` for seconds.

Affects all three callers: `create_notebook`, `connect_notebook` (by path), and `connect_notebook` (by id).

## Test plan

- [ ] `create_notebook(package_manager="conda", working_dir="/dir/with/env.yml")` where env.yml declares a missing named env → response should include `kernel_status: "error"`, `error_reason: "conda_env_yml_missing"`, `error_details` with the env name and fix command
- [ ] `create_notebook(package_manager="uv")` with no project file → `kernel_status: "starting"` (no regression for happy path)
- [ ] `connect_notebook(path="notebook.ipynb")` for a notebook in a dir with broken conda env.yml → error surfaced
- [ ] Legitimate slow env builds still return `kernel_status: "starting"` (the 500ms ceiling doesn't block)