### PR TITLE
feat(runtimed): refresh ProjectContext on untitled promotion and save-as

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -64,10 +64,10 @@ pub async fn get_or_create_room(
     }
 
     // Record the notebook's project-file context on the runtime-state doc.
-    // Single-writer invariant: only the daemon writes this key, and only
-    // during room creation. Refreshes on save-as / move are follow-up
-    // work; see issue #2208.
-    super::project_context::populate_project_context_on_open(&room, path.as_deref());
+    // Single-writer invariant: only the daemon writes this key. Also
+    // re-runs after untitled promotion and save-as rename; see
+    // `project_context::refresh_project_context` callers.
+    super::project_context::refresh_project_context(&room, path.as_deref());
 
     // Insert into path_index (under a separate lock per the locking convention).
     if let Some(ref p) = path {

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -69,6 +69,7 @@ pub(crate) use nbformat_convert::*;
 pub use path_index::{PathIndex, PathIndexError};
 pub(crate) use peer::*;
 pub(crate) use persist::*;
+pub(crate) use project_context::refresh_project_context_on_save_as;
 pub(crate) use room::*;
 pub(crate) use runtime_bridge::*;
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -367,6 +367,11 @@ pub(crate) async fn finalize_untitled_promotion(room: &Arc<NotebookRoom>, canoni
         warn!("[notebook-sync] set_path on promote failed: {}", e);
     }
 
+    // Project context was `Pending` for untitled; now that we have a
+    // real path, walk up from it. Same call shape catalog uses on room
+    // creation.
+    super::project_context::refresh_project_context(room, Some(canonical.as_path()));
+
     info!(
         "[notebook-sync] Promoted untitled room {} to file-backed path {:?}",
         room.id, canonical

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -6,9 +6,16 @@
 //! `set_project_context`; clients read via the normal RuntimeState sync
 //! path.
 //!
-//! Scope: write once per room creation from the notebook's on-disk
-//! location. `save_notebook_as` and filesystem watch refreshes are
-//! follow-up work.
+//! Write triggers:
+//!
+//! - Room creation (`get_or_create_room` in `catalog.rs`).
+//! - Untitled → file-backed promotion, after `finalize_untitled_promotion`
+//!   stamps the new path.
+//! - Save-as rename, after `save_notebook_to_disk` moves the file and
+//!   `set_path` updates the room.
+//!
+//! Filesystem watches for external project-file edits or for the
+//! notebook being moved out from under us are still follow-up work.
 //!
 //! Parsing is line-based on purpose. Adding `toml` / `serde_yaml` /
 //! `pathdiff` to `runtimed` just for the commit-2 extraction round
@@ -30,12 +37,24 @@ use crate::project_file::{self as daemon_project_file, DetectedProjectFile};
 
 use super::room::NotebookRoom;
 
+/// Cross-module entrypoint for the save-as handler. Save-as hands us a
+/// concrete path (no `Option`), and lives in `crate::requests`, outside
+/// `notebook_sync_server`'s `pub(super)` visibility.
+pub(crate) fn refresh_project_context_on_save_as(room: &Arc<NotebookRoom>, canonical: &Path) {
+    refresh_project_context(room, Some(canonical));
+}
+
 /// Walk up from the notebook path, parse what the daemon can, and write
 /// the result into the room's `RuntimeStateDoc.project_context`.
 ///
 /// Untitled notebooks (no path) leave the field at `Pending`; a sentinel
 /// write would be misleading because there's nothing to refresh against.
-pub(super) fn populate_project_context_on_open(room: &Arc<NotebookRoom>, path: Option<&Path>) {
+///
+/// Re-runnable: the caller may invoke this whenever the room's on-disk
+/// path changes (untitled promotion, save-as rename). The setter clears
+/// variant-specific fields before writing, so a `Detected` → `NotFound`
+/// transition doesn't leave ghost data.
+pub(super) fn refresh_project_context(room: &Arc<NotebookRoom>, path: Option<&Path>) {
     let Some(notebook_path) = path else {
         return;
     };
@@ -558,6 +577,45 @@ mod tests {
                 Path::new("/foo/pyproject.toml"),
             ),
             "../pyproject.toml"
+        );
+    }
+
+    #[test]
+    fn build_context_reflects_new_location_on_rerun() {
+        // Locks in the "re-runnable on path change" promise in
+        // refresh_project_context's doc comment. Building against
+        // location A then rebuilding against location B must produce
+        // B's answer, not a merge of both.
+        let temp = TempDir::new().unwrap();
+        let with_pyproject = temp.path().join("with");
+        let bare = temp.path().join("bare");
+        std::fs::create_dir_all(&with_pyproject).unwrap();
+        std::fs::create_dir_all(&bare).unwrap();
+        write(
+            &with_pyproject,
+            "pyproject.toml",
+            "[project]\nname = \"demo\"\ndependencies = [\"pandas\"]\n",
+        );
+
+        let nb_in_project = write(&with_pyproject, "demo.ipynb", "{}");
+        let nb_no_project = write(&bare, "demo.ipynb", "{}");
+
+        // First location: Detected against pyproject.toml.
+        let first = build_context(&nb_in_project);
+        assert!(
+            matches!(first, ProjectContext::Detected { .. }),
+            "expected Detected for notebook under project dir, got {first:?}"
+        );
+
+        // Save-as to a bare directory: should now be NotFound, with no
+        // leaked fields from the earlier Detected. `set_project_context`
+        // does the field-clearing in the CRDT setter; here we just
+        // confirm `build_context` returns the unambiguous answer for
+        // the new path.
+        let second = build_context(&nb_no_project);
+        assert!(
+            matches!(second, ProjectContext::NotFound { .. }),
+            "expected NotFound for notebook in bare dir, got {second:?}"
         );
     }
 }

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -150,6 +150,12 @@ pub(crate) async fn handle(
             if let Err(e) = room.state.with_doc(|sd| sd.set_path(Some(&path_str))) {
                 tracing::warn!("[save_notebook] set_path failed: {}", e);
             }
+            // Walk up from the new location; the previous project_context
+            // reflected the old parent directory and is now stale.
+            crate::notebook_sync_server::refresh_project_context_on_save_as(
+                room,
+                canonical.as_path(),
+            );
         }
         // If path didn't change, this is save-in-place: nothing else.
     }


