### PR TITLE
chore(xtask): drop deprecated build-e2e and install-nightly aliases

### DIFF
--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -10,7 +10,7 @@ description: Develop, debug, and manage the runtimed daemon. Use when working on
 | Task | Command |
 |------|---------|
 | Start dev daemon | `cargo xtask dev-daemon` |
-| Install nightly (Linux/headless only) | `cargo xtask install-nightly` |
+| Install nightly (Linux/headless only) | `./scripts/install-nightly` |
 | Check status | `./target/debug/runt daemon status` |
 | Check status (JSON) | `./target/debug/runt daemon status --json` |
 | Tail logs | `./target/debug/runt daemon logs -f` |
@@ -46,7 +46,7 @@ The notebook app auto-connects to or starts the daemon. If unavailable, falls ba
 When you change daemon code and want the system service to pick it up on a cloud box or headless Linux machine:
 
 ```bash
-cargo xtask install-nightly
+./scripts/install-nightly
 ```
 
 Builds runtimed + runt + nteract-mcp (release), installs them to `~/.local/share/runt-nightly/bin/` with channel-suffixed names, writes + starts the systemd user unit on first install, upgrades in place on subsequent runs. On macOS it refuses by default — use the nteract Nightly app (it auto-updates). Pass `--on-macos` to override, `--replace-installed-app` if an app bundle is already present.
@@ -272,7 +272,7 @@ Check that uv/conda are installed and working.
 ## Stopping the Daemon
 
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
-- `cargo xtask install-nightly` — gracefully installs/reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
+- `./scripts/install-nightly` — gracefully installs/reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
 
 Avoid system-wide process killers (`pkill`, `killall`) — they affect every worktree and every other agent on the machine.
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -194,7 +194,7 @@ The repo includes `.zed/tasks.json` with pre-configured tasks (use cmd-shift-t):
 **Daemon code changes not taking effect:**
 1. In dev mode: restart `cargo xtask dev-daemon`
 2. In production mode on macOS: reinstall the nteract Nightly .app (it auto-updates its daemon)
-3. In production mode on Linux / headless: run `cargo xtask install-nightly`
+3. In production mode on Linux / headless: run `./scripts/install-nightly`
 4. Check which daemon: `./target/debug/runt daemon status`
 
 **App says "Dev daemon not running":**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ The rustflag goes through direnv, not `.cargo/config.toml`, so CI runners and co
 - Binaries: `~/.local/share/runt-nightly/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}`
 - Symlinks: `/usr/local/bin/{runtimed-nightly,runt-nightly,nteract-mcp-nightly}` → the install dir
 - Daemon socket: `~/.cache/runt-nightly/runtimed.sock`
-- Install command: `cargo xtask install-nightly` (refuses on macOS and when an app bundle is installed — see § `install-nightly` below)
+- Install command: `./scripts/install-nightly` (refuses on macOS and when an app bundle is installed)
 - Version: Built from source, updated after each PR merge
 
 **Verification steps:** See `.claude/rules/mcp-servers.md` § Verifying Daemon Isolation.
@@ -437,7 +437,7 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask build-dmg` | Build a DMG bundle (CI/release packaging) |
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
 | | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
-| | `cargo xtask install-nightly` | Install runtimed + runt + nteract-mcp as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
+| | `./scripts/install-nightly` | Install runtimed + runt + nteract-mcp as the local nightly (cloud-box / headless-Linux first-install). Refuses on macOS unless `--on-macos`; refuses when an app bundle is installed unless `--replace-installed-app`. |
 | MCP | `cargo xtask run-mcp` | nteract-dev (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask mcp-inspector` | Launch MCP Inspector UI for testing runt mcp |
@@ -457,7 +457,7 @@ The daemon is a separate process from the notebook app. When you change code in 
 ### Stopping the Daemon
 
 - `./target/debug/runt daemon stop` — stops only your worktree's daemon
-- `cargo xtask install-nightly` — gracefully installs or reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
+- `./scripts/install-nightly` — gracefully installs or reinstalls the full nightly stack (Linux/headless only; refuses on macOS by default)
 
 Avoid system-wide process killers (`pkill`, `killall`) — they affect every worktree and every other agent on the machine.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cargo xtask dev
 | Lint (check) | `cargo xtask lint` | Check formatting and linting across Rust, JS/TS, Python |
 | Lint (fix) | `cargo xtask lint --fix` | Auto-fix formatting and linting |
 | Dev daemon | `cargo xtask dev-daemon` | Run per-worktree dev daemon |
-| Install nightly (Linux/headless) | `cargo xtask install-nightly` | Build + install runtimed + runt + nteract-mcp as the local nightly. Refuses on macOS and when an app bundle is installed. |
+| Install nightly (Linux/headless) | `./scripts/install-nightly` | Build + install runtimed + runt + nteract-mcp as the local nightly. Refuses on macOS and when an app bundle is installed. |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
 | Generate icons | `cargo xtask icons [source.png]` | Generate icon variants from source image |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -236,13 +236,13 @@ unset RUNTIMED_WORKSPACE_PATH
 
 # On macOS: install the nteract Nightly .app and let SMAppService manage the daemon.
 # On Linux / headless: rebuild and reinstall the full nightly stack from source:
