### PR TITLE
fix(xtask): derive worktree env for dev daemon

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -37,6 +37,14 @@ Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` t
 
 `nteract-dev` proxies `runt mcp` (Rust-native, direct Automerge access, no Python overhead). It auto-builds `runt` on startup and watches `crates/runt-mcp/src/` for hot reload. For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
 
+`nteract-dev` runs in explicit modes. Claude Code uses owner mode from
+`.mcp.json`, so it may start, restart, rebuild, and stop the worktree daemon.
+Codex project config uses attach mode, so Codex connects to an already-running
+worktree daemon but does not own its lifecycle. When falling back to manual
+commands, `cargo xtask dev-daemon`, `cargo xtask notebook`, and
+`cargo xtask run-mcp` derive the current git worktree and pass the dev env to
+subprocesses; direnv is not required for those xtask paths.
+
 ## System daemon CLI (`runt` / `runt-nightly`)
 
 When running CLI commands against system-installed daemons from a dev environment, **always use `env -i`** to strip dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) that would otherwise redirect commands to the per-worktree dev daemon:
@@ -53,11 +61,13 @@ env -i HOME=$HOME /usr/local/bin/runt diagnostics
 env -i HOME=$HOME /usr/local/bin/runt daemon status
 ```
 
-For the dev daemon, use `./target/debug/runt` directly (no `env -i` needed — dev env vars are correct).
+For the dev daemon, prefer `nteract-dev` tools or `cargo xtask` commands. If you
+run `./target/debug/runt` directly, set `RUNTIMED_DEV=1` and
+`RUNTIMED_WORKSPACE_PATH="$(pwd)"` unless your shell already has them.
 
 ## Verifying Daemon Isolation
 
-After setting up direnv, verify that the three MCP servers connect to the correct daemons:
+Verify that the three MCP servers connect to the correct daemons:
 
 ```bash
 # 1. Check nteract-dev status (should show worktrees/ socket)
@@ -84,8 +94,10 @@ env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status --json | jq -r '.soc
 ```
 
 **Red flags:**
-- nteract-dev socket path doesn't contain `worktrees/` → direnv not active, using system daemon
+- nteract-dev socket path doesn't contain `worktrees/` → using system daemon instead of a worktree daemon
 - nteract-nightly shows empty notebook list → connecting to dev daemon instead of system daemon
 - nteract-nightly MCP process has `RUNTIMED_DEV=1` in environment → env var stripping failed
 
-**Fix:** If direnv is not active, install it and run `direnv allow` in the repo root. See CLAUDE.md § Development Setup.
+**Fix:** Start the dev daemon from the repo root with `cargo xtask dev-daemon`
+or use the owner-mode `nteract-dev` `up` tool. Use direnv only if you want the
+repo's `bin/` wrappers on PATH for interactive shell commands.

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -312,17 +312,23 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.nteract.runtimed.plis
 
 Each git worktree can run its own isolated daemon.
 
-**Conductor users:** Automatic. `cargo xtask dev-daemon` translates `CONDUCTOR_WORKSPACE_PATH` to `RUNTIMED_WORKSPACE_PATH`.
+**xtask-managed commands:** `cargo xtask dev-daemon`, `cargo xtask notebook`,
+and `cargo xtask run-mcp` derive the current git worktree and pass
+`RUNTIMED_DEV=1` plus `RUNTIMED_WORKSPACE_PATH` to subprocesses. Conductor users
+get the same behavior from `CONDUCTOR_WORKSPACE_PATH`.
 
-**Non-Conductor users:** Set `RUNTIMED_DEV=1`:
+No extra environment is needed for the normal two-terminal xtask workflow:
 
 ```bash
 # Terminal 1
-RUNTIMED_DEV=1 cargo xtask dev-daemon
+cargo xtask dev-daemon
 
 # Terminal 2
-RUNTIMED_DEV=1 cargo xtask notebook
+cargo xtask notebook
 ```
+
+Set `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` only for raw
+`./target/debug/runt ...` commands or other processes not launched by xtask.
 
 **State location** (macOS: `~/Library/Caches/`, Linux: `~/.cache/`):
 

