### PR TITLE
fix(sift): prevent Safari brush text selection

### DIFF
--- a/packages/sift/src/sparkline.test.ts
+++ b/packages/sift/src/sparkline.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from "vite-plus/test";
-import { binOverlapsFilter } from "./sparkline";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { binOverlapsFilter, renderColumnSummary, unmountColumnSummary } from "./sparkline";
+
+function pointerEvent(type: string, clientX: number) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    button: { value: 0 },
+    clientX: { value: clientX },
+    clientY: { value: 0 },
+    pointerId: { value: 1 },
+    pointerType: { value: "mouse" },
+  });
+  return event;
+}
+
+afterEach(() => {
+  document.querySelector(".sift-brush-overlay")?.remove();
+  document.documentElement.classList.remove("sift-brushing");
+});
 
 describe("binOverlapsFilter", () => {
   it("treats overlapping ranges as active (normal case)", () => {
@@ -53,5 +71,80 @@ describe("binOverlapsFilter", () => {
   it("point-bin and point-filter at the same value overlap", () => {
     expect(binOverlapsFilter(5, 5, 5, 5)).toBe(true);
     expect(binOverlapsFilter(5, 5, 6, 6)).toBe(false);
+  });
+});
+
+describe("histogram brushing", () => {
+  it("captures document-level drag and blocks native text selection", async () => {
+    const onFilter = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    try {
+      await act(async () => {
+        renderColumnSummary(
+          container,
+          {
+            kind: "numeric",
+            min: 0,
+            max: 100,
+            bins: [
+              { x0: 0, x1: 50, count: 10 },
+              { x0: 50, x1: 100, count: 5 },
+            ],
+          },
+          100,
+          undefined,
+          undefined,
+          onFilter,
+        );
+      });
+
+      const brushTarget = container.querySelector<HTMLDivElement>(".sift-brush-hit-target");
+      expect(brushTarget).toBeTruthy();
+
+      Object.defineProperty(brushTarget, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 100,
+          bottom: 48,
+          width: 100,
+          height: 48,
+          toJSON: () => ({}),
+        }),
+      });
+
+      const down = pointerEvent("pointerdown", 20);
+      await act(async () => {
+        brushTarget!.dispatchEvent(down);
+      });
+
+      expect(down.defaultPrevented).toBe(true);
+      expect(document.documentElement.classList.contains("sift-brushing")).toBe(true);
+      expect(document.querySelector(".sift-brush-overlay")).toBeTruthy();
+
+      const selectStart = new Event("selectstart", { bubbles: true, cancelable: true });
+      document.dispatchEvent(selectStart);
+      expect(selectStart.defaultPrevented).toBe(true);
+
+      await act(async () => {
+        document.dispatchEvent(pointerEvent("pointermove", 80));
+        document.dispatchEvent(pointerEvent("pointerup", 80));
+      });
+
+      expect(document.querySelector(".sift-brush-overlay")).toBeTruthy();
+      await new Promise((resolve) => setTimeout(resolve, 180));
+
+      expect(document.querySelector(".sift-brush-overlay")).toBeNull();
+      expect(document.documentElement.classList.contains("sift-brushing")).toBe(false);
+      expect(onFilter).toHaveBeenCalledWith({ kind: "range", min: 20, max: 80 });
+    } finally {
+      unmountColumnSummary(container);
+      container.remove();
+    }
   });
 });

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -20,6 +20,16 @@ type NonNullSummary =
 type FilterCallback = (filter: ColumnFilter) => void;
 
 const CHART_HEIGHT = 48;
+const BRUSHING_CLASS = "sift-brushing";
+
+type BrushState = {
+  startX: number;
+  currentX: number;
+};
+
+function clearNativeSelection() {
+  document.getSelection()?.removeAllRanges();
+}
 
 /**
  * Does a bin with range [x0, x1] overlap the active range filter?
@@ -71,11 +81,16 @@ function BrushLayer({
   activeFilter?: RangeFilter | null;
   onFilter: FilterCallback;
 }) {
-  const svgRef = useRef<SVGSVGElement>(null);
-  const [brushState, setBrushState] = useState<{
-    startX: number;
-    currentX: number;
-  } | null>(null);
+  const hitTargetRef = useRef<HTMLDivElement>(null);
+  const brushStateRef = useRef<BrushState | null>(null);
+  const stopBrushCaptureRef = useRef<(() => void) | null>(null);
+  const [brushState, setBrushState] = useState<BrushState | null>(null);
+
+  useEffect(() => {
+    return () => {
+      stopBrushCaptureRef.current?.();
+    };
+  }, []);
 
   // When min === max (the filtered slice is a single value), the brush's
   // value↔pixel mapping would divide by zero and produce NaN coordinates,
@@ -99,57 +114,158 @@ function BrushLayer({
     [width, min, span],
   );
 
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
-    const svg = svgRef.current!;
-    svg.setPointerCapture(e.pointerId);
-    const rect = svg.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    setBrushState({ startX: x, currentX: x });
-  }, []);
-
-  const onPointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!brushState) return;
-      const rect = svgRef.current!.getBoundingClientRect();
-      const x = Math.max(0, Math.min(width, e.clientX - rect.left));
-      setBrushState({ ...brushState, currentX: x });
+  const clientXToBrushX = useCallback(
+    (clientX: number) => {
+      const rect = hitTargetRef.current!.getBoundingClientRect();
+      return Math.max(0, Math.min(width, clientX - rect.left));
     },
-    [brushState, width],
+    [width],
   );
 
-  const onPointerUp = useCallback(() => {
-    if (!brushState) return;
-    const x0 = Math.min(brushState.startX, brushState.currentX);
-    const x1 = Math.max(brushState.startX, brushState.currentX);
-    setBrushState(null);
+  const setBrush = useCallback((state: BrushState | null) => {
+    brushStateRef.current = state;
+    setBrushState(state);
+  }, []);
 
-    // If the drag was tiny, treat as a click → clear filter
-    if (x1 - x0 < 3) {
-      onFilter(null);
-      return;
-    }
+  const finishBrush = useCallback(
+    (state: BrushState) => {
+      const x0 = Math.min(state.startX, state.currentX);
+      const x1 = Math.max(state.startX, state.currentX);
+      setBrush(null);
 
-    // Constant-slice column (span === 0): xToValue maps every pixel to
-    // `min`, so v0 === v1 === min === max and the "entire range" check
-    // below would fire on every real drag and clear the filter. Let the
-    // user pin the single value instead so their filter survives
-    // subsequent changes on other columns.
-    if (span <= 0) {
-      onFilter({ kind: "range", min, max });
-      return;
-    }
+      // If the drag was tiny, treat as a click → clear filter
+      if (x1 - x0 < 3) {
+        onFilter(null);
+        return;
+      }
 
-    const v0 = xToValue(x0);
-    const v1 = xToValue(x1);
+      // Constant-slice column (span === 0): xToValue maps every pixel to
+      // `min`, so v0 === v1 === min === max and the "entire range" check
+      // below would fire on every real drag and clear the filter. Let the
+      // user pin the single value instead so their filter survives
+      // subsequent changes on other columns.
+      if (span <= 0) {
+        onFilter({ kind: "range", min, max });
+        return;
+      }
 
-    // If the entire range is selected, clear instead of filtering
-    if (v0 <= min && v1 >= max) {
-      onFilter(null);
-      return;
-    }
+      const v0 = xToValue(x0);
+      const v1 = xToValue(x1);
 
-    onFilter({ kind: "range", min: v0, max: v1 });
-  }, [brushState, xToValue, onFilter, min, max, span]);
+      // If the entire range is selected, clear instead of filtering
+      if (v0 <= min && v1 >= max) {
+        onFilter(null);
+        return;
+      }
+
+      onFilter({ kind: "range", min: v0, max: v1 });
+    },
+    [setBrush, onFilter, span, min, max, xToValue],
+  );
+
+  const stopBrushCapture = useCallback(() => {
+    stopBrushCaptureRef.current?.();
+    stopBrushCaptureRef.current = null;
+  }, []);
+
+  const startBrushCapture = useCallback(
+    (pointerId: number) => {
+      stopBrushCapture();
+
+      const overlay = document.createElement("div");
+      overlay.className = "sift-brush-overlay";
+      document.body.appendChild(overlay);
+      document.documentElement.classList.add(BRUSHING_CLASS);
+      clearNativeSelection();
+      let active = true;
+      let releaseTimer: number | null = null;
+
+      const blockSelection = (event: Event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        clearNativeSelection();
+      };
+
+      const onSelectionChange = () => {
+        if (active) clearNativeSelection();
+      };
+
+      const shouldHandlePointer = (event: PointerEvent) => event.pointerId === pointerId;
+
+      const cleanup = () => {
+        if (!active) return;
+        active = false;
+        if (releaseTimer !== null) window.clearTimeout(releaseTimer);
+        document.removeEventListener("selectstart", blockSelection, true);
+        document.removeEventListener("dragstart", blockSelection, true);
+        document.removeEventListener("selectionchange", onSelectionChange, true);
+        document.removeEventListener("pointermove", onMove, true);
+        document.removeEventListener("pointerup", onUp, true);
+        document.removeEventListener("pointercancel", onCancel, true);
+        overlay.remove();
+        document.documentElement.classList.remove(BRUSHING_CLASS);
+        clearNativeSelection();
+      };
+
+      const releaseAfterSafariSelectionSettles = () => {
+        clearNativeSelection();
+        requestAnimationFrame(clearNativeSelection);
+        releaseTimer = window.setTimeout(cleanup, 150);
+      };
+
+      const onMove = (event: PointerEvent) => {
+        if (!shouldHandlePointer(event)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        clearNativeSelection();
+
+        const state = brushStateRef.current;
+        if (!state) return;
+        setBrush({ ...state, currentX: clientXToBrushX(event.clientX) });
+      };
+
+      const onUp = (event: PointerEvent) => {
+        if (!shouldHandlePointer(event)) return;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const state = brushStateRef.current;
+        clearNativeSelection();
+        if (state) finishBrush(state);
+        releaseAfterSafariSelectionSettles();
+      };
+
+      const onCancel = (event: PointerEvent) => {
+        if (!shouldHandlePointer(event)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        setBrush(null);
+        releaseAfterSafariSelectionSettles();
+      };
+
+      document.addEventListener("selectstart", blockSelection, true);
+      document.addEventListener("dragstart", blockSelection, true);
+      document.addEventListener("selectionchange", onSelectionChange, true);
+      document.addEventListener("pointermove", onMove, true);
+      document.addEventListener("pointerup", onUp, true);
+      document.addEventListener("pointercancel", onCancel, true);
+
+      stopBrushCaptureRef.current = cleanup;
+    },
+    [clientXToBrushX, finishBrush, setBrush, stopBrushCapture],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const x = clientXToBrushX(e.clientX);
+      setBrush({ startX: x, currentX: x });
+      startBrushCapture(e.pointerId);
+    },
+    [clientXToBrushX, setBrush, startBrushCapture],
+  );
 
   // Render brush rect for active selection
   let brushRect = null;
@@ -157,7 +273,14 @@ function BrushLayer({
     const x = Math.min(brushState.startX, brushState.currentX);
     const w = Math.abs(brushState.currentX - brushState.startX);
     brushRect = (
-      <rect x={x} y={0} width={w} height={CHART_HEIGHT} fill="var(--sift-accent)" opacity={0.2} />
+      <div
+        className="sift-brush-selection"
+        style={{
+          left: x,
+          width: w,
+          opacity: 0.2,
+        }}
+      />
     );
   } else if (activeFilter) {
     // When the filtered slice has collapsed to a single value (span === 0),
@@ -189,37 +312,28 @@ function BrushLayer({
       w = valueToX(activeFilter.max) - x;
     }
     brushRect = (
-      <rect
-        x={x}
-        y={0}
-        width={w}
-        height={CHART_HEIGHT}
-        fill="var(--sift-accent)"
-        opacity={0.15}
-        rx={2}
+      <div
+        className="sift-brush-selection sift-brush-selection-active"
+        style={{
+          left: x,
+          width: w,
+        }}
       />
     );
   }
 
   return (
-    <svg
-      ref={svgRef}
-      width={width}
-      height={CHART_HEIGHT}
-      viewBox={`0 0 ${width} ${CHART_HEIGHT}`}
+    <div
+      ref={hitTargetRef}
+      className="sift-brush-hit-target"
       style={{
-        position: "absolute",
-        top: 0,
-        left: 0,
-        cursor: "crosshair",
-        touchAction: "none",
+        width,
+        height: CHART_HEIGHT,
       }}
       onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
     >
       {brushRect}
-    </svg>
+    </div>
   );
 }
 

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -330,6 +330,8 @@ h1 {
   width: 100%;
   overflow: hidden;
   animation: summary-fade-in 300ms ease-out;
+  -webkit-user-select: none;
+  user-select: none;
   --sift-chart-bg: transparent;
   --sift-chart-text: var(--sift-muted);
   --sift-chart-text-secondary: var(--sift-muted);
@@ -341,6 +343,49 @@ h1 {
 .sift-th-summary svg,
 .sift-th-summary canvas {
   display: block;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.sift-brush-hit-target {
+  position: absolute;
+  inset: 0 auto auto 0;
+  cursor: crosshair;
+  touch-action: none;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.sift-brush-selection {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: var(--sift-accent);
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.sift-brush-selection-active {
+  opacity: 0.15;
+}
+
+.sift-brushing,
+.sift-brushing * {
+  -webkit-user-select: none !important;
+  user-select: none !important;
+}
+
+.sift-brush-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  cursor: crosshair;
+  background: transparent;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 @keyframes summary-fade-in {


### PR DESCRIPTION
## Summary

- Move histogram brush input from the SVG overlay to an HTML hit target while leaving the chart SVG as the visual layer.
- Capture brush drags at the document level and suppress native text selection while the brush is active.
- Add coverage for document-level brushing and selection blocking.

## Why

Safari can begin native text selection when a histogram brush drag crosses from a header mini-chart into the next column heading. The brush itself still filters, but the browser leaves selected header text behind. Treating brushing as a document-modal interaction, with an HTML hit target and temporary capture overlay, keeps the cross-filter gesture from becoming a text-selection gesture.

## Validation

- `pnpm --dir packages/sift test`
- `cargo xtask lint --fix`
- `git diff --check`
- Tested in Safari against the Sift generated dataset: dragging from the Score mini-chart into the Email heading applies the Score filter and leaves `document.getSelection()` empty.