### PR TITLE
test(runtimed-py): preserve daemon.log on integration test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -712,6 +712,10 @@ jobs:
           export RUNTIMED_BINARY="${GITHUB_WORKSPACE}/target/release/runtimed"
           export RUNTIMED_LOG_LEVEL=debug
           export RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
+          # Tells the test fixture to copy daemon.log into the artifact
+          # dir on teardown so a post-mortem has the daemon's side of any
+          # failure (see #2290).
+          export RUNTIMED_INTEGRATION_LOG_DIR="${GITHUB_WORKSPACE}/python/runtimed/integration-logs"
 
           # Pin uv to the workspace venv so dx + pandas + pyarrow + polars
           # are importable for test_dx_integration. The cwd stays at

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -482,6 +482,21 @@ def daemon_process():
                 proc.kill()
                 proc.wait()
 
+            # Copy daemon.log into the persistent artifact dir (CI sets this).
+            # The tmpdir gets cleaned up when this `with` block exits, taking
+            # the daemon log with it. Without this copy, post-mortem on test
+            # failures has only the pytest stdout, never the daemon's side
+            # of any failure (see #2290).
+            artifact_dir = os.environ.get("RUNTIMED_INTEGRATION_LOG_DIR")
+            if artifact_dir and log_file.exists():
+                import shutil
+
+                dest_dir = Path(artifact_dir)
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                dest = dest_dir / "daemon.log"
+                shutil.copy2(log_file, dest)
+                print(f"[test] Copied daemon log to {dest}", file=sys.stderr)
+
             # Print daemon logs for debugging
             if log_file.exists():
                 logs = log_file.read_text()


### PR DESCRIPTION
## Summary

When a runtimed-py integration test fails, the daemon's side of the failure is currently invisible. Post-mortem on a test like `test_create_deno_notebook` (the canary tracked in #2290) only has pytest's stdout, which says "Kernel auto-launch failed during notebook creation" with no trace of which of the five daemon-side `RuntimeLifecycle::Error` paths actually fired or why.

This PR copies the test fixture's `daemon.log` (today written into a per-test `tmpdir/` and discarded on cleanup) into `python/runtimed/integration-logs/` so it ships with the existing artifact upload.

## Mechanism

- `python/runtimed/tests/test_daemon_integration.py` (`daemon_process` fixture, finally block): copies `tmpdir/daemon.log` to `$RUNTIMED_INTEGRATION_LOG_DIR/daemon.log` after daemon teardown when the env var is set. No-ops in dev mode (env var not set), so interactive `pytest` runs don't litter `integration-logs/` directories.
- `.github/workflows/build.yml` (`runtimed-py-integration` job): exports `RUNTIMED_INTEGRATION_LOG_DIR=$GITHUB_WORKSPACE/python/runtimed/integration-logs` before pytest.
- The existing `Upload test logs` step already grabs everything in `python/runtimed/integration-logs/`. No workflow upload changes needed.

## Why this design

- **Module-scoped daemon, single log.** The fixture spawns one daemon per pytest module and reuses it across tests, so we get a single daemon log spanning the whole suite. That's plenty of context for diagnosing a test like `test_create_deno_notebook` because both pytest's test-output.log and daemon.log have timestamps (test-output from CI runner, daemon from `tracing-subscriber`), making correlation straightforward.
- **Env-var gated.** Writing to `integration-logs/` unconditionally would clutter dev-mode runs with stale logs across pytest invocations.
- **Copy in `finally:` after daemon terminate.** Done inside the `with tempfile.TemporaryDirectory(...)` block so the source still exists. Copy happens before the tmpdir cleanup pulls the rug.

## Test plan

- [ ] Linux integration job uploads `daemon.log` alongside `test-output.log` in the `runtimed-py-integration-logs` artifact
- [ ] Next time `test_create_deno_notebook` (or any other test) flakes on CI, download the artifact and read `daemon.log` to identify which `RuntimeLifecycle::Error` path fired

## Related

- #2290: tracking issue for the deno-create canary; this PR is the diagnosis-unblocker called out in its "Suggested fix" section
- #2289: cross-platform smoke also produces a daemon log pair (`runtimed.stdout.log` + `runtimed.log`); same idea, different fixture path
