### PR TITLE
chore(notebook): drop toml + serde_yaml deps and stale tombstone comment

### DIFF
--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -52,8 +52,6 @@ tauri-plugin-log = "2"
 strsim = "0.11"  # For Levenshtein distance (typosquat detection)
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 dirs = "6"
-toml = "1"
-serde_yaml = "0.9"
 pathdiff = "0.2"
 rfd = "0.17"  # Native dialogs for pre-window error display
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2908,17 +2908,6 @@ async fn send_frame_bytes(
 }
 
 // ============================================================================
-// pyproject.toml Discovery and Environment Commands
-// ============================================================================
-//
-// Deleted in favour of daemon-side walk-up (#2208). The daemon writes
-// `RuntimeStateDoc.project_context` on notebook open and save-as; the
-// frontend reads it reactively via `useDependencies`, and the import
-// flow writes UV deps through the existing WASM metadata helpers.
-// No `detect_pyproject` / `get_pyproject_dependencies` /
-// `import_pyproject_dependencies` commands anymore.
-
-// ============================================================================
 // Trust Verification Commands
 // ============================================================================
 


### PR DESCRIPTION
Follow-up cleanup on #2220. The pyproject / pixi / environment.yml parser modules in `crates/notebook/src/` were deleted in that PR; `toml` and `serde_yaml` were only used by them. Dropped from `crates/notebook/Cargo.toml`. Workspace compiles (`cargo check -p notebook`).

Also dropped the block comment at the old pyproject-commands site that described what used to live there — the repo rule is that comments describe the code that's there, not the code that used to be there.