--- a/.claude/skills/diagnostics/SKILL.md
+++ b/.claude/skills/diagnostics/SKILL.md
@@ -7,9 +7,17 @@ description: Collect and analyze nteract diagnostic logs. Use when debugging iss
 
 ## Why `env -i`?
 
-In the dev environment, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` are set (by direnv, xtask, or `nteract-dev`). These cause `runt` to target the per-worktree dev daemon. System diagnostics need to target the **system-installed** daemon, so we use `env -i` to strip all env vars except `PATH` and `HOME`.
+In the dev environment, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` may be set
+by direnv, xtask-managed subprocesses, or `nteract-dev`. These cause `runt` to
+target the per-worktree dev daemon. System diagnostics need to target the
+**system-installed** daemon, so we use `env -i` to strip all env vars except
+`PATH` and `HOME`.
 
-The repo-local `bin/runt` wrapper is first in `$PATH` — it runs `./target/debug/runt`, which is the dev build. That's fine for quick checks, but for true system diagnostics, call the system binary by its channel-specific name (`runt` for stable, `runt-nightly` for nightly) via `env -i` so dev env vars don't leak through.
+The repo-local `bin/runt` wrapper may be first in `$PATH` when direnv is active
+— it runs `./target/debug/runt`, which is the dev build. That's fine for quick
+checks, but for true system diagnostics, call the system binary by its
+channel-specific name (`runt` for stable, `runt-nightly` for nightly) via
+`env -i` so dev env vars don't leak through.
 
 ## Collecting Diagnostics
 
@@ -25,6 +33,7 @@ env -i HOME=$HOME /usr/local/bin/runt diagnostics
 
 **Dev daemon** (per-worktree, no `env -i` needed):
 ```bash
+RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
 ./target/debug/runt diagnostics
 ```
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -98,14 +98,20 @@ cargo xtask dev --skip-install --skip-build  # Fast repeat
 
 ### Conductor vs Non-Conductor
 
-**Conductor users:** Dev mode is automatic. `CONDUCTOR_WORKSPACE_PATH` is translated to `RUNTIMED_WORKSPACE_PATH` by xtask commands.
+**xtask-managed commands:** `cargo xtask dev-daemon`, `cargo xtask notebook`,
+`cargo xtask dev`, and `cargo xtask run-mcp` derive the current git worktree and
+pass the dev env to subprocesses. Conductor users get the same behavior from
+`CONDUCTOR_WORKSPACE_PATH`.
 
-**Non-Conductor users:** Set `RUNTIMED_DEV=1` explicitly:
+No extra environment is needed for the normal two-terminal xtask workflow:
 
 ```bash
-RUNTIMED_DEV=1 cargo xtask dev-daemon    # Terminal 1
-RUNTIMED_DEV=1 cargo xtask notebook      # Terminal 2
+cargo xtask dev-daemon    # Terminal 1
+cargo xtask notebook      # Terminal 2
 ```
+
+Set `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` only for raw
+`./target/debug/runt ...` commands or other processes not launched by xtask.
 
 ### Useful Daemon Commands
 
@@ -144,7 +150,8 @@ Use `nteract-dev` as the repo-local MCP server name so it stays distinct from an
     "nteract-dev": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
-      "env": { "RUNTIMED_DEV": "1" }
+      "cwd": ".",
+      "env": { "NTERACT_DEV_MODE": "owner", "RUNTIMED_DEV": "1" }
     }
   }
 }
@@ -182,8 +189,8 @@ The repo includes `.zed/tasks.json` with pre-configured tasks (use cmd-shift-t):
 
 | Task | What it does |
 |------|-------------|
-| Dev Daemon | `cargo xtask dev-daemon` with dev env vars |
-| Dev App | `cargo xtask notebook` with dev env vars and auto Vite port |
+| Dev Daemon | `cargo xtask dev-daemon`; xtask derives the worktree env |
+| Dev App | `cargo xtask notebook`; xtask derives the worktree env and auto Vite port |
 | Daemon Status | `./target/debug/runt daemon status` |
 | Daemon Logs | `./target/debug/runt daemon logs -f` |
 | Format | `cargo xtask lint --fix` (Rust + JS/TS via vp + Python ruff) |

