### PR TITLE
refactor(sync): consolidate dependency guard naming

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import {
   deriveEnvManager,
   deriveRuntimeKind,
-  type GuardedDependencyProvenance,
+  type DependencyGuard,
   type GuardedNotebookProvenance,
   NotebookClient,
   type SessionStatus,
@@ -85,7 +85,7 @@ type PendingTrustAction =
       provenance: GuardedNotebookProvenance;
       dependencyFingerprint: string;
     }
-  | { kind: "sync_deps"; provenance: GuardedDependencyProvenance };
+  | { kind: "sync_deps"; provenance: DependencyGuard };
 
 const EMPTY_DEPENDENCY_FINGERPRINT = "{}";
 
@@ -751,7 +751,7 @@ function AppContent() {
   );
 
   const performTrustedSyncDeps = useCallback(
-    async (guard?: GuardedDependencyProvenance): Promise<boolean> => {
+    async (guard?: DependencyGuard): Promise<boolean> => {
       // For UV or Conda inline deps with only additions, try hot-sync first
       const isUvInline = envSource === "uv:inline";
       const isCondaInline = envSource === "conda:inline";

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -11,10 +11,10 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type DaemonQueueState,
+  type DependencyGuard,
   deriveEnvSyncState,
   deriveKernelInfo,
   deriveQueueState,
-  type GuardedDependencyProvenance,
   type GuardedNotebookProvenance,
   type KernelStatus,
   type NotebookClient,
@@ -293,8 +293,7 @@ export function useDaemonKernel({
   );
 
   const syncEnvironment = useCallback(
-    (provenance?: GuardedDependencyProvenance) =>
-      client.syncEnvironment(provenance) as Promise<NotebookResponse>,
+    (guard?: DependencyGuard) => client.syncEnvironment(guard) as Promise<NotebookResponse>,
     [client],
   );
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1910,7 +1910,6 @@ impl Daemon {
         async fn send_error_response<W: AsyncWrite + Unpin>(
             writer: &mut W,
             error: String,
-            _client_protocol_version: u8,
         ) -> anyhow::Result<()> {
             let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
@@ -1937,7 +1936,6 @@ impl Daemon {
                      Untitled notebooks must reconnect via notebook_id, not OpenNotebook path.",
                     path
                 ),
-                client_protocol_version,
             )
             .await?;
             return Ok(());
@@ -1968,7 +1966,6 @@ impl Daemon {
                         send_error_response(
                             &mut writer,
                             format!("Directory '{}' is not writable: {}", path, e),
-                            client_protocol_version,
                         )
                         .await?;
                         return Ok(());
@@ -2014,7 +2011,6 @@ impl Daemon {
                 send_error_response(
                     &mut writer,
                     format!("Cannot access notebook '{}': {}", path, e),
-                    client_protocol_version,
                 )
                 .await?;
                 return Ok(());
@@ -2033,7 +2029,6 @@ impl Daemon {
                     send_error_response(
                         &mut writer,
                         format!("Cannot resolve notebook path '{}': {}", path, e),
-                        client_protocol_version,
                     )
                     .await?;
                     return Ok(());
@@ -2120,7 +2115,6 @@ impl Daemon {
                 send_error_response(
                     &mut writer,
                     format!("Failed to create notebook '{}': {}", path, e),
-                    client_protocol_version,
                 )
                 .await?;
                 return Ok(());

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -114,7 +114,6 @@ export type {
   CommRequestMessage,
   CompletionItem,
   DependencyGuard,
-  GuardedDependencyProvenance,
   GuardedNotebookProvenance,
   HistoryEntry,
   NotebookRequest,

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -13,7 +13,7 @@ import type { NotebookTransport } from "./transport";
 import type {
   CommRequestMessage,
   CompletionItem,
-  GuardedDependencyProvenance,
+  DependencyGuard,
   GuardedNotebookProvenance,
   HistoryEntry,
   NotebookRequest,
@@ -161,15 +161,15 @@ export class NotebookClient {
   }
 
   /** Hot-sync environment — install new packages without restart (UV only). */
-  async syncEnvironment(provenance?: GuardedDependencyProvenance): Promise<NotebookResponse> {
+  async syncEnvironment(guard?: DependencyGuard): Promise<NotebookResponse> {
     try {
       const response = await this.sendRequest({
         type: "sync_environment",
-        ...(provenance
+        ...(guard
           ? {
               guard: {
-                observed_heads: provenance.observed_heads,
-                dependency_fingerprint: provenance.dependency_fingerprint,
+                observed_heads: guard.observed_heads,
+                dependency_fingerprint: guard.dependency_fingerprint,
               },
             }
           : {}),

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -12,11 +12,6 @@ export interface GuardedNotebookProvenance {
   observed_heads: string[];
 }
 
-export interface GuardedDependencyProvenance {
-  observed_heads: string[];
-  dependency_fingerprint: string;
-}
-
 export interface DependencyGuard {
   observed_heads: string[];
   dependency_fingerprint: string;


### PR DESCRIPTION
## Summary

Small cleanup follow-up after daemon-enforced trust landed.

- removes the dead `_client_protocol_version` argument from the `OpenNotebook` error-response helper
- consolidates TypeScript dependency-sync guard naming on `DependencyGuard`
- removes the duplicate `GuardedDependencyProvenance` export and app usage
- keeps protocol v4 and the `sync_environment` wire shape unchanged

## Validation

- `cargo check -p runtimed`
- `pnpm exec vp test run packages/runtimed/tests/notebook-client.test.ts`
- `pnpm exec vp check`
- `git diff --check`
