### PR TITLE
fix(ci): pin llvm@18 for macOS WASM clang fallback

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -55,14 +55,15 @@ runs:
 
     # Apple's system clang can't target wasm32-unknown-unknown.
     # Prepend Homebrew LLVM to PATH so cc-rs finds a wasm-capable clang.
+    # Pin llvm@18 to match what macos-latest runners have pre-cached.
     - name: Ensure wasm-capable clang (macOS)
       if: inputs.skip-wasm != 'true' && runner.os == 'macOS'
       shell: bash
       run: |
-        LLVM_BIN="$(brew --prefix llvm)/bin"
+        LLVM_BIN="$(brew --prefix llvm@18)/bin"
         if [ ! -d "$LLVM_BIN" ]; then
-          brew install llvm
-          LLVM_BIN="$(brew --prefix llvm)/bin"
+          brew install llvm@18
+          LLVM_BIN="$(brew --prefix llvm@18)/bin"
         fi
         echo "$LLVM_BIN" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
Follow-up to #2298. Pin `llvm@18` instead of unversioned `llvm` in the macOS clang self-install step. macos-latest runners have llvm@18 pre-cached. The unversioned formula could install a different version on warm vs cold runners, wasting the Homebrew cache.