### PR TITLE
fix(notebook-sync): keep frame pump hot during parallel sync

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -12,7 +12,7 @@ paths:
 
 Two independent version numbers, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `2`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `3`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v3 adds `SessionControl`; v2 clients are still accepted but are served without `SessionControl` frames.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) -- governs Automerge document compatibility. Bump when document structure changes.
 
 These are just incrementing integers that evolve independently from each other and from the artifact version.
@@ -24,7 +24,7 @@ Every connection starts with 5 bytes before the JSON handshake:
 | Bytes | Content |
 |-------|---------|
 | 0-3 | Magic: `0xC0 0xDE 0x01 0xAC` |
-| 4 | Protocol version (currently `2`) |
+| 4 | Protocol version (currently `3`) |
 
 The daemon validates both before reading the handshake. Non-runtimed connections get "invalid magic bytes". Protocol mismatches are rejected before JSON parsing.
 
@@ -32,8 +32,8 @@ The daemon validates both before reading the handshake. Non-runtimed connections
 
 1. **Opening** -- Frontend invokes Tauri command; relay connects to daemon Unix socket and sends handshake.
 2. **Handshake** -- JSON with `channel`, `notebook_id`, `protocol`. Daemon responds with `NotebookConnectionInfo` (protocol, notebook_id, cell_count, needs_trust_approval). The `Handshake` enum uses `#[serde(tag = "channel")]` -- flat wire format with `"channel"` discriminator.
-3. **Initial sync** -- Both sides exchange Automerge sync messages until convergence. Frontend starts empty; all state comes from daemon. 2s connection timeout, 100ms per-frame timeout.
-4. **Steady state** -- Concurrent Automerge sync, request/response, and broadcasts.
+3. **Initial sync** -- Both sides exchange Automerge sync messages until convergence. Frontend starts empty; all state comes from daemon. v3 clients also receive `SessionControl::SyncStatus` frames for notebook-doc, runtime-state, and initial-load readiness.
+4. **Steady state** -- Concurrent Automerge sync, request/response, RuntimeStateDoc sync, PoolDoc sync, presence, broadcasts, and session-control frames. The frame consumer must stay hot: request and confirmation waits belong in pending maps/waiter lists, not blocking `recv()` loops.
 5. **Disconnection** -- Relay emits `daemon:disconnected`. Generation counter prevents stale callbacks.
 
 ## Wire Format
@@ -53,8 +53,11 @@ After handshake, frames are typed by first byte:
 | `0x04` | Presence | Binary (CBOR) |
 | `0x05` | RuntimeStateSync | Binary (raw Automerge sync for RuntimeStateDoc) |
 | `0x06` | PoolStateSync | Binary (raw Automerge sync for PoolDoc — global daemon pool state) |
+| `0x07` | SessionControl | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
 
-Only `0x00` (AutomergeSync), `0x04` (Presence), and `0x06` (PoolStateSync) are valid outgoing types from the frontend.
+Only `0x00` (AutomergeSync), `0x01` (NotebookRequest), `0x04` (Presence), and `0x06` (PoolStateSync) are valid outgoing frame types from the frontend/relay. `0x07` is daemon-originated.
+
+Notebook request and response frames use `NotebookRequestEnvelope` and `NotebookResponseEnvelope`. Every overlapping request must carry an `id`, and responses must route by id rather than by receive order.
 
 ## Key Request Types
 
@@ -90,6 +93,19 @@ After progressively migrating room state to `RuntimeStateDoc`, broadcasts are no
 |-----------|---------|
 | `Comm { msg_type, content, buffers }` | Jupyter comm message (widget). Custom one-shot events; widget *state* syncs via RuntimeStateDoc. |
 | `EnvProgress { env_type, phase }` | Environment install/solve/download progress (high-frequency stream). |
+
+## SessionControl
+
+`SessionControl` frames (`0x07`) are connection-local daemon messages, not room
+broadcasts. Today they carry `SessionControlMessage::SyncStatus`, a full
+readiness snapshot with:
+
+- `notebook_doc`: `pending | syncing | interactive`
+- `runtime_state`: `pending | syncing | ready`
+- `initial_load`: `not_needed | streaming | ready | failed`
+
+The daemon emits the full current state on transitions. v2 clients do not
+receive these frames.
 
 ## Tauri Event Bridge
 

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -14,6 +14,27 @@ When changing the wire handshake or typed frame semantics, also inspect:
 - `crates/notebook-protocol/src/protocol.rs`
 - `contributing/protocol.md`
 
+## Frame pump invariants
+
+Frame readers are only half the fix. A dedicated reader prevents cancel-unsafe
+partial reads, but the consumer must also stay hot enough to drain the bounded
+frame queue.
+
+- Confirmation waits must be waiter-based: register the target heads, send any
+  immediate sync frame, and let normal inbound `AutomergeSync` handling resolve
+  the waiter.
+- Request waits must be pending-map based: every overlapping request needs a
+  correlation id, and responses must route by id instead of by "next response
+  wins".
+- Do not put `recv()` loops inside command handlers. Long waits in command code
+  starve broadcasts, state sync, session-control frames, and sync replies.
+- Bounded frame queues still backpressure the socket when the consumer is
+  blocked. Treat any per-command sleep, timeout loop, or "drain a few frames"
+  helper in the sync task as a potential session-drop bug.
+- Broadcasts and RuntimeStateSync frames can arrive while requests and confirms
+  are pending. Route them through the main frame handler instead of dropping or
+  deferring them.
+
 ## MIME classification contract
 
 Single canonical Rust implementation in `crates/notebook-doc/src/mime.rs` (`is_binary_mime()`, `mime_kind()`, `MimeKind` enum). All Rust crates use this module. The old per-crate copies have been deleted. WASM owns MIME classification end-to-end. A `looksLikeBinaryMime()` safety net remains in `manifest-resolution.ts` for blob refs that WASM couldn't resolve — it is not an authoritative copy.

--- a/.codex/skills/nteract-testing/references/test-matrix.md
+++ b/.codex/skills/nteract-testing/references/test-matrix.md
@@ -61,3 +61,21 @@ cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb
 - Some Deno tests type-check poorly in spite of working at runtime; `--no-check` is often the intended mode in this repo.
 - Python integration failures are often socket-selection problems before they are logic regressions.
 - E2E flows should go through `cargo xtask e2e ...`; it builds the webdriver-enabled binary, launches the app on port `4445`, and runs `pnpm test:e2e` with the right wiring.
