### PR TITLE
fix(notebook-sync): replace blocking confirm_sync with passive waiters

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -575,16 +575,33 @@ impl DocHandle {
 
     /// Confirm that the daemon has merged all our local changes.
     ///
-    /// Performs up to 5 sync round-trips, checking that the daemon's
-    /// shared_heads include our local heads. Call this before executing
-    /// a cell to ensure the daemon has the cell's source.
+    /// Registers a non-blocking waiter in the sync task. The waiter resolves
+    /// when incoming sync frames advance `shared_heads` past our current doc
+    /// heads. This is typically a single round-trip (milliseconds).
+    ///
+    /// Times out after 5s — if the daemon hasn't acked by then, returns Ok
+    /// anyway (best-effort, matching the old behavior of continuing after
+    /// 5 rounds of 2s each).
     pub async fn confirm_sync(&self) -> Result<(), SyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
             .send(SyncCommand::ConfirmSync { reply: reply_tx })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        match tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(SyncError::Disconnected),
+            Err(_) => {
+                // Timeout — best-effort, likely synced. The waiter will be
+                // pruned from the sync task's list on the next check (its
+                // receiver is dropped).
+                debug!(
+                    "[doc-handle] confirm_sync timed out for {} (best-effort OK)",
+                    self.notebook_id
+                );
+                Ok(())
+            }
+        }
     }
 
     /// Flush pending RuntimeStateDoc sync frames from the daemon.

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -115,6 +115,14 @@ pub enum SyncCommand {
     },
 }
 
+/// Interval for the maintenance tick that re-drives sync for pending waiters.
+///
+/// This is the safety-net retry: after an inbound `AutomergeSync` frame clears
+/// Automerge's in_flight state, `generate_sync_message()` may now succeed for
+/// changes that were previously blocked. The primary re-drive happens inline in
+/// the Frame arm; this tick catches edge cases (e.g. no further inbound frames).
+const MAINTENANCE_TICK: Duration = Duration::from_millis(200);
+
 /// A pending `ConfirmSync` waiter.
 ///
 /// Instead of blocking the select loop for up to 10s (5 rounds × 2s),
@@ -163,6 +171,48 @@ fn resolve_sync_waiters(waiters: &mut Vec<SyncWaiter>, doc: &Arc<Mutex<SharedDoc
         }
         i += 1;
     }
+}
+
+/// Re-drive Automerge sync if waiters are pending and `generate_sync_message`
+/// was previously blocked by in_flight state.
+///
+/// **Why this is needed:** Automerge's sync protocol marks outbound messages
+/// as `in_flight` until the peer acknowledges them. While in_flight,
+/// `generate_sync_message()` returns `None` — even if newer local changes
+/// exist that the peer hasn't seen. When a `ConfirmSync` arrives during this
+/// window, the sync task registers the waiter but can't send the new changes.
+/// Once the daemon's ack clears `in_flight`, we must re-call
+/// `generate_sync_message()` to flush those blocked changes; otherwise the
+/// waiter hangs until its 5s timeout and the caller reads a stale doc.
+///
+/// Returns `Err` only on fatal write errors (caller should break the loop).
+async fn drive_sync_for_waiters<W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+    waiters: &[SyncWaiter],
+    notebook_id: &str,
+) -> Result<(), SyncError> {
+    if waiters.is_empty() {
+        return Ok(());
+    }
+
+    let msg_bytes = {
+        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.generate_sync_message().map(|m| m.encode())
+    };
+
+    if let Some(bytes) = msg_bytes {
+        debug!(
+            "[notebook-sync] Re-driving sync for {} pending waiter(s) on {}",
+            waiters.len(),
+            notebook_id
+        );
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+            .await
+            .map_err(SyncError::Io)?;
+    }
+
+    Ok(())
 }
 
 /// Configuration for the sync task.
@@ -214,7 +264,7 @@ where
     // exact failure mode that desyncs the wire under stream-output
     // pressure.
     let buffered = tokio::io::BufReader::new(reader);
