### PR TITLE
fix(runtimed): drop reserved listeners before kernel spawn on Windows

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -703,7 +703,28 @@ impl KernelConnection for JupyterKernel {
                 )
                 .await?;
 
+                // Order the listener drop relative to spawn per platform.
+                //
+                // Windows: child processes inherit the parent's socket handles
+                // by default. If `cmd.spawn()` ran while the listeners were
+                // alive, the kernel would inherit handles for ports 9000-9004
+                // and ipykernel's first `s.bind('tcp://...:9003')` would fail
+                // with EADDRINUSE - the kernel itself already owns a listener
+                // on that port via inheritance. The 9000-9999 reserved range
+                // is outside the dynamic ephemeral pool, so the OS allocator
+                // can't reclaim a freed port between drop and the kernel's
+                // bind. Drop early.
+                //
+                // Linux/macOS: FD_CLOEXEC is the default, so the child can't
+                // inherit the listener. The risk is the opposite - on the
+                // fallback path where ports come from the OS ephemeral
+                // allocator, the OS could re-hand a freed port to some other
+                // process between drop and the kernel's bind. Hold the
+                // listeners across spawn so that window stays closed.
+                #[cfg(windows)]
+                drop(listeners);
                 let mut process = cmd.spawn()?;
+                #[cfg(not(windows))]
                 drop(listeners);
 
                 let stderr_buffer: Arc<StdMutex<VecDeque<String>>> =


### PR DESCRIPTION
Caught while reproducing #2274 on a real Windows EC2 box (winlab2). The retry layer from #2278 was firing 4 times on every kernel launch, each retry exiting with the same `Address in use (addr='tcp://127.0.0.1:9003')` for shell_port. Reserved-range allocator picked 9000-9004 deterministically and the kernel could not bind the 4th port no matter what.

`Get-NetTCPConnection` snapshot every 200 ms across the 3-second launch window:

```
[06:27:46.649] 9000/Listen/pid=5856/runtimed | 9001/Listen/... | 9003/Listen/pid=5856/runtimed | ...
[06:27:47.555] 9000/Listen/pid=5856/runtimed | 9001/Listen/... | 9003/Listen/pid=5856/runtimed | ...
[06:27:48.024] 9000/Listen/pid=5856/runtimed | 9001/Listen/... | 9003/Listen/pid=5856/runtimed | ...
...
```

runtimed itself was holding listeners on 9000-9004 for the entire kernel-launch duration — the explicit `drop(listeners)` at line 707 wasn't actually freeing the sockets.

## Diagnosis

On Windows, child processes inherit the parent's socket handles by default. There's no FD_CLOEXEC equivalent — sockets are inheritable unless explicitly marked otherwise. The previous order was

```rust
let mut process = cmd.spawn()?;
drop(listeners);
```

So at `cmd.spawn()` time, the kernel child duplicates live SOCKET handles for all 5 reserved ports into its own handle table. After that point, even though the parent calls `drop(listeners)` and closes its handles, the *child still has its own handles to the same listening sockets* — keeping the ports in LISTEN state. ipykernel's first `s.bind('tcp://127.0.0.1:9003')` then fails because the kernel itself already owns a listener on that port via the inherited handle.

The retry layer (#2278) couldn't fix this. Every retry binds the same 9003, the same inheritance happens, the same bind fails. Net effect: the reservation feature actively *broke* kernel launches on Windows in a way the pre-#2276 runtimelib path didn't.

## Fix

Platform-conditional ordering of `drop(listeners)` relative to `cmd.spawn()`.

```rust
#[cfg(windows)]
drop(listeners);
let mut process = cmd.spawn()?;
#[cfg(not(windows))]
drop(listeners);
```

**Windows** (drop early): the 9000-9999 reserved range is outside the Windows dynamic ephemeral pool (default 49152-65535), so the OS allocator can't reclaim a freed port between drop and the kernel's bind. We don't need to hold listeners across spawn, and holding them is the bug.

**Linux/macOS** (drop late, original behavior): FD_CLOEXEC keeps the child from inheriting the listener either way, so the inheritance bug doesn't apply. But the fallback path (`runtimelib::peek_ports_with_listeners`) can hand out OS-ephemeral ports that *could* be reassigned to a different process if the listener is released too early. Holding the listener across spawn keeps that window closed.

## Behavioral coverage

| Platform | Range | Pre-fix | Post-fix |
|---|---|---|---|
| Windows | reserved 9000-9999 | every launch fails (inheritance) | clean launch |
| Windows | fallback (ephemeral) | inheritance + TOCTOU | TOCTOU only (was always broken on this path; runtimelib fix tracked separately) |
| Linux/macOS | reserved 9000-9999 | clean | clean (unchanged) |
| Linux/macOS | fallback (ephemeral) | clean (rare race) | clean (unchanged) |

## Validation on winlab2

```
=== VERDICT ===
Address-in-use: 0, Codec Error: 0, Retries: 0
PASS (default test): kernel started clean
```

MCP `create_notebook` + `create_cell(print(2+2), and_run=true)` returns `done [1]` with output `4` on attempt 1. Daemon log shows only the STARTUP line — no warnings, no retries.

## Test plan
- [x] Default Windows ephemeral range (49152-65535) — reserved 9000-9999 path on winlab2: passes
- [ ] Stretched ephemeral range (overlapping reserved) — would fall through to runtimelib path; same race as before, mitigated by retry. Still working as designed.
- [ ] CI: nightly Windows smoke run
