### PR TITLE
fix(runtimed): codex P2 follow-ups — malformed pyproject + watcher arm race + ty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,7 +4462,6 @@ dependencies = [
  "runtimed-client",
  "serde",
  "serde_json",
- "serde_yaml",
  "strsim",
  "tauri",
  "tauri-build",
@@ -4475,7 +4474,6 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
  "uuid",
  "wry",
 ]

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -102,12 +102,20 @@ async fn rearm_project_file_watcher(room: &Arc<NotebookRoom>, detected_path: Opt
         return;
     };
 
-    let shutdown_tx = spawn_project_file_watcher(watch_path, room.clone());
+    let (shutdown_tx, ready_rx) = spawn_project_file_watcher(watch_path, room.clone());
     *room
         .persistence
         .project_file_watcher_shutdown_tx
         .lock()
         .await = Some(shutdown_tx);
+    // Block until the watcher task has actually installed its
+    // subscription (or failed trying). Without this, events that land
+    // between "we returned from this function" and "notify attached
+    // itself" go unreported. On the failure path the sender is dropped
+    // and the receiver returns `Err(RecvError)` — we just continue,
+    // because the task has already logged the error and there's no
+    // watcher to wait on anyway.
+    let _ = ready_rx.await;
 }
 
 /// Watch a single project file and call `refresh_project_context_async`
