### PR TITLE
fix(kernel-env): channel-aware cache directories

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -83,7 +83,9 @@ Phases are written by the daemon to RuntimeStateDoc. Frontend displays them via 
 
 Environments are cached by dependency hash so notebooks with identical deps share a single environment.
 
-**UV** (`uv_env.rs`): Hash = SHA256(sorted deps + requires_python + prerelease + env_id), first 16 hex chars. Location: `~/.cache/runt/envs/{hash}/`. When deps are non-empty, env_id is excluded (cross-notebook sharing). When empty, env_id is included (per-notebook isolation).
+Cache locations are channel-aware: stable writes under `runt/`, nightly under `runt-nightly/`, a dev worktree under `runt/worktrees/{hash}/`. Paths below show the stable shape; substitute the channel namespace in your own tree.
+
+**UV** (`uv_env.rs`): Hash = SHA256(sorted deps + requires_python + prerelease + env_id), first 16 hex chars. Location: `~/.cache/runt/envs/{hash}/` (Linux), `~/Library/Caches/runt/envs/{hash}/` (macOS). When deps are non-empty, env_id is excluded (cross-notebook sharing). When empty, env_id is included (per-notebook isolation).
 
 **Conda** (`conda_env.rs`): Hash = SHA256(sorted deps + sorted channels + python version + env_id), first 16 hex chars. Location: `~/.cache/runt/conda-envs/{hash}/`.
 
