### PR TITLE
refactor(runtimed): route output ingest through jupyter-protocol Media

### DIFF
--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1008,73 +1008,91 @@ async fn convert_data_bundle(
 ) -> io::Result<HashMap<String, ContentRef>> {
     let mut result = HashMap::new();
 
-    if let Some(Value::Object(map)) = data {
-        for (mime_type, value) in map {
-            // dx blob-ref MIME: the kernel already uploaded the bytes via
-            // the nteract.dx.blob comm. Compose a ContentRef under the
-            // wrapped content_type without a new BlobStore::put call. The
-            // blob-ref MIME itself is NOT emitted as a manifest entry — it
-            // is a transport detail, not display content.
-            if mime_type == notebook_doc::mime::BLOB_REF_MIME {
-                let hash = value.get("hash").and_then(|v| v.as_str());
-                let target_ct = value.get("content_type").and_then(|v| v.as_str());
-                let size = value.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
-                match (hash, target_ct) {
-                    (Some(h), Some(ct)) => {
-                        if blob_store.exists(h) {
-                            result
-                                .insert(ct.to_string(), ContentRef::from_hash(h.to_string(), size));
-                        } else {
-                            tracing::warn!(
-                                "[dx] blob-ref MIME references missing blob hash={} (dropping)",
-                                h
-                            );
-                        }
-                    }
-                    _ => {
-                        tracing::warn!(
-                            "[dx] blob-ref MIME missing hash or content_type (dropping)"
-                        );
-                    }
-                }
-                continue;
-            }
+    let Some(Value::Object(map)) = data else {
+        return Ok(result);
+    };
 
-            let content_ref = if is_binary_mime(mime_type) {
-                // Binary MIME type: base64-decode → store raw bytes in blob.
-                // Jupyter sends image data as base64 strings on the wire.
-                // We decode to actual bytes so the blob store holds real
-                // binary content and the HTTP server serves it correctly.
-                let base64_str = value_to_string(value);
-                let raw_bytes = base64::engine::general_purpose::STANDARD
-                    .decode(&base64_str)
-                    .map_err(|e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("base64 decode failed for {}: {}", mime_type, e),
-                        )
-                    })?;
-                ContentRef::from_binary(&raw_bytes, mime_type, blob_store).await?
-            } else if mime_type == "application/json" || mime_type.ends_with("+json") {
-                // JSON-shaped MIME: kernels emit these as structured
-                // `Value::Object`/`Value::Array`. Serialize to JSON text for
-                // storage; `resolve_data_bundle` parses them back into
-                // structured form on save. Pairs with the symmetric branch
-                // in that function.
-                let content_str = value_to_string(value);
-                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?
-            } else {
-                // Text MIME type: store as a single string. Jupyter writes
-                // multi-line text as `["<div>\n", "<style>\n", ...]` — join
-                // those back into the canonical string form here so the blob
-                // holds the same text the kernel produced, not its JSON
-                // encoding. nbformat re-splits on save via
-                // `serialize_media_for_notebook`.
-                let content_str = normalize_text(value);
-                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?
-            };
-            result.insert(mime_type.clone(), content_ref);
+    // Normalize the bundle once through jupyter_protocol's typed Media
+    // deserializer. It joins array-of-strings for text MIMEs, keeps
+    // structured Value for `application/json` / `*+json`, and preserves
+    // unknown MIMEs via `Other` with the same array-rejoin logic. This
+    // replaces the per-MIME hand-roll that accidentally JSON-stringified
+    // multi-line text (#2242) and flattened JSON objects (#2246).
+    //
+    // BLOB_REF_MIME is handled before Media ever sees it: its payload is
+    // a transport-level `{hash, content_type, size}` object that the
+    // typed enum doesn't know about, and we want to swap the MIME key out
+    // for the target content_type anyway.
+    let mut bundle: serde_json::Map<String, Value> = map.clone();
+    if let Some(ref_value) = bundle.remove(notebook_doc::mime::BLOB_REF_MIME) {
+        let hash = ref_value.get("hash").and_then(|v| v.as_str());
+        let target_ct = ref_value.get("content_type").and_then(|v| v.as_str());
+        let size = ref_value.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+        match (hash, target_ct) {
+            (Some(h), Some(ct)) => {
+                if blob_store.exists(h) {
+                    result.insert(ct.to_string(), ContentRef::from_hash(h.to_string(), size));
+                } else {
+                    tracing::warn!(
+                        "[dx] blob-ref MIME references missing blob hash={} (dropping)",
+                        h
+                    );
+                }
+            }
+            _ => {
+                tracing::warn!("[dx] blob-ref MIME missing hash or content_type (dropping)");
+            }
         }
+    }
+
+    let media: jupyter_protocol::media::Media = serde_json::from_value(Value::Object(bundle))
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to deserialize media bundle: {e}"),
+            )
+        })?;
+    let normalized: HashMap<String, Value> =
+        serde_json::from_value(serde_json::to_value(&media).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to re-serialize media bundle: {e}"),
+            )
+        })?)
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to collect normalized media bundle: {e}"),
+            )
+        })?;
+
+    for (mime_type, value) in normalized {
+        let content_ref = if is_binary_mime(&mime_type) {
+            // Binary MIME type: Media leaves the base64 string intact;
+            // decode to raw bytes so the blob store holds real binary
+            // content and the HTTP server can serve it with the right
+            // Content-Type.
+            let base64_str = value_to_string(&value);
+            let raw_bytes = base64::engine::general_purpose::STANDARD
+                .decode(&base64_str)
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("base64 decode failed for {}: {}", mime_type, e),
+                    )
+                })?;
+            ContentRef::from_binary(&raw_bytes, &mime_type, blob_store).await?
+        } else {
+            // Text or JSON MIME. For text MIMEs Media gave us a
+            // `Value::String` (arrays already joined); for JSON MIMEs
+            // it gave us the structured `Value`. `value_to_string`
+            // handles both: strings pass through, objects/arrays are
+            // serialized. `resolve_data_bundle` re-parses JSON MIMEs on
+            // save.
+            let content_str = value_to_string(&value);
+            ContentRef::from_data(&content_str, &mime_type, blob_store, threshold).await?
+        };
+        result.insert(mime_type, content_ref);
     }
 
     Ok(result)
