### PR TITLE
perf(runtimed): add request telemetry to peer request worker

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3457,7 +3457,10 @@ pub(crate) async fn handle_notebook_request(
     request: NotebookRequest,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) -> NotebookResponse {
-    debug!("[notebook-sync] Handling request: {:?}", request);
+    debug!(
+        "[notebook-sync] Handling request: {}",
+        request_label(&request)
+    );
 
     match request {
         NotebookRequest::LaunchKernel {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3418,6 +3418,39 @@ pub(crate) async fn update_kernel_presence(
     }
 }
 
+/// Short label for a request variant, used in telemetry logs.
+///
+/// Returns a static string — no allocation — suitable for structured logging
+/// fields.  Intentionally avoids `Debug` formatting because some variants
+/// carry large payloads (snapshot JSON, doc bytes) that would bloat log lines.
+pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
+    match req {
+        NotebookRequest::LaunchKernel { .. } => "LaunchKernel",
+        NotebookRequest::ExecuteCell { .. } => "ExecuteCell",
+        NotebookRequest::ExecuteCellGuarded { .. } => "ExecuteCellGuarded",
+        NotebookRequest::ClearOutputs { .. } => "ClearOutputs",
+        NotebookRequest::InterruptExecution { .. } => "InterruptExecution",
+        NotebookRequest::ShutdownKernel { .. } => "ShutdownKernel",
+        NotebookRequest::GetKernelInfo { .. } => "GetKernelInfo",
+        NotebookRequest::GetQueueState { .. } => "GetQueueState",
+        NotebookRequest::RunAllCells { .. } => "RunAllCells",
+        NotebookRequest::RunAllCellsGuarded { .. } => "RunAllCellsGuarded",
+        NotebookRequest::SendComm { .. } => "SendComm",
+        NotebookRequest::GetHistory { .. } => "GetHistory",
+        NotebookRequest::Complete { .. } => "Complete",
+        NotebookRequest::SaveNotebook { .. } => "SaveNotebook",
+        NotebookRequest::CloneAsEphemeral { .. } => "CloneAsEphemeral",
+        NotebookRequest::SyncEnvironment { .. } => "SyncEnvironment",
+        NotebookRequest::SyncEnvironmentGuarded { .. } => "SyncEnvironmentGuarded",
+        NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
+        NotebookRequest::GetRawMetadata { .. } => "GetRawMetadata",
+        NotebookRequest::SetRawMetadata { .. } => "SetRawMetadata",
+        NotebookRequest::GetMetadataSnapshot { .. } => "GetMetadataSnapshot",
+        NotebookRequest::SetMetadataSnapshot { .. } => "SetMetadataSnapshot",
+        NotebookRequest::CheckToolAvailable { .. } => "CheckToolAvailable",
+    }
+}
+
 /// Handle a NotebookRequest and return a NotebookResponse.
 pub(crate) async fn handle_notebook_request(
     room: &Arc<NotebookRoom>,

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -1186,6 +1186,15 @@ impl PeerWriter {
         let payload = serde_json::to_vec(value)?;
         self.send_frame(frame_type, payload)
     }
+
+    /// Number of free slots in the outbound channel.
+    ///
+    /// `PEER_OUTBOUND_QUEUE_CAPACITY - capacity()` gives the number of
+    /// in-flight frames waiting to be flushed to the socket — useful as a
+    /// backpressure signal in telemetry.
+    fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
 }
 
 impl PeerRequestWorker {
@@ -1240,7 +1249,22 @@ fn spawn_peer_request_worker(
     );
     let handle = tokio::spawn(async move {
         while let Some(envelope) = rx.recv().await {
+            let label = metadata::request_label(&envelope.request);
+            let req_id = envelope.id.as_deref().unwrap_or("-");
+            let writer_queue_depth = PEER_OUTBOUND_QUEUE_CAPACITY - writer.capacity();
+            debug!(
+                "[notebook-sync] Request {} id={} peer={} notebook={} writer_queue={}",
+                label, req_id, peer_id, notebook_id, writer_queue_depth,
+            );
+
+            let start = std::time::Instant::now();
             let response = handle_notebook_request(&room, envelope.request, daemon.clone()).await;
+            let elapsed = start.elapsed();
+            debug!(
+                "[notebook-sync] Request {} id={} completed in {:?}",
+                label, req_id, elapsed,
+            );
+
             let reply = notebook_protocol::protocol::NotebookResponseEnvelope {
                 id: envelope.id,
                 response,
@@ -1778,6 +1802,13 @@ where
                                 // request order and echoes the id on the response.
                                 let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
                                     serde_json::from_slice(&frame.payload)?;
+                                debug!(
+                                    "[notebook-sync] Enqueuing {} id={} peer={} notebook={}",
+                                    metadata::request_label(&envelope.request),
+                                    envelope.id.as_deref().unwrap_or("-"),
+                                    peer_id,
+                                    notebook_id,
+                                );
                                 if let Err(e) = request_worker.enqueue(envelope) {
                                     match e {
                                         RequestEnqueueError::Full(envelope) => {


### PR DESCRIPTION
## Summary

Adds request handling telemetry to the peer request worker from #2292. Ported from #2294's telemetry commit, adapted to fit the single-worker structure.

- **`request_label()`** in `metadata.rs` — allocation-free `&'static str` variant names for all 23 `NotebookRequest` variants. Avoids `Debug` formatting which can dump large payloads (snapshot JSON, doc bytes) into log lines.
- **Enqueue-time logging** in the frame arm — logs request type, envelope ID, peer ID, notebook ID when a request is dispatched to the worker queue.
- **Worker-loop logging** — logs request type, envelope ID, peer ID, notebook ID, PeerWriter queue depth at handler start; logs request type, envelope ID, and handler duration at completion.

## What this enables

- Measure baseline handler latency per request type in production
- Identify which handlers cause head-of-line blocking (LaunchKernel, SaveNotebook, Complete)
- Monitor PeerWriter queue depth as a backpressure signal
- Compare before/after performance across builds

## Test plan

- [x] `cargo check -p runtimed` passes
- [x] `cargo xtask lint` passes
- [ ] All existing tests in #2292 still pass