### PR TITLE
feat(notebook): gate kernel actions on first RuntimeStateSync

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { deriveEnvManager, deriveRuntimeKind, NotebookClient } from "runtimed";
+import { deriveEnvManager, deriveRuntimeKind, NotebookClient, type SessionStatus } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -55,6 +55,7 @@ import {
 } from "./lib/cell-ui-state";
 import { startCursorDispatch } from "./lib/cursor-registry";
 import { KERNEL_STATUS } from "./lib/kernel-status";
+import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { getNotebookCellsSnapshot } from "./lib/notebook-cells";
 import { useDetectRuntime } from "./lib/notebook-metadata";
@@ -177,9 +178,18 @@ function AppContent() {
     flushSync,
     getHandle,
     getEngine,
+    sessionStatus$,
     triggerSync,
     localActor,
   } = useAutomergeNotebook();
+
+  // Daemon sync status. Drives the kernel-action gate: until the daemon
+  // has confirmed the first RuntimeStateSync round-trip (`runtime_state ==
+  // "ready"`), trust state is unknown and kernel-modifying actions must
+  // fail-closed. `sessionStatus$` is a ReplaySubject(1) on the engine;
+  // `useObservable` seeds with `null` until the engine emits.
+  const sessionStatus = useObservable<SessionStatus | null>(sessionStatus$, null);
+  const sessionReady = sessionStatus?.runtime_state === "ready";
 
   // Global find (Cmd+F)
   const globalFind = useGlobalFind(cellIds);
