### PR TITLE
fix(sift): resolve wasm package for tsc

### DIFF
--- a/packages/sift/tsconfig.json
+++ b/packages/sift/tsconfig.json
@@ -14,6 +14,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "sift-wasm/*": ["../../crates/sift-wasm/pkg/*"]
+    },
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary

- Add a TypeScript path mapping for Sift's generated `sift-wasm` package.
- Keep `tsc` resolution aligned with the existing Vite alias used by the Sift app and library builds.

## Why

`pnpm --dir packages/sift build` runs `tsc` before Vite. Vite already aliases `sift-wasm` to `crates/sift-wasm/pkg`, but TypeScript did not know about that alias, so the build failed on `import("sift-wasm/sift_wasm.js")` even when the generated WASM package existed.

## Validation

- `pnpm --dir packages/sift build`
- `pnpm --dir packages/sift test`
- `git diff --check origin/main...HEAD`