### PR TITLE
chore(notebook): kill save_notebook/has_notebook_path/verify_notebook_trust Tauri proxies

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -614,8 +614,12 @@ export function useAutomergeNotebook() {
   // ── File operations ────────────────────────────────────────────────
 
   const save = useCallback(async () => {
-    await saveNotebook(host, flushSync);
-  }, [host, flushSync]);
+    // `runtimeState.path` is the authoritative source: the daemon writes
+    // it on save / save-as / untitled promotion. Reading it here avoids
+    // a Tauri round-trip to the WindowNotebookRegistry.
+    const hasPath = runtimePath != null;
+    await saveNotebook(host, flushSync, hasPath);
+  }, [host, flushSync, runtimePath]);
 
   const openNotebook = useCallback(() => openNotebookFile(host), [host]);
 

--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -1,8 +1,10 @@
 import { useNotebookHost } from "@nteract/notebook-host";
 import type { TrustInfo, TyposquatWarning } from "@nteract/notebook-host";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { logger } from "../lib/logger";
-import { useRuntimeState } from "../lib/runtime-state";
+import { useRuntimeState, useRuntimeStateLoaded } from "../lib/runtime-state";
+import { useCondaDependencies } from "./useCondaDependencies";
+import { useDependencies } from "./useDependencies";
 
 export type { TrustInfo, TyposquatWarning };
 
