### PR TITLE
fix(ci): build WASM once on Linux, share across all jobs

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -9,6 +9,10 @@ description: >-
   before invoking; this action only adds Node, pnpm, wasm-pack, and runs the
   build.
 
+  Pass skip-wasm: true when pre-built WASM artifacts have already been
+  downloaded from an earlier job (the build-wasm pattern). Node/pnpm setup
+  still runs so downstream steps like `pnpm build` work.
+
 inputs:
   wasm-pack-version:
     description: wasm-pack version to install (must support --profile)
@@ -18,6 +22,12 @@ inputs:
     description: Node.js version
     required: false
     default: "22"
+  skip-wasm:
+    description: >-
+      Skip WASM + renderer-plugin builds. Use when pre-built artifacts
+      have been downloaded from a build-wasm job.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -38,10 +48,35 @@ runs:
       run: pnpm install
 
     - name: Install wasm-pack
+      if: inputs.skip-wasm != 'true'
       uses: taiki-e/install-action@v2
       with:
         tool: wasm-pack@${{ inputs.wasm-pack-version }}
 
+    # Apple's system clang can't target wasm32-unknown-unknown.
+    # Prepend Homebrew LLVM to PATH so cc-rs finds a wasm-capable clang.
+    - name: Ensure wasm-capable clang (macOS)
+      if: inputs.skip-wasm != 'true' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        LLVM_BIN="$(brew --prefix llvm)/bin"
+        if [ ! -d "$LLVM_BIN" ]; then
+          brew install llvm
+          LLVM_BIN="$(brew --prefix llvm)/bin"
+        fi
+        echo "$LLVM_BIN" >> "$GITHUB_PATH"
+
+    # Windows runners may not have clang on PATH.
+    - name: Ensure wasm-capable clang (Windows)
+      if: inputs.skip-wasm != 'true' && runner.os == 'Windows'
+      shell: bash
+      run: |
+        if ! command -v clang >/dev/null 2>&1; then
+          choco install llvm --no-progress -y
+        fi
+        echo "C:\\Program Files\\LLVM\\bin" >> "$GITHUB_PATH"
+
     - name: Build wasm + renderer plugins
+      if: inputs.skip-wasm != 'true'
       shell: bash
       run: cargo xtask wasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,18 @@ jobs:
             apps/notebook/dist/
           retention-days: 1
 
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-artifacts
+          retention-days: 1
+          path: |
+            apps/notebook/src/wasm/runtimed-wasm/
+            crates/sift-wasm/pkg/
+            packages/sift/public/wasm/
+            crates/runt-mcp/assets/plugins/
+            apps/notebook/src/renderer-plugins/
+
   js-tests:
     name: JS Tests & Benchmarks
     needs: [changes]
@@ -227,6 +239,11 @@ jobs:
           name: ui-build-dist
           path: apps/notebook/dist
 
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -242,8 +259,9 @@ jobs:
         with:
           shared-key: ubuntu-release
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
@@ -407,9 +425,16 @@ jobs:
         with:
           shared-key: ${{ matrix.platform.runner }}
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      - name: Download WASM artifacts
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+        with:
+          skip-wasm: true
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -74,10 +74,38 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "TIMESTAMP=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
 
+  build-wasm:
+    name: Build WASM artifacts
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "wasm-build"
+
+      - uses: ./.github/actions/build-runtime-artifacts
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-artifacts
+          retention-days: 1
+          path: |
+            apps/notebook/src/wasm/runtimed-wasm/
+            crates/sift-wasm/pkg/
+            packages/sift/public/wasm/
+            crates/runt-mcp/assets/plugins/
+            apps/notebook/src/renderer-plugins/
+
   build-linux:
     name: Build Linux Executables
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -97,9 +125,14 @@ jobs:
         with:
           shared-key: "linux-release"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build UI
         run: pnpm build
