### PR TITLE
fix(outputs): stop iframe wheel handoff

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -558,6 +558,7 @@ export function OutputArea({
                 colorTheme={colorTheme}
                 minHeight={24}
                 maxHeight={maxHeight ?? 2000}
+                allowWheelBoundaryScroll={false}
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}
                 onMouseDown={onIframeMouseDown}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -32,17 +32,23 @@ vi.mock("@/components/isolated/iframe-libraries", () => ({
 vi.mock("@/components/isolated", async () => {
   const React = await import("react");
 
-  const MockIsolatedFrame = React.forwardRef<typeof mockFrameHandle, { onReady?: () => void }>(
-    function MockIsolatedFrame({ onReady }, ref) {
-      React.useImperativeHandle(ref, () => mockFrameHandle);
+  const MockIsolatedFrame = React.forwardRef<
+    typeof mockFrameHandle,
+    { allowWheelBoundaryScroll?: boolean; onReady?: () => void }
+  >(function MockIsolatedFrame({ allowWheelBoundaryScroll, onReady }, ref) {
+    React.useImperativeHandle(ref, () => mockFrameHandle);
 
-      React.useEffect(() => {
-        onReady?.();
-      }, [onReady]);
+    React.useEffect(() => {
+      onReady?.();
+    }, [onReady]);
 
-      return <div data-testid="isolated-frame" />;
-    },
-  );
+    return (
+      <div
+        data-allow-wheel-boundary-scroll={String(allowWheelBoundaryScroll)}
+        data-testid="isolated-frame"
+      />
+    );
+  });
 
   return {
     CommBridgeManager: class CommBridgeManager {},
@@ -106,5 +112,13 @@ describe("OutputArea iframe theme sync", () => {
     await waitFor(() => {
       expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, null);
     });
+  });
+
+  it("does not forward iframe wheel boundary scroll from notebook outputs", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+
+    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "false",
+    );
   });
 });

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -86,6 +86,13 @@ export interface IsolatedFrameProps {
   className?: string;
 
   /**
+   * When true, wheel events that reach a scroll boundary inside the iframe
+   * are forwarded to the nearest scrollable parent.
+   * @default true
+   */
+  allowWheelBoundaryScroll?: boolean;
+
+  /**
    * Callback when the iframe is ready to receive messages.
    */
   onReady?: () => void;
@@ -276,6 +283,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       maxHeight = 2000,
       autoHeight = false,
       className = "",
+      allowWheelBoundaryScroll = true,
       onReady,
       onResize,
       onLinkClick,
@@ -333,6 +341,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onWidgetUpdateRef = useRef(onWidgetUpdate);
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
+    const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
 
     // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
@@ -343,6 +352,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onWidgetUpdateRef.current = onWidgetUpdate;
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
+    allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
 
     // Create blob URL on mount (only once, with initial darkMode)
     useEffect(() => {
@@ -543,6 +553,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
                 onMouseDownRef.current?.();
               });
               transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
+                if (!allowWheelBoundaryScrollRef.current) {
+                  return;
+                }
                 scrollFrameWheelBoundary(iframeRef.current, params as { deltaY?: number });
               });
               transport.onNotification(NTERACT_DOUBLE_CLICK, () => {


### PR DESCRIPTION
## Summary
- add an opt-out for isolated iframe wheel-boundary forwarding
- have notebook OutputArea disable that handoff so iframe/table scroll boundaries do not fling the notebook
- leave stdout/stderr, output rendering, and output UI unchanged

## Verification
- pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx
- pnpm --dir apps/notebook build
- cargo xtask lint --fix

Replaces the closed output-well experiment in #2271 with the smallest cleanup path.