--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,12 @@
-# Dev environment — activated automatically by direnv (https://direnv.net)
+# Optional dev environment — activated automatically by direnv
+# (https://direnv.net)
 #
 # This makes `runt` resolve to the local debug build (bin/runt wrapper)
 # instead of the system-wide /usr/local/bin/runt install.
 # Same with `notebook` and `runtimed`.
+# xtask commands also derive the worktree path themselves, so direnv is a
+# convenience for interactive shells rather than a requirement for daemon
+# isolation.
 PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,19 @@ Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task m
 
 ## Development Setup Requirements
 
-### direnv (Required for Daemon Isolation)
+### direnv (Optional Convenience)
 
-**direnv is required** to automatically set `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH` when you enter the repo directory. Without it, the dev daemon and system nightly daemon will conflict, and nteract-dev MCP will connect to the wrong daemon.
+direnv is useful because it automatically puts the repo's `bin/` wrappers on
+`PATH` and enables the local linker/cache environment when you enter the repo
+directory. It is **not required** for `cargo xtask dev-daemon`, `cargo xtask
+notebook`, or `cargo xtask run-mcp`: xtask detects the current git worktree and
+passes `RUNTIMED_DEV=1` plus `RUNTIMED_WORKSPACE_PATH` to the subprocesses it
+starts.
+
+You still want direnv if you run unqualified commands like `runt daemon status`
+and expect the repo's `bin/runt` wrapper to shadow the system install. Without
+direnv, use `./target/debug/runt ...` or pass the dev env vars explicitly for raw
+commands.
 
 **Install and configure:**
 ```bash
@@ -40,8 +50,8 @@ The `.envrc` file sets:
 **Verify it works:**
 ```bash
 cd /path/to/nteract/desktop
-echo $RUNTIMED_DEV              # Should print "1"
-echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path
+echo $RUNTIMED_DEV              # Should print "1" when direnv is active
+echo $RUNTIMED_WORKSPACE_PATH   # Should print the repo path when direnv is active
 which runt                      # Should be repo/bin/runt (not /usr/local/bin/runt)
 ```
 
@@ -68,7 +78,7 @@ The rustflag goes through direnv, not `.cargo/config.toml`, so CI runners and co
 1. **nteract-dev** (development, per-worktree daemon)
    - Command: `cargo run -p mcp-supervisor` (used by `.mcp.json`). Build cost is small now that the supervisor no longer links `runtimed-client` — first run after `cargo clean` takes a few seconds, warm runs are instant.
    - Working directory: `/path/to/nteract/desktop`
-   - Env vars: Inherits from shell (direnv provides RUNTIMED_DEV, RUNTIMED_WORKSPACE_PATH)
+   - Env vars: `.mcp.json`/`.codex/config.toml` set the mode; the supervisor derives the worktree path from the repo root
    - Socket: `~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock`
    - Tools: 26 nteract tools (proxied from `runt mcp`) + 5 dev tools (`up`, `down`, `status`, `logs`, `vite_logs`)
 
@@ -118,10 +128,15 @@ If your MCP client provides `up`, `down`, `status`, `logs`, `vite_logs` (provide
 
 ### Manual commands (when nteract-dev is not available)
 
-For raw terminal commands, opt into dev mode explicitly. `RUNTIMED_DEV=1` is what enables per-worktree daemon isolation. `RUNTIMED_WORKSPACE_PATH` is the safest way to pin the current worktree, though binaries launched from the repo root can also discover the worktree via git.
+For `cargo xtask dev-daemon`, `cargo xtask notebook`, and `cargo xtask run-mcp`,
+no extra env vars are needed: xtask derives the current git worktree and passes
+the dev env to subprocesses. For raw `./target/debug/runt ...` commands, opt
+into dev mode explicitly. `RUNTIMED_DEV=1` is what enables per-worktree daemon
+isolation. `RUNTIMED_WORKSPACE_PATH` is the safest way to pin the current
+worktree.
 
 ```bash