@@ -12,44 +14,75 @@ export type TrustStatusType = TrustInfo["status"];
 export function useTrust() {
   const host = useNotebookHost();
   const runtimeState = useRuntimeState();
-  const runtimeTrustNeedsApproval = runtimeState.trust.needs_approval;
+  // Until the first RuntimeStateDoc frame lands, `runtimeState.trust` is
+  // the static `DEFAULT_RUNTIME_STATE` value (`status: "no_dependencies"`).
+  // Treating that as authoritative would fail-open the kernel-launch
+  // trust gate — `tryStartKernel` reads `no_dependencies` as trusted and
+  // would fire `LaunchKernel`, which the daemon honors by marking trust
+  // approved before resolving. Hold `trustInfo` at `null` until the
+  // daemon has actually spoken; call sites already fail-closed on null.
+  const runtimeLoaded = useRuntimeStateLoaded();
+  const { dependencies: uvDeps } = useDependencies();
+  const { dependencies: condaDeps } = useCondaDependencies();
 
-  const [trustInfo, setTrustInfo] = useState<TrustInfo | null>(null);
   const [typosquatWarnings, setTyposquatWarnings] = useState<TyposquatWarning[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Check trust status
-  const checkTrust = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const info = await host.trust.verify();
-      setTrustInfo(info);
+  // Compose TrustInfo from RuntimeStateDoc + dep hooks. Daemon is the sole
+  // writer of `trust.status`; deps are synced via the notebook CRDT. No
+  // Tauri round-trip.
+  const trustInfo: TrustInfo | null = useMemo(() => {
+    if (!runtimeLoaded) return null;
+    const uvList = uvDeps?.dependencies ?? [];
+    const condaList = condaDeps?.dependencies ?? [];
+    const channels = condaDeps?.channels ?? [];
+    return {
+      status: runtimeState.trust.status,
+      uv_dependencies: uvList,
+      conda_dependencies: condaList,
+      conda_channels: channels,
+    };
+  }, [
+    runtimeLoaded,
+    runtimeState.trust.status,
+    uvDeps?.dependencies,
+    condaDeps?.dependencies,
+    condaDeps?.channels,
+  ]);
 
-      // Check for typosquats in all dependencies
-      const allDeps = [...info.uv_dependencies, ...info.conda_dependencies];
-      if (allDeps.length > 0) {
-        const warnings = await host.deps.checkTyposquats(allDeps);
-        setTyposquatWarnings(warnings);
-      } else {
-        setTyposquatWarnings([]);
-      }
-
-      return info;
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      setError(message);
-      if (message === "Not connected to daemon") {
-        logger.debug("Trust check deferred: daemon not yet connected");
-      } else {
-        logger.error("Failed to check trust:", e);
-      }
-      return null;
-    } finally {
-      setLoading(false);
+  // Typosquat check is the only piece still on the host. Reruns whenever
+  // the effective dep list changes.
+  const uvList = trustInfo?.uv_dependencies;
+  const condaList = trustInfo?.conda_dependencies;
+  useEffect(() => {
+    if (!uvList || !condaList) return;
+    const allDeps = [...uvList, ...condaList];
+    if (allDeps.length === 0) {
+      setTyposquatWarnings([]);
+      return;
     }
-  }, [host]);
+    let cancelled = false;
+    setLoading(true);
+    host.deps
+      .checkTyposquats(allDeps)
+      .then((warnings) => {
+        if (!cancelled) setTyposquatWarnings(warnings);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : String(e);
+          setError(message);
+          logger.error("Failed to check typosquats:", e);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [host, uvList, condaList]);
 
   // Approve the notebook (sign dependencies)
   const approveTrust = useCallback(async () => {
@@ -57,8 +90,6 @@ export function useTrust() {
     setError(null);
     try {
       await host.trust.approve();
-      // Re-check trust status after approval
-      await checkTrust();
       return true;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -68,32 +99,24 @@ export function useTrust() {
     } finally {
       setLoading(false);
     }
-  }, [host, checkTrust]);
+  }, [host]);
 
-  // Check trust on mount
-  useEffect(() => {
-    checkTrust();
-  }, [checkTrust]);
-
-  // Re-check trust when daemon (re)connects — handles the startup race where
-  // the initial mount-time check fires before the relay handle is stored.
-  useEffect(() => {
-    return host.daemonEvents.onReady(() => {
-      checkTrust();
-    });
-  }, [host, checkTrust]);
-
-  // Computed properties
+  // Computed properties. While `trustInfo` is null (daemon hasn't pushed
+  // a state yet), nothing is known — default everything to the safe side:
+  // untrusted, no deps, no approval pending. `needsApproval` stays false
+  // to avoid flashing the trust dialog on a stale default; `tryStartKernel`
+  // gates on `checkTrust()` returning non-null and will show the dialog
+  // once real state lands.
   const isTrusted = trustInfo?.status === "trusted" || trustInfo?.status === "no_dependencies";
-  const needsApproval =
-    trustInfo?.status === "untrusted" ||
-    trustInfo?.status === "signature_invalid" ||
-    runtimeTrustNeedsApproval; // From RuntimeStateDoc — arrives via sync, no race
-  const hasDependencies = trustInfo?.status !== "no_dependencies";
-
-  // Total dependency count
-  const totalDependencies =
-    (trustInfo?.uv_dependencies.length ?? 0) + (trustInfo?.conda_dependencies.length ?? 0);
+  const needsApproval = trustInfo
+    ? trustInfo.status === "untrusted" ||
+      trustInfo.status === "signature_invalid" ||
+      runtimeState.trust.needs_approval
+    : false;
+  const hasDependencies = trustInfo ? trustInfo.status !== "no_dependencies" : false;
+  const totalDependencies = trustInfo
+    ? trustInfo.uv_dependencies.length + trustInfo.conda_dependencies.length
+    : 0;
 
   return {
     trustInfo,
@@ -104,7 +127,10 @@ export function useTrust() {
     needsApproval,
     hasDependencies,
     totalDependencies,
-    checkTrust,
+    // Returns the current composed TrustInfo, or null if the daemon has
+    // not yet pushed a RuntimeStateDoc snapshot. Callers that gate kernel
+    // launch on trust must fail-closed on null.
+    checkTrust: useCallback(() => Promise.resolve(trustInfo), [trustInfo]),
     approveTrust,
   };
 }

--- a/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { clearMocks, mockIPC } from "@tauri-apps/api/mocks";
 import type { NotebookHost } from "@nteract/notebook-host";
+import type { NotebookTransport } from "runtimed";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   cloneNotebookFile,
@@ -15,7 +16,22 @@ const mockSaveDialog = vi.fn<
   (opts?: { filters?: unknown; defaultPath?: string }) => Promise<string | null>
 >();
 
+/**
+ * Minimal NotebookTransport stub for the save-path test. `sendRequest` is
+ * what `NotebookClient.saveNotebook` calls — the rest of the transport
+ * surface is unused in these tests.
+ */
+const mockSendRequest = vi.fn();
+const stubTransport = {
+  sendRequest: (req: unknown) => mockSendRequest(req),
+  sendFrame: async () => {},
+  onFrame: () => () => {},
+  connected: true,
+  disconnect: () => {},
+} as unknown as NotebookTransport;
+
 const stubHost = {
+  transport: stubTransport,
   dialog: {
     openFile: (opts?: { filters?: unknown; defaultPath?: string }) => mockOpenDialog(opts),
     saveFile: (opts?: { filters?: unknown; defaultPath?: string }) => mockSaveDialog(opts),
@@ -32,6 +48,7 @@ afterEach(() => {
   mockInvoke.mockReset();
   mockOpenDialog.mockReset();
   mockSaveDialog.mockReset();
+  mockSendRequest.mockReset();
   clearMocks();
 });
 
@@ -46,26 +63,28 @@ describe("saveNotebook", () => {
     flushSync.mockClear();
   });
 
-  it("saves in place when the notebook already has a path", async () => {
-    mockInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "has_notebook_path") return true;
-      return undefined;
+  it("saves in place through the transport when the notebook has a path", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      result: "notebook_saved",
+      path: "/home/user/notebooks/MyNotebook.ipynb",
     });
 
-    const result = await saveNotebook(stubHost, flushSync);
+    const result = await saveNotebook(stubHost, flushSync, true);
 
     expect(result).toBe(true);
     expect(flushSync).toHaveBeenCalledTimes(1);
-    expect(mockInvoke).toHaveBeenCalledWith(
-      "has_notebook_path",
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "save_notebook", format_cells: true }),
+    );
+    // No Tauri round-trip for save-in-place.
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "save_notebook",
       expect.anything(),
     );
-    expect(mockInvoke).toHaveBeenCalledWith("save_notebook", expect.anything());
   });
 
   it("opens a save dialog for untitled notebooks", async () => {
     mockInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "has_notebook_path") return false;
       if (cmd === "get_default_save_directory") return "/home/user/notebooks";
       return undefined;
     });
