### PR TITLE
perf(sift): batch viewport cell reads

### DIFF
--- a/apps/notebook/src/renderer-plugins/sift.js
+++ b/apps/notebook/src/renderer-plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cacc957f8557861b763e58b54e631a8d125694aaed8e033086ba8928b3c0c507
-size 388013
+oid sha256:e8ab7f94f7bd39379cbb2ca2a09b2244c2a21774f02abfa0fad70e79842680e7
+size 388218

--- a/crates/runt-mcp/assets/plugins/sift.js
+++ b/crates/runt-mcp/assets/plugins/sift.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf72b369d8c0abe3dfe42f8c29884a81cf967e30e4e9eebd6a30b9594c2edcd9
-size 388206
+oid sha256:29ae16c6391e878ba5fea0c2ca62ca1e33be721b65c05862096e4ad2ad89e4d3
+size 388411

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b10eb8a58ed1fce698213d19fb594c9e27fa8aafe7baffb1fd957992d9fe9c53
-size 6801448
+oid sha256:c8662063b6cd241db5c7687673a2bf55ca471a8793f8aea45f3bb6b1c21fb562
+size 6807534

--- a/crates/sift-wasm/pkg/sift_wasm.d.ts
+++ b/crates/sift-wasm/pkg/sift_wasm.d.ts
@@ -182,6 +182,14 @@ export function store_temporal_histogram(handle: number, col: number): any;
 export function store_value_counts(handle: number, col: number): any;
 
 /**
+ * Batch-fetch display strings and raw numeric values for viewport rows.
+ *
+ * The frontend calls this once per render window instead of calling
+ * is_null/get_cell_string/get_cell_f64 for every visible cell.
+ */
+export function store_viewport_cells(handle: number, rows: Uint32Array): any;
+
+/**
  * Search a string column for values containing a substring.
  * Returns indices of matching rows as a Uint32Array.
  *
@@ -259,6 +267,7 @@ export interface InitOutput {
     readonly store_sort_indices: (a: number, b: number, c: number) => [number, number, number, number];
     readonly store_temporal_histogram: (a: number, b: number) => [number, number, number];
     readonly store_value_counts: (a: number, b: number) => [number, number, number];
+    readonly store_viewport_cells: (a: number, b: number, c: number) => [number, number, number];
     readonly string_contains: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
     readonly undo_cast_column: (a: number, b: number) => [number, number, number, number];
     readonly value_counts: (a: number, b: number, c: number) => [number, number, number];

--- a/crates/sift-wasm/pkg/sift_wasm.js
+++ b/crates/sift-wasm/pkg/sift_wasm.js
@@ -511,6 +511,25 @@ export function store_value_counts(handle, col) {
 }
 
 /**
+ * Batch-fetch display strings and raw numeric values for viewport rows.
+ *
+ * The frontend calls this once per render window instead of calling
+ * is_null/get_cell_string/get_cell_f64 for every visible cell.
+ * @param {number} handle
+ * @param {Uint32Array} rows
+ * @returns {any}
+ */
+export function store_viewport_cells(handle, rows) {
+    const ptr0 = passArray32ToWasm0(rows, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.store_viewport_cells(handle, ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
  * Search a string column for values containing a substring.
  * Returns indices of matching rows as a Uint32Array.
  *

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b10eb8a58ed1fce698213d19fb594c9e27fa8aafe7baffb1fd957992d9fe9c53
-size 6801448
+oid sha256:c8662063b6cd241db5c7687673a2bf55ca471a8793f8aea45f3bb6b1c21fb562
+size 6807534

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm.d.ts
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm.d.ts
@@ -31,6 +31,7 @@ export const store_histogram: (a: number, b: number, c: number) => [number, numb
 export const store_sort_indices: (a: number, b: number, c: number) => [number, number, number, number];
 export const store_temporal_histogram: (a: number, b: number) => [number, number, number];
 export const store_value_counts: (a: number, b: number) => [number, number, number];
+export const store_viewport_cells: (a: number, b: number, c: number) => [number, number, number];
 export const string_contains: (a: number, b: number, c: number, d: number, e: number) => [number, number, number, number];
 export const undo_cast_column: (a: number, b: number) => [number, number, number, number];
 export const value_counts: (a: number, b: number, c: number) => [number, number, number];

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -12,7 +12,7 @@ use arrow_select::concat::concat;
 use chrono::DateTime;
 use nteract_predicate::summary::{CategoryCount, HistogramBin};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::sync::Mutex;
@@ -31,6 +31,14 @@ struct DataStore {
     /// Original column arrays saved before casting, keyed by column index.
     /// Used to restore original data when casting back to the original type.
     original_columns: HashMap<usize, (Vec<arrow::array::ArrayRef>, String)>,
+}
+
+#[derive(Serialize)]
+struct ViewportCells {
+    rows: Vec<u32>,
+    strings: Vec<String>,
+    numeric_values: Vec<Option<f64>>,
+    nulls: Vec<bool>,
 }
 
 impl DataStore {
@@ -297,6 +305,136 @@ fn format_timestamp_ms(ms: i64, tz: Option<&str>, has_time: bool) -> String {
     }
 }
 
+fn cell_string_for(store: &DataStore, col: usize, column: &dyn Array, local_row: usize) -> String {
+    if column.is_null(local_row) {
+        return String::new();
+    }
+
+    // Strings (Utf8 / LargeUtf8 / Utf8View / Dict<string>) route through
+    // the shared helper so all variants dispatch correctly.
+    if let Some(s) = nteract_predicate::arrow_utils::string_at(column, local_row) {
+        return s;
+    }
+
+    // Timestamps → human-readable date in the column's timezone (or UTC)
+    if let Some(ms) = timestamp_cell_ms(column, local_row) {
+        let tz = store.col_timezones.get(col).and_then(|t| t.as_deref());
+        let has_time = matches!(column.data_type(), DataType::Timestamp(_, _));
+        return format_timestamp_ms(ms, tz, has_time);
+    }
+
+    match column.data_type() {
+        DataType::Boolean => column
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .map(|a| {
+                if a.value(local_row) {
+                    "Yes".into()
+                } else {
+                    "No".into()
+                }
+            })
+            .unwrap_or_default(),
+        DataType::Int32 => column
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .map(|a| a.value(local_row).to_string())
+            .unwrap_or_default(),
+        DataType::Int64 => column
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .map(|a| a.value(local_row).to_string())
+            .unwrap_or_default(),
+        DataType::Float64 => column
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .map(|a| format!("{}", a.value(local_row)))
+            .unwrap_or_default(),
+        _ => ArrayFormatter::try_new(column, &Default::default())
+            .ok()
+            .map(|f| f.value(local_row).to_string())
+            .unwrap_or_default(),
+    }
+}
+
+fn cell_f64_for(column: &dyn Array, local_row: usize) -> f64 {
+    if column.is_null(local_row) {
+        return f64::NAN;
+    }
+
+    // Timestamps → epoch ms as f64
+    if let Some(ms) = timestamp_cell_ms(column, local_row) {
+        return ms as f64;
+    }
+
+    match column.data_type() {
+        DataType::Float64 => column
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .map(|a| a.value(local_row))
+            .unwrap_or(f64::NAN),
+        DataType::Int32 => column
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .map(|a| a.value(local_row) as f64)
+            .unwrap_or(f64::NAN),
+        DataType::Int64 => column
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .map(|a| a.value(local_row) as f64)
+            .unwrap_or(f64::NAN),
+        _ => f64::NAN,
+    }
+}
+
+fn viewport_cells_for(s: &DataStore, rows: &[u32]) -> ViewportCells {
+    let cell_count = rows.len().saturating_mul(s.num_cols);
+    let mut out = ViewportCells {
+        rows: Vec::with_capacity(rows.len()),
+        strings: Vec::with_capacity(cell_count),
+        numeric_values: Vec::with_capacity(cell_count),
+        nulls: Vec::with_capacity(cell_count),
+    };
+
+    for &row_u32 in rows {
+        out.rows.push(row_u32);
+        let Some((batch_idx, local_row)) = s.resolve_row(row_u32 as usize) else {
+            for _ in 0..s.num_cols {
+                out.strings.push(String::new());
+                out.numeric_values.push(None);
+                out.nulls.push(true);
+            }
+            continue;
+        };
+
+        let batch = &s.batches[batch_idx];
+        for col in 0..s.num_cols {
+            let column = batch.column(col);
+            let is_null = column.is_null(local_row);
+            out.nulls.push(is_null);
+            if is_null {
+                out.strings.push(String::new());
+                out.numeric_values.push(None);
+                continue;
+            }
+
+            out.strings
+                .push(cell_string_for(s, col, column.as_ref(), local_row));
+            if matches!(
+                s.col_types.get(col).map(String::as_str),
+                Some("numeric" | "timestamp")
+            ) {
+                out.numeric_values
+                    .push(Some(cell_f64_for(column.as_ref(), local_row)));
+            } else {
+                out.numeric_values.push(None);
+            }
+        }
+    }
+
+    out
+}
+
 /// Get a cell value as a formatted string (for display).
 #[wasm_bindgen]
 pub fn get_cell_string(handle: u32, row: usize, col: usize) -> Result<String, JsValue> {
@@ -310,51 +448,7 @@ pub fn get_cell_string(handle: u32, row: usize, col: usize) -> Result<String, Js
             return String::new();
         }
 
-        // Strings (Utf8 / LargeUtf8 / Utf8View / Dict<string>) route through
-        // the shared helper so all variants dispatch correctly.
-        if let Some(s) = nteract_predicate::arrow_utils::string_at(column.as_ref(), local_row) {
-            return s;
-        }
-
-        // Timestamps → human-readable date in the column's timezone (or UTC)
-        if let Some(ms) = timestamp_cell_ms(column.as_ref(), local_row) {
-            let tz = s.col_timezones.get(col).and_then(|t| t.as_deref());
-            let has_time = matches!(column.data_type(), DataType::Timestamp(_, _));
-            return format_timestamp_ms(ms, tz, has_time);
-        }
-
-        match column.data_type() {
-            DataType::Boolean => column
-                .as_any()
-                .downcast_ref::<BooleanArray>()
-                .map(|a| {
-                    if a.value(local_row) {
-                        "Yes".into()
-                    } else {
-                        "No".into()
-                    }
-                })
-                .unwrap_or_default(),
-            DataType::Int32 => column
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .map(|a| a.value(local_row).to_string())
-                .unwrap_or_default(),
-            DataType::Int64 => column
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .map(|a| a.value(local_row).to_string())
-                .unwrap_or_default(),
-            DataType::Float64 => column
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .map(|a| format!("{}", a.value(local_row)))
-                .unwrap_or_default(),
-            _ => ArrayFormatter::try_new(column.as_ref(), &Default::default())
-                .ok()
-                .map(|f| f.value(local_row).to_string())
-                .unwrap_or_default(),
-        }
+        cell_string_for(s, col, column.as_ref(), local_row)
     })
     .map_err(|e| JsValue::from_str(&e))
 }
@@ -373,29 +467,20 @@ pub fn get_cell_f64(handle: u32, row: usize, col: usize) -> Result<f64, JsValue>
             return f64::NAN;
         }
 
