### PR TITLE
test(protocol): cover old stable daemon upgrade probe

### DIFF
--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -26,7 +26,7 @@ Every connection starts with 5 bytes before the JSON handshake:
 | 0-3 | Magic: `0xC0 0xDE 0x01 0xAC` |
 | 4 | Protocol version (currently `4`) |
 
-The daemon validates magic bytes before reading the handshake. Protocol version is checked after parsing the handshake channel: the Pool channel accepts any version (older stable apps ping during upgrade), all other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
+There is no no-preamble fallback. The daemon validates magic bytes before reading the handshake. Protocol version is checked after parsing the handshake channel: the Pool channel accepts any version so older stable apps can ping during upgrade and read `protocol_version` / `daemon_version` from `Pong`; all other channels require `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
 
 ## Connection Lifecycle
 

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -14,6 +14,18 @@ When changing the wire handshake or typed frame semantics, also inspect:
 - `crates/notebook-protocol/src/protocol.rs`
 - `contributing/protocol.md`
 
+## Connection compatibility invariants
+
+- Every daemon connection sends the 5-byte magic preamble before the JSON
+  handshake. There is no no-preamble fallback.
+- The Pool channel is the only version-tolerant channel. It accepts older
+  preamble versions so stable apps from previous releases can ping the daemon
+  during upgrade and read `protocol_version` / `daemon_version` from `Pong`.
+- Notebook, runtime, settings, blob, and open/create channels reject versions
+  outside `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
+- When bumping `PROTOCOL_VERSION`, keep the old-stable Pool ping test aligned
+  with the launcher semantics instead of downloading an old daemon binary.
+
 ## Frame pump invariants
 
 Frame readers are only half the fix. A dedicated reader prevents cancel-unsafe

--- a/.codex/skills/nteract-testing/references/test-matrix.md
+++ b/.codex/skills/nteract-testing/references/test-matrix.md
@@ -79,3 +79,17 @@ MCP paths that issue parallel cell mutations, add or run tests with this shape:
   return responses out of order, interleave a broadcast, and assert each caller
   receives its own response while broadcasts still reach request progress
   subscribers.
+
+## Protocol upgrade compatibility
+
+When a change touches the connection preamble, handshake routing, pool daemon
+requests, or `PROTOCOL_VERSION`, keep a raw daemon integration test with this
+shape:
+
+- Send the magic preamble with a stable-era older protocol byte (for example,
+  `2`), then a Pool handshake, then `{"type":"ping"}`.
+- Assert the daemon returns `Pong` with the current `protocol_version` and a
+  non-empty `daemon_version`. This is the launcher upgrade probe and must keep
+  working across protocol bumps.
+- If changing non-Pool version checks, also assert an old-version notebook sync
+  handshake is rejected before any notebook/session state is created.

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -6,7 +6,7 @@ This document describes the wire protocol between notebook clients (frontend WAS
 
 Two independent version numbers handle compatibility, separate from the artifact version:
 
-- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `4`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes. Protocol v4 removes legacy environment-sync request/response variants and requires current clients.
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `4`) — governs wire compatibility. Every connection sends the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of the stream. Bump when the framing, handshake shape, or message serialization format changes. Protocol v4 removes legacy environment-sync request/response variants. The Pool channel remains version-tolerant for daemon upgrade probes; all notebook/runtime channels require current clients.
 - **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `4`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes. The current schema stores cells as a fractional-indexed `Map` and keeps outputs in `RuntimeStateDoc` keyed by `execution_id`, with per-output `output_id` UUIDs on manifests. Future bumps MUST ship a `migrate_vN_to_v(N+1)` function that preserves user data — v1–v3 were pre-release and the v4 load path discards older docs on load, which is only safe because no real user data lives at those versions.
 
 These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol or schema bump doesn't automatically force a major version bump — that depends on whether the change is user-facing.
