### PR TITLE
chore(protocol): remove legacy no-preamble path, keep pool version-tolerant

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -26,7 +26,7 @@ Every connection starts with 5 bytes before the JSON handshake:
 | 0-3 | Magic: `0xC0 0xDE 0x01 0xAC` |
 | 4 | Protocol version (currently `4`) |
 
-The daemon validates both before reading the handshake. Non-runtimed connections get "invalid magic bytes". Protocol mismatches are rejected before JSON parsing.
+The daemon validates magic bytes before reading the handshake. Protocol version is checked after parsing the handshake channel: the Pool channel accepts any version (older stable apps ping during upgrade), all other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
 
 ## Connection Lifecycle
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1600,19 +1600,18 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         // Read preamble + handshake with a timeout so that idle/stalled
-        // connections don't hold resources.
+        // connections don't hold resources. All clients must send the 5-byte
+        // magic preamble (0xC0DE01AC + version byte) before the JSON handshake.
         //
-        // Backward compatibility: old clients (pre-2.0.0) send a length-prefixed
-        // JSON handshake without the magic bytes preamble. We detect this by
-        // peeking at the first byte: 0xC0 = new protocol (magic preamble),
-        // 0x00 = old protocol (4-byte big-endian length prefix for any
-        // reasonable handshake size). This allows the daemon upgrade to succeed
-        // even when the old app is still verifying daemon health.
-        let (handshake_bytes, client_protocol_version, has_preamble) =
+        // The preamble version is validated in two tiers:
+        //   - Pool channel: any version with valid magic is accepted. Older
+        //     stable apps ping the daemon during upgrade; rejecting them would
+        //     break the version-check → upgrade_daemon_via_sidecar flow.
+        //   - All other channels: MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION.
+        let (handshake_bytes, client_protocol_version) =
             tokio::time::timeout(std::time::Duration::from_secs(10), async {
-                // Peek at first byte to detect protocol version
-                let mut first_byte = [0u8; 1];
-                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte)
+                let mut preamble = [0u8; connection::PREAMBLE_LEN];
+                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut preamble)
                     .await
                     .map_err(|e| {
                         if e.kind() == std::io::ErrorKind::UnexpectedEof {
@@ -1622,77 +1621,38 @@ impl Daemon {
                         }
                     })?;
 
-                if first_byte[0] == connection::MAGIC[0] {
-                    // New protocol: read remaining 4 bytes of preamble (3 more magic + 1 version)
-                    let mut rest = [0u8; 4];
-                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut rest)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
-
-                    if rest[..3] != connection::MAGIC[1..] {
-                        anyhow::bail!(
-                            "invalid magic bytes: expected {:02X?}, got {:02X?}",
-                            connection::MAGIC,
-                            [&first_byte[..], &rest[..3]].concat()
-                        );
-                    }
-
-                    let version = rest[3];
-                    if version < connection::MIN_PROTOCOL_VERSION as u8
-                        || version > connection::PROTOCOL_VERSION as u8
-                    {
-                        anyhow::bail!(
-                            "unsupported protocol version: got {}, supported range [{}, {}]",
-                            version,
-                            connection::MIN_PROTOCOL_VERSION,
-                            connection::PROTOCOL_VERSION
-                        );
-                    }
-                    // Read the JSON handshake frame
-                    let bytes = connection::recv_control_frame(&mut stream)
-                        .await
-                        .context("handshake read error")?
-                        .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
-                    Ok((bytes, version, true))
-                } else {
-                    // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
-                    // big-endian length prefix. Keep this only for the pool health
-                    // check used by installed-client upgrade probes; notebook sync
-                    // channels are rejected below unless they use the v4 preamble.
-                    tracing::debug!("[runtimed] Legacy client detected (no magic preamble)");
-                    let mut len_rest = [0u8; 3];
-                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("legacy length read: {}", e))?;
-
-                    let len_bytes = [first_byte[0], len_rest[0], len_rest[1], len_rest[2]];
-                    let len = u32::from_be_bytes(len_bytes) as usize;
-
-                    if len > 64 * 1024 {
-                        anyhow::bail!("legacy handshake frame too large: {} bytes", len);
-                    }
-
-                    let mut buf = vec![0u8; len];
-                    tokio::io::AsyncReadExt::read_exact(&mut stream, &mut buf)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("legacy handshake read: {}", e))?;
-
-                    Ok((buf, connection::PROTOCOL_VERSION as u8, false))
+                if preamble[..4] != connection::MAGIC {
+                    anyhow::bail!(
+                        "invalid magic bytes: expected {:02X?}, got {:02X?}",
+                        connection::MAGIC,
+                        &preamble[..4]
+                    );
                 }
