### PR TITLE
Fix Safari scrolling in Sift

### DIFF
--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -649,8 +649,11 @@ h1 {
 
 /* --- Type-aware cells --- */
 
+.sift-cell-numeric,
 .sift-cell-timestamp {
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .sift-badge {

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -103,6 +103,27 @@ describe("createTable", () => {
       const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("50");
     });
+
+    it("does not let long numeric values expand row height", async () => {
+      const numericContainer = document.createElement("div");
+      document.body.appendChild(numericContainer);
+      const longNumber = `0.${"0".repeat(300)}5`;
+      const numericEngine = createTable(
+        numericContainer,
+        makeTableData([[1, "Person 1", longNumber, true]]),
+      );
+      const viewport = numericContainer.querySelector<HTMLElement>(".sift-viewport")!;
+      Object.defineProperty(viewport, "clientHeight", { value: 400, configurable: true });
+      viewport.dispatchEvent(new Event("scroll"));
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      const row = numericContainer.querySelector<HTMLElement>(".sift-row")!;
+      expect(Number.parseFloat(row.style.height || "0")).toBeLessThan(80);
+
+      numericEngine.destroy();
+      numericContainer.remove();
+    });
   });
 
   describe("filtering", () => {
@@ -413,6 +434,26 @@ describe("createTable", () => {
       expect(total).toBeGreaterThanOrEqual(1600 - 2);
       e.destroy();
       wide.remove();
+    });
+
+    it("does not shrink the last column when the table is wider than the viewport", async () => {
+      const narrow = document.createElement("div");
+      document.body.appendChild(narrow);
+      const e = createTable(narrow, makeTableData(makeRows(10)));
+      await flushRAF();
+
+      const viewport = narrow.querySelector<HTMLElement>(".sift-viewport")!;
+      const headers = narrow.querySelectorAll<HTMLElement>(".sift-th");
+      const last = headers[headers.length - 1];
+      const initialLastWidth = Number.parseFloat(last.style.width || "0");
+
+      Object.defineProperty(viewport, "clientWidth", { value: 300, configurable: true });
+      window.dispatchEvent(new Event("resize"));
+      await flushRAF();
+
+      expect(Number.parseFloat(last.style.width || "0")).toBe(initialLastWidth);
+      e.destroy();
+      narrow.remove();
     });
   });
 });

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -248,8 +248,13 @@ export function createTable(
       const cell = cache[c];
       const cellW = Math.max(1, colWidths[c] - CELL_PAD_H);
       if (cell.lastWidth !== cellW) {
-        const { height } = layout(cell.prepared, cellW, LINE_HEIGHT);
-        cell.lastHeight = height;
+        const colType = columns[c].columnType;
+        if (colType === "numeric" || colType === "timestamp" || colType === "boolean") {
+          cell.lastHeight = LINE_HEIGHT;
+        } else {
+          const { height } = layout(cell.prepared, cellW, LINE_HEIGHT);
+          cell.lastHeight = height;
+        }
         cell.lastWidth = cellW;
       }
       if (cell.lastHeight > maxH) maxH = cell.lastHeight;
@@ -905,6 +910,7 @@ export function createTable(
   // user resizes the last column explicitly. Re-runs on viewport resize and
   // after non-last column resizes, so maximize/restore just works.
   let lastColumnAutoFill = true;
+  const lastColumnAutoFillMinWidth = colWidths[columns.length - 1] ?? MIN_COL_WIDTH;
 
   function fitLastColumnToViewport() {
     if (!lastColumnAutoFill) return;
@@ -914,7 +920,7 @@ export function createTable(
     if (viewportW <= 0) return;
     let fixedW = 0;
     for (let c = 0; c < last; c++) fixedW += colWidths[c];
-    const target = Math.max(MIN_COL_WIDTH, viewportW - fixedW);
+    const target = Math.max(lastColumnAutoFillMinWidth, viewportW - fixedW);
     if (target === colWidths[last]) return;
     colWidths[last] = target;
     headerCells[last].style.width = target + "px";
@@ -1149,6 +1155,9 @@ export function createTable(
         break;
       }
       default:
+        if (col.columnType === "numeric") {
+          cellEl.classList.add("sift-cell-numeric");
+        }
         if (
           Array.isArray(raw) &&
           raw.length > 0 &&


### PR DESCRIPTION
## Summary
- Keep numeric, timestamp, and boolean cells on a single line so long values do not inflate row height in Safari.
- Preserve the last column’s measured width instead of shrinking autofill to the minimum width when the table is wider than the viewport.
- Add regression tests for long numeric row height and last-column autofill behavior.

## Testing
- `pnpm --dir packages/sift test src/table.test.ts`
- `pnpm --dir packages/sift test`