### PR TITLE
feat(safari-timeline): add timeline splat tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "gremlin ; sys_platform == 'darwin'",
     "dx",
     "nteract-kernel-launcher",
+    "safari-timeline",
     "pandas",
     "polars",
     "pyarrow>=14",
@@ -24,7 +25,7 @@ build-backend = "setuptools.build_meta"
 packages = []
 
 [tool.uv.workspace]
-members = ["python/runtimed", "python/nteract", "python/gremlin", "python/prewarm", "python/dx", "python/nteract-kernel-launcher"]
+members = ["python/runtimed", "python/nteract", "python/gremlin", "python/prewarm", "python/dx", "python/nteract-kernel-launcher", "python/safari-timeline"]
 
 [tool.uv.sources]
 runtimed = { workspace = true }
@@ -32,6 +33,7 @@ nteract = { workspace = true }
 gremlin = { workspace = true }
 dx = { workspace = true }
 nteract-kernel-launcher = { workspace = true }
+safari-timeline = { workspace = true }
 
 [tool.ruff]
 line-length = 100
@@ -50,7 +52,7 @@ select = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["runtimed", "nteract", "prewarm"]
+known-first-party = ["runtimed", "nteract", "prewarm", "safari_timeline"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["SIM105", "SIM117"]
@@ -84,6 +86,7 @@ extra-paths = [
     "python/gremlin/src",
     "python/prewarm/src",
     "python/dx/src",
+    "python/safari-timeline/src",
     # nteract-kernel-launcher is a single top-level .py file, no src/ layout
     "python/nteract-kernel-launcher",
     # Integration tests sit side-by-side under tests/ and share fixtures

--- a/python/safari-timeline/.gitignore
+++ b/python/safari-timeline/.gitignore
@@ -1,0 +1,5 @@
+dist/
+*.egg-info/
+.pytest_cache/
+__pycache__/
+**/__pycache__/

--- a/python/safari-timeline/README.md
+++ b/python/safari-timeline/README.md
@@ -1,0 +1,23 @@
+# Safari Timeline
+
+Utilities for turning Safari Web Inspector timeline exports into readable files.
+
+The root workspace depends on this package, so project-backed notebooks opened
+from the repository root can import it directly:
+
+```python
+from safari_timeline import SplatOptions, splat_recording
+```
+
+```bash
+uv run --package safari-timeline safari-timeline-splat ~/Documents/127.0.0.1-recording.json .context/safari-recording
+```
+
+The splat output includes:
+
+- `summary.json` with recording metadata, record counts, and frame timing stats.
+- `records/all.jsonl` with one compact record per line.
+- `records/<record-type>.jsonl` split by top-level Safari timeline record type.
+- `screenshots/*.png` and `screenshots/index.jsonl` when screenshot extraction is enabled.
+
+Use `--screenshots none` when you only need record metadata and frame timings.

--- a/python/safari-timeline/pyproject.toml
+++ b/python/safari-timeline/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "safari-timeline"
+version = "0.0.1"
+description = "Tools for unpacking Safari Web Inspector timeline recordings."
+readme = "README.md"
+license = "BSD-3-Clause"
+authors = [
+    { name = "Kyle Kelley", email = "rgbkrk@gmail.com" }
+]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+safari-timeline-splat = "safari_timeline.splat:main"
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/safari_timeline"]

--- a/python/safari-timeline/src/safari_timeline/__init__.py
+++ b/python/safari-timeline/src/safari_timeline/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for Safari Web Inspector timeline recordings."""
+
+from .splat import SplatOptions, splat_recording
+
+__all__ = ["SplatOptions", "splat_recording"]

--- a/python/safari-timeline/src/safari_timeline/__main__.py
+++ b/python/safari-timeline/src/safari_timeline/__main__.py
@@ -1,0 +1,4 @@
+from .splat import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/safari-timeline/src/safari_timeline/splat.py
+++ b/python/safari-timeline/src/safari_timeline/splat.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import statistics
+from collections import Counter
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Literal
+
+ScreenshotMode = Literal["all", "none"]
+
+RECORDS_MARKER = b'"records":['
+DATA_URL_PREFIX = "data:image/"
+
+
+@dataclass(frozen=True)
+class SplatOptions:
+    screenshots: ScreenshotMode = "all"
+
+
+def splat_recording(input_path: Path, output_dir: Path, options: SplatOptions) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records_dir = output_dir / "records"
+    screenshots_dir = output_dir / "screenshots"
+    records_dir.mkdir(exist_ok=True)
+    if options.screenshots == "all":
+        screenshots_dir.mkdir(exist_ok=True)
+
+    all_records = (records_dir / "all.jsonl").open("w", encoding="utf-8")
+    per_type_handles: dict[str, Any] = {}
+    screenshot_index = None
+    if options.screenshots == "all":
+        screenshot_index = (screenshots_dir / "index.jsonl").open("w", encoding="utf-8")
+
+    metadata, record_iter = _open_record_stream(input_path)
+    record_counts: Counter[str] = Counter()
+    frame_durations: list[float] = []
+    top_frames: list[dict[str, Any]] = []
+    screenshot_count = 0
+
+    try:
+        for record_index, raw_record in enumerate(record_iter, start=1):
+            record = json.loads(raw_record)
+            record_type = str(record.get("type", "unknown"))
+            record_counts[record_type] += 1
+
+            if record_type == "timeline-record-type-rendering-frame":
+                duration_ms = _duration_ms(record)
+                if duration_ms is not None:
+                    frame_durations.append(duration_ms)
+                    _track_top_frame(top_frames, record_index, record, duration_ms)
+
+            if isinstance(record.get("imageData"), str):
+                image_data = record.pop("imageData")
+                if options.screenshots == "all" and screenshot_index is not None:
+                    screenshot_count += 1
+                    image_name, image_size = _write_screenshot(
+                        screenshots_dir, screenshot_count, record, image_data
+                    )
+                    record["imageFile"] = f"screenshots/{image_name}"
+                    record["imageBytes"] = image_size
+                    screenshot_index.write(
+                        json.dumps(
+                            {
+                                "recordIndex": record_index,
+                                "timestamp": record.get("timestamp"),
+                                "file": image_name,
+                                "bytes": image_size,
+                            },
+                            sort_keys=True,
+                        )
+                        + "\n"
+                    )
+                else:
+                    record["imageDataRemoved"] = True
+
+            line = json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            all_records.write(line + "\n")
+            handle = _record_type_handle(records_dir, per_type_handles, record_type)
+            handle.write(line + "\n")
+    finally:
+        all_records.close()
+        if screenshot_index is not None:
+            screenshot_index.close()
+        for handle in per_type_handles.values():
+            handle.close()
+
+    summary = {
+        "input": str(input_path),
+        "metadata": metadata,
+        "recordCounts": dict(sorted(record_counts.items())),
+        "screenshots": {
+            "mode": options.screenshots,
+            "count": screenshot_count,
+        },
+        "renderingFrames": _frame_summary(frame_durations, top_frames),
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return summary
+
+
+def _open_record_stream(input_path: Path) -> tuple[dict[str, Any], Iterator[bytes]]:
+    handle = input_path.open("rb")
+    prefix, remainder = _read_until_records(handle)
+    metadata = _parse_metadata(prefix)
+
+    def records() -> Iterator[bytes]:
+        try:
+            yield from _iter_record_objects(handle, remainder)
+        finally:
+            handle.close()
+
+    return metadata, records()
+
+
+def _read_until_records(handle: BinaryIO) -> tuple[bytes, bytes]:
+    chunks: list[bytes] = []
+    while True:
+        chunk = handle.read(1024 * 1024)
+        if not chunk:
+            raise ValueError("Could not find recording.records array")
+        chunks.append(chunk)
+        data = b"".join(chunks)
+        marker_index = data.find(RECORDS_MARKER)
+        if marker_index != -1:
+            after_marker = marker_index + len(RECORDS_MARKER)
+            return data[:after_marker], data[after_marker:]
+
+
+def _parse_metadata(prefix: bytes) -> dict[str, Any]:
+    text = prefix.decode("utf-8", errors="replace")
+    metadata: dict[str, Any] = {}
+
+    version = _regex_value(text, r'"version":(\d+)')
+    if version is not None:
+        metadata["version"] = int(version)
+
+    display_name = _regex_value(text, r'"displayName":"((?:\\.|[^"])*)"')
+    if display_name is not None:
+        metadata["displayName"] = json.loads(f'"{display_name}"')
+
+    for key in ("startTime", "endTime"):
+        value = _regex_value(text, rf'"{key}":([0-9.]+)')
+        if value is not None:
+            metadata[key] = float(value)
+
+    instruments = _regex_value(text, r'"instrumentTypes":(\[[^\]]*\])')
+    if instruments is not None:
+        metadata["instrumentTypes"] = json.loads(instruments)
+
+    if "startTime" in metadata and "endTime" in metadata:
+        metadata["durationSeconds"] = metadata["endTime"] - metadata["startTime"]
+
+    return metadata
+
+
+def _regex_value(text: str, pattern: str) -> str | None:
+    match = re.search(pattern, text)
+    return match.group(1) if match else None
+
+
+def _iter_record_objects(handle: BinaryIO, initial: bytes) -> Iterator[bytes]:
+    buffer = initial
+    depth = 0
+    in_string = False
+    escaped = False
+    record = bytearray()
+
+    while True:
+        if not buffer:
+            buffer = handle.read(1024 * 1024)
+            if not buffer:
+                break
+
+        for byte in buffer:
+            if depth == 0:
+                if byte == ord("{"):
+                    depth = 1
+                    in_string = False
+                    escaped = False
+                    record = bytearray(b"{")
+                elif byte == ord("]"):
+                    return
+                continue
+
+            record.append(byte)
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif byte == ord("\\"):
+                    escaped = True
+                elif byte == ord('"'):
+                    in_string = False
+            elif byte == ord('"'):
+                in_string = True
+            elif byte == ord("{"):
+                depth += 1
+            elif byte == ord("}"):
+                depth -= 1
+                if depth == 0:
+                    yield bytes(record)
+
+        buffer = b""
+
+
+def _duration_ms(record: dict[str, Any]) -> float | None:
+    start = record.get("startTime")
+    end = record.get("endTime")
+    if isinstance(start, int | float) and isinstance(end, int | float):
+        return (end - start) * 1000
+    return None
+
+
+def _track_top_frame(
+    top_frames: list[dict[str, Any]], record_index: int, record: dict[str, Any], duration_ms: float
+) -> None:
+    top_frames.append(
+        {
+            "recordIndex": record_index,
+            "startTime": record.get("startTime"),
+            "endTime": record.get("endTime"),
+            "durationMs": duration_ms,
+        }
+    )
+    top_frames.sort(key=lambda frame: frame["durationMs"], reverse=True)
+    del top_frames[20:]
+
+
+def _write_screenshot(
+    screenshots_dir: Path, screenshot_count: int, record: dict[str, Any], image_data: str
+) -> tuple[str, int]:
+    match = re.match(r"data:image/([a-zA-Z0-9.+-]+);base64,(.*)", image_data)
+    if not match:
+        raise ValueError("Unsupported screenshot imageData URL")
+
+    extension = "jpg" if match.group(1).lower() == "jpeg" else match.group(1).lower()
+    name = f"screenshot-{screenshot_count:05d}"
+    timestamp = record.get("timestamp")
+    if isinstance(timestamp, int | float):
+        name += f"-{timestamp:.3f}"
+    file_name = f"{name}.{extension}"
+    image_bytes = base64.b64decode(match.group(2), validate=True)
+    (screenshots_dir / file_name).write_bytes(image_bytes)
+    return file_name, len(image_bytes)
+
+
+def _record_type_handle(records_dir: Path, handles: dict[str, Any], record_type: str):
+    safe_name = _safe_file_stem(record_type)
+    if safe_name not in handles:
+        handles[safe_name] = (records_dir / f"{safe_name}.jsonl").open("w", encoding="utf-8")
+    return handles[safe_name]
+
+
+def _safe_file_stem(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return safe or "unknown"
+
+
+def _frame_summary(
+    frame_durations: list[float], top_frames: list[dict[str, Any]]
+) -> dict[str, Any]:
+    if not frame_durations:
+        return {"count": 0, "topFrames": []}
+
+    sorted_durations = sorted(frame_durations)
+    return {
+        "count": len(frame_durations),
+        "minMs": min(frame_durations),
+        "medianMs": statistics.median(frame_durations),
+        "meanMs": statistics.fmean(frame_durations),
+        "p90Ms": _quantile(sorted_durations, 0.90),
+        "p95Ms": _quantile(sorted_durations, 0.95),
+        "p99Ms": _quantile(sorted_durations, 0.99),
+        "maxMs": max(frame_durations),
+        "over16_7Ms": sum(duration > 16.667 for duration in frame_durations),
+        "over33_3Ms": sum(duration > 33.333 for duration in frame_durations),
+        "topFrames": top_frames,
+    }
+
+
+def _quantile(sorted_values: list[float], p: float) -> float:
+    index = round((len(sorted_values) - 1) * p)
+    return sorted_values[index]
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Splat a Safari Web Inspector timeline recording into readable files."
+    )
+    parser.add_argument("input", type=Path, help="Safari timeline export JSON")
+    parser.add_argument("output_dir", type=Path, help="Directory to write splat output")
+    parser.add_argument(
+        "--screenshots",
+        choices=("all", "none"),
+        default="all",
+        help="Extract screenshot imageData to PNG files or strip it from JSONL output.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    summary = splat_recording(
+        args.input,
+        args.output_dir,
+        SplatOptions(screenshots=args.screenshots),
+    )
+    frames = summary["renderingFrames"]
+    print(f"Wrote Safari timeline splat to {args.output_dir}")
+    print(f"Records: {sum(summary['recordCounts'].values())}")
+    print(f"Screenshots: {summary['screenshots']['count']} ({summary['screenshots']['mode']})")
+    if frames["count"]:
+        print(
+            "Frames: "
+            f"{frames['count']} total, median {frames['medianMs']:.2f}ms, "
+            f"p99 {frames['p99Ms']:.2f}ms, max {frames['maxMs']:.2f}ms"
+        )
+    return 0

--- a/python/safari-timeline/tests/test_splat.py
+++ b/python/safari-timeline/tests/test_splat.py
@@ -1,0 +1,89 @@
+import base64
+import json
+
+from safari_timeline import SplatOptions, splat_recording
+
+PNG_1X1 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+).decode("ascii")
+
+
+def test_splat_recording_streams_records_and_extracts_screenshots(tmp_path):
+    recording = tmp_path / "recording.json"
+    recording.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "recording": {
+                    "displayName": "Test Recording",
+                    "startTime": 1.0,
+                    "endTime": 2.0,
+                    "instrumentTypes": [
+                        "timeline-record-type-rendering-frame",
+                        "timeline-record-type-screenshots",
+                    ],
+                    "records": [
+                        {
+                            "type": "timeline-record-type-rendering-frame",
+                            "startTime": 1.0,
+                            "endTime": 1.02,
+                        },
+                        {
+                            "type": "timeline-record-type-screenshots",
+                            "timestamp": 1.01,
+                            "imageData": f"data:image/png;base64,{PNG_1X1}",
+                        },
+                        {
+                            "type": "timeline-record-type-layout",
+                            "startTime": 1.015,
+                            "endTime": 1.016,
+                            "data": {"text": 'brace } and quote " inside a string'},
+                        },
+                    ],
+                },
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "out"
+    summary = splat_recording(recording, output, SplatOptions(screenshots="all"))
+
+    assert summary["metadata"]["displayName"] == "Test Recording"
+    assert summary["recordCounts"]["timeline-record-type-rendering-frame"] == 1
+    assert summary["renderingFrames"]["maxMs"] == 20.000000000000018
+    assert summary["screenshots"]["count"] == 1
+
+    screenshot_files = list((output / "screenshots").glob("*.png"))
+    assert len(screenshot_files) == 1
+    assert screenshot_files[0].read_bytes().startswith(b"\x89PNG")
+
+    lines = (output / "records" / "all.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    screenshot_record = json.loads(lines[1])
+    assert "imageData" not in screenshot_record
+    assert screenshot_record["imageFile"].startswith("screenshots/screenshot-00001")
+
+
+def test_splat_recording_can_strip_screenshots(tmp_path):
+    recording = tmp_path / "recording.json"
+    recording.write_text(
+        (
+            '{"version":1,"recording":{"displayName":"No Images","startTime":0,'
+            '"endTime":1,"instrumentTypes":[],"records":['
+            '{"type":"timeline-record-type-screenshots","timestamp":0.5,'
+            f'"imageData":"data:image/png;base64,{PNG_1X1}"}}'
+            "]}}"
+        ),
+        encoding="utf-8",
+    )
+
+    output = tmp_path / "out"
+    summary = splat_recording(recording, output, SplatOptions(screenshots="none"))
+
+    assert summary["screenshots"]["count"] == 0
+    assert not (output / "screenshots").exists()
+    record = json.loads((output / "records" / "all.jsonl").read_text(encoding="utf-8"))
+    assert record["imageDataRemoved"] is True

--- a/traces/.gitignore
+++ b/traces/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/traces/README.md
+++ b/traces/README.md
@@ -1,0 +1,26 @@
+# Trace Dumps
+
+Drop local profiling traces, Safari timeline splats, notebooks, screenshots, and
+other investigation artifacts here.
+
+This directory is intentionally gitignored except for this README and its
+`.gitignore`. Use `safari-timeline-splat` to unpack Safari Web Inspector exports:
+
+```bash
+uv run --package safari-timeline safari-timeline-splat path/to/recording.json traces/run-name
+```
+
+Project-backed notebooks opened from the repository root can also import the
+parser directly:
+
+```python
+from pathlib import Path
+
+from safari_timeline import SplatOptions, splat_recording
+
+splat_recording(
+    Path("path/to/recording.json"),
+    Path("traces/run-name"),
+    SplatOptions(screenshots="none"),
+)
+```


### PR DESCRIPTION
## Summary

- add a `safari-timeline` Python workspace package with a `safari-timeline-splat` CLI
- stream Safari Web Inspector timeline exports into compact JSONL record files, summary stats, and optional screenshot PNGs
- add a tracked `traces/` dump directory that ignores local trace/notebook artifacts
- wire the package into the root Python workspace so project-backed notebooks can `import safari_timeline`

## Validation

- `uv run --package safari-timeline pytest python/safari-timeline/tests -q`
- `uv run ruff check python/safari-timeline`
- `uv run ruff format --check python/safari-timeline`
- `uv run python -c 'from safari_timeline import SplatOptions, splat_recording; print(SplatOptions(screenshots="none"))'`
- `git diff --check`

## Notes

Tested on a Safari Sift trace export. Compact mode produced readable JSONL and summary output without duplicating screenshots; default mode extracted all screenshots successfully.