### PR TITLE
ci: pause stable PyPI publishing for runtimed, nteract, dx

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1286,11 +1286,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      # PyPI publish steps fail the release if they error. Nightly runs
-      # generate unique per-minute versions (e.g. 2.2.1a202604150406) so
-      # "version already exists" collisions shouldn't happen under normal
-      # scheduling. If they do happen, the right response is to fail loudly
-      # and investigate — not pretend the release shipped.
+      # PyPI publishes are gated to pre-releases (nightly) only. Stable
+      # publishes are paused while the `runtimed` / `nteract` / `dx`
+      # library surface is still in flux — see #2217. Pre-releases carry
+      # unique per-minute versions (e.g. 2.2.1a202604150406) so there's
+      # no collision risk.
       #
       # Trusted-publisher config on PyPI must include an entry for this
       # workflow (`release-common.yml`) per published project. Missing
@@ -1298,12 +1298,15 @@ jobs:
       # project 'X'". Fix at https://pypi.org/manage/project/{name}/settings/publishing/.
 
       - name: Publish runtimed to PyPI
+        if: inputs.github_release_prerelease
         run: uv publish --trusted-publishing always ./wheels/*.whl
 
       - name: Publish nteract to PyPI
+        if: inputs.github_release_prerelease
         run: uv publish --trusted-publishing always ./nteract-dist/*
 
       - name: Publish dx to PyPI
+        if: inputs.github_release_prerelease
         run: uv publish --trusted-publishing always ./dx-dist/*
 
       - name: Generate release body

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -30,7 +30,7 @@ graph TD
 
     subgraph "Bundled Artifacts"
         APP["Notebook .app / .dmg<br/>.AppImage / .exe"]
-        PY["Python wheel<br/><i>pip install runtimed</i>"]
+        PY["Python wheel<br/><i>pip install --pre runtimed</i>"]
     end
 
     %% Frontend → Rust compile-time dependencies

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -7,8 +7,8 @@ The `runtimed` Python package provides programmatic access to the notebook daemo
 ## Installation
 
 ```bash
-# From PyPI
-pip install runtimed
+# From PyPI (pre-release channel — stable is paused, see #2217)
+pip install --pre runtimed
 
 # From source (inside the python/runtimed package directory)
 cd python/runtimed

--- a/python/dx/README.md
+++ b/python/dx/README.md
@@ -8,16 +8,16 @@
 
 ```bash
 # pandas
-pip install "dx[pandas]"
+pip install --pre "dx[pandas]"
 
 # polars
-pip install "dx[polars]"
+pip install --pre "dx[polars]"
 
 # both
-pip install "dx[pandas,polars]"
+pip install --pre "dx[pandas,polars]"
 ```
 
-Python 3.10+.
+Python 3.10+. Only pre-release wheels are being published while the library surface settles — the stable channel is frozen. See [#2217](https://github.com/nteract/desktop/issues/2217). Most nteract users don't install `dx` directly: the kernel launcher calls `dx.install()` during bootstrap, so DataFrames render through the blob store inside the nteract desktop app automatically.
 
 ## Use
 

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -15,13 +15,15 @@ The plugin ships the right binary for your platform — no app install required 
 
 ## Install via uvx (alternative)
 
-If you'd rather go through `uvx`:
+If you'd rather go through `uvx`, use the pre-release channel:
 
 ```bash
-claude mcp add nteract -- uvx nteract
+claude mcp add nteract -- uvx --prerelease allow nteract
 ```
 
 That will run this PyPI package, which locates `runt mcp` from your nteract desktop install and exec's it.
+
+Only pre-release wheels are being published while the library surface settles — the stable channel is frozen. See [#2217](https://github.com/nteract/desktop/issues/2217).
 
 ## What you get
 

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -9,10 +9,11 @@ Python bindings for the [nteract](https://nteract.io) runtime daemon. Execute co
 ## Installation
 
 ```bash
-pip install runtimed
+pip install --pre runtimed
+# or: uv pip install --prerelease allow runtimed
 ```
 
-The stable release matches the [nteract desktop stable app](https://nteract.io). If you're running the nightly desktop app, install the pre-release to match: `pip install --pre runtimed` (or `uv pip install --prerelease allow runtimed`). The nightly build automatically discovers the nightly daemon socket.
+Only pre-release wheels are being published while the library surface settles. The stable channel is frozen at the last-shipped release; the `--pre` channel tracks the nightly desktop app and discovers the nightly daemon socket automatically. See [#2217](https://github.com/nteract/desktop/issues/2217) for context.
 
 `Client()` and the high-level Python API use `default_socket_path()` by default. That helper respects `RUNTIMED_SOCKET_PATH`, so exported test or MCP sockets take precedence over the package's default channel.
 


### PR DESCRIPTION
Closes #2217.

Gates the three `uv publish` steps in `release-common.yml` on `inputs.github_release_prerelease`. Only nightly runs push to PyPI. Stable builds still produce wheels and attach them to the GitHub Release page for direct download — only the PyPI upload is skipped.

## Why

The `runtimed` / `nteract` / `dx` Python API is still in flux. `RuntimeState.project_context` just landed in #2216/#2218, more pyclass redesigns are queued behind #2208, and every shape change becomes a public-API change while `pip install <name>` goes to the stable channel. Pausing stable publish lets the library shape keep moving without churning PyPI's "what does `pip install runtimed` get me today" answer every week.

## Behavior

| Channel | Wheel build | GH Release attach | PyPI upload |
|---------|-------------|-------------------|-------------|
| Nightly (`github_release_prerelease: true`)  | ✅ | ✅ | ✅ |
| Stable (`github_release_prerelease: false`)  | ✅ | ✅ | ⛔ (this PR) |

## Docs

`pip install` examples now lead with `--pre` so readers land on the channel that's actually receiving updates:

- `python/runtimed/README.md`, `python/dx/README.md`, `python/nteract/README.md` — `--pre` install, short note linking #2217.
- `python/nteract/README.md` — `uvx` example becomes `uvx --prerelease allow nteract`.
- `docs/python-bindings.md`, `contributing/build-dependencies.md` — `--pre` in install command and architecture diagram.

The release-body template in `release-common.yml` already uses `--pre` on both channels, so no change needed there.

## Out of scope

- Re-enabling stable publish once the library API settles. Probably post-#2208 or whenever an external consumer's version-pinning pushes us.
- The stale `python-package.yml` reference in `contributing/releasing.md` — that workflow doesn't exist; separate cleanup.

## Test plan

- [ ] Next nightly run publishes wheels to PyPI as today.
- [ ] Next stable release skips the three publish steps (visible in the Actions log as `Skipped`) but still attaches `./wheels/*.whl`, `./nteract-dist/*`, `./dx-dist/*` to the GitHub release.