-    let mut framed_reader = connection::FramedReader::spawn(buffered, 16);
+    let mut framed_reader = connection::FramedReader::spawn(buffered, 64);
     let mut writer = tokio::io::BufWriter::new(writer);
 
     let notebook_id = {
@@ -230,6 +280,13 @@ where
     // advance shared_heads past the waiter's target. This replaces the old
     // blocking confirm_sync_impl that monopolized the select loop.
     let mut sync_waiters: Vec<SyncWaiter> = Vec::new();
+
+    // Maintenance tick: safety-net retry for pending waiters. When Automerge's
+    // in_flight state clears, we may need to re-drive generate_sync_message()
+    // to flush changes that were blocked. The primary re-drive happens inline
+    // after each AutomergeSync frame; this tick catches edge cases.
+    let mut maintenance = tokio::time::interval(MAINTENANCE_TICK);
+    maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Track last metadata for change detection (used for SyncUpdate-like behavior)
     let mut _last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
@@ -247,9 +304,10 @@ where
         // > Frame), bursts of local mutations and confirm_sync commands starved
         // inbound frame processing, causing daemon write failures.
         enum SelectResult {
-            Changed,
-            Command(Option<SyncCommand>),
             Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
+            Command(Option<SyncCommand>),
+            Changed,
+            Maintenance,
         }
 
         let select_result = tokio::select! {
@@ -270,6 +328,9 @@ where
                 }
                 SelectResult::Changed
             }
+
+            // Maintenance tick — re-drive sync for pending waiters
+            _ = maintenance.tick() => SelectResult::Maintenance,
         };
 
         match select_result {
@@ -435,6 +496,27 @@ where
                     // Resolve any ConfirmSync waiters whose targets are now met.
                     if is_sync_frame {
                         resolve_sync_waiters(&mut sync_waiters, &config.doc);
+
+                        // P1 correctness fix: if waiters remain, re-drive
+                        // generate_sync_message(). The ack we just processed may
+                        // have cleared Automerge's in_flight state, unblocking
+                        // newer changes that were queued when confirm_sync arrived
+                        // but couldn't be sent. Without this, those changes never
+                        // reach the daemon and the waiter times out → stale doc.
+                        if let Err(e) = drive_sync_for_waiters(
+                            &config.doc,
+                            &mut writer,
+                            &sync_waiters,
+                            &notebook_id,
+                        )
+                        .await
+                        {
+                            warn!(
+                                "[notebook-sync] Failed to re-drive sync for {}: {}",
+                                notebook_id, e
+                            );
+                            break;
+                        }
                     }
                 }
                 None => {
@@ -452,6 +534,30 @@ where
                     break;
                 }
             },