### PR DESCRIPTION
Third commit on #2208. The daemon now refreshes `RuntimeStateDoc.project_context` whenever the room's on-disk location changes, so the field stops reflecting the old parent directory.

## New refresh call sites

Both come after the new path has been committed to the room:

- **`persist::finalize_untitled_promotion`** — the end of the untitled → file-backed transition. Field was `Pending` before; now picks up whatever project file (if any) sits above the newly-written `.ipynb`.
- **`requests::save_notebook`** — save-as rename branch, gated on `path_changed`. Save-in-place keeps its existing no-op behaviour.

## Design decision: reuse, don't duplicate

The helper is the same one `catalog.rs` already calls on room creation, renamed from `populate_project_context_on_open` to `refresh_project_context` to reflect that it's no longer open-only. The CRDT setter (`set_project_context`) already clears variant-specific fields before writing, so a `Detected` → `NotFound` transition on save-as to a bare directory doesn't leave ghost `project_file` / `parsed.dependencies` behind.

A thin `pub(crate)` wrapper, `refresh_project_context_on_save_as`, gives `requests/save_notebook.rs` a cleanly-named entrypoint without widening the internal module's surface. The rest of `notebook_sync_server` calls the `pub(super)` form.

## Behavioral coverage

| Trigger | Before | After |
|---|---|---|
| Room creation | walk + write | (unchanged) |
| Untitled → save (first save with a path) | `Pending` stuck | walk + write from new path |
| Save-as rename (file-backed → new path, parent dir differs) | stale pointer | walk + write from new path |
| Save-in-place | no-op | no-op (path unchanged) |

## Tests

- `build_context_reflects_new_location_on_rerun` in `project_context` tests: build against a pyproject'd dir → assert `Detected`; build against a bare dir → assert `NotFound`. Confirms the "re-runnable" claim in the helper's doc comment.
- Existing 8 project_context tests untouched.

## Still deferred per #2208

- Filesystem watchers on the notebook or its project file. External moves that skip the save-as path still leave a stale pointer until next open.
- App-side walk-up cutover (`crates/notebook/src/{pyproject,pixi,environment_yml}.rs`).
- Python `.pyi` stubs intentionally unchanged (see #2217 / #2216 PR body for the runtimed-publish-cadence rationale).

## Related

- Issue #2208 — design and phase plan.
- #2209 — commit 1 (schema).
- #2216 — commit 2 (populate on open).