-# ── Recommended env vars for raw dev-daemon commands ───────────────
+# ── Recommended env vars for raw runt commands ───────────────
 export RUNTIMED_DEV=1
 export RUNTIMED_WORKSPACE_PATH="$(pwd)"
 ```
@@ -183,8 +198,8 @@ Without `nteract-dev` (human runs both):
 # Terminal 1: Start dev daemon
 cargo xtask dev-daemon
 
-# Terminal 2: Start the app (MUST have env vars to avoid clobbering system daemon)
-RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) cargo xtask notebook
+# Terminal 2: Start the app
+cargo xtask notebook
 ```
 
 ### WASM rebuild (after changing notebook-doc, runtimed-wasm, or sift-wasm)

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -195,16 +195,20 @@ cargo xtask build --rust-only && cargo xtask run  # Fast iteration
 
 The app detects dev mode and connects to the per-worktree daemon instead of installing/starting the system daemon.
 
-**Conductor users:** When using `cargo xtask dev`, `cargo xtask notebook`, or `cargo xtask dev-daemon`, the xtask commands automatically translate `CONDUCTOR_WORKSPACE_PATH` to `RUNTIMED_WORKSPACE_PATH`, enabling dev mode.
+**Worktree isolation:** When using `cargo xtask dev`, `cargo xtask notebook`,
+`cargo xtask dev-daemon`, or `cargo xtask run-mcp`, xtask automatically enables
+dev mode and passes the current git worktree as `RUNTIMED_WORKSPACE_PATH` to the
+subprocesses it starts. Conductor users get the same behavior via
+`CONDUCTOR_WORKSPACE_PATH`.
 
-**Non-Conductor users:** Set `RUNTIMED_DEV=1`:
+**Non-Conductor users:** No extra environment is needed for xtask commands:
 
 ```bash
 # Terminal 1
-RUNTIMED_DEV=1 cargo xtask dev-daemon
+cargo xtask dev-daemon
 
 # Terminal 2
-RUNTIMED_DEV=1 cargo xtask notebook
+cargo xtask notebook
 ```
 
 **Useful commands:**
@@ -217,7 +221,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 Per-worktree state is stored in `<cache>/{cache_namespace}/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`). Source builds default to `runt-nightly`; set `RUNT_BUILD_CHANNEL=stable` only when you intentionally need the stable flow.
 