+
+            // ─── Maintenance tick ─────────────────────────────────────────
+            SelectResult::Maintenance => {
+                // Prune closed waiters and re-drive sync for any that remain.
+                // This is the safety-net for edge cases where no further inbound
+                // frames arrive after in_flight clears.
+                if !sync_waiters.is_empty() {
+                    resolve_sync_waiters(&mut sync_waiters, &config.doc);
+                    if let Err(e) = drive_sync_for_waiters(
+                        &config.doc,
+                        &mut writer,
+                        &sync_waiters,
+                        &notebook_id,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to re-drive sync on maintenance tick for {}: {}",
+                            notebook_id, e
+                        );
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -92,8 +92,9 @@ pub enum SyncCommand {
 
     /// Confirm that the daemon has merged all our local changes.
     ///
-    /// Performs up to 5 sync round-trips, checking that the daemon's
-    /// shared_heads include our local heads.
+    /// Non-blocking: registers a waiter that resolves when the daemon's
+    /// `shared_heads` include our current heads. Resolved by the Frame arm
+    /// after processing AutomergeSync frames.
     ConfirmSync {
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
@@ -112,6 +113,56 @@ pub enum SyncCommand {
         data: Vec<u8>,
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
+}
+
+/// A pending `ConfirmSync` waiter.
+///
+/// Instead of blocking the select loop for up to 10s (5 rounds × 2s),
+/// each `ConfirmSync` registers a waiter with the doc's current heads.
+/// The waiter resolves when incoming `AutomergeSync` frames advance
+/// `shared_heads` past the target — typically within one round-trip.
+///
+/// N concurrent `ConfirmSync` calls produce N waiters, all resolved by
+/// the same O(1) incoming sync frames. This eliminates the serialized
+/// head-of-line blocking that caused daemon backpressure and connection
+/// drops under parallel MCP tool calls.
+struct SyncWaiter {
+    /// The heads that must appear in the peer's `shared_heads`.
+    target_heads: Vec<automerge::ChangeHash>,
+    /// Reply channel for the caller.
+    reply: oneshot::Sender<Result<(), SyncError>>,
+}
+
+/// Check and resolve any sync waiters whose target heads are now confirmed.
+///
+/// Also prunes waiters whose callers have timed out (receiver dropped).
+fn resolve_sync_waiters(waiters: &mut Vec<SyncWaiter>, doc: &Arc<Mutex<SharedDocState>>) {
+    if waiters.is_empty() {
+        return;
+    }
+    let shared_heads = {
+        let state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.peer_state.shared_heads.clone()
+    };
+    let mut i = 0;
+    while i < waiters.len() {
+        // Prune canceled waiters (caller timed out / dropped the receiver)
+        if waiters[i].reply.is_closed() {
+            waiters.swap_remove(i);
+            continue;
+        }
+        if waiters[i].target_heads.is_empty()
+            || waiters[i]
+                .target_heads
+                .iter()
+                .all(|h| shared_heads.contains(h))
+        {
+            let waiter = waiters.swap_remove(i);
+            let _ = waiter.reply.send(Ok(()));
+            continue;
+        }
+        i += 1;
+    }
 }
 
 /// Configuration for the sync task.
@@ -174,6 +225,12 @@ where
     let mut loop_count: u64 = 0;
     let mut saw_session_status = false;
 
+    // Non-blocking confirm_sync waiters: each ConfirmSync command registers
+    // a waiter here. Waiters are resolved when incoming AutomergeSync frames
+    // advance shared_heads past the waiter's target. This replaces the old
+    // blocking confirm_sync_impl that monopolized the select loop.
+    let mut sync_waiters: Vec<SyncWaiter> = Vec::new();
+
     // Track last metadata for change detection (used for SyncUpdate-like behavior)
     let mut _last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
         let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
@@ -183,8 +240,12 @@ where
     loop {
         loop_count += 1;
 
-        // Use select! with biased mode so we prioritize local changes and commands
-        // over incoming frames (prevents starvation when the daemon is chatty).
+        // Biased select: prioritize *incoming frames* over commands and local
+        // changes. This is the critical change that prevents session drops —
+        // the daemon's outbound frames must be consumed quickly so its write
+        // buffer never fills. Under the old priority order (Changed > Command
+        // > Frame), bursts of local mutations and confirm_sync commands starved
+        // inbound frame processing, causing daemon write failures.
         enum SelectResult {
             Changed,
             Command(Option<SyncCommand>),
@@ -193,6 +254,12 @@ where
 
         let select_result = tokio::select! {
             biased;
+
+            // Incoming frame from daemon — highest priority to keep the socket drained
+            frame = framed_reader.recv() => SelectResult::Frame(frame),
+
+            // Protocol command (request/response, confirm_sync, etc.)
+            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
 
             // Local document was mutated by a handle
             result = config.changed_rx.recv() => {
@@ -203,12 +270,6 @@ where
                 }
                 SelectResult::Changed
             }
-
-            // Protocol command (request/response, confirm_sync, etc.)
-            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
-
-            // Incoming frame from daemon (cancel-safe: actor owns read_exact)
-            frame = framed_reader.recv() => SelectResult::Frame(frame),
         };
 
         match select_result {
@@ -239,32 +300,11 @@ where
                     }
                 }
 
-                // Wait briefly for an ack from the daemon (like sync_to_daemon)
-                match tokio::time::timeout(Duration::from_millis(500), framed_reader.recv()).await {
-                    Ok(Some(Ok(frame))) => {
-                        SyncFrameContext {
-                            doc: &config.doc,
-                            snapshot_tx: &config.snapshot_tx,
-                            status_tx: &config.status_tx,
-                            broadcast_tx: &config.broadcast_tx,
-                            notebook_id: &notebook_id,
-                            saw_session_status: &mut saw_session_status,
-                        }
-                        .handle_incoming_frame(&frame, &mut writer)
-                        .await;
-                    }
-                    Ok(None) => {
-                        info!("[notebook-sync] Connection closed for {}", notebook_id);
-                        break;
-                    }
-                    Ok(Some(Err(e))) => {
-                        warn!("[notebook-sync] Socket error for {}: {}", notebook_id, e);
-                        break;
-                    }
-                    Err(_) => {
-                        // Timeout — daemon hasn't responded yet, that's fine
-                    }
-                }
+                // No ack wait — the daemon's reply will arrive in the Frame arm
+                // and resolve any pending ConfirmSync waiters there. The previous
+                // 500ms blocking wait was the secondary bottleneck (after the
+                // blocking confirm_sync_impl): it prevented the select loop from
+                // processing incoming frames during local-change bursts.
             }
 
             // ─── Protocol commands ─────────────────────────────────────────
@@ -297,26 +337,52 @@ where
                                 notebook_id: &notebook_id,
                                 saw_session_status: &mut saw_session_status,
                             },
+                            &mut sync_waiters,
                         )
                         .await;
                         let _ = reply.send(result);
                     }
 
                     SyncCommand::ConfirmSync { reply } => {
-                        let result = confirm_sync_impl(
-                            &mut framed_reader,
-                            &mut writer,
-                            &mut SyncFrameContext {
-                                doc: &config.doc,
-                                snapshot_tx: &config.snapshot_tx,
-                                status_tx: &config.status_tx,
-                                broadcast_tx: &config.broadcast_tx,
-                                notebook_id: &notebook_id,
-                                saw_session_status: &mut saw_session_status,
-                            },
-                        )
-                        .await;
-                        let _ = reply.send(result);
+                        // Non-blocking: register a waiter with the current doc
+                        // heads. The waiter resolves when incoming AutomergeSync
+                        // frames advance shared_heads past these targets.
+                        let (our_heads, already_confirmed) = {
+                            let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
+                            let heads = state.doc.get_heads();
+                            let shared = &state.peer_state.shared_heads;
+                            let confirmed =
+                                heads.is_empty() || heads.iter().all(|h| shared.contains(h));
+                            (heads, confirmed)
+                        };
+
+                        if already_confirmed {
+                            let _ = reply.send(Ok(()));
+                        } else {
+                            // Also generate and send a sync message if needed
+                            // so the daemon has something to ack.
+                            let msg_bytes = {
+                                let mut state =
+                                    config.doc.lock().unwrap_or_else(|e| e.into_inner());
+                                state.generate_sync_message().map(|m| m.encode())
+                            };
+                            if let Some(bytes) = msg_bytes {
+                                if let Err(e) = connection::send_typed_frame(
+                                    &mut writer,
+                                    NotebookFrameType::AutomergeSync,
+                                    &bytes,
+                                )
+                                .await
+                                {
+                                    let _ = reply.send(Err(SyncError::Io(e)));
+                                    continue;
+                                }
+                            }
+                            sync_waiters.push(SyncWaiter {
+                                target_heads: our_heads,
+                                reply,
+                            });
+                        }
                     }
 
                     SyncCommand::ConfirmStateSync { reply } => {
@@ -352,6 +418,7 @@ where
             // ─── Incoming frame from daemon ────────────────────────────────
             SelectResult::Frame(frame_result) => match frame_result {
                 Some(Ok(frame)) => {
+                    let is_sync_frame = frame.frame_type == NotebookFrameType::AutomergeSync;
                     SyncFrameContext {
                         doc: &config.doc,
                         snapshot_tx: &config.snapshot_tx,
@@ -362,6 +429,13 @@ where
                     }
                     .handle_incoming_frame(&frame, &mut writer)
                     .await;
+
+                    // After processing an AutomergeSync frame, the daemon may
+                    // have acknowledged our changes (advancing shared_heads).
+                    // Resolve any ConfirmSync waiters whose targets are now met.
+                    if is_sync_frame {
+                        resolve_sync_waiters(&mut sync_waiters, &config.doc);
+                    }
                 }
                 None => {
                     info!(
@@ -379,6 +453,12 @@ where
                 }
             },
         }
+    }
+
+    // Resolve remaining ConfirmSync waiters with Disconnected errors
+    // so callers don't hang on a channel that will never deliver.
+    for waiter in sync_waiters.drain(..) {
+        let _ = waiter.reply.send(Err(SyncError::Disconnected));
     }
 
     mark_disconnected(&config.status_tx);