@@ -133,7 +166,7 @@ jobs:
   build-macos:
     name: Build macOS Executables
     runs-on: macos-latest
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -150,9 +183,14 @@ jobs:
         with:
           shared-key: "macos-release"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build UI
         run: pnpm build
@@ -192,7 +230,7 @@ jobs:
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
     runs-on: macos-latest
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -206,9 +244,14 @@ jobs:
         with:
           shared-key: "macos-notebook-arm64"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build frontend
         run: pnpm build
@@ -355,7 +398,7 @@ jobs:
   build-notebook-macos-x64:
     name: Build macOS x64 Notebook
     runs-on: macos-latest
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -372,9 +415,14 @@ jobs:
         with:
           shared-key: "macos-notebook-x64"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build frontend
         run: pnpm build
@@ -521,7 +569,7 @@ jobs:
   build-notebook-windows-x64:
     name: Build Windows x64 Notebook
     runs-on: blacksmith-4vcpu-windows-2025
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -535,9 +583,14 @@ jobs:
         with:
           shared-key: "windows-notebook-x64"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build frontend
         run: pnpm build
@@ -651,7 +704,7 @@ jobs:
   build-notebook-linux-x64:
     name: Build Linux x64 Notebook
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -671,9 +724,14 @@ jobs:
         with:
           shared-key: "linux-notebook-x64"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them).
-      # Also handles node + pnpm + vp + pnpm install setup.
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build frontend
         run: pnpm build
@@ -840,7 +898,7 @@ jobs:
   build-python-wheels:
     name: Build Python Wheels (${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
-    needs: compute-version
+    needs: [compute-version, build-wasm]
     strategy:
       matrix:
         platform:
@@ -865,8 +923,14 @@ jobs:
         with:
           shared-key: "python-${{ matrix.platform.target }}"
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          skip-wasm: true
 
       - name: Build runtimed binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
The LFS-to-source migration (#2281, #2286) moved sift-wasm from prebuilt LFS blobs to `cargo xtask wasm` on every CI runner. sift-wasm depends on zstd-sys, which cross-compiles C to wasm32-unknown-unknown via cc-rs. That needs a wasm-capable clang. Apple's system clang doesn't have the wasm32 backend. Blacksmith Windows runners don't have clang at all. Linux passes because Blacksmith Ubuntu ships LLVM clang.

Since WASM output is architecture-independent (`--target web`), building it 10 times across 10 jobs was redundant anyway.

## Design

**release-common.yml**: New `build-wasm` job runs `cargo xtask wasm` on Linux, uploads the five gitignored output directories as a single artifact. All 8 downstream jobs download instead of rebuilding and pass `skip-wasm: true` to the composite action.

**build.yml**: The existing `build-ui` job (Linux) now uploads WASM alongside UI artifacts. `build-linux` and the macOS/Windows matrix download and skip.

**build-runtime-artifacts action**: New `skip-wasm` input. When false (default), the action also self-installs LLVM clang on macOS (Homebrew) and Windows (choco) as a safety net for one-off workflows (`smoke.yml`, `pr-binary-generation.yml`) that can't share artifacts across jobs.

## Behavioral coverage

| Surface | Before | After |
|---------|--------|-------|
| release-common macOS/Windows | Fail (no wasm-capable clang) | Download pre-built artifact |
| release-common Linux | Build locally (works) | Download pre-built artifact |
| build.yml macOS/Windows matrix | Fail (same) | Download from build-ui |
| build.yml Linux-only jobs (wasm-deno, js-tests, etc.) | Build locally | Unchanged (still build locally) |
| smoke.yml Windows | Fail (no clang) | Action self-installs LLVM |
| pr-binary-generation.yml macOS/Windows | Fail (no clang) | Action self-installs LLVM |

## Test plan

- [ ] Nightly release succeeds (all 10 jobs green)
- [ ] PR build succeeds on macOS/Windows matrix legs
- [ ] smoke.yml Windows leg passes