-        // Timestamps → epoch ms as f64
-        if let Some(ms) = timestamp_cell_ms(column.as_ref(), local_row) {
-            return ms as f64;
-        }
+        cell_f64_for(column.as_ref(), local_row)
+    })
+    .map_err(|e| JsValue::from_str(&e))
+}
 
-        match column.data_type() {
-            DataType::Float64 => column
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .map(|a| a.value(local_row))
-                .unwrap_or(f64::NAN),
-            DataType::Int32 => column
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .map(|a| a.value(local_row) as f64)
-                .unwrap_or(f64::NAN),
-            DataType::Int64 => column
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .map(|a| a.value(local_row) as f64)
-                .unwrap_or(f64::NAN),
-            _ => f64::NAN,
-        }
+/// Batch-fetch display strings and raw numeric values for viewport rows.
+///
+/// The frontend calls this once per render window instead of calling
+/// is_null/get_cell_string/get_cell_f64 for every visible cell.
+#[wasm_bindgen]
+pub fn store_viewport_cells(handle: u32, rows: &[u32]) -> Result<JsValue, JsValue> {
+    with_store(handle, |s| {
+        let out = viewport_cells_for(s, rows);
+        serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
     })
     .map_err(|e| JsValue::from_str(&e))
 }
@@ -1731,6 +1816,10 @@ fn get_string_value(arr: &dyn Array, row: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int32Array, StringArray};
+    use arrow::datatypes::{Field, Schema};
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn format_date_only() {
@@ -1777,6 +1866,71 @@ mod tests {
         assert_eq!(
             format_timestamp_ms(i64::MAX, None, false),
             i64::MAX.to_string()
+        );
+    }
+
+    #[test]
+    fn viewport_cells_are_flattened_in_requested_order() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("score", DataType::Float64, true),
+            Field::new("active", DataType::Boolean, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["Alice", "Bob"])) as ArrayRef,
+                Arc::new(Float64Array::from(vec![None, Some(88.0)])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![true, false])) as ArrayRef,
+            ],
+        )
+        .expect("record batch");
+        let store = DataStore {
+            batches: vec![batch],
+            batch_offsets: vec![0],
+            total_rows: 2,
+            num_cols: 4,
+            col_names: vec![
+                "id".to_string(),
+                "name".to_string(),
+                "score".to_string(),
+                "active".to_string(),
+            ],
+            col_types: vec![
+                "numeric".to_string(),
+                "categorical".to_string(),
+                "numeric".to_string(),
+                "boolean".to_string(),
+            ],
+            col_timezones: vec![None, None, None, None],
+            original_columns: HashMap::new(),
+        };
+
+        let out = viewport_cells_for(&store, &[1, 0]);
+
+        assert_eq!(out.rows, vec![1, 0]);
+        assert_eq!(
+            out.strings,
+            vec!["2", "Bob", "88", "No", "1", "Alice", "", "Yes"]
+        );
+        assert_eq!(
+            out.numeric_values,
+            vec![
+                Some(2.0),
+                None,
+                Some(88.0),
+                None,
+                Some(1.0),
+                None,
+                None,
+                None
+            ]
+        );
+        assert_eq!(
+            out.nulls,
+            vec![false, false, false, false, false, false, true, false]
         );
     }
 }

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -12,6 +12,13 @@ export type FilterSpecJson =
   | { kind: "not_in"; col: number; values: string[] }
   | { kind: "boolean"; col: number; value: boolean };
 
