### PR TITLE
perf(xtask): drop dev-mcp + maturin from cargo xtask build

### DIFF
--- a/.claude/skills/build-system/SKILL.md
+++ b/.claude/skills/build-system/SKILL.md
@@ -11,13 +11,15 @@ For commands and dev workflows, see `CLAUDE.md` → "Build System" and run `carg
 
 Three phases:
 
-1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p mcp-supervisor -p notebook` in one invocation (workspace feature unification happens once, so the final tauri step doesn't recompile). Sidecars (`runtimed`, `runt`) are copied to `crates/notebook/binaries/` for Tauri bundling.
+1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p mcp-supervisor -p notebook` in one invocation (workspace feature unification happens once, so the final tauri step doesn't recompile). Sidecars (`runtimed`, `runt`, `nteract-mcp`) are copied to `crates/notebook/binaries/` for Tauri bundling.
 
-2. **Frontend + Python bindings in parallel** — `pnpm build` (TypeScript + Vite) and `maturin develop` (Python `.so`) run concurrently. Both must finish before phase 3.
+2. **Frontend build** — `pnpm build` (TypeScript + Vite). Must finish before phase 3.
 
 3. **Tauri link** — `cargo tauri build --debug --no-bundle` links the notebook binary with embedded frontend assets. Rust is cached from phase 1.
 
 `--rust-only` skips the frontend build in phase 2 and reuses existing `apps/notebook/dist/`.
+
+Python bindings (`maturin develop`) are no longer part of `cargo xtask build`. Run `cargo xtask integration` (builds bindings for pytest), use the nteract-dev MCP `up rebuild=true` tool, or invoke `maturin develop` directly under `crates/runtimed-py/` when you need the `.so`. CI builds them explicitly.
 
 ## Key constraints
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -156,8 +156,8 @@ Use `nteract-dev` as the repo-local MCP server name so it stays distinct from an
 # Terminal 1: start dev daemon
 cargo xtask dev-daemon
 
-# Terminal 2: build bindings + launch MCP server
-cargo xtask dev-mcp
+# Terminal 2: launch MCP server directly (Rust-native, no Python)
+./target/debug/runt mcp
 ```
 
 ### nteract-dev Tools

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -104,8 +104,8 @@
     "reveal_target": "dock",
   },
   {
-    "label": "Dev MCP (print config)",
-    "command": "cargo xtask dev-mcp --print-config",
+    "label": "MCP (print config)",
+    "command": "cargo xtask run-mcp --print-config",
     "env": {
       "RUNTIMED_DEV": "1",
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ uv run nteract   # Alternative: finds and launches runt mcp
 
 - Source builds default to the `nightly` channel. Only `RUNT_BUILD_CHANNEL=stable` opts a source-built `cargo xtask` or `cargo` flow into stable names, app launch behavior, and cache/socket namespaces.
 - Use the default nightly flow for normal repo development. Opt into stable only when you are specifically validating stable branding, stable socket/cache paths, or stable app-launch behavior.
-- `cargo xtask dev-daemon`, `cargo xtask notebook`, `cargo xtask run`, `cargo xtask run-mcp`, and `cargo xtask dev-mcp` all follow `RUNT_BUILD_CHANNEL`.
+- `cargo xtask dev-daemon`, `cargo xtask notebook`, `cargo xtask run`, and `cargo xtask run-mcp` all follow `RUNT_BUILD_CHANNEL`.
 
 ### Telemetry
 
@@ -440,8 +440,6 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask install-nightly` | Install runtimed + runt + nteract-mcp as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
 | MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
-| | `cargo xtask dev-mcp` | Direct `runt mcp` (no proxy, no auto-restart) |
-| | `cargo xtask dev-mcp --print-config` | Print direct MCP client config JSON |
 | | `cargo xtask mcp-inspector` | Launch MCP Inspector UI for testing runt mcp |
 | Lint | `cargo xtask lint` | Check formatting (Rust fmt, JS/TS, Python) |
 | | `cargo xtask lint --fix` | Auto-fix formatting |

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -76,9 +76,9 @@ here is what happens under the hood:
 ```mermaid
 graph LR
     A["1. pnpm install"] --> M["2. Build MCP widget HTML<br/>crates/runt-mcp/assets/_output.html"]
-    M --> R["3. cargo build<br/>-p runtimed -p runt -p mcp-supervisor -p notebook"]
+    M --> R["3. cargo build<br/>-p runtimed -p runt -p nteract-mcp -p mcp-supervisor"]
     R --> E["4. Copy sidecar binaries<br/>for Tauri bundling"]
-    E --> P["5. In parallel:<br/>uv sync + maturin develop<br/>and pnpm frontend build"]
+    E --> P["5. pnpm frontend build"]
     P --> F["6. cargo tauri build<br/>or debug link step"]
 
     classDef step fill:#f3e5f5,stroke:#7b1fa2

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -16,7 +16,7 @@
 | Build release DMG | `cargo xtask build-dmg` |
 | nteract-dev MCP server | `cargo xtask run-mcp` |
 | MCP config JSON | `cargo xtask run-mcp --print-config` |
-| Direct `runt mcp` (no proxy) | `cargo xtask dev-mcp` |
+| Direct `runt mcp` (no proxy) | `./target/debug/runt mcp` |
 | Lint (check mode) | `cargo xtask lint` |
 | Lint (auto-fix) | `cargo xtask lint --fix` |
 
@@ -396,15 +396,15 @@ These tools are always available, even when the child `runt mcp` is down:
 
 ### Direct mode (no proxy)
 
-If you don't need auto-restart or file watching, `dev-mcp` runs `runt mcp`
-directly:
+If you don't need auto-restart or file watching, run `runt mcp`
+directly from the dev build:
 
 ```bash
 # Terminal 1: start the dev daemon
 cargo xtask dev-daemon
 
-# Terminal 2: build bindings + launch MCP server
-cargo xtask dev-mcp
+# Terminal 2: launch MCP server (Rust-native, no Python)
+./target/debug/runt mcp
 ```
 
 ### How it works

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -823,16 +823,11 @@ fn cmd_build(rust_only: bool) {
     copy_sidecar_binary("runt", false);
     copy_sidecar_binary("nteract-mcp", false);
 
-    // Phase 2: Run independent tasks in parallel.
-    // - Python env sync + maturin develop (builds .so for MCP server)
-    // - Frontend build (pnpm/vite, completely independent of Rust)
-    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
-
-    handles.push(thread::spawn(|| {
-        ensure_python_env();
-        ensure_maturin_develop();
-    }));
-
+    // Phase 2: Build the frontend. Python bindings are no longer part of
+    // the default build — `runt mcp` is Rust-native, and agents iterating
+    // on runtimed-py should use `cargo xtask integration` (which runs
+    // `maturin develop`) or rebuild via the nteract-dev MCP (`up
+    // rebuild=true`). CI still runs maturin explicitly in build.yml.
     if rust_only {
         let dist_dir = Path::new("apps/notebook/dist");
         if !dist_dir.exists() {
@@ -842,17 +837,8 @@ fn cmd_build(rust_only: bool) {
         }
         println!("Skipping frontend build (--rust-only), reusing existing assets");
     } else {
-        handles.push(thread::spawn(|| {
-            println!("Building frontend (notebook)...");
-            run_frontend_build(true);
-        }));
-    }
-
-    for handle in handles {
-        handle.join().unwrap_or_else(|_| {
-            eprintln!("A parallel build task panicked");
-            exit(1);
-        });
+        println!("Building frontend (notebook)...");
+        run_frontend_build(true);
     }
 
     // Phase 3: Tauri build. With all Rust already compiled and frontend

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -104,10 +104,6 @@ fn main() {
             let release = args.iter().any(|a| a == "--release");
             cmd_dev_daemon(release);
         }
-        "dev-mcp" => {
-            let print_config = args.iter().any(|a| a == "--print-config");
-            cmd_dev_mcp(print_config);
-        }
         "run-mcp" | "mcp" => {
             let print_config = args.iter().any(|a| a == "--print-config");
             let release = args.iter().any(|a| a == "--release");
@@ -191,8 +187,6 @@ Daemon:
 MCP:
   run-mcp [--release]        Build and run the nteract-dev MCP supervisor (proxy + daemon + auto-restart)
   run-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)
-  dev-mcp                    Build Python bindings and launch nteract MCP server directly (no supervisor)
-  dev-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)
   mcp-inspector              Launch MCPJam Inspector UI to test runt mcp (MCP Apps)
 
 Linting:
@@ -1923,117 +1917,6 @@ fn cmd_mcp_inspector() {
 
     if !status.success() {
         exit(status.code().unwrap_or(1));
-    }
-}
-
-fn cmd_dev_mcp(print_config: bool) {
-    // Step 1: Build the runt CLI so we can query daemon status
-    if !Path::new(dev_runt_cli_binary()).exists() {
-        println!("Building runt CLI...");
-        run_cmd("cargo", &["build", "-p", "runt"]);
-    }
-
-    // Step 2: Resolve the socket path from the dev daemon
-    let socket_path = {
-        let mut command = Command::new(dev_runt_cli_binary());
-        command
-            .args(["daemon", "status", "--json"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        apply_worktree_env(&mut command, true);
-
-        let output = command.output().unwrap_or_else(|e| {
-            eprintln!("Failed to run runt daemon status: {e}");
-            eprintln!("Build the CLI first: cargo build -p runt");
-            exit(1);
-        });
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("runt daemon status failed:");
-            if !stderr.trim().is_empty() {
-                eprintln!("{}", stderr.trim());
-            }
-            exit(1);
-        }
-
-        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
-            eprintln!("Failed to parse daemon status JSON: {e}");
-            exit(1);
-        });
-
-        let path = json
-            .get("socket_path")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_else(|| {
-                eprintln!("No socket_path in daemon status output");
-                exit(1);
-            })
-            .to_string();
-
-        let running = json
-            .get("running")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-
-        if !running && !print_config {
-            eprintln!("Warning: dev daemon is not running.");
-            eprintln!("Start it first: cargo xtask dev-daemon");
-            eprintln!();
-        }
-
-        path
-    };
-
-    // Step 3: Sync Python workspace + build native bindings
-    ensure_python_env();
-    ensure_maturin_develop();
-
-    // Step 4: Print config or launch
-    let workspace_dir = fs::canonicalize(".").unwrap_or_else(|e| {
-        eprintln!("Failed to resolve workspace directory: {e}");
-        exit(1);
-    });
-
-    if print_config {
-        let config = serde_json::json!({
-            "command": "uv",
-            "args": ["run", "--no-sync", "--directory", workspace_dir.to_string_lossy(), "nteract"],
-            "env": {
-                "RUNTIMED_SOCKET_PATH": socket_path
-            }
-        });
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
-                eprintln!("Failed to serialize MCP config: {e}");
-                exit(1);
-            })
-        );
-    } else {
-        println!();
-        println!("Launching nteract MCP server...");
-        println!("Socket: {socket_path}");
-        println!();
-
-        let status = Command::new("uv")
-            .args([
-                "run",
-                "--no-sync",
-                "--directory",
-                &workspace_dir.to_string_lossy(),
-                "nteract",
-            ])
-            .env("RUNTIMED_SOCKET_PATH", &socket_path)
-            .status()
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to launch nteract MCP server: {e}");
-                exit(1);
-            });
-
-        if !status.success() {
-            exit(status.code().unwrap_or(1));
-        }
     }
 }
 