@@ -1533,6 +1551,46 @@ mod tests {
                 serde_json::from_str(&content).expect("stored content should parse as JSON");
             assert_eq!(parsed, payload, "round-trip mismatch for {mime}");
         }
+    }
+
+    /// SVG arrives as text in nbformat (Jupyter splits multi-line text MIMEs
+    /// on save) but lands in `MediaType::Svg` on deserialize. Ingest should
+    /// join the lines back into a single string, not JSON-stringify them.
+    #[tokio::test]
+    async fn svg_array_is_joined_like_other_text_mimes() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "image/svg+xml": [
+                    "<svg xmlns=\"http://www.w3.org/2000/svg\">\n",
+                    "  <circle r=\"10\"/>\n",
+                    "</svg>",
+                ],
+            },
+            "metadata": {},
+        });
+
+        let manifest = create_manifest(&output, &blob_store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let data = match manifest {
+            OutputManifest::DisplayData { data, .. } => data,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+
+        let content = data
+            .get("image/svg+xml")
+            .expect("image/svg+xml missing")
+            .resolve(&blob_store)
+            .await
+            .unwrap();
+        assert_eq!(
+            content,
+            "<svg xmlns=\"http://www.w3.org/2000/svg\">\n  <circle r=\"10\"/>\n</svg>",
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1032,9 +1032,15 @@ async fn convert_data_bundle(
             (Some(h), Some(ct)) => {
                 if blob_store.exists(h) {
                     result.insert(ct.to_string(), ContentRef::from_hash(h.to_string(), size));
+                    // Claimed the target MIME via the blob-ref. Any
+                    // fallback entry the kernel inlined under the same
+                    // key is redundant; strip it so the Media pass below
+                    // doesn't overwrite the authoritative ContentRef.
+                    bundle.remove(ct);
                 } else {
                     tracing::warn!(
-                        "[dx] blob-ref MIME references missing blob hash={} (dropping)",
+                        "[dx] blob-ref MIME references missing blob hash={} (falling back to \
+                         inline entry if present)",
                         h
                     );
                 }
@@ -1397,6 +1403,97 @@ mod tests {
                 assert_eq!(*size, raw.len() as u64);
             }
             other => panic!("expected blob ref, got {other:?}"),
+        }
+    }
+
+    /// When a bundle carries BOTH a BLOB_REF_MIME and a fallback entry under
+    /// the same target content_type (e.g. a kernel that emits `parquet` via
+    /// a blob-ref but also inlines a small base64 body for backward
+    /// compatibility), the blob-ref wins — it's the authoritative content
+    /// and we don't want to double-store or reinterpret the base64.
+    #[tokio::test]
+    async fn blob_ref_wins_over_duplicate_fallback_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let raw = b"PAR1-authoritative-parquet-body";
+        let hash = blob_store
+            .put(raw, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        // Fallback body the kernel also included — a short base64 string
+        // under the same MIME. If the blob-ref path didn't win, ingest
+        // would base64-decode this instead and lose the canonical blob.
+        let fallback_body = base64::engine::general_purpose::STANDARD.encode(b"fallback-bytes");
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                notebook_doc::mime::BLOB_REF_MIME: {
+                    "hash": hash,
+                    "content_type": "application/vnd.apache.parquet",
+                    "size": raw.len(),
+                },
+                "application/vnd.apache.parquet": fallback_body,
+            },
+        });
+
+        let manifest = create_manifest(&output, &blob_store, 1024).await.unwrap();
+        let data = match manifest {
+            OutputManifest::DisplayData { data, .. } => data,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+
+        match data.get("application/vnd.apache.parquet").unwrap() {
+            ContentRef::Blob { blob, size } => {
+                assert_eq!(blob, &hash, "blob-ref hash should win over fallback");
+                assert_eq!(*size, raw.len() as u64);
+            }
+            other => panic!("expected blob ref to win, got {other:?}"),
+        }
+    }
+
+    /// If the blob-ref references a hash that isn't in the store, the ref
+    /// can't be honored. In that case the fallback body (if the bundle
+    /// carries one under the target content_type) should be used instead
+    /// of dropping the entry entirely.
+    #[tokio::test]
+    async fn missing_blob_ref_falls_back_to_duplicate_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let fallback_body = base64::engine::general_purpose::STANDARD.encode(b"fallback-bytes");
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                notebook_doc::mime::BLOB_REF_MIME: {
+                    "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "content_type": "application/vnd.apache.parquet",
+                    "size": 999,
+                },
+                "application/vnd.apache.parquet": fallback_body,
+            },
+        });
+
+        let manifest = create_manifest(&output, &blob_store, 1024).await.unwrap();
+        let data = match manifest {
+            OutputManifest::DisplayData { data, .. } => data,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+
+        let entry = data
+            .get("application/vnd.apache.parquet")
+            .expect("fallback should have landed");
+        match entry {
+            ContentRef::Blob { blob, .. } => {
+                assert_ne!(
+                    blob, "0000000000000000000000000000000000000000000000000000000000000000",
+                    "should not reuse the missing blob-ref hash"
+                );
+            }
+            ContentRef::Inline { .. } => {}
         }
     }
 


