### PR TITLE
chore: bump all packages by patch version (2.3.3) + add `xtask bump`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/.claude/plugins/nteract/.claude-plugin/plugin.json
+++ b/.claude/plugins/nteract/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nteract",
   "description": "Open, run, and edit nteract notebooks from Claude Code",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "automerge",
  "serde_json",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4138,7 +4138,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dirs",
  "libc",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "automerge",
  "automunge",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "kernel-env",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "automerge",
  "log",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -6935,7 +6935,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "rmcp",
  "schemars 1.2.1",
@@ -7008,7 +7008,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dirs",
  "hex",
@@ -7023,7 +7023,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7036,7 +7036,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "automerge",
  "automunge",
@@ -7048,7 +7048,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7110,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -7138,7 +7138,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7164,7 +7164,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "kernel-env",
  "log",
@@ -7183,7 +7183,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -7890,7 +7890,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11105,7 +11105,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ee922b442faeb1dabbdf984d4c232ebbfa4932b09771b7d75548673ee06c726
-size 1593977
+oid sha256:dab70a30f38df332a4bd025871041e2dd7d98d5543180fda10ef25162b343980
+size 1593672

--- a/apps/notebook/src/renderer-plugins/sift.css
+++ b/apps/notebook/src/renderer-plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38727be06a1d4acf367b1bd8fcdf7ea46f67dc2f0ffd010962bedbbb84cf9792
-size 137606
+oid sha256:1391902531e50478c4a520fb11f4f3361f755d140a2eed7b37c9139719e043eb
+size 137301

--- a/apps/notebook/src/wasm/runtimed-wasm/package.json
+++ b/apps/notebook/src/wasm/runtimed-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "runtimed-wasm",
   "type": "module",
   "description": "WASM bindings for runtimed notebook document operations, compiled from the same automerge crate as the daemon",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:985b4f456e792b74c5f16d2de393994711fa4c790bc584508230495cb04033d1
+oid sha256:b2c8cdaf5b01fd8cbc102e5f300d36efd265a84b380c00359aa71d48c0d79108
 size 2553621

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.3.2"
+version = "2.3.3"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-mcp/assets/plugins/sift.css
+++ b/crates/runt-mcp/assets/plugins/sift.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38727be06a1d4acf367b1bd8fcdf7ea46f67dc2f0ffd010962bedbbb84cf9792
-size 137606
+oid sha256:1391902531e50478c4a520fb11f4f3361f755d140a2eed7b37c9139719e043eb
+size 137301

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cd9a4f54d070fa80c82aa8da276a098eb3b375ee37d5a71fe926e602678a356
-size 6801448
+oid sha256:06fa5dfca2aad94003f32708997b68bb59039df22db81dda9b92849f445cce96
+size 6801633

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.3.2"
+version = "2.3.3"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.3.2"
+version = "2.3.3"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.3.2"
+version = "2.3.3"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.3.2"
+version = "2.3.3"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository.workspace = true

--- a/crates/sift-wasm/pkg/package.json
+++ b/crates/sift-wasm/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "sift-wasm",
   "type": "module",
   "description": "WASM bindings for nteract-predicate — used by @nteract/sift",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cd9a4f54d070fa80c82aa8da276a098eb3b375ee37d5a71fe926e602678a356