@@ -116,15 +124,32 @@ async fn rearm_project_file_watcher(room: &Arc<NotebookRoom>, detected_path: Opt
 /// suppress — any event from `notify` is an external change worth
 /// re-parsing.
 ///
-/// Returns the oneshot sender the caller stores; dropping or sending
-/// on it stops the watcher.
+/// Returns two channels:
+///
+/// - `shutdown_tx`: the caller stores it; sending (or dropping) stops
+///   the watcher.
+/// - `ready_rx`: resolves when the task has actually installed the
+///   FSEvents subscription (or hit an error and given up). Callers
+///   await this before returning to guarantee that events after the
+///   return point actually reach the watcher.
 fn spawn_project_file_watcher(
     project_file_path: PathBuf,
     room: Arc<NotebookRoom>,
-) -> oneshot::Sender<()> {
+) -> (oneshot::Sender<()>, oneshot::Receiver<()>) {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel::<()>();
 
     spawn_best_effort("project-file-watcher", async move {
+        // Signals readiness or gives up, running `ready_tx.send(())`
+        // exactly once on any exit path. Dropping without sending (the
+        // error arms below) still unblocks the waiter via `RecvError`.
+        let mut ready_tx = Some(ready_tx);
+        let signal_ready = |slot: &mut Option<oneshot::Sender<()>>| {
+            if let Some(tx) = slot.take() {
+                let _ = tx.send(());
+            }
+        };
+
         let (tx, mut rx) = tokio::sync::mpsc::channel::<DebounceEventResult>(16);
         let debouncer_result = notify_debouncer_mini::new_debouncer(
             std::time::Duration::from_millis(500),
@@ -177,6 +202,10 @@ fn spawn_project_file_watcher(
             project_file_path, parent_dir
         );
 
+        // Subscription is live; unblock the waiter. From this point on,
+        // events that land against `project_file_path` reach `rx`.
+        signal_ready(&mut ready_tx);
+
         loop {
             tokio::select! {
                 Some(result) = rx.recv() => {
@@ -215,7 +244,7 @@ fn spawn_project_file_watcher(
         }
     });
 
-    shutdown_tx
+    (shutdown_tx, ready_rx)
 }
 
 /// Detect + parse, translating the daemon's internal `DetectedProjectFile`
@@ -314,7 +343,7 @@ fn parse_detected(
     content: &str,
 ) -> Result<ProjectFileParsed, String> {
     match detected.kind {
-        daemon_project_file::ProjectFileKind::PyprojectToml => Ok(parse_pyproject_toml(content)),
+        daemon_project_file::ProjectFileKind::PyprojectToml => parse_pyproject_toml(content),
         daemon_project_file::ProjectFileKind::PixiToml => Ok(parse_pixi_toml(content)),
         daemon_project_file::ProjectFileKind::EnvironmentYml => {
             parse_environment_yml(&detected.path, content)
@@ -327,12 +356,14 @@ fn parse_detected(
 ///
 /// Uses real TOML parsing via `serde`. PEP 508 specs such as
 /// `requests[security,socks]>=2` include commas inside bracket groups,
-/// which earlier line-scanning extraction could not distinguish from
-/// list separators. A parse failure falls back to an empty
-/// `ProjectFileParsed` rather than propagating — the caller already has
-/// `ProjectContext::Unreadable` for genuinely broken project files, and
-/// we only hit this arm on well-formed TOML.
-fn parse_pyproject_toml(content: &str) -> ProjectFileParsed {
+/// which a line scanner couldn't distinguish from list separators.
+///
+/// Parse errors — both raw-TOML syntax failures and schema-valid but
+/// shape-invalid inputs (`dependencies = "pandas"` where a list is
+/// expected) — route to `Err(reason)` so `build_context` emits
+/// `ProjectContext::Unreadable` and the UI surfaces the problem instead
+/// of silently reporting zero deps.
+fn parse_pyproject_toml(content: &str) -> Result<ProjectFileParsed, String> {
     #[derive(serde::Deserialize, Default)]
     struct Root {
         #[serde(default)]
@@ -361,25 +392,15 @@ fn parse_pyproject_toml(content: &str) -> ProjectFileParsed {
         dev_dependencies: Vec<String>,
     }
 
-    match toml::from_str::<Root>(content) {
-        Ok(root) => ProjectFileParsed {
-            dependencies: root.project.dependencies,
-            dev_dependencies: root.tool.uv.dev_dependencies,
-            requires_python: root.project.requires_python,
-            prerelease: None,
-            extras: ProjectFileExtras::None,
-        },
-        Err(e) => {
-            debug!("[notebook-sync] pyproject.toml parse skipped: {}", e);
-            ProjectFileParsed {
-                dependencies: Vec::new(),
-                dev_dependencies: Vec::new(),
-                requires_python: None,
-                prerelease: None,
-                extras: ProjectFileExtras::None,
-            }
-        }
-    }
+    let root: Root =
+        toml::from_str(content).map_err(|e| format!("pyproject.toml parse failed: {e}"))?;
+    Ok(ProjectFileParsed {
+        dependencies: root.project.dependencies,
+        dev_dependencies: root.tool.uv.dev_dependencies,
+        requires_python: root.project.requires_python,
+        prerelease: None,
+        extras: ProjectFileExtras::None,
+    })
 }
 
 /// Commit-2 pixi parsing keeps the easy signals: channels (top-level
@@ -677,6 +698,28 @@ mod tests {
         };
         assert_eq!(parsed.dependencies, vec!["pandas"]);
         assert_eq!(parsed.dev_dependencies, vec!["pytest", "ruff>=0.6"]);
+    }
+
+    #[test]
+    fn build_context_pyproject_schema_mismatch_routes_to_unreadable() {
+        // Well-formed TOML, wrong shape: `dependencies` should be a
+        // list of strings, not a bare string. The prior fallback
+        // silently reported zero deps — now it surfaces as Unreadable
+        // so the UI can explain what's wrong.
+        let temp = TempDir::new().unwrap();
+        write(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"demo\"\ndependencies = \"pandas\"\n",
+        );
+        let notebook = write(temp.path(), "demo.ipynb", "{}");
+
+        let (ctx, _) = build_context(&notebook);
+        let ProjectContext::Unreadable { path, reason, .. } = ctx else {
+            panic!("expected Unreadable, got {ctx:?}");
+        };
+        assert!(path.ends_with("pyproject.toml"));
+        assert!(reason.contains("parse failed"));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6370,14 +6370,12 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
         .await
         .is_some());
 
-    // Give FSEvents a moment to wire up the watch. Without this the
-    // write below can race the kernel-side subscription registration
-    // (observed empirically on macOS).
-    sleep(Duration::from_millis(500)).await;
-
-    // External edit: add a dep. `notify` picks up the write, debounces
-    // for 500ms, then fires. We poll the CRDT up to 15s for the new
-    // state to appear so the test stays robust across CI jitter.
+    // External edit: add a dep. `refresh_project_context_async`
+    // already awaited the watcher's ready signal before returning, so
+    // the subscription is live — no pre-write settle needed. `notify`
+    // picks up the write, debounces for 500ms, then fires. We poll the
+    // CRDT up to 15s for the new state to appear so the test stays
+    // robust across CI jitter.
     std::fs::write(
         &pyproject_path,
         "[project]\nname = \"demo\"\ndependencies = [\"pandas\", \"numpy\"]\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,15 @@ include = ["python/gremlin/**"]
 [tool.ty.overrides.rules]
 unresolved-import = "ignore"
 
+# nteract_kernel_launcher uses function-attribute idempotency tags
+# (`hook._nteract_installed = True`). ruff's B010 refactors away the
+# alternative `setattr(...)` form, so we can't mask this on the call
+# site. Scope the override narrowly to the launcher package.
+[[tool.ty.overrides]]
+include = ["python/nteract-kernel-launcher/**"]
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
+
 
 
 [tool.ruff.format]

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
@@ -120,7 +120,7 @@ def buffer_hook(msg: dict) -> dict | None:
 
 
 # Tag the callable so re-installs can detect us without stacking duplicates.
-buffer_hook._nteract_installed = True  # type: ignore[attr-defined]
+buffer_hook._nteract_installed = True
 
 
 def install(ip: Any) -> None:

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -268,6 +268,6 @@ def install(ip: Any) -> None:
                     original(etype, evalue, stb)
 
     # Tag for idempotency.
-    _safe_showtraceback._nteract_installed = True  # type: ignore[attr-defined]
+    _safe_showtraceback._nteract_installed = True
 
     ip._showtraceback = types.MethodType(_safe_showtraceback, ip)


### PR DESCRIPTION
Follow-up on #2220 cleaning up the two Codex P2 findings filed in the PR body, plus a small build/ty change to keep the lint chain green on the latest `ty`.

## Fix 1: malformed pyproject.toml now routes to `Unreadable`

`parse_pyproject_toml` was swallowing `toml::from_str` errors and returning an empty `ProjectFileParsed`, so schema-valid but shape-wrong TOML (e.g. `dependencies = "pandas"` where a list is expected) surfaced as `ProjectContext::Detected` with zero deps. Users saw a banner that said "no dependencies declared" instead of "your pyproject.toml is broken."

Parser now returns `Result<ProjectFileParsed, String>`. `build_context` routes failures to `ProjectContext::Unreadable`, same path `parse_environment_yml` already takes. Regression test locks it in.

## Fix 2: watcher arm race closed with a ready ack

`refresh_project_context_async` used to return as soon as it spawned the watcher task. The task's `watcher.watch()` call ran async, so events that landed between the return and the subscription install were lost. The test masked this with a 500ms sleep before the write.

`spawn_project_file_watcher` now also returns a `oneshot::Receiver<()>` that resolves after `watcher.watch()` succeeds (or after an error arm drops the sender). `rearm_project_file_watcher` awaits it before returning. Test sleep is gone; it runs in ~0.6s instead of ~1.1s.

## Fix 3: `ty` unresolved-attribute on launcher idempotency tags

`ty 0.0.28` flags `hook._nteract_installed = True` as `unresolved-attribute` — the old `# type: ignore[attr-defined]` pragma is a mypy suppressor that ty doesn't honor. Rewriting to `setattr(...)` works for ty but ruff's `B010` auto-reverts it. No call-site fix wins under both linters.

Narrowly-scoped ty override for `python/nteract-kernel-launcher/**` marks `unresolved-attribute` as ignore. Pattern is only used in that package. Dead mypy pragmas dropped. Also refreshed `Cargo.lock` — stale after #2228's dep removal.

## Test plan

- [x] `cargo test -p runtimed --lib notebook_sync_server::` — 217 pass
- [x] `cargo clippy -p runtimed --all-targets -- -D warnings` — clean
- [x] `cargo xtask lint` — all checks pass
