### PR TITLE
fix(runt-mcp): reject execute_cell on non-code cells

### DIFF
--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -67,6 +67,17 @@ pub async fn execute_cell(
 
     assert_cell_exists(&handle, cell_id)?;
 
+    // Only code cells can be executed. Markdown/raw cells get queued by the
+    // daemon but the kernel never processes them, so the agent would see
+    // "running" forever with no outputs. Fail early with a clear message.
+    let cell_type = handle.get_cell_type(cell_id).unwrap_or_default();
+    if cell_type != "code" {
+        return tool_error(&format!(
+            "Cannot execute cell '{cell_id}' of type '{cell_type}'. \
+             Only 'code' cells can be executed."
+        ));
+    }
+
     let peer_label = server.get_peer_label().await;
     crate::presence::emit_focus(&handle, cell_id, &peer_label).await;
 


### PR DESCRIPTION
## Summary

- `execute_cell(markdown_cell_id)` would silently return "running" but the kernel never processes non-code cells, leaving agents stuck waiting for outputs that never arrive
- Add a cell type check after `assert_cell_exists` that returns a clear error: `"Cannot execute cell '<id>' of type 'markdown'. Only 'code' cells can be executed."`
- `create_cell(and_run)` and `set_cell(and_run)` already had this guard — only the standalone `execute_cell` was missing it

Closes part of #2160.

## Test plan

- [ ] `cargo test -p runt-mcp` — 102 tests pass
- [ ] `execute_cell` with a markdown cell ID returns error instead of silent "running"
- [ ] `execute_cell` with a code cell ID still works as before