### PR DESCRIPTION
Two changes, one motivation: `cargo xtask build` was paying for a Python `.so` that no default dev workflow actually loads. The Tauri app doesn't link runtimed-py. The canonical MCP path (`runt mcp`, sidecar in the desktop app) is Rust-native. And `cargo xtask dev-mcp` — the only `cargo xtask` subcommand that called `runt mcp` through a Python wrapper — is redundant with the direct binary.

## Commits

### 1. `refactor(xtask): drop dev-mcp subcommand`

`cargo xtask dev-mcp` shelled out to `uv run nteract`, which boots a Python entry point that then exec's `runt mcp` after a maturin develop + venv sync. The Python wrapper was the *only* reason maturin ran here — the MCP server itself is Rust.

Use either path instead:
- `cargo xtask run-mcp` — the nteract-dev supervisor (auto-restart, dev tools, daemon lifecycle).
- `./target/debug/runt mcp` — raw `runt mcp`, no supervisor, matches what `dev-mcp` was doing minus the Python detour.

### 2. `perf(xtask): drop maturin build from cargo xtask build`

Phase 2 of `cmd_build` used to spawn two parallel threads: frontend build and `ensure_python_env + ensure_maturin_develop`. The Python leg was paying for itself back when `uv run nteract` was the MCP path, but that wrapper's gone. With the maturin leg removed, phase 2 collapses to a single inline frontend build — no threadpool, no join.

