### PR TITLE
fix(notebook): avoid restoring focus after iframe outputs

### DIFF
--- a/apps/notebook/src/lib/__tests__/window-focus.test.ts
+++ b/apps/notebook/src/lib/__tests__/window-focus.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { NotebookHost } from "@nteract/notebook-host";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { startWindowFocusHandler } from "../window-focus";
+
+function makeHost(): NotebookHost {
+  return {
+    window: {
+      onFocusChange: vi.fn(() => vi.fn()),
+    },
+  } as unknown as NotebookHost;
+}
+
+function createEditor(doc = "hello"): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({ doc }),
+  });
+
+  Object.defineProperty(view, "hasFocus", {
+    value: true,
+    writable: true,
+    configurable: true,
+  });
+
+  return view;
+}
+
+function focusEditor(view: EditorView): void {
+  view.contentDOM.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+}
+
+describe("window-focus", () => {
+  let cleanup: (() => void) | undefined;
+  let view: EditorView | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    view?.destroy();
+    view = undefined;
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("restores the focused editor after a real window blur/focus cycle", () => {
+    cleanup = startWindowFocusHandler(makeHost());
+    view = createEditor();
+    focusEditor(view);
+
+    const focusSpy = vi.spyOn(view, "focus").mockImplementation(() => undefined);
+    const blurSpy = vi.spyOn(view.contentDOM, "blur").mockImplementation(() => undefined);
+    const measureSpy = vi.spyOn(view, "requestMeasure").mockImplementation(() => undefined);
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+
+    expect(blurSpy).toHaveBeenCalledTimes(1);
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(measureSpy).toHaveBeenCalled();
+  });
+
+  it("does not restore the previous editor when focus returns from an iframe output", () => {
+    cleanup = startWindowFocusHandler(makeHost());
+    view = createEditor();
+    focusEditor(view);
+
+    const focusSpy = vi.spyOn(view, "focus").mockImplementation(() => undefined);
+    const blurSpy = vi.spyOn(view.contentDOM, "blur").mockImplementation(() => undefined);
+    const measureSpy = vi.spyOn(view, "requestMeasure").mockImplementation(() => undefined);
+
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    iframe.focus();
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+
+    expect(blurSpy).not.toHaveBeenCalled();
+    expect(focusSpy).not.toHaveBeenCalled();
+    expect(measureSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses iframe pointerdown as an early guard before window blur snapshots selection", () => {
+    cleanup = startWindowFocusHandler(makeHost());
+    view = createEditor();
+    focusEditor(view);
+
+    const focusSpy = vi.spyOn(view, "focus").mockImplementation(() => undefined);
+    const blurSpy = vi.spyOn(view.contentDOM, "blur").mockImplementation(() => undefined);
+
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    iframe.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+
+    expect(blurSpy).not.toHaveBeenCalled();
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -34,6 +34,13 @@ let savedSelection: { anchor: number; head: number } | null = null;
 /** Whether the window currently has focus (dedup guard). */
 let windowFocused = true;
 
+/**
+ * Set when the parent document loses focus because the user entered an
+ * iframe output. Returning from that iframe should not restore the previous
+ * editor because the next click may be targeting a different cell.
+ */
+let skipNextRestoreFromIframe = false;
+
 // ── Editor focus tracking ────────────────────────────────────────────
 
 /**
@@ -49,6 +56,10 @@ let windowFocused = true;
 function trackEditorFocus(e: FocusEvent): void {
   const target = e.target as HTMLElement | null;
   if (!target) return;
+
+  if (target instanceof HTMLIFrameElement) {
+    skipNextRestoreFromIframe = true;
+  }
 
   const cmEditor = target.closest?.(".cm-editor");
   if (!cmEditor) {
@@ -68,11 +79,26 @@ function trackEditorFocus(e: FocusEvent): void {
   }
 }
 
+function trackIframePointerDown(e: PointerEvent): void {
+  if (e.target instanceof HTMLIFrameElement) {
+    skipNextRestoreFromIframe = true;
+    savedView = null;
+    savedSelection = null;
+  }
+}
+
 // ── Focus / blur handlers ────────────────────────────────────────────
 
 function handleWindowBlur(): void {
   if (!windowFocused) return; // already blurred (dedup)
   windowFocused = false;
+
+  if (document.activeElement instanceof HTMLIFrameElement) {
+    skipNextRestoreFromIframe = true;
+    savedSelection = null;
+    logger.debug("[window-focus] Window blur entered iframe; skipping next restore");
+    return;
+  }
 
   // Snapshot the selection from the tracked editor. CM6's internal
   // state.selection is always valid regardless of DOM focus.
@@ -105,6 +131,13 @@ function handleWindowFocus(): void {
  * during the focus event.
  */
 function restoreEditorFocus(): void {
+  if (skipNextRestoreFromIframe) {
+    skipNextRestoreFromIframe = false;
+    savedSelection = null;
+    logger.debug("[window-focus] Skipping restore after iframe interaction");
+    return;
+  }
+
   // Don't steal focus from iframe interactions (user may be in a widget)
   if (document.activeElement instanceof HTMLIFrameElement) {
     logger.debug("[window-focus] Skipping restore — iframe has focus");
@@ -171,6 +204,7 @@ function restoreEditorFocus(): void {
 export function startWindowFocusHandler(host: NotebookHost): () => void {
   // Track which CM editor has focus (capture phase for earliest signal).
   document.addEventListener("focusin", trackEditorFocus, true);
+  document.addEventListener("pointerdown", trackIframePointerDown, true);
 
   // Web-standard focus / blur on the window object. These fire
   // synchronously with the OS focus change — BEFORE any keystroke
@@ -201,12 +235,15 @@ export function startWindowFocusHandler(host: NotebookHost): () => void {
 
   return () => {
     document.removeEventListener("focusin", trackEditorFocus, true);
+    document.removeEventListener("pointerdown", trackIframePointerDown, true);
     window.removeEventListener("focus", handleWindowFocus);
     window.removeEventListener("blur", handleWindowBlur);
     document.removeEventListener("visibilitychange", handleVisibility);
     hostUnlisten();
     savedView = null;
     savedSelection = null;
+    windowFocused = true;
+    skipNextRestoreFromIframe = false;
     logger.info("[window-focus] Handler stopped");
   };
 }


### PR DESCRIPTION
## Summary
- prevent the window-focus recovery path from restoring a stale CodeMirror editor after iframe output interactions
- clear saved editor focus state on iframe pointer entry before blur snapshots selection
- add focused jsdom coverage for normal window restore and iframe skip behavior

## Root cause
Clicking into an output iframe can look like a window blur/focus transition to the parent document. The existing recovery path then restored the previous CodeMirror editor before the next cell editor click could take focus, causing the notebook to scroll back to the earlier cell.

## Validation
- cargo xtask lint --fix
- pnpm test:run apps/notebook/src/lib/__tests__/window-focus.test.ts