### PR TITLE
fix(runtimed): enforce trust for launch and env sync

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -12,7 +12,7 @@ paths:
 
 Two independent version numbers, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `3`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v3 adds `SessionControl`; v2 clients are still accepted but are served without `SessionControl` frames.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `4`) -- governs wire compatibility. Validated by the 5-byte magic preamble at connection start. Bump when framing, handshake shape, or serialization format changes. v4 removes legacy environment-sync request/response variants and requires current clients.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) -- governs Automerge document compatibility. Bump when document structure changes.
 
 These are just incrementing integers that evolve independently from each other and from the artifact version.
@@ -24,7 +24,7 @@ Every connection starts with 5 bytes before the JSON handshake:
 | Bytes | Content |
 |-------|---------|
 | 0-3 | Magic: `0xC0 0xDE 0x01 0xAC` |
-| 4 | Protocol version (currently `3`) |
+| 4 | Protocol version (currently `4`) |
 
 The daemon validates both before reading the handshake. Non-runtimed connections get "invalid magic bytes". Protocol mismatches are rejected before JSON parsing.
 
@@ -32,7 +32,7 @@ The daemon validates both before reading the handshake. Non-runtimed connections
 
 1. **Opening** -- Frontend invokes Tauri command; relay connects to daemon Unix socket and sends handshake.
 2. **Handshake** -- JSON with `channel`, `notebook_id`, `protocol`. Daemon responds with `NotebookConnectionInfo` (protocol, notebook_id, cell_count, needs_trust_approval). The `Handshake` enum uses `#[serde(tag = "channel")]` -- flat wire format with `"channel"` discriminator.
-3. **Initial sync** -- Both sides exchange Automerge sync messages until convergence. Frontend starts empty; all state comes from daemon. v3 clients also receive `SessionControl::SyncStatus` frames for notebook-doc, runtime-state, and initial-load readiness.
+3. **Initial sync** -- Both sides exchange Automerge sync messages until convergence. Frontend starts empty; all state comes from daemon. v4 clients receive `SessionControl::SyncStatus` frames for notebook-doc, runtime-state, and initial-load readiness.
 4. **Steady state** -- Concurrent Automerge sync, request/response, RuntimeStateDoc sync, PoolDoc sync, presence, broadcasts, and session-control frames. The frame consumer must stay hot: request and confirmation waits belong in pending maps/waiter lists, not blocking `recv()` loops.
 5. **Disconnection** -- Relay emits `daemon:disconnected`. Generation counter prevents stale callbacks.
 
@@ -104,8 +104,7 @@ readiness snapshot with:
 - `runtime_state`: `pending | syncing | ready`
 - `initial_load`: `not_needed | streaming | ready | failed`
 
