### PR TITLE
perf(dx): drop sccache auto-wiring for local dev

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,17 +8,6 @@ PATH_add bin
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_DEV=1
 
-# Share sccache + non-incremental across every cargo invocation, not
-# just xtask paths. A direct `cargo check` or `cargo test` otherwise
-# bypasses sccache entirely and uses a different `CARGO_INCREMENTAL`
-# value than xtask, giving the same crate two cache key spaces. Both
-# gated on `has sccache` so contributors without sccache installed
-# still get a working cargo.
-if has sccache; then
-  export RUSTC_WRAPPER=sccache
-  export CARGO_INCREMENTAL=0
-fi
-
 # Link through LLVM lld on macOS arm64 when it's installed. Local dev
 # gets the faster linker; CI and contributors without lld fall back to
 # Apple's default ld. Scoped via CARGO_TARGET_<triple>_RUSTFLAGS so it
@@ -26,3 +15,10 @@ fi
 if has ld64.lld; then
   export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 fi
+
+# Local cargo defaults kick in: CARGO_INCREMENTAL=1 + no RUSTC_WRAPPER.
+# Tight edit-check loops on one crate reuse rustc's per-function
+# incremental artifacts and run in seconds. sccache is still useful
+# for CI (fresh target dir every run) but its "can't cache incremental"
+# constraint makes it a net loss locally when the incremental cache is
+# already warm. Set RUSTC_WRAPPER=sccache yourself if you want it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,23 +35,21 @@ The `.envrc` file sets:
 - `PATH_add bin` — adds `bin/runt` wrapper to PATH (shadows system `runt`)
 - `export RUNTIMED_DEV=1` — enables per-worktree daemon isolation
 - `export RUNTIMED_WORKSPACE_PATH="$(pwd)"` — pins daemon to this worktree
-- `export RUSTC_WRAPPER=sccache` (if installed) — routes direct cargo through sccache
-- `export CARGO_INCREMENTAL=0` (if sccache installed) — matches xtask so both share cache keys
+- `export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"` (if `ld64.lld` is installed) — uses LLVM's lld linker on macOS arm64
 
 **Verify it works:**
 ```bash
 cd /path/to/nteract/desktop
 echo $RUNTIMED_DEV              # Should print "1"
 echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path
-echo $RUSTC_WRAPPER             # Should print "sccache" when sccache is on PATH
 which runt                      # Should be repo/bin/runt (not /usr/local/bin/runt)
 ```
 
-**Install sccache:**
-```bash
-brew install sccache
-```
-Optional but strongly recommended. `cargo xtask` paths already wire sccache in; putting it in `.envrc` makes direct `cargo build` / `cargo check` / `cargo test` share the same cache instead of cold-compiling every crate.
+### Build cache story
+
+Local dev uses cargo's incremental cache. Tight edit-check loops on one crate reuse rustc's per-function incremental artifacts and run in seconds. No extra setup required.
+
+sccache is not wired on by default locally. It can't cache incremental builds, so turning it on forces `CARGO_INCREMENTAL=0` and loses the edit-loop speedup. It's still useful for CI (fresh target dir every run) and for the rare cross-worktree case. If you want it locally, opt in with `NTERACT_SCCACHE=1` and install with `brew install sccache`.
 
 ### lld linker (macOS arm64)
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2692,15 +2692,33 @@ fn run_frontend_build(debug_bundle: bool) {
     }
 }
 
-/// Set `RUSTC_WRAPPER=sccache` when sccache is available.
+/// Set `RUSTC_WRAPPER=sccache` for CI runs. Off for local dev by default.
 ///
-/// Skips detection entirely if `RUSTC_WRAPPER` is already set in the
-/// environment (respects existing tooling). Detection runs `sccache
-/// --version` once and caches the result for the lifetime of the process.
+/// sccache can't cache incremental builds, so turning it on forces
+/// `CARGO_INCREMENTAL=0` and loses cargo's per-function incremental
+/// speedup. That's fine in CI (fresh target dir every run) and bad
+/// locally (the incremental cache is already warm).
+///
+/// Enabled when `CI=1`/`CI=true` is set. Overridable in either
+/// direction:
+///
+/// - `NTERACT_SCCACHE=1` forces sccache on even for local runs.
+/// - `NTERACT_SCCACHE=0` forces it off even in CI.
+/// - An existing `RUSTC_WRAPPER` is always respected.
 fn apply_sccache_env(command: &mut Command) {
     if env::var_os("RUSTC_WRAPPER").is_some() {
         return;
     }
+
+    let want_sccache = match env::var("NTERACT_SCCACHE").as_deref() {
+        Ok("1") | Ok("true") => true,
+        Ok("0") | Ok("false") => false,
+        _ => matches!(env::var("CI").as_deref(), Ok("1") | Ok("true")),
+    };
+    if !want_sccache {
+        return;
+    }
+
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     let available = *AVAILABLE.get_or_init(|| {
         let found = Command::new("sccache")


### PR DESCRIPTION
sccache cannot cache incremental builds. Auto-wiring it for local dev via `.envrc` forced `CARGO_INCREMENTAL=0` and lost cargo's per-function incremental speedup on tight edit-check loops. Observed Rust cache-hit rate on a working machine after the lld invalidation churn settled: 1%. The incremental loss was pure cost.

## Change

Local cargo now runs with defaults: `CARGO_INCREMENTAL=1`, no `RUSTC_WRAPPER`. Edit one file in a crate, `cargo check -p <that crate>` runs in seconds because rustc reuses function-level incremental artifacts.

sccache stays useful for CI (fresh target dir every run, nothing to lose). `xtask::apply_sccache_env` now enables it only when `CI=1` or `CI=true`. Two escape hatches:

- `NTERACT_SCCACHE=1` — force sccache on for local runs
- `NTERACT_SCCACHE=0` — force it off even in CI

An existing `RUSTC_WRAPPER` is always respected.

lld stays on locally via the `.envrc` rustflag from #2213. It composes cleanly with incremental.

## What's not in this PR

The main CI release workflows (`release-common.yml` `cargo build --release` steps) call cargo directly, not through xtask. So `apply_sccache_env` doesn't reach them. Wiring sccache into those jobs explicitly is a separate change - probably via `mozilla-actions/sccache-action` or setting `RUSTC_WRAPPER` at the job env level.

## Docs

AGENTS.md updated. The new setup story:

- sccache install is no longer recommended.
- lld install is still recommended.
- `.envrc` no longer exports `RUSTC_WRAPPER` or `CARGO_INCREMENTAL`.