-size 6801448
+oid sha256:06fa5dfca2aad94003f32708997b68bb59039df22db81dda9b92849f445cce96
+size 6801633

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -1,0 +1,482 @@
+//! `cargo xtask bump [patch|minor|major]` — bump every versioned artifact in
+//! the repo in lockstep.
+//!
+//! The repo ships a single coordinated version per release: the Tauri app,
+//! daemon, CLI, Python wheels, frontend packages, WASM bindings, and plugin
+//! manifests all move together. This command is the source of truth for that
+//! set. Add an entry to `TARGETS` when a new versioned file lands.
+//!
+//! The match is deliberately line-local (no TOML/JSON parser): a pyproject
+//! may list `version = "1"` inside a dep spec, a package.json may list
+//! `"version": "..."` inside `devDependencies`. We only touch the first
+//! top-level `version` line per file.
+
+use std::fs;
+use std::path::Path;
+use std::process::{exit, Command};
+
+use crate::ensure_workspace_root_cwd;
+
+#[derive(Clone, Copy)]
+enum BumpKind {
+    Patch,
+    Minor,
+    Major,
+}
+
+#[derive(Clone, Copy)]
+enum Format {
+    /// Line starts with `version = "..."` (TOML `[package]` / `[project]`).
+    Toml,
+    /// Line contains `"version": "..."` (JSON, any indentation).
+    Json,
+}
+
+struct Target {
+    path: &'static str,
+    format: Format,
+    /// How many version occurrences to bump in the file. `.claude-plugin/marketplace.json`
+    /// has two plugin entries; everything else has one top-level version.
+    matches: usize,
+}
+
+const TARGETS: &[Target] = &[
+    // Rust workspace crates (keep in sync with [workspace.members] in /Cargo.toml)
+    Target {
+        path: "crates/runt/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/notebook/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-py/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-client/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/notebook-doc/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/notebook-sync/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/notebook-protocol/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-wasm/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runt-mcp/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/mcp-supervisor/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runt-trust/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runt-workspace/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/kernel-launch/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/kernel-env/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-node/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runt-mcp-proxy/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/nteract-mcp/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/repr-llm/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/nteract-predicate/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/sift-wasm/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/automunge/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtime-doc/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/xtask/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    // Tauri app config (version surfaces in the .app bundle / installer)
+    Target {
+        path: "crates/notebook/tauri.conf.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    // Frontend packages
+    Target {
+        path: "apps/notebook/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "apps/notebook/src/wasm/runtimed-wasm/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "crates/sift-wasm/pkg/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/sift/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/runtimed/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/notebook-host/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "packages/runtimed-node/package.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    // Python packages
+    Target {
+        path: "python/nteract/pyproject.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "python/runtimed/pyproject.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "python/dx/pyproject.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "python/nteract-kernel-launcher/pyproject.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "python/prewarm/pyproject.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    // Agent plugin manifests (shipped through the Claude/Codex marketplace)
+    Target {
+        path: ".claude/plugins/nteract/.claude-plugin/plugin.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "plugins/nightly/.claude-plugin/plugin.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "plugins/nightly/.codex-plugin/plugin.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "plugins/nteract/.claude-plugin/plugin.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: "plugins/nteract/.codex-plugin/plugin.json",
+        format: Format::Json,
+        matches: 1,
+    },
+    Target {
+        path: ".claude-plugin/marketplace.json",
+        format: Format::Json,
+        matches: 2,
+    },
+];
+
+pub fn cmd_bump(level: &str) {
+    ensure_workspace_root_cwd();
+    let kind = match level {
+        "patch" => BumpKind::Patch,
+        "minor" => BumpKind::Minor,
+        "major" => BumpKind::Major,
+        other => {
+            eprintln!("Unknown bump level: {other:?}. Use: patch, minor, major.");
+            exit(1);
+        }
+    };
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut total = 0usize;
+    for target in TARGETS {
+        let path = Path::new(target.path);
+        match bump_file(path, target.format, target.matches, kind) {
+            Ok(changes) => {
+                for (old, new) in &changes {
+                    println!("  {:<60} {old} -> {new}", target.path);
+                }
+                total += changes.len();
+            }
+            Err(e) => errors.push(e),
+        }
+    }
+
+    if !errors.is_empty() {
+        for e in errors {
+            eprintln!("error: {e}");
+        }
+        exit(1);
+    }
+    println!();
+    println!(
+        "bumped {total} version field(s) across {} file(s)",
+        TARGETS.len()
+    );
+
+    println!("Running cargo update -w ...");
+    let status = Command::new("cargo")
+        .args(["update", "-w"])
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("failed to run cargo update -w: {e}");
+            exit(1);
+        });
+    if !status.success() {
+        eprintln!("cargo update -w failed");
+        exit(status.code().unwrap_or(1));
+    }
+
+    println!();
+    println!("Next:");
+    println!("  cargo xtask wasm   # rebuild runtimed-wasm, sift-wasm, and renderer plugins");
+}
+
+fn bump_file(
+    path: &Path,
+    format: Format,
+    expected: usize,
+    kind: BumpKind,
+) -> Result<Vec<(String, String)>, String> {
+    let contents = fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut bumps = Vec::new();
+    let mut out = String::with_capacity(contents.len());
+    let parts: Vec<&str> = contents.split('\n').collect();
+    let last_idx = parts.len().saturating_sub(1);
+    for (i, line) in parts.iter().enumerate() {
+        let replaced = if bumps.len() < expected {
+            match format {
+                Format::Toml => try_bump_toml_line(line, kind),
+                Format::Json => try_bump_json_line(line, kind),
+            }
+        } else {
+            None
+        };
+        match replaced {
+            Some((old, new, new_line)) => {
+                bumps.push((old, new));
+                out.push_str(&new_line);
+            }
+            None => out.push_str(line),
+        }
+        if i != last_idx {
+            out.push('\n');
+        }
+    }
+
+    if bumps.len() != expected {
+        return Err(format!(
+            "{}: expected {expected} version line(s), found {}",
+            path.display(),
+            bumps.len()
+        ));
+    }
+
+    fs::write(path, out).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(bumps)
+}
+
+fn try_bump_toml_line(line: &str, kind: BumpKind) -> Option<(String, String, String)> {
+    let prefix = "version = \"";
+    if !line.starts_with(prefix) {
+        return None;
+    }
+    let rest = &line[prefix.len()..];
+    let end = rest.find('"')?;
+    let old = &rest[..end];
+    let new = bump_str(old, kind)?;
+    let suffix = &rest[end + 1..];
+    let new_line = format!("{prefix}{new}\"{suffix}");
+    Some((old.to_string(), new, new_line))
+}
+
+fn try_bump_json_line(line: &str, kind: BumpKind) -> Option<(String, String, String)> {
+    let key = "\"version\"";
+    let key_pos = line.find(key)?;
+    let after_key = &line[key_pos + key.len()..];
+    let colon_pos = after_key.find(':')?;
+    let after_colon = &after_key[colon_pos + 1..];
+    let trimmed = after_colon.trim_start();
+    let ws_len = after_colon.len() - trimmed.len();
+    if !trimmed.starts_with('"') {
+        return None;
+    }
+    let after_open = &trimmed[1..];
+    let close = after_open.find('"')?;
+    let old = &after_open[..close];
+    let new = bump_str(old, kind)?;
+    let suffix = &after_open[close + 1..];
+    let prefix_end = key_pos + key.len() + colon_pos + 1 + ws_len + 1;
+    let prefix = &line[..prefix_end];
+    let new_line = format!("{prefix}{new}\"{suffix}");
+    Some((old.to_string(), new, new_line))
+}
+
+fn bump_str(version: &str, kind: BumpKind) -> Option<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let major: u64 = parts[0].parse().ok()?;
+    let minor: u64 = parts[1].parse().ok()?;
+    let patch: u64 = parts[2].parse().ok()?;
+    let (major, minor, patch) = match kind {
+        BumpKind::Major => (major + 1, 0, 0),
+        BumpKind::Minor => (major, minor + 1, 0),
+        BumpKind::Patch => (major, minor, patch + 1),
+    };
+    Some(format!("{major}.{minor}.{patch}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toml_line_roundtrip() {
+        let (old, new, line) = try_bump_toml_line("version = \"1.2.3\"", BumpKind::Patch).unwrap();
+        assert_eq!(old, "1.2.3");
+        assert_eq!(new, "1.2.4");
+        assert_eq!(line, "version = \"1.2.4\"");
+    }
+
+    #[test]
+    fn toml_minor_bump() {
+        let (_, new, _) = try_bump_toml_line("version = \"2.3.9\"", BumpKind::Minor).unwrap();
+        assert_eq!(new, "2.4.0");
+    }
+
+    #[test]
+    fn toml_major_bump() {
+        let (_, new, _) = try_bump_toml_line("version = \"1.9.9\"", BumpKind::Major).unwrap();
+        assert_eq!(new, "2.0.0");
+    }
+
+    #[test]
+    fn toml_ignores_dep_lines() {
+        // Inline version fields in dep tables should not match — those don't
+        // start at column 0 and use `version = "1"` inside `{ ... }`.
+        assert!(try_bump_toml_line("  version = \"1.0.0\"", BumpKind::Patch).is_none());
+        assert!(try_bump_toml_line(
+            "serde = { version = \"1\", features = [\"derive\"] }",
+            BumpKind::Patch
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn json_line_roundtrip() {
+        let (old, new, line) =
+            try_bump_json_line("  \"version\": \"0.1.2\",", BumpKind::Patch).unwrap();
+        assert_eq!(old, "0.1.2");
+        assert_eq!(new, "0.1.3");
+        assert_eq!(line, "  \"version\": \"0.1.3\",");
+    }
+
+    #[test]
+    fn json_line_without_trailing_comma() {
+        let (_, _, line) = try_bump_json_line("  \"version\": \"0.1.2\"", BumpKind::Patch).unwrap();
+        assert_eq!(line, "  \"version\": \"0.1.3\"");
+    }
+
+    #[test]
+    fn json_spacing_variations() {
+        let (_, _, line) =
+            try_bump_json_line("    \"version\":\"1.0.0\",", BumpKind::Patch).unwrap();
+        assert_eq!(line, "    \"version\":\"1.0.1\",");
+    }
+
+    #[test]
+    fn rejects_malformed_version() {
+        assert!(try_bump_toml_line("version = \"1.2\"", BumpKind::Patch).is_none());
+        assert!(try_bump_toml_line("version = \"beta\"", BumpKind::Patch).is_none());
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -10,6 +10,8 @@ use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
+mod bump;
+
 /// Find the workspace root (nearest ancestor containing a Cargo.toml with
 /// a `[workspace]` section). Subcommands that need repo-relative paths
 /// can call `ensure_workspace_root_cwd()` from within the subcommand to
@@ -37,7 +39,7 @@ fn find_workspace_root() -> Option<PathBuf> {
 /// those must stay relative to the shell cwd where the user invoked
 /// `cargo xtask`. A global cd silently reinterprets those args against
 /// the workspace root and opens/writes the wrong files.
-fn ensure_workspace_root_cwd() {
+pub(crate) fn ensure_workspace_root_cwd() {
     if let Some(root) = find_workspace_root() {
         let _ = env::set_current_dir(&root);
     }
@@ -149,6 +151,10 @@ fn main() {
             cmd_sync_tool_cache(check);
         }
         "check-dep-budget" => cmd_check_dep_budget(),
+        "bump" => {
+            let level = args.get(1).map(String::as_str).unwrap_or("patch");
+            bump::cmd_bump(level);
+        }
         "--help" | "-h" | "help" => print_help(),
         cmd => {
             eprintln!("Unknown command: {cmd}");
@@ -223,6 +229,9 @@ Other:
   sync-tool-cache            Regenerate tool-cache.json + MCPB manifests from runt binary
   sync-tool-cache --check    Check caches are up to date + description byte budget (for CI)
   check-dep-budget           Check transitive dependency counts against per-crate budgets
+  bump [patch|minor|major]   Bump every versioned artifact (crates, Tauri app,
+                             Python, frontend packages, plugin manifests) in
+                             lockstep and regenerate Cargo.lock. Defaults to patch.
   help                       Show this help
 "
     );

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/runtimed-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node.js bindings for the runtimed daemon client (napi-rs).",
   "private": true,
   "type": "module",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.0.4"
+version = "2.0.5"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.2.2"
+version = "0.2.3"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.3.2"
+version = "2.3.3"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.0.5"
+version = "0.0.6"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.3.2"
+version = "2.3.3"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Patch-bump every artifact in the repo so we can cut a stable release over last week's work. First PR to use the new `cargo xtask bump` command instead of hand-editing ~50 files.

## The bump command

`cargo xtask bump [patch|minor|major]` rewrites every versioned artifact -- Rust crates, Tauri app, Python wheels, frontend packages, WASM bindings, plugin manifests -- and regenerates `Cargo.lock`. Defaults to patch.

The match is deliberately line-local (no TOML/JSON parser). A pyproject may list `version = "1"` inside a dep spec, a package.json may list `"version": "..."` inside `devDependencies`. We only touch the first top-level `version` line per file and refuse to write anything if the expected match count isn't hit, so a drifted `TARGETS` list fails loud instead of silently skipping files.

Unit tests cover TOML/JSON line parsing, dep-line rejection, spacing variations, and malformed versions.

When a new versioned file lands, add it to `TARGETS` in `crates/xtask/src/bump.rs`.

## Version moves

- Tauri desktop app, runtimed daemon, runt CLI, Python wheels: `2.3.2 -> 2.3.3`
- Workspace crates: each by patch
- Frontend packages: each by patch
- Python packages: each by patch
- Claude/Codex plugin manifests + marketplace: `0.1.2 -> 0.1.3`

## Artifacts regenerated

- `Cargo.lock` via `cargo update -w`
- `runtimed-wasm` and `sift-wasm` via `cargo xtask wasm`
- Renderer plugin JS/CSS bundles (chained off `wasm sift`)

## Post-merge

Tag `v2.3.3` to trigger the stable release pipeline.

## Test plan

- [x] `cargo test -p xtask` (17 tests pass, including 8 new bump tests)
- [x] `cargo xtask bump patch` produces the expected 44 version bumps across 43 files
- [x] `cargo xtask wasm` regenerates artifacts cleanly
- [x] `cargo xtask lint` clean