Default `cargo xtask build` now skips the ~5-30s incremental (~1-2min cold) maturin step, which also kept a second target dir warm under `target/maturin/` for no downstream consumer.

Where maturin still runs:
- `cargo xtask integration` (pytest needs the bindings)
- `up rebuild=true` via the nteract-dev MCP (agent iteration)
- CI (`.github/workflows/build.yml` runs `maturin develop` explicitly)

### 3. `docs: drop dev-mcp + maturin-in-build references`

`AGENTS.md` (= `CLAUDE.md` symlink), `contributing/development.md`, `contributing/build-dependencies.md`, `.claude/skills/build-system/SKILL.md`, `.claude/skills/frontend-dev/SKILL.md`, `.zed/tasks.json`. Direct-mode MCP instructions now point at `./target/debug/runt mcp`. The build-system skill calls out where maturin still runs so readers aren't surprised.

## Test plan

- [x] `cargo build -p xtask` clean
- [x] `cargo xtask lint` clean
- [x] `cargo xtask help` shows no `dev-mcp`; `MCP:` section lists `run-mcp` + `mcp-inspector` only
- [x] `grep -rn "dev-mcp\|dev_mcp" .` across `*.md *.rs *.toml *.yml *.json` returns zero hits outside `target/`, `node_modules/`, `.venv/`
- [ ] CI `.github/workflows/build.yml` still runs maturin explicitly (not affected by this PR)