+export type ViewportCells = {
+  rows: number[];
+  strings: string[];
+  numeric_values: (number | null)[];
+  nulls: boolean[];
+};
+
 type PredicateModule = {
   // Data store
   load_ipc(ipc_bytes: Uint8Array): number;
@@ -31,6 +38,7 @@ type PredicateModule = {
   get_cell_string(handle: number, row: number, col: number): string;
   get_cell_f64(handle: number, row: number, col: number): number;
   is_null(handle: number, row: number, col: number): boolean;
+  store_viewport_cells(handle: number, rows: Uint32Array): ViewportCells;
   // Store-based summaries (operates on handle, iterates in Rust)
   store_value_counts(handle: number, col: number): { label: string; count: number }[];
   store_histogram(

--- a/packages/sift/src/wasm-table-data.test.ts
+++ b/packages/sift/src/wasm-table-data.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { createWasmTableData } from "./wasm-table-data";
+
+const predicateModule = vi.hoisted(() => ({
+  num_rows: vi.fn(() => 2),
+  num_cols: vi.fn(() => 4),
+  col_names: vi.fn(() => ["id", "name", "score", "active"]),
+  col_type: vi.fn((_handle: number, col: number) =>
+    col === 0 || col === 2 ? "numeric" : col === 3 ? "boolean" : "categorical",
+  ),
+  col_timezone: vi.fn(() => null),
+  store_viewport_cells: vi.fn((_handle: number, rows: Uint32Array) => {
+    const requested = Array.from(rows);
+    expect(requested).toEqual([1, 0]);
+    return {
+      rows: requested,
+      strings: ["2", "Bob", "88", "No", "1", "Alice", "", "Yes"],
+      numeric_values: [2, null, 88, null, 1, null, null, null],
+      nulls: [false, false, false, false, false, false, true, false],
+    };
+  }),
+  is_null: vi.fn(() => {
+    throw new Error("is_null should not be called during batched prefetch");
+  }),
+  get_cell_string: vi.fn(() => {
+    throw new Error("get_cell_string should not be called during batched prefetch");
+  }),
+  get_cell_f64: vi.fn(() => {
+    throw new Error("get_cell_f64 should not be called during batched prefetch");
+  }),
+}));
+
+vi.mock("./predicate", () => ({
+  getModuleSync: () => predicateModule,
+}));
+
+describe("createWasmTableData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefetches visible cells with one batched WASM call", () => {
+    const { tableData, prefetchViewport } = createWasmTableData(7);
+
+    prefetchViewport([1, 0]);
+
+    expect(predicateModule.store_viewport_cells).toHaveBeenCalledTimes(1);
+    expect(predicateModule.store_viewport_cells.mock.calls[0][0]).toBe(7);
+    expect(Array.from(predicateModule.store_viewport_cells.mock.calls[0][1])).toEqual([1, 0]);
+
+    expect(tableData.getCell(1, 1)).toBe("Bob");
+    expect(tableData.getCellRaw(1, 0)).toBe(2);
+    expect(tableData.getCellRaw(1, 2)).toBe(88);
+    expect(tableData.getCellRaw(1, 3)).toBe(false);
+    expect(tableData.getCell(0, 2)).toBe("");
+    expect(tableData.getCellRaw(0, 2)).toBeNull();
+    expect(tableData.getCellRaw(0, 3)).toBe(true);
+
+    prefetchViewport([1]);
+    expect(predicateModule.store_viewport_cells).toHaveBeenCalledTimes(1);
+    expect(predicateModule.is_null).not.toHaveBeenCalled();
+    expect(predicateModule.get_cell_string).not.toHaveBeenCalled();
+    expect(predicateModule.get_cell_f64).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sift/src/wasm-table-data.ts
+++ b/packages/sift/src/wasm-table-data.ts
@@ -6,7 +6,7 @@
  * getCell/getCellRaw read from the JS-side cache — no per-cell FFI.
  */
 import { autoWidth } from "./auto-width";
-import type { FilterSpecJson } from "./predicate";
+import type { FilterSpecJson, ViewportCells } from "./predicate";
 import { getModuleSync } from "./predicate";
 import type { Column, ColumnType, TableData } from "./table";
 
@@ -72,23 +72,26 @@ export function createWasmTableData(
     const uncached = dataRowIndices.filter((r) => !cache.has(r));
     if (uncached.length === 0) return;
 
-    for (const dataRow of uncached) {
+    const batch = mod.store_viewport_cells(handle, Uint32Array.from(uncached)) as ViewportCells;
+    for (let rowOffset = 0; rowOffset < batch.rows.length; rowOffset++) {
+      const dataRow = batch.rows[rowOffset];
       const strings: string[] = [];
       const raws: unknown[] = [];
 
       for (let c = 0; c < numCols; c++) {
-        if (mod.is_null(handle, dataRow, c)) {
+        const cellOffset = rowOffset * numCols + c;
+        const s = batch.strings[cellOffset] ?? "";
+        if (batch.nulls[cellOffset]) {
           strings.push("");
           raws.push(null);
           continue;
         }
 
-        const s = mod.get_cell_string(handle, dataRow, c);
         strings.push(s);
 
         const colType = columns[c].columnType;
         if (colType === "numeric" || colType === "timestamp") {
-          raws.push(mod.get_cell_f64(handle, dataRow, c));
+          raws.push(batch.numeric_values[cellOffset] ?? Number.NaN);
         } else if (colType === "boolean") {
           raws.push(s === "Yes");
         } else {


### PR DESCRIPTION
## Summary

- Add a `store_viewport_cells(handle, rows)` WASM export that returns a flat batch of display strings, numeric raw values, and null flags for requested viewport rows.
- Route Sift viewport prefetch through the batch export so visible rows are cached with one WASM call instead of per-cell `is_null`, `get_cell_string`, and `get_cell_f64` calls.
- Keep the existing per-cell methods as fallback paths for uncached access.
- Rebuild the WASM bindings and embedded Sift renderer plugin artifacts.

## Why

The table render path already prefetched visible rows, but the implementation still crossed the JS/WASM boundary for every visible cell. With overscan and wide dataframes, that means thousands of calls per render frame. The new export keeps the data formatting in Rust/WASM and amortizes the boundary crossing over the whole viewport window.

## Validation

- `cargo test -p sift-wasm`
- `pnpm --filter @nteract/sift exec vp test run`
- `pnpm --filter @nteract/sift exec playwright test e2e/notebook.spec.ts`
- `cargo xtask wasm`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`