@@ -589,6 +599,15 @@ function AppContent() {
   // Check trust and start kernel if trusted, otherwise show dialog.
   // Returns true if kernel was started, false if trust dialog opened or error.
   const tryStartKernel = useCallback(async (): Promise<boolean> => {
+    // Fail-closed until the daemon has confirmed first RuntimeStateSync.
+    // Before that, `runtimeState.trust.status` is the default and cannot
+    // gate an install. Buttons are disabled in this state, but keyboard
+    // shortcuts and menu routes still call in — so guard here too.
+    if (!sessionReady) {
+      logger.debug("[App] tryStartKernel: session not ready, skipping");
+      return false;
+    }
+
     // Re-check trust status (may have changed)
     const info = await checkTrust();
     if (!info) return false;
@@ -607,11 +626,19 @@ function AppContent() {
     pendingKernelStartRef.current = true;
     setTrustDialogOpen(true);
     return false;
-  }, [checkTrust, launchKernel]);
+  }, [sessionReady, checkTrust, launchKernel]);
 
   // Handler to sync deps - tries hot-sync for UV additions, falls back to restart
   // Always checks trust before any operation that installs packages
   const handleSyncDeps = useCallback(async (): Promise<boolean> => {
+    // Fail-closed until the daemon has pushed initial RuntimeStateSync.
+    // Hot-sync and restart both install packages; can't run either if we
+    // don't have authoritative trust state yet.
+    if (!sessionReady) {
+      logger.debug("[App] handleSyncDeps: session not ready, skipping");
+      return false;
+    }
+
     // Reset any previous error state before attempting
     envProgress.reset();
 
@@ -668,6 +695,7 @@ function AppContent() {
     }
     return started;
   }, [
+    sessionReady,
     envSource,
     envSyncState,
     envProgress,
@@ -679,6 +707,12 @@ function AppContent() {
 
   // Restart and run all cells
   const restartAndRunAll = useCallback(async () => {
+    // Same fail-closed reasoning as handleRestartKernel: don't shut
+    // down before first RuntimeStateSync.
+    if (!sessionReady) {
+      logger.debug("[App] restartAndRunAll: session not ready, skipping");
+      return;
+    }
     if (runAllInFlightRef.current) {
       logger.debug("[App] restartAndRunAll: already in flight, skipping");
       return;
@@ -708,7 +742,7 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [flushSync, shutdownKernel, tryStartKernel, daemonRunAllCells]);
+  }, [sessionReady, flushSync, shutdownKernel, tryStartKernel, daemonRunAllCells]);
 
   // Handle trust approval from dialog
   const handleTrustApprove = useCallback(async () => {
@@ -716,13 +750,16 @@ function AppContent() {
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
       // Fire and forget - dialog closes immediately, kernel starts in background
-      // Use "auto" for both - daemon detects from Automerge doc
-      launchKernel("auto", "auto").catch((e) => {
+      // Use "auto" for both - daemon detects from Automerge doc. Route
+      // through `tryStartKernel` so the sessionReady guard applies; if
+      // a slow first sync hasn't landed yet, the launch is deferred
+      // rather than firing against stale state.
+      tryStartKernel().catch((e) => {
         logger.error("[App] kernel launch after trust approval failed:", e);
       });
     }
     return success;
-  }, [approveTrust, launchKernel]);
+  }, [approveTrust, tryStartKernel]);
 
   // Handle trust decline from dialog
   const handleTrustDecline = useCallback(() => {
@@ -732,14 +769,27 @@ function AppContent() {
 
   // Start kernel explicitly with pyproject.toml (user action from DependencyHeader)
   const handleStartKernelWithPyproject = useCallback(async () => {
+    if (!sessionReady) {
+      logger.debug("[App] handleStartKernelWithPyproject: session not ready, skipping");
+      return;
+    }
     const response = await launchKernel("python", "uv:pyproject");
     if (response.result === "error") {
       logger.error("[App] handleStartKernelWithPyproject: daemon error", response.error);
     }
-  }, [launchKernel]);
+  }, [sessionReady, launchKernel]);
 
   const handleExecuteCell = useCallback(
     async (cellId: string) => {
+      // Fail-closed until the daemon has confirmed first RuntimeStateSync.
+      // If a runtime agent is already alive from a prior session,
+      // `execute_cell` would otherwise queue into RuntimeStateDoc before
+      // we've verified trust (see crates/runtimed/src/requests/execute_cell.rs).
+      if (!sessionReady) {
+        logger.debug("[App] handleExecuteCell: session not ready, skipping");
+        return;
+      }
+
       // Resolve cell up front before awaiting sync operations.
       const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
       if (!cell || cell.cell_type !== "code") return;
@@ -796,7 +846,7 @@ function AppContent() {
         }, 150);
       }
     },
-    [flushSync, kernelStatus, tryStartKernel, executeCell],
+    [sessionReady, flushSync, kernelStatus, tryStartKernel, executeCell],
   );
 
   const handleAddCell = useCallback(
@@ -816,11 +866,29 @@ function AppContent() {
 
   // Restart kernel (shutdown then start)
   const handleRestartKernel = useCallback(async () => {
+    // Fail-closed until first RuntimeStateSync. Shutdown writes
+    // RuntimeLifecycle::Shutdown via the runtime-agent request path, so
+    // firing it against a still-syncing session would mutate kernel
+    // state before we've seen the authoritative snapshot — and the
+    // follow-up tryStartKernel would then no-op, leaving the kernel
+    // stopped.
+    if (!sessionReady) {
+      logger.debug("[App] handleRestartKernel: session not ready, skipping");
+      return;
+    }
     await shutdownKernel();
     await tryStartKernel();
-  }, [shutdownKernel, tryStartKernel]);
+  }, [sessionReady, shutdownKernel, tryStartKernel]);
 
   const handleRunAllCells = useCallback(async () => {
+    // Fail-closed until first RuntimeStateSync. Same reasoning as
+    // handleExecuteCell: if a runtime agent is already alive, the daemon
+    // would queue into RuntimeStateDoc before we've verified trust.
+    if (!sessionReady) {
+      logger.debug("[App] handleRunAllCells: session not ready, skipping");
+      return;
+    }
+
     if (runAllInFlightRef.current) {
       logger.debug("[App] handleRunAllCells: already in flight, skipping");
       return;
@@ -852,7 +920,7 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [kernelStatus, tryStartKernel, flushSync, daemonRunAllCells]);
+  }, [sessionReady, kernelStatus, tryStartKernel, flushSync, daemonRunAllCells]);
 
   const handleRestartAndRunAll = useCallback(async () => {
     // Backend clears outputs and emits cells:outputs_cleared before queuing,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,8 +1,8 @@
 import { useNotebookHost } from "@nteract/notebook-host";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
 import { DEFAULT_MIME_PRIORITY, SyncEngine } from "runtimed";
-import { concatMap, from, switchMap } from "rxjs";
+import { concatMap, from, Observable, switchMap } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { materializeChangeset } from "../lib/frame-pipeline";
@@ -674,6 +674,32 @@ export function useAutomergeNotebook() {
   /** Accessor for the SyncEngine (for subscribing to commChanges$ etc.). */
   const getEngine = useCallback(() => engineRef.current, []);
 
+  /**
+   * Stable `sessionStatus$` proxy. The underlying engine is constructed
+   * in this hook's `useEffect`, so subscribers must survive the "engine
+   * not yet ready" window. The proxy is built once at hook-init; on each
+   * subscribe it attaches to whichever engine is current. Subscribers
+   * that call in before the engine exists get the ReplaySubject(1)'s
+   * latest as soon as the engine wires itself up — no drop.
+   *
+   * Child `useEffect`s run before parent's in React, so in practice any
+   * component consuming `sessionStatus$` via `useObservable` attaches
+   * after this hook's effect has populated `engineRef`. The null guard
+   * is a safety net for unusual render orders (e.g. StrictMode).
+   */
+  const sessionStatus$ = useMemo(
+    () =>
+      new Observable<SessionStatus>((subscriber) => {
+        const engine = engineRef.current;
+        if (!engine) {
+          // Extremely narrow window. The next mount cycle will re-subscribe.
+          return;
+        }
+        return engine.sessionStatus$.subscribe(subscriber);
+      }),
+    [],
+  );
+
   return {
     cellIds,
     isLoading,
@@ -698,6 +724,7 @@ export function useAutomergeNotebook() {
     // CRDT bridge context deps
     getHandle,
     getEngine,
+    sessionStatus$,
     triggerSync,
     localActor,
   };

--- a/apps/notebook/src/lib/__tests__/use-observable.test.tsx
+++ b/apps/notebook/src/lib/__tests__/use-observable.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { BehaviorSubject, Subject } from "rxjs";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { useObservable } from "../use-observable";
+
+function Probe({ obs$, initial }: { obs$: Parameters<typeof useObservable>[0]; initial: unknown }) {
+  const value = useObservable(obs$ as never, initial as never);
+  return <span data-testid="value">{String(value)}</span>;
+}
+
+describe("useObservable", () => {
+  afterEach(() => {
+    // No global mocks to clear; kept for parity with the other suites.
+  });
+
+  it("returns `initial` until the source emits", () => {
+    const subject = new Subject<string>();
+    const { getByTestId } = render(<Probe obs$={subject} initial="init" />);
+    expect(getByTestId("value").textContent).toBe("init");
+  });
+
+  it("returns the most recent value after emission", () => {
+    const subject = new Subject<string>();
+    const { getByTestId } = render(<Probe obs$={subject} initial="init" />);
+    act(() => subject.next("one"));
+    expect(getByTestId("value").textContent).toBe("one");
+    act(() => subject.next("two"));
+    expect(getByTestId("value").textContent).toBe("two");
+  });
+
+  it("synchronously reflects BehaviorSubject seed after commit", () => {
+    const subject = new BehaviorSubject<number>(42);
+    const { getByTestId } = render(<Probe obs$={subject} initial={0} />);
+    // BehaviorSubject fires synchronously on subscribe; the effect runs
+    // after the first commit, so the seed lands on the very next render.
+    act(() => {
+      // Force a re-render via another emission so the effect-driven
+      // setState is visible to the assertion below.
+      subject.next(42);
+    });
+    expect(getByTestId("value").textContent).toBe("42");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const subject = new Subject<string>();
+    const { unmount, getByTestId } = render(<Probe obs$={subject} initial="init" />);
+    act(() => subject.next("one"));
+    expect(getByTestId("value").textContent).toBe("one");
+    unmount();
+    // No observers left; emitting shouldn't throw and the component is gone.
+    expect(() => subject.next("two")).not.toThrow();
+  });
+});

--- a/apps/notebook/src/lib/use-observable.ts
+++ b/apps/notebook/src/lib/use-observable.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import type { Observable } from "rxjs";
+
+/**
+ * Subscribe to an RxJS `Observable<T>` from a React component.
+ *
+ * Returns the most recently emitted value, or `initial` until the
+ * observable emits. Re-renders on each emission.
+ *
+ * First render shows `initial` because the subscription is set up inside
+ * `useEffect`, which runs after commit. For `BehaviorSubject` /
+ * `ReplaySubject(1)` sources the cached value lands on the next tick.
+ * Consumers that need safe defaults (e.g. a disabled button) should pick
+ * `initial` to reflect that "not-yet-loaded" state honestly.
+ *
+ * The observable must be stable across renders — pass a memoized
+ * reference (e.g. `engine.sessionStatus$`) rather than a pipeline built
+ * inline, or the subscription tears down and rebuilds every render.
+ * Memoize pipelines with `useMemo`.
+ */
+export function useObservable<T>(observable: Observable<T>, initial: T): T {
+  const [value, setValue] = useState<T>(initial);
+  useEffect(() => {
+    const sub = observable.subscribe((next) => setValue(next));
+    return () => sub.unsubscribe();
+  }, [observable]);
+  return value;
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1094,7 +1094,12 @@ export class SyncEngine {
    * Reset the engine for a new bootstrap cycle (e.g. daemon:ready).
    *
    * Clears status / execution tracking so the next round of frames is
-   * treated as a fresh connection.
+   * treated as a fresh connection. Also emits a fully-pending
+   * `SessionStatus` so late subscribers (ReplaySubject(1) cache) see
+   * "not ready" immediately — without this, downstream consumers that
+   * gate on `sessionStatus.runtime_state === "ready"` would keep the
+   * previous session's `ready` value until the next daemon status
+   * frame arrives, leaving a rebootstrap-sized fail-open window.
    */
   resetForBootstrap(): void {
     this.opts.logger.info("[sync-engine] Resetting for bootstrap");
@@ -1102,5 +1107,10 @@ export class SyncEngine {
     this.prevExecutions = {};
     this.commDiffState = { comms: {}, json: {} };
     this.lastRuntimeState = null;
+    this._sessionStatus$.next({
+      notebook_doc: "pending",
+      runtime_state: "pending",
+      initial_load: { phase: "not_needed" },
+    });
   }
 }

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -265,6 +265,34 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("resetForBootstrap emits a pending status so stale ready doesn't leak across reconnect", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+        sessionStatusEvent(interactiveStatus()),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const statuses: SessionStatus[] = [];
+      engine.sessionStatus$.subscribe((status) => statuses.push(status));
+
+      // First session reaches ready.
+      transport.deliver(Array.from([0x07, 1]));
+      expect(statuses.at(-1)?.runtime_state).toBe("ready");
+
+      // Rebootstrap (daemon:ready path). ReplaySubject(1) must now carry
+      // a pending value so late subscribers don't see a stale ready.
+      engine.resetForBootstrap();
+      expect(statuses.at(-1)?.runtime_state).toBe("pending");
+
+      // A fresh subscriber also gets the pending cache, not the old ready.
+      let lateSeen: SessionStatus | null = null;
+      engine.sessionStatus$.subscribe((status) => (lateSeen = status));
+      expect(lateSeen!.runtime_state).toBe("pending");
+
+      engine.stop();
+    });
+
     it("emits cell changes before initialSyncComplete$ when sync frames arrive first", () => {
       const changeset: CellChangeset = {
         changed: [{ cell_id: "cell-1", fields: { source: true } }],


### PR DESCRIPTION
Follow-up to #2238. The trust-verification refactor left a small window where kernel-launch actions could fire against default (unloaded) trust state. #2238's `trustInfo === null` guard in `useTrust` closes the hole when handlers check trust — this PR closes it at the action-handler entry point so keyboard shortcuts and menu routes can't bypass it either.

## Shape

No new state, no new named observable. The engine already exposes `sessionStatus$` as a `ReplaySubject(1)` carrying `{ notebook_doc, runtime_state, initial_load }`. App subscribes to it via a new generic `useObservable(obs$, initial)` helper and derives:

```ts
const sessionStatus = useObservable<SessionStatus | null>(sessionStatus$, null);
const sessionReady = sessionStatus?.runtime_state === "ready";
```

`runtime_state === "ready"` means the daemon received and acked the first RuntimeStateSync round-trip. Before that, `runtimeState.trust.status` is the static default and must not be used to gate trust-relevant actions.

## Gated handlers

- `tryStartKernel` — launches or routes to trust dialog.
- `handleSyncDeps` — hot-sync or restart with package install.
- `handleStartKernelWithPyproject` — direct `launchKernel("python", "uv:pyproject")` path.
- `handleTrustApprove` post-success launch now routes through `tryStartKernel` rather than calling `launchKernel` directly.

All fail-closed with a debug log when `sessionReady` is false. Not gated: `handleExecuteCell` against an already-running kernel (no install, no trust implication), and `save`/`openNotebook`/`cloneNotebook` (unrelated to trust).

## Design choice

Exposed `sessionStatus$` as a stable proxy `Observable` off `useAutomergeNotebook` rather than adding a named `runtimeStateReady$: Observable<boolean>` on the engine. The state machine already exists — collapsing it to a bool at the engine boundary loses information (e.g., a future caller that also wants `initial_load === "ready"` would need another named observable). Per-consumer derivation keeps the engine surface lean and stays aligned with the "React components subscribe to engine observables" direction.

The `useObservable` helper is the payload: any future piece of UI state driven by an engine observable can be read with one line, no module-level store, and the component is testable by pushing values through a mock subject.

## Test plan

- [x] `cargo check -p notebook`
- [x] `cargo xtask lint` (clean after `--fix`)
- [x] `pnpm test:run` (1103/1103 + 3 skipped across 67 suites)
- [x] Added `use-observable.test.tsx` covering initial value, emission, unmount-unsubscribe
- [ ] Cmd+Return on a cell before first sync completes: handler no-ops with debug log (in Nightly logs, not visible)
- [ ] Cmd+Return after sync completes: executes normally
- [ ] Click "Start Kernel" button before sync: no launch fires
- [ ] Click "Sync Deps" before sync: no install fires
- [ ] Trust dialog approve → kernel launches
