### PR TITLE
fix(runtimed): move peer requests off reactor

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3418,13 +3418,49 @@ pub(crate) async fn update_kernel_presence(
     }
 }
 
+/// Short label for a request variant, used in telemetry logs.
+///
+/// Returns a static string — no allocation — suitable for structured logging
+/// fields.  Intentionally avoids `Debug` formatting because some variants
+/// carry large payloads (snapshot JSON, doc bytes) that would bloat log lines.
+pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
+    match req {
+        NotebookRequest::LaunchKernel { .. } => "LaunchKernel",
+        NotebookRequest::ExecuteCell { .. } => "ExecuteCell",
+        NotebookRequest::ExecuteCellGuarded { .. } => "ExecuteCellGuarded",
+        NotebookRequest::ClearOutputs { .. } => "ClearOutputs",
+        NotebookRequest::InterruptExecution { .. } => "InterruptExecution",
+        NotebookRequest::ShutdownKernel { .. } => "ShutdownKernel",
+        NotebookRequest::GetKernelInfo { .. } => "GetKernelInfo",
+        NotebookRequest::GetQueueState { .. } => "GetQueueState",
+        NotebookRequest::RunAllCells { .. } => "RunAllCells",
+        NotebookRequest::RunAllCellsGuarded { .. } => "RunAllCellsGuarded",
+        NotebookRequest::SendComm { .. } => "SendComm",
+        NotebookRequest::GetHistory { .. } => "GetHistory",
+        NotebookRequest::Complete { .. } => "Complete",
+        NotebookRequest::SaveNotebook { .. } => "SaveNotebook",
+        NotebookRequest::CloneAsEphemeral { .. } => "CloneAsEphemeral",
+        NotebookRequest::SyncEnvironment { .. } => "SyncEnvironment",
+        NotebookRequest::SyncEnvironmentGuarded { .. } => "SyncEnvironmentGuarded",
+        NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
+        NotebookRequest::GetRawMetadata { .. } => "GetRawMetadata",
+        NotebookRequest::SetRawMetadata { .. } => "SetRawMetadata",
+        NotebookRequest::GetMetadataSnapshot { .. } => "GetMetadataSnapshot",
+        NotebookRequest::SetMetadataSnapshot { .. } => "SetMetadataSnapshot",
+        NotebookRequest::CheckToolAvailable { .. } => "CheckToolAvailable",
+    }
+}
+
 /// Handle a NotebookRequest and return a NotebookResponse.
 pub(crate) async fn handle_notebook_request(
     room: &Arc<NotebookRoom>,
     request: NotebookRequest,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) -> NotebookResponse {
-    debug!("[notebook-sync] Handling request: {:?}", request);
+    debug!(
+        "[notebook-sync] Handling request: {}",
+        request_label(&request)
+    );
 
     match request {
         NotebookRequest::LaunchKernel {

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1121,6 +1121,7 @@ where
 }
 
 const PEER_OUTBOUND_QUEUE_CAPACITY: usize = 1024;
+const PEER_REQUEST_QUEUE_CAPACITY: usize = 64;
 
 struct OutboundFrame {
     frame_type: NotebookFrameType,
@@ -1136,7 +1137,24 @@ struct PeerWriterTask {
     handle: tokio::task::JoinHandle<anyhow::Result<()>>,
 }
 
+struct PeerRequestWorker {
+    tx: mpsc::Sender<notebook_protocol::protocol::NotebookRequestEnvelope>,
+    handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+#[derive(Debug)]
+enum RequestEnqueueError {
+    Full(notebook_protocol::protocol::NotebookRequestEnvelope),
+    Closed(notebook_protocol::protocol::NotebookRequestEnvelope),
+}
+
 impl Drop for PeerWriterTask {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl Drop for PeerRequestWorker {
     fn drop(&mut self) {
         self.handle.abort();
     }
@@ -1170,6 +1188,18 @@ impl PeerWriter {
     }
 }
 
+impl PeerRequestWorker {
+    fn enqueue(
+        &self,
+        envelope: notebook_protocol::protocol::NotebookRequestEnvelope,
+    ) -> Result<(), RequestEnqueueError> {
+        self.tx.try_send(envelope).map_err(|e| match e {
+            mpsc::error::TrySendError::Full(envelope) => RequestEnqueueError::Full(envelope),
+            mpsc::error::TrySendError::Closed(envelope) => RequestEnqueueError::Closed(envelope),
+        })
+    }
+}
+
 fn spawn_peer_writer<W>(
     mut writer: W,
     notebook_id: String,
@@ -1196,6 +1226,55 @@ where
         Ok(())
     });
     (PeerWriter { tx }, PeerWriterTask { handle })
+}
+
+fn spawn_peer_request_worker(
+    room: Arc<NotebookRoom>,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
+    writer: PeerWriter,
+    notebook_id: String,
+    peer_id: String,
+) -> PeerRequestWorker {
+    let (tx, mut rx) = mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(
+        PEER_REQUEST_QUEUE_CAPACITY,
+    );
+    let handle = tokio::spawn(async move {
+        while let Some(envelope) = rx.recv().await {
+            let response = handle_notebook_request(&room, envelope.request, daemon.clone()).await;
+            let reply = notebook_protocol::protocol::NotebookResponseEnvelope {
+                id: envelope.id,
+                response,
+            };
+            writer
+                .send_json(NotebookFrameType::Response, &reply)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to queue response to peer {} for {}: {}",
+                        peer_id,
+                        notebook_id,
+                        e
+                    )
+                })?;
+        }
+        Ok(())
+    });
+    PeerRequestWorker { tx, handle }
+}
+
+fn queue_request_error(
+    writer: &PeerWriter,
+    id: Option<String>,
+    error: impl Into<String>,
+) -> anyhow::Result<()> {
+    writer.send_json(
+        NotebookFrameType::Response,
+        &notebook_protocol::protocol::NotebookResponseEnvelope {
+            id,
+            response: notebook_protocol::protocol::NotebookResponse::Error {
+                error: error.into(),
+            },
+        },
+    )
 }
 
 fn queue_session_status(
@@ -1540,6 +1619,13 @@ where
     // client is temporarily slow to read daemon frames.
     let (peer_writer, mut writer_task) =
         spawn_peer_writer(writer, notebook_id.clone(), peer_id.to_string());
+    let mut request_worker = spawn_peer_request_worker(
+        room.clone(),
+        daemon.clone(),
+        peer_writer.clone(),
+        notebook_id.clone(),
+        peer_id.to_string(),
+    );
 
     // Hand the reader off to a dedicated FramedReader actor before
     // entering the busy `select!` below. `recv_typed_frame`'s internal
@@ -1558,6 +1644,17 @@ where
                     Ok(result) => result,
                     Err(e) => Err(anyhow::anyhow!(
                         "peer writer task stopped for {}: {}",
+                        notebook_id,
+                        e
+                    )),
+                };
+            }
+
+            request_worker_result = &mut request_worker.handle => {
+                return match request_worker_result {
+                    Ok(result) => result,
+                    Err(e) => Err(anyhow::anyhow!(
+                        "peer request worker stopped for {}: {}",
                         notebook_id,
                         e
                     )),
@@ -1676,27 +1773,41 @@ where
                             }
 
                             NotebookFrameType::Request => {
-                                // Decode the envelope, dispatch the inner request,
-                                // echo the id on the response envelope so the caller
-                                // can correlate multiple in-flight requests.
+                                // Decode and enqueue the request, then return to
+                                // frame reads. The per-peer request worker preserves
+                                // request order and echoes the id on the response.
                                 let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
                                     serde_json::from_slice(&frame.payload)?;
-                                let response = handle_notebook_request(
-                                    room,
-                                    envelope.request,
-                                    daemon.clone(),
-                                )
-                                .await;
-
-                                // Promotion from untitled → file-backed is now handled
-                                // entirely inside handle_notebook_request (SaveNotebook arm).
-                                // Save path update is handled inside handle_notebook_request.
-
-                                let reply = notebook_protocol::protocol::NotebookResponseEnvelope {
-                                    id: envelope.id,
-                                    response,
-                                };
-                                peer_writer.send_json(NotebookFrameType::Response, &reply)?;
+                                if let Err(e) = request_worker.enqueue(envelope) {
+                                    match e {
+                                        RequestEnqueueError::Full(envelope) => {
+                                            warn!(
+                                                "[notebook-sync] Peer request queue full for {} (peer_id={})",
+                                                notebook_id, peer_id
+                                            );
+                                            queue_request_error(
+                                                &peer_writer,
+                                                envelope.id,
+                                                "Peer request queue full",
+                                            )?;
+                                        }
+                                        RequestEnqueueError::Closed(envelope) => {
+                                            warn!(
+                                                "[notebook-sync] Peer request worker stopped for {} (peer_id={})",
+                                                notebook_id, peer_id
+                                            );
+                                            queue_request_error(
+                                                &peer_writer,
+                                                envelope.id,
+                                                "Peer request worker stopped",
+                                            )?;
+                                            return Err(anyhow::anyhow!(
+                                                "peer request worker stopped for {}",
+                                                notebook_id
+                                            ));
+                                        }
+                                    }
+                                }
                             }
 
                             NotebookFrameType::Presence => {
@@ -2372,5 +2483,44 @@ mod peer_writer_tests {
             result.is_err(),
             "closed socket should surface as a writer task error"
         );
+    }
+
+    #[tokio::test]
+    async fn peer_request_enqueue_reports_full_without_waiting_for_worker() {
+        let (tx, mut rx) = mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        let (started_tx, started_rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _first = rx.recv().await;
+            let _ = started_tx.send(());
+            std::future::pending::<anyhow::Result<()>>().await
+        });
+        let worker = PeerRequestWorker { tx, handle };
+
+        worker
+            .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
+                id: Some("first".to_string()),
+                request: NotebookRequest::GetKernelInfo {},
+            })
+            .expect("first request should enqueue");
+        started_rx.await.expect("worker should start first request");
+        worker
+            .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
+                id: Some("second".to_string()),
+                request: NotebookRequest::GetKernelInfo {},
+            })
+            .expect("second request should fill the queue");
+
+        let start = std::time::Instant::now();
+        let err = worker
+            .enqueue(notebook_protocol::protocol::NotebookRequestEnvelope {
+                id: Some("third".to_string()),
+                request: NotebookRequest::GetKernelInfo {},
+            })
+            .expect_err("full queue should reject immediately");
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(50),
+            "request enqueue should not wait for the busy worker"
+        );
+        assert!(matches!(err, RequestEnqueueError::Full(_)));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1186,6 +1186,15 @@ impl PeerWriter {
         let payload = serde_json::to_vec(value)?;
         self.send_frame(frame_type, payload)
     }
