### PR TITLE
feat(runtimed): surface kernel-launch failures through RuntimeStateDoc

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -315,6 +315,7 @@ function AppContent() {
     statusKey,
     lifecycle,
     errorReason,
+    errorDetails,
     kernelInfo,
     queueState,
     envSyncState,
@@ -1158,6 +1159,7 @@ function AppContent() {
           statusKey={statusKey}
           lifecycle={lifecycle}
           errorReason={errorReason}
+          kernelErrorMessage={errorDetails}
           envSource={envSource}
           envTypeHint={envTypeHint}
           envProgress={envProgress.isActive || envProgress.error ? envProgress : null}

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1876,15 +1876,32 @@ pub(crate) fn is_untitled_notebook(notebook_id: &str) -> bool {
     uuid::Uuid::parse_str(notebook_id).is_ok()
 }
 
-/// Reset runtime state to "not_started" (clears any stale starting phase).
-/// Used when an early exit prevents kernel launch after status was set to "starting".
+/// Outcome the caller wants for `RuntimeStateDoc.kernel` after tearing
+/// down a failed or stale runtime agent.
+pub(crate) enum ResetOutcome<'a> {
+    /// Clear the starting phase and leave the kernel in `NotStarted`. The
+    /// frontend's auto-launch path can retry cleanly.
+    NotStarted,
+    /// Mark the kernel as `Error` and attach an error_details string the
+    /// UI can render. `reason` is the typed key (or `None` for generic
+    /// errors that don't fit the `KernelErrorReason` enum).
+    Error {
+        reason: Option<runtime_doc::KernelErrorReason>,
+        details: &'a str,
+    },
+}
+
+/// Reset runtime state after a failed or aborted launch. Writes the
+/// requested outcome to `RuntimeStateDoc.kernel` and clears the stale
+/// runtime agent handle / request channel / pending connect sender.
 ///
 /// `expected_runtime_agent_id`: If `Some`, only reset if the current runtime agent
 /// matches — prevents a stale error handler from clobbering a newer agent's state.
 /// Pre-spawn callers pass `None` (no agent exists yet, always safe to reset).
-pub(crate) async fn reset_starting_state(
+pub(crate) async fn reset_starting_state_with_outcome<'a>(
     room: &NotebookRoom,
     expected_runtime_agent_id: Option<&str>,
+    outcome: ResetOutcome<'a>,
 ) {
     // For guarded resets (post-spawn error paths), atomically check-and-clear
     // provenance AND capture the generation counter in a single write lock scope.
@@ -1916,7 +1933,18 @@ pub(crate) async fn reset_starting_state(
     // state handle uses std::sync::Mutex - no lock ordering concern
     // with runtime_agent_handle (tokio::sync::Mutex).
     if let Err(e) = room.state.with_doc(|sd| {
-        sd.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
+        match outcome {
+            ResetOutcome::NotStarted => {
+                sd.set_lifecycle(&RuntimeLifecycle::NotStarted)?;
+            }
+            ResetOutcome::Error { reason, details } => {
+                sd.set_lifecycle_with_error_details(
+                    &RuntimeLifecycle::Error,
+                    reason,
+                    Some(details),
+                )?;
+            }
+        }
         sd.set_prewarmed_packages(&[])?;
         Ok(())
     }) {
@@ -1958,6 +1986,20 @@ pub(crate) async fn reset_starting_state(
         }
         *guard = None;
     }
+}
+
+/// Reset runtime state to `NotStarted`. Convenience wrapper around
+/// [`reset_starting_state_with_outcome`] for call sites that don't have
+/// a specific error message to surface — e.g. pool-empty, a user-side
+/// config error the caller has already encoded in its own
+/// `NotebookResponse::Error`, or a path that only needs to unwind the
+/// "starting" state so auto-launch can retry.
+pub(crate) async fn reset_starting_state(
+    room: &NotebookRoom,
+    expected_runtime_agent_id: Option<&str>,
+) {
+    reset_starting_state_with_outcome(room, expected_runtime_agent_id, ResetOutcome::NotStarted)
+        .await;
 }
 
 /// Try to satisfy UV inline deps from the prewarmed pool.
@@ -3256,23 +3298,62 @@ pub(crate) async fn auto_launch_kernel(
                     }
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                         warn!("[notebook-sync] Agent kernel launch failed: {}", error);
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
+                        // Surface the failure through CRDT so the UI
+                        // doesn't sit on "starting" forever. The error
+                        // string usually carries the stderr tail from
+                        // `jupyter_kernel.rs` — exactly what the user
+                        // needs to see.
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: &error,
+                            },
+                        )
+                        .await;
                     }
                     Ok(_) => {
                         warn!(
                             "[notebook-sync] Unexpected runtime agent response during auto-launch"
                         );
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: "Unexpected runtime agent response during kernel launch",
+                            },
+                        )
+                        .await;
                     }
                     Err(e) => {
                         warn!("[notebook-sync] Agent communication error: {}", e);
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
+                        let details = format!("Agent communication error: {e}");
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: &details,
+                            },
+                        )
+                        .await;
                     }
                 }
             }
             Err(e) => {
                 warn!("[notebook-sync] Failed to spawn runtime agent: {}", e);
-                reset_starting_state(room, None).await;
+                let details = format!("Failed to spawn runtime agent: {e}");
+                reset_starting_state_with_outcome(
+                    room,
+                    None,
+                    ResetOutcome::Error {
+                        reason: None,
+                        details: &details,
+                    },
+                )
+                .await;
             }
         }
     }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6414,3 +6414,43 @@ async fn project_file_watcher_refreshes_context_on_external_edit() {
         let _ = tx.send(());
     }
 }