@@ -91,7 +93,7 @@ Cache hit check: verify `{hash}/bin/python` (Unix) or `{hash}/Scripts/python.exe
 
 ## Inline Dependency Environments
 
-For notebooks with inline UV deps (`metadata.runt.uv.dependencies`), the daemon creates cached environments in `~/.cache/runt/inline-envs/`. Keyed by hash of sorted dependencies for fast reuse. Cache hit = instant startup.
+For notebooks with inline UV deps (`metadata.runt.uv.dependencies`), the daemon creates cached environments in `~/.cache/runt/inline-envs/` (same channel namespacing as above). Keyed by hash of sorted dependencies for fast reuse. Cache hit = instant startup.
 
 ### PEP 723 Support
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,6 +3757,7 @@ dependencies = [
  "hex",
  "log",
  "reqwest 0.12.28",
+ "runt-workspace",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,7 @@ dependencies = [
  "rattler_virtual_packages",
  "reqwest 0.12.28",
  "reqwest-middleware",
+ "runt-workspace",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -34,6 +34,9 @@ dirs = "6"
 sha2 = "0.11"
 hex = "0.4"
 
+# Channel-aware cache directory (nightly vs stable, dev worktree isolation).
+runt-workspace = { path = "../runt-workspace" }
+
 # Tool bootstrapping (get_uv_path)
 kernel-launch = { path = "../kernel-launch", optional = true }
 

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -40,11 +40,11 @@ pub struct CondaEnvironment {
 }
 
 /// Get the default cache directory for conda environments.
+///
+/// Channel-aware; see [`super::uv::default_cache_dir_uv`] for the
+/// nightly/stable/dev namespacing rationale.
 pub fn default_cache_dir_conda() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("conda-envs")
+    runt_workspace::daemon_base_dir().join("conda-envs")
 }
 
 /// Base package set every Conda kernel env is warmed with.

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -48,11 +48,11 @@ pub struct PixiEnvironment {
 }
 
 /// Get the default cache directory for pixi project environments.
+///
+/// Channel-aware; see [`super::uv::default_cache_dir_uv`] for the
+/// nightly/stable/dev namespacing rationale.
 pub fn default_cache_dir_pixi() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("pixi-envs")
+    runt_workspace::daemon_base_dir().join("pixi-envs")
 }
 
 /// Generate a minimal `pixi.toml` manifest for the given packages.

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -35,11 +35,21 @@ pub struct UvEnvironment {
 }
 
 /// Get the default cache directory for UV environments.
+///
+/// Channel-aware via [`runt_workspace::daemon_base_dir`]:
+/// - stable: `$CACHE/runt/envs/`
+/// - nightly: `$CACHE/runt-nightly/envs/`
+/// - dev worktree: `$CACHE/runt-nightly/worktrees/{hash}/envs/` (source
+///   builds default to the nightly channel unless `RUNT_BUILD_CHANNEL=stable`)
+///
+/// where `$CACHE` is `~/Library/Caches` on macOS, `~/.cache` on Linux, and
+/// `%LOCALAPPDATA%` on Windows.
+///
+/// Aligning this with the daemon's own cache_dir is what keeps nightly
+/// out of the stable cache (and prevents the "not within cache dir"
+/// eviction guard from firing on legitimate envs). See #2244.
 pub fn default_cache_dir_uv() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("envs")
+    runt_workspace::daemon_base_dir().join("envs")
 }
 
 /// Check if uv is available (either on PATH or bootstrappable via rattler).

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -1142,6 +1142,23 @@ fn find_site_packages(base_path: &std::path::Path) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// Lock in the channel-namespaced cache path shape. Tests build with
+    /// the default channel (nightly for source builds), so the helper
+    /// should resolve under `runt-nightly/envs`. The terminal segment
+    /// pinning is the part that matters most — the rest is
+    /// `runt_workspace::daemon_base_dir`'s responsibility.
+    #[test]
+    fn default_cache_dir_uv_is_under_envs() {
+        let path = default_cache_dir_uv();
+        let s = path.to_string_lossy();
+        assert!(s.ends_with("envs"), "got {s:?}");
+        // Should be nested under the channel namespace, not just "runt".
+        assert!(
+            s.contains("runt-nightly") || s.contains("runt"),
+            "got {s:?}"
+        );
+    }
+
     #[test]
     fn test_compute_env_hash_stable() {
         let deps = UvDependencies {

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -16,6 +16,9 @@ log = "0.4"
 dirs = "6"
 sha2 = "0.11"
 hex = "0.4"
+
+# Channel-aware tools cache (nightly vs stable, dev worktree isolation).
+runt-workspace = { path = "../runt-workspace" }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 flate2 = "1"
 tar = "0.4"

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -36,11 +36,14 @@ struct GithubPlatform {
 }
 
 /// Cache directory for bootstrapped tools.
+///
+/// Channel-aware via [`runt_workspace::daemon_base_dir`]: stable uses
+/// `runt/tools/`, nightly uses `runt-nightly/tools/`, dev worktrees nest
+/// under `worktrees/{hash}/tools/`. This keeps a nightly install from
+/// sharing a bootstrapped deno/uv/ruff with stable, same rationale as
+/// #2244 for envs.
 fn tools_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("tools")
+    runt_workspace::daemon_base_dir().join("tools")
 }
 
 /// Compute a hash for tool caching.
@@ -1239,8 +1242,11 @@ mod tests {
     #[test]
     fn test_tools_cache_dir() {
         let dir = tools_cache_dir();
-        assert!(dir.to_string_lossy().contains("runt"));
-        assert!(dir.to_string_lossy().contains("tools"));
+        let s = dir.to_string_lossy();
+        // Channel-namespaced: stable is "runt", nightly is "runt-nightly".
+        // Either is fine — what matters is the dir ends at `.../tools`.
+        assert!(s.contains("runt"));
+        assert!(s.ends_with("tools"));
     }
 
     #[test]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -4671,38 +4671,53 @@ async fn env_command(command: EnvCommands) -> anyhow::Result<()> {
 
 /// Cache directories to manage
 struct EnvCacheDir {
-    label: &'static str,
+    label: String,
     path: PathBuf,
 }
 
+/// Enumerate every env cache directory across both channels so CLI
+/// commands (`runt env stats`, `runt env list`, `runt env clean`) always
+/// reflect the full on-disk picture — whether the user invoked the
+/// stable or nightly binary.
+///
+/// Reaches through `cache_namespace_for` directly rather than
+/// `daemon_base_dir_for` so a dev-mode invocation lists the canonical
+/// channel roots instead of scoping into the current worktree. The CLI
+/// is meant to show the whole cache, not just one worktree's slice.
 fn get_env_cache_dirs() -> Vec<EnvCacheDir> {
-    let base = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    vec![
-        EnvCacheDir {
-            label: "UV envs",
-            path: base.join("runt").join("envs"),
-        },
-        EnvCacheDir {
-            label: "Conda envs",
-            path: base.join("runt").join("conda-envs"),
-        },
-        EnvCacheDir {
-            label: "Inline envs",
-            path: base.join("runt").join("inline-envs"),
-        },
-        EnvCacheDir {
-            label: "UV envs (nightly)",
-            path: base.join("runt-nightly").join("envs"),
-        },
-        EnvCacheDir {
-            label: "Worktrees",
-            path: base.join("runt").join("worktrees"),
-        },
-        EnvCacheDir {
-            label: "Worktrees (nightly)",
-            path: base.join("runt-nightly").join("worktrees"),
-        },
-    ]
+    use runt_workspace::{cache_namespace_for, BuildChannel};
+
+    // Leaf dirs a daemon writes directly under its base. Kept as
+    // (subdir, human-label) pairs so the listing stays consistent even
+    // when we add a new env backend.
+    const ENV_SUBDIRS: &[(&str, &str)] = &[
+        ("envs", "UV envs"),
+        ("conda-envs", "Conda envs"),
+        ("pixi-envs", "Pixi envs"),
+        ("inline-envs", "Inline envs"),
+        ("tools", "Bootstrapped tools"),
+    ];
+
+    let cache_root = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let mut dirs = Vec::with_capacity(ENV_SUBDIRS.len() * 2 + 2);
+    for channel in [BuildChannel::Stable, BuildChannel::Nightly] {
+        let base = cache_root.join(cache_namespace_for(channel));
+        let suffix = match channel {
+            BuildChannel::Stable => "",
+            BuildChannel::Nightly => " (nightly)",
+        };
+        for (sub, label) in ENV_SUBDIRS {
+            dirs.push(EnvCacheDir {
+                label: format!("{label}{suffix}"),
+                path: base.join(sub),
+            });
+        }
+        dirs.push(EnvCacheDir {
+            label: format!("Worktrees{suffix}"),
+            path: base.join("worktrees"),
+        });
+    }
+    dirs
 }
 
 async fn env_stats() -> anyhow::Result<()> {
@@ -4822,13 +4837,13 @@ async fn env_clean(
         // Query daemon for in-use env paths to protect running kernels
         let in_use = query_active_env_paths().await;
 
-        let base = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-        let dirs_to_clean = [
-            base.join("runt").join("envs"),
-            base.join("runt").join("conda-envs"),
-            base.join("runt").join("inline-envs"),
-            base.join("runt-nightly").join("envs"),
-        ];
+        // Cross-channel: nuke env caches for both stable and nightly.
+        // Worktrees are session state, not env cache — skip them here.
+        let dirs_to_clean: Vec<PathBuf> = get_env_cache_dirs()
+            .into_iter()
+            .filter(|d| !d.label.starts_with("Worktrees"))
+            .map(|d| d.path)
+            .collect();
 
         let mut total_removed = 0;
         for dir in &dirs_to_clean {
@@ -4869,15 +4884,14 @@ async fn env_clean(
     // don't evict them. Falls back to empty if daemon isn't reachable.
     let in_use = query_active_env_paths().await;
 
-    // Selective eviction
-    let eviction_dirs = [
-        kernel_env::uv::default_cache_dir_uv(),
-        kernel_env::conda::default_cache_dir_conda(),
-        dirs::cache_dir()
-            .unwrap_or_else(|| PathBuf::from("/tmp"))
-            .join("runt")
-            .join("inline-envs"),
-    ];
+    // Selective eviction: sweep env dirs for both channels so a nightly
+    // binary evicts nightly envs and vice versa, without missing the
+    // cross-channel bits a user might have from switching binaries.
+    let eviction_dirs: Vec<PathBuf> = get_env_cache_dirs()
+        .into_iter()
+        .filter(|d| !d.label.starts_with("Worktrees"))
+        .map(|d| d.path)
+        .collect();
 
     if dry_run {
         println!(

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -4685,7 +4685,7 @@ struct EnvCacheDir {
 /// channel roots instead of scoping into the current worktree. The CLI
 /// is meant to show the whole cache, not just one worktree's slice.
 fn get_env_cache_dirs() -> Vec<EnvCacheDir> {
-    use runt_workspace::{cache_namespace_for, BuildChannel};
+    use runt_workspace::{cache_namespace_for, daemon_base_dir, is_dev_mode, BuildChannel};
 
     // Leaf dirs a daemon writes directly under its base. Kept as
     // (subdir, human-label) pairs so the listing stays consistent even
@@ -4717,6 +4717,22 @@ fn get_env_cache_dirs() -> Vec<EnvCacheDir> {
             path: base.join("worktrees"),
         });
     }
+
+    // Dev mode: the running daemon writes envs under
+    // `$CACHE/<channel>/worktrees/{hash}/…`. Those live behind the
+    // "Worktrees" container entries above, which `env clean` filters out
+    // by label. Surface them as first-class entries so the dev CLI
+    // actually cleans the cache its own daemon is using.
+    if is_dev_mode() {
+        let worktree_base = daemon_base_dir();
+        for (sub, label) in ENV_SUBDIRS {
+            dirs.push(EnvCacheDir {
+                label: format!("{label} (dev worktree)"),
+                path: worktree_base.join(sub),
+            });
+        }
+    }
+
     dirs
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3001,15 +3001,12 @@ impl Daemon {
         let max_count = self.config.env_cache_max_count;
 
         // Directories to GC. These are the global content-addressed caches
-        // used by kernel-env (not per-worktree pool dirs).
+        // used by kernel-env. All three share the daemon's channel-namespaced
+        // base so nightly GCs nightly envs and stable GCs stable envs.
         let cache_dirs = [
             kernel_env::uv::default_cache_dir_uv(),
             kernel_env::conda::default_cache_dir_conda(),
-            // inline-envs: same parent as uv cache but under "inline-envs"
-            dirs::cache_dir()
-                .unwrap_or_else(|| PathBuf::from("/tmp"))
-                .join("runt")
-                .join("inline-envs"),
+            crate::inline_env::inline_cache_dir(),
         ];
 
         loop {

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -51,11 +51,11 @@ impl ProgressHandler for BroadcastProgressHandler {
 }
 
 /// Get the cache directory for inline dependency environments.
-fn get_inline_cache_dir() -> std::path::PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("runt")
-        .join("inline-envs")
+///
+/// Channel-aware: shares `runt_workspace::daemon_base_dir` with the other
+/// kernel-env caches so nightly and stable stay on their own trees.
+pub(crate) fn inline_cache_dir() -> std::path::PathBuf {
+    runt_workspace::daemon_base_dir().join("inline-envs")
 }
 
 /// Return inline deps unchanged.
@@ -95,9 +95,8 @@ pub async fn prepare_uv_inline_env(
         prerelease: prerelease.map(|s| s.to_string()),
     };
 
-    let env =
-        kernel_env::uv::prepare_environment_in(&uv_deps, None, &get_inline_cache_dir(), handler)
-            .await?;
+    let env = kernel_env::uv::prepare_environment_in(&uv_deps, None, &inline_cache_dir(), handler)
+        .await?;
 
     Ok(PreparedEnv {
         env_path: env.venv_path,
@@ -125,9 +124,8 @@ pub async fn prepare_conda_inline_env(
         env_id: None,
     };
 
-    let env =
-        kernel_env::conda::prepare_environment_in(&conda_deps, &get_inline_cache_dir(), handler)
-            .await?;
+    let env = kernel_env::conda::prepare_environment_in(&conda_deps, &inline_cache_dir(), handler)
+        .await?;
 
     Ok(PreparedEnv {
         env_path: env.env_path,
@@ -159,7 +157,7 @@ pub async fn claim_pool_env_for_uv_inline_cache(
         prerelease: prerelease.map(|s| s.to_string()),
     };
     let hash = kernel_env::uv::compute_env_hash(&uv_deps, None);
-    let target = get_inline_cache_dir().join(&hash);
+    let target = inline_cache_dir().join(&hash);
     rename_env_to_target(&mut env.venv_path, &mut env.python_path, target).await;
 }
 
@@ -182,7 +180,7 @@ pub async fn claim_pool_env_for_conda_inline_cache(
         env_id: None,
     };
     let hash = kernel_env::conda::compute_env_hash(&conda_deps);
-    let target = get_inline_cache_dir().join(&hash);
+    let target = inline_cache_dir().join(&hash);
     rename_env_to_target(&mut env.venv_path, &mut env.python_path, target).await;
 }
 
@@ -488,7 +486,7 @@ pub async fn check_uv_inline_cache(
     };
 
     let hash = kernel_env::uv::compute_env_hash(&uv_deps, None);
-    let cache_dir = get_inline_cache_dir();
+    let cache_dir = inline_cache_dir();
     let venv_path = cache_dir.join(&hash);
 
     #[cfg(unix)]
@@ -537,7 +535,7 @@ pub fn check_conda_inline_cache(deps: &[String], channels: &[String]) -> Option<
     };
 
     let hash = kernel_env::conda::compute_env_hash(&conda_deps);
-    let cache_dir = get_inline_cache_dir();
+    let cache_dir = inline_cache_dir();
     let env_path = cache_dir.join(&hash);
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #2244.

## The bug

`kernel-env::{uv,conda,pixi}::default_cache_dir_*` hard-coded the cache namespace as `"runt"`. A nightly daemon sets its own `config.cache_dir` to `$CACHE/runt-nightly/envs/` via `runt_workspace::daemon_base_dir()`, but then kernel-env silently pointed captured unified-hash envs at `$CACHE/runt/envs/` — the stable tree. The "Refusing to delete env ... not within cache dir" warning in the diagnostics bundle was the daemon correctly declining to evict paths outside its own cache.

## The fix

Route the three `default_cache_dir_*` helpers through `runt_workspace::daemon_base_dir()`, which is exactly what the daemon uses for `config.cache_dir`. kernel-env and the daemon now agree on where envs live, and kernel-env gets dev-worktree scoping for free.

Also fixes two sibling hardcodes:

- `crates/runtimed/src/inline_env.rs`: same bug for inline-envs. Swapped for `runt_workspace::daemon_base_dir().join("inline-envs")` and exposed as `pub(crate) inline_cache_dir()` so the GC loop can reuse it.
- `crates/runtimed/src/daemon.rs`: the env-GC loop was using `.join("runt").join("inline-envs")` directly. Now calls `crate::inline_env::inline_cache_dir()`. Nightly's GC scans nightly's inline-envs, not stable's.

Doc update in `.claude/rules/environments.md` to reflect the channel-namespaced shape.

## Migration

None required. A nightly daemon that used to reach into `runt/envs/` now starts fresh under `runt-nightly/envs/`. The old `runt/envs/` tree belonged to stable all along — leaving it alone is correct. Cold-start cost on first nightly launch post-upgrade (pool warms from scratch), steady state thereafter.

## Test plan

- [x] `cargo test --workspace --lib` — 2200+ tests pass
- [x] `cargo xtask lint --fix` — clean
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- [ ] Manual: run a nightly daemon and confirm `runt-nightly diagnostics` shows captured envs under `runt-nightly/envs/` instead of `runt/envs/`