+
+    /// Number of free slots in the outbound channel.
+    ///
+    /// `PEER_OUTBOUND_QUEUE_CAPACITY - capacity()` gives the number of
+    /// in-flight frames waiting to be flushed to the socket — useful as a
+    /// backpressure signal in telemetry.
+    fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
 }
 
 impl PeerRequestWorker {
@@ -1240,7 +1249,22 @@ fn spawn_peer_request_worker(
     );
     let handle = tokio::spawn(async move {
         while let Some(envelope) = rx.recv().await {
+            let label = metadata::request_label(&envelope.request);
+            let req_id = envelope.id.as_deref().unwrap_or("-");
+            let writer_queue_depth = PEER_OUTBOUND_QUEUE_CAPACITY - writer.capacity();
+            debug!(
+                "[notebook-sync] Request {} id={} peer={} notebook={} writer_queue={}",
+                label, req_id, peer_id, notebook_id, writer_queue_depth,
+            );
+
+            let start = std::time::Instant::now();
             let response = handle_notebook_request(&room, envelope.request, daemon.clone()).await;
+            let elapsed = start.elapsed();
+            debug!(
+                "[notebook-sync] Request {} id={} completed in {:?}",
+                label, req_id, elapsed,
+            );
+
             let reply = notebook_protocol::protocol::NotebookResponseEnvelope {
                 id: envelope.id,
                 response,
@@ -1778,6 +1802,13 @@ where
                                 // request order and echoes the id on the response.
                                 let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
                                     serde_json::from_slice(&frame.payload)?;
+                                debug!(
+                                    "[notebook-sync] Enqueuing {} id={} peer={} notebook={}",
+                                    metadata::request_label(&envelope.request),
+                                    envelope.id.as_deref().unwrap_or("-"),
+                                    peer_id,
+                                    notebook_id,
+                                );
                                 if let Err(e) = request_worker.enqueue(envelope) {
                                     match e {
                                         RequestEnqueueError::Full(envelope) => {

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -704,6 +704,77 @@ async fn test_parallel_cell_mutations_same_session_no_disconnect() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
+#[tokio::test]
+async fn test_parallel_daemon_requests_same_session_no_disconnect() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap();
+    let handle = result.handle;
+
+    assert!(
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state"
+    );
+    assert!(
+        wait_for_cells_map(&handle, Duration::from_secs(5)).await,
+        "client should receive daemon-created cells map"
+    );
+
+    let mut joins = Vec::new();
+    for index in 0..10 {
+        let handle = handle.clone();
+        joins.push(tokio::spawn(async move {
+            if index % 2 == 0 {
+                handle.send_request(NotebookRequest::GetDocBytes {}).await
+            } else {
+                handle.send_request(NotebookRequest::GetKernelInfo {}).await
+            }
+        }));
+    }
+
+    tokio::time::timeout(Duration::from_secs(20), async {
+        for (index, join) in joins.into_iter().enumerate() {
+            let response = join.await.unwrap().unwrap();
+            if index % 2 == 0 {
+                assert!(matches!(response, NotebookResponse::DocBytes { .. }));
+            } else {
+                assert!(matches!(response, NotebookResponse::KernelInfo { .. }));
+            }
+        }
+    })
+    .await
+    .expect("parallel daemon requests should complete without hanging");
+
+    assert_eq!(
+        handle.status().connection,
+        notebook_sync::ConnectionState::Connected,
+        "client should stay connected after parallel daemon requests"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
 /// Test that untitled notebook state survives room eviction via Automerge persistence.
 ///
 /// Design: Untitled notebooks (UUID IDs) have no .ipynb on disk — their Automerge


### PR DESCRIPTION
## Summary
- move `NotebookFrameType::Request` handling off the notebook peer reactor into a per-peer FIFO request worker
- preserve request ordering while letting the socket/frame loop keep draining inbound frames
- route worker responses through the existing ordered `PeerWriter` from #2288
- add request queue backpressure handling and tests for concurrent request behavior
- add request-worker telemetry for enqueue/start/completion, handler duration, and writer queue depth without full request payload logging

## Why
After the client-side reactor and daemon writer-queue fixes, the remaining daemon-side shape is long control work inside the frame arm: `handle_notebook_request(...).await` still blocks the peer loop from reading frames. This PR keeps the conservative behavior first: one request worker per peer, FIFO execution, request IDs preserved, and no wire/API changes.

The telemetry added from #2295 makes the next bottlenecks visible without reintroducing large `Debug` logs for request payloads.

## Validation
- `cargo check -p runtimed` on the merged #2292 head (`a98d39b3`) in a detached temp worktree
- `cargo test -p runtimed notebook_sync_server::peer::peer_writer_tests -- --nocapture` on the merged #2292 head
- `cargo test -p runtimed peer_request_enqueue_reports_full_without_waiting_for_worker --lib`
- `cargo test -p runtimed --test integration test_parallel_daemon_requests_same_session_no_disconnect -- --nocapture`
- `cargo test -p runtimed --test integration test_parallel_cell_mutations_same_session_no_disconnect -- --nocapture`
- `cargo clippy -p runtimed --all-targets -- -D warnings`
- `git diff --check`