+
+/// Kernel launch can fail before the kernel ever connects to the
+/// daemon — e.g. the subprocess exits with status 1 because a required
+/// module isn't installed. The failure arms in
+/// `notebook_sync_server::metadata` and `requests::launch_kernel` now
+/// use `reset_starting_state_with_outcome(..., ResetOutcome::Error)`
+/// so the CRDT carries `Error + error_details` instead of quietly
+/// reverting to `NotStarted`. This covers the wiring.
+#[tokio::test]
+async fn reset_starting_state_error_variant_writes_details() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "launch-failure.ipynb");
+
+    // Seed a non-Error lifecycle so the transition under test is observable.
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Launching))
+        .unwrap();
+
+    let stderr_tail = "Kernel process exited immediately: status 1\nstderr tail:\n/path/to/python: No module named foo\n";
+    reset_starting_state_with_outcome(
+        &room,
+        None,
+        ResetOutcome::Error {
+            reason: None,
+            details: stderr_tail,
+        },
+    )
+    .await;
+
+    let state = room.state.with_doc(|sd| Ok(sd.read_state())).unwrap();
+    assert!(
+        matches!(state.kernel.lifecycle, RuntimeLifecycle::Error),
+        "expected Error lifecycle, got {:?}",
+        state.kernel.lifecycle
+    );
+    assert_eq!(state.kernel.error_details.as_deref(), Some(stderr_tail));
+    // No typed reason (generic launch error); `error_reason` is empty
+    // but present so readers can skip typed-reason branches cleanly.
+    assert_eq!(state.kernel.error_reason.as_deref(), Some(""));
+}

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -19,9 +19,9 @@ use crate::notebook_sync_server::{
     captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
     extract_pixi_toml_deps, get_inline_conda_channels, get_inline_conda_deps, get_inline_uv_deps,
     get_inline_uv_prerelease, promote_inline_deps_to_project, publish_kernel_state_presence,
-    reset_starting_state, resolve_metadata_snapshot, send_runtime_agent_request,
-    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, unified_env_on_disk,
-    CapturedEnvRuntime, NotebookRoom,
+    reset_starting_state, reset_starting_state_with_outcome, resolve_metadata_snapshot,
+    send_runtime_agent_request, try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps,
+    unified_env_on_disk, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 
@@ -1393,30 +1393,64 @@ pub(crate) async fn handle(
                         }
                     }
                     Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