-The daemon emits the full current state on transitions. v2 clients do not
-receive these frames.
+The daemon emits the full current state on transitions.
 
 ## Tauri Event Bridge
 

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -97,7 +97,7 @@ Builds macOS + Linux wheels and publishes to PyPI.
 ## Protocol Version Change Procedure
 
 1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`
-2. Update `PROTOCOL_V2` string constant if the version string changes
+2. Update the `PROTOCOL_V*` string constant if the version string changes
 3. Update `contributing/protocol.md`
 4. Decide version bump type based on user impact
 

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -372,7 +372,6 @@ function AppContent() {
     interruptKernel,
     shutdownKernel,
     syncEnvironment,
-    syncEnvironmentGuarded,
     runAllCells: daemonRunAllCells,
     runAllCellsGuarded,
     sendCommMessage,
@@ -736,6 +735,10 @@ function AppContent() {
           logger.error("[App] tryStartKernel: daemon error", response.error);
           return false;
         }
+        if (response.result === "guard_rejected") {
+          setTrustActionNotice(response.reason);
+          return false;
+        }
         return true;
       }
       // Untrusted - show dialog and mark pending start
@@ -744,7 +747,7 @@ function AppContent() {
       setTrustDialogOpen(true);
       return false;
     },
-    [sessionReady, checkTrust, launchKernel, setBlockedTrustAction],
+    [sessionReady, checkTrust, launchKernel, setBlockedTrustAction, setTrustActionNotice],
   );
 
   const performTrustedSyncDeps = useCallback(
@@ -757,7 +760,7 @@ function AppContent() {
 
       if ((isUvInline || isCondaInline) && hasOnlyAdditions) {
         logger.debug("[App] Trying hot-sync for additions");
-        const response = guard ? await syncEnvironmentGuarded(guard) : await syncEnvironment();
+        const response = await syncEnvironment(guard);
 
         if (response.result === "sync_environment_complete") {
           logger.debug("[App] Hot-sync succeeded:", response.synced_packages);
@@ -796,15 +799,7 @@ function AppContent() {
       }
       return started;
     },
-    [
-      envSource,
-      envSyncState,
-      envProgress,
-      syncEnvironment,
-      syncEnvironmentGuarded,
-      shutdownKernel,
-      tryStartKernel,
-    ],
+    [envSource, envSyncState, envProgress, syncEnvironment, shutdownKernel, tryStartKernel],
   );
 
   // Handler to sync deps - tries hot-sync for UV additions, falls back to restart
@@ -949,6 +944,11 @@ function AppContent() {
           setTrustActionNotice(response.error);
           return;
         }
+        if (response.result === "guard_rejected") {
+          setTrustApprovalHandoffPending(false);
+          setTrustActionNotice(response.reason);
+          return;
+        }
         await runTrustApprovedAction(action);
       } catch (e) {
         logger.error("[App] kernel launch after trust approval failed:", e);
@@ -956,7 +956,7 @@ function AppContent() {
         setTrustActionNotice(e instanceof Error ? e.message : String(e));
       }
     },
-    [sessionReady, launchKernel, runTrustApprovedAction],
+    [sessionReady, launchKernel, runTrustApprovedAction, setTrustActionNotice],
   );
 
   // Handle trust approval from dialog
@@ -1035,8 +1035,10 @@ function AppContent() {
     const response = await launchKernel("python", "uv:pyproject");
     if (response.result === "error") {
       logger.error("[App] handleStartKernelWithPyproject: daemon error", response.error);
+    } else if (response.result === "guard_rejected") {
+      setTrustActionNotice(response.reason);
     }
-  }, [sessionReady, launchKernel]);
+  }, [sessionReady, launchKernel, setTrustActionNotice]);
 
   const handleExecuteCell = useCallback(
     async (cellId: string) => {

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -293,13 +293,8 @@ export function useDaemonKernel({
   );
 
   const syncEnvironment = useCallback(
-    () => client.syncEnvironment() as Promise<NotebookResponse>,
-    [client],
-  );
-
-  const syncEnvironmentGuarded = useCallback(
-    (provenance: GuardedDependencyProvenance) =>
-      client.syncEnvironmentGuarded(provenance) as Promise<NotebookResponse>,
+    (provenance?: GuardedDependencyProvenance) =>
+      client.syncEnvironment(provenance) as Promise<NotebookResponse>,
     [client],
   );
 
@@ -342,7 +337,6 @@ export function useDaemonKernel({
     interruptKernel,
     shutdownKernel,
     syncEnvironment,
-    syncEnvironmentGuarded,
     runAllCells,
     runAllCellsGuarded,
     sendCommMessage,

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -198,7 +198,6 @@ export type DaemonNotebookResponse =
     }
   | { result: "ok" }
   | { result: "error"; error: string }
-  | { result: "sync_environment_started"; packages: string[] }
   | { result: "sync_environment_complete"; synced_packages: string[] }
   | {
       result: "sync_environment_failed";

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -6,7 +6,7 @@ This document describes the wire protocol between notebook clients (frontend WAS
 
 Two independent version numbers handle compatibility, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `3`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes. Protocol v3 adds `SessionControl` readiness/status frames; v2 clients are accepted for compatibility but do not receive those frames.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `4`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes. Protocol v4 removes legacy environment-sync request/response variants and requires current clients.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes. The current schema stores cells as a fractional-indexed `Map` and keeps outputs in `RuntimeStateDoc` keyed by `execution_id`, with per-output `output_id` UUIDs on manifests. Future bumps MUST ship a `migrate_vN_to_v(N+1)` function that preserves user data — v1–v3 were pre-release and the v4 load path discards older docs on load, which is only safe because no real user data lives at those versions.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol or schema bump doesn't automatically force a major version bump — that depends on whether the change is user-facing.
@@ -30,7 +30,7 @@ Every connection starts with a 5-byte preamble before the JSON handshake frame:
 | Bytes | Content |
 |-------|---------|
 | 0–3 | Magic: `0xC0 0xDE 0x01 0xAC` |
-| 4 | Protocol version (currently `3`) |
+| 4 | Protocol version (currently `4`) |
 
 The daemon validates both before reading the handshake. Non-runtimed connections get a clear "invalid magic bytes" error. Protocol mismatches are rejected before any JSON parsing.
 
@@ -87,7 +87,7 @@ The first frame is a JSON `Handshake` message:
 {
   "channel": "notebook_sync",
   "notebook_id": "/path/to/notebook.ipynb",
-  "protocol": "v3"
+  "protocol": "v4"
 }
 ```
 
