### PR TITLE
fix(sift): reposition lazy measured rows before paint

### DIFF
--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { layout, prepare } from "@chenglou/pretext";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { type Column, createTable, type TableData, type TableEngine } from "./table";
 
 // --- Test helpers ---
@@ -63,6 +64,15 @@ async function flushRAF() {
   await vi.advanceTimersByTimeAsync(0);
 }
 
+function resetPretextMocks() {
+  vi.mocked(prepare).mockImplementation(
+    () => ({ __brand: "PreparedText" }) as unknown as ReturnType<typeof prepare>,
+  );
+  vi.mocked(layout).mockImplementation(
+    () => ({ lineCount: 1, height: 20 }) as ReturnType<typeof layout>,
+  );
+}
+
 // --- Tests ---
 
 describe("createTable", () => {
@@ -73,11 +83,18 @@ describe("createTable", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    resetPretextMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
     rows = makeRows(50);
     data = makeTableData(rows);
     engine = createTable(container, data);
+  });
+
+  afterEach(() => {
+    engine.destroy();
+    container.remove();
+    vi.useRealTimers();
   });
 
   describe("DOM structure", () => {
@@ -123,6 +140,32 @@ describe("createTable", () => {
 
       numericEngine.destroy();
       numericContainer.remove();
+    });
+
+    it("positions rows with freshly measured lazy heights before painting", async () => {
+      engine.destroy();
+      container.innerHTML = "";
+
+      vi.mocked(prepare).mockImplementation(
+        (text: string) =>
+          ({ __brand: "PreparedText", text }) as unknown as ReturnType<typeof prepare>,
+      );
+      vi.mocked(layout).mockImplementation((prepared: unknown) => {
+        const { text } = prepared as { text?: string };
+        return {
+          lineCount: text?.includes("tall wrapped categorical text") ? 6 : 1,
+          height: text?.includes("tall wrapped categorical text") ? 120 : 20,
+        } as ReturnType<typeof layout>;
+      });
+
+      const tallRows = makeRows(8);
+      tallRows[1][1] = "tall wrapped categorical text";
+      engine = createTable(container, makeTableData(tallRows));
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      const thirdRenderedRow = container.querySelector<HTMLElement>('[aria-rowindex="4"]');
+      expect(thirdRenderedRow?.style.transform).toBe("translateY(172px)");
     });
   });
 

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1247,7 +1247,18 @@ export function createTable(
         rowHeights[r] = computeRowHeight(r);
         lazyPrepared = true;
       }
+    }
 
+    // Newly measured rows can shift every downstream row position. Rebuild
+    // before assigning transforms so Safari never paints a mixed frame where
+    // some rows use measured heights and others still use estimated offsets.
+    if (lazyPrepared) {
+      rebuildPositions();
+      scrollContent.style.height = totalHeight + headerH + "px";
+    }
+
+    for (let r = first; r <= last; r++) {
+      const dataRow = viewIndices[r];
       let existing = false;
       for (const pr of pool) {
         if (pr.assignedRow === r) {
@@ -1274,22 +1285,7 @@ export function createTable(
       }
     }
 
-    // If we lazy-prepared any rows, their heights shifted downstream row
-    // positions. The original code then reset the entire pool and re-rendered
-    // the whole visible range with corrected positions, doubling paint cost
-    // on every scroll that pulled in fresh rows — Safari white-screened on
-    // downward momentum scroll because the compositor starved waiting for
-    // main. Update positions now and let the next rAF tick reposition the
-    // pool. The displayed rows sit at slightly-stale transforms for one
-    // frame (≤ one row height ≈ 20px, ≈ 16ms) — invisible in practice; the
-    // scroll stays smooth.
-    if (lazyPrepared) {
-      rebuildPositions();
-      scrollContent.style.height = totalHeight + "px";
-      scheduleRender();
-    }
-
-    if (lastScrollTop === scrollTop && lastViewportHeight === viewportH) {
+    if (lazyPrepared || (lastScrollTop === scrollTop && lastViewportHeight === viewportH)) {
       for (const pr of pool) {
         if (pr.assignedRow === -1) continue;
         for (let c = 0; c < columns.length; c++) {


### PR DESCRIPTION
## Summary
- Rebuild row positions immediately after lazy text measurement changes row heights.
- Reposition mounted rows in the same render so Safari does not paint mixed estimated and measured positions.
- Add a regression test that makes pretext layout increase a row height before checking the downstream row transform.

## Notes
Tested with the generated Sift dataset in Safari. I could not reproduce the row overlap after this change.

## Checks
- cargo xtask lint --fix
- pnpm --dir packages/sift test