+                        // Mirror the response into CRDT so UIs that
+                        // watch RuntimeStateDoc (not the RPC reply)
+                        // also see the failure.
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: &error,
+                            },
+                        )
+                        .await;
                         NotebookResponse::Error {
                             error: format!("Agent kernel launch failed: {}", error),
                         }
                     }
                     Ok(_) => {
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
+                        let msg = "Unexpected runtime agent response";
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: msg,
+                            },
+                        )
+                        .await;
                         NotebookResponse::Error {
-                            error: "Unexpected runtime agent response".to_string(),
+                            error: msg.to_string(),
                         }
                     }
                     Err(e) => {
-                        reset_starting_state(room, Some(&runtime_agent_id)).await;
-                        NotebookResponse::Error {
-                            error: format!("Agent communication error: {}", e),
-                        }
+                        let details = format!("Agent communication error: {e}");
+                        reset_starting_state_with_outcome(
+                            room,
+                            Some(&runtime_agent_id),
+                            ResetOutcome::Error {
+                                reason: None,
+                                details: &details,
+                            },
+                        )
+                        .await;
+                        NotebookResponse::Error { error: details }
                     }
                 }
             }
             Err(e) => {
-                reset_starting_state(room, None).await;
-                NotebookResponse::Error {
-                    error: format!("Failed to spawn runtime agent: {}", e),
-                }
+                let details = format!("Failed to spawn runtime agent: {e}");
+                reset_starting_state_with_outcome(
+                    room,
+                    None,
+                    ResetOutcome::Error {
+                        reason: None,
+                        details: &details,
+                    },
+                )
+                .await;
+                NotebookResponse::Error { error: details }
             }
         }
     }


### PR DESCRIPTION
Follow-up on #2220. When a kernel subprocess exits before connecting to the daemon — for instance the `No module named nteract_kernel_launcher` pixi bug that took a day to diagnose because the UI was silent — the daemon would log the failure (with stderr tail) and then call `reset_starting_state`, quietly flipping `RuntimeStateDoc.kernel` back to `NotStarted`. The frontend's status pill sat on "Starting…" forever with nothing in the error fields.

## Change

Generalized `reset_starting_state` into `reset_starting_state_with_outcome(room, expected_id, ResetOutcome)` where `ResetOutcome` is either:

- `NotStarted` — original behavior, kept as the thin `reset_starting_state` wrapper so all the pool-empty / early-bailout call sites need no changes.
- `Error { reason, details }` — writes `RuntimeLifecycle::Error` plus `error_reason` / `error_details` via the existing `set_lifecycle_with_error_details` helper.

Four error arms switched to the `Error` variant:

- `notebook_sync_server::metadata::handle_auto_launch` — agent `Error` / unexpected response / communication error / spawn failure
- `requests::launch_kernel::handle` — the same four shapes on the explicit RPC path

The `details` strings carry what the log line already had:

| Arm | `details` content |
|---|---|
| Agent `Error { error }` | `<error>` — usually `"Kernel process exited immediately: …\nstderr tail:\n…"` from `jupyter_kernel.rs` |
| Agent communication `Err(e)` | `"Agent communication error: <e>"` |
| Spawn `Err(e)` | `"Failed to spawn runtime agent: <e>"` |
| Unexpected response | `"Unexpected runtime agent response during kernel launch"` |

## Frontend

`errorDetails` was already exposed through `useDaemonKernel`. App.tsx now passes it to `NotebookToolbar` as `kernelErrorMessage` — the same prop the existing Deno-not-available handler uses. Visible pill stays the compact "error" label; tooltip / aria-label carries the full details string. No new UI components; a full error banner can be added on top of this surface when we want one.

## Test plan

- [x] `cargo test -p runtimed --lib` — 507 pass (+1 new)
- [x] `cargo clippy -p runtimed --all-targets -- -D warnings` — clean
- [x] `cargo xtask lint` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] New unit test `reset_starting_state_error_variant_writes_details` exercises the CRDT write + read-back

The two existing typed-reason error writers (`MissingIpykernel`, `CondaEnvYmlMissing`) are unchanged; this just closes the gap for the untyped generic-launch-failure case.
