### PR TITLE
chore: drop unused deps across workspace (cargo-machete sweep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,6 @@ dependencies = [
  "notebook-protocol",
  "runt-workspace",
  "runtime-doc",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4584,12 +4583,8 @@ name = "nteract-predicate"
 version = "0.1.5"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-buffer",
  "arrow-cast",
- "arrow-ord",
  "arrow-select",
- "arrow-string",
  "bytes",
  "chrono",
  "parquet",
@@ -6938,13 +6933,10 @@ name = "runt-mcp-proxy"
 version = "0.1.5"
 dependencies = [
  "rmcp",
- "schemars 1.2.1",
- "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -7034,7 +7026,6 @@ dependencies = [
  "runtime-doc",
  "runtimed-client",
  "runtimelib",
- "schemars 1.2.1",
  "serde",
  "serde_json",
  "serial_test",
@@ -7045,7 +7036,6 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
- "ts-rs",
  "uuid",
  "windows-sys 0.52.0",
 ]
@@ -7085,11 +7075,9 @@ dependencies = [
  "arrow",
  "base64 0.22.1",
  "bytes",
- "log",
  "napi",
  "napi-build",
  "napi-derive",
- "notebook-doc",
  "notebook-protocol",
  "notebook-sync",
  "nteract-predicate",
@@ -7131,8 +7119,6 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
- "js-sys",
- "log",
  "notebook-doc",
  "runtime-doc",
  "serde",

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -15,7 +15,6 @@ notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
 notebook-protocol = { path = "../notebook-protocol" }
 tokio = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -75,3 +75,9 @@ tempfile = "3"
 [build-dependencies]
 serde_json = { workspace = true }
 tauri-build = { version = "2", features = [] }
+
+[package.metadata.cargo-machete]
+# `wry` is depended on only to activate its `fullscreen` Cargo feature
+# via feature unification — no direct code uses it. See the wry line
+# in [dependencies] for the full rationale.
+ignored = ["wry"]

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -12,14 +12,13 @@ serde = { workspace = true }
 bytes = { workspace = true }
 chrono = { version = "0.4", default-features = false }
 
-# Arrow with compute kernels
+# Arrow with compute kernels. `arrow` re-exports array/buffer/ord/string
+# under its own module tree; those sub-crates are pulled in transitively
+# and don't need direct entries. `arrow-cast` and `arrow-select` are
+# imported directly (see `summary.rs`, `filter.rs`) and stay explicit.
 arrow = { version = "54", default-features = false, features = ["ipc", "ffi"] }
-arrow-array = { version = "54", default-features = false }
-arrow-buffer = { version = "54", default-features = false }
 arrow-cast = { version = "54", default-features = false }
-arrow-ord = { version = "54", default-features = false }
 arrow-select = { version = "54", default-features = false }
-arrow-string = { version = "54", default-features = false }
 
 # Parquet reader
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "flate2", "zstd"] }

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -10,11 +10,8 @@ publish = false
 [dependencies]
 rmcp = { version = "1.4", features = ["server", "client", "transport-child-process", "transport-io"] }
 tokio = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
-schemars = { workspace = true }
 tracing = "0.1"
-uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["cdylib"]
 napi = { version = "3", default-features = false, features = ["napi9", "async", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 runtimed-client = { path = "../runtimed-client" }
-notebook-doc = { path = "../notebook-doc" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 runtime-doc = { path = "../runtime-doc" }
@@ -26,7 +25,6 @@ tokio = { version = "1", features = ["full"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
-log = "0.4"
 thiserror = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -14,12 +14,13 @@ automerge = "0.8"
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
 wasm-bindgen = "0.2"
-js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
-log = "0.4"
 web-sys = { version = "0.3", features = ["console"] }
+# getrandom (both versions) stays to activate the wasm_js / js feature
+# for transitive crates. Removing either line breaks the wasm build
+# because uuid / rand can't find a browser RNG.
 getrandom = { version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 console_error_panic_hook = "0.1"
@@ -29,6 +30,12 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[package.metadata.cargo-machete]
+# Both `getrandom` entries are here purely to activate the `wasm_js` /
+# `js` feature on the transitive dep so uuid / rand can find a browser
+# RNG. No direct code uses them; deleting either breaks the wasm build.
+ignored = ["getrandom", "getrandom_02"]
 
 [lints]
 workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -91,12 +91,6 @@ kernel-launch = { path = "../kernel-launch" }
 # Shared environment management (UV + Conda) with progress reporting
 kernel-env = { path = "../kernel-env" }
 
-# JSON Schema generation
-schemars = { workspace = true }
-
-# TypeScript type generation
-ts-rs = { workspace = true }
-
 # File watching for external settings.json changes
 notify = { workspace = true }
 notify-debouncer-mini = { workspace = true }


### PR DESCRIPTION
Workspace-wide `cargo machete` sweep. Every removal verified against its crate's build and tests; feature-unification deps stay, documented via `[package.metadata.cargo-machete].ignored` so they stop being flagged.

## Removed outright

| Crate | Unused deps |
|---|---|
| `notebook-sync` | `serde` |
| `nteract-predicate` | `arrow-array`, `arrow-buffer`, `arrow-ord`, `arrow-string` |
| `runt-mcp-proxy` | `serde`, `schemars`, `uuid` |
| `runtimed` | `schemars`, `ts-rs` |
| `runtimed-node` | `log`, `notebook-doc` |

The arrow-\* removals deserve a note: `nteract-predicate` uses `StringArray` / `LargeStringArray` / `AsArray` etc. but reaches them through the `arrow` umbrella crate's module tree (`arrow::array::*`), not through the individual sub-crates. The sub-crates were pulled in transitively anyway. `arrow-cast` and `arrow-select` stay because `summary.rs` and `filter.rs` import them directly.

## Kept + annotated

| Crate | Dep | Why |
|---|---|---|
| `notebook` | `wry` | Feature unification for `fullscreen`. Already documented in `[dependencies]`. |
| `runtimed-wasm` | `getrandom`, `getrandom_02` | Activate `wasm_js` / `js` features so transitive `uuid` / `rand` find a browser RNG. Removing either breaks the wasm build. |

Marked via `[package.metadata.cargo-machete].ignored` with a comment pointing at the rationale, so future `cargo machete` runs stay clean.

## Verified

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --exclude runtimed-py --all-targets -- -D warnings` — clean
- [x] `cargo test -p notebook-sync -p runtimed -p runt-mcp-proxy -p runtimed-node -p nteract-predicate --lib` — 506+ pass
- [x] `cargo check -p runtimed-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo machete` — no unused deps left
- [x] `cargo xtask lint` — clean