+
+## Sync backpressure regressions
+
+When a change touches `crates/notebook-sync/src/sync_task.rs`,
+`crates/notebook-sync/src/relay_task.rs`, request/response envelopes, or
+MCP paths that issue parallel cell mutations, add or run tests with this shape:
+
+- Tiny-buffer duplex unit test: issue concurrent `confirm_sync()` calls while a
+  fake daemon sends interleaved `AutomergeSync`, `RuntimeStateSync`, broadcast,
+  or `SessionControl` frames. The sync task must keep draining and every waiter
+  must resolve without a socket close.
+- Daemon integration test: create 8-10 cells through the same session with
+  parallel mutation/confirm tasks, assert the original peer remains connected,
+  then reconnect a fresh peer and verify every cell converged.
+- Request-routing unit test: send overlapping daemon requests with request ids,
+  return responses out of order, interleave a broadcast, and assert each caller
+  receives its own response while broadcasts still reach request progress
+  subscribers.

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -6,7 +6,7 @@ This document describes the wire protocol between notebook clients (frontend WAS
 
 Two independent version numbers handle compatibility, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `2`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `3`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes. Protocol v3 adds `SessionControl` readiness/status frames; v2 clients are accepted for compatibility but do not receive those frames.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes. The current schema stores cells as a fractional-indexed `Map` and keeps outputs in `RuntimeStateDoc` keyed by `execution_id`, with per-output `output_id` UUIDs on manifests. Future bumps MUST ship a `migrate_vN_to_v(N+1)` function that preserves user data — v1–v3 were pre-release and the v4 load path discards older docs on load, which is only safe because no real user data lives at those versions.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol or schema bump doesn't automatically force a major version bump — that depends on whether the change is user-facing.
@@ -30,7 +30,7 @@ Every connection starts with a 5-byte preamble before the JSON handshake frame:
 | Bytes | Content |
 |-------|---------|
 | 0–3 | Magic: `0xC0 0xDE 0x01 0xAC` |
-| 4 | Protocol version (currently `2`) |
+| 4 | Protocol version (currently `3`) |
 
 The daemon validates both before reading the handshake. Non-runtimed connections get a clear "invalid magic bytes" error. Protocol mismatches are rejected before any JSON parsing.
 
@@ -42,11 +42,13 @@ The desktop app bundles its own daemon binary. Version-mismatch detection betwee
 
 ## Overview
 
-The notebook app communicates with runtimed over a Unix socket (named pipe on Windows) using length-prefixed, typed frames. The protocol carries three kinds of traffic:
+The notebook app communicates with runtimed over a Unix socket (named pipe on Windows) using length-prefixed, typed frames. The protocol carries several classes of traffic:
 
 1. **Automerge sync** — binary CRDT sync messages that keep the notebook document consistent between the frontend WASM peer and the daemon peer
 2. **Request/response** — JSON messages where a client asks the daemon to do something (execute a cell, launch a kernel) and gets a reply
-3. **Broadcasts** — JSON messages the daemon pushes to all connected clients (kernel output, status changes, environment progress)
+3. **Runtime and pool state sync** — binary Automerge sync for daemon-authored state documents
+4. **Broadcasts** — JSON messages the daemon pushes to all connected clients for comm messages and environment progress
+5. **Presence and session control** — binary presence updates plus daemon-originated readiness/status frames
 
 ## Connection Topology
 
@@ -85,7 +87,7 @@ The first frame is a JSON `Handshake` message:
 {
   "channel": "notebook_sync",
   "notebook_id": "/path/to/notebook.ipynb",
-  "protocol": "v2"
+  "protocol": "v3"
 }
 ```
 
@@ -97,7 +99,7 @@ The daemon responds with a `NotebookConnectionInfo`:
 
 ```json
 {
-  "protocol": "v2",
+  "protocol": "v3",
   "notebook_id": "derived-id",
   "cell_count": 5,
   "needs_trust_approval": false
@@ -108,11 +110,19 @@ The `protocol_version`, `daemon_version`, and `error` fields are `Option` types 
 
 ### 3. Initial Automerge sync
 
-After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. A 2-second timeout guards against the initial socket connection; the sync loop itself uses a 100ms per-frame timeout to drain incoming frames.
+After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. Protocol v3 clients receive `SessionControl::SyncStatus` frames as the daemon advances notebook-doc, runtime-state, and initial-load readiness.
 
 ### 4. Steady state
 
-Once synced, the connection carries all three frame types concurrently: ongoing Automerge sync for cell edits, request/response for explicit actions, and broadcasts for kernel activity.
+Once synced, the connection carries all frame classes concurrently: ongoing Automerge sync for cell edits, request/response for explicit actions, RuntimeStateDoc sync, PoolDoc sync, presence, broadcasts, and session-control frames.
+
+Steady-state frame fairness is a correctness requirement. A dedicated framed
+reader prevents cancel-unsafe partial reads, but the consumer must also keep
+draining its bounded queue. Confirmation waits should register target-head
+waiters, request waits should register id-keyed pending entries, and command
+handlers should return to the main frame loop after writing any immediate
+outbound frame. Blocking `recv()` loops inside a command path can backpressure
+the socket and make the daemon drop the peer.
 
 ### 5. Disconnection
 
@@ -147,6 +157,12 @@ After the handshake, frames are typed by their first byte:
 | `0x04`    | Presence           | Binary (CBOR, see `notebook_doc::presence`) |
 | `0x05`    | RuntimeStateSync   | Binary (raw Automerge sync for per-notebook `RuntimeStateDoc`) |
 | `0x06`    | PoolStateSync      | Binary (raw Automerge sync for the per-daemon `PoolDoc`) |
+| `0x07`    | SessionControl     | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
+
+`NotebookRequest` and `NotebookResponse` payloads are carried in flattened
+`NotebookRequestEnvelope` and `NotebookResponseEnvelope` values. Concurrent
+requests must include an `id`, and clients must route responses by id because
+broadcasts, state sync, and out-of-order responses may interleave freely.
 
 ## Automerge Sync
 

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -448,12 +448,13 @@ pub enum Handshake {
     SettingsSync,
     /// Automerge notebook sync (per-notebook room).
     ///
-    /// The optional `protocol` field is accepted for future version negotiation.
-    /// Currently only v2 (typed frames) is supported. After handshake, the server
-    /// sends a `ProtocolCapabilities` response before starting sync.
+    /// The optional `protocol` field is accepted for version negotiation.
+    /// v3 clients receive SessionControl frames; v2 clients are accepted for
+    /// compatibility without those frames. After handshake, the server sends a
+    /// `ProtocolCapabilities` response before starting sync.
     NotebookSync {
         notebook_id: String,
-        /// Protocol version requested by client. Currently only v2 is supported.
+        /// Protocol version requested by client (`v3` preferred, `v2` compatible).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
         /// Working directory for untitled notebooks (used for project file detection).

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -573,15 +573,34 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
-    /// Confirm that the daemon has merged all our local changes.
+    /// Confirm that the daemon has merged our current local heads.
     ///
-    /// Performs up to 5 sync round-trips, checking that the daemon's
-    /// shared_heads include our local heads. Call this before executing
-    /// a cell to ensure the daemon has the cell's source.
+    /// Captures the current document heads and registers a passive waiter with
+    /// the sync task. The sync task keeps draining frames normally and resolves
+    /// the waiter once inbound Automerge sync advances the daemon's
+    /// `shared_heads` to include these heads. Timeout remains best-effort, so
+    /// this is a freshness hint rather than a strict durability barrier. Call
+    /// it before daemon RPCs that read notebook source from the Automerge doc.
     pub async fn confirm_sync(&self) -> Result<(), SyncError> {
+        let target_heads = {
+            let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+            let heads = state.doc.get_heads();
+            if heads.is_empty()
+                || heads
+                    .iter()
+                    .all(|head| state.peer_state.shared_heads.contains(head))
+            {
+                return Ok(());
+            }
+            heads
+        };
+
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
-            .send(SyncCommand::ConfirmSync { reply: reply_tx })
+            .send(SyncCommand::ConfirmSync {
+                target_heads,
+                reply: reply_tx,
+            })
             .await
             .map_err(|_| SyncError::Disconnected)?;
         reply_rx.await.map_err(|_| SyncError::Disconnected)?

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -17,27 +17,32 @@
 //! Document mutations do NOT go through this task. Callers mutate directly
 //! via `DocHandle::with_doc`. This task is purely for network synchronization.
 
+use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use automerge::sync;
+use automerge::{sync, AutoCommit, ChangeHash};
 use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use notebook_protocol::connection::{self, NotebookFrameType};
 use notebook_protocol::protocol::{
-    NotebookBroadcast, NotebookRequest, NotebookResponse, SessionControlMessage,
-    SessionSyncStatusWire,
+    NotebookBroadcast, NotebookRequest, NotebookRequestEnvelope, NotebookResponse,
+    NotebookResponseEnvelope, SessionControlMessage, SessionSyncStatusWire,
 };
-
-use automerge::AutoCommit;
 
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
 use crate::status::{ConnectionState, InitialLoadPhase, SyncStatus};
+
+const CONFIRM_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
+const CONFIRM_SYNC_RETRY: Duration = Duration::from_millis(200);
+const STATE_SYNC_QUIET_TIMEOUT: Duration = Duration::from_millis(200);
+const STATE_SYNC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
+const MAINTENANCE_TICK: Duration = Duration::from_millis(50);
 
 /// Rebuild a `SharedDocState` after an automerge panic by round-tripping
 /// save→load to clear corrupted internal indices, then resetting the
@@ -92,17 +97,22 @@ pub enum SyncCommand {
 
     /// Confirm that the daemon has merged all our local changes.
     ///
-    /// Performs up to 5 sync round-trips, checking that the daemon's
-    /// shared_heads include our local heads.
+    /// The caller captures the target heads before enqueueing this command.
+    /// The sync task registers a passive waiter and resolves it once inbound
+    /// sync frames advance the daemon's `shared_heads` to include the target.
+    /// Timeout remains best-effort: an expired waiter returns `Ok(())` so
+    /// callers keep the historical non-strict durability semantics.
     ConfirmSync {
+        target_heads: Vec<ChangeHash>,
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
 
     /// Flush pending RuntimeStateDoc sync frames from the daemon.
     ///
-    /// Generates and sends a state sync message, then drains incoming
-    /// frames until a short timeout. Since the client is read-only for
-    /// the state doc, this is a flush — not a convergence handshake.
+    /// Generates and sends a state sync message, then waits for a quiet
+    /// window while the main frame pump keeps processing every inbound frame.
+    /// Since the client is read-only for the state doc, this is a flush — not
+    /// a convergence handshake.
     ConfirmStateSync {
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
@@ -144,6 +154,25 @@ struct SyncFrameContext<'a> {
     saw_session_status: &'a mut bool,
 }
 
+struct PendingRequest {
+    reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+    broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
+    deadline: Instant,
+}
+
+struct ConfirmWaiter {
+    target_heads: Vec<ChangeHash>,
+    sent_generation: Option<u64>,
+    reply: oneshot::Sender<Result<(), SyncError>>,
+    deadline: Instant,
+}
+
+struct StateSyncWaiter {
+    reply: oneshot::Sender<Result<(), SyncError>>,
+    quiet_deadline: Instant,
+    deadline: Instant,
+}
+
 /// Run the sync task.
 ///
 /// This is spawned as a background tokio task. It runs until the socket
@@ -157,13 +186,12 @@ where
     W: AsyncWrite + Unpin,
 {
     // Hand the read half to a dedicated FramedReader actor so the
-    // busy `select!` (and the `timeout(.., recv)` ack pattern) below
-    // stay cancel-safe. `recv_typed_frame`'s internal `read_exact`
-    // drops bytes mid-read whenever its future is cancelled — the
-    // exact failure mode that desyncs the wire under stream-output
+    // busy `select!` stays cancel-safe. `recv_typed_frame`'s internal
+    // `read_exact` drops bytes mid-read whenever its future is cancelled —
+    // the exact failure mode that desyncs the wire under stream-output
     // pressure.
     let buffered = tokio::io::BufReader::new(reader);
-    let mut framed_reader = connection::FramedReader::spawn(buffered, 16);
+    let mut framed_reader = connection::FramedReader::spawn(buffered, 64);
     let mut writer = tokio::io::BufWriter::new(writer);
 
     let notebook_id = {
@@ -173,64 +201,112 @@ where
 
     let mut loop_count: u64 = 0;
     let mut saw_session_status = false;
-
-    // Track last metadata for change detection (used for SyncUpdate-like behavior)
-    let mut _last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
-        let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
-        notebook_doc::get_metadata_snapshot_from_doc(&state.doc)
-    };
+    let mut pending_requests: HashMap<String, PendingRequest> = HashMap::new();
+    let mut confirm_waiters: Vec<ConfirmWaiter> = Vec::new();
+    let mut state_sync_waiters: Vec<StateSyncWaiter> = Vec::new();
+    let mut next_confirm_sync_attempt = Instant::now();
+    let mut sync_generation: u64 = 0;
+    let mut acked_sync_generation: u64 = 0;
+    let mut maintenance = tokio::time::interval(MAINTENANCE_TICK);
+    maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         loop_count += 1;
 
-        // Use select! with biased mode so we prioritize local changes and commands
-        // over incoming frames (prevents starvation when the daemon is chatty).
+        // Keep the inbound frame pump hot. Commands must only register work
+        // and write immediate outbound frames; waits resolve from the normal
+        // frame path so the daemon never backs up behind a command subloop.
         enum SelectResult {
-            Changed,
-            Command(Option<SyncCommand>),
             Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
+            Changed(Option<()>),
+            Command(Option<SyncCommand>),
+            Maintenance,
         }
 
         let select_result = tokio::select! {
             biased;
 
+            // Incoming frame from daemon (cancel-safe: actor owns read_exact)
+            frame = framed_reader.recv() => SelectResult::Frame(frame),
+
             // Local document was mutated by a handle
-            result = config.changed_rx.recv() => {
-                if result.is_none() {
-                    // All handles dropped — shut down
-                    info!("[notebook-sync] All handles dropped for {}, shutting down", notebook_id);
-                    break;
-                }
-                SelectResult::Changed
-            }
+            result = config.changed_rx.recv() => SelectResult::Changed(result),
 
             // Protocol command (request/response, confirm_sync, etc.)
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
 
-            // Incoming frame from daemon (cancel-safe: actor owns read_exact)
-            frame = framed_reader.recv() => SelectResult::Frame(frame),
+            _ = maintenance.tick() => SelectResult::Maintenance,
         };
 
         match select_result {
-            // ─── Local changes: generate sync message and send to daemon ───
-            SelectResult::Changed => {
-                // Drain any additional notifications (coalesce multiple mutations)
-                while config.changed_rx.try_recv().is_ok() {}
-
-                // Generate and send sync message
-                let msg_bytes = {
-                    let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
-                    state.generate_sync_message().map(|msg| msg.encode())
-                };
-
-                if let Some(bytes) = msg_bytes {
-                    if let Err(e) = connection::send_typed_frame(
+            // ─── Incoming frame from daemon ────────────────────────────────
+            SelectResult::Frame(frame_result) => match frame_result {
+                Some(Ok(frame)) => {
+                    note_frame_activity(&mut state_sync_waiters);
+                    let mut ctx = SyncFrameContext {
+                        doc: &config.doc,
+                        snapshot_tx: &config.snapshot_tx,
+                        status_tx: &config.status_tx,
+                        broadcast_tx: &config.broadcast_tx,
+                        notebook_id: &notebook_id,
+                        saw_session_status: &mut saw_session_status,
+                    };
+                    handle_task_frame(&frame, &mut pending_requests, &mut ctx, &mut writer).await;
+                    if frame.frame_type == NotebookFrameType::AutomergeSync {
+                        acked_sync_generation = sync_generation;
+                    }
+                    resolve_confirm_waiters(
+                        &config.doc,
+                        &mut confirm_waiters,
+                        &notebook_id,
+                        acked_sync_generation,
+                    );
+                    if let Err(e) = drive_confirm_sync_round(
+                        &config.doc,
                         &mut writer,
-                        NotebookFrameType::AutomergeSync,
-                        &bytes,
+                        &mut confirm_waiters,
+                        &notebook_id,
+                        &mut next_confirm_sync_attempt,
+                        &mut sync_generation,
+                        acked_sync_generation,
                     )
                     .await
                     {
+                        warn!(
+                            "[notebook-sync] Failed to continue confirm_sync for {}: {}",
+                            notebook_id, e
+                        );
+                        break;
+                    }
+                    resolve_state_sync_waiters(&mut state_sync_waiters);
+                }
+                None => {
+                    info!(
+                        "[notebook-sync] Disconnected from daemon for {}, loop_count={}",
+                        notebook_id, loop_count
+                    );
+                    break;
+                }
+                Some(Err(e)) => {
+                    warn!(
+                        "[notebook-sync] Socket error for {}: {}, loop_count={}",
+                        notebook_id, e, loop_count
+                    );
+                    break;
+                }
+            },
+
+            // ─── Local changes: generate sync message and send to daemon ───
+            SelectResult::Changed(Some(())) => {
+                // Drain any additional notifications (coalesce multiple mutations)
+                while config.changed_rx.try_recv().is_ok() {}
+
+                match send_doc_sync_round(&config.doc, &mut writer, &mut sync_generation).await {
+                    Ok(Some(generation)) => {
+                        mark_unsent_confirm_waiters(&mut confirm_waiters, generation);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
                         warn!(
                             "[notebook-sync] Failed to send sync message for {}: {}",
                             notebook_id, e
@@ -239,32 +315,20 @@ where
                     }
                 }
 
-                // Wait briefly for an ack from the daemon (like sync_to_daemon)
-                match tokio::time::timeout(Duration::from_millis(500), framed_reader.recv()).await {
-                    Ok(Some(Ok(frame))) => {
-                        SyncFrameContext {
-                            doc: &config.doc,
-                            snapshot_tx: &config.snapshot_tx,
-                            status_tx: &config.status_tx,
-                            broadcast_tx: &config.broadcast_tx,
-                            notebook_id: &notebook_id,
-                            saw_session_status: &mut saw_session_status,
-                        }
-                        .handle_incoming_frame(&frame, &mut writer)
-                        .await;
-                    }
-                    Ok(None) => {
-                        info!("[notebook-sync] Connection closed for {}", notebook_id);
-                        break;
-                    }
-                    Ok(Some(Err(e))) => {
-                        warn!("[notebook-sync] Socket error for {}: {}", notebook_id, e);
-                        break;
-                    }
-                    Err(_) => {
-                        // Timeout — daemon hasn't responded yet, that's fine
-                    }
-                }
+                resolve_confirm_waiters(
+                    &config.doc,
+                    &mut confirm_waiters,
+                    &notebook_id,
+                    acked_sync_generation,
+                );
+            }
+            SelectResult::Changed(None) => {
+                // All handles dropped — shut down
+                info!(
+                    "[notebook-sync] All handles dropped for {}, shutting down",
+                    notebook_id
+                );
+                break;
             }
 
             // ─── Protocol commands ─────────────────────────────────────────
@@ -284,56 +348,63 @@ where
                         reply,
                         broadcast_tx: req_broadcast_tx,
                     } => {
-                        let result = send_request_impl(
-                            &mut framed_reader,
+                        register_request(
+                            &mut pending_requests,
                             &mut writer,
-                            req_broadcast_tx.as_ref(),
-                            &request,
-                            &mut SyncFrameContext {
-                                doc: &config.doc,
-                                snapshot_tx: &config.snapshot_tx,
-                                status_tx: &config.status_tx,
-                                broadcast_tx: &config.broadcast_tx,
-                                notebook_id: &notebook_id,
-                                saw_session_status: &mut saw_session_status,
-                            },
+                            request,
+                            reply,
+                            req_broadcast_tx,
                         )
                         .await;
-                        let _ = reply.send(result);
                     }
 
-                    SyncCommand::ConfirmSync { reply } => {
-                        let result = confirm_sync_impl(
-                            &mut framed_reader,
-                            &mut writer,
-                            &mut SyncFrameContext {
-                                doc: &config.doc,
-                                snapshot_tx: &config.snapshot_tx,
-                                status_tx: &config.status_tx,
-                                broadcast_tx: &config.broadcast_tx,
-                                notebook_id: &notebook_id,
-                                saw_session_status: &mut saw_session_status,
-                            },
-                        )
-                        .await;
-                        let _ = reply.send(result);
+                    SyncCommand::ConfirmSync {
+                        target_heads,
+                        reply,
+                    } => {
+                        if target_heads_confirmed(&config.doc, &target_heads) {
+                            let _ = reply.send(Ok(()));
+                        } else {
+                            let sent_generation = match send_doc_sync_round(
+                                &config.doc,
+                                &mut writer,
+                                &mut sync_generation,
+                            )
+                            .await
+                            {
+                                Ok(generation) => generation,
+                                Err(e) => {
+                                    let _ = reply.send(Err(e));
+                                    continue;
+                                }
+                            };
+                            confirm_waiters.push(ConfirmWaiter {
+                                target_heads,
+                                sent_generation,
+                                reply,
+                                deadline: Instant::now() + CONFIRM_SYNC_TIMEOUT,
+                            });
+                            next_confirm_sync_attempt = Instant::now() + CONFIRM_SYNC_RETRY;
+                            resolve_confirm_waiters(
+                                &config.doc,
+                                &mut confirm_waiters,
+                                &notebook_id,
+                                acked_sync_generation,
+                            );
+                        }
                     }
 
                     SyncCommand::ConfirmStateSync { reply } => {
-                        let result = confirm_state_sync_impl(
-                            &mut framed_reader,
-                            &mut writer,
-                            &mut SyncFrameContext {
-                                doc: &config.doc,
-                                snapshot_tx: &config.snapshot_tx,
-                                status_tx: &config.status_tx,
-                                broadcast_tx: &config.broadcast_tx,
-                                notebook_id: &notebook_id,
-                                saw_session_status: &mut saw_session_status,
-                            },
-                        )
-                        .await;
-                        let _ = reply.send(result);
+                        if let Err(e) = send_state_sync_message(&config.doc, &mut writer).await {
+                            let _ = reply.send(Err(e));
+                        } else {
+                            let now = Instant::now();
+                            state_sync_waiters.push(StateSyncWaiter {
+                                reply,
+                                quiet_deadline: now + STATE_SYNC_QUIET_TIMEOUT,
+                                deadline: now + STATE_SYNC_MAX_TIMEOUT,
+                            });
+                        }
                     }
 
                     SyncCommand::SendPresence { data, reply } => {
@@ -349,38 +420,43 @@ where
                 }
             }
 
-            // ─── Incoming frame from daemon ────────────────────────────────
-            SelectResult::Frame(frame_result) => match frame_result {
-                Some(Ok(frame)) => {
-                    SyncFrameContext {
-                        doc: &config.doc,
-                        snapshot_tx: &config.snapshot_tx,
-                        status_tx: &config.status_tx,
-                        broadcast_tx: &config.broadcast_tx,
-                        notebook_id: &notebook_id,
-                        saw_session_status: &mut saw_session_status,
+            SelectResult::Maintenance => {
+                resolve_confirm_waiters(
+                    &config.doc,
+                    &mut confirm_waiters,
+                    &notebook_id,
+                    acked_sync_generation,
+                );
+                if !confirm_waiters.is_empty() && Instant::now() >= next_confirm_sync_attempt {
+                    if let Err(e) = drive_confirm_sync_round(
+                        &config.doc,
+                        &mut writer,
+                        &mut confirm_waiters,
+                        &notebook_id,
+                        &mut next_confirm_sync_attempt,
+                        &mut sync_generation,
+                        acked_sync_generation,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to retry confirm_sync for {}: {}",
+                            notebook_id, e
+                        );
+                        break;
                     }
-                    .handle_incoming_frame(&frame, &mut writer)
-                    .await;
                 }
-                None => {
-                    info!(
-                        "[notebook-sync] Disconnected from daemon for {}, loop_count={}",
-                        notebook_id, loop_count
-                    );
-                    break;
-                }
-                Some(Err(e)) => {
-                    warn!(
-                        "[notebook-sync] Socket error for {}: {}, loop_count={}",
-                        notebook_id, e, loop_count
-                    );
-                    break;
-                }
-            },
+                resolve_state_sync_waiters(&mut state_sync_waiters);
+                expire_pending_requests(&mut pending_requests, &notebook_id);
+            }
         }
     }
 
+    disconnect_pending(
+        &mut pending_requests,
+        &mut confirm_waiters,
+        &mut state_sync_waiters,
+    );
     mark_disconnected(&config.status_tx);
 
     info!(
@@ -659,260 +735,312 @@ impl SyncFrameContext<'_> {
     }
 }
 
-/// Send a request to the daemon and wait for a response.
-///
-/// While waiting, also processes AutomergeSync and Broadcast frames that arrive
-/// interleaved with the response.
-async fn send_request_impl<W: AsyncWrite + Unpin>(
-    framed: &mut connection::FramedReader,
+async fn send_doc_sync_message<W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
     writer: &mut W,
-    req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
-    request: &NotebookRequest,
-    ctx: &mut SyncFrameContext<'_>,
-) -> Result<NotebookResponse, SyncError> {
-    // Serialize and send the request
-    let payload =
-        serde_json::to_vec(request).map_err(|e| SyncError::Serialization(e.to_string()))?;
-
-    connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
-        .await
-        .map_err(SyncError::Io)?;
-
-    // Determine timeout based on request type
-    let timeout_secs = match request {
-        NotebookRequest::LaunchKernel { .. } => 300, // 5 minutes for env creation
-        _ => 30,
-    };
-
-    // Wait for a Response frame, processing other frames that arrive meanwhile
-    let result = tokio::time::timeout(
-        Duration::from_secs(timeout_secs),
-        wait_for_response(framed, writer, req_broadcast_tx, ctx),
-    )
-    .await;
-
-    match result {
-        Ok(Ok(response)) => Ok(response),
-        Ok(Err(e)) => Err(e),
-        Err(_) => Err(SyncError::Timeout),
-    }
-}
-
-/// Wait for a Response frame from the daemon, processing other frames.
-async fn wait_for_response<W: AsyncWrite + Unpin>(
-    framed: &mut connection::FramedReader,
-    writer: &mut W,
-    req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
-    ctx: &mut SyncFrameContext<'_>,
-) -> Result<NotebookResponse, SyncError> {
-    loop {
-        let frame = framed
-            .recv()
-            .await
-            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?
-            .map_err(SyncError::Io)?;
-
-        match frame.frame_type {
-            NotebookFrameType::Response => {
-                let response: NotebookResponse = serde_json::from_slice(&frame.payload)
-                    .map_err(|e| SyncError::Serialization(e.to_string()))?;
-                return Ok(response);
-            }
-
-            NotebookFrameType::AutomergeSync => {
-                // Apply sync message while waiting for response
-                let msg = sync::Message::decode(&frame.payload)
-                    .map_err(|e| SyncError::Protocol(format!("Decode sync: {}", e)))?;
-
-                let ack_bytes = {
-                    let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
-
-                    // Guard both receive and generate against automerge panics
-                    let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.receive_sync_message(msg)
-                    }));
-                    match recv_result {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
-                            warn!(
-                                "[notebook-sync] receive_sync_message error in wait_for_response for {}: {}",
-                                ctx.notebook_id, e
-                            );
-                            continue;
-                        }
-                        Err(panic_payload) => {
-                            let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
-                                s.as_str()
-                            } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                                s
-                            } else {
-                                "unknown panic"
-                            };
-                            warn!(
-                                "[notebook-sync] Automerge panicked in wait_for_response for {} \
-                                 (upstream bug): {}",
-                                ctx.notebook_id, msg
-                            );
-                            rebuild_shared_doc_state(&mut state);
-                            continue;
-                        }
-                    }
-
-                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.generate_sync_message().map(|m| m.encode())
-                    })) {
-                        Ok(bytes) => bytes,
-                        Err(_) => {
-                            warn!(
-                                "[notebook-sync] generate_sync_message panicked in wait_for_response for {}",
-                                ctx.notebook_id
-                            );
-                            rebuild_shared_doc_state(&mut state);
-                            None
-                        }
-                    }
-                };
-
-                publish_snapshot(ctx.doc, ctx.snapshot_tx);
-
-                if let Some(bytes) = ack_bytes {
-                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
-                        .await
-                        .map_err(SyncError::Io)?;
-                }
-            }
-
-            NotebookFrameType::Broadcast => {
-                if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
-                    // Send to request-specific broadcast channel if provided (for real-time
-                    // progress during long requests like LaunchKernel)
-                    if let Some(tx) = req_broadcast_tx {
-                        let _ = tx.send(bc.clone());
-                    }
-                    // Also send to the main broadcast channel
-                    let _ = ctx.broadcast_tx.send(bc);
-                }
-            }
-
-            // Process all other frame types (RuntimeStateSync, Presence, etc.)
-            // while waiting for the response. Dropping these frames would stall
-            // the Automerge sync protocol — the daemon marks sent messages as
-            // in_flight, and generate_sync_message() returns None until the peer
-            // acknowledges. A dropped RuntimeStateSync causes permanent sync
-            // stall for RuntimeStateDoc (no execution results, no status updates).
-            _ => {
-                ctx.handle_incoming_frame(&frame, writer).await;
-            }
-        }
-    }
-}
-
-/// Confirm that the daemon has merged all our local changes.
-///
-/// Performs sync rounds until our local heads are in the peer's shared_heads,
-/// or until we've done 5 rounds (best-effort).
-async fn confirm_sync_impl<W: AsyncWrite + Unpin>(
-    framed: &mut connection::FramedReader,
-    writer: &mut W,
-    ctx: &mut SyncFrameContext<'_>,
-) -> Result<(), SyncError> {
-    for round in 0..5 {
-        // Generate and send sync message
-        let (msg_bytes, our_heads, shared_heads) = {
-            let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
-            let our_heads = state.doc.get_heads();
-            let shared = state.peer_state.shared_heads.clone();
-            let msg = state.generate_sync_message().map(|m| m.encode());
-            (msg, our_heads, shared)
-        };
-
-        // Check if already confirmed
-        if our_heads.is_empty() || our_heads.iter().all(|h| shared_heads.contains(h)) {
-            debug!(
-                "[notebook-sync] Sync confirmed for {} after {} rounds",
-                ctx.notebook_id, round
-            );
-            return Ok(());
-        }
-
-        // Send sync message if there is one
-        if let Some(bytes) = msg_bytes {
-            connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
-                .await
-                .map_err(SyncError::Io)?;
-        }
-
-        // Wait for response
-        match tokio::time::timeout(Duration::from_millis(2000), framed.recv()).await {
-            Ok(Some(Ok(frame))) => {
-                ctx.handle_incoming_frame(&frame, writer).await;
-            }
-            Ok(None) => {
-                return Err(SyncError::Protocol(
-                    "Connection closed during confirm_sync".into(),
-                ));
-            }
-            Ok(Some(Err(e))) => {
-                return Err(SyncError::Io(e));
-            }
-            Err(_) => {
-                // Timeout — try next round
-                debug!(
-                    "[notebook-sync] confirm_sync round {} timed out for {}",
-                    round, ctx.notebook_id
-                );
-            }
-        }
-    }
-
-    // Best-effort: likely confirmed even if heads don't fully match
-    debug!(
-        "[notebook-sync] confirm_sync: heads not fully confirmed after 5 rounds for {}",
-        ctx.notebook_id
-    );
-    Ok(())
-}
-
-/// Flush pending RuntimeStateDoc sync frames.
-///
-/// The client never writes to the state doc, so there is no convergence
-/// to negotiate. We send our current heads (so the daemon can reply with
-/// anything we're missing) and then drain frames with a short timeout.
-async fn confirm_state_sync_impl<W: AsyncWrite + Unpin>(
-    framed: &mut connection::FramedReader,
-    writer: &mut W,
-    ctx: &mut SyncFrameContext<'_>,
-) -> Result<(), SyncError> {
-    // Send our state doc heads so the daemon knows what we have.
+) -> Result<bool, SyncError> {
     let msg_bytes = {
-        let mut state = ctx.doc.lock().unwrap_or_else(|e| e.into_inner());
-        state.generate_state_sync_message().map(|m| m.encode())
+        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.generate_sync_message().map(|msg| msg.encode())
     };
+
+    if let Some(bytes) = msg_bytes {
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+            .await
+            .map_err(SyncError::Io)?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+async fn send_doc_sync_round<W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+    sync_generation: &mut u64,
+) -> Result<Option<u64>, SyncError> {
+    if send_doc_sync_message(doc, writer).await? {
+        *sync_generation += 1;
+        Ok(Some(*sync_generation))
+    } else {
+        Ok(None)
+    }
+}
+
+fn mark_unsent_confirm_waiters(waiters: &mut [ConfirmWaiter], generation: u64) {
+    for waiter in waiters {
+        if waiter.sent_generation.is_none() {
+            waiter.sent_generation = Some(generation);
+        }
+    }
+}
+
+async fn send_state_sync_message<W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+) -> Result<(), SyncError> {
+    let msg_bytes = {
+        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.generate_state_sync_message().map(|msg| msg.encode())
+    };
+
     if let Some(bytes) = msg_bytes {
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &bytes)
             .await
             .map_err(SyncError::Io)?;
     }
 
-    // Drain up to 10 frames with a 200ms per-frame timeout.
-    for _ in 0..10 {
-        match tokio::time::timeout(Duration::from_millis(200), framed.recv()).await {
-            Ok(Some(Ok(frame))) => {
-                ctx.handle_incoming_frame(&frame, writer).await;
+    Ok(())
+}
+
+async fn register_request<W: AsyncWrite + Unpin>(
+    pending: &mut HashMap<String, PendingRequest>,
+    writer: &mut W,
+    request: NotebookRequest,
+    reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+    broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
+) {
+    let id = uuid::Uuid::new_v4().to_string();
+    let deadline = Instant::now() + crate::relay_task::request_timeout(&request);
+    let envelope = NotebookRequestEnvelope {
+        id: Some(id.clone()),
+        request,
+    };
+
+    let payload = match serde_json::to_vec(&envelope) {
+        Ok(payload) => payload,
+        Err(e) => {
+            let _ = reply.send(Err(SyncError::Serialization(e.to_string())));
+            return;
+        }
+    };
+
+    // Register before sending so a fast daemon response cannot beat the
+    // pending entry. The main frame loop owns all response routing.
+    pending.insert(
+        id.clone(),
+        PendingRequest {
+            reply,
+            broadcast_tx,
+            deadline,
+        },
+    );
+
+    if let Err(e) = connection::send_typed_frame(writer, NotebookFrameType::Request, &payload).await
+    {
+        if let Some(entry) = pending.remove(&id) {
+            let _ = entry.reply.send(Err(SyncError::Io(e)));
+        }
+    }
+}
+
+async fn handle_task_frame<W: AsyncWrite + Unpin>(
+    frame: &connection::TypedNotebookFrame,
+    pending: &mut HashMap<String, PendingRequest>,
+    ctx: &mut SyncFrameContext<'_>,
+    writer: &mut W,
+) {
+    match frame.frame_type {
+        NotebookFrameType::Response => {
+            match serde_json::from_slice::<NotebookResponseEnvelope>(&frame.payload) {
+                Ok(envelope) => {
+                    let entry = envelope.id.as_deref().and_then(|id| pending.remove(id));
+                    if let Some(entry) = entry {
+                        let _ = entry.reply.send(Ok(envelope.response));
+                    } else {
+                        warn!(
+                            "[notebook-sync] Unknown Response id for {}: {:?}",
+                            ctx.notebook_id, envelope.id
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Malformed response envelope for {}: {}",
+                        ctx.notebook_id, e
+                    );
+                }
             }
-            Ok(None) => {
-                return Err(SyncError::Protocol(
-                    "Connection closed during state sync flush".into(),
-                ));
+        }
+
+        NotebookFrameType::Broadcast => {
+            match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                Ok(bc) => {
+                    for entry in pending.values() {
+                        if let Some(tx) = &entry.broadcast_tx {
+                            let _ = tx.send(bc.clone());
+                        }
+                    }
+                    let _ = ctx.broadcast_tx.send(bc);
+                }
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to parse broadcast for {}: {}",
+                        ctx.notebook_id, e
+                    );
+                }
             }
-            Ok(Some(Err(e))) => {
-                return Err(SyncError::Io(e));
-            }
-            Err(_) => break, // timeout — done draining
+        }
+
+        _ => ctx.handle_incoming_frame(frame, writer).await,
+    }
+}
+
+fn heads_confirmed_by_peer(
+    target_heads: &[ChangeHash],
+    shared_heads: &[ChangeHash],
+    their_heads: Option<&[ChangeHash]>,
+) -> bool {
+    if target_heads.is_empty() || target_heads.iter().all(|head| shared_heads.contains(head)) {
+        return true;
+    }
+
+    their_heads
+        .map(|heads| target_heads.iter().all(|head| heads.contains(head)))
+        .unwrap_or(false)
+}
+
+fn target_heads_confirmed(doc: &Arc<Mutex<SharedDocState>>, target_heads: &[ChangeHash]) -> bool {
+    if target_heads.is_empty() {
+        return true;
+    }
+    let state = doc.lock().unwrap_or_else(|e| e.into_inner());
+    heads_confirmed_by_peer(
+        target_heads,
+        &state.peer_state.shared_heads,
+        state.peer_state.their_heads.as_deref(),
+    )
+}
+
+fn resolve_confirm_waiters(
+    doc: &Arc<Mutex<SharedDocState>>,
+    waiters: &mut Vec<ConfirmWaiter>,
+    notebook_id: &str,
+    acked_sync_generation: u64,
+) {
+    if waiters.is_empty() {
+        return;
+    }
+
+    let (shared_heads, their_heads) = {
+        let state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        (
+            state.peer_state.shared_heads.clone(),
+            state.peer_state.their_heads.clone(),
+        )
+    };
+    let now = Instant::now();
+    let mut pending = Vec::with_capacity(waiters.len());
+
+    for waiter in waiters.drain(..) {
+        if heads_confirmed_by_peer(&waiter.target_heads, &shared_heads, their_heads.as_deref())
+            || waiter
+                .sent_generation
+                .map(|generation| generation <= acked_sync_generation)
+                .unwrap_or(false)
+        {
+            let _ = waiter.reply.send(Ok(()));
+        } else if now >= waiter.deadline {
+            debug!(
+                "[notebook-sync] confirm_sync timed out before heads fully confirmed for {}",
+                notebook_id
+            );
+            let _ = waiter.reply.send(Ok(()));
+        } else {
+            pending.push(waiter);
         }
     }
 
+    *waiters = pending;
+}
+
+async fn drive_confirm_sync_round<W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+    waiters: &mut Vec<ConfirmWaiter>,
+    notebook_id: &str,
+    next_attempt: &mut Instant,
+    sync_generation: &mut u64,
+    acked_sync_generation: u64,
+) -> Result<(), SyncError> {
+    if waiters.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(generation) = send_doc_sync_round(doc, writer, sync_generation).await? {
+        mark_unsent_confirm_waiters(waiters, generation);
+    }
+    *next_attempt = Instant::now() + CONFIRM_SYNC_RETRY;
+    resolve_confirm_waiters(doc, waiters, notebook_id, acked_sync_generation);
     Ok(())
+}
+
+fn note_frame_activity(waiters: &mut [StateSyncWaiter]) {
+    if waiters.is_empty() {
+        return;
+    }
+    let now = Instant::now();
+    for waiter in waiters {
+        waiter.quiet_deadline = (now + STATE_SYNC_QUIET_TIMEOUT).min(waiter.deadline);
+    }
+}
+
+fn resolve_state_sync_waiters(waiters: &mut Vec<StateSyncWaiter>) {
+    if waiters.is_empty() {
+        return;
+    }
+    let now = Instant::now();
+    let mut pending = Vec::with_capacity(waiters.len());
+
+    for waiter in waiters.drain(..) {
+        if now >= waiter.quiet_deadline || now >= waiter.deadline {
+            let _ = waiter.reply.send(Ok(()));
+        } else {
+            pending.push(waiter);
+        }
+    }
+
+    *waiters = pending;
+}
+
+fn expire_pending_requests(pending: &mut HashMap<String, PendingRequest>, notebook_id: &str) {
+    if pending.is_empty() {
+        return;
+    }
+    let now = Instant::now();
+    pending.retain(|id, entry| {
+        if now >= entry.deadline {
+            warn!(
+                "[notebook-sync] Request {} timed out for {}",
+                id, notebook_id
+            );
+            let (reply, _broadcast_tx, _deadline) = (
+                std::mem::replace(&mut entry.reply, oneshot::channel().0),
+                entry.broadcast_tx.take(),
+                entry.deadline,
+            );
+            let _ = reply.send(Err(SyncError::Timeout));
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn disconnect_pending(
+    requests: &mut HashMap<String, PendingRequest>,
+    confirm_waiters: &mut Vec<ConfirmWaiter>,
+    state_sync_waiters: &mut Vec<StateSyncWaiter>,
+) {
+    for (_, entry) in requests.drain() {
+        let _ = entry.reply.send(Err(SyncError::Disconnected));
+    }
+    for waiter in confirm_waiters.drain(..) {
+        let _ = waiter.reply.send(Err(SyncError::Disconnected));
+    }
+    for waiter in state_sync_waiters.drain(..) {
+        let _ = waiter.reply.send(Err(SyncError::Disconnected));
+    }
 }
 
 /// Publish a snapshot from the current document state.
@@ -1001,10 +1129,60 @@ fn apply_sync_status(
 mod tests {
     use super::*;
 
+    use notebook_protocol::connection::send_typed_json_frame;
     use notebook_protocol::protocol::{
-        InitialLoadPhaseWire, NotebookDocPhaseWire, RuntimeStatePhaseWire,
+        InitialLoadPhaseWire, NotebookDocPhaseWire, NotebookRequestEnvelope,
+        NotebookResponseEnvelope, RuntimeStatePhaseWire,
     };
+    use serde_json::json;
+    use tokio::io::{BufReader, BufWriter};
     use tokio::sync::{broadcast, mpsc, watch};
+    use tokio::time::timeout;
+
+    fn test_handle_and_config() -> (crate::DocHandle, SyncTaskConfig) {
+        let shared = Arc::new(Mutex::new(SharedDocState::new(
+            notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+            "test-notebook".into(),
+        )));
+        let initial_snapshot = {
+            let state = shared.lock().unwrap();
+            NotebookSnapshot::from_doc(&state.doc)
+        };
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+        let snapshot_tx = Arc::new(snapshot_tx);
+        let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+        let (broadcast_tx, _broadcast_rx) = broadcast::channel::<NotebookBroadcast>(32);
+
+        let handle = crate::DocHandle::new(
+            Arc::clone(&shared),
+            changed_tx,
+            cmd_tx,
+            Arc::clone(&snapshot_tx),
+            snapshot_rx,
+            status_rx,
+            "test-notebook".to_string(),
+        );
+        let config = SyncTaskConfig {
+            doc: shared,
+            changed_rx,
+            cmd_rx,
+            snapshot_tx,
+            status_tx,
+            broadcast_tx,
+        };
+
+        (handle, config)
+    }
+
+    fn interactive_status() -> SessionControlMessage {
+        SessionControlMessage::SyncStatus(SessionSyncStatusWire {
+            notebook_doc: NotebookDocPhaseWire::Interactive,
+            runtime_state: RuntimeStatePhaseWire::Ready,
+            initial_load: InitialLoadPhaseWire::NotNeeded,
+        })
+    }
 
     #[tokio::test]
     async fn first_session_status_accepts_streaming_initial_load() {
@@ -1116,5 +1294,186 @@ mod tests {
         .await;
 
         assert_eq!(status_rx.borrow().connection, ConnectionState::Disconnected);
+    }
+
+    #[tokio::test]
+    async fn parallel_confirm_sync_does_not_starve_frame_pump() {
+        let (handle, config) = test_handle_and_config();
+
+        let mut after_cell_id: Option<String> = None;
+        for index in 0..10 {
+            let cell_id = format!("cell-{index}");
+            handle
+                .add_cell_with_source(
+                    &cell_id,
+                    "code",
+                    after_cell_id.as_deref(),
+                    &format!("print({index})"),
+                )
+                .expect("cell added");
+            after_cell_id = Some(cell_id);
+        }
+
+        let (client, server) = tokio::io::duplex(128);
+        let (client_read, client_write) = tokio::io::split(client);
+        let (server_read, server_write) = tokio::io::split(server);
+
+        let sync_task = tokio::spawn(run(config, client_read, client_write));
+        let daemon = tokio::spawn(async move {
+            let mut reader = connection::FramedReader::spawn(BufReader::new(server_read), 64);
+            let mut writer = BufWriter::new(server_write);
+            let mut daemon_state = SharedDocState::new(AutoCommit::new(), "test-notebook".into());
+
+            loop {
+                let frame = timeout(Duration::from_secs(15), reader.recv())
+                    .await
+                    .expect("daemon received sync frame")
+                    .expect("client stayed connected")
+                    .expect("sync frame read");
+
+                if frame.frame_type != NotebookFrameType::AutomergeSync {
+                    continue;
+                }
+
+                let msg = sync::Message::decode(&frame.payload).expect("valid sync message");
+                daemon_state
+                    .receive_sync_message(msg)
+                    .expect("daemon receives client sync");
+
+                if let Some(reply) = daemon_state.generate_sync_message() {
+                    connection::send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::AutomergeSync,
+                        &reply.encode(),
+                    )
+                    .await
+                    .expect("daemon sends sync reply");
+                }
+
+                for _ in 0..32 {
+                    send_typed_json_frame(
+                        &mut writer,
+                        NotebookFrameType::SessionControl,
+                        &interactive_status(),
+                    )
+                    .await
+                    .expect("daemon sends interleaved control frame");
+                }
+
+                let cell_count = notebook_doc::get_cells_from_doc(&daemon_state.doc).len();
+                if cell_count >= 10 {
+                    return cell_count;
+                }
+            }
+        });
+
+        let mut waiters = Vec::new();
+        for _ in 0..10 {
+            let handle = handle.clone();
+            waiters.push(tokio::spawn(async move { handle.confirm_sync().await }));
+        }
+
+        timeout(Duration::from_secs(15), async {
+            for waiter in waiters {
+                waiter.await.expect("join").expect("confirm_sync");
+            }
+        })
+        .await
+        .expect("parallel confirm_sync waiters resolved without blocking frames");
+
+        assert_eq!(daemon.await.expect("daemon task"), 10);
+        drop(handle);
+        sync_task.await.expect("sync task exits");
+    }
+
+    #[tokio::test]
+    async fn concurrent_send_request_routes_responses_by_id() {
+        let (handle, config) = test_handle_and_config();
+        let (client, server) = tokio::io::duplex(256);
+        let (client_read, client_write) = tokio::io::split(client);
+        let (server_read, server_write) = tokio::io::split(server);
+
+        let sync_task = tokio::spawn(run(config, client_read, client_write));
+        let daemon = tokio::spawn(async move {
+            let mut reader = connection::FramedReader::spawn(BufReader::new(server_read), 64);
+            let mut writer = BufWriter::new(server_write);
+            let mut ids = Vec::new();
+
+            while ids.len() < 2 {
+                let frame = timeout(Duration::from_secs(15), reader.recv())
+                    .await
+                    .expect("daemon received request")
+                    .expect("client stayed connected")
+                    .expect("request frame read");
+                if frame.frame_type != NotebookFrameType::Request {
+                    continue;
+                }
+                let envelope: NotebookRequestEnvelope =
+                    serde_json::from_slice(&frame.payload).expect("request envelope");
+                ids.push(envelope.id.expect("request id"));
+            }
+
+            send_typed_json_frame(
+                &mut writer,
+                NotebookFrameType::Broadcast,
+                &NotebookBroadcast::Comm {
+                    msg_type: "comm_msg".into(),
+                    content: json!({"comm_id": "abc", "data": {}}),
+                    buffers: Vec::new(),
+                },
+            )
+            .await
+            .expect("daemon sends broadcast");
+
+            send_typed_json_frame(
+                &mut writer,
+                NotebookFrameType::Response,
+                &NotebookResponseEnvelope {
+                    id: Some(ids[1].clone()),
+                    response: NotebookResponse::NoKernel {},
+                },
+            )
+            .await
+            .expect("daemon sends second response first");
+
+            send_typed_json_frame(
+                &mut writer,
+                NotebookFrameType::Response,
+                &NotebookResponseEnvelope {
+                    id: Some(ids[0].clone()),
+                    response: NotebookResponse::KernelInfo {
+                        kernel_type: Some("python".into()),
+                        env_source: Some("uv:inline".into()),
+                        status: "idle".into(),
+                    },
+                },
+            )
+            .await
+            .expect("daemon sends first response second");
+        });
+
+        let (progress_tx, mut progress_rx) = broadcast::channel(8);
+        let first =
+            handle.send_request_with_broadcast(NotebookRequest::GetKernelInfo {}, progress_tx);
+        let second = handle.send_request(NotebookRequest::GetKernelInfo {});
+
+        let (first_response, second_response) = tokio::join!(first, second);
+        let first_response = first_response.expect("first response");
+        let second_response = second_response.expect("second response");
+        let progress = progress_rx
+            .recv()
+            .await
+            .expect("request progress broadcast");
+
+        assert!(matches!(
+            first_response,
+            NotebookResponse::KernelInfo { .. }
+        ));
+        assert!(matches!(second_response, NotebookResponse::NoKernel {}));
+        assert!(matches!(progress, NotebookBroadcast::Comm { .. }));
+
+        daemon.await.expect("daemon task");
+        drop(handle);
+        sync_task.await.expect("sync task exits");
     }
 }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -142,9 +142,6 @@ pub async fn create_cell(
         (handle, cell_id)
     };
 
-    // Sync so the daemon (and peers) know about the new cell before we send presence
-    let _ = handle.confirm_sync().await;
-
     // Cursor at end of source (shows "finished typing")
     let peer_label = server.get_peer_label().await;
     let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
@@ -197,9 +194,6 @@ pub async fn set_cell(
         handle
             .update_source(cell_id, src)
             .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;
-
-        // Sync so peers see the edit before the cursor
-        let _ = handle.confirm_sync().await;
 
         // Cursor at end of new source
         let peer_label = server.get_peer_label().await;

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -77,9 +77,9 @@ pub async fn get_cell(
     let mut raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
 
     // If the cell has been executed but outputs haven't synced yet,
-    // force a sync round-trip to process pending RuntimeStateSync frames.
+    // flush pending RuntimeStateSync frames.
     if raw_outputs.is_empty() && !ec.is_empty() {
-        let _ = handle.confirm_sync().await;
+        let _ = handle.confirm_state_sync().await;
         raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
     }
 

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -164,6 +164,21 @@ async fn wait_for_session_ready(handle: &notebook_sync::DocHandle, timeout: Dura
     )
 }
 
+async fn wait_for_cell_count(
+    handle: &notebook_sync::DocHandle,
+    expected: usize,
+    timeout: Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if handle.get_cells().len() >= expected {
+            return true;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
 #[cfg(unix)]
 type LegacyPoolStream = tokio::net::UnixStream;
 
@@ -597,6 +612,94 @@ async fn test_notebook_sync_cross_window_propagation() {
     // is resolved from RuntimeStateDoc at save time and by the frontend.
 
     // Shutdown
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_parallel_cell_mutations_same_session_no_disconnect() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap();
+    let notebook_id = result.info.notebook_id.clone();
+    let handle = result.handle;
+
+    assert!(
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state"
+    );
+    assert!(
+        wait_for_cells_map(&handle, Duration::from_secs(5)).await,
+        "client should receive daemon-created cells map"
+    );
+
+    let mut joins = Vec::new();
+    for index in 0..10 {
+        let handle = handle.clone();
+        joins.push(tokio::spawn(async move {
+            let cell_id = format!("parallel-{index}");
+            handle.add_cell_with_source(&cell_id, "code", None, &format!("print({index})"))?;
+            handle.confirm_sync().await
+        }));
+    }
+
+    tokio::time::timeout(Duration::from_secs(20), async {
+        for join in joins {
+            join.await.unwrap().unwrap();
+        }
+    })
+    .await
+    .expect("parallel cell mutations should sync without hanging");
+
+    assert_eq!(
+        handle.status().connection,
+        notebook_sync::ConnectionState::Connected,
+        "original client should stay connected after parallel confirms"
+    );
+
+    let fresh = connect::connect(socket_path.clone(), notebook_id, "test")
+        .await
+        .unwrap()
+        .handle;
+    assert!(
+        wait_for_session_ready(&fresh, SESSION_READY_TIMEOUT).await,
+        "fresh client should reach session-ready state"
+    );
+    assert!(
+        wait_for_cells_map(&fresh, Duration::from_secs(5)).await,
+        "fresh client should receive cells map"
+    );
+    assert!(
+        wait_for_cell_count(&fresh, 10, Duration::from_secs(5)).await,
+        "fresh client should see every parallel-created cell"
+    );
+
+    let ids: std::collections::HashSet<_> =
+        fresh.get_cells().into_iter().map(|cell| cell.id).collect();
+    for index in 0..10 {
+        assert!(ids.contains(&format!("parallel-{index}")));
+    }
+
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }


### PR DESCRIPTION
## Summary
- keep notebook-sync inbound frame processing hot while confirmations and daemon requests are pending
- replace blocking confirm/request waits with passive waiters and request-id pending maps
- reduce avoidable MCP confirm pressure for non-executing cell edits
- add regression coverage and update protocol/skill guidance for frame-pump backpressure

## Validation
- cargo test -p notebook-sync
- cargo test -p notebook-protocol framed_reader_does_not_desync_in_select_under_pressure
- cargo test -p runtimed --test integration test_parallel_cell_mutations_same_session_no_disconnect -- --nocapture
- cargo test -p runt-mcp --no-run