### PR TITLE
feat(outputs): add passive output well

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -18,3 +18,8 @@ command = "RUNTIMED_DEV=1 RUST_LOG=debug cargo xtask dev-daemon --release"
 name = "Daemon Status"
 icon = "tool"
 command = "./target/debug/runt daemon status"
+
+[[actions]]
+name = "Notebook App"
+icon = "tool"
+command = "RUNTIMED_DEV=1 RUST_LOG=debug cargo xtask dev"

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,11 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff } from "lucide-react";
+import {
+  ChevronRight,
+  Code2,
+  EyeOff,
+  SquareDashedMousePointer,
+  SquareMousePointer,
+} from "lucide-react";
 import {
   lazy,
   memo,
@@ -13,7 +19,7 @@ import {
 } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
-import { OutputArea } from "@/components/cell/OutputArea";
+import { anyOutputNeedsIsolation, OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -115,12 +121,14 @@ export const CodeCell = memo(function CodeCell({
   const isGroupExecuting = useIsGroupExecuting(hiddenGroupCellIds);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+  const [isOutputWellInteractive, setIsOutputWellInteractive] = useState(false);
   const presence = usePresenceContext();
   const { extension: crdtBridgeExt, bridge } = useCrdtBridge(cell.id);
   // Subscribe to outputs via the per-execution / per-output stores rather
   // than `cell.outputs`. Content changes no longer invalidate the cell
   // snapshot — CodeCell re-renders only when its chrome state changes.
   const outputs = useCellOutputs(cell.id);
+  const hasInteractiveOutputWell = anyOutputNeedsIsolation(outputs);
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -131,6 +139,12 @@ export const CodeCell = memo(function CodeCell({
   // Fully collapsed when source is hidden AND there's nothing else to show
   // (outputs explicitly hidden, or no outputs at all).
   const bothHidden = isSourceHidden && (isOutputsHidden || outputs.length === 0);
+
+  useEffect(() => {
+    if (!hasInteractiveOutputWell || isOutputsHidden || outputs.length === 0) {
+      setIsOutputWellInteractive(false);
+    }
+  }, [hasInteractiveOutputWell, isOutputsHidden, outputs.length]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -384,20 +398,57 @@ export const CodeCell = memo(function CodeCell({
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
               onIframeMouseDown={onFocus}
+              iframeInteractive={isOutputWellInteractive}
+              onIframeInteractiveChange={setIsOutputWellInteractive}
             />
           )
         }
         outputRightGutterContent={
-          onToggleOutputsHidden && outputs.length > 0 && !isOutputsHidden ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => onToggleOutputsHidden(true)}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
-              title="Hide outputs"
-            >
-              <EyeOff className="h-3.5 w-3.5" />
-            </button>
+          outputs.length > 0 && !isOutputsHidden ? (
+            <>
+              {hasInteractiveOutputWell && (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-pressed={isOutputWellInteractive}
+                  onClick={() => {
+                    const nextInteractive = !isOutputWellInteractive;
+                    if (nextInteractive) {
+                      onFocus();
+                    }
+                    setIsOutputWellInteractive(nextInteractive);
+                  }}
+                  className={cn(
+                    "flex items-center justify-center rounded border p-1 transition-colors",
+                    isOutputWellInteractive
+                      ? "border-ring/40 bg-accent text-foreground"
+                      : "border-transparent text-muted-foreground/40 hover:text-foreground",
+                  )}
+                  title={
+                    isOutputWellInteractive
+                      ? "Output is interactive"
+                      : "Click to interact with output"
+                  }
+                >
+                  {isOutputWellInteractive ? (
+                    <SquareMousePointer className="h-3.5 w-3.5" />
+                  ) : (
+                    <SquareDashedMousePointer className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              )}
+              {onToggleOutputsHidden && (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={() => onToggleOutputsHidden(true)}
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+                  title="Hide outputs"
+                >
+                  <EyeOff className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </>
           ) : undefined
         }
         hideOutput={outputs.length === 0 || bothHidden}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -307,6 +307,7 @@ export const CodeCell = memo(function CodeCell({
         presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
+        isOutputActive={isOutputWellInteractive}
         codeContent={
           <>
             {/* Source visibility toggle + Editor */}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -19,7 +19,7 @@ import {
 } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
-import { anyOutputNeedsIsolation, OutputArea } from "@/components/cell/OutputArea";
+import { outputNeedsWell, OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -128,7 +128,7 @@ export const CodeCell = memo(function CodeCell({
   // than `cell.outputs`. Content changes no longer invalidate the cell
   // snapshot — CodeCell re-renders only when its chrome state changes.
   const outputs = useCellOutputs(cell.id);
-  const hasInteractiveOutputWell = anyOutputNeedsIsolation(outputs);
+  const hasOutputWell = outputNeedsWell(outputs);
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -141,10 +141,10 @@ export const CodeCell = memo(function CodeCell({
   const bothHidden = isSourceHidden && (isOutputsHidden || outputs.length === 0);
 
   useEffect(() => {
-    if (!hasInteractiveOutputWell || isOutputsHidden || outputs.length === 0) {
+    if (!hasOutputWell || isOutputsHidden || outputs.length === 0) {
       setIsOutputWellInteractive(false);
     }
-  }, [hasInteractiveOutputWell, isOutputsHidden, outputs.length]);
+  }, [hasOutputWell, isOutputsHidden, outputs.length]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -398,15 +398,15 @@ export const CodeCell = memo(function CodeCell({
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
               onIframeMouseDown={onFocus}
-              iframeInteractive={isOutputWellInteractive}
-              onIframeInteractiveChange={setIsOutputWellInteractive}
+              outputWellInteractive={isOutputWellInteractive}
+              onOutputWellInteractiveChange={setIsOutputWellInteractive}
             />
           )
         }
         outputRightGutterContent={
           outputs.length > 0 && !isOutputsHidden ? (
             <>
-              {hasInteractiveOutputWell && (
+              {hasOutputWell && (
                 <button
                   type="button"
                   tabIndex={-1}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -21,6 +21,8 @@ interface CellContainerProps {
   rightGutterContent?: ReactNode;
   /** Content to render in the right margin aligned with output row (e.g., output controls) */
   outputRightGutterContent?: ReactNode;
+  /** Whether the output row has active user interaction focus. */
+  isOutputActive?: boolean;
   /** Remote peer presence indicators (colored dots showing who's on this cell) */
   presenceIndicators?: ReactNode;
   /** Custom color configuration for cell types not in defaults */
@@ -50,6 +52,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       gutterContent,
       rightGutterContent,
       outputRightGutterContent,
+      isOutputActive = false,
       presenceIndicators,
       customGutterColors,
       isPreviousCellFromFocused = false,
@@ -62,8 +65,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
   ) => {
     const colors = getGutterColors(cellType, customGutterColors);
     const ribbonColor = isFocused ? colors.ribbon.focused : colors.ribbon.default;
-    const outputRibbonColor = isFocused ? colors.outputRibbon.focused : colors.outputRibbon.default;
+    const outputRibbonColor =
+      isFocused || isOutputActive ? colors.outputRibbon.focused : colors.outputRibbon.default;
     const bgColor = isFocused ? colors.background.focused : undefined;
+    const outputBgColor = isOutputActive ? colors.background.focused : undefined;
 
     // Use segmented ribbon when codeContent is provided
     const useSegmentedRibbon = codeContent !== undefined;
@@ -122,7 +127,16 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             {/* Output row - ribbon + content + right gutter
                 onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
-              <div className={cn("flex", hideOutput && "hidden")} onMouseDown={onFocus}>
+              <div
+                className={cn(
+                  "flex transition-colors duration-150",
+                  outputBgColor,
+                  isOutputActive && "-mx-16 px-16",
+                  hideOutput && "hidden",
+                )}
+                data-output-active={isOutputActive ? "true" : "false"}
+                onMouseDown={onFocus}
+              >
                 <div className={cn("w-1 transition-colors duration-150", outputRibbonColor)} />
                 <div
                   className={cn(

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -104,21 +104,35 @@ interface OutputAreaProps {
    */
   onIframeMouseDown?: () => void;
   /**
-   * Controlled interaction state for isolated output iframes.
-   * When false, the iframe is visible but pointer-inert so page scrolling wins.
+   * Controlled interaction state for bounded output wells.
+   * When false, the output is visible but pointer-inert so page scrolling wins.
    */
-  iframeInteractive?: boolean;
+  outputWellInteractive?: boolean;
   /**
-   * Callback when the isolated output iframe interaction state changes.
+   * Callback when the bounded output well interaction state changes.
    */
-  onIframeInteractiveChange?: (interactive: boolean) => void;
+  onOutputWellInteractiveChange?: (interactive: boolean) => void;
 }
+
+const LARGE_IN_DOM_OUTPUT_CHAR_THRESHOLD = 8_000;
+const LARGE_IN_DOM_OUTPUT_LINE_THRESHOLD = 120;
 
 /**
  * Normalize stream text (can be string or string array).
  */
 function normalizeText(text: string | string[]): string {
   return Array.isArray(text) ? text.join("") : text;
+}
+
+function countLines(text: string): number {
+  return text.length === 0 ? 0 : text.split(/\r\n|\r|\n/).length;
+}
+
+function textExceedsOutputWellThreshold(text: string): boolean {
+  return (
+    text.length >= LARGE_IN_DOM_OUTPUT_CHAR_THRESHOLD ||
+    countLines(text) >= LARGE_IN_DOM_OUTPUT_LINE_THRESHOLD
+  );
 }
 
 /**
@@ -163,6 +177,30 @@ export function anyOutputNeedsIsolation(
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {
   return outputs.some((output) => outputNeedsIsolation(output, priority));
+}
+
+function outputNeedsBoundedInDomWell(output: JupyterOutput): boolean {
+  if (output.output_type === "stream") {
+    return textExceedsOutputWellThreshold(normalizeText(output.text));
+  }
+
+  if (output.output_type === "error") {
+    return textExceedsOutputWellThreshold(output.traceback.join("\n"));
+  }
+
+  const plain = output.data["text/plain"];
+  return typeof plain === "string" && textExceedsOutputWellThreshold(plain);
+}
+
+function anyOutputNeedsBoundedInDomWell(outputs: JupyterOutput[]): boolean {
+  return outputs.some(outputNeedsBoundedInDomWell);
+}
+
+export function outputNeedsWell(
+  outputs: JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return anyOutputNeedsIsolation(outputs, priority) || anyOutputNeedsBoundedInDomWell(outputs);
 }
 
 /**
@@ -265,15 +303,15 @@ export function OutputArea({
   searchQuery,
   onSearchMatchCount,
   onIframeMouseDown,
-  iframeInteractive,
-  onIframeInteractiveChange,
+  outputWellInteractive,
+  onOutputWellInteractiveChange,
 }: OutputAreaProps) {
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
   const outputWellRef = useRef<HTMLDivElement>(null);
-  const [uncontrolledIframeInteractive, setUncontrolledIframeInteractive] = useState(false);
+  const [uncontrolledOutputWellInteractive, setUncontrolledOutputWellInteractive] = useState(false);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
@@ -298,19 +336,21 @@ export function OutputArea({
   const shouldIsolate =
     outputs.length > 0 &&
     (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
+  const needsBoundedInDomWell = !shouldIsolate && anyOutputNeedsBoundedInDomWell(outputs);
 
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
-  const isIframeInteractive = iframeInteractive ?? uncontrolledIframeInteractive;
-  const setIframeInteractive = useCallback(
+  const hasOutputWell = shouldIsolate || needsBoundedInDomWell;
+  const isOutputWellInteractive = outputWellInteractive ?? uncontrolledOutputWellInteractive;
+  const setOutputWellInteractive = useCallback(
     (interactive: boolean) => {
-      if (iframeInteractive === undefined) {
-        setUncontrolledIframeInteractive(interactive);
+      if (outputWellInteractive === undefined) {
+        setUncontrolledOutputWellInteractive(interactive);
       }
-      onIframeInteractiveChange?.(interactive);
+      onOutputWellInteractiveChange?.(interactive);
     },
-    [iframeInteractive, onIframeInteractiveChange],
+    [outputWellInteractive, onOutputWellInteractiveChange],
   );
 
   // Check if we have widgets and should set up comm bridge
@@ -534,24 +574,24 @@ export function OutputArea({
   const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
 
   useEffect(() => {
-    if (!shouldIsolate || collapsed || isPreloadOnly) {
-      setIframeInteractive(false);
+    if (!hasOutputWell || collapsed || isPreloadOnly) {
+      setOutputWellInteractive(false);
     }
-  }, [collapsed, isPreloadOnly, setIframeInteractive, shouldIsolate]);
+  }, [collapsed, hasOutputWell, isPreloadOnly, setOutputWellInteractive]);
 
   useEffect(() => {
-    if (!isIframeInteractive) {
+    if (!isOutputWellInteractive) {
       return;
     }
 
     const handlePointerDown = (event: PointerEvent) => {
       if (!outputWellRef.current?.contains(event.target as Node | null)) {
-        setIframeInteractive(false);
+        setOutputWellInteractive(false);
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setIframeInteractive(false);
+        setOutputWellInteractive(false);
       }
     };
 
@@ -561,12 +601,12 @@ export function OutputArea({
       window.removeEventListener("pointerdown", handlePointerDown, true);
       window.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [isIframeInteractive, setIframeInteractive]);
+  }, [isOutputWellInteractive, setOutputWellInteractive]);
 
   const activateOutputWell = useCallback(() => {
     onIframeMouseDown?.();
-    setIframeInteractive(true);
-  }, [onIframeMouseDown, setIframeInteractive]);
+    setOutputWellInteractive(true);
+  }, [onIframeMouseDown, setOutputWellInteractive]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -612,10 +652,10 @@ export function OutputArea({
             <div
               ref={outputWellRef}
               data-slot="output-well"
-              data-interactive={isIframeInteractive ? "true" : "false"}
+              data-interactive={isOutputWellInteractive ? "true" : "false"}
               className={cn(
                 "relative rounded-sm ring-1 ring-transparent transition-shadow",
-                isIframeInteractive && "ring-ring/60",
+                isOutputWellInteractive && "ring-ring/60",
                 shouldIsolate ? undefined : "hidden",
               )}
             >
@@ -625,7 +665,7 @@ export function OutputArea({
                 colorTheme={colorTheme}
                 minHeight={24}
                 maxHeight={maxHeight ?? 2000}
-                className={cn(!isIframeInteractive && "pointer-events-none")}
+                className={cn(!isOutputWellInteractive && "pointer-events-none")}
                 allowWheelBoundaryScroll={false}
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}
@@ -634,11 +674,11 @@ export function OutputArea({
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}
               />
-              {shouldIsolate && !isIframeInteractive && (
+              {shouldIsolate && !isOutputWellInteractive && (
                 <button
                   type="button"
                   data-slot="output-well-activator"
-                  aria-label="Activate interactive output"
+                  aria-label="Activate output well"
                   className="absolute inset-0 z-10 cursor-default bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   onClick={activateOutputWell}
                 />
@@ -648,32 +688,60 @@ export function OutputArea({
 
           {/* In-DOM outputs (when not using isolation) */}
           {!shouldIsolate && (
-            <div ref={inDomOutputRef}>
-              {outputs.map((output, index) => {
-                // Prefer daemon-stamped output_id for stable React keys so a
-                // stream append doesn't re-mount sibling outputs. Fall back
-                // to positional when a render path skipped the id.
-                const key = output.output_id ?? `output-${index}`;
-                return (
-                  <div key={key} data-slot="output-item" data-output-index={index}>
-                    <ErrorBoundary
-                      resetKeys={[output]}
-                      fallback={(error, reset) => (
-                        <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
-                      )}
-                      onError={(error, errorInfo) => {
-                        console.error(
-                          `[OutputArea] Error rendering output ${index}:`,
-                          error,
-                          errorInfo.componentStack,
-                        );
-                      }}
-                    >
-                      {renderOutput(output, index, renderers, priority)}
-                    </ErrorBoundary>
-                  </div>
-                );
-              })}
+            <div
+              ref={needsBoundedInDomWell ? outputWellRef : undefined}
+              data-slot={needsBoundedInDomWell ? "output-well" : undefined}
+              data-interactive={
+                needsBoundedInDomWell ? (isOutputWellInteractive ? "true" : "false") : undefined
+              }
+              className={cn(
+                needsBoundedInDomWell &&
+                  "relative rounded-sm ring-1 ring-transparent transition-shadow",
+                needsBoundedInDomWell && isOutputWellInteractive && "ring-ring/60",
+              )}
+            >
+              <div
+                ref={inDomOutputRef}
+                className={cn(
+                  needsBoundedInDomWell && "max-h-[420px] overflow-y-auto overscroll-contain pr-2",
+                  needsBoundedInDomWell && !isOutputWellInteractive && "pointer-events-none",
+                )}
+              >
+                {outputs.map((output, index) => {
+                  // Prefer daemon-stamped output_id for stable React keys so a
+                  // stream append doesn't re-mount sibling outputs. Fall back
+                  // to positional when a render path skipped the id.
+                  const key = output.output_id ?? `output-${index}`;
+                  return (
+                    <div key={key} data-slot="output-item" data-output-index={index}>
+                      <ErrorBoundary
+                        resetKeys={[output]}
+                        fallback={(error, reset) => (
+                          <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
+                        )}
+                        onError={(error, errorInfo) => {
+                          console.error(
+                            `[OutputArea] Error rendering output ${index}:`,
+                            error,
+                            errorInfo.componentStack,
+                          );
+                        }}
+                      >
+                        {renderOutput(output, index, renderers, priority)}
+                      </ErrorBoundary>
+                    </div>
+                  );
+                })}
+              </div>
+              {needsBoundedInDomWell && !isOutputWellInteractive && (
+                <button
+                  type="button"
+                  data-slot="output-well-activator"
+                  aria-label="Activate output well"
+                  className="absolute inset-0 z-10 cursor-default bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  onClick={activateOutputWell}
+                />
+              )}
             </div>
           )}
         </div>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   CommBridgeManager,
   type IframeToParentMessage,
@@ -261,6 +261,8 @@ export function OutputArea({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
+  const outputWellRef = useRef<HTMLDivElement>(null);
+  const [isIframeInteractive, setIsIframeInteractive] = useState(false);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
@@ -507,13 +509,39 @@ export function OutputArea({
     return cleanup;
   }, [searchQuery, shouldIsolate, outputs, onSearchMatchCount]);
 
+  // Hide the entire output area when only preloading (no visible outputs)
+  const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
+
+  useEffect(() => {
+    if (!shouldIsolate || collapsed || isPreloadOnly) {
+      setIsIframeInteractive(false);
+    }
+  }, [collapsed, isPreloadOnly, shouldIsolate]);
+
+  useEffect(() => {
+    if (!isIframeInteractive) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!outputWellRef.current?.contains(event.target as Node | null)) {
+        setIsIframeInteractive(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    return () => window.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [isIframeInteractive]);
+
+  const activateOutputWell = useCallback(() => {
+    onIframeMouseDown?.();
+    setIsIframeInteractive(true);
+  }, [onIframeMouseDown]);
+
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
     return null;
   }
-
-  // Hide the entire output area when only preloading (no visible outputs)
-  const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
 
   // pl-6 pr-3 matches the code editor row padding so outputs align
   // flush with the editor content. The CellContainer output wrapper
@@ -551,13 +579,20 @@ export function OutputArea({
         >
           {/* Preloaded or active isolated frame */}
           {(shouldIsolate || showPreloadedIframe) && (
-            <div className={shouldIsolate ? undefined : "hidden"}>
+            <div
+              ref={outputWellRef}
+              data-slot="output-well"
+              data-interactive={isIframeInteractive ? "true" : "false"}
+              className={cn("relative", shouldIsolate ? undefined : "hidden")}
+            >
               <IsolatedFrame
                 ref={frameRef}
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 minHeight={24}
                 maxHeight={maxHeight ?? 2000}
+                className={cn(!isIframeInteractive && "pointer-events-none")}
+                allowWheelBoundaryScroll={false}
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}
                 onMouseDown={onIframeMouseDown}
@@ -565,6 +600,15 @@ export function OutputArea({
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}
               />
+              {shouldIsolate && !isIframeInteractive && (
+                <button
+                  type="button"
+                  data-slot="output-well-activator"
+                  aria-label="Activate interactive output"
+                  className="absolute inset-0 z-10 cursor-default bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  onClick={activateOutputWell}
+                />
+              )}
             </div>
           )}
 

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -103,6 +103,15 @@ interface OutputAreaProps {
    * Use to update cell focus when the click is captured by the iframe.
    */
   onIframeMouseDown?: () => void;
+  /**
+   * Controlled interaction state for isolated output iframes.
+   * When false, the iframe is visible but pointer-inert so page scrolling wins.
+   */
+  iframeInteractive?: boolean;
+  /**
+   * Callback when the isolated output iframe interaction state changes.
+   */
+  onIframeInteractiveChange?: (interactive: boolean) => void;
 }
 
 /**
@@ -149,7 +158,7 @@ function outputNeedsIsolation(
  * Check if any outputs in the array need iframe isolation.
  * If any output needs isolation, ALL outputs should go to the iframe.
  */
-function anyOutputNeedsIsolation(
+export function anyOutputNeedsIsolation(
   outputs: JupyterOutput[],
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {
@@ -256,13 +265,15 @@ export function OutputArea({
   searchQuery,
   onSearchMatchCount,
   onIframeMouseDown,
+  iframeInteractive,
+  onIframeInteractiveChange,
 }: OutputAreaProps) {
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
   const outputWellRef = useRef<HTMLDivElement>(null);
-  const [isIframeInteractive, setIsIframeInteractive] = useState(false);
+  const [uncontrolledIframeInteractive, setUncontrolledIframeInteractive] = useState(false);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
@@ -291,6 +302,16 @@ export function OutputArea({
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
+  const isIframeInteractive = iframeInteractive ?? uncontrolledIframeInteractive;
+  const setIframeInteractive = useCallback(
+    (interactive: boolean) => {
+      if (iframeInteractive === undefined) {
+        setUncontrolledIframeInteractive(interactive);
+      }
+      onIframeInteractiveChange?.(interactive);
+    },
+    [iframeInteractive, onIframeInteractiveChange],
+  );
 
   // Check if we have widgets and should set up comm bridge
   const hasWidgets = hasWidgetOutputs(outputs, priority);
@@ -514,9 +535,9 @@ export function OutputArea({
 
   useEffect(() => {
     if (!shouldIsolate || collapsed || isPreloadOnly) {
-      setIsIframeInteractive(false);
+      setIframeInteractive(false);
     }
-  }, [collapsed, isPreloadOnly, shouldIsolate]);
+  }, [collapsed, isPreloadOnly, setIframeInteractive, shouldIsolate]);
 
   useEffect(() => {
     if (!isIframeInteractive) {
@@ -525,18 +546,27 @@ export function OutputArea({
 
     const handlePointerDown = (event: PointerEvent) => {
       if (!outputWellRef.current?.contains(event.target as Node | null)) {
-        setIsIframeInteractive(false);
+        setIframeInteractive(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIframeInteractive(false);
       }
     };
 
     window.addEventListener("pointerdown", handlePointerDown, true);
-    return () => window.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [isIframeInteractive]);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isIframeInteractive, setIframeInteractive]);
 
   const activateOutputWell = useCallback(() => {
     onIframeMouseDown?.();
-    setIsIframeInteractive(true);
-  }, [onIframeMouseDown]);
+    setIframeInteractive(true);
+  }, [onIframeMouseDown, setIframeInteractive]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -583,7 +613,11 @@ export function OutputArea({
               ref={outputWellRef}
               data-slot="output-well"
               data-interactive={isIframeInteractive ? "true" : "false"}
-              className={cn("relative", shouldIsolate ? undefined : "hidden")}
+              className={cn(
+                "relative rounded-sm ring-1 ring-transparent transition-shadow",
+                isIframeInteractive && "ring-ring/60",
+                shouldIsolate ? undefined : "hidden",
+              )}
             >
               <IsolatedFrame
                 ref={frameRef}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -692,7 +692,7 @@ export function OutputArea({
               }
               className={cn(
                 needsBoundedInDomWell && "relative border-y border-border/50 transition-colors",
-                needsBoundedInDomWell && isOutputWellInteractive && "border-ring/50",
+                needsBoundedInDomWell && isOutputWellInteractive && "border-border/70",
               )}
             >
               <div

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -653,11 +653,7 @@ export function OutputArea({
               ref={outputWellRef}
               data-slot="output-well"
               data-interactive={isOutputWellInteractive ? "true" : "false"}
-              className={cn(
-                "relative rounded-sm ring-1 ring-transparent transition-shadow",
-                isOutputWellInteractive && "ring-ring/60",
-                shouldIsolate ? undefined : "hidden",
-              )}
+              className={cn("relative", shouldIsolate ? undefined : "hidden")}
             >
               <IsolatedFrame
                 ref={frameRef}
@@ -695,9 +691,8 @@ export function OutputArea({
                 needsBoundedInDomWell ? (isOutputWellInteractive ? "true" : "false") : undefined
               }
               className={cn(
-                needsBoundedInDomWell &&
-                  "relative rounded-sm ring-1 ring-transparent transition-shadow",
-                needsBoundedInDomWell && isOutputWellInteractive && "ring-ring/60",
+                needsBoundedInDomWell && "relative border-y border-border/50 transition-colors",
+                needsBoundedInDomWell && isOutputWellInteractive && "border-ring/50",
               )}
             >
               <div

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -32,17 +32,24 @@ vi.mock("@/components/isolated/iframe-libraries", () => ({
 vi.mock("@/components/isolated", async () => {
   const React = await import("react");
 
-  const MockIsolatedFrame = React.forwardRef<typeof mockFrameHandle, { onReady?: () => void }>(
-    function MockIsolatedFrame({ onReady }, ref) {
-      React.useImperativeHandle(ref, () => mockFrameHandle);
+  const MockIsolatedFrame = React.forwardRef<
+    typeof mockFrameHandle,
+    { allowWheelBoundaryScroll?: boolean; className?: string; onReady?: () => void }
+  >(function MockIsolatedFrame({ allowWheelBoundaryScroll, className, onReady }, ref) {
+    React.useImperativeHandle(ref, () => mockFrameHandle);
 
-      React.useEffect(() => {
-        onReady?.();
-      }, [onReady]);
+    React.useEffect(() => {
+      onReady?.();
+    }, [onReady]);
 
-      return <div data-testid="isolated-frame" />;
-    },
-  );
+    return (
+      <div
+        className={className}
+        data-allow-wheel-boundary-scroll={String(allowWheelBoundaryScroll)}
+        data-testid="isolated-frame"
+      />
+    );
+  });
 
   return {
     CommBridgeManager: class CommBridgeManager {},
@@ -60,7 +67,7 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
   ];
 }
 
-describe("OutputArea iframe theme sync", () => {
+describe("OutputArea isolated iframe", () => {
   beforeEach(() => {
     mockDarkMode = false;
     mockColorTheme = undefined;
@@ -106,5 +113,26 @@ describe("OutputArea iframe theme sync", () => {
     await waitFor(() => {
       expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, null);
     });
+  });
+
+  it("keeps isolated output iframes passive until the output well is activated", async () => {
+    const onIframeMouseDown = vi.fn();
+
+    render(
+      <OutputArea outputs={makeMarkdownOutput()} isolated onIframeMouseDown={onIframeMouseDown} />,
+    );
+
+    const frame = screen.getByTestId("isolated-frame");
+    expect(frame.getAttribute("class") ?? "").toContain("pointer-events-none");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+
+    const activator = screen.getByRole("button", { name: "Activate interactive output" });
+    fireEvent.click(activator);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Activate interactive output" })).toBeNull();
+    });
+    expect(frame.getAttribute("class") ?? "").not.toContain("pointer-events-none");
+    expect(onIframeMouseDown).toHaveBeenCalled();
   });
 });

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -67,7 +67,17 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
   ];
 }
 
-describe("OutputArea isolated iframe", () => {
+function makeLargeStreamOutput(): JupyterOutput[] {
+  return [
+    {
+      output_type: "stream",
+      name: "stdout",
+      text: Array.from({ length: 160 }, (_, index) => `log line ${index}`).join("\n"),
+    },
+  ];
+}
+
+describe("OutputArea output well", () => {
   beforeEach(() => {
     mockDarkMode = false;
     mockColorTheme = undefined;
@@ -126,13 +136,33 @@ describe("OutputArea isolated iframe", () => {
     expect(frame.getAttribute("class") ?? "").toContain("pointer-events-none");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
 
-    const activator = screen.getByRole("button", { name: "Activate interactive output" });
+    const activator = screen.getByRole("button", { name: "Activate output well" });
     fireEvent.click(activator);
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Activate interactive output" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Activate output well" })).toBeNull();
     });
     expect(frame.getAttribute("class") ?? "").not.toContain("pointer-events-none");
     expect(onIframeMouseDown).toHaveBeenCalled();
+  });
+
+  it("bounds large in-DOM stream outputs behind the same output well", async () => {
+    const onOutputWellInteractiveChange = vi.fn();
+    const { container } = render(
+      <OutputArea
+        outputs={makeLargeStreamOutput()}
+        outputWellInteractive={false}
+        onOutputWellInteractiveChange={onOutputWellInteractiveChange}
+      />,
+    );
+
+    const outputWell = container.querySelector('[data-slot="output-well"]');
+    expect(outputWell?.getAttribute("data-interactive")).toBe("false");
+    expect(container.querySelector('[data-slot="isolated-frame"]')).toBeNull();
+    expect(container.querySelector(".max-h-\\[420px\\]")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Activate output well" }));
+
+    expect(onOutputWellInteractiveChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -86,6 +86,13 @@ export interface IsolatedFrameProps {
   className?: string;
 
   /**
+   * When true, wheel events that reach a scroll boundary inside the iframe
+   * are forwarded to the nearest scrollable parent.
+   * @default true
+   */
+  allowWheelBoundaryScroll?: boolean;
+
+  /**
    * Callback when the iframe is ready to receive messages.
    */
   onReady?: () => void;
@@ -276,6 +283,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       maxHeight = 2000,
       autoHeight = false,
       className = "",
+      allowWheelBoundaryScroll = true,
       onReady,
       onResize,
       onLinkClick,
@@ -333,6 +341,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onWidgetUpdateRef = useRef(onWidgetUpdate);
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
+    const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
 
     // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
@@ -343,6 +352,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onWidgetUpdateRef.current = onWidgetUpdate;
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
+    allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
 
     // Create blob URL on mount (only once, with initial darkMode)
     useEffect(() => {
@@ -543,6 +553,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
                 onMouseDownRef.current?.();
               });
               transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
+                if (!allowWheelBoundaryScrollRef.current) {
+                  return;
+                }
                 scrollFrameWheelBoundary(iframeRef.current, params as { deltaY?: number });
               });
               transport.onNotification(NTERACT_DOUBLE_CLICK, () => {


### PR DESCRIPTION
## Summary
- make isolated output iframes passive until the output well is activated
- stop notebook scroll handoff from iframe wheel-boundary notifications for notebook outputs
- add a right-ribbon interaction-state affordance for iframe-backed outputs

## Verification
- pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx
- pnpm --dir apps/notebook build
- cargo xtask lint --fix