### PR TITLE
feat(app): banner for untyped kernel-launch failures

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { deriveEnvManager, deriveRuntimeKind, KERNEL_ERROR_REASON, NotebookClient } from "runtimed";
+import { deriveEnvManager, deriveRuntimeKind, NotebookClient } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -22,7 +22,10 @@ import { NotebookView } from "./components/NotebookView";
 import { PixiDependencyHeader } from "./components/PixiDependencyHeader";
 import { PoolErrorBanner } from "./components/PoolErrorBanner";
 import { TrustDialog } from "./components/TrustDialog";
-import { KernelLaunchErrorBanner } from "./components/KernelLaunchErrorBanner";
+import {
+  KernelLaunchErrorBanner,
+  shouldShowKernelLaunchErrorBanner,
+} from "./components/KernelLaunchErrorBanner";
 import { UntrustedBanner } from "./components/UntrustedBanner";
 import { PresenceProvider } from "./contexts/PresenceContext";
 import { useAutomergeNotebook } from "./hooks/useAutomergeNotebook";
@@ -1169,16 +1172,15 @@ function AppContent() {
               }}
             />
           )}
-        {lifecycle.lifecycle === "Error" &&
-          errorDetails &&
-          errorDetails.length > 0 &&
-          // Skip when a typed reason owns the UX (missing_ipykernel has a
-          // targeted toolbar prompt; conda_env_yml_missing has its own flow).
-          errorReason !== KERNEL_ERROR_REASON.MISSING_IPYKERNEL &&
-          errorReason !== KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING &&
+        {shouldShowKernelLaunchErrorBanner({
+          lifecycle,
+          errorDetails,
+          errorReason,
+          runtime,
+        }) &&
           dismissedLaunchError !== errorDetails && (
             <KernelLaunchErrorBanner
-              errorDetails={errorDetails}
+              errorDetails={errorDetails as string}
               onRetry={() => {
                 setDismissedLaunchError(null);
                 tryStartKernel();

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { deriveEnvManager, deriveRuntimeKind, NotebookClient } from "runtimed";
+import { deriveEnvManager, deriveRuntimeKind, KERNEL_ERROR_REASON, NotebookClient } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -22,6 +22,7 @@ import { NotebookView } from "./components/NotebookView";
 import { PixiDependencyHeader } from "./components/PixiDependencyHeader";
 import { PoolErrorBanner } from "./components/PoolErrorBanner";
 import { TrustDialog } from "./components/TrustDialog";
+import { KernelLaunchErrorBanner } from "./components/KernelLaunchErrorBanner";
 import { UntrustedBanner } from "./components/UntrustedBanner";
 import { PresenceProvider } from "./contexts/PresenceContext";
 import { useAutomergeNotebook } from "./hooks/useAutomergeNotebook";
@@ -186,6 +187,11 @@ function AppContent() {
   const [clearingDeps, setClearingDeps] = useState(false);
   // Track when sync/restart just completed for success feedback
   const [justSynced, setJustSynced] = useState(false);
+  // Per-error-instance dismissal for the kernel-launch error banner.
+  // Stores the `errorDetails` string the user dismissed; cleared
+  // whenever the kernel transitions out of Error (so the next failure
+  // shows the banner fresh) or a different details string arrives.
+  const [dismissedLaunchError, setDismissedLaunchError] = useState<string | null>(null);
 
   // Daemon startup status (installing, starting, failed, etc.)
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);
@@ -335,6 +341,15 @@ function AppContent() {
 
   // Derive values from daemon kernel
   const envSource = kernelInfo.envSource ?? null;
+
+  // Clear banner dismissal whenever the kernel leaves Error or the
+  // details text changes, so the next failure re-presents the banner
+  // even if the user dismissed an earlier identical-looking one.
+  useEffect(() => {
+    if (lifecycle.lifecycle !== "Error") {
+      setDismissedLaunchError(null);
+    }
+  }, [lifecycle.lifecycle]);
 
   // Set up daemon comm sender for widget messages
   useEffect(() => {
@@ -1152,6 +1167,23 @@ function AppContent() {
                 pendingKernelStartRef.current = true;
                 setTrustDialogOpen(true);
               }}
+            />
+          )}
+        {lifecycle.lifecycle === "Error" &&
+          errorDetails &&
+          errorDetails.length > 0 &&
+          // Skip when a typed reason owns the UX (missing_ipykernel has a
+          // targeted toolbar prompt; conda_env_yml_missing has its own flow).
+          errorReason !== KERNEL_ERROR_REASON.MISSING_IPYKERNEL &&
+          errorReason !== KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING &&
+          dismissedLaunchError !== errorDetails && (
+            <KernelLaunchErrorBanner
+              errorDetails={errorDetails}
+              onRetry={() => {
+                setDismissedLaunchError(null);
+                tryStartKernel();
+              }}
+              onDismiss={() => setDismissedLaunchError(errorDetails)}
             />
           )}
         <NotebookToolbar

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -1,0 +1,61 @@
+import { AlertCircle, RotateCw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface KernelLaunchErrorBannerProps {
+  /**
+   * Stderr tail or other free-form details from the daemon's failed
+   * launch. Usually multi-line. Rendered monospace + preserving
+   * newlines so stack traces / subprocess errors stay readable.
+   */
+  errorDetails: string;
+  onRetry: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Banner surfaced when the daemon reports `RuntimeLifecycle::Error`
+ * without a typed `KernelErrorReason`. Those typed cases
+ * (`MissingIpykernel`, `CondaEnvYmlMissing`) have their own targeted
+ * prompts; this one covers everything else — subprocess crashes,
+ * import errors, rate-limited env builds, etc.
+ *
+ * App.tsx gates visibility on lifecycle + a non-typed reason and
+ * resets the dismiss state when `errorDetails` changes, so a new
+ * failure after a retry re-shows the banner.
+ */
+export function KernelLaunchErrorBanner({
+  errorDetails,
+  onRetry,
+  onDismiss,
+}: KernelLaunchErrorBannerProps) {
+  return (
+    <div className="flex items-start gap-3 border-b border-red-600/50 bg-red-600/10 px-3 py-2 text-xs text-red-900 dark:text-red-200">
+      <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5 text-red-600 dark:text-red-400" />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">Kernel failed to start</div>
+        <pre className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap break-words rounded bg-red-950/5 px-2 py-1 font-mono text-[11px] leading-snug text-red-950/90 dark:bg-red-950/30 dark:text-red-100/90">
+          {errorDetails}
+        </pre>
+      </div>
+      <div className="flex flex-shrink-0 items-center gap-1">
+        <Button
+          size="sm"
+          variant="secondary"
+          className="h-6 px-2 text-xs bg-red-100 text-red-900 hover:bg-red-200 dark:bg-red-900/40 dark:text-red-100 dark:hover:bg-red-900/60"
+          onClick={onRetry}
+        >
+          <RotateCw className="h-3 w-3 mr-1" />
+          Retry
+        </Button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded p-0.5 text-red-700 transition-colors hover:bg-red-500/20 dark:text-red-300"
+          aria-label="Dismiss"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -1,5 +1,41 @@
 import { AlertCircle, RotateCw, X } from "lucide-react";
+import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import { Button } from "@/components/ui/button";
+
+/**
+ * Decide whether the generic kernel-launch banner should render.
+ *
+ * Exported as a pure function so unit tests can exercise the gating
+ * without mounting App.tsx (which needs a NotebookHost + WASM). The
+ * call site in App.tsx composes this with `dismissedLaunchError` for
+ * dismissal state.
+ *
+ * Rules:
+ *
+ * - Only show in `Error` state with non-empty `errorDetails`.
+ * - Skip `MissingIpykernel`: toolbar renders a targeted "install
+ *   ipykernel" prompt that already consumes the error message.
+ * - Skip `runtime === "deno"`: toolbar renders the Deno
+ *   "auto-install failed" prompt that already consumes it.
+ *
+ * Everything else — including `CondaEnvYmlMissing`, stderr tails from
+ * generic subprocess crashes, env-build rate limits — falls through
+ * to this banner. `CondaEnvYmlMissing`'s `error_details` carries the
+ * conda env name + remediation command; surfacing that string in the
+ * banner is a strict upgrade on the previous tooltip-only surface.
+ */
+export function shouldShowKernelLaunchErrorBanner(params: {
+  lifecycle: RuntimeLifecycle;
+  errorDetails: string | null;
+  errorReason: string | null;
+  runtime: string | null;
+}): boolean {
+  if (params.lifecycle.lifecycle !== "Error") return false;
+  if (!params.errorDetails || params.errorDetails.length === 0) return false;
+  if (params.errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL) return false;
+  if (params.runtime === "deno") return false;
+  return true;
+}
 
 interface KernelLaunchErrorBannerProps {
   /**

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for KernelLaunchErrorBanner:
+ * - Renders the stderr tail preserving newlines
+ * - Retry button invokes onRetry callback
+ * - Dismiss button invokes onDismiss callback
+ * - Heading + icon rendered
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { KernelLaunchErrorBanner } from "../KernelLaunchErrorBanner";
+
+const STDERR_TAIL = [
+  "Kernel process exited immediately: exit status: 1",
+  "stderr tail:",
+  "/path/to/python: No module named nteract_kernel_launcher",
+].join("\n");
+
+describe("KernelLaunchErrorBanner", () => {
+  it("shows the failure heading", () => {
+    render(
+      <KernelLaunchErrorBanner
+        errorDetails={STDERR_TAIL}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.getByText("Kernel failed to start")).toBeInTheDocument();
+  });
+
+  it("renders the details string in a <pre> preserving the raw newlines", () => {
+    render(
+      <KernelLaunchErrorBanner
+        errorDetails={STDERR_TAIL}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    // RTL's default matcher normalizes whitespace, so look at the
+    // underlying <pre> node directly — it preserves the \n from the
+    // daemon's stderr tail.
+    const pre = screen.getByText((_, element) => element?.tagName.toLowerCase() === "pre");
+    expect(pre.textContent).toBe(STDERR_TAIL);
+  });
+
+  it("invokes onRetry when Retry is clicked", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <KernelLaunchErrorBanner errorDetails={STDERR_TAIL} onRetry={onRetry} onDismiss={() => {}} />,
+    );
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onDismiss when the X is clicked", async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(
+      <KernelLaunchErrorBanner
+        errorDetails={STDERR_TAIL}
+        onRetry={() => {}}
+        onDismiss={onDismiss}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -4,12 +4,19 @@
  * - Retry button invokes onRetry callback
  * - Dismiss button invokes onDismiss callback
  * - Heading + icon rendered
+ * - Gating helper `shouldShowKernelLaunchErrorBanner` exhaustively
+ *   covers the cases App.tsx composes against (typed reasons, runtime,
+ *   lifecycle, details presence).
  */
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { KernelLaunchErrorBanner } from "../KernelLaunchErrorBanner";
+import {
+  KernelLaunchErrorBanner,
+  shouldShowKernelLaunchErrorBanner,
+} from "../KernelLaunchErrorBanner";
 
 const STDERR_TAIL = [
   "Kernel process exited immediately: exit status: 1",
@@ -66,5 +73,91 @@ describe("KernelLaunchErrorBanner", () => {
     );
     await user.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("shouldShowKernelLaunchErrorBanner", () => {
+  const ERROR: RuntimeLifecycle = { lifecycle: "Error" };
+  const IDLE: RuntimeLifecycle = { lifecycle: "Running", activity: "Idle" };
+
+  it("shows for a plain Error with details and no typed reason", () => {
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: STDERR_TAIL,
+        errorReason: "",
+        runtime: "python",
+      }),
+    ).toBe(true);
+  });
+
+  it("hides when lifecycle is not Error", () => {
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: IDLE,
+        errorDetails: STDERR_TAIL,
+        errorReason: null,
+        runtime: "python",
+      }),
+    ).toBe(false);
+  });
+
+  it("hides when errorDetails is null or empty", () => {
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: null,
+        errorReason: null,
+        runtime: "python",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: "",
+        errorReason: null,
+        runtime: "python",
+      }),
+    ).toBe(false);
+  });
+
+  it("hides for MissingIpykernel (toolbar prompt owns that UX)", () => {
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: "ipykernel not declared",
+        errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
+        runtime: "python",
+      }),
+    ).toBe(false);
+  });
+
+  it("shows for CondaEnvYmlMissing — no dedicated UI exists yet", () => {
+    // Codex review on #2236: excluding this reason suppressed the only
+    // real rendered surface the daemon's `error_details` has.
+    // `environment.yml` unbuilt-env failures now use the generic banner.
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails:
+          "environment.yml declares conda env 'analysis', which is not built. Run: conda env create -f environment.yml",
+        errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
+        runtime: "python",
+      }),
+    ).toBe(true);
+  });
+
+  it("hides for Deno runtime (toolbar renders its own install prompt)", () => {
+    // Deno failures show `Deno not available. Auto-install failed…`
+    // in NotebookToolbar. Rendering the red banner on top would be
+    // duplicate noise with two retry surfaces.
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: "deno binary not on PATH",
+        errorReason: null,
+        runtime: "deno",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Visual polish on #2234. The daemon now writes `RuntimeLifecycle::Error` + `error_details` for every failed kernel launch, but the only surface was `NotebookToolbar`'s aria-label + title — stderr tails with five or six lines aren't going to read well in a `title` attribute.

## Component

`KernelLaunchErrorBanner` — destructive-red, alert icon, "Kernel failed to start" heading, a scrollable `<pre>` that preserves newlines / monospace (`max-h-32` so a pathological traceback doesn't eat the whole window), Retry + dismiss X. Icon uses the existing `AlertCircle` / `RotateCw` / `X` set for visual coherence with the other banners.

## App.tsx wiring

Renders above the toolbar, below `UntrustedBanner`. Gated on:

- `lifecycle.lifecycle === "Error"`
- `errorDetails` non-empty
- `errorReason` is **neither** `MissingIpykernel` (toolbar prompt has targeted install guidance) **nor** `CondaEnvYmlMissing` (has its own flow)

Dismissal state (`dismissedLaunchError: string | null`) is cleared in a `useEffect` whenever the kernel leaves Error, so the next failure from any retry path (banner button, toolbar restart, automatic relaunch) re-shows the banner fresh. The earlier draft had a bug where toolbar-initiated retries inherited a banner dismissal; effect-based clearing fixes it.

Retry wires to `tryStartKernel`.

## Test

`apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx` — four cases:

- Heading rendered
- Multi-line details preserved under the `<pre>` (RTL normalizes whitespace in its default matcher, so we read `textContent` directly)
- Retry callback
- Dismiss callback

## Test plan

- [x] `pnpm test:run apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx` — 4 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `cargo xtask lint` — clean

Would pair naturally with manual QA once a repro is available (kill `nteract_kernel_launcher` from the launcher cache, launch any python notebook, banner should show the stderr tail).
