### PR TITLE
chore: bump all packages to 2.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.1.3"
+      "version": "0.1.4"
     }
   ]
 }

--- a/.claude/plugins/nteract/.claude-plugin/plugin.json
+++ b/.claude/plugins/nteract/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nteract",
   "description": "Open, run, and edit nteract notebooks from Claude Code",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "automerge",
  "serde_json",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4134,7 +4134,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dirs",
  "libc",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "automerge",
  "automunge",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "kernel-env",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "automerge",
  "log",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -6873,7 +6873,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -6932,7 +6932,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dirs",
  "hex",
@@ -6958,7 +6958,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "automerge",
  "automunge",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "kernel-env",
  "log",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -7820,7 +7820,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11014,7 +11014,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/apps/notebook/src/wasm/runtimed-wasm/package.json
+++ b/apps/notebook/src/wasm/runtimed-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "runtimed-wasm",
   "type": "module",
   "description": "WASM bindings for runtimed notebook document operations, compiled from the same automerge crate as the daemon",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.3.3"
+version = "2.3.4"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.3.3"
+version = "2.3.4"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.3.3"
+version = "2.3.4"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.3.3"
+version = "2.3.4"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository.workspace = true

--- a/crates/sift-wasm/pkg/package.json
+++ b/crates/sift-wasm/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "sift-wasm",
   "type": "module",
   "description": "WASM bindings for nteract-predicate — used by @nteract/sift",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/runtimed-node",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Node.js bindings for the runtimed daemon client (napi-rs).",
   "private": true,
   "type": "module",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/desktop"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.0.5"
+version = "2.0.6"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.2.3"
+version = "0.2.4"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.3.3"
+version = "2.3.4"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.0.6"
+version = "0.0.7"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.3.3"
+version = "2.3.4"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
`cargo xtask bump`. One patch across every package:

- Rust workspace crates: 2.3.3 → 2.3.4, 0.2.5 → 0.2.6, 0.1.3 → 0.1.4, 0.1.5 → 0.1.6
- Python packages: dx 2.0.5 → 2.0.6, prewarm 0.0.6 → 0.0.7, nteract-kernel-launcher 0.2.3 → 0.2.4

Paves the next nightly release.
