### PR TITLE
ci(smoke): cross-platform smoke gate for daemon + kernel-launch

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,13 @@ jobs:
     name: Windows (build + install + smoke)
     runs-on: windows-latest
     timeout-minutes: 75
+    # Push-to-main + manual dispatch only. The Windows leg currently runs
+    # ~32 minutes (cargo build + NSIS bundling + smoke). Gating PRs on it
+    # would tax every diff, including frontend-only changes that have no
+    # Windows surface. We run it post-merge and surface failures via
+    # Discord (#windows) so the team can react fast without blocking
+    # unrelated PRs.
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
 
@@ -281,6 +288,33 @@ jobs:
           path: target/release/bundle/nsis/*.exe
           if-no-files-found: warn
           retention-days: 14
+
+      # Post-merge canary: ping #windows when this leg fails so the team
+      # can react without us having to gate every PR on the 32-minute
+      # Windows build. No-ops cleanly when the webhook secret is unset
+      # (e.g. fork PRs).
+      - name: Notify #windows on failure
+        if: failure()
+        shell: bash
+        env:
+          DISCORD_WEBHOOK_WINDOWS: ${{ secrets.DISCORD_WEBHOOK_WINDOWS }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref_name }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_WINDOWS" ]; then
+            echo "DISCORD_WEBHOOK_WINDOWS not set, skipping notification"
+            exit 0
+          fi
+          SHORT_SHA=$(echo "$SHA" | cut -c1-7)
+          curl --fail-with-body -sS -H "Content-Type: application/json" -d "{
+            \"embeds\": [{
+              \"title\": \"Windows smoke failed on $REF\",
+              \"description\": \"Commit \`$SHORT_SHA\` broke the Windows smoke gate. [View run]($RUN_URL).\",
+              \"url\": \"$RUN_URL\",
+              \"color\": 15158332
+            }]
+          }" "$DISCORD_WEBHOOK_WINDOWS"
 
   linux-smoke:
     name: Linux (build + smoke)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,8 +30,6 @@ jobs:
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
-        with:
-          lfs: true
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -40,15 +38,8 @@ jobs:
         with:
           shared-key: windows-smoke
 
-      - uses: voidzero-dev/setup-vp@v1
-        with:
-          run-install: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: pnpm
-      - run: pnpm install
+      - name: Build runtime artifacts (wasm + renderer plugins)
+        uses: ./.github/actions/build-runtime-artifacts
 
       - name: Build frontend
         run: pnpm build
@@ -297,8 +288,6 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-        with:
-          lfs: true
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -307,15 +296,8 @@ jobs:
         with:
           shared-key: linux-smoke
 
-      - uses: voidzero-dev/setup-vp@v1
-        with:
-          run-install: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: pnpm
-      - run: pnpm install
+      - name: Build runtime artifacts (wasm + renderer plugins)
+        uses: ./.github/actions/build-runtime-artifacts
 
       # runt-mcp's include_str! pulls in the MCP output widget HTML. Build
       # before compiling Rust so the assets/_output.html target exists.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,421 @@
+name: Smoke
+
+# Cross-platform end-to-end smoke for the runtimed daemon: install (Windows)
+# or build-from-source (Linux), spawn the daemon, drive it via MCP through
+# `runt mcp`, and assert a real Python kernel launches and runs `print(1+1)`
+# returning "2". Catches breakage in the install + daemon + kernel-launch
+# path that the regular CI doesn't exercise.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUNT_BUILD_CHANNEL: stable
+
+jobs:
+  windows-smoke:
+    name: Windows (build + install + smoke)
+    runs-on: windows-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-smoke
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Build frontend
+        run: pnpm build
+
+      - name: Install cargo-binstall
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy Unrestricted -Scope Process -Force
+          iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
+
+      - name: Install Tauri CLI
+        run: cargo binstall tauri-cli --no-confirm --locked --force
+
+      # Build the MCP output widget HTML. runt-mcp's include_str! needs it
+      # before we compile the Rust binaries.
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+
+      - name: Build external binaries
+        shell: bash
+        run: |
+          cargo build --release -p runtimed -p runt -p nteract-mcp
+          TARGET=$(rustc --print host-tuple)
+          mkdir -p crates/notebook/binaries
+          cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
+          cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
+          cp target/release/nteract-mcp.exe "crates/notebook/binaries/nteract-mcp-$TARGET.exe"
+
+      - name: Generate throwaway updater keypair
+        # tauri.conf.json declares an updater pubkey for production releases,
+        # so Tauri's config validator requires a matching private key at
+        # build time. --config overrides can't skip this (an empty pubkey
+        # still counts as "set"). Generate a single-use keypair on the
+        # runner. The signature it produces is meaningless once the runner
+        # tears down, which matches the install-and-throw-away smoke shape.
+        shell: pwsh
+        run: |
+          $keyPath = "$env:RUNNER_TEMP\tauri-smoke.key"
+          npx -y @tauri-apps/cli signer generate -w $keyPath --ci
+          $keyContent = Get-Content $keyPath -Raw
+          "TAURI_SIGNING_PRIVATE_KEY<<EOF" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          "$keyContent" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          "EOF" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
+      - name: Build NSIS installer
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: crates/notebook
+          args: --bundles nsis --config '{"build":{"beforeBuildCommand":""}}'
+          includeUpdaterJson: false
+
+      - name: Locate installer
+        id: locate
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path target/release/bundle/nsis -Filter *.exe | Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "No NSIS installer (.exe) found in target/release/bundle/nsis"
+            exit 1
+          }
+          Write-Host "Installer: $($exe.FullName)"
+          "installer=$($exe.FullName)" | Out-File -Append -FilePath $env:GITHUB_OUTPUT
+
+      - name: Install silently
+        # NSIS /S = silent. /D=path must be the LAST argument and unquoted (NSIS
+        # convention). We pin the install dir so the smoke script knows where
+        # to find runt.exe regardless of Tauri's installMode default.
+        shell: pwsh
+        run: |
+          $installer = "${{ steps.locate.outputs.installer }}"
+          $installDir = "$env:RUNNER_TEMP\nteract"
+          Write-Host "Installing $installer to $installDir"
+          $proc = Start-Process -FilePath $installer -ArgumentList "/S", "/D=$installDir" -Wait -PassThru -NoNewWindow
+          if ($proc.ExitCode -ne 0) {
+            Write-Error "Installer exited with code $($proc.ExitCode)"
+            exit $proc.ExitCode
+          }
+          Write-Host "Install dir contents:"
+          Get-ChildItem -Path $installDir -Recurse | Select-Object FullName | Format-Table -AutoSize
+          "INSTALL_DIR=$installDir" | Out-File -Append -FilePath $env:GITHUB_ENV
+          "RUNT=$installDir\runt.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
+          "RUNTIMED=$installDir\runtimed.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
+
+      - name: runt --version
+        shell: pwsh
+        run: |
+          if (-not (Test-Path $env:RUNT)) {
+            Write-Error "runt.exe not found at $env:RUNT"
+            exit 1
+          }
+          & $env:RUNT --version
+
+      - name: Set up Python for MCP smoke
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MCP client SDK
+        shell: pwsh
+        run: pip install "mcp>=1.0"
+
+      - name: Run daemon and smoke (single step)
+        # Variant 1: keep the daemon and the smoke script inside one step,
+        # so the daemon's parent pwsh process lives for the whole duration.
+        # Run #24972607401 spawned the daemon in one step and tried to use
+        # it in the next; the runner's job object reaped the daemon when
+        # the spawning step ended (visible as runtimed.log holding only
+        # the early-startup line, then `runt ps` failing with "file not
+        # found"). Collapsing into one step avoids that lifecycle issue.
+        #
+        # Pool sizes: 1 UV env, no conda or pixi. Pass args as a single
+        # string (PowerShell -ArgumentList array form re-tokenizes
+        # inconsistently and silently dropped --uv-pool-size 1 in the prior
+        # run, defaulting to a 3-env warm).
+        shell: pwsh
+        timeout-minutes: 15
+        run: |
+          $logOut = "$env:RUNNER_TEMP\runtimed.stdout.log"
+          $logErr = "$env:RUNNER_TEMP\runtimed.stderr.log"
+          $daemon = Start-Process -FilePath $env:RUNTIMED `
+            -ArgumentList @('run', '--uv-pool-size', '1', '--conda-pool-size', '0', '--pixi-pool-size', '0') `
+            -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput $logOut -RedirectStandardError $logErr
+          Write-Host "Daemon pid: $($daemon.Id)"
+
+          $ready = $false
+          for ($i = 0; $i -lt 30; $i++) {
+            Start-Sleep -Seconds 1
+            if ($daemon.HasExited) {
+              Write-Error "Daemon exited prematurely (code $($daemon.ExitCode)) after ${i}s"
+              break
+            }
+            $result = & $env:RUNT daemon status --json 2>$null
+            if ($LASTEXITCODE -eq 0) {
+              try {
+                $parsed = $result | ConvertFrom-Json
+                if ($parsed.running -eq $true) {
+                  Write-Host "Daemon ready after ${i}s"
+                  Write-Host $result
+                  $ready = $true
+                  break
+                }
+              } catch {}
+            }
+          }
+          if (-not $ready) {
+            Write-Host "--- runtimed.stdout ---"
+            if (Test-Path $logOut) { Get-Content $logOut }
+            Write-Host "--- runtimed.stderr ---"
+            if (Test-Path $logErr) { Get-Content $logErr }
+            exit 1
+          }
+
+          Write-Host "=== runt ps ==="
+          & $env:RUNT ps
+          if ($LASTEXITCODE -ne 0) { Write-Error "runt ps failed"; exit 1 }
+
+          Write-Host "=== runt diagnostics ==="
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\diag" | Out-Null
+          Push-Location "$env:RUNNER_TEMP\diag"
+          & $env:RUNT diagnostics
+          $diagExit = $LASTEXITCODE
+          Pop-Location
+          if ($diagExit -ne 0) { Write-Error "runt diagnostics failed: $diagExit"; exit $diagExit }
+          Get-ChildItem "$env:RUNNER_TEMP\diag"
+
+          Write-Host "=== MCP smoke ==="
+          python scripts/smoke-mcp.py "$env:RUNT"
+          $smokeExit = $LASTEXITCODE
+
+          Write-Host "=== Tearing down daemon ==="
+          if (-not $daemon.HasExited) {
+            Stop-Process -Id $daemon.Id -Force -ErrorAction SilentlyContinue
+          }
+
+          if ($smokeExit -ne 0) { exit $smokeExit }
+
+      - name: Dump daemon stdout/stderr to CI console
+        if: always()
+        shell: pwsh
+        run: |
+          Write-Host "=== runtimed.stdout.log ==="
+          if (Test-Path "$env:RUNNER_TEMP\runtimed.stdout.log") {
+            Get-Content "$env:RUNNER_TEMP\runtimed.stdout.log"
+          } else {
+            Write-Host "(not present)"
+          }
+          Write-Host ""
+          Write-Host "=== runtimed.stderr.log ==="
+          if (Test-Path "$env:RUNNER_TEMP\runtimed.stderr.log") {
+            Get-Content "$env:RUNNER_TEMP\runtimed.stderr.log"
+          } else {
+            Write-Host "(not present)"
+          }
+          Write-Host ""
+          Write-Host "=== runtimed.log (daemon log via dirs::cache_dir) ==="
+          $logPath = "$env:LOCALAPPDATA\runt\runtimed.log"
+          if (Test-Path $logPath) {
+            Get-Content $logPath
+          } else {
+            Write-Host "(not present at $logPath)"
+            Write-Host "Searching for runtimed.log under LOCALAPPDATA..."
+            Get-ChildItem -Path $env:LOCALAPPDATA -Filter runtimed.log -Recurse -ErrorAction SilentlyContinue | Select-Object FullName | Format-Table -AutoSize
+          }
+
+      - name: Re-run diagnostics post-smoke
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\diag-post" | Out-Null
+          Push-Location "$env:RUNNER_TEMP\diag-post"
+          & $env:RUNT diagnostics
+          Pop-Location
+          Get-ChildItem "$env:RUNNER_TEMP\diag-post"
+
+      - name: Upload diagnostics tarballs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-smoke-diagnostics
+          path: |
+            ${{ runner.temp }}\diag\*.tar.gz
+            ${{ runner.temp }}\diag-post\*.tar.gz
+            ${{ runner.temp }}\runtimed.stdout.log
+            ${{ runner.temp }}\runtimed.stderr.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload installer
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-smoke-installer
+          path: target/release/bundle/nsis/*.exe
+          if-no-files-found: warn
+          retention-days: 14
+
+  linux-smoke:
+    name: Linux (build + smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-smoke
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          run-install: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install
+
+      # runt-mcp's include_str! pulls in the MCP output widget HTML. Build
+      # before compiling Rust so the assets/_output.html target exists.
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+
+      - name: Build runtimed and runt
+        run: cargo build --release -p runtimed -p runt -p nteract-mcp
+
+      - name: Set up Python for MCP smoke
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MCP client SDK
+        run: pip install "mcp>=1.0"
+
+      - name: Run daemon and smoke
+        timeout-minutes: 15
+        run: |
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/diag"
+          LOG_OUT="$RUNNER_TEMP/runtimed.stdout.log"
+          LOG_ERR="$RUNNER_TEMP/runtimed.stderr.log"
+
+          ./target/release/runtimed run \
+            --uv-pool-size 1 \
+            --conda-pool-size 0 \
+            --pixi-pool-size 0 \
+            > "$LOG_OUT" 2> "$LOG_ERR" &
+          DAEMON_PID=$!
+          echo "Daemon pid: $DAEMON_PID"
+
+          ready=0
+          for i in $(seq 1 30); do
+            sleep 1
+            if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+              echo "Daemon exited prematurely"
+              break
+            fi
+            STATUS=$(./target/release/runt daemon status --json 2>/dev/null || true)
+            if [ -n "$STATUS" ] && echo "$STATUS" | python3 -c 'import sys,json; sys.exit(0 if json.load(sys.stdin).get("running") else 1)' 2>/dev/null; then
+              echo "Daemon ready after ${i}s"
+              echo "$STATUS"
+              ready=1
+              break
+            fi
+          done
+
+          if [ "$ready" -ne 1 ]; then
+            echo "--- runtimed.stdout ---"; cat "$LOG_OUT" 2>/dev/null || true
+            echo "--- runtimed.stderr ---"; cat "$LOG_ERR" 2>/dev/null || true
+            kill "$DAEMON_PID" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "=== runt ps ==="
+          ./target/release/runt ps || { kill "$DAEMON_PID" 2>/dev/null || true; exit 1; }
+
+          echo "=== runt diagnostics ==="
+          (cd "$RUNNER_TEMP/diag" && "$GITHUB_WORKSPACE/target/release/runt" diagnostics)
+          ls "$RUNNER_TEMP/diag"
+
+          echo "=== MCP smoke ==="
+          set +e
+          python scripts/smoke-mcp.py ./target/release/runt
+          smoke_exit=$?
+          set -e
+
+          echo "=== Tearing down daemon ==="
+          kill "$DAEMON_PID" 2>/dev/null || true
+          wait "$DAEMON_PID" 2>/dev/null || true
+
+          exit "$smoke_exit"
+
+      - name: Dump daemon stdout/stderr to CI console
+        if: always()
+        run: |
+          echo "=== runtimed.stdout.log ==="
+          cat "$RUNNER_TEMP/runtimed.stdout.log" 2>/dev/null || echo "(not present)"
+          echo
+          echo "=== runtimed.stderr.log ==="
+          cat "$RUNNER_TEMP/runtimed.stderr.log" 2>/dev/null || echo "(not present)"
+          echo
+          echo "=== runtimed.log (daemon log via dirs::cache_dir) ==="
+          for log in "$HOME/.cache/runt/runtimed.log" "$HOME/.cache/runt-nightly/runtimed.log"; do
+            if [ -f "$log" ]; then
+              echo "--- $log ---"
+              cat "$log"
+            fi
+          done
+
+      - name: Upload diagnostics tarballs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-smoke-diagnostics
+          path: |
+            ${{ runner.temp }}/diag/*.tar.gz
+            ${{ runner.temp }}/runtimed.stdout.log
+            ${{ runner.temp }}/runtimed.stderr.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -346,7 +346,23 @@ const TAURI_INSTALL: &str = "cargo install tauri-cli";
 const WASM_PACK_INSTALL: &str = "cargo install wasm-pack";
 
 fn require_pnpm() {
-    require_tool("pnpm", PNPM_INSTALL);
+    require_tool(pnpm_bin(), PNPM_INSTALL);
+}
+
+/// Name to invoke pnpm under for `Command::new`.
+///
+/// On Windows, `pnpm/action-setup@v4` (and corepack) install pnpm as a
+/// `pnpm.cmd` shim wrapping node. There is no `pnpm.exe`. Rust's
+/// `Command::new("pnpm")` calls `CreateProcess` directly, which does not
+/// apply `PATHEXT` resolution, so it fails with "not found in PATH" even
+/// when `pnpm.cmd` is on `PATH` and `pnpm install` works fine from the
+/// surrounding bash/pwsh shell. Always invoke `pnpm.cmd` on Windows.
+fn pnpm_bin() -> &'static str {
+    if cfg!(windows) {
+        "pnpm.cmd"
+    } else {
+        "pnpm"
+    }
 }
 
 fn require_tauri() {

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -1,0 +1,139 @@
+"""Cross-platform CI smoke test driving the runtimed daemon over MCP.
+
+Spawns `runt mcp` (or `runt.exe mcp`) over stdio, creates an ephemeral
+notebook, runs a trivial code cell, and asserts the output. Exits
+non-zero on any failure.
+
+Usage:
+    python scripts/smoke-mcp.py <path-to-runt>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+# The MCP server's tool-result formatter uses ━ (U+2501) as a section
+# separator. Windows runners default to cp1252, which can't encode that.
+# Force UTF-8 on stdout/stderr so the smoke can print every response.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding and sys.stderr.encoding.lower() != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+from mcp import ClientSession, StdioServerParameters  # noqa: E402
+from mcp.client.stdio import stdio_client  # noqa: E402
+
+CELL_ID_RE = re.compile(r"cell-[0-9a-f-]{36}")
+EXEC_ID_RE = re.compile(r"exec=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
+DONE_RE = re.compile(r"\bdone\b", re.IGNORECASE)
+ERROR_RE = re.compile(r"\berror\b", re.IGNORECASE)
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def text_of(result) -> str:
+    """Concat all text-typed content blocks from a tool result."""
+    return "\n".join(c.text for c in result.content if hasattr(c, "text"))
+
+
+async def smoke(runt_exe: Path) -> None:
+    params = StdioServerParameters(command=str(runt_exe), args=["mcp"])
+
+    async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+        print("[smoke] MCP session initialized")
+
+        tools = await session.list_tools()
+        tool_names = sorted(t.name for t in tools.tools)
+        print(f"[smoke] {len(tool_names)} tools available")
+        for required in ("create_notebook", "create_cell", "execute_cell", "get_results"):
+            if required not in tool_names:
+                fail(f"required tool missing: {required}")
+
+        print("[smoke] create_notebook")
+        create = await session.call_tool("create_notebook", {})
+        if create.isError:
+            fail(f"create_notebook errored: {text_of(create)}")
+        print(text_of(create))
+
+        print("[smoke] create_cell (code: 1+1)")
+        cell = await session.call_tool(
+            "create_cell",
+            {"cell_type": "code", "source": "print(1 + 1)"},
+        )
+        if cell.isError:
+            fail(f"create_cell errored: {text_of(cell)}")
+        print(text_of(cell))
+
+        match = CELL_ID_RE.search(text_of(cell))
+        if not match:
+            fail(f"could not parse cell_id from create_cell response: {text_of(cell)}")
+        cell_id = match.group(0)
+
+        print(f"[smoke] execute_cell {cell_id}")
+        exec_result = await session.call_tool("execute_cell", {"cell_id": cell_id})
+        if exec_result.isError:
+            fail(f"execute_cell errored: {text_of(exec_result)}")
+        print(text_of(exec_result))
+
+        match = EXEC_ID_RE.search(text_of(exec_result))
+        if not match:
+            fail(f"could not parse execution_id from execute_cell response: {text_of(exec_result)}")
+        execution_id = match.group(1)
+        print(f"[smoke] execution_id={execution_id}")
+
+        # Two paths: execute_cell can return synchronously (small fast cell) or
+        # leave us to poll get_results. Treat both uniformly by extracting the
+        # actual stdout portion (after the trailing ━━━ separator from the
+        # rich tool formatter).
+        def stdout_of(body: str) -> str:
+            parts = body.split("━━━")
+            return parts[-1].strip() if len(parts) > 1 else body.strip()
+
+        if DONE_RE.search(text_of(exec_result)):
+            out = stdout_of(text_of(exec_result))
+            if out == "2":
+                print("[smoke] PASS - synchronous execution returned '2'")
+                return
+            if ERROR_RE.search(text_of(exec_result)):
+                fail(f"execute_cell reported error: {text_of(exec_result)}")
+            print(f"[smoke] execute_cell returned 'done' but output was {out!r}; polling anyway")
+
+        print(f"[smoke] poll get_results({execution_id})")
+        for attempt in range(60):
+            await asyncio.sleep(2)
+            results = await session.call_tool("get_results", {"execution_id": execution_id})
+            body = text_of(results)
+            if ERROR_RE.search(body) and "Execution not found" not in body:
+                fail(f"execution errored: {body}")
+            if DONE_RE.search(body):
+                print(f"[smoke] result after {attempt * 2}s:")
+                print(body)
+                out = stdout_of(body)
+                if out == "2":
+                    print("[smoke] PASS - polled result was '2'")
+                    return
+                fail(f"execution finished but stdout was {out!r}, expected '2'")
+            print(f"[smoke] attempt {attempt}: still pending")
+
+        fail("execution did not complete within 120s")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    runt_exe = Path(sys.argv[1])
+    if not runt_exe.exists():
+        fail(f"runt exe not found: {runt_exe}")
+    asyncio.run(smoke(runt_exe))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Cross-platform end-to-end smoke for the runtimed daemon. Two jobs:

- **Linux (build + smoke)** runs on every PR and every push to `main`. ~5 minutes. Required gate.
- **Windows (build + install + smoke)** runs only on push to `main` and `workflow_dispatch`. ~32 minutes (cargo build + NSIS bundling + install + smoke), so gating PRs on it would tax every diff including frontend-only changes with no Windows surface. Failures ping `#windows` via Discord webhook (`secrets.DISCORD_WEBHOOK_WINDOWS`) so the team can react post-merge without blocking the rest of development.

The smoke itself is a real Python kernel launch through the runtimed daemon, driven over MCP via `runt mcp`:

```
create_notebook -> create_cell("print(1+1)") -> execute_cell -> get_results -> assert stdout == "2"
```

This catches breakage that clippy and unit tests miss: install failures, daemon-spawn failures, kernel-launch failures, MCP wire-format regressions, end-to-end output paths.

## Why this shape

- 32m × every PR is untenable for a project that ships frequently. A sift-only PR (wasm/js/css) has no Windows-specific risk yet would pay the full Windows tax.
- Linux-on-PR catches most regressions: the daemon, kernel-launch, MCP wire format, and renderer plugins are all the same code on both platforms. Windows-specific breakage (NSIS install, named pipes, socket inheritance) is rarer and Windows-on-main catches it within hours of merge.
- Discord notification on failure means the canary is loud, not silent.

## Why MCP-driven instead of `runt jupyter` or e2e

- `runt jupyter` was deprecated in #2275. Wrong surface anyway, bypasses the daemon.
- The WebDriver e2e harness needs a working WebView2 driver on Windows. Non-trivial to set up; not done.
- `runt mcp` is the daemon path the desktop app uses. Exercising it from a script proves install + daemon + named-pipe IPC + kernel launch through the same code path as the app, without GUI dependency.

## What's in this PR

- New `.github/workflows/smoke.yml` with `linux-smoke` (PR + push) and `windows-smoke` (push only, with Discord-on-failure).
- `scripts/smoke-mcp.py`: MCP client that drives the kernel-launch sequence above. Cross-platform; the cp1252 stdout reconfig at the top is a no-op on Linux.
- Both jobs share `./.github/actions/build-runtime-artifacts` (introduced in #2281) so the gitignored wasm + renderer-plugin assets get rebuilt before `cargo build -p runtimed`.
- `fix(xtask): resolve pnpm shim via PATHEXT-aware name on Windows`. `Command::new("pnpm").arg("--version")` doesn't apply Windows PATHEXT, so xtask's pnpm probe fails on `windows-latest` even when bash and pwsh find the `pnpm.cmd` shim from `pnpm/action-setup`. Routes `require_pnpm` through `pnpm_bin()` which returns `"pnpm.cmd"` on Windows. The build.yml `Windows (clippy)` job hides this trap because it cross-compiles from ubuntu; the matrix `Windows` job has `run_on_pr: false` and was cancelled in the last two main runs.

## Predecessor work (already merged)

- #2275: deprecate `runt jupyter`
- #2276: reserved-port range fix
- #2278: EADDRINUSE retry layer
- #2281: drop Git LFS, rebuild artifacts in CI
- #2283: drop reserved listeners before kernel spawn on Windows (the actual root cause)

## Test plan

- [x] Linux smoke green on this PR (run 24998645462, 5m12s)
- [x] Windows smoke green on prior commit (run 24998645462, 32m9s, before the trigger split landed; Windows now skips on PR)
- [x] `DISCORD_WEBHOOK_WINDOWS` repo secret is set
- [ ] After merge: first push-to-main runs Windows smoke; verify the workflow shape end-to-end
- [ ] After at least one successful main-side run, mark `Linux (build + smoke)` required in branch protection
- [ ] Confirm the workflow triggers on PRs from forks, or document if not (`secrets.GITHUB_TOKEN` works for forks but `pull_request_target` would be needed for explicit secrets)

## Related

The build.yml `Windows (windows-latest)` matrix entry has `run_on_pr: false` and was cancelled in the last two main runs. With this gate live, that entry can either drop `run_on_pr: false` (and pay the same per-PR tax we're trying to avoid here, so probably not) or be folded into smoke. Tracking that as cleanup work.