-**For AI agents:** If the repo-local `nteract-dev` MCP entry is available, prefer its `up` / `down` / `status` / `logs` / `vite_logs` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
+**For AI agents:** If the repo-local `nteract-dev` MCP entry is available, prefer its `up` / `down` / `status` / `logs` / `vite_logs` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using raw `./target/debug/runt` commands outside an xtask-managed subprocess, set the env vars manually:
 
 ```bash
 export RUNTIMED_DEV=1
@@ -441,12 +445,14 @@ docs(agents): enforce conventional commit format
 
 ## Zed Editor Integration
 
-The repo includes `.zed/tasks.json` with pre-configured tasks that set the correct environment variables for dev mode. Use `task: spawn` (cmd-shift-t) to run them:
+The repo includes `.zed/tasks.json` with pre-configured tasks. xtask-managed
+tasks derive the correct worktree environment automatically. Use `task: spawn`
+(cmd-shift-t) to run them:
 
 | Task | What it does |
 |------|-------------|
-| **Dev Daemon** | `cargo xtask dev-daemon` with `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH` |
-| **Dev App** | `cargo xtask notebook` with dev env vars and auto-assigned Vite port |
+| **Dev Daemon** | `cargo xtask dev-daemon`; xtask derives the worktree env |
+| **Dev App** | `cargo xtask notebook`; xtask derives the worktree env and auto-assigned Vite port |
 | **Daemon Status** | `./target/debug/runt daemon status` pointed at the worktree daemon |
 | **Daemon Logs** | `./target/debug/runt daemon logs -f` with live tail |
 | **Format** | `cargo xtask lint --fix` (Rust + JS/TS via vp + Python ruff) |

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -765,9 +765,9 @@ impl Supervisor {
         if !state.socket_path.is_empty() && !state.socket_path.contains("worktrees/") {
             warn!(
                 "⚠️  Socket path does not contain 'worktrees/': {}\n\
-                 This may indicate direnv is not active and the supervisor is \
-                 connecting to the system daemon instead of a per-worktree dev daemon.\n\
-                 Fix: run `direnv allow` in the repo root.",
+                 This may indicate the supervisor is connecting to the system \
+                 daemon instead of a per-worktree dev daemon.\n\
+                 Fix: start the dev daemon from the repo root with `cargo xtask dev-daemon`.",
                 state.socket_path
             );
         }
@@ -2854,9 +2854,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ if mode == DevMode::Attach => {
                 let message = format!(
                     "Attach mode requires an already-running worktree daemon for {}. \
-                     Start it from an owner-mode session or with `RUNTIMED_DEV=1 \
-                     RUNTIMED_WORKSPACE_PATH={} cargo xtask dev-daemon`.",
-                    daemon_workspace_path.display(),
+                     Start it from an owner-mode session or run `cargo xtask dev-daemon` \
+                     from that worktree.",
                     daemon_workspace_path.display()
                 );
                 error!("{message}");

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1765,22 +1765,22 @@ fn cmd_mcp(print_config: bool, release: bool) {
             eprintln!("Failed to resolve supervisor binary path: {e}");
             exit(1);
         });
-        let config = if release {
-            serde_json::json!({
-                "command": binary_path.to_string_lossy(),
-                "env": {
-                    "RUNTIMED_DEV": "1",
-                    "RUNTIMED_RELEASE": "1"
-                }
-            })
-        } else {
-            serde_json::json!({
-                "command": binary_path.to_string_lossy(),
-                "env": {
-                    "RUNTIMED_DEV": "1"
-                }
-            })
-        };
+        let mut env_map = serde_json::Map::new();
+        env_map.insert("RUNTIMED_DEV".into(), serde_json::json!("1"));
+        if release {
+            env_map.insert("RUNTIMED_RELEASE".into(), serde_json::json!("1"));
+        }
+        if let Some(path) = runt_workspace::get_workspace_path() {
+            env_map.insert(
+                "RUNTIMED_WORKSPACE_PATH".into(),
+                serde_json::json!(path.to_string_lossy()),
+            );
+        }
+
+        let config = serde_json::json!({
+            "command": binary_path.to_string_lossy(),
+            "env": env_map,
+        });
         println!(
             "{}",
             serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
@@ -1929,15 +1929,9 @@ fn cmd_dev_daemon(release: bool) {
     println!("Press Ctrl+C to stop.");
     println!();
 
-    // Run the daemon with --dev flag
     let mut cmd = Command::new(binary);
     cmd.args(["--dev", "run"]);
-    cmd.env("RUNTIMED_DEV", "1");
-
-    // Translate Conductor → Runtimed for Conductor workspace users
-    if let Ok(path) = env::var("CONDUCTOR_WORKSPACE_PATH") {
-        cmd.env("RUNTIMED_WORKSPACE_PATH", &path);
-    }
+    apply_worktree_env(&mut cmd, true);
     let status = cmd.status().unwrap_or_else(|e| {
         eprintln!("Failed to run runtimed: {e}");
         exit(1);


### PR DESCRIPTION
## Summary
- Make `cargo xtask dev-daemon` use the shared worktree env helper so it passes `RUNTIMED_DEV=1` and the derived `RUNTIMED_WORKSPACE_PATH` without requiring direnv.
- Include the derived workspace path in `cargo xtask run-mcp --print-config` output.
- Update AGENTS/Claude/contributing docs to describe direnv as an interactive-shell convenience and document Claude owner mode vs Codex attach mode.

## Verification
- `cargo xtask lint --fix`
- `cargo test -p xtask`
- `cargo test -p mcp-supervisor`
- `git diff --check`
