### PR TITLE
chore(deps): bump to jupyter-protocol 2.0 / nbformat 3.0 / runtimelib 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebf93748a4d7fff4b475da4f50d95b1ea6cf9ed528ed5ec26db8228eabc112a"
+checksum = "67c8c5887974082be34e2bdac6b9b9dd8ad89951cae918b197959035b0673f6f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4337,9 +4337,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f087777e48fa554e45b44dcae410ced729351730def45e6c651d90f65888b67c"
+checksum = "b2c06543f305caee515923b125a737c4d58079c063e25701f93f45077bb8d622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7131,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "1.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c46eb84b80531e9745a859f60fd599eab9f6397d0db1bda8c99720796d3000"
+checksum = "8a95a93931b98c47a6201d5edd6e5b3545758fb475703bc797ba866b089ee6dd"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,9 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.6.0", default-features = false }
-jupyter-protocol = "1.4.0"
+runtimelib = { version = "2.0.0", default-features = false }
+jupyter-protocol = "2.0.0"
+nbformat = "3.0.0"
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -46,7 +46,7 @@ notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 runt-trust = { path = "../runt-trust" }
 runt-workspace = { path = "../runt-workspace" }
-nbformat = "2.2.0"
+nbformat = { workspace = true }
 log = "0.4"
 tauri-plugin-log = "2"
 strsim = "0.11"  # For Levenshtein distance (typosquat detection)

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -35,7 +35,7 @@ dirs = "6"
 
 # Jupyter kernel management
 jupyter-protocol = { workspace = true }
-nbformat = "2.2.0"
+nbformat = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 petname = "2"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }


### PR DESCRIPTION
Pulls in the [runtimed/runtimed 2.0 cycle](https://github.com/runtimed/runtimed/pull/300) published today.

## Version moves

| Crate | From | To |
|---|---|---|
| `jupyter-protocol` | 1.4.0 | 2.0.0 |
| `runtimelib` | 1.6.0 | 2.0.0 |
| `nbformat` | 2.2.0 | 3.0.0 |

`nbformat` is now a workspace dep (was pinned inline in `crates/notebook` and `crates/runtimed`). Matches the existing pattern for jupyter-protocol and runtimelib.

## Source impact

Zero. The 2.0 cycle's public breaking changes:

1. `MediaType` is now `#[non_exhaustive]` so future variants are additive. We already match with `if let`, `matches!`, and wildcard arms — no exhaustive match sites hit.
2. `runtimelib::media`, `runtimelib::media::*`, and `runtimelib::ExecutionCount` re-exports are gone (they were `#[deprecated(since = "0.24.0")]`). We import from `jupyter_protocol::...` directly throughout.
3. `jupyter-serde` crate was deleted. Not a consumer.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --lib` all green
- [x] `cargo xtask lint --fix` clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` clean