@@ -99,7 +99,7 @@ The daemon responds with a `NotebookConnectionInfo`:
 
 ```json
 {
-  "protocol": "v3",
+  "protocol": "v4",
   "notebook_id": "derived-id",
   "cell_count": 5,
   "needs_trust_approval": false
@@ -110,7 +110,7 @@ The `protocol_version`, `daemon_version`, and `error` fields are `Option` types 
 
 ### 3. Initial Automerge sync
 
-After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. Protocol v3 clients receive `SessionControl::SyncStatus` frames as the daemon advances notebook-doc, runtime-state, and initial-load readiness.
+After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. Protocol v4 clients receive `SessionControl::SyncStatus` frames as the daemon advances notebook-doc, runtime-state, and initial-load readiness.
 
 ### 4. Steady state
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -115,7 +115,7 @@ This builds macOS and Linux Python artifacts for both `runtimed` and `nteract`, 
 When making a breaking wire protocol change:
 
 1. Bump `PROTOCOL_VERSION` in `crates/notebook-protocol/src/connection.rs`
-2. Update `PROTOCOL_V2` string constant if the version string changes
+2. Update the `PROTOCOL_V*` string constant if the version string changes
 3. Update `contributing/protocol.md`
 4. Decide whether this warrants a major, minor, or patch version bump based on user impact
 

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -449,12 +449,11 @@ pub enum Handshake {
     /// Automerge notebook sync (per-notebook room).
     ///
     /// The optional `protocol` field is accepted for version negotiation.
-    /// v3 clients receive SessionControl frames; v2 clients are accepted for
-    /// compatibility without those frames. After handshake, the server sends a
-    /// `ProtocolCapabilities` response before starting sync.
+    /// v4 clients receive SessionControl frames. After handshake, the server
+    /// sends a `ProtocolCapabilities` response before starting sync.
     NotebookSync {
         notebook_id: String,
-        /// Protocol version requested by client (`v3` preferred, `v2` compatible).
+        /// Protocol version requested by client (`v4`).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
         /// Working directory for untitled notebooks (used for project file detection).
@@ -524,20 +523,17 @@ pub enum Handshake {
     },
 }
 
-/// Protocol version constants (strings for handshake compatibility).
-pub const PROTOCOL_V2: &str = "v2";
-pub const PROTOCOL_V3: &str = "v3";
+pub const PROTOCOL_V4: &str = "v4";
 
 /// Numeric protocol version for version negotiation.
 /// Increment this when making breaking protocol changes.
 ///
-/// Protocol v3 adds explicit session-control status frames for notebook
-/// bootstrap/readiness and is not wire-compatible with v2 clients.
-pub const PROTOCOL_VERSION: u32 = 3;
+/// Protocol v4 removes legacy environment-sync request/response variants and
+/// is not wire-compatible with v3 clients.
+pub const PROTOCOL_VERSION: u32 = 4;
 
-/// Minimum protocol version accepted by v3 daemons for backward compatibility.
-/// v2 clients are served without SESSION_CONTROL frames.
-pub const MIN_PROTOCOL_VERSION: u32 = 2;
+/// Minimum protocol version accepted by v4 daemons.
+pub const MIN_PROTOCOL_VERSION: u32 = 4;
 
 /// Magic bytes identifying the runtimed protocol.
 /// Sent as the first 4 bytes of every connection, before the handshake frame.
@@ -616,7 +612,7 @@ pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Res
 /// Used by the `NotebookSync` handshake variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Protocol version string (currently always "v3").
+    /// Protocol version string (currently always "v4").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     /// Clients can compare this against their expected version.
@@ -634,7 +630,7 @@ pub struct ProtocolCapabilities {
 /// Contains notebook_id derived by the daemon (from path or generated env_id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version string (currently always "v3").
+    /// Protocol version string (currently always "v4").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1167,30 +1163,30 @@ mod tests {
         .unwrap();
         assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
 
-        // NotebookSync with v2 protocol
+        // NotebookSync with v4 protocol
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
-            protocol: Some("v2".into()),
+            protocol: Some(PROTOCOL_V4.into()),
             working_dir: None,
             initial_metadata: None,
         })
         .unwrap();
         assert_eq!(
             json,
-            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v2"}"#
+            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v4"}"#
         );
 
         // NotebookSync with working_dir for untitled notebook
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
-            protocol: Some("v2".into()),
+            protocol: Some(PROTOCOL_V4.into()),
             working_dir: Some("/home/user/project".into()),
             initial_metadata: None,
         })
         .unwrap();
         assert_eq!(
             json,
-            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v2","working_dir":"/home/user/project"}"#
+            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v4","working_dir":"/home/user/project"}"#
         );
 
         // Blob
@@ -1254,7 +1250,7 @@ mod tests {
     fn test_notebook_connection_info_serialization() {
         // Success case (minimal - no optional fields)
         let info = NotebookConnectionInfo {
-            protocol: "v2".into(),
+            protocol: PROTOCOL_V4.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "/home/user/notebook.ipynb".into(),
@@ -1267,12 +1263,12 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
             json,
-            r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false,"ephemeral":false}"#
+            r#"{"protocol":"v4","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false,"ephemeral":false}"#
         );
 
         // With version info
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V3.into(),
+            protocol: PROTOCOL_V4.into(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some("0.1.0+abc123".into()),
             notebook_id: "/home/user/notebook.ipynb".into(),
@@ -1288,7 +1284,7 @@ mod tests {
 
         // With trust approval needed
         let info = NotebookConnectionInfo {
-            protocol: "v2".into(),
+            protocol: PROTOCOL_V4.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
@@ -1303,7 +1299,7 @@ mod tests {
 
         // Error case
         let info = NotebookConnectionInfo {
-            protocol: "v2".into(),
+            protocol: PROTOCOL_V4.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: String::new(),
@@ -1318,7 +1314,7 @@ mod tests {
 
         // With notebook_path
         let info = NotebookConnectionInfo {
-            protocol: "v2".into(),
+            protocol: PROTOCOL_V4.into(),
             protocol_version: None,
             daemon_version: None,
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -135,9 +135,9 @@ pub struct GuardedNotebookProvenance {
     pub observed_heads: Vec<String>,
 }
 
-/// Frontend-observed dependency state used to guard trust-approved sync.
+/// Dependency state used to guard trust-approved sync.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct GuardedDependencyProvenance {
+pub struct DependencyGuard {
     pub observed_heads: Vec<String>,
     pub dependency_fingerprint: String,
 }
@@ -425,14 +425,13 @@ pub enum NotebookRequest {
     },
 
     /// Sync environment with current metadata (hot-install new packages).
-    /// Only supported for UV inline deps. Falls back to restart for removals/conda.
-    SyncEnvironment {},
-
-    /// Sync environment only if dependency metadata still matches the state
-    /// the user approved in the trust dialog.
-    SyncEnvironmentGuarded {
-        observed_heads: Vec<String>,
-        dependency_fingerprint: String,
+    ///
+    /// The daemon always enforces trust before installing. `guard` is supplied
+    /// when the request follows a trust dialog and must still match the
+    /// dependency metadata the user approved.
+    SyncEnvironment {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        guard: Option<DependencyGuard>,
     },
 
     /// Approve the current dependency metadata for this notebook.
@@ -549,12 +548,6 @@ pub enum NotebookResponse {
         items: Vec<CompletionItem>,
         cursor_start: usize,
         cursor_end: usize,
-    },
-
-    /// Environment sync started (installing new packages).
-    SyncEnvironmentStarted {
-        /// Packages being installed
-        packages: Vec<String>,
     },
 
     /// Environment sync completed successfully.
@@ -917,9 +910,11 @@ mod tests {
             NotebookRequest::RunAllCellsGuarded {
                 observed_heads: observed_heads.clone(),
             },
-            NotebookRequest::SyncEnvironmentGuarded {
-                observed_heads,
-                dependency_fingerprint,
+            NotebookRequest::SyncEnvironment {
+                guard: Some(DependencyGuard {
+                    observed_heads,
+                    dependency_fingerprint,
+                }),
             },
             NotebookRequest::ApproveTrust {
                 dependency_fingerprint: Some("{\"uv\":{\"dependencies\":[\"numpy\"]}}".into()),
@@ -1007,11 +1002,13 @@ mod tests {
                 serde_json::json!({ "action": "sync_environment" }),
             ),
             (
-                "sync_environment_guarded",
+                "sync_environment_with_guard",
                 serde_json::json!({
-                    "action": "sync_environment_guarded",
-                    "observed_heads": ["abc"],
-                    "dependency_fingerprint": "{}",
+                    "action": "sync_environment",
+                    "guard": {
+                        "observed_heads": ["abc"],
+                        "dependency_fingerprint": "{}",
+                    },
                 }),
             ),
             (

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -25,7 +25,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
-    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V3,
+    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
 };
 use notebook_protocol::protocol::NotebookBroadcast;
 
@@ -180,7 +180,7 @@ pub async fn connect_with_options(
     // Send handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V3.to_string()),
+        protocol: Some(PROTOCOL_V4.to_string()),
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         initial_metadata: initial_metadata.clone(),
     };
@@ -559,7 +559,7 @@ pub async fn connect_relay(
     // Send notebook sync handshake
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
-        protocol: Some(PROTOCOL_V3.to_string()),
+        protocol: Some(PROTOCOL_V4.to_string()),
         initial_metadata: None,
         working_dir: None,
     };
@@ -567,7 +567,7 @@ pub async fn connect_relay(
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive protocol capabilities (v3 handshake)
+    // Receive protocol capabilities (v4 handshake)
     let caps_data = connection::recv_frame(&mut reader)
         .await?
         .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -234,7 +234,7 @@ pub async fn add_dependency(
         "sync" => {
             // Attempt hot-install (UV only; conda/pixi will report needs_restart)
             match handle
-                .send_request(NotebookRequest::SyncEnvironment {})
+                .send_request(NotebookRequest::SyncEnvironment { guard: None })
                 .await
             {
                 Ok(NotebookResponse::SyncEnvironmentComplete {
@@ -245,10 +245,11 @@ pub async fn add_dependency(
                         "synced_packages": synced_packages,
                     });
                 }
-                Ok(NotebookResponse::SyncEnvironmentStarted { packages }) => {
+                Ok(NotebookResponse::GuardRejected { reason }) => {
                     result["sync"] = serde_json::json!({
-                        "success": true,
-                        "synced_packages": packages,
+                        "success": false,
+                        "error": reason,
+                        "needs_restart": false,
                     });
                 }
                 Ok(NotebookResponse::SyncEnvironmentFailed {
@@ -327,6 +328,12 @@ pub async fn add_dependency(
                     result["restart"] = serde_json::json!({
                         "success": false,
                         "error": error,
+                    });
+                }
+                Ok(NotebookResponse::GuardRejected { reason }) => {
+                    result["restart"] = serde_json::json!({
+                        "success": false,
+                        "error": reason,
                     });
                 }
                 Err(e) => {
@@ -430,7 +437,7 @@ pub async fn sync_environment(
     }
 
     match handle
-        .send_request(NotebookRequest::SyncEnvironment {})
+        .send_request(NotebookRequest::SyncEnvironment { guard: None })
         .await
     {
         Ok(NotebookResponse::SyncEnvironmentComplete {
@@ -442,14 +449,6 @@ pub async fn sync_environment(
             });
             tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
         }
-        Ok(NotebookResponse::SyncEnvironmentStarted { packages }) => {
-            // Sync started but hasn't completed yet — return started status
-            let result = serde_json::json!({
-                "success": true,
-                "synced_packages": packages,
-            });
-            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
-        }
         Ok(NotebookResponse::SyncEnvironmentFailed {
             error,
             needs_restart,
@@ -458,6 +457,14 @@ pub async fn sync_environment(
                 "success": false,
                 "error": error,
                 "needs_restart": needs_restart,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(NotebookResponse::GuardRejected { reason }) => {
+            let result = serde_json::json!({
+                "success": false,
+                "error": reason,
+                "needs_restart": false,
             });
             tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
         }

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -142,6 +142,11 @@ pub async fn restart_kernel(
                 Some(s) => {
                     let fresh_handle = s.handle.clone();
                     drop(guard);
+                    if let Err(e) = fresh_handle.confirm_sync().await {
+                        tracing::warn!(
+                            "confirm_sync failed before restart_kernel retry launch: {e}"
+                        );
+                    }
                     fresh_handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: kernel_type.clone(),
@@ -198,6 +203,9 @@ pub async fn restart_kernel(
         Ok(NotebookResponse::Error { error }) => {
             tool_error(&format!("Failed to restart kernel: {error}"))
         }
+        Ok(NotebookResponse::GuardRejected { reason }) => tool_error(&format!(
+            "Kernel restart blocked by notebook trust: {reason}"
+        )),
         Ok(_) => tool_success(&serde_json::json!({ "restarted": true }).to_string()),
         Err(e) => tool_error(&format!("Failed to restart kernel: {e}")),
     }

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -15,9 +15,9 @@ use crate::{EnvType, PoolState, PooledEnv};
 
 // Re-export all notebook protocol types from the shared crate.
 pub use notebook_protocol::protocol::{
-    CompletionItem, DenoLaunchedConfig, EnvSyncDiff, GuardedDependencyProvenance,
-    GuardedNotebookProvenance, HistoryEntry, LaunchedEnvConfig, NotebookBroadcast, NotebookRequest,
-    NotebookResponse, QueueEntry,
+    CompletionItem, DenoLaunchedConfig, DependencyGuard, EnvSyncDiff, GuardedNotebookProvenance,
+    HistoryEntry, LaunchedEnvConfig, NotebookBroadcast, NotebookRequest, NotebookResponse,
+    QueueEntry,
 };
 
 /// Requests that clients can send to the daemon.

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -188,12 +188,13 @@ impl Session {
         };
         handle.confirm_sync().await.map_err(to_napi_err)?;
         let response = handle
-            .send_request(NotebookRequest::SyncEnvironment {})
+            .send_request(NotebookRequest::SyncEnvironment { guard: None })
             .await
             .map_err(to_napi_err)?;
         match response {
             NotebookResponse::SyncEnvironmentComplete { .. } => Ok(()),
             NotebookResponse::SyncEnvironmentFailed { error, .. } => Err(Error::from_reason(error)),
+            NotebookResponse::GuardRejected { reason } => Err(Error::from_reason(reason)),
             NotebookResponse::Error { error } => Err(Error::from_reason(error)),
             other => Err(Error::from_reason(format!(
                 "Unexpected response: {other:?}"
@@ -423,6 +424,7 @@ async fn ensure_kernel_started(state: &Arc<Mutex<SessionState>>) -> Result<()> {
             .ok_or_else(|| Error::from_reason("Not connected"))?
             .clone()
     };
+    handle.confirm_sync().await.map_err(to_napi_err)?;
     let response = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: runtime.clone(),
@@ -438,6 +440,7 @@ async fn ensure_kernel_started(state: &Arc<Mutex<SessionState>>) -> Result<()> {
             st.kernel_started = true;
             Ok(())
         }
+        NotebookResponse::GuardRejected { reason } => Err(Error::from_reason(reason)),
         NotebookResponse::Error { error } => Err(Error::from_reason(error)),
         other => Err(Error::from_reason(format!(
             "Unexpected response: {other:?}"

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -711,7 +711,7 @@ impl SyncEnvironmentResult {
 #[pyclass(get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version (currently "v2").
+    /// Protocol version (currently "v4").
     pub protocol: String,
     /// Numeric protocol version for explicit version checking.
     pub protocol_version: Option<u32>,

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -524,18 +524,22 @@ pub(crate) async fn start_kernel(
     env_source: &str,
     notebook_path: Option<&str>,
 ) -> PyResult<()> {
-    let mut st = state.lock().await;
+    // Resolve notebook path: explicit arg > stored state > None, then release
+    // the session lock before the sync confirmation and launch request.
+    let (handle, resolved_path) = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?
+            .clone();
+        let resolved_path = notebook_path
+            .map(|p| p.to_string())
+            .or_else(|| st.notebook_path.clone());
+        (handle, resolved_path)
+    };
 
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
-
-    // Resolve notebook path: explicit arg > stored state > None
-    let resolved_path = notebook_path
-        .map(|p| p.to_string())
-        .or_else(|| st.notebook_path.clone());
-
+    handle.confirm_sync().await.map_err(to_py_err)?;
     let response = handle
         .send_request(NotebookRequest::LaunchKernel {
             kernel_type: kernel_type.to_string(),
@@ -545,6 +549,7 @@ pub(crate) async fn start_kernel(
         .await
         .map_err(to_py_err)?;
 
+    let mut st = state.lock().await;
     match response {
         NotebookResponse::KernelLaunched {
             kernel_type: actual_type,
@@ -578,6 +583,7 @@ pub(crate) async fn start_kernel(
             }
             Ok(())
         }
+        NotebookResponse::GuardRejected { reason } => Err(to_py_err(reason)),
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }
@@ -675,6 +681,7 @@ pub(crate) async fn restart_kernel(
     let mut progress_messages: Vec<String> = Vec::new();
     let launch_timeout = std::time::Duration::from_secs(120);
 
+    handle.confirm_sync().await.map_err(to_py_err)?;
     let launch_fut = handle.send_request(NotebookRequest::LaunchKernel {
         kernel_type: restart_kernel_type,
         env_source: restart_env_source,
@@ -733,6 +740,7 @@ pub(crate) async fn restart_kernel(
                 st.kernel_type = Some(actual_type);
                 st.env_source = Some(actual_env);
             }
+            NotebookResponse::GuardRejected { reason } => return Err(to_py_err(reason)),
             NotebookResponse::Error { error } => return Err(to_py_err(error)),
             other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
         }
@@ -2164,18 +2172,19 @@ pub(crate) async fn set_notebook_metadata(
 pub(crate) async fn sync_environment_impl(
     state: &Arc<Mutex<SessionState>>,
 ) -> PyResult<SyncEnvironmentResult> {
-    let response = {
+    let handle = {
         let st = state.lock().await;
-        let handle = st
-            .handle
+        st.handle
             .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        handle
-            .send_request(NotebookRequest::SyncEnvironment {})
-            .await
-            .map_err(to_py_err)?
+            .ok_or_else(|| to_py_err("Not connected"))?
+            .clone()
     };
+
+    handle.confirm_sync().await.map_err(to_py_err)?;
+    let response = handle
+        .send_request(NotebookRequest::SyncEnvironment { guard: None })
+        .await
+        .map_err(to_py_err)?;
 
     match response {
         NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
@@ -2206,6 +2215,12 @@ pub(crate) async fn sync_environment_impl(
             synced_packages: vec![],
             error: Some(error),
             needs_restart: true,
+        }),
+        NotebookResponse::GuardRejected { reason } => Ok(SyncEnvironmentResult {
+            success: false,
+            synced_packages: vec![],
+            error: Some(reason),
+            needs_restart: false,
         }),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1608,7 +1608,7 @@ impl Daemon {
         // 0x00 = old protocol (4-byte big-endian length prefix for any
         // reasonable handshake size). This allows the daemon upgrade to succeed
         // even when the old app is still verifying daemon health.
-        let (handshake_bytes, client_protocol_version) =
+        let (handshake_bytes, client_protocol_version, has_preamble) =
             tokio::time::timeout(std::time::Duration::from_secs(10), async {
                 // Peek at first byte to detect protocol version
                 let mut first_byte = [0u8; 1];
@@ -1648,22 +1648,17 @@ impl Daemon {
                             connection::PROTOCOL_VERSION
                         );
                     }
-                    if version < connection::PROTOCOL_VERSION as u8 {
-                        tracing::info!(
-                        "[runtimed] v{} client connected, serving without session-control frames",
-                        version
-                    );
-                    }
-
                     // Read the JSON handshake frame
                     let bytes = connection::recv_control_frame(&mut stream)
                         .await
                         .context("handshake read error")?
                         .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
-                    Ok((bytes, version))
+                    Ok((bytes, version, true))
                 } else {
                     // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
-                    // big-endian length prefix. Read remaining 3 length bytes.
+                    // big-endian length prefix. Keep this only for the pool health
+                    // check used by installed-client upgrade probes; notebook sync
+                    // channels are rejected below unless they use the v4 preamble.
                     tracing::debug!("[runtimed] Legacy client detected (no magic preamble)");
                     let mut len_rest = [0u8; 3];
                     tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
@@ -1682,12 +1677,23 @@ impl Daemon {
                         .await
                         .map_err(|e| anyhow::anyhow!("legacy handshake read: {}", e))?;
 
-                    Ok((buf, connection::MIN_PROTOCOL_VERSION as u8))
+                    Ok((buf, connection::PROTOCOL_VERSION as u8, false))
                 }
             })
             .await
             .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
+
+        if !has_preamble {
+            return match handshake {
+                Handshake::Pool => self.handle_pool_connection(stream).await,
+                _ => anyhow::bail!(
+                    "legacy notebook protocol without preamble is no longer supported; \
+                     expected protocol v{}",
+                    connection::PROTOCOL_VERSION
+                ),
+            };
+        }
 
         match handshake {
             Handshake::Pool => self.handle_pool_connection(stream).await,
@@ -1715,11 +1721,11 @@ impl Daemon {
                 info!(
                     "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
                     notebook_id,
-                    protocol.as_deref().unwrap_or("v2"),
+                    protocol.as_deref().unwrap_or("v4"),
                     working_dir
                 );
                 let docs_dir = self.config.notebook_docs_dir.clone();
-                // For the legacy NotebookSync handshake:
+                // For the NotebookSync handshake:
                 // - UUID notebook_id → untitled room (path=None)
                 // - Path notebook_id → file-backed room (path=Some)
                 //
@@ -1875,7 +1881,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
@@ -1904,13 +1910,9 @@ impl Daemon {
         async fn send_error_response<W: AsyncWrite + Unpin>(
             writer: &mut W,
             error: String,
-            client_protocol_version: u8,
+            _client_protocol_version: u8,
         ) -> anyhow::Result<()> {
-            let (proto_str, proto_ver) = if client_protocol_version >= 3 {
-                (PROTOCOL_V3, PROTOCOL_VERSION)
-            } else {
-                (connection::PROTOCOL_V2, 2)
-            };
+            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
                 protocol: proto_str.to_string(),
                 protocol_version: Some(proto_ver),
@@ -2165,11 +2167,7 @@ impl Daemon {
         // `notebook_id` variable in this handler is the canonical path string
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = if client_protocol_version >= 3 {
-            (PROTOCOL_V3, PROTOCOL_VERSION)
-        } else {
-            (connection::PROTOCOL_V2, 2)
-        };
+        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let response = NotebookConnectionInfo {
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),
@@ -2228,7 +2226,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use crate::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V3, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
         };
 
         info!(
@@ -2304,11 +2302,7 @@ impl Daemon {
                 );
             }
             let (mut reader, mut writer) = tokio::io::split(stream);
-            let (proto_str, proto_ver) = if client_protocol_version >= 3 {
-                (PROTOCOL_V3, PROTOCOL_VERSION)
-            } else {
-                (connection::PROTOCOL_V2, 2)
-            };
+            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
                 protocol: proto_str.to_string(),
                 protocol_version: Some(proto_ver),
@@ -2330,11 +2324,7 @@ impl Daemon {
         // Always send the room's UUID on the wire, even when the caller
         // provided a notebook_id_hint — room.id is the canonical source.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = if client_protocol_version >= 3 {
-            (PROTOCOL_V3, PROTOCOL_VERSION)
-        } else {
-            (connection::PROTOCOL_V2, 2)
-        };
+        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let notebook_path = room
             .identity
             .path

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3442,7 +3442,6 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
         NotebookRequest::SaveNotebook { .. } => "SaveNotebook",
         NotebookRequest::CloneAsEphemeral { .. } => "CloneAsEphemeral",
         NotebookRequest::SyncEnvironment { .. } => "SyncEnvironment",
-        NotebookRequest::SyncEnvironmentGuarded { .. } => "SyncEnvironmentGuarded",
         NotebookRequest::ApproveTrust { .. } => "ApproveTrust",
         NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
         NotebookRequest::CheckToolAvailable { .. } => "CheckToolAvailable",
@@ -3525,20 +3524,8 @@ pub(crate) async fn handle_notebook_request(
             crate::requests::clone_notebook::handle(&daemon, source_notebook_id).await
         }
 
-        NotebookRequest::SyncEnvironment {} => {
-            crate::requests::sync_environment::handle(room).await
-        }
-
-        NotebookRequest::SyncEnvironmentGuarded {
-            observed_heads,
-            dependency_fingerprint,
-        } => {
-            crate::requests::sync_environment::handle_guarded(
-                room,
-                observed_heads,
-                dependency_fingerprint,
-            )
-            .await
+        NotebookRequest::SyncEnvironment { guard } => {
+            crate::requests::sync_environment::handle(room, guard).await
         }
 
         NotebookRequest::ApproveTrust {

--- a/crates/runtimed/src/notebook_sync_server/peer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer.rs
@@ -386,8 +386,8 @@ pub async fn handle_notebook_sync_connection<R, W>(
     // True if this is a newly-created notebook at a non-existent path.
     // Used to enable auto-launch for notebooks created via `runt notebook newfile.ipynb`.
     created_new_at_path: bool,
-    // Protocol version from the client preamble. v2 clients don't understand
-    // SessionControl frames, so we skip them when this is < 3.
+    // Protocol version from the client preamble. v4 is required at connection
+    // setup, so SessionControl frames are always supported.
     client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
@@ -570,13 +570,8 @@ where
     }
 
     // Send capabilities response unless already sent via NotebookConnectionInfo.
-    // v2 clients expect PROTOCOL_V2 and don't understand session-control frames.
     if !skip_capabilities {
-        let (proto_str, proto_ver) = if client_protocol_version >= 3 {
-            (connection::PROTOCOL_V3, connection::PROTOCOL_VERSION)
-        } else {
-            (connection::PROTOCOL_V2, 2)
-        };
+        let (proto_str, proto_ver) = (connection::PROTOCOL_V4, connection::PROTOCOL_VERSION);
         let caps = connection::ProtocolCapabilities {
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -24,6 +24,7 @@ use crate::notebook_sync_server::{
     unified_env_on_disk, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
+use crate::requests::guarded;
 
 pub(crate) async fn handle(
     room: &Arc<NotebookRoom>,
@@ -32,6 +33,10 @@ pub(crate) async fn handle(
     env_source: String,
     notebook_path: Option<String>,
 ) -> NotebookResponse {
+    if let Err(rejection) = guarded::ensure_trusted(room).await {
+        return rejection.into_response();
+    }
+
     // Fall back to the room's on-disk path when the caller doesn't
     // supply one. The frontend typically launches with
     // `notebook_path: None` and relies on the room knowing its own

--- a/crates/runtimed/src/requests/sync_environment.rs
+++ b/crates/runtimed/src/requests/sync_environment.rs
@@ -6,30 +6,27 @@
 //! dispatcher reads uniformly.
 
 use crate::notebook_sync_server::{handle_sync_environment, NotebookRoom};
-use crate::protocol::NotebookResponse;
+use crate::protocol::{DependencyGuard, NotebookResponse};
 use crate::requests::guarded;
 
-pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
-    handle_sync_environment(room).await
-}
-
-pub(crate) async fn handle_guarded(
+pub(crate) async fn handle(
     room: &NotebookRoom,
-    observed_heads: Vec<String>,
-    dependency_fingerprint: String,
+    guard: Option<DependencyGuard>,
 ) -> NotebookResponse {
     if let Err(rejection) = guarded::ensure_trusted(room).await {
         return rejection.into_response();
     }
 
-    {
+    if let Some(guard) = guard {
         let mut doc = room.doc.write().await;
-        if let Err(rejection) =
-            guarded::validate_sync_environment(&mut doc, &observed_heads, &dependency_fingerprint)
-        {
+        if let Err(rejection) = guarded::validate_sync_environment(
+            &mut doc,
+            &guard.observed_heads,
+            &guard.dependency_fingerprint,
+        ) {
             return rejection.into_response();
         }
     }
 
-    handle(room).await
+    handle_sync_environment(room).await
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -8,10 +8,11 @@
 use std::time::Duration;
 
 use notebook_sync::connect;
+use runtime_doc::RuntimeLifecycle;
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::notebook_doc::frame_types;
-use runtimed::protocol::{NotebookRequest, NotebookResponse};
+use runtimed::protocol::{DependencyGuard, NotebookRequest, NotebookResponse};
 use runtimed::EnvType;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -699,6 +700,181 @@ async fn test_parallel_cell_mutations_same_session_no_disconnect() {
     for index in 0..10 {
         assert!(ids.contains(&format!("parallel-{index}")));
     }
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_untrusted_launch_and_sync_environment_are_daemon_rejected() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap();
+    let handle = result.handle;
+
+    assert!(
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state"
+    );
+
+    handle.add_uv_dependency("requests").unwrap();
+    handle.confirm_sync().await.unwrap();
+
+    let launch = handle
+        .send_request(NotebookRequest::LaunchKernel {
+            kernel_type: "python".to_string(),
+            env_source: "auto".to_string(),
+            notebook_path: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(launch, NotebookResponse::GuardRejected { .. }),
+        "untrusted LaunchKernel should be rejected by the daemon, got {launch:?}"
+    );
+    assert_eq!(
+        handle.get_runtime_state().unwrap().kernel.lifecycle,
+        RuntimeLifecycle::NotStarted,
+        "rejected LaunchKernel must not claim or mutate runtime lifecycle"
+    );
+
+    let sync = handle
+        .send_request(NotebookRequest::SyncEnvironment { guard: None })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sync, NotebookResponse::GuardRejected { .. }),
+        "untrusted SyncEnvironment should be rejected before NoKernel, got {sync:?}"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_sync_environment_guard_rejects_stale_dependency_fingerprint() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        Some(notebook_protocol::connection::PackageManager::Uv),
+        vec!["pandas".to_string()],
+    )
+    .await
+    .unwrap();
+    let handle = result.handle;
+
+    assert!(
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state"
+    );
+
+    let observed_heads: Vec<String> = handle
+        .with_doc(|doc| {
+            doc.get_heads()
+                .iter()
+                .map(|head| head.to_string())
+                .collect()
+        })
+        .unwrap();
+    let response = handle
+        .send_request(NotebookRequest::SyncEnvironment {
+            guard: Some(DependencyGuard {
+                observed_heads,
+                dependency_fingerprint: "{}".to_string(),
+            }),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(response, NotebookResponse::GuardRejected { .. }),
+        "stale dependency guard should reject before sync-env logic, got {response:?}"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_sync_environment_no_deps_reaches_existing_no_kernel_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .unwrap();
+    let handle = result.handle;
+
+    assert!(
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state"
+    );
+
+    let response = handle
+        .send_request(NotebookRequest::SyncEnvironment { guard: None })
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            response,
+            NotebookResponse::SyncEnvironmentFailed {
+                ref error,
+                needs_restart: false,
+            } if error == "No kernel running"
+        ),
+        "trusted/no-deps SyncEnvironment should reach existing NoKernel path, got {response:?}"
+    );
 
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -113,6 +113,7 @@ export { NotebookClient, type NotebookClientOptions, SaveNotebookError } from ".
 export type {
   CommRequestMessage,
   CompletionItem,
+  DependencyGuard,
   GuardedDependencyProvenance,
   GuardedNotebookProvenance,
   HistoryEntry,

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -161,29 +161,25 @@ export class NotebookClient {
   }
 
   /** Hot-sync environment — install new packages without restart (UV only). */
-  async syncEnvironment(): Promise<NotebookResponse> {
+  async syncEnvironment(provenance?: GuardedDependencyProvenance): Promise<NotebookResponse> {
     try {
-      const response = await this.sendRequest({ type: "sync_environment" });
+      const response = await this.sendRequest({
+        type: "sync_environment",
+        ...(provenance
+          ? {
+              guard: {
+                observed_heads: provenance.observed_heads,
+                dependency_fingerprint: provenance.dependency_fingerprint,
+              },
+            }
+          : {}),
+      });
       if ((response as { result: string }).result === "error") {
         this.log.error("[notebook-client] Sync env failed:", (response as { error: string }).error);
       }
       return response;
     } catch (e) {
       this.log.error("[notebook-client] Sync environment failed:", e);
-      throw e;
-    }
-  }
-
-  /** Hot-sync environment only if dependencies still match the observed trust-dialog state. */
-  async syncEnvironmentGuarded(provenance: GuardedDependencyProvenance): Promise<NotebookResponse> {
-    try {
-      return await this.sendRequest({
-        type: "sync_environment_guarded",
-        observed_heads: provenance.observed_heads,
-        dependency_fingerprint: provenance.dependency_fingerprint,
-      });
-    } catch (e) {
-      this.log.error("[notebook-client] Guarded sync environment failed:", e);
       throw e;
     }
   }

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -17,6 +17,11 @@ export interface GuardedDependencyProvenance {
   dependency_fingerprint: string;
 }
 
+export interface DependencyGuard {
+  observed_heads: string[];
+  dependency_fingerprint: string;
+}
+
 export type NotebookRequest =
   | {
       type: "launch_kernel";
@@ -29,8 +34,7 @@ export type NotebookRequest =
   | { type: "clear_outputs"; cell_id: string }
   | { type: "interrupt_execution" }
   | { type: "shutdown_kernel" }
-  | { type: "sync_environment" }
-  | { type: "sync_environment_guarded"; observed_heads: string[]; dependency_fingerprint: string }
+  | { type: "sync_environment"; guard?: DependencyGuard }
   | { type: "approve_trust"; dependency_fingerprint?: string }
   | { type: "run_all_cells" }
   | { type: "run_all_cells_guarded"; observed_heads: string[] }
@@ -108,7 +112,6 @@ export type NotebookResponse =
     }
   | { result: "ok" }
   | { result: "error"; error: string }
-  | { result: "sync_environment_started"; packages: string[] }
   | { result: "sync_environment_complete"; synced_packages: string[] }
   | {
       result: "sync_environment_failed";

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -1,0 +1,42 @@
+import { NotebookClient, type NotebookTransport } from "runtimed";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+function stubClient() {
+  const sendRequest = vi.fn().mockResolvedValue({ result: "sync_environment_complete" });
+  const transport = {
+    sendFrame: async () => {},
+    onFrame: () => () => {},
+    sendRequest,
+    connected: true,
+    disconnect: () => {},
+  } satisfies NotebookTransport;
+
+  return { client: new NotebookClient({ transport }), sendRequest };
+}
+
+describe("NotebookClient", () => {
+  it("emits unguarded sync_environment requests", async () => {
+    const { client, sendRequest } = stubClient();
+
+    await client.syncEnvironment();
+
+    expect(sendRequest).toHaveBeenCalledWith({ type: "sync_environment" });
+  });
+
+  it("emits guarded sync_environment requests with dependency provenance", async () => {
+    const { client, sendRequest } = stubClient();
+
+    await client.syncEnvironment({
+      observed_heads: ["head-a", "head-b"],
+      dependency_fingerprint: '{"uv":{"dependencies":["numpy"]}}',
+    });
+
+    expect(sendRequest).toHaveBeenCalledWith({
+      type: "sync_environment",
+      guard: {
+        observed_heads: ["head-a", "head-b"],
+        dependency_fingerprint: '{"uv":{"dependencies":["numpy"]}}',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Moves launch and environment-sync trust enforcement fully into daemon request handling.

- bumps the notebook wire protocol to v4 and removes stale sync-env request/response variants
- replaces split guarded/unguarded sync-env requests with `SyncEnvironment { guard: Option<DependencyGuard> }`
- rejects untrusted `LaunchKernel` and `SyncEnvironment` before lifecycle, trust-state, env resolution, or runtime-agent work
- updates frontend, TS client, MCP, Python, and Node callers to confirm CRDT sync before daemon-read operations and surface `GuardRejected`
- preserves the legacy no-preamble pool health probe used during installed-client daemon upgrade checks while requiring v4 for notebook/control channels

## Validation

- `cargo test -p notebook-protocol`
- `cargo test -p runtimed`
- `cargo check -p runt-mcp -p runtimed-py -p runtimed-node`
- `pnpm exec vp test run packages/runtimed/tests/notebook-client.test.ts`
- `pnpm exec vp check`
- `git diff --check`
