### PR TITLE
test(smoke): add polars dataframe pass

### DIFF
--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -1,8 +1,15 @@
 """Cross-platform CI smoke test driving the runtimed daemon over MCP.
 
-Spawns `runt mcp` (or `runt.exe mcp`) over stdio, creates an ephemeral
-notebook, runs a trivial code cell, and asserts the output. Exits
-non-zero on any failure.
+Spawns `runt mcp` (or `runt.exe mcp`) over stdio and runs two passes:
+
+  1. Basic: ephemeral notebook, `print(1+1)`, assert stdout == "2".
+     Proves install + daemon + IPC + kernel-launch wire up end-to-end.
+  2. Polars: ephemeral notebook with `dependencies=["polars"]`, build a
+     small DataFrame, render it as the cell's execute_result, assert the
+     rendered output contains the expected column names and values.
+     Proves uv env resolution + package install + dataframe display.
+
+Exits non-zero on any failure.
 
 Usage:
     python scripts/smoke-mcp.py <path-to-runt>
@@ -42,6 +49,115 @@ def text_of(result) -> str:
     return "\n".join(c.text for c in result.content if hasattr(c, "text"))
 
 
+def stdout_of(body: str) -> str:
+    """Strip the rich tool formatter's ━━━ banner so we get the kernel output.
+
+    `execute_cell` and `get_results` both return human-formatted text where
+    the actual stdout / execute_result body sits after the trailing ━━━
+    separator. Take the last segment, or the whole body if no banner.
+    """
+    parts = body.split("━━━")
+    return parts[-1].strip() if len(parts) > 1 else body.strip()
+
+
+async def run_cell_and_get_body(session: ClientSession, source: str, label: str) -> str:
+    """Create a code cell, execute it, return the result body once `done`.
+
+    Polls `get_results` for up to 240s to cover the slow path where the
+    kernel needs to install dependencies on first execute.
+    """
+    print(f"[{label}] create_cell")
+    cell = await session.call_tool(
+        "create_cell",
+        {"cell_type": "code", "source": source},
+    )
+    if cell.isError:
+        fail(f"create_cell errored: {text_of(cell)}")
+    print(text_of(cell))
+
+    match = CELL_ID_RE.search(text_of(cell))
+    if not match:
+        fail(f"could not parse cell_id from create_cell response: {text_of(cell)}")
+    cell_id = match.group(0)
+
+    print(f"[{label}] execute_cell {cell_id}")
+    exec_result = await session.call_tool("execute_cell", {"cell_id": cell_id})
+    if exec_result.isError:
+        fail(f"execute_cell errored: {text_of(exec_result)}")
+    print(text_of(exec_result))
+
+    body = text_of(exec_result)
+    if DONE_RE.search(body):
+        if ERROR_RE.search(body):
+            fail(f"execute_cell reported error: {body}")
+        return body
+
+    match = EXEC_ID_RE.search(body)
+    if not match:
+        fail(f"could not parse execution_id from execute_cell response: {body}")
+    execution_id = match.group(1)
+    print(f"[{label}] execution_id={execution_id} - polling get_results")
+
+    for attempt in range(120):
+        await asyncio.sleep(2)
+        results = await session.call_tool("get_results", {"execution_id": execution_id})
+        body = text_of(results)
+        if ERROR_RE.search(body) and "Execution not found" not in body:
+            fail(f"execution errored: {body}")
+        if DONE_RE.search(body):
+            print(f"[{label}] result after {attempt * 2}s:")
+            print(body)
+            return body
+        if attempt % 5 == 0:
+            print(f"[{label}] attempt {attempt}: still pending")
+
+    fail(f"[{label}] execution did not complete within 240s")
+
+
+async def basic_pass(session: ClientSession) -> None:
+    """Sanity-check pass: ephemeral notebook + `print(1+1)`."""
+    print("[basic] create_notebook")
+    create = await session.call_tool("create_notebook", {})
+    if create.isError:
+        fail(f"create_notebook errored: {text_of(create)}")
+    print(text_of(create))
+
+    body = await run_cell_and_get_body(session, "print(1 + 1)", "basic")
+    out = stdout_of(body)
+    if out != "2":
+        fail(f"[basic] stdout was {out!r}, expected '2'")
+    print("[basic] PASS")
+
+
+async def polars_pass(session: ClientSession) -> None:
+    """Deeper pass: install polars in a fresh uv-backed notebook, render a DataFrame."""
+    print("[polars] create_notebook(dependencies=['polars'])")
+    create = await session.call_tool(
+        "create_notebook",
+        {"dependencies": ["polars"]},
+    )
+    if create.isError:
+        fail(f"create_notebook(polars) errored: {text_of(create)}")
+    print(text_of(create))
+
+    # Final expression `df` triggers an execute_result with the polars repr
+    # (text/html + text/plain). Asserting on column names and values keeps the
+    # test resilient to repr formatting changes (tabular characters, padding).
+    src = (
+        "import polars as pl\n"
+        "df = pl.DataFrame({'name': ['a', 'b', 'c'], 'value': [10, 20, 30]})\n"
+        "df\n"
+    )
+    body = await run_cell_and_get_body(session, src, "polars")
+    out = stdout_of(body)
+
+    expected_tokens = ("name", "value", "10", "20", "30")
+    missing = [tok for tok in expected_tokens if tok not in out]
+    if missing:
+        fail(f"[polars] result missing tokens {missing!r}; rendered output was:\n{out}")
+    print("[polars] PASS")
+
+
 async def smoke(runt_exe: Path) -> None:
     params = StdioServerParameters(command=str(runt_exe), args=["mcp"])
 
@@ -56,73 +172,9 @@ async def smoke(runt_exe: Path) -> None:
             if required not in tool_names:
                 fail(f"required tool missing: {required}")
 
-        print("[smoke] create_notebook")
-        create = await session.call_tool("create_notebook", {})
-        if create.isError:
-            fail(f"create_notebook errored: {text_of(create)}")
-        print(text_of(create))
-
-        print("[smoke] create_cell (code: 1+1)")
-        cell = await session.call_tool(
-            "create_cell",
-            {"cell_type": "code", "source": "print(1 + 1)"},
-        )
-        if cell.isError:
-            fail(f"create_cell errored: {text_of(cell)}")
-        print(text_of(cell))
-
-        match = CELL_ID_RE.search(text_of(cell))
-        if not match:
-            fail(f"could not parse cell_id from create_cell response: {text_of(cell)}")
-        cell_id = match.group(0)
-
-        print(f"[smoke] execute_cell {cell_id}")
-        exec_result = await session.call_tool("execute_cell", {"cell_id": cell_id})
-        if exec_result.isError:
-            fail(f"execute_cell errored: {text_of(exec_result)}")
-        print(text_of(exec_result))
-
-        match = EXEC_ID_RE.search(text_of(exec_result))
-        if not match:
-            fail(f"could not parse execution_id from execute_cell response: {text_of(exec_result)}")
-        execution_id = match.group(1)
-        print(f"[smoke] execution_id={execution_id}")
-
-        # Two paths: execute_cell can return synchronously (small fast cell) or
-        # leave us to poll get_results. Treat both uniformly by extracting the
-        # actual stdout portion (after the trailing ━━━ separator from the
-        # rich tool formatter).
-        def stdout_of(body: str) -> str:
-            parts = body.split("━━━")
-            return parts[-1].strip() if len(parts) > 1 else body.strip()
-
-        if DONE_RE.search(text_of(exec_result)):
-            out = stdout_of(text_of(exec_result))
-            if out == "2":
-                print("[smoke] PASS - synchronous execution returned '2'")
-                return
-            if ERROR_RE.search(text_of(exec_result)):
-                fail(f"execute_cell reported error: {text_of(exec_result)}")
-            print(f"[smoke] execute_cell returned 'done' but output was {out!r}; polling anyway")
-
-        print(f"[smoke] poll get_results({execution_id})")
-        for attempt in range(60):
-            await asyncio.sleep(2)
-            results = await session.call_tool("get_results", {"execution_id": execution_id})
-            body = text_of(results)
-            if ERROR_RE.search(body) and "Execution not found" not in body:
-                fail(f"execution errored: {body}")
-            if DONE_RE.search(body):
-                print(f"[smoke] result after {attempt * 2}s:")
-                print(body)
-                out = stdout_of(body)
-                if out == "2":
-                    print("[smoke] PASS - polled result was '2'")
-                    return
-                fail(f"execution finished but stdout was {out!r}, expected '2'")
-            print(f"[smoke] attempt {attempt}: still pending")
-
-        fail("execution did not complete within 120s")
+        await basic_pass(session)
+        await polars_pass(session)
+        print("[smoke] ALL PASSES GREEN")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Extends the cross-platform smoke (#2280) with a second pass that proves the uv env resolution + package install + execute_result rendering paths, not just the bare kernel-launch path. The basic `print(1+1)` pass is preserved as the first stage so install-and-daemon-spawn breakage still surfaces fast.

## What the new pass does

Inside the same `runt mcp` session, after the basic pass:

1. `create_notebook(dependencies=["polars"])`. The daemon resolves a uv-backed env with polars added to the base set.
2. `execute_cell` runs:
   ```python
   import polars as pl
   df = pl.DataFrame({"name": ["a", "b", "c"], "value": [10, 20, 30]})
   df
   ```
3. Polls `get_results` until done (up to 240s; first-execute can pay an install cost). Asserts the rendered output contains `name`, `value`, `10`, `20`, `30`.

The token-based assertion is deliberate: it doesn't pin the polars repr formatting (border characters, padding, dtype headers) so a polars version bump or a daemon-side renderer tweak won't false-positive.

## Why this is meaningful coverage

The basic pass exercises install + daemon-spawn + named-pipe IPC + kernel launch. The polars pass adds:

- uv env resolution from a `dependencies` list passed at `create_notebook` time (the path apps use)
- pip install on first execute (or warm-pool reuse if the env already had polars in the base set, depending on configuration)
- Final-expression handling on the kernel side that produces an `execute_result` with `text/html` + `text/plain`, not just stdout
- The text-formatter path through `runt mcp` that flattens the rendered output for the MCP client

These are exactly the paths a sift-touching or env-touching change is most likely to break.

## Cost

Linux smoke: ~5min today. Polars install warm pulls ~30s, cold ~60-90s. Expecting Linux to land somewhere between 5m30s and 6m30s. Still well under the threshold where blocking PRs becomes painful.

Windows smoke (post-merge only after #2280): adds the same delta to the ~32min baseline. Negligible.

## Test plan

- [ ] Linux smoke green on this PR
- [ ] After merge: post-merge Windows smoke green on first main-side run

## Related

- #2280: cross-platform smoke gate (parent)
- (cosmetic cleanups discovered while diagnosing the smoke logs):
  - `early_log` in runtimed/main.rs writes "runtimed starting: pid=..." for every binary invocation, including the runtime-agent subprocess. Misleading because it suggests "second daemon" when it is the daemon's own kernel-runtime child.
  - `connection closed before preamble` is logged at ERROR level, but it fires on routine 500ms-bounded daemon-info probes from `runt mcp` startup. Should be DEBUG.