+
+                let version = preamble[4];
+                let bytes = connection::recv_control_frame(&mut stream)
+                    .await
+                    .context("handshake read error")?
+                    .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
+                Ok((bytes, version))
             })
             .await
             .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
-        if !has_preamble {
-            return match handshake {
-                Handshake::Pool => self.handle_pool_connection(stream).await,
-                _ => anyhow::bail!(
-                    "legacy notebook protocol without preamble is no longer supported; \
-                     expected protocol v{}",
+        // Pool connections accept any preamble version (upgrade compat).
+        // Everything else must be within the supported range.
+        if !matches!(handshake, Handshake::Pool) {
+            if client_protocol_version < connection::MIN_PROTOCOL_VERSION as u8
+                || client_protocol_version > connection::PROTOCOL_VERSION as u8
+            {
+                anyhow::bail!(
+                    "unsupported protocol version: got {}, supported range [{}, {}]",
+                    client_protocol_version,
+                    connection::MIN_PROTOCOL_VERSION,
                     connection::PROTOCOL_VERSION
-                ),
-            };
+                );
+            }
         }
 
         match handshake {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1642,17 +1642,16 @@ impl Daemon {
 
         // Pool connections accept any preamble version (upgrade compat).
         // Everything else must be within the supported range.
-        if !matches!(handshake, Handshake::Pool) {
-            if client_protocol_version < connection::MIN_PROTOCOL_VERSION as u8
-                || client_protocol_version > connection::PROTOCOL_VERSION as u8
-            {
-                anyhow::bail!(
-                    "unsupported protocol version: got {}, supported range [{}, {}]",
-                    client_protocol_version,
-                    connection::MIN_PROTOCOL_VERSION,
-                    connection::PROTOCOL_VERSION
-                );
-            }
+        if !matches!(handshake, Handshake::Pool)
+            && (client_protocol_version < connection::MIN_PROTOCOL_VERSION as u8
+                || client_protocol_version > connection::PROTOCOL_VERSION as u8)
+        {
+            anyhow::bail!(
+                "unsupported protocol version: got {}, supported range [{}, {}]",
+                client_protocol_version,
+                connection::MIN_PROTOCOL_VERSION,
+                connection::PROTOCOL_VERSION
+            );
         }
 
         match handshake {

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -180,39 +180,6 @@ async fn wait_for_cell_count(
     false
 }
 
-#[cfg(unix)]
-type LegacyPoolStream = tokio::net::UnixStream;
-
-#[cfg(windows)]
-type LegacyPoolStream = tokio::net::windows::named_pipe::NamedPipeClient;
-
-#[cfg(unix)]
-async fn connect_legacy_pool_stream(
-    socket_path: &std::path::Path,
-) -> Result<LegacyPoolStream, std::io::Error> {
-    tokio::net::UnixStream::connect(socket_path).await
-}
-
-#[cfg(windows)]
-async fn connect_legacy_pool_stream(
-    socket_path: &std::path::Path,
-) -> Result<LegacyPoolStream, std::io::Error> {
-    const ERROR_PIPE_BUSY: i32 = 231;
-    let pipe_name = socket_path.to_string_lossy().to_string();
-    let mut attempts = 0;
-
-    loop {
-        match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-            Ok(client) => return Ok(client),
-            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
-                attempts += 1;
-                sleep(Duration::from_millis(50)).await;
-            }
-            Err(err) => return Err(err),
-        }
-    }
-}
-
 #[tokio::test]
 async fn test_daemon_ping_pong() {
     let temp_dir = TempDir::new().unwrap();
@@ -1665,12 +1632,11 @@ async fn test_streaming_load_second_client_joins() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
-/// Test that a legacy client (pre-2.0.0, no magic bytes preamble) can still
-/// connect to the daemon. This is critical for the upgrade path: the old app
-/// installs the new daemon binary, then pings it to verify it's running.
-/// Without backward compat, the upgrade fails with "daemon did not become ready."
+/// An older stable app (e.g. protocol v2) pings the daemon during upgrade to
+/// check if it's running and query its version. The pool channel must accept
+/// any preamble version so the upgrade flow doesn't break.
 #[tokio::test]
-async fn test_legacy_client_no_preamble() {
+async fn test_pool_ping_accepts_older_preamble_version() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);
     let socket_path = config.socket_path.clone();
@@ -1680,22 +1646,26 @@ async fn test_legacy_client_no_preamble() {
         daemon.run().await.ok();
     });
 
-    // Wait for daemon with a modern client first
     let client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&client).await);
 
-    // Now connect as a legacy client: send a raw length-prefixed JSON
-    // handshake WITHOUT the magic bytes preamble.
-    let mut stream = connect_legacy_pool_stream(&socket_path)
+    // Connect a raw stream and send a preamble with an older protocol version
+    // (simulating a v2.2.0 stable app that ships protocol v2).
+    let mut stream = tokio::net::UnixStream::connect(&socket_path)
         .await
-        .expect("legacy client should connect");
+        .expect("should connect");
 
-    // Send Pool handshake as length-prefixed JSON (old protocol)
+    // Send preamble with protocol version 2 (old stable)
+    let mut preamble = [0u8; 5];
+    preamble[..4].copy_from_slice(&[0xC0, 0xDE, 0x01, 0xAC]);
+    preamble[4] = 2; // old protocol version
+    stream.write_all(&preamble).await.unwrap();
+
+    // Send Pool handshake as a length-prefixed JSON frame
     let handshake = br#"{"channel":"pool"}"#;
     let len = (handshake.len() as u32).to_be_bytes();
     stream.write_all(&len).await.unwrap();
     stream.write_all(handshake).await.unwrap();
-    stream.flush().await.unwrap();
 
     // Send a Ping request
     let ping = br#"{"type":"ping"}"#;
@@ -1704,7 +1674,7 @@ async fn test_legacy_client_no_preamble() {
     stream.write_all(ping).await.unwrap();
     stream.flush().await.unwrap();
 
-    // Read the response — should be a Pong
+    // Should get a Pong back despite the version mismatch
     let mut resp_len = [0u8; 4];
     stream.read_exact(&mut resp_len).await.unwrap();
     let resp_size = u32::from_be_bytes(resp_len) as usize;
@@ -1714,14 +1684,9 @@ async fn test_legacy_client_no_preamble() {
     let resp: serde_json::Value = serde_json::from_slice(&resp_buf).unwrap();
     assert_eq!(
         resp["type"], "pong",
-        "legacy client should get a Pong response"
+        "pool ping from older client should get a Pong"
     );
 
-    // Also verify a modern client still works alongside
-    let result = client.ping().await;
-    assert!(result.is_ok(), "modern client should still work");
-
-    // Shutdown
     client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -180,6 +180,35 @@ async fn wait_for_cell_count(
     false
 }
 
+#[cfg(unix)]
+type RawStream = tokio::net::UnixStream;
+
+#[cfg(windows)]
+type RawStream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+#[cfg(unix)]
+async fn connect_raw_stream(socket_path: &std::path::Path) -> Result<RawStream, std::io::Error> {
+    tokio::net::UnixStream::connect(socket_path).await
+}
+
+#[cfg(windows)]
+async fn connect_raw_stream(socket_path: &std::path::Path) -> Result<RawStream, std::io::Error> {
+    const ERROR_PIPE_BUSY: i32 = 231;
+    let pipe_name = socket_path.to_string_lossy().to_string();
+    let mut attempts = 0;
+
+    loop {
+        match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
+            Ok(client) => return Ok(client),
+            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
+                attempts += 1;
+                sleep(Duration::from_millis(50)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_daemon_ping_pong() {
     let temp_dir = TempDir::new().unwrap();
@@ -1651,7 +1680,7 @@ async fn test_pool_ping_accepts_older_preamble_version() {
 
     // Connect a raw stream and send a preamble with an older protocol version
     // (simulating a v2.2.0 stable app that ships protocol v2).
-    let mut stream = tokio::net::UnixStream::connect(&socket_path)
+    let mut stream = connect_raw_stream(&socket_path)
         .await
         .expect("should connect");
 


### PR DESCRIPTION
The no-preamble code path accepted pre-2.0 clients that sent a raw length-prefixed JSON handshake without the magic bytes. Every stable release ships the preamble, so this path is dead. Removes the first-byte peek, legacy length-prefix read, and the `has_preamble` gate.

Pool connections still accept any preamble version. Older stable apps (e.g. v2.2.0 with protocol v2) ping the daemon during upgrade to check version alignment before calling `upgrade_daemon_via_sidecar`. Rejecting their preamble would break that probe. Non-pool channels enforce `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION` as before.

## Validation

- `cargo test -p runtimed --test integration` (34/34 pass)
- `cargo test -p notebook-protocol`
- `cargo xtask lint`
- New test `test_pool_ping_accepts_older_preamble_version` confirms a v2 preamble gets a Pong on the pool channel

Closes #2301
