### PR TITLE
fix(runt-mcp): reject set_cell with empty source

### DIFF
--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -194,6 +194,16 @@ pub async fn set_cell(
     }
 
     if let Some(src) = source {
+        // Reject empty source — agents accidentally wiping code is a common
+        // silent-corruption pattern. Use delete_cell to intentionally remove
+        // a cell, or omit 'source' to leave it unchanged.
+        if src.is_empty() {
+            return tool_error(
+                "Cell source cannot be empty. \
+                 Use delete_cell to remove the cell, \
+                 or omit 'source' to leave it unchanged.",
+            );
+        }
         handle
             .update_source(cell_id, src)
             .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;


### PR DESCRIPTION
## Summary

- `set_cell(source="")` would silently wipe a cell's code — a common accidental corruption pattern by agents
- Add an empty source guard inside the `if let Some(src)` block, before `update_source` is called, so the CRDT is never modified
- Returns a clear error: "Cell source cannot be empty. Use delete_cell to remove the cell, or omit 'source' to leave it unchanged."

Closes part of #2160.

## Test plan

- [ ] `cargo test -p runt-mcp` — 102 tests pass
- [ ] `set_cell(cell_id, source="")` returns error instead of silently wiping source
- [ ] `set_cell(cell_id, source="x = 1")` still works as before
- [ ] `set_cell(cell_id)` with no source param still returns "unchanged" (no regression)