@@ -73,7 +92,7 @@ describe("saveNotebook", () => {
       "/home/user/notebooks/MyNotebook.ipynb",
     );
 
-    const result = await saveNotebook(stubHost, flushSync);
+    const result = await saveNotebook(stubHost, flushSync, false);
 
     expect(result).toBe(true);
     expect(mockSaveDialog).toHaveBeenCalledTimes(1);
@@ -83,17 +102,17 @@ describe("saveNotebook", () => {
         path: "/home/user/notebooks/MyNotebook.ipynb",
       }),
     );
+    expect(mockSendRequest).not.toHaveBeenCalled();
   });
 
   it("returns false when the save dialog is cancelled", async () => {
     mockInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "has_notebook_path") return false;
       if (cmd === "get_default_save_directory") return "/tmp";
       return undefined;
     });
     mockSaveDialog.mockResolvedValueOnce(null);
 
-    const result = await saveNotebook(stubHost, flushSync);
+    const result = await saveNotebook(stubHost, flushSync, false);
 
     expect(result).toBe(false);
     // save_notebook_as should NOT be called
@@ -103,18 +122,29 @@ describe("saveNotebook", () => {
     expect(saveAsCalls).toHaveLength(0);
   });
 
-  it("returns false and logs on error", async () => {
-    mockInvoke.mockRejectedValue(new Error("disk full"));
+  it("returns false on daemon save errors", async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      result: "save_error",
+      error: { type: "io", message: "disk full" },
+    });
 
-    const result = await saveNotebook(stubHost, flushSync);
+    const result = await saveNotebook(stubHost, flushSync, true);
 
     expect(result).toBe(false);
   });
 
