### PR TITLE
feat(runt-mcp): persist terminal execution results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6925,6 +6925,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -31,3 +31,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 chrono = "0.4"
+tempfile = "3"

--- a/crates/runt-mcp/assets/plugins/sift_wasm.wasm
+++ b/crates/runt-mcp/assets/plugins/sift_wasm.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3999ca4a96b755cc726f5f57ca817edd9e7311a2349b33c93e60aace318bc186
+oid sha256:f0f98461ba6208ad3e3b49280b5bac176fb5f4436c29a9ff3268590467134f0a
 size 6806028

--- a/crates/runt-mcp/src/daemon_watch.rs
+++ b/crates/runt-mcp/src/daemon_watch.rs
@@ -399,6 +399,7 @@ mod tests {
             version: version.to_string(),
             started_at: Utc::now(),
             blob_port: None,
+            execution_store_dir: None,
             worktree_path: None,
             workspace_description: None,
         }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -37,6 +37,7 @@ pub struct NteractMcp {
     socket_path: PathBuf,
     blob_base_url: Option<String>,
     blob_store_path: Option<PathBuf>,
+    execution_store_path: PathBuf,
     session: Arc<RwLock<Option<NotebookSession>>>,
     /// Context from the most recently dropped session — allows error messages
     /// to tell agents *why* the session was lost and *which notebook_id* to
@@ -67,6 +68,7 @@ impl NteractMcp {
             socket_path,
             blob_base_url,
             blob_store_path,
+            execution_store_path: runtimed_client::default_execution_store_dir(),
             session: Arc::new(RwLock::new(None)),
             last_session_drop: Arc::new(RwLock::new(None)),
             peer_label: Arc::new(RwLock::new("Inkwell".to_string())),
@@ -90,6 +92,14 @@ impl NteractMcp {
     /// Called by the `runt mcp` binary after a best-effort daemon query.
     pub fn with_daemon_version(mut self, version: Option<String>) -> Self {
         self.daemon_version = version;
+        self
+    }
+
+    /// Set the durable execution-store path discovered from daemon info.
+    pub fn with_execution_store_path(mut self, path: Option<PathBuf>) -> Self {
+        if let Some(path) = path {
+            self.execution_store_path = path;
+        }
         self
     }
 

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -316,22 +316,60 @@ pub async fn get_results(
     })?;
     let full_output = arg_bool(request, "full_output").unwrap_or(false);
 
-    let handle = require_handle!(server);
-
-    let runtime_state = handle.get_runtime_state().map_err(|_| {
-        McpError::internal_error("Failed to read RuntimeStateDoc".to_string(), None)
-    })?;
-
-    let exec = match runtime_state.executions.get(execution_id) {
-        Some(e) => e,
-        None => {
-            return tool_error(&format!(
-                "Execution not found: {execution_id}. \
-                 It may have been evicted when the notebook room closed."
-            ));
-        }
+    let handle = {
+        let guard = server.session.read().await;
+        guard.as_ref().map(|session| session.handle.clone())
     };
 
+    if let Some(handle) = handle.as_ref() {
+        let runtime_state = handle.get_runtime_state().map_err(|_| {
+            McpError::internal_error("Failed to read RuntimeStateDoc".to_string(), None)
+        })?;
+        if let Some(exec) = runtime_state.executions.get(execution_id) {
+            let cell = handle.get_cell(&exec.cell_id);
+            return render_execution_result(
+                server,
+                execution_id,
+                exec,
+                Some(&runtime_state.comms),
+                cell,
+                full_output,
+            )
+            .await;
+        }
+    }
+
+    let store =
+        runtimed_client::execution_store::ExecutionStore::new(server.execution_store_path.clone());
+    if let Some(record) = store.read_record(execution_id).await {
+        let exec = runtime_doc::ExecutionState {
+            cell_id: record.cell_id.clone().unwrap_or_default(),
+            status: record.status,
+            execution_count: record.execution_count,
+            success: record.success,
+            outputs: record.outputs,
+            source: record.source,
+            seq: record.seq,
+        };
+        let cell = handle
+            .as_ref()
+            .and_then(|handle| handle.get_cell(&exec.cell_id));
+        return render_execution_result(server, execution_id, &exec, None, cell, full_output).await;
+    }
+
+    tool_error(&format!(
+        "Execution not found: {execution_id}. It may have been evicted and no durable result record was found."
+    ))
+}
+
+async fn render_execution_result(
+    server: &NteractMcp,
+    execution_id: &str,
+    exec: &runtime_doc::ExecutionState,
+    comms: Option<&std::collections::HashMap<String, runtime_doc::CommDocEntry>>,
+    cell: Option<notebook_doc::CellSnapshot>,
+    full_output: bool,
+) -> Result<CallToolResult, McpError> {
     // Determine display status with clear indication of completeness
     let (display_status, is_terminal) = match exec.status.as_str() {
         "done" => ("done", true),
@@ -354,7 +392,6 @@ pub async fn get_results(
     );
 
     // Resolve outputs from the execution's manifests
-    let comms = Some(&runtime_state.comms);
     let outputs = if !exec.outputs.is_empty() {
         output_resolver::resolve_cell_outputs_for_llm(
             &exec.outputs,
@@ -391,40 +428,129 @@ pub async fn get_results(
     }
 
     // Build structured content from the execution's output manifests
-    let cell = handle.get_cell(&exec.cell_id);
-    let mut structured_content = if let Some(snap) = cell {
-        if exec.outputs.is_empty() {
-            None
-        } else {
-            let wrapped = crate::structured::cell_structured_content_from_manifests(
-                &snap.id,
-                &snap.cell_type,
-                &snap.source,
-                &exec.outputs,
-                exec.execution_count,
-                display_status,
-                &server.blob_base_url,
-            );
-            wrapped.get("cell").cloned().map(|mut cell_data| {
-                if let Some(obj) = cell_data.as_object_mut() {
-                    obj.insert(
-                        "execution_id".to_string(),
-                        serde_json::Value::String(execution_id.to_string()),
-                    );
-                }
-                // Wrap as top-level with blob_base_url
-                let mut top = serde_json::json!({ "cell": cell_data });
-                if let Some(base) = &server.blob_base_url {
-                    top["blob_base_url"] = serde_json::Value::String(base.clone());
-                }
-                top
-            })
-        }
-    } else {
+    let fallback_source = exec.source.as_deref().unwrap_or_default();
+    let fallback_cell = notebook_doc::CellSnapshot {
+        id: exec.cell_id.clone(),
+        cell_type: "code".to_string(),
+        position: String::new(),
+        source: fallback_source.to_string(),
+        execution_count: exec
+            .execution_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "null".to_string()),
+        metadata: serde_json::json!({}),
+        resolved_assets: std::collections::HashMap::new(),
+    };
+    let snap = cell.unwrap_or(fallback_cell);
+    let mut structured_content = if exec.outputs.is_empty() {
         None
+    } else {
+        let wrapped = crate::structured::cell_structured_content_from_manifests(
+            &snap.id,
+            &snap.cell_type,
+            &snap.source,
+            &exec.outputs,
+            exec.execution_count,
+            display_status,
+            &server.blob_base_url,
+        );
+        wrapped.get("cell").cloned().map(|mut cell_data| {
+            if let Some(obj) = cell_data.as_object_mut() {
+                obj.insert(
+                    "execution_id".to_string(),
+                    serde_json::Value::String(execution_id.to_string()),
+                );
+            }
+            // Wrap as top-level with blob_base_url
+            let mut top = serde_json::json!({ "cell": cell_data });
+            if let Some(base) = &server.blob_base_url {
+                top["blob_base_url"] = serde_json::Value::String(base.clone());
+            }
+            top
+        })
     };
 
     let mut call_result = rmcp::model::CallToolResult::success(items);
     call_result.structured_content = structured_content.take();
     Ok(call_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn make_request(args: serde_json::Value) -> CallToolRequestParams {
+        serde_json::from_value(serde_json::json!({
+            "name": "get_results",
+            "arguments": args,
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_results_reads_durable_store_without_active_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = runtimed_client::execution_store::ExecutionStore::new(tmp.path());
+        store
+            .write_record(runtimed_client::execution_store::ExecutionRecord {
+                schema_version: runtimed_client::execution_store::EXECUTION_RECORD_SCHEMA_VERSION,
+                execution_id: "exec-durable".to_string(),
+                context_kind: "notebook".to_string(),
+                context_id: "/tmp/notebook.ipynb".to_string(),
+                notebook_path: Some("/tmp/notebook.ipynb".to_string()),
+                cell_id: Some("cell-1".to_string()),
+                status: "done".to_string(),
+                success: Some(true),
+                execution_count: Some(3),
+                source: Some("print('hi')".to_string()),
+                seq: Some(0),
+                outputs: vec![serde_json::json!({
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": {"inline": "hi\n"}
+                })],
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None)
+            .with_execution_store_path(Some(tmp.path().to_path_buf()));
+        let result = get_results(
+            &server,
+            &make_request(serde_json::json!({"execution_id": "exec-durable"})),
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(result.is_error, Some(true));
+        let content = serde_json::to_string(&result.content).unwrap();
+        assert!(content.contains("exec-durable"));
+        assert!(content.contains("hi"));
+        assert_eq!(
+            result.structured_content.unwrap()["cell"]["execution_id"],
+            "exec-durable"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_results_missing_durable_record_omits_unknown_cell_recovery_hint() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let server = NteractMcp::new(PathBuf::from("/tmp/missing.sock"), None, None)
+            .with_execution_store_path(Some(tmp.path().to_path_buf()));
+        let result = get_results(
+            &server,
+            &make_request(serde_json::json!({"execution_id": "exec-missing"})),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        let content = serde_json::to_string(&result.content).unwrap();
+        assert!(content.contains("Execution not found"));
+        assert!(!content.contains("get_cell("));
+    }
 }

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -351,10 +351,7 @@ pub async fn get_results(
             source: record.source,
             seq: record.seq,
         };
-        let cell = handle
-            .as_ref()
-            .and_then(|handle| handle.get_cell(&exec.cell_id));
-        return render_execution_result(server, execution_id, &exec, None, cell, full_output).await;
+        return render_execution_result(server, execution_id, &exec, None, None, full_output).await;
     }
 
     tool_error(&format!(

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -814,14 +814,18 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     // detect daemon upgrades across child restarts. If the daemon isn't up
     // yet (common at launch), we skip it — the proxy will degrade to a
     // "child restarted" message, which is accurate.
-    let daemon_version = tokio::time::timeout(
+    let daemon_info = tokio::time::timeout(
         std::time::Duration::from_millis(500),
         runtimed_client::singleton::query_daemon_info(socket_path.clone()),
     )
     .await
     .ok()
-    .flatten()
-    .map(|info| info.version);
+    .flatten();
+    let daemon_version = daemon_info.as_ref().map(|info| info.version.clone());
+    let execution_store_path = daemon_info
+        .as_ref()
+        .and_then(|info| info.execution_store_dir.as_ref())
+        .map(PathBuf::from);
 
     use rmcp::service::ServiceExt;
     let server = if no_show {
@@ -829,7 +833,8 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     } else {
         runt_mcp::NteractMcp::new(socket_path.clone(), blob_base_url, blob_store_path)
     }
-    .with_daemon_version(daemon_version);
+    .with_daemon_version(daemon_version)
+    .with_execution_store_path(execution_store_path);
 
     // Grab shared state handles before serving (serve consumes the server)
     let session = server.session().clone();

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -88,6 +88,8 @@ pub struct DaemonInfo {
     /// HTTP port for the content-addressed blob server. `None` if the
     /// blob server hasn't finished binding yet.
     pub blob_port: Option<u16>,
+    /// Directory for durable execution result records.
+    pub execution_store_dir: Option<String>,
     /// Path to the git worktree this dev daemon is pinned to.
     pub worktree_path: Option<String>,
     /// Human-readable workspace description (dev mode only).
@@ -217,6 +219,7 @@ impl PoolClient {
                 pid,
                 started_at,
                 blob_port,
+                execution_store_dir,
                 worktree_path,
                 workspace_description,
             } => Ok(DaemonInfo {
@@ -225,6 +228,7 @@ impl PoolClient {
                 pid,
                 started_at,
                 blob_port,
+                execution_store_dir,
                 worktree_path,
                 workspace_description,
             }),

--- a/crates/runtimed-client/src/execution_store.rs
+++ b/crates/runtimed-client/src/execution_store.rs
@@ -1,0 +1,456 @@
+//! Durable execution-result store.
+//!
+//! RuntimeStateDoc remains the live, daemon-authoritative sync document. This
+//! store is a small sidecar ledger for terminal executions so tools can recover
+//! `get_results(execution_id)` after a room is evicted.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const EXECUTION_RECORD_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExecutionRecord {
+    pub schema_version: u32,
+    pub execution_id: String,
+    pub context_kind: String,
+    pub context_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notebook_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_count: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
+    #[serde(default)]
+    pub outputs: Vec<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ExecutionRecord {
+    pub fn from_execution_state(
+        execution_id: &str,
+        context_kind: impl Into<String>,
+        context_id: impl Into<String>,
+        notebook_path: Option<String>,
+        exec: &runtime_doc::ExecutionState,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            schema_version: EXECUTION_RECORD_SCHEMA_VERSION,
+            execution_id: execution_id.to_string(),
+            context_kind: context_kind.into(),
+            context_id: context_id.into(),
+            notebook_path,
+            cell_id: Some(exec.cell_id.clone()),
+            status: exec.status.clone(),
+            success: exec.success,
+            execution_count: exec.execution_count,
+            source: exec.source.clone(),
+            seq: exec.seq,
+            outputs: exec.outputs.clone(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.status.as_str(), "done" | "error")
+    }
+
+    pub fn matches_notebook_cell(
+        &self,
+        context_id: &str,
+        notebook_path: Option<&str>,
+        cell_id: &str,
+        source: &str,
+        execution_count: Option<i64>,
+        outputs: &[serde_json::Value],
+    ) -> bool {
+        self.schema_version == EXECUTION_RECORD_SCHEMA_VERSION
+            && self.context_kind == "notebook"
+            && self.context_id == context_id
+            && self.notebook_path.as_deref() == notebook_path
+            && self.cell_id.as_deref() == Some(cell_id)
+            && self.source.as_deref() == Some(source)
+            && self.execution_count == execution_count
+            && outputs_match_for_reload(&self.outputs, outputs)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionStore {
+    root: PathBuf,
+}
+
+impl ExecutionStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub async fn write_record(&self, mut record: ExecutionRecord) -> std::io::Result<()> {
+        validate_execution_id(&record.execution_id)?;
+        tokio::fs::create_dir_all(&self.root).await?;
+        if let Some(existing) = self.read_record(&record.execution_id).await {
+            record.created_at = existing.created_at;
+        }
+        record.updated_at = Utc::now();
+        let path = self.path_for_id(&record.execution_id)?;
+        let tmp = self.root.join(format!(
+            "{}.{}.tmp",
+            record.execution_id,
+            uuid::Uuid::new_v4()
+        ));
+        let bytes = serde_json::to_vec_pretty(&record).map_err(std::io::Error::other)?;
+        tokio::fs::write(&tmp, bytes).await?;
+        tokio::fs::rename(&tmp, &path).await?;
+        Ok(())
+    }
+
+    pub async fn read_record(&self, execution_id: &str) -> Option<ExecutionRecord> {
+        let path = self.path_for_id(execution_id).ok()?;
+        let bytes = tokio::fs::read(&path).await.ok()?;
+        match serde_json::from_slice::<ExecutionRecord>(&bytes) {
+            Ok(record) if record.schema_version == EXECUTION_RECORD_SCHEMA_VERSION => Some(record),
+            Ok(_) => None,
+            Err(e) => {
+                log::warn!(
+                    "[execution-store] Ignoring corrupt execution record {:?}: {}",
+                    path,
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    pub async fn list_records(&self) -> Vec<ExecutionRecord> {
+        let mut records = Vec::new();
+        let mut entries = match tokio::fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return records,
+            Err(e) => {
+                log::warn!(
+                    "[execution-store] Failed to read execution store {:?}: {}",
+                    self.root,
+                    e
+                );
+                return records;
+            }
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            match tokio::fs::read(&path).await {
+                Ok(bytes) => match serde_json::from_slice::<ExecutionRecord>(&bytes) {
+                    Ok(record) if record.schema_version == EXECUTION_RECORD_SCHEMA_VERSION => {
+                        records.push(record);
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::warn!(
+                            "[execution-store] Ignoring corrupt execution record {:?}: {}",
+                            path,
+                            e
+                        );
+                    }
+                },
+                Err(e) => {
+                    log::warn!(
+                        "[execution-store] Failed to read execution record {:?}: {}",
+                        path,
+                        e
+                    );
+                }
+            }
+        }
+        records
+    }
+
+    pub async fn list_context(&self, context_kind: &str, context_id: &str) -> Vec<ExecutionRecord> {
+        self.list_records()
+            .await
+            .into_iter()
+            .filter(|record| record.context_kind == context_kind && record.context_id == context_id)
+            .collect()
+    }
+
+    pub async fn find_matching_notebook_cell(
+        &self,
+        context_id: &str,
+        notebook_path: Option<&str>,
+        cell_id: &str,
+        source: &str,
+        execution_count: Option<i64>,
+        outputs: &[serde_json::Value],
+    ) -> Option<ExecutionRecord> {
+        self.list_context("notebook", context_id)
+            .await
+            .into_iter()
+            .find(|record| {
+                record.matches_notebook_cell(
+                    context_id,
+                    notebook_path,
+                    cell_id,
+                    source,
+                    execution_count,
+                    outputs,
+                )
+            })
+    }
+
+    pub async fn prune_older_than(&self, cutoff: DateTime<Utc>) -> usize {
+        let mut removed = 0usize;
+        for record in self.list_records().await {
+            if record.updated_at >= cutoff {
+                continue;
+            }
+            if let Ok(path) = self.path_for_id(&record.execution_id) {
+                match tokio::fs::remove_file(&path).await {
+                    Ok(()) => removed += 1,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        log::warn!(
+                            "[execution-store] Failed to prune execution record {:?}: {}",
+                            path,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+        removed
+    }
+
+    pub async fn referenced_blob_hashes(&self) -> HashSet<String> {
+        let mut hashes = HashSet::new();
+        for record in self.list_records().await {
+            for output in &record.outputs {
+                collect_blob_hashes(output, &mut hashes);
+            }
+        }
+        hashes
+    }
+
+    fn path_for_id(&self, execution_id: &str) -> std::io::Result<PathBuf> {
+        validate_execution_id(execution_id)?;
+        Ok(self.root.join(format!("{execution_id}.json")))
+    }
+}
+
+fn validate_execution_id(execution_id: &str) -> std::io::Result<()> {
+    if execution_id.is_empty()
+        || !execution_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid execution_id for file-backed store: {execution_id:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn outputs_match_for_reload(a: &[serde_json::Value], b: &[serde_json::Value]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b).all(|(left, right)| {
+            normalize_output_for_match(left) == normalize_output_for_match(right)
+        })
+}
+
+fn normalize_output_for_match(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(obj) => {
+            let mut normalized = serde_json::Map::new();
+            for (key, val) in obj {
+                if matches!(key.as_str(), "output_id" | "llm_preview" | "rich") {
+                    continue;
+                }
+                normalized.insert(key.clone(), normalize_output_for_match(val));
+            }
+            serde_json::Value::Object(normalized)
+        }
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.iter().map(normalize_output_for_match).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+fn collect_blob_hashes(
+    manifest: &serde_json::Value,
+    hashes: &mut std::collections::HashSet<String>,
+) {
+    if let Some(data) = manifest.get("data").and_then(|d| d.as_object()) {
+        for mime_data in data.values() {
+            collect_blob_hashes_recursive(mime_data, hashes);
+        }
+    }
+    if let Some(text) = manifest.get("text") {
+        collect_blob_hashes_recursive(text, hashes);
+    }
+    if let Some(traceback) = manifest.get("traceback") {
+        collect_blob_hashes_recursive(traceback, hashes);
+    }
+}
+
+fn collect_blob_hashes_recursive(
+    value: &serde_json::Value,
+    hashes: &mut std::collections::HashSet<String>,
+) {
+    match value {
+        serde_json::Value::Object(obj) => {
+            if let Some(hash) = obj.get("blob").and_then(|b| b.as_str()) {
+                hashes.insert(hash.to_string());
+            }
+            for value in obj.values() {
+                collect_blob_hashes_recursive(value, hashes);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_blob_hashes_recursive(value, hashes);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: &str) -> ExecutionRecord {
+        ExecutionRecord {
+            schema_version: EXECUTION_RECORD_SCHEMA_VERSION,
+            execution_id: id.to_string(),
+            context_kind: "notebook".to_string(),
+            context_id: "/tmp/a.ipynb".to_string(),
+            notebook_path: Some("/tmp/a.ipynb".to_string()),
+            cell_id: Some("cell-1".to_string()),
+            status: "done".to_string(),
+            success: Some(true),
+            execution_count: Some(1),
+            source: Some("1 + 1".to_string()),
+            seq: Some(0),
+            outputs: vec![serde_json::json!({
+                "output_type": "stream",
+                "output_id": "old",
+                "text": {"blob": "abc", "size": 3}
+            })],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_and_read_round_trips() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        store.write_record(record("exec-1")).await.unwrap();
+
+        let loaded = store.read_record("exec-1").await.unwrap();
+        assert_eq!(loaded.execution_id, "exec-1");
+        assert_eq!(loaded.outputs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn corrupt_records_are_ignored() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        tokio::fs::write(tmp.path().join("exec-1.json"), b"{not json")
+            .await
+            .unwrap();
+
+        assert!(store.read_record("exec-1").await.is_none());
+        assert!(store.list_records().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_context_filters_records() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        store.write_record(record("exec-1")).await.unwrap();
+        let mut other = record("exec-2");
+        other.context_id = "/tmp/b.ipynb".to_string();
+        other.notebook_path = Some("/tmp/b.ipynb".to_string());
+        store.write_record(other).await.unwrap();
+
+        let records = store.list_context("notebook", "/tmp/a.ipynb").await;
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].execution_id, "exec-1");
+    }
+
+    #[tokio::test]
+    async fn find_matching_notebook_cell_ignores_runtime_only_output_fields() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        store.write_record(record("exec-1")).await.unwrap();
+
+        let loaded = store
+            .find_matching_notebook_cell(
+                "/tmp/a.ipynb",
+                Some("/tmp/a.ipynb"),
+                "cell-1",
+                "1 + 1",
+                Some(1),
+                &[serde_json::json!({
+                    "output_type": "stream",
+                    "output_id": "new",
+                    "llm_preview": "preview",
+                    "text": {"blob": "abc", "size": 3}
+                })],
+            )
+            .await
+            .unwrap();
+        assert_eq!(loaded.execution_id, "exec-1");
+    }
+
+    #[tokio::test]
+    async fn prune_removes_old_records() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        let mut old = record("exec-1");
+        old.updated_at = Utc::now() - chrono::Duration::days(31);
+        tokio::fs::create_dir_all(tmp.path()).await.unwrap();
+        tokio::fs::write(
+            tmp.path().join("exec-1.json"),
+            serde_json::to_vec_pretty(&old).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let removed = store
+            .prune_older_than(Utc::now() - chrono::Duration::days(30))
+            .await;
+        assert_eq!(removed, 1);
+        assert!(store.read_record("exec-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn referenced_blob_hashes_collects_output_refs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        store.write_record(record("exec-1")).await.unwrap();
+
+        let hashes = store.referenced_blob_hashes().await;
+        assert!(hashes.contains("abc"));
+    }
+}

--- a/crates/runtimed-client/src/execution_store.rs
+++ b/crates/runtimed-client/src/execution_store.rs
@@ -68,6 +68,25 @@ impl ExecutionRecord {
         matches!(self.status.as_str(), "done" | "error")
     }
 
+    pub fn terminal_success(&self) -> bool {
+        self.success.unwrap_or(self.status == "done")
+    }
+
+    pub fn payload_matches(&self, other: &Self) -> bool {
+        self.schema_version == other.schema_version
+            && self.execution_id == other.execution_id
+            && self.context_kind == other.context_kind
+            && self.context_id == other.context_id
+            && self.notebook_path == other.notebook_path
+            && self.cell_id == other.cell_id
+            && self.status == other.status
+            && self.success == other.success
+            && self.execution_count == other.execution_count
+            && self.source == other.source
+            && self.seq == other.seq
+            && self.outputs == other.outputs
+    }
+
     pub fn matches_notebook_cell(
         &self,
         context_id: &str,
@@ -95,7 +114,9 @@ pub struct ExecutionStore {
 
 impl ExecutionStore {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        let root = root.into();
+        cleanup_tmp_files_sync(&root);
+        Self { root }
     }
 
     pub fn root(&self) -> &Path {
@@ -106,6 +127,9 @@ impl ExecutionStore {
         validate_execution_id(&record.execution_id)?;
         tokio::fs::create_dir_all(&self.root).await?;
         if let Some(existing) = self.read_record(&record.execution_id).await {
+            if existing.payload_matches(&record) {
+                return Ok(());
+            }
             record.created_at = existing.created_at;
         }
         record.updated_at = Utc::now();
@@ -222,6 +246,10 @@ impl ExecutionStore {
                 continue;
             }
             if let Ok(path) = self.path_for_id(&record.execution_id) {
+                match self.read_record(&record.execution_id).await {
+                    Some(latest) if latest.updated_at < cutoff => {}
+                    Some(_) | None => continue,
+                }
                 match tokio::fs::remove_file(&path).await {
                     Ok(()) => removed += 1,
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -251,6 +279,25 @@ impl ExecutionStore {
     fn path_for_id(&self, execution_id: &str) -> std::io::Result<PathBuf> {
         validate_execution_id(execution_id)?;
         Ok(self.root.join(format!("{execution_id}.json")))
+    }
+}
+
+fn cleanup_tmp_files_sync(root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("tmp") {
+            continue;
+        }
+        if let Err(e) = std::fs::remove_file(&path) {
+            log::warn!(
+                "[execution-store] Failed to remove stale temp record {:?}: {}",
+                path,
+                e
+            );
+        }
     }
 }
 
@@ -372,6 +419,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unchanged_write_preserves_updated_at() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        let mut first = record("exec-1");
+        first.updated_at = Utc::now() - chrono::Duration::days(5);
+        tokio::fs::create_dir_all(tmp.path()).await.unwrap();
+        tokio::fs::write(
+            tmp.path().join("exec-1.json"),
+            serde_json::to_vec_pretty(&first).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let mut same_payload = first.clone();
+        same_payload.updated_at = Utc::now();
+        store.write_record(same_payload).await.unwrap();
+
+        let loaded = store.read_record("exec-1").await.unwrap();
+        assert_eq!(loaded.updated_at, first.updated_at);
+    }
+
+    #[test]
+    fn new_removes_stale_tmp_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("exec-1.abc.tmp"), b"partial").unwrap();
+
+        let _store = ExecutionStore::new(tmp.path());
+
+        assert!(!tmp.path().join("exec-1.abc.tmp").exists());
+    }
+
+    #[tokio::test]
     async fn corrupt_records_are_ignored() {
         let tmp = tempfile::TempDir::new().unwrap();
         let store = ExecutionStore::new(tmp.path());
@@ -442,6 +521,36 @@ mod tests {
             .await;
         assert_eq!(removed, 1);
         assert!(store.read_record("exec-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn prune_rereads_before_delete() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = ExecutionStore::new(tmp.path());
+        let mut old = record("exec-1");
+        old.updated_at = Utc::now() - chrono::Duration::days(31);
+        tokio::fs::create_dir_all(tmp.path()).await.unwrap();
+        tokio::fs::write(
+            tmp.path().join("exec-1.json"),
+            serde_json::to_vec_pretty(&old).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let mut refreshed = old.clone();
+        refreshed.updated_at = Utc::now();
+        tokio::fs::write(
+            tmp.path().join("exec-1.json"),
+            serde_json::to_vec_pretty(&refreshed).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let removed = store
+            .prune_older_than(Utc::now() - chrono::Duration::days(30))
+            .await;
+        assert_eq!(removed, 0);
+        assert!(store.read_record("exec-1").await.is_some());
     }
 
     #[tokio::test]

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 pub mod client;
 pub mod daemon_connection;
 pub mod daemon_paths;
+pub mod execution_store;
 pub mod output_resolver;
 pub mod resolved_output;
 pub use notebook_doc;
@@ -204,6 +205,11 @@ pub fn default_cache_dir() -> PathBuf {
 /// Get the default directory for the content-addressed blob store.
 pub fn default_blob_store_dir() -> PathBuf {
     daemon_base_dir().join("blobs")
+}
+
+/// Get the default directory for durable execution records.
+pub fn default_execution_store_dir() -> PathBuf {
+    daemon_base_dir().join("executions")
 }
 
 /// Get the directory for kernel connection files.

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -123,6 +123,9 @@ pub enum Response {
         /// blob server hasn't finished binding yet.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         blob_port: Option<u16>,
+        /// Directory for durable execution result records.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        execution_store_dir: Option<String>,
         /// Path to the git worktree this dev daemon is pinned to.
         /// Non-dev daemons return None.
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -22,6 +22,9 @@ pub struct DaemonInfo {
     /// HTTP port for the blob server (if running).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blob_port: Option<u16>,
+    /// Directory for durable execution result records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_store_dir: Option<String>,
     /// Path to the git worktree (dev mode only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
@@ -77,6 +80,7 @@ pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<Daemon
             version: info.daemon_version,
             started_at: info.started_at,
             blob_port: info.blob_port,
+            execution_store_dir: info.execution_store_dir,
             worktree_path: info.worktree_path,
             workspace_description: info.workspace_description,
         });

--- a/crates/runtimed/examples/test_inline_deps.rs
+++ b/crates/runtimed/examples/test_inline_deps.rs
@@ -57,6 +57,7 @@ async fn main() -> anyhow::Result<()> {
         socket_path: temp_dir.path().join("test-daemon.sock"),
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
+        execution_store_dir: temp_dir.path().join("executions"),
         notebook_docs_dir: temp_dir.path().join("notebook-docs"),
         uv_pool_size: 0, // Don't create real envs
         conda_pool_size: 0,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -44,6 +44,8 @@ pub struct DaemonConfig {
     pub cache_dir: PathBuf,
     /// Directory for the content-addressed blob store.
     pub blob_store_dir: PathBuf,
+    /// Directory for durable execution result records.
+    pub execution_store_dir: PathBuf,
     /// Directory for persisted notebook Automerge documents.
     pub notebook_docs_dir: PathBuf,
     /// Target number of UV environments to maintain.
@@ -95,6 +97,7 @@ impl Default for DaemonConfig {
             socket_path: default_socket_path(),
             cache_dir: default_cache_dir(),
             blob_store_dir: default_blob_store_dir(),
+            execution_store_dir: crate::default_execution_store_dir(),
             notebook_docs_dir: crate::default_notebook_docs_dir(),
             uv_pool_size: 3,
             conda_pool_size: 3,
@@ -867,6 +870,12 @@ impl Daemon {
             pid: std::process::id(),
             started_at: self.started_at,
             blob_port,
+            execution_store_dir: Some(
+                self.config
+                    .execution_store_dir
+                    .to_string_lossy()
+                    .to_string(),
+            ),
             worktree_path,
             workspace_description,
         }
@@ -1834,6 +1843,7 @@ impl Daemon {
                             room,
                             notebook_id,
                             runtime_agent_id,
+                            self.config.execution_store_dir.clone(),
                         )
                         .await;
                         Ok(())
@@ -3188,6 +3198,12 @@ impl Daemon {
                 // safe (the persisted-doc walk below still gathers refs for
                 // anything they might reopen). Without this distinction, a
                 // daemon that stays open while idle would never GC again.
+                let blob_max_age = blob_gc_grace();
+                let execution_store_refs = Self::collect_execution_store_refs_for_gc(
+                    &self.config.execution_store_dir,
+                    blob_max_age,
+                )
+                .await;
                 let rooms_empty = room_arcs.is_empty();
                 if Self::should_skip_blob_sweep(
                     rooms_empty,
@@ -3198,10 +3214,10 @@ impl Daemon {
                         "[runtimed] GC: 0 active rooms and no room has loaded since startup; skipping blob sweep this cycle"
                     );
                 } else {
-                    let blob_max_age = blob_gc_grace();
-                    let referenced_hashes =
+                    let mut referenced_hashes =
                         Self::collect_blob_refs_for_gc(&room_arcs, &self.config.notebook_docs_dir)
                             .await;
+                    referenced_hashes.extend(execution_store_refs);
                     Self::sweep_orphaned_blobs(&self.blob_store, &referenced_hashes, blob_max_age)
                         .await;
                 }
@@ -3478,6 +3494,25 @@ impl Daemon {
         }
 
         referenced_hashes
+    }
+
+    /// Prune expired durable execution records, then return blob hashes
+    /// referenced by the remaining records.
+    pub(crate) async fn collect_execution_store_refs_for_gc(
+        execution_store_dir: &Path,
+        retention: std::time::Duration,
+    ) -> std::collections::HashSet<String> {
+        let store = runtimed_client::execution_store::ExecutionStore::new(execution_store_dir);
+        let retention_secs = retention.as_secs().min(i64::MAX as u64) as i64;
+        let cutoff = chrono::Utc::now() - chrono::Duration::seconds(retention_secs);
+        let pruned = store.prune_older_than(cutoff).await;
+        if pruned > 0 {
+            info!(
+                "[runtimed] GC: pruned {} expired durable execution records",
+                pruned
+            );
+        }
+        store.referenced_blob_hashes().await
     }
 
     /// Sweep the blob store, deleting blobs that are not in
@@ -5893,6 +5928,73 @@ mod tests {
             "persisted-doc blob ref should be collected, got {:?}",
             refs
         );
+    }
+
+    #[tokio::test]
+    async fn execution_store_gc_prunes_expired_records_before_marking_blobs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = runtimed_client::execution_store::ExecutionStore::new(tmp.path());
+        store
+            .write_record(runtimed_client::execution_store::ExecutionRecord {
+                schema_version: runtimed_client::execution_store::EXECUTION_RECORD_SCHEMA_VERSION,
+                execution_id: "exec-live".to_string(),
+                context_kind: "notebook".to_string(),
+                context_id: "/tmp/live.ipynb".to_string(),
+                notebook_path: Some("/tmp/live.ipynb".to_string()),
+                cell_id: Some("cell-live".to_string()),
+                status: "done".to_string(),
+                success: Some(true),
+                execution_count: Some(1),
+                source: Some("display('live')".to_string()),
+                seq: Some(0),
+                outputs: vec![serde_json::json!({
+                    "output_type": "display_data",
+                    "data": {"image/png": {"blob": "live-blob", "size": 4}}
+                })],
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let expired = runtimed_client::execution_store::ExecutionRecord {
+            schema_version: runtimed_client::execution_store::EXECUTION_RECORD_SCHEMA_VERSION,
+            execution_id: "exec-expired".to_string(),
+            context_kind: "notebook".to_string(),
+            context_id: "/tmp/expired.ipynb".to_string(),
+            notebook_path: Some("/tmp/expired.ipynb".to_string()),
+            cell_id: Some("cell-expired".to_string()),
+            status: "done".to_string(),
+            success: Some(true),
+            execution_count: Some(1),
+            source: Some("display('expired')".to_string()),
+            seq: Some(0),
+            outputs: vec![serde_json::json!({
+                "output_type": "display_data",
+                "data": {"image/png": {"blob": "expired-blob", "size": 4}}
+            })],
+            created_at: chrono::Utc::now() - chrono::Duration::days(31),
+            updated_at: chrono::Utc::now() - chrono::Duration::days(31),
+        };
+        tokio::fs::write(
+            tmp.path().join("exec-expired.json"),
+            serde_json::to_vec_pretty(&expired).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let refs = Daemon::collect_execution_store_refs_for_gc(
+            tmp.path(),
+            std::time::Duration::from_secs(BLOB_GC_GRACE_SECS),
+        )
+        .await;
+
+        assert!(refs.contains("live-blob"), "live record should mark blob");
+        assert!(
+            !refs.contains("expired-blob"),
+            "expired record should be pruned before blob marking"
+        );
+        assert!(store.read_record("exec-expired").await.is_none());
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -714,7 +714,7 @@ pub struct Daemon {
 #[derive(Debug, thiserror::Error)]
 #[error("Another daemon is already running: {info:?}")]
 pub struct DaemonAlreadyRunning {
-    pub info: DaemonInfo,
+    pub info: Box<DaemonInfo>,
 }
 
 impl Daemon {

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -401,6 +401,7 @@ async fn run_daemon(
         socket_path: socket.unwrap_or_else(runtimed::default_socket_path),
         cache_dir: cache_dir.unwrap_or_else(runtimed::default_cache_dir),
         blob_store_dir: blob_store_dir.unwrap_or_else(runtimed::default_blob_store_dir),
+        execution_store_dir: runtimed::default_execution_store_dir(),
         uv_pool_size,
         conda_pool_size,
         pixi_pool_size,
@@ -411,6 +412,7 @@ async fn run_daemon(
     info!("  Socket: {:?}", config.socket_path);
     info!("  Cache dir: {:?}", config.cache_dir);
     info!("  Blob store: {:?}", config.blob_store_dir);
+    info!("  Execution store: {:?}", config.execution_store_dir);
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
     info!("  Pixi pool size: {}", config.pixi_pool_size);

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -459,6 +459,15 @@ where
         path.display(),
         start.elapsed()
     );
+    let notebook_path = room
+        .identity
+        .path
+        .read()
+        .await
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string());
+    let context_id = super::notebook_execution_context_id(room, notebook_path.as_deref());
+    let durable_records = durable_execution_records(execution_store, &context_id).await;
 
     // 2. Stream cells in batches
     let mut cell_iter = cells.into_iter().enumerate().peekable();
@@ -491,37 +500,35 @@ where
             batch.push((idx, cell, output_refs, resolved_assets));
         }
 
-        // Store outputs in RuntimeStateDoc with durable execution_ids when a
+        // Store outputs in RuntimeStateDoc with durable execution state when a
         // matching terminal record exists, otherwise mint synthetic IDs.
-        // Collect (cell_id, eid) pairs for linking below.
-        let mut cell_eids: HashMap<String, String> = HashMap::new();
-        let context_id = path.to_string_lossy().to_string();
+        // Collect (cell_id, execution) pairs for linking below.
+        let mut cell_executions: HashMap<String, LoadedExecution> = HashMap::new();
         for (_idx, cell, output_refs, _resolved_assets) in &batch {
             if output_refs.is_empty() {
                 continue;
             }
             let parsed_ec = cell.execution_count.parse::<i64>().ok();
-            let eid = durable_or_synthetic_execution_id(
-                execution_store,
+            let execution = durable_or_synthetic_execution(
+                &durable_records,
                 &context_id,
-                Some(&context_id),
+                notebook_path.as_deref(),
                 &cell.id,
                 &cell.source,
                 parsed_ec,
                 output_refs,
-            )
-            .await;
-            cell_eids.insert(cell.id.clone(), eid);
+            );
+            cell_executions.insert(cell.id.clone(), execution);
         }
         let _ = room.state.with_doc(|sd| {
             for (_idx, cell, output_refs, _resolved_assets) in &batch {
-                if let Some(eid) = cell_eids.get(&cell.id) {
-                    let _ = sd.create_execution(eid, &cell.id);
-                    let _ = sd.set_outputs(eid, output_refs);
+                if let Some(execution) = cell_executions.get(&cell.id) {
+                    let _ = sd.create_execution(&execution.execution_id, &cell.id);
+                    let _ = sd.set_outputs(&execution.execution_id, output_refs);
                     if let Ok(ec) = cell.execution_count.parse::<i64>() {
-                        let _ = sd.set_execution_count(eid, ec);
+                        let _ = sd.set_execution_count(&execution.execution_id, ec);
                     }
-                    let _ = sd.set_execution_done(eid, true);
+                    let _ = sd.set_execution_done(&execution.execution_id, execution.success);
                 }
             }
             Ok(())
@@ -541,8 +548,8 @@ where
                 )
                 .map_err(|e| format!("Failed to add cell {}: {}", cell.id, e))?;
                 // Link cell to its synthetic execution_id
-                if let Some(eid) = cell_eids.get(&cell.id) {
-                    let _ = doc.set_execution_id(&cell.id, Some(eid));
+                if let Some(execution) = cell_executions.get(&cell.id) {
+                    let _ = doc.set_execution_id(&cell.id, Some(&execution.execution_id));
                 }
                 doc.set_cell_resolved_assets(&cell.id, resolved_assets)
                     .map_err(|e| format!("Failed to set resolved assets for {}: {}", cell.id, e))?;
@@ -744,6 +751,8 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
         attachments: nbformat_attachments,
     } = parse_cells_from_ipynb(&json)
         .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
+    let context_id = path.to_string_lossy().to_string();
+    let durable_records = durable_execution_records(execution_store, &context_id).await;
 
     // Populate cells in the doc
     for (i, cell) in cells.iter().enumerate() {
@@ -766,29 +775,27 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
             } else {
                 Vec::new()
             };
-            let context_id = path.to_string_lossy().to_string();
-            let execution_id = durable_or_synthetic_execution_id(
-                execution_store,
+            let execution = durable_or_synthetic_execution(
+                &durable_records,
                 &context_id,
                 Some(&context_id),
                 &cell.id,
                 &cell.source,
                 parsed_ec,
                 &output_refs,
-            )
-            .await;
+            );
             if let Some(ref mut sd) = state_doc {
-                let _ = sd.create_execution(&execution_id, &cell.id);
+                let _ = sd.create_execution(&execution.execution_id, &cell.id);
                 if has_outputs {
-                    sd.set_outputs(&execution_id, &output_refs)
+                    sd.set_outputs(&execution.execution_id, &output_refs)
                         .map_err(|e| format!("Failed to set outputs in state doc: {}", e))?;
                 }
                 if let Some(ec) = parsed_ec {
-                    let _ = sd.set_execution_count(&execution_id, ec);
+                    let _ = sd.set_execution_count(&execution.execution_id, ec);
                 }
-                let _ = sd.set_execution_done(&execution_id, true);
+                let _ = sd.set_execution_done(&execution.execution_id, execution.success);
             }
-            doc.set_execution_id(&cell.id, Some(&execution_id))
+            doc.set_execution_id(&cell.id, Some(&execution.execution_id))
                 .map_err(|e| format!("Failed to set execution_id: {}", e))?;
         }
         if should_resolve_markdown_assets(&cell.cell_type) {
@@ -813,31 +820,51 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
     Ok(cells.len())
 }
 
-async fn durable_or_synthetic_execution_id(
+#[derive(Debug, Clone)]
+struct LoadedExecution {
+    execution_id: String,
+    success: bool,
+}
+
+async fn durable_execution_records(
     execution_store: Option<&runtimed_client::execution_store::ExecutionStore>,
+    context_id: &str,
+) -> Vec<runtimed_client::execution_store::ExecutionRecord> {
+    match execution_store {
+        Some(store) => store.list_context("notebook", context_id).await,
+        None => Vec::new(),
+    }
+}
+
+fn durable_or_synthetic_execution(
+    durable_records: &[runtimed_client::execution_store::ExecutionRecord],
     context_id: &str,
     notebook_path: Option<&str>,
     cell_id: &str,
     source: &str,
     execution_count: Option<i64>,
     outputs: &[serde_json::Value],
-) -> String {
-    if let Some(store) = execution_store {
-        if let Some(record) = store
-            .find_matching_notebook_cell(
-                context_id,
-                notebook_path,
-                cell_id,
-                source,
-                execution_count,
-                outputs,
-            )
-            .await
-        {
-            return record.execution_id;
-        }
+) -> LoadedExecution {
+    if let Some(record) = durable_records.iter().find(|record| {
+        record.matches_notebook_cell(
+            context_id,
+            notebook_path,
+            cell_id,
+            source,
+            execution_count,
+            outputs,
+        )
+    }) {
+        return LoadedExecution {
+            execution_id: record.execution_id.clone(),
+            success: record.terminal_success(),
+        };
     }
-    uuid::Uuid::new_v4().to_string()
+
+    LoadedExecution {
+        execution_id: uuid::Uuid::new_v4().to_string(),
+        success: true,
+    }
 }
 
 /// Create a new empty notebook with a single code cell.

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -429,6 +429,7 @@ pub(crate) async fn streaming_load_cells<R, W>(
     writer: &mut W,
     room: &NotebookRoom,
     path: &Path,
+    execution_store: Option<&runtimed_client::execution_store::ExecutionStore>,
     peer_state: &mut sync::State,
 ) -> Result<usize, String>
 where
@@ -490,17 +491,37 @@ where
             batch.push((idx, cell, output_refs, resolved_assets));
         }
 
-        // Store outputs in RuntimeStateDoc with synthetic execution_ids.
-        // Collect (cell_id, synthetic_eid) pairs for linking below.
+        // Store outputs in RuntimeStateDoc with durable execution_ids when a
+        // matching terminal record exists, otherwise mint synthetic IDs.
+        // Collect (cell_id, eid) pairs for linking below.
         let mut cell_eids: HashMap<String, String> = HashMap::new();
+        let context_id = path.to_string_lossy().to_string();
+        for (_idx, cell, output_refs, _resolved_assets) in &batch {
+            if output_refs.is_empty() {
+                continue;
+            }
+            let parsed_ec = cell.execution_count.parse::<i64>().ok();
+            let eid = durable_or_synthetic_execution_id(
+                execution_store,
+                &context_id,
+                Some(&context_id),
+                &cell.id,
+                &cell.source,
+                parsed_ec,
+                output_refs,
+            )
+            .await;
+            cell_eids.insert(cell.id.clone(), eid);
+        }
         let _ = room.state.with_doc(|sd| {
             for (_idx, cell, output_refs, _resolved_assets) in &batch {
-                if !output_refs.is_empty() {
-                    let synthetic_eid = uuid::Uuid::new_v4().to_string();
-                    let _ = sd.create_execution(&synthetic_eid, &cell.id);
-                    let _ = sd.set_outputs(&synthetic_eid, output_refs);
-                    let _ = sd.set_execution_done(&synthetic_eid, true);
-                    cell_eids.insert(cell.id.clone(), synthetic_eid);
+                if let Some(eid) = cell_eids.get(&cell.id) {
+                    let _ = sd.create_execution(eid, &cell.id);
+                    let _ = sd.set_outputs(eid, output_refs);
+                    if let Ok(ec) = cell.execution_count.parse::<i64>() {
+                        let _ = sd.set_execution_count(eid, ec);
+                    }
+                    let _ = sd.set_execution_done(eid, true);
                 }
             }
             Ok(())
@@ -687,9 +708,23 @@ pub(crate) async fn load_notebook_from_disk(
 #[cfg(test)]
 pub(crate) async fn load_notebook_from_disk_with_state_doc(
     doc: &mut NotebookDoc,
+    state_doc: Option<&mut RuntimeStateDoc>,
+    path: &std::path::Path,
+    blob_store: &BlobStore,
+) -> Result<usize, String> {
+    load_notebook_from_disk_with_state_doc_and_execution_store(
+        doc, state_doc, path, blob_store, None,
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) async fn load_notebook_from_disk_with_state_doc_and_execution_store(
+    doc: &mut NotebookDoc,
     mut state_doc: Option<&mut RuntimeStateDoc>,
     path: &std::path::Path,
     blob_store: &BlobStore,
+    execution_store: Option<&runtimed_client::execution_store::ExecutionStore>,
 ) -> Result<usize, String> {
     // Read the file
     let content = tokio::fs::read_to_string(path)
@@ -731,19 +766,29 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc(
             } else {
                 Vec::new()
             };
-            let synthetic_eid = uuid::Uuid::new_v4().to_string();
+            let context_id = path.to_string_lossy().to_string();
+            let execution_id = durable_or_synthetic_execution_id(
+                execution_store,
+                &context_id,
+                Some(&context_id),
+                &cell.id,
+                &cell.source,
+                parsed_ec,
+                &output_refs,
+            )
+            .await;
             if let Some(ref mut sd) = state_doc {
-                let _ = sd.create_execution(&synthetic_eid, &cell.id);
+                let _ = sd.create_execution(&execution_id, &cell.id);
                 if has_outputs {
-                    sd.set_outputs(&synthetic_eid, &output_refs)
+                    sd.set_outputs(&execution_id, &output_refs)
                         .map_err(|e| format!("Failed to set outputs in state doc: {}", e))?;
                 }
                 if let Some(ec) = parsed_ec {
-                    let _ = sd.set_execution_count(&synthetic_eid, ec);
+                    let _ = sd.set_execution_count(&execution_id, ec);
                 }
-                let _ = sd.set_execution_done(&synthetic_eid, true);
+                let _ = sd.set_execution_done(&execution_id, true);
             }
-            doc.set_execution_id(&cell.id, Some(&synthetic_eid))
+            doc.set_execution_id(&cell.id, Some(&execution_id))
                 .map_err(|e| format!("Failed to set execution_id: {}", e))?;
         }
         if should_resolve_markdown_assets(&cell.cell_type) {
@@ -766,6 +811,33 @@ pub(crate) async fn load_notebook_from_disk_with_state_doc(
     }
 
     Ok(cells.len())
+}
+
+async fn durable_or_synthetic_execution_id(
+    execution_store: Option<&runtimed_client::execution_store::ExecutionStore>,
+    context_id: &str,
+    notebook_path: Option<&str>,
+    cell_id: &str,
+    source: &str,
+    execution_count: Option<i64>,
+    outputs: &[serde_json::Value],
+) -> String {
+    if let Some(store) = execution_store {
+        if let Some(record) = store
+            .find_matching_notebook_cell(
+                context_id,
+                notebook_path,
+                cell_id,
+                source,
+                execution_count,
+                outputs,
+            )
+            .await
+        {
+            return record.execution_id;
+        }
+    }
+    uuid::Uuid::new_v4().to_string()
 }
 
 /// Create a new empty notebook with a single code cell.

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -141,6 +141,10 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let mut state_changed_rx = room.state.subscribe();
     let execution_store =
         runtimed_client::execution_store::ExecutionStore::new(execution_store_dir);
+    let mut persisted_execution_records: std::collections::HashMap<
+        String,
+        runtimed_client::execution_store::ExecutionRecord,
+    > = std::collections::HashMap::new();
     let mut pending_replies: std::collections::HashMap<
         String,
         tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
@@ -202,7 +206,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 ).await;
                             }
                             if state_changed {
-                                persist_terminal_execution_records(&room, &execution_store).await;
+                                persist_terminal_execution_records(
+                                    &room,
+                                    &execution_store,
+                                    &mut persisted_execution_records,
+                                ).await;
                             }
                         }
                     }
@@ -1215,6 +1223,10 @@ where
 
     let mut state_peer_state = sync::State::new();
     let mut pool_peer_state = sync::State::new();
+    let mut persisted_execution_records: std::collections::HashMap<
+        String,
+        runtimed_client::execution_store::ExecutionRecord,
+    > = std::collections::HashMap::new();
 
     // Initial RuntimeStateDoc sync — encode inside lock, send outside.
     // Uses bounded generation to compact atomically if the message would exceed
@@ -1740,6 +1752,7 @@ where
                                     &runtimed_client::execution_store::ExecutionStore::new(
                                         daemon.config.execution_store_dir.clone(),
                                     ),
+                                    &mut persisted_execution_records,
                                 )
                                 .await;
 
@@ -2154,6 +2167,10 @@ async fn send_doc_sync<W: tokio::io::AsyncWrite + Unpin>(
 async fn persist_terminal_execution_records(
     room: &NotebookRoom,
     store: &runtimed_client::execution_store::ExecutionStore,
+    persisted_records: &mut std::collections::HashMap<
+        String,
+        runtimed_client::execution_store::ExecutionRecord,
+    >,
 ) {
     let notebook_path = room
         .identity
@@ -2188,11 +2205,19 @@ async fn persist_terminal_execution_records(
         .unwrap_or_default();
 
     for record in records {
-        if let Err(e) = store.write_record(record).await {
+        if persisted_records
+            .get(&record.execution_id)
+            .is_some_and(|existing| existing.payload_matches(&record))
+        {
+            continue;
+        }
+        if let Err(e) = store.write_record(record.clone()).await {
             warn!(
                 "[execution-store] Failed to persist execution record: {}",
                 e
             );
+        } else {
+            persisted_records.insert(record.execution_id.clone(), record);
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -31,6 +31,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     room: Arc<NotebookRoom>,
     notebook_id: String,
     runtime_agent_id: String,
+    execution_store_dir: PathBuf,
 ) where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send,
@@ -138,6 +139,8 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // ── 5. Sync loop ─────────────────────────────────────────────────
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
     let mut state_changed_rx = room.state.subscribe();
+    let execution_store =
+        runtimed_client::execution_store::ExecutionStore::new(execution_store_dir);
     let mut pending_replies: std::collections::HashMap<
         String,
         tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
@@ -178,11 +181,13 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     }
                     NotebookFrameType::RuntimeStateSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                            let mut state_changed = false;
                             let reply_encoded = room.state.with_doc(|sd| {
                                 if let Ok(changed) = sd.receive_sync_message_with_changes(
                                     &mut state_sync_state, msg,
                                 ) {
                                     if changed {
+                                        state_changed = true;
                                         // Notification handled by with_doc heads check
                                     }
                                 }
@@ -195,6 +200,9 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                     NotebookFrameType::RuntimeStateSync,
                                     &encoded,
                                 ).await;
+                            }
+                            if state_changed {
+                                persist_terminal_execution_records(&room, &execution_store).await;
                             }
                         }
                     }
@@ -1257,7 +1265,18 @@ where
     // frontend can observe progressive notebook-doc updates.
     if let Some(load_path) = needs_load {
         if room.try_start_loading() {
-            match streaming_load_cells(&mut reader, writer, room, load_path, &mut peer_state).await
+            let execution_store = runtimed_client::execution_store::ExecutionStore::new(
+                daemon.config.execution_store_dir.clone(),
+            );
+            match streaming_load_cells(
+                &mut reader,
+                writer,
+                room,
+                load_path,
+                Some(&execution_store),
+                &mut peer_state,
+            )
+            .await
             {
                 Ok(count) => {
                     room.finish_loading();
@@ -1716,6 +1735,14 @@ where
                                     .await?;
                                 }
 
+                                persist_terminal_execution_records(
+                                    room,
+                                    &runtimed_client::execution_store::ExecutionStore::new(
+                                        daemon.config.execution_store_dir.clone(),
+                                    ),
+                                )
+                                .await;
+
                                 if runtime_state_phase
                                     != notebook_protocol::protocol::RuntimeStatePhaseWire::Ready
                                 {
@@ -2122,4 +2149,59 @@ async fn send_doc_sync<W: tokio::io::AsyncWrite + Unpin>(
         connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded).await?;
     }
     Ok(())
+}
+
+async fn persist_terminal_execution_records(
+    room: &NotebookRoom,
+    store: &runtimed_client::execution_store::ExecutionStore,
+) {
+    let notebook_path = room
+        .identity
+        .path
+        .read()
+        .await
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string());
+    let context_id = notebook_execution_context_id(room, notebook_path.as_deref());
+    let records = room
+        .state
+        .read(|sd| {
+            sd.read_state()
+                .executions
+                .into_iter()
+                .filter_map(|(execution_id, exec)| {
+                    if !matches!(exec.status.as_str(), "done" | "error") {
+                        return None;
+                    }
+                    Some(
+                        runtimed_client::execution_store::ExecutionRecord::from_execution_state(
+                            &execution_id,
+                            "notebook",
+                            context_id.clone(),
+                            notebook_path.clone(),
+                            &exec,
+                        ),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    for record in records {
+        if let Err(e) = store.write_record(record).await {
+            warn!(
+                "[execution-store] Failed to persist execution record: {}",
+                e
+            );
+        }
+    }
+}
+
+pub(crate) fn notebook_execution_context_id(
+    room: &NotebookRoom,
+    notebook_path: Option<&str>,
+) -> String {
+    notebook_path
+        .map(str::to_string)
+        .unwrap_or_else(|| room.id.to_string())
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1928,8 +1928,8 @@ async fn test_load_notebook_reuses_matching_durable_execution_id() {
             context_id: context_id.clone(),
             notebook_path: Some(context_id.clone()),
             cell_id: Some("cell-1".to_string()),
-            status: "done".to_string(),
-            success: Some(true),
+            status: "error".to_string(),
+            success: Some(false),
             execution_count: Some(7),
             source: Some("print('hi')".to_string()),
             seq: Some(0),
@@ -1956,13 +1956,10 @@ async fn test_load_notebook_reuses_matching_durable_execution_id() {
         reload_doc.get_execution_id("cell-1").as_deref(),
         Some("durable-exec-1")
     );
-    assert_eq!(
-        reload_state
-            .get_execution("durable-exec-1")
-            .unwrap()
-            .execution_count,
-        Some(7)
-    );
+    let reloaded_execution = reload_state.get_execution("durable-exec-1").unwrap();
+    assert_eq!(reloaded_execution.execution_count, Some(7));
+    assert_eq!(reloaded_execution.status, "error");
+    assert_eq!(reloaded_execution.success, Some(false));
 }
 
 #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1872,6 +1872,177 @@ async fn test_load_notebook_from_disk_routes_outputs_through_blob_store() {
 }
 
 #[tokio::test]
+async fn test_load_notebook_reuses_matching_durable_execution_id() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+
+    let notebook_json = serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "id": "cell-1",
+                "cell_type": "code",
+                "source": "print('hi')",
+                "execution_count": 7,
+                "metadata": {},
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": "hi\n"
+                    }
+                ]
+            }
+        ]
+    });
+    let ipynb_path = tmp.path().join("durable.ipynb");
+    std::fs::write(
+        &ipynb_path,
+        serde_json::to_string_pretty(&notebook_json).unwrap(),
+    )
+    .unwrap();
+
+    let context_id = ipynb_path.to_string_lossy().to_string();
+    let mut first_doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut first_state = RuntimeStateDoc::new();
+    load_notebook_from_disk_with_state_doc(
+        &mut first_doc,
+        Some(&mut first_state),
+        &ipynb_path,
+        &blob_store,
+    )
+    .await
+    .unwrap();
+    let first_execution_id = first_doc.get_execution_id("cell-1").unwrap();
+    let outputs = first_state.get_outputs(&first_execution_id);
+
+    let store =
+        runtimed_client::execution_store::ExecutionStore::new(tmp.path().join("execution-store"));
+    store
+        .write_record(runtimed_client::execution_store::ExecutionRecord {
+            schema_version: runtimed_client::execution_store::EXECUTION_RECORD_SCHEMA_VERSION,
+            execution_id: "durable-exec-1".to_string(),
+            context_kind: "notebook".to_string(),
+            context_id: context_id.clone(),
+            notebook_path: Some(context_id.clone()),
+            cell_id: Some("cell-1".to_string()),
+            status: "done".to_string(),
+            success: Some(true),
+            execution_count: Some(7),
+            source: Some("print('hi')".to_string()),
+            seq: Some(0),
+            outputs,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let mut reload_doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut reload_state = RuntimeStateDoc::new();
+    load_notebook_from_disk_with_state_doc_and_execution_store(
+        &mut reload_doc,
+        Some(&mut reload_state),
+        &ipynb_path,
+        &blob_store,
+        Some(&store),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        reload_doc.get_execution_id("cell-1").as_deref(),
+        Some("durable-exec-1")
+    );
+    assert_eq!(
+        reload_state
+            .get_execution("durable-exec-1")
+            .unwrap()
+            .execution_count,
+        Some(7)
+    );
+}
+
+#[tokio::test]
+async fn test_load_notebook_mints_execution_id_when_durable_record_no_longer_matches() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+
+    let notebook_json = serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "id": "cell-1",
+                "cell_type": "code",
+                "source": "print('changed externally')",
+                "execution_count": 7,
+                "metadata": {},
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": "hi\n"
+                    }
+                ]
+            }
+        ]
+    });
+    let ipynb_path = tmp.path().join("changed.ipynb");
+    std::fs::write(
+        &ipynb_path,
+        serde_json::to_string_pretty(&notebook_json).unwrap(),
+    )
+    .unwrap();
+
+    let context_id = ipynb_path.to_string_lossy().to_string();
+    let store =
+        runtimed_client::execution_store::ExecutionStore::new(tmp.path().join("execution-store"));
+    store
+        .write_record(runtimed_client::execution_store::ExecutionRecord {
+            schema_version: runtimed_client::execution_store::EXECUTION_RECORD_SCHEMA_VERSION,
+            execution_id: "durable-exec-1".to_string(),
+            context_kind: "notebook".to_string(),
+            context_id: context_id.clone(),
+            notebook_path: Some(context_id.clone()),
+            cell_id: Some("cell-1".to_string()),
+            status: "done".to_string(),
+            success: Some(true),
+            execution_count: Some(7),
+            source: Some("print('hi')".to_string()),
+            seq: Some(0),
+            outputs: vec![serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": {"inline": "hi\n"}
+            })],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    let mut doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut state_doc = RuntimeStateDoc::new();
+    load_notebook_from_disk_with_state_doc_and_execution_store(
+        &mut doc,
+        Some(&mut state_doc),
+        &ipynb_path,
+        &blob_store,
+        Some(&store),
+    )
+    .await
+    .unwrap();
+
+    let execution_id = doc.get_execution_id("cell-1").unwrap();
+    assert_ne!(execution_id, "durable-exec-1");
+    assert!(state_doc.get_execution(&execution_id).is_some());
+}
+
+#[tokio::test]
 async fn test_load_notebook_from_disk_resolves_nbformat_attachments() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -33,7 +33,7 @@ impl DaemonLock {
     /// instead of the default. This is primarily for testing.
     pub fn try_acquire(
         custom_lock_dir: Option<&PathBuf>,
-    ) -> Result<Self, client_singleton::DaemonInfo> {
+    ) -> Result<Self, Box<client_singleton::DaemonInfo>> {
         let (lock_path, info_path) = if let Some(dir) = custom_lock_dir {
             (dir.join("daemon.lock"), dir.join("daemon.json"))
         } else {
@@ -60,10 +60,10 @@ impl DaemonLock {
                 warn!("[singleton] Failed to open lock file: {}", e);
                 // Try to read existing daemon info
                 if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(info);
+                    return Err(Box::new(info));
                 }
                 // No info available, create a placeholder
-                return Err(client_singleton::DaemonInfo {
+                return Err(Box::new(client_singleton::DaemonInfo {
                     endpoint: "unknown".to_string(),
                     pid: 0,
                     version: "unknown".to_string(),
@@ -72,7 +72,7 @@ impl DaemonLock {
                     execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
-                });
+                }));
             }
         };
 
@@ -86,9 +86,9 @@ impl DaemonLock {
                 // Another process holds the lock
                 info!("[singleton] Another daemon is already running");
                 if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(info);
+                    return Err(Box::new(info));
                 }
-                return Err(client_singleton::DaemonInfo {
+                return Err(Box::new(client_singleton::DaemonInfo {
                     endpoint: "unknown".to_string(),
                     pid: 0,
                     version: "unknown".to_string(),
@@ -97,7 +97,7 @@ impl DaemonLock {
                     execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
-                });
+                }));
             }
         }
 
@@ -125,9 +125,9 @@ impl DaemonLock {
             if result == 0 {
                 info!("[singleton] Another daemon is already running");
                 if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(info);
+                    return Err(Box::new(info));
                 }
-                return Err(client_singleton::DaemonInfo {
+                return Err(Box::new(client_singleton::DaemonInfo {
                     endpoint: "unknown".to_string(),
                     pid: 0,
                     version: "unknown".to_string(),
@@ -136,7 +136,7 @@ impl DaemonLock {
                     execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
-                });
+                }));
             }
         }
 

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -69,6 +69,7 @@ impl DaemonLock {
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
                     blob_port: None,
+                    execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
                 });
@@ -93,6 +94,7 @@ impl DaemonLock {
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
                     blob_port: None,
+                    execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
                 });
@@ -131,6 +133,7 @@ impl DaemonLock {
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
                     blob_port: None,
+                    execution_store_dir: None,
                     worktree_path: None,
                     workspace_description: None,
                 });
@@ -164,6 +167,11 @@ impl DaemonLock {
             version: crate::daemon_version().to_string(),
             started_at: Utc::now(),
             blob_port,
+            execution_store_dir: Some(
+                crate::default_execution_store_dir()
+                    .to_string_lossy()
+                    .to_string(),
+            ),
             worktree_path,
             workspace_description,
         };

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -78,6 +78,7 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         socket_path,
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
+        execution_store_dir: temp_dir.path().join("executions"),
         notebook_docs_dir: temp_dir.path().join("notebook-docs"),
         uv_pool_size: 0, // Don't create real envs in tests
         conda_pool_size: 0,
@@ -294,6 +295,7 @@ async fn test_singleton_prevents_second_daemon() {
         socket_path: socket_path.clone(),
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
+        execution_store_dir: temp_dir.path().join("executions"),
         notebook_docs_dir: temp_dir.path().join("notebook-docs"),
         uv_pool_size: 0,
         conda_pool_size: 0,

--- a/crates/sift-wasm/pkg/sift_wasm_bg.wasm
+++ b/crates/sift-wasm/pkg/sift_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3999ca4a96b755cc726f5f57ca817edd9e7311a2349b33c93e60aace318bc186
+oid sha256:f0f98461ba6208ad3e3b49280b5bac176fb5f4436c29a9ff3268590467134f0a
 size 6806028


### PR DESCRIPTION
## Summary
- add a daemon-owned durable execution store for terminal execution snapshots
- expose execution_store_dir through daemon info and wire runt-mcp to read it
- make get_results(execution_id) fall back to durable records after room eviction or reconnect
- reuse matching durable execution IDs when loading saved notebook outputs
- mark durable execution blob refs during GC and prune records on the existing 30-day retention window

Refs #2263

## Verification
- cargo fmt
- git diff --check
- cargo test -p runtimed-client execution_store --lib
- cargo test -p runt-mcp get_results_ --lib
- cargo test -p runtimed durable --lib
- cargo test -p runtimed execution_store_gc --lib
- cargo check -p runt