### PR DESCRIPTION
Follows #2245 and #2246. Replaces the hand-rolled MIME dispatch in `convert_data_bundle` with `jupyter_protocol::media::Media`'s typed deserializer.

## Why

The hand-roll shipped two bugs in a week:
- **#2242**: text branch JSON-stringified multi-line arrays.
- **#2246**: JSON branch flattened structured JSON to empty string.

Both bugs are impossible to write through `Media`. Its `deserialize_media` already joins arrays for text MIMEs, keeps structured `Value` for `application/json` and `*+json`, keeps base64 strings for binary text-payload variants (`image/png`, `image/jpeg`, `image/gif`), and routes unknown MIMEs through `Other` with the same array-rejoin logic via `rejoin_notebook_mime_value`.

## How

1. Pop the `BLOB_REF_MIME` entry out of the bundle first — it's a transport-level `{hash, content_type, size}` envelope that Media doesn't model, and we want to swap the MIME key out for the target `content_type` anyway.
2. `serde_json::from_value::<Media>(...)` on the remaining bundle. Typed deserializer normalizes every entry.
3. `serde_json::to_value(&media)` → back to a flat `HashMap<String, Value>` in wire form (no multiline splits).
4. Walk the normalized map. Single branch: binary (base64-decode into the blob store) vs not-binary (stringify + `ContentRef::from_data`).

## Scope

Pure refactor. No behavior change for correct inputs. All 58 `output_store` tests pass, all 218 `notebook_sync_server` tests pass. No other file touched.

## Sanity test

Added `svg_array_is_joined_like_other_text_mimes` to lock in `image/svg+xml` behavior (SVG lands in `MediaType::Svg(String)`, not a text-MIME catch-all — good to pin).

Kept the existing `text_mime_array_of_strings_is_joined_into_content` (#2242), `json_mime_object_value_is_serialized_to_json_text` (#2246), binary round-trip, and dx blob-ref tests as regression guards against any future refactor that tries to replace Media with something ad-hoc.

## Test plan

- [x] `cargo test -p runtimed --lib output_store` — 58/58
- [x] `cargo test -p runtimed --lib notebook_sync_server` — 218/218
- [x] `cargo xtask lint --fix` — clean
- [x] `cargo clippy -p runtimed --lib --no-deps -- -D warnings` — clean