@@ -662,13 +742,16 @@ impl SyncFrameContext<'_> {
 /// Send a request to the daemon and wait for a response.
 ///
 /// While waiting, also processes AutomergeSync and Broadcast frames that arrive
-/// interleaved with the response.
+/// interleaved with the response. Resolves pending ConfirmSync waiters when
+/// AutomergeSync frames are processed — this prevents long requests (like
+/// `LaunchKernel`) from starving sync confirmation.
 async fn send_request_impl<W: AsyncWrite + Unpin>(
     framed: &mut connection::FramedReader,
     writer: &mut W,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
     ctx: &mut SyncFrameContext<'_>,
+    sync_waiters: &mut Vec<SyncWaiter>,
 ) -> Result<NotebookResponse, SyncError> {
     // Serialize and send the request
     let payload =
@@ -687,7 +770,7 @@ async fn send_request_impl<W: AsyncWrite + Unpin>(
     // Wait for a Response frame, processing other frames that arrive meanwhile
     let result = tokio::time::timeout(
         Duration::from_secs(timeout_secs),
-        wait_for_response(framed, writer, req_broadcast_tx, ctx),
+        wait_for_response(framed, writer, req_broadcast_tx, ctx, sync_waiters),
     )
     .await;
 
@@ -704,6 +787,7 @@ async fn wait_for_response<W: AsyncWrite + Unpin>(
     writer: &mut W,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     ctx: &mut SyncFrameContext<'_>,
+    sync_waiters: &mut Vec<SyncWaiter>,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = framed
@@ -780,6 +864,11 @@ async fn wait_for_response<W: AsyncWrite + Unpin>(
                         .await
                         .map_err(SyncError::Io)?;
                 }
+
+                // Resolve ConfirmSync waiters while inside wait_for_response —
+                // long requests (LaunchKernel, 5min) would otherwise starve
+                // sync confirmation for the entire duration.
+                resolve_sync_waiters(sync_waiters, ctx.doc);
             }
 
             NotebookFrameType::Broadcast => {
@@ -807,71 +896,17 @@ async fn wait_for_response<W: AsyncWrite + Unpin>(
     }
 }
 
-/// Confirm that the daemon has merged all our local changes.
-///
-/// Performs sync rounds until our local heads are in the peer's shared_heads,
-/// or until we've done 5 rounds (best-effort).
-async fn confirm_sync_impl<W: AsyncWrite + Unpin>(
-    framed: &mut connection::FramedReader,
-    writer: &mut W,
-    ctx: &mut SyncFrameContext<'_>,
-) -> Result<(), SyncError> {
-    for round in 0..5 {
-        // Generate and send sync message
-        let (msg_bytes, our_heads, shared_heads) = {
-            let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
-            let our_heads = state.doc.get_heads();
-            let shared = state.peer_state.shared_heads.clone();
-            let msg = state.generate_sync_message().map(|m| m.encode());
-            (msg, our_heads, shared)
-        };
-
-        // Check if already confirmed
-        if our_heads.is_empty() || our_heads.iter().all(|h| shared_heads.contains(h)) {
-            debug!(
-                "[notebook-sync] Sync confirmed for {} after {} rounds",
-                ctx.notebook_id, round
-            );
-            return Ok(());
-        }
-
-        // Send sync message if there is one
-        if let Some(bytes) = msg_bytes {
-            connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
-                .await
-                .map_err(SyncError::Io)?;
-        }
-
-        // Wait for response
-        match tokio::time::timeout(Duration::from_millis(2000), framed.recv()).await {
-            Ok(Some(Ok(frame))) => {
-                ctx.handle_incoming_frame(&frame, writer).await;
-            }
-            Ok(None) => {
-                return Err(SyncError::Protocol(
-                    "Connection closed during confirm_sync".into(),
-                ));
-            }
-            Ok(Some(Err(e))) => {
-                return Err(SyncError::Io(e));
-            }
-            Err(_) => {
-                // Timeout — try next round
-                debug!(
-                    "[notebook-sync] confirm_sync round {} timed out for {}",
-                    round, ctx.notebook_id
-                );
-            }
-        }
-    }
-
-    // Best-effort: likely confirmed even if heads don't fully match
-    debug!(
-        "[notebook-sync] confirm_sync: heads not fully confirmed after 5 rounds for {}",
-        ctx.notebook_id
-    );
-    Ok(())
-}
+// confirm_sync_impl has been removed: see `SyncWaiter` and `resolve_sync_waiters`.
+//
+// The old implementation ran up to 5 rounds × 2s timeout inside the
+// select loop, monopolizing both the frame reader and the writer.
+// Under 8+ concurrent MCP tool calls, this caused daemon write-buffer
+// back-pressure and deterministic session drops.
+//
+// The new approach registers passive waiters that are resolved by the
+// Frame arm after processing AutomergeSync frames. The select loop
+// never blocks on ConfirmSync, so all incoming frames are processed
+// promptly.
 
 /// Flush pending RuntimeStateDoc sync frames.
 ///

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -142,10 +142,11 @@ pub async fn create_cell(
         (handle, cell_id)
     };
 
-    // Sync so the daemon (and peers) know about the new cell before we send presence
-    let _ = handle.confirm_sync().await;
-
-    // Cursor at end of source (shows "finished typing")
+    // Cursor at end of source (shows "finished typing").
+    // No confirm_sync needed — the sync task sends the mutation to the daemon
+    // asynchronously, and if `and_run` is set, `execute_and_wait` calls
+    // confirm_sync before submitting the execution request (the one place
+    // where the daemon actually needs the cell source).
     let peer_label = server.get_peer_label().await;
     let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
     crate::presence::emit_cursor(&handle, &cell_id, end_line, end_col, &peer_label).await;
@@ -198,10 +199,9 @@ pub async fn set_cell(
             .update_source(cell_id, src)
             .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;
 
-        // Sync so peers see the edit before the cursor
-        let _ = handle.confirm_sync().await;
-
-        // Cursor at end of new source
+        // Cursor at end of new source. No confirm_sync — the mutation
+        // propagates asynchronously. If `and_run` follows, execute_and_wait
+        // calls confirm_sync before the execution request.
         let peer_label = server.get_peer_label().await;
         let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
         crate::presence::emit_cursor(&handle, cell_id, end_line, end_col, &peer_label).await;


### PR DESCRIPTION
## Summary

Parallel MCP tool calls (8+ concurrent `create_cell`) deterministically dropped notebook sessions. Root cause: `confirm_sync_impl` monopolized the single-threaded sync task select loop for up to 10s (5 rounds × 2s), starving inbound frame processing. The daemon's write buffer filled → `send_typed_frame` error → peer disconnected.

Three changes fix the bottleneck:

- **Replace blocking `confirm_sync_impl` with passive `SyncWaiter`s.** Each `ConfirmSync` command registers target heads + reply oneshot. Waiters resolve when the Frame arm processes `AutomergeSync` frames that advance `shared_heads`. N concurrent calls → N waiters resolved by O(1) incoming frames.
- **Flip biased select priority: Frame > Command > Changed.** Incoming daemon frames are consumed first, preventing socket backpressure. The old `Changed > Command > Frame` order starved frame processing during mutation bursts.
- **Remove the 500ms ack wait after local changes.** The daemon's ack arrives in the Frame arm. The inline wait was a secondary bottleneck during mutation bursts.

Also drops unnecessary `confirm_sync` calls in `create_cell` and `set_cell` — non-executing CRDT mutations don't need sync confirmation (the sync task propagates changes asynchronously; `execute_and_wait` calls `confirm_sync` before execution requests where the daemon actually needs the cell source).

## Evidence

| Metric | Before | After |
|--------|--------|-------|
| Session drops (notebook-stress, 8-10 concurrent create_cell) | 33 (100% repro) | 0 expected |
| Session drops (30-gremlin bug bash) | 84 total (2.8/gremlin avg) | Near-zero expected |
| confirm_sync worst-case latency | 10s (5 rounds × 2s) | ~1 round-trip (ms) |
| Select loop availability during confirm_sync | 0% (blocked) | 100% (non-blocking) |

## Files changed

- `crates/notebook-sync/src/sync_task.rs` — Core fix: `SyncWaiter`, `resolve_sync_waiters`, select priority flip, 500ms wait removal
- `crates/notebook-sync/src/handle.rs` — `confirm_sync()` timeout (5s best-effort, matching old 5×2s budget)
- `crates/runt-mcp/src/tools/cell_crud.rs` — Drop redundant `confirm_sync` in `create_cell`/`set_cell`

## Test plan

- [x] All 41 existing `notebook-sync` unit tests pass
- [x] Release build compiles and installs as nightly
- [x] Nightly daemon starts and reports correct version
- [ ] Gremlin replay: notebook-stress suite with 8-10 concurrent `create_cell` batches
- [ ] Gremlin replay: full 30-gremlin bug bash — session drop count should be near zero
- [ ] Manual: `execute_cell` after `create_cell` still works (confirm_sync in execute path preserved)
- [ ] Manual: `add_dependency` + `sync_environment` still works (confirm_sync in deps path preserved)