-  it("always flushes sync before checking path", async () => {
-    mockInvoke.mockRejectedValue(new Error("fail"));
+  it("returns false on transport failure", async () => {
+    mockSendRequest.mockRejectedValueOnce(new Error("transport down"));
 
-    await saveNotebook(stubHost, flushSync);
+    const result = await saveNotebook(stubHost, flushSync, true);
+
+    expect(result).toBe(false);
+  });
+
+  it("always flushes sync before saving", async () => {
+    mockSendRequest.mockRejectedValueOnce(new Error("fail"));
+
+    await saveNotebook(stubHost, flushSync, true);
 
     expect(flushSync).toHaveBeenCalledTimes(1);
   });

--- a/apps/notebook/src/lib/notebook-file-ops.ts
+++ b/apps/notebook/src/lib/notebook-file-ops.ts
@@ -1,14 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { NotebookHost } from "@nteract/notebook-host";
+import { NotebookClient, SaveNotebookError } from "runtimed";
 import { logger } from "./logger";
 
 /**
  * Notebook file operations — save, open, clone.
  *
- * Host-agnostic wrappers: dialogs go through `host.dialog`, the invoke
- * calls below remain until the daemon-request thin-wrapper PR. Taking
- * `host` as a parameter (vs. a module-level ref) keeps these functions
- * pure and trivially testable with a stub host.
+ * In-place save goes straight to the daemon via `host.transport`. Save-as
+ * and clone still route through Tauri commands because they have
+ * Tauri-only side effects (file dialog, recent-menu updates, window
+ * creation, kernel relaunch).
  */
 
 const IPYNB_FILTER = { name: "Jupyter Notebook", extensions: ["ipynb"] };
@@ -16,25 +17,30 @@ const IPYNB_FILTER = { name: "Jupyter Notebook", extensions: ["ipynb"] };
 /**
  * Save the current notebook to disk.
  *
- * If the notebook already has a path, saves in place. Otherwise opens
- * a save dialog for the user to choose a location.
+ * If the notebook already has a path, saves in place via the daemon.
+ * Otherwise opens a save dialog for the user to choose a location and
+ * forwards to `save_notebook_as` (still Tauri-side because save-as has
+ * window/menu side effects).
  *
- * @param host - The notebook host (for dialogs).
+ * @param host - The notebook host (for dialogs and transport).
  * @param flushSync - Flush any pending debounced sync before saving so
  *   the daemon has the latest source when writing to disk.
+ * @param hasPath - Whether the notebook has a saved path. Read from
+ *   `runtimeState.path` by the caller; passed in so this helper doesn't
+ *   need to round-trip to Tauri for the check.
  * @returns `true` if saved successfully, `false` on cancel or error.
  */
 export async function saveNotebook(
   host: NotebookHost,
   flushSync: () => Promise<void>,
+  hasPath: boolean,
 ): Promise<boolean> {
   try {
     await flushSync();
 
-    const hasPath = await invoke<boolean>("has_notebook_path");
-
     if (hasPath) {
-      await invoke("save_notebook");
+      const client = new NotebookClient({ transport: host.transport });
+      await client.saveNotebook({ formatCells: true });
     } else {
       const defaultDir = await invoke<string>("get_default_save_directory");
       const filePath = await host.dialog.saveFile({
@@ -47,7 +53,11 @@ export async function saveNotebook(
 
     return true;
   } catch (e) {
-    logger.error("[notebook-file-ops] Save failed:", e);
+    if (e instanceof SaveNotebookError) {
+      logger.error("[notebook-file-ops] Save failed:", e.message);
+    } else {
+      logger.error("[notebook-file-ops] Save failed:", e);
+    }
     return false;
   }
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -31,6 +31,11 @@ import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
 // ── Store ────────────────────────────────────────────────────────────
 
 let currentState: RuntimeState = DEFAULT_RUNTIME_STATE;
+// Tracks whether the daemon has pushed at least one RuntimeStateDoc frame
+// since connect/reset. While false, `currentState` is the static default,
+// and fields like `trust.status` must NOT be used as authoritative signals
+// (the default "no_dependencies" would fail-open a trust gate).
+let loaded = false;
 const subscribers = new Set<() => void>();
 
 function notifySubscribers(): void {
@@ -46,18 +51,30 @@ function notifySubscribers(): void {
 /** Update the runtime state snapshot. Called by the frame pipeline. */
 export function setRuntimeState(state: RuntimeState): void {
   currentState = state;
+  loaded = true;
   notifySubscribers();
 }
 
 /** Reset to default state (e.g., on disconnect). */
 export function resetRuntimeState(): void {
   currentState = DEFAULT_RUNTIME_STATE;
+  loaded = false;
   notifySubscribers();
 }
 
 /** Read the current snapshot (non-reactive). */
 export function getRuntimeState(): RuntimeState {
   return currentState;
+}
+
+/**
+ * Whether the daemon has pushed at least one RuntimeStateDoc snapshot
+ * since connect. Consumers that make authoritative decisions from state
+ * (trust gates, dirty tracking) must check this first — a false value
+ * means the current snapshot is `DEFAULT_RUNTIME_STATE`, not a real read.
+ */
+export function isRuntimeStateLoaded(): boolean {
+  return loaded;
 }
 
 // ── React hook ───────────────────────────────────────────────────────
@@ -81,4 +98,12 @@ function getSnapshot(): RuntimeState {
  */
 export function useRuntimeState(): RuntimeState {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Subscribe to the loaded flag. Re-renders on the transition from
+ * "no snapshot yet" to "first snapshot applied" (and back on reset).
+ */
+export function useRuntimeStateLoaded(): boolean {
+  return useSyncExternalStore(subscribe, () => loaded, () => loaded);
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -436,18 +436,6 @@ async fn set_metadata_snapshot(
     }
 }
 
-/// Read the metadata `additional` fields from the daemon's Automerge doc.
-/// Returns a HashMap with the `runt` field as a JSON value for trust verification.
-async fn get_raw_metadata_additional(
-    handle: &RelayHandle,
-) -> Option<HashMap<String, serde_json::Value>> {
-    let snapshot = get_metadata_snapshot(handle).await?;
-    let runt_value = serde_json::to_value(&snapshot.runt).ok()?;
-    let mut additional = HashMap::new();
-    additional.insert("runt".to_string(), runt_value);
-    Some(additional)
-}
-
 /// Connect to the daemon by opening an existing notebook file.
 ///
 /// The daemon loads the file, derives notebook_id, creates the room, and populates
@@ -1786,17 +1774,6 @@ async fn complete_onboarding(
     Ok(())
 }
 
-/// Check if the notebook has a file path set
-#[tauri::command]
-async fn has_notebook_path(
-    window: tauri::Window,
-    registry: tauri::State<'_, WindowNotebookRegistry>,
-) -> Result<bool, String> {
-    let path = path_for_window(&window, registry.inner())?;
-    let path = path.lock().map_err(|e| e.to_string())?;
-    Ok(path.is_some())
-}
-
 /// Sync the Tauri window's local path state and title with a `PathChanged`
 /// broadcast from the daemon. Called by the frontend when another peer (an
 /// MCP agent, a sibling window) saves or renames the notebook — without this,
@@ -1839,65 +1816,6 @@ fn apply_path_changed(
     // touch `window.set_title(...)` here — a Rust-side write would race
     // against the frontend's concurrent title update from the same
     // `path_changed` broadcast.
-
-    Ok(())
-}
-
-/// Format all code cells in the notebook and save.
-/// Formatting is best-effort - cells that fail to format are saved as-is.
-///
-/// The daemon handles both formatting and disk persistence:
-/// - Formats code cells using ruff (Python) or deno fmt (Deno)
-/// - Updates the Automerge doc with formatted sources (synced to all clients)
-/// - Writes the .ipynb file to disk
-#[tauri::command]
-async fn save_notebook(
-    window: tauri::Window,
-    registry: tauri::State<'_, WindowNotebookRegistry>,
-) -> Result<(), String> {
-    info!(
-        "[save] save_notebook command invoked by window {}",
-        window.label()
-    );
-    let path = path_for_window(&window, registry.inner())?;
-    let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-
-    // Verify we have a path - daemon will use the room's notebook_path
-    {
-        let p = path.lock().map_err(|e| e.to_string())?;
-        if p.is_none() {
-            return Err("No file path set - use save_notebook_as".to_string());
-        }
-    }
-
-    // Save via daemon - daemon handles formatting and disk write
-    // Formatted sources are synced back via Automerge
-    let sync_handle = notebook_sync.lock().await.clone();
-    let handle = sync_handle.ok_or("Not connected to daemon")?;
-
-    match handle
-        .send_request(NotebookRequest::SaveNotebook {
-            format_cells: true, // Daemon formats cells before saving
-            path: None,         // Use room's notebook_path
-        })
-        .await
-    {
-        Ok(NotebookResponse::NotebookSaved { path, .. }) => {
-            info!("[save] Notebook saved via daemon to: {}", path);
-        }
-        Ok(NotebookResponse::SaveError { error }) => {
-            return Err(format_save_error(&error));
-        }
-        Ok(NotebookResponse::Error { error }) => {
-            return Err(format!("Daemon save failed: {}", error));
-        }
-        Ok(other) => {
-            return Err(format!("Unexpected daemon response: {:?}", other));
-        }
-        Err(e) => {
-            return Err(format!("Daemon request failed: {}", e));
-        }
-    }
 
     Ok(())
 }
@@ -2805,26 +2723,14 @@ async fn send_frame_bytes(
 }
 
 // ============================================================================
-// Trust Verification Commands
+// Trust approval
 // ============================================================================
-
-/// Verify the trust status of the current notebook's dependencies.
-///
-/// Returns the trust status and information about what packages would be installed.
-#[tauri::command]
-async fn verify_notebook_trust(
-    window: tauri::Window,
-    registry: tauri::State<'_, WindowNotebookRegistry>,
-) -> Result<trust::TrustInfo, String> {
-    let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-    let guard = notebook_sync.lock().await;
-    let handle = guard.as_ref().ok_or("Not connected to daemon")?;
-    // Use raw metadata to preserve trust_signature (not in the typed RuntMetadata struct)
-    let additional = get_raw_metadata_additional(handle)
-        .await
-        .ok_or("Failed to read metadata from daemon")?;
-    trust::verify_notebook_trust(&additional)
-}
+//
+// Trust *status* is authored by the daemon on `RuntimeStateDoc.trust` and
+// reaches the frontend via CRDT sync. Only the explicit approval action
+// stays Tauri-side, because it needs the local HMAC key to sign. That
+// will move to the daemon in a follow-up, at which point this command
+// (and the `runt-trust` crate dep on `notebook`) can be dropped too.
 
 /// Approve the notebook's dependencies and sign them with the local trust key.
 ///
@@ -3775,10 +3681,11 @@ pub fn run(
         .manage(daemon_status_state)
         .manage(SyncReadyState::default())
         .invoke_handler(tauri::generate_handler![
-            // Notebook file operations
-            has_notebook_path,
+            // Notebook file operations. In-place saves go straight from the
+            // frontend to the daemon via `send_frame(0x01)`; this handler
+            // only covers the paths that need Tauri-side side effects
+            // (save-as: dialog + recent-menu, clone: new window).
             apply_path_changed,
-            save_notebook,
             save_notebook_as,
             get_default_save_directory,
             clone_notebook_to_ephemeral,
@@ -3804,8 +3711,9 @@ pub fn run(
             // pyproject / pixi / environment.yml: discovery + import
             // now flow through RuntimeStateDoc.project_context and
             // WASM metadata writes. No Tauri commands live here.
-            // Trust verification
-            verify_notebook_trust,
+            // Trust. Status reads come off `RuntimeStateDoc.trust` via
+            // CRDT sync; only the explicit approval (HMAC signing with the
+            // local trust key) stays on the Tauri side for now.
             approve_notebook_trust,
             check_typosquats,
             // Synced settings (via runtimed Automerge)

--- a/docs/superpowers/specs/2026-04-25-kill-notebook-mutation-proxies-phase-1.md
+++ b/docs/superpowers/specs/2026-04-25-kill-notebook-mutation-proxies-phase-1.md
@@ -1,0 +1,95 @@
+# Kill notebook-mutation Tauri proxies (phase 1)
+
+Delete three Tauri commands from `crates/notebook` that duplicate work the daemon already owns. Part of a larger sweep to thin out `crates/notebook`'s role to "OS-chrome and window lifecycle", not "request router and re-verifier".
+
+## What goes away
+
+Three `#[tauri::command]` functions in `crates/notebook/src/lib.rs`:
+
+| Command | What it does now | Replacement |
+|---------|-----------------|-------------|
+| `save_notebook` | Wraps `NotebookRequest::SaveNotebook { format_cells: true, path: None }` | Frontend sends the request directly via `host.transport.sendRequest` |
+| `has_notebook_path` | Reads `context.path` from `WindowNotebookRegistry` | Frontend reads `runtimeState.path` from `useRuntimeState()` |
+| `verify_notebook_trust` | Fetches metadata from daemon, re-runs `runt_trust::verify_notebook_trust`, returns `TrustInfo` | Frontend composes an equivalent shape from `runtimeState.trust.status` + `useDependencies()` + `useCondaDependencies()` |
+
+All three are pure pass-throughs or CRDT re-reads. The daemon already does the work and publishes authoritative state.
+
+## What stays
+
+- `save_notebook_as` — has Tauri-only side effects (`recent::record_open`, `refresh_native_menu`, kernel relaunch on path change). Moves in phase 2.
+- `clone_notebook_to_ephemeral` — opens a new window, inherently Tauri-side. Can be slimmed in phase 2 by letting the frontend drive the daemon request and a separate window-open command.
+- `approve_notebook_trust` — signs with the HMAC key. Moves in phase 2 together with the `runt-trust` crate-dep drop.
+- `apply_path_changed` — real Tauri state (session restore, window title fallback cache). Stays.
+
+After this phase, `crates/notebook` still links `runt-trust` because `approve_notebook_trust` needs it. The dep drop is phase 2.
+
+## Architecture
+
+### Trust verification (the only non-trivial change)
+
+Today, `useTrust()` has two data sources:
+
+1. `host.trust.verify()` → `TrustInfo { status, uv_dependencies, conda_dependencies, conda_channels }`
+2. `runtimeState.trust.needs_approval` (already daemon-sourced)
+
+After:
+
+1. `runtimeState.trust.status` → `"trusted" | "untrusted" | "signature_invalid" | "no_dependencies"` (already written by daemon in `room.rs` and `metadata.rs`)
+2. `useDependencies().dependencies.dependencies` → UV package list
+3. `useCondaDependencies().dependencies.{dependencies,channels}` → Conda list + channels
+4. `runtimeState.trust.needs_approval` → unchanged
+
+`useTrust()` composes these into the existing `TrustInfo` shape locally. The `TrustInfo` type becomes a frontend-only aggregate (still exported from `@nteract/notebook-host` for the `TrustDialog` prop). No wire type changes.
+
+Callers that read `trustInfo.status`, `trustInfo.uv_dependencies`, `trustInfo.conda_dependencies`, `trustInfo.conda_channels` continue to work unchanged. The `TrustDialog` component is unaffected.
+
+### Save
+
+`saveNotebook(host, flushSync, hasPath)` takes a `hasPath` boolean as a third parameter. The one caller (`useAutomergeNotebook.ts`) computes it from `runtimePath != null` and passes it in. Removes a Tauri round-trip on every save.
+
+The `save_notebook` request handling in the frontend uses a new helper `notebookClient.saveNotebook({ formatCells: true })`. It wraps `transport.sendRequest` with the `NotebookResponse::NotebookSaved | SaveError | Error` match that lives on the Rust side today, and re-uses the same user-facing error mapping (`SaveErrorKind::PathAlreadyOpen` → "Cannot save: {path} is already open…").
+
+Put this helper on the existing `NotebookClient` class in `packages/runtimed/src/notebook-client.ts`, next to `launchKernel` / `executeCell` etc. Frontend callers that don't want to instantiate a `NotebookClient` can call `transport.sendRequest(...)` directly — the helper is convenience, not a required path.
+
+### Has-path
+
+Direct CRDT read. No new code surface. Just wire `runtimeState.path != null` into the `saveNotebook` call.
+
+## Changed files (estimate)
+
+**Rust (`crates/notebook/src/lib.rs`)**
+- Delete fns: `save_notebook` (~50 lines), `has_notebook_path` (~8 lines), `verify_notebook_trust` (~14 lines).
+- Remove the three entries from the `tauri::generate_handler![]` invocation in `run()`.
+- The `format_save_error` function becomes unused — delete it.
+- `SaveErrorKind` import becomes unused — remove.
+
+**TypeScript**
+- `apps/notebook/src/lib/notebook-file-ops.ts` — `saveNotebook` signature change (adds `hasPath: boolean`), remove the `has_notebook_path` and `save_notebook` `invoke` calls, route save through `notebookClient.saveNotebook`.
+- `apps/notebook/src/hooks/useAutomergeNotebook.ts` — pass `runtimePath != null` through the `save` callback.
+- `apps/notebook/src/hooks/useTrust.ts` — replace `host.trust.verify()` with composition of `runtimeState.trust.status` + `useDependencies()` + `useCondaDependencies()`.
+- `packages/notebook-host/src/types.ts` — drop `verify` from `HostTrust`.
+- `packages/notebook-host/src/tauri/index.ts` — drop `trust.verify` implementation.
+- `packages/runtimed/src/notebook-client.ts` — add `saveNotebook({ formatCells })` helper plus a `SaveNotebookError` typed error that carries `SaveErrorKind`.
+- `apps/notebook/src/lib/__tests__/notebook-file-ops.test.ts` — update for new `saveNotebook` signature (no `has_notebook_path` mock; pass `hasPath` directly).
+- `packages/notebook-host/tests/tauri-host.test.ts` — drop the `trust.verify` test if one exists.
+
+## Out of scope
+
+- `runt-trust` crate-dep removal (still used by `approve_notebook_trust`).
+- `save_notebook_as` removal (side effects to migrate).
+- Ephemeral clone window-open refactor.
+- Any changes to how the daemon writes trust state — it already does this correctly.
+- MIME / WASM changes. Any `useSyncedSettings`/`rotate_install_id`-style daemon proxies (those are a separate lane).
+
+## Verification
+
+1. `cargo xtask lint` — formatting + clippy clean.
+2. `cargo build -p notebook` — compiles without `runt_trust::verify_notebook_trust` import.
+3. Tauri app: Cmd+S on an untitled notebook → opens save dialog, writes file, title updates. Cmd+S on a saved notebook → silent save, no dialog, no round-trip to `has_notebook_path`.
+4. Trust dialog: open a notebook with inline UV deps, no signature → dialog shows uv/conda dep lists, typosquat warnings render, approve button still works via `host.trust.approve()`.
+5. Dep edit from another peer (daemon writes `RuntimeStateDoc.trust.status = "signature_invalid"`): dialog re-renders with the correct status without a Tauri round-trip.
+6. `notebook-file-ops.test.ts` passes with the new signature.
+
+## Rollout
+
+One PR. Small enough to review in a sitting. No feature flag needed — the daemon already publishes the state we're switching to read from.

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -50,7 +50,6 @@ import type {
   HostUpdater,
   HostWindow,
   NotebookHost,
-  TrustInfo,
   TyposquatWarning,
   Unlisten,
 } from "../types";
@@ -115,9 +114,6 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   };
 
   const trust: HostTrust = {
-    async verify() {
-      return invoke<TrustInfo>("verify_notebook_trust");
-    },
     async approve() {
       await invoke("approve_notebook_trust");
     },

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -109,9 +109,16 @@ export interface HostBlobs {
   port(): Promise<number>;
 }
 
-/** Notebook trust state (attestation + approval, nothing else). */
+/**
+ * Notebook trust approval.
+ *
+ * Trust *status* is read from `RuntimeStateDoc.trust` via
+ * `useRuntimeState()`; the daemon is the sole writer. This namespace
+ * exists only for the explicit user action (signing with the local
+ * HMAC key), which still has to happen Tauri-side until the signing
+ * flow moves to the daemon.
+ */
 export interface HostTrust {
-  verify(): Promise<TrustInfo>;
   approve(): Promise<void>;
 }
 

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -22,13 +22,6 @@ vi.mock("@tauri-apps/api/core", () => ({
         });
       case "get_blob_port":
         return Promise.resolve(12345);
-      case "verify_notebook_trust":
-        return Promise.resolve({
-          status: "trusted",
-          uv_dependencies: [],
-          conda_dependencies: [],
-          conda_channels: [],
-        });
       case "check_typosquats":
         return Promise.resolve([]);
       case "get_username":
@@ -195,15 +188,10 @@ describe("createTauriHost()", () => {
     expect(capturedInvokes.at(-1)?.cmd).toBe("get_blob_port");
   });
 
-  it("routes trust.verify / approve to the correct commands", async () => {
+  it("routes trust.approve to approve_notebook_trust", async () => {
     const host = createTauriHost({ transport: stubTransport });
-    const verify = await host.trust.verify();
-    expect(verify.status).toBe("trusted");
     await host.trust.approve();
-    const cmds = capturedInvokes.map((x) => x.cmd);
-    expect(cmds).toEqual(
-      expect.arrayContaining(["verify_notebook_trust", "approve_notebook_trust"]),
-    );
+    expect(capturedInvokes.map((x) => x.cmd)).toContain("approve_notebook_trust");
   });
 
   it("routes deps.checkTyposquats to check_typosquats (not trust)", async () => {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -53,6 +53,7 @@ export {
   type RuntimeLifecycle,
   type RuntimeState,
   type TrustState,
+  type TrustStatus,
   diffExecutions,
   getExecutionCountForCell,
 } from "./runtime-state";
@@ -108,13 +109,14 @@ export {
 } from "./derived-state";
 
 // Notebook client
-export { NotebookClient, type NotebookClientOptions } from "./notebook-client";
+export { NotebookClient, type NotebookClientOptions, SaveNotebookError } from "./notebook-client";
 export type {
   CommRequestMessage,
   CompletionItem,
   HistoryEntry,
   NotebookRequest,
   NotebookResponse,
+  SaveErrorKind,
 } from "./request-types";
 
 // MIME priority

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -16,7 +16,36 @@ import type {
   HistoryEntry,
   NotebookRequest,
   NotebookResponse,
+  SaveErrorKind,
 } from "./request-types";
+
+/**
+ * Thrown when `NotebookClient.saveNotebook` receives a structured
+ * `SaveErrorKind` from the daemon. Callers that need to branch on the
+ * kind (e.g., to surface the conflicting UUID on `path_already_open`)
+ * can inspect `.kind`. `.message` is a user-facing rendering suitable
+ * for display.
+ */
+export class SaveNotebookError extends Error {
+  readonly kind: SaveErrorKind;
+  constructor(kind: SaveErrorKind) {
+    super(formatSaveError(kind));
+    this.name = "SaveNotebookError";
+    this.kind = kind;
+  }
+}
+
+function formatSaveError(kind: SaveErrorKind): string {
+  switch (kind.type) {
+    case "path_already_open":
+      return (
+        `Cannot save: ${kind.path} is already open in another notebook window. ` +
+        `Close that window first, or choose a different path.`
+      );
+    case "io":
+      return `Failed to save notebook: ${kind.message}`;
+  }
+}
 
 const nullLogger: SyncEngineLogger = {
   debug() {},
@@ -193,6 +222,44 @@ export class NotebookClient {
     } catch (e) {
       this.log.error("[notebook-client] Complete failed:", e);
       throw e;
+    }
+  }
+
+  /**
+   * Save the notebook to disk via the daemon.
+   *
+   * Pass `path` to save-as. Without `path`, saves in place — the daemon
+   * uses the room's current path and returns `save_error` if the room
+   * is still untitled.
+   *
+   * Throws `SaveNotebookError` on structured `save_error` responses (the
+   * `.kind` payload carries `path_already_open` / `io` details). Throws
+   * a plain `Error` on transport failures or unexpected response shapes.
+   */
+  async saveNotebook(options: { formatCells: boolean; path?: string }): Promise<{ path: string }> {
+    const request: NotebookRequest = {
+      type: "save_notebook",
+      format_cells: options.formatCells,
+      ...(options.path !== undefined ? { path: options.path } : {}),
+    };
+
+    let response: NotebookResponse;
+    try {
+      response = await this.sendRequest(request);
+    } catch (e) {
+      this.log.error("[notebook-client] Save request failed:", e);
+      throw e;
+    }
+
+    switch (response.result) {
+      case "notebook_saved":
+        return { path: response.path };
+      case "save_error":
+        throw new SaveNotebookError(response.error);
+      case "error":
+        throw new Error(`Daemon save failed: ${response.error}`);
+      default:
+        throw new Error(`Unexpected save_notebook response: ${JSON.stringify(response)}`);
     }
   }
 

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -31,7 +31,14 @@ export type NotebookRequest =
       /** Deduplicate identical entries when true. */
       unique: boolean;
     }
-  | { type: "complete"; code: string; cursor_pos: number };
+  | { type: "complete"; code: string; cursor_pos: number }
+  | {
+      type: "save_notebook";
+      /** Format code cells (ruff / deno fmt) before writing to disk. */
+      format_cells: boolean;
+      /** Target path. Omit to save in place. */
+      path?: string;
+    };
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {
@@ -100,4 +107,20 @@ export type NotebookResponse =
       items: CompletionItem[];
       cursor_start: number;
       cursor_end: number;
-    };
+    }
+  | { result: "notebook_saved"; path: string }
+  | { result: "save_error"; error: SaveErrorKind };
+
+/**
+ * Structured save failures returned in `NotebookResponse::SaveError`.
+ * Mirrors `notebook_protocol::protocol::SaveErrorKind`.
+ */
+export type SaveErrorKind =
+  | {
+      type: "path_already_open";
+      /** UUID of the room that currently holds this path. */
+      uuid: string;
+      /** The conflicting path. */
+      path: string;
+    }
+  | { type: "io"; message: string };

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -104,8 +104,14 @@ export interface EnvState {
   prewarmed_packages: string[];
 }
 
+/**
+ * Trust status mirrors `runt_trust::TrustStatus` serialized with
+ * `rename_all = "snake_case"`.
+ */
+export type TrustStatus = "trusted" | "untrusted" | "signature_invalid" | "no_dependencies";
+
 export interface TrustState {
-  status: string;
+  status: TrustStatus;
   needs_approval: boolean;
 }
 


### PR DESCRIPTION
Three Tauri commands in `crates/notebook` were duplicating work the daemon already owns. Delete them and route callers to the authoritative path.

## What went away

| Command | Was | Is now |
|---|---|---|
| `save_notebook` | Tauri proxy for `NotebookRequest::SaveNotebook { format_cells: true }` | `host.transport.sendRequest` via new `NotebookClient.saveNotebook({ formatCells })` + `SaveNotebookError` |
| `has_notebook_path` | Read `context.path` from `WindowNotebookRegistry` | `runtimeState.path != null` from `useRuntimeState()` |
| `verify_notebook_trust` | Fetch metadata, re-run `runt_trust::verify_notebook_trust` in the Tauri process | `useTrust()` composes `TrustInfo` from `runtimeState.trust.status` + `useDependencies()` + `useCondaDependencies()` |

## Design decision

Trust *verification* moves to "read from daemon's CRDT" instead of "ask Tauri, which re-verifies locally against the daemon's metadata". The daemon already runs `runt_trust::verify_notebook_trust` internally on every metadata change and writes the result to `RuntimeStateDoc.trust.status`. The Tauri command was a redundant second pass. Trust *approval* (signing with the local HMAC key) stays Tauri-side for this PR — it moves to the daemon in a follow-up, at which point `runt-trust` can drop out of `crates/notebook`'s dep graph entirely.

The save-in-place path loses one round-trip (`has_notebook_path`) and reads path state from the CRDT it was already listening to.

## What stays

- `save_notebook_as` — has Tauri-side side effects (recent-menu refresh, kernel relaunch on path change).
- `clone_notebook_to_ephemeral` — opens a new window.
- `approve_notebook_trust` — HMAC signing client-side.
- `apply_path_changed` — real Tauri bookkeeping (session restore, window-title cache).

These go in phase 2 once the side effects have landing zones on the daemon side.

## Test plan

- [x] `cargo check -p notebook`
- [x] `cargo xtask lint`
- [x] `cargo xtask clippy`
- [x] `cargo test -p notebook --lib` (66/66)
- [x] `pnpm test:run` (1085/1085 + 3 skipped across 63 suites)
- [ ] Cmd+S on a saved notebook: silent save, no `has_notebook_path` round-trip
- [ ] Cmd+S on an untitled notebook: save dialog → daemon writes file → title updates
- [ ] Trust dialog: open a notebook with inline UV deps and no signature → dep lists + typosquat warnings render, approve button works
- [ ] Concurrent peer edits deps from an MCP agent → `runtimeState.trust.status` flips to `signature_invalid`, dialog re-renders without a Tauri round-trip

Design notes: `docs/superpowers/specs/2026-04-25-kill-notebook-mutation-proxies-phase-1.md`