-cargo xtask install-nightly
+./scripts/install-nightly
 
 # Run the app (it will connect to the system daemon)
 cargo xtask notebook
 ```
 
-Note: `cargo xtask install-nightly` refuses on macOS by default (the app bundle manages the daemon itself). Pass `--on-macos` if you really need to install out-of-bundle binaries, and `--replace-installed-app` if an app bundle is already present.
+Note: `./scripts/install-nightly` refuses on macOS by default (the app bundle manages the daemon itself). Pass `--on-macos` if you really need to install out-of-bundle binaries, and `--replace-installed-app` if an app bundle is already present.
 
 ### Daemon logs
 
@@ -262,7 +262,7 @@ runt daemon logs -f | grep -i "kernel\|auto-detect"
 If your daemon code changes aren't taking effect:
 1. **In dev mode:** Did you restart `cargo xtask dev-daemon`?
 2. **In production mode (macOS):** Re-install the nteract Nightly .app (it auto-updates the bundled daemon).
-3. **In production mode (Linux / headless):** Did you run `cargo xtask install-nightly`?
+3. **In production mode (Linux / headless):** Did you run `./scripts/install-nightly`?
 4. Check which daemon is running: `runt daemon status`
 
 If the app says "Dev daemon not running":

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -19,7 +19,7 @@ cargo xtask e2e test        # Smoke/default E2E run
 cargo xtask e2e test-all    # Full suite, including fixture coverage
 ```
 
-`cargo xtask e2e ...` handles app launch, waits for the embedded WebDriver server on port `4445`, runs `pnpm test:e2e`, and then cleans up. The older `cargo xtask build-e2e` alias still exists, but it is deprecated.
+`cargo xtask e2e ...` handles app launch, waits for the embedded WebDriver server on port `4445`, runs `pnpm test:e2e`, and then cleans up
 
 #### Fixture Tests
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -6,7 +6,7 @@ The runtime daemon manages prewarmed Python environments, notebook document sync
 
 | Task | Command |
 |------|---------|
-| Install nightly from source (Linux/headless) | `cargo xtask install-nightly` |
+| Install nightly from source (Linux/headless) | `./scripts/install-nightly` |
 | Run daemon | `cargo run -p runtimed` |
 | Run with debug logs | `RUST_LOG=debug cargo run -p runtimed` |
 | Check status | `cargo run -p runt -- daemon status` |
@@ -97,7 +97,7 @@ The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `cra
 On Linux cloud boxes and headless dev environments:
 
 ```bash
-cargo xtask install-nightly
+./scripts/install-nightly
 ```
 
 This builds `runtimed`, `runt`, and `nteract-mcp` in release mode and installs all three into `~/.local/share/runt-nightly/bin/` with channel-suffixed names (`runtimed-nightly`, `runt-nightly`, `nteract-mcp-nightly`). On first run it writes the systemd user unit and starts it; on subsequent runs it upgrades in place. After the initial install the command prints the follow-up `sudo ln -sf` symlink commands for `/usr/local/bin/` and the `sudo loginctl enable-linger` step that keeps the user service alive across logout.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -84,22 +84,8 @@ fn main() {
             let sub_args: Vec<String> = args[1..].to_vec();
             cmd_e2e(sub_args);
         }
-        "build-e2e" => cmd_build_e2e(),
         "build-dmg" => cmd_build_dmg(),
         "build-app" => cmd_build_app(),
-        "install-nightly" => {
-            eprintln!("install-nightly is a shell script now.");
-            eprintln!();
-            eprintln!("Run it from the repo root:");
-            eprintln!();
-            eprintln!("    ./scripts/install-nightly");
-            eprintln!();
-            eprintln!(
-                "It was moved out of xtask so `cargo xtask lint` doesn't have to pay \
-                 runtimed-client's (~750 crate) compile cost."
-            );
-            exit(1);
-        }
         "dev-daemon" => {
             let release = args.iter().any(|a| a == "--release");
             cmd_dev_daemon(release);
@@ -886,11 +872,6 @@ fn cmd_run(notebook: Option<&str>) {
         Some(path) => run_cmd("./target/debug/notebook", &[path]),
         None => run_cmd("./target/debug/notebook", &[]),
     }
-}
-
-fn cmd_build_e2e() {
-    eprintln!("Note: 'build-e2e' is deprecated, use 'cargo xtask e2e build' instead.");
-    cmd_e2e_build();
 }
 
 fn print_e2e_help() {


### PR DESCRIPTION
Two dispatch entries in `cargo xtask` were thin shims over their real implementation:

- `cargo xtask build-e2e` → printed a deprecation note, then called `cargo xtask e2e build`.
- `cargo xtask install-nightly` → printed "use `./scripts/install-nightly`" and exited.

Both existed to soften migrations. They've outlived their reason.

## What's untouched

- `cargo xtask e2e build` still builds the WebDriver-enabled debug app (`VITE_E2E=1`, `--features e2e-webdriver`, port 4445). This is the real path for building a local E2E-capable binary.
- `./scripts/install-nightly` still installs `runtimed + runt + nteract-mcp` on Linux/headless. Sandbox provisioning, CI doc pointers, and agent skills already use the shell script path.

## Docs

Every mention of `cargo xtask install-nightly` flips to `./scripts/install-nightly`. The "`cargo xtask build-e2e` alias still exists, but it is deprecated" sentence in `contributing/e2e.md` is deleted. A dangling "see § install-nightly below" pointer in `AGENTS.md` that pointed to a section that doesn't exist is dropped.

## Test plan

- [x] `cargo build -p xtask` clean
- [x] `cargo xtask lint` clean
- [x] `grep -rn "build-e2e\|cargo xtask install-nightly" .` returns zero hits outside `target/`, `node_modules/`, `.venv/`