@@ -32,7 +32,16 @@ Every connection starts with a 5-byte preamble before the JSON handshake frame:
 | 0–3 | Magic: `0xC0 0xDE 0x01 0xAC` |
 | 4 | Protocol version (currently `4`) |
 
-The daemon validates both before reading the handshake. Non-runtimed connections get a clear "invalid magic bytes" error. Protocol mismatches are rejected before any JSON parsing.
+There is no no-preamble fallback. The daemon validates magic bytes before
+reading the handshake, so non-runtimed connections get a clear "invalid magic
+bytes" error. It checks the protocol version after parsing the handshake
+channel:
+
+- `Pool` accepts any preamble version so older stable apps can ping the daemon
+  during upgrade and read `protocol_version` / `daemon_version` metadata from
+  the `Pong` response.
+- All other channels reject versions outside
+  `MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION`.
 
 After the preamble, the notebook sync path also returns `protocol_version` and `daemon_version` in its `ProtocolCapabilities` / `NotebookConnectionInfo` responses for informational purposes.
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1751,8 +1751,8 @@ impl Daemon {
                     self.clone(),
                     working_dir_path,
                     initial_metadata,
-                    false, // Send ProtocolCapabilities for legacy NotebookSync handshake
-                    None,  // No streaming load for legacy handshake
+                    false, // Send ProtocolCapabilities for direct NotebookSync handshake
+                    None,  // No streaming load for direct NotebookSync handshake
                     false, // Not a newly-created notebook at path
                     client_protocol_version,
                 )

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1661,11 +1661,11 @@ async fn test_streaming_load_second_client_joins() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
-/// An older stable app (e.g. protocol v2) pings the daemon during upgrade to
-/// check if it's running and query its version. The pool channel must accept
-/// any preamble version so the upgrade flow doesn't break.
+/// An older stable app sends a pool ping during upgrade to check whether a
+/// daemon is already running and whether it needs replacement. The pool channel
+/// must accept the old preamble version and still return version metadata.
 #[tokio::test]
-async fn test_pool_ping_accepts_older_preamble_version() {
+async fn test_pool_ping_from_old_stable_preamble_returns_version_metadata() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);
     let socket_path = config.socket_path.clone();
@@ -1703,7 +1703,8 @@ async fn test_pool_ping_accepts_older_preamble_version() {
     stream.write_all(ping).await.unwrap();
     stream.flush().await.unwrap();
 
-    // Should get a Pong back despite the version mismatch
+    // Should get a Pong back despite the version mismatch, including the
+    // metadata older launchers need to decide whether to upgrade the daemon.
     let mut resp_len = [0u8; 4];
     stream.read_exact(&mut resp_len).await.unwrap();
     let resp_size = u32::from_be_bytes(resp_len) as usize;
@@ -1714,6 +1715,17 @@ async fn test_pool_ping_accepts_older_preamble_version() {
     assert_eq!(
         resp["type"], "pong",
         "pool ping from older client should get a Pong"
+    );
+    assert_eq!(
+        resp["protocol_version"],
+        serde_json::json!(notebook_protocol::connection::PROTOCOL_VERSION),
+        "pool ping should report the daemon's current protocol version"
+    );
+    assert!(
+        resp["daemon_version"]
+            .as_str()
+            .is_some_and(|version| !version.is_empty()),
+        "pool ping should report a daemon version for upgrade checks"
     );
 
     client.shutdown().await.ok();


### PR DESCRIPTION
## Summary
- strengthen the raw pool compatibility test so a stable-era v2 preamble can still ping the daemon and receive version metadata
- document the final preamble/version policy: mandatory magic preamble, pool-only version tolerance, strict notebook/runtime channel versions
- update Codex/Claude protocol guidance so future protocol bumps keep the upgrade probe covered

## Test Plan
- cargo fmt
- cargo test -p runtimed --test integration test_pool_ping_from_old_stable_preamble_returns_version_metadata -- --nocapture
- cargo test -p notebook-protocol
- cargo check -p runtimed
- git diff --check