### PR TITLE
fix(notebook): prevent markdown focus scroll

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -400,7 +400,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   useEffect(() => {
     if (isFocused && !editing) {
       requestAnimationFrame(() => {
-        viewRef.current?.focus();
+        viewRef.current?.focus({ preventScroll: true });
       });
     }
   }, [isFocused, editing]);

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -5,6 +5,7 @@ import type { MarkdownCell as MarkdownCellType } from "../../types";
 
 let mockDarkMode = false;
 let mockColorTheme: string | undefined;
+let mockIsFocused = false;
 const isolatedFrameProps: Array<Record<string, unknown>> = [];
 
 const mockFrameHandle = {
@@ -95,7 +96,7 @@ vi.mock("../../lib/blob-port", () => ({
 }));
 
 vi.mock("../../lib/cell-ui-state", () => ({
-  useIsCellFocused: () => false,
+  useIsCellFocused: () => mockIsFocused,
   useIsNextCellFromFocused: () => false,
   useIsPreviousCellFromFocused: () => false,
   useSearchQuery: () => "",
@@ -142,6 +143,7 @@ describe("MarkdownCell theme sync", () => {
   beforeEach(() => {
     mockDarkMode = false;
     mockColorTheme = undefined;
+    mockIsFocused = false;
     isolatedFrameProps.length = 0;
     mockFrameHandle.send.mockClear();
     mockFrameHandle.render.mockClear();
@@ -176,6 +178,23 @@ describe("MarkdownCell theme sync", () => {
         cellId: "md-1",
         replace: true,
       });
+    });
+  });
+
+  it("focuses the markdown preview without scrolling when the cell becomes focused", async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
+
+    const { rerender } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    expect(focusSpy).not.toHaveBeenCalledWith({ preventScroll: true });
+
+    mockIsFocused = true;
+    rerender(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
+
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
   });
 });


### PR DESCRIPTION
## Summary
- keep markdown preview focus from scrolling the notebook viewport
- preserve visual cell focus and keyboard target behavior
- add focused coverage for the preventScroll focus path

## Root cause
When a markdown cell became focused in preview mode, the component focused the preview element with a plain DOM focus call. Browsers may scroll focused elements into view, which made selecting a markdown cell jostle the notebook even though the user only needed the green focused-cell state.

## Validation
- cargo xtask lint --fix
- pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx