### PR TITLE
fix(installer): bootstrap nightly installs on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,24 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
+  nsis-bootstrap:
+    name: NSIS Bootstrap Syntax
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install NSIS
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y nsis
+
+      - name: Compile bootstrap hook fixture
+        run: |
+          cd crates/notebook/nsis
+          makensis -V4 validate-bootstrap.nsi
+
   windows-clippy:
     name: Windows (clippy)
     needs: [changes]

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -149,12 +149,16 @@ jobs:
         run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
 
       - name: Build for Linux x64
-        run: cargo build --release --target x86_64-unknown-linux-gnu -p runt
+        run: cargo build --release --target x86_64-unknown-linux-gnu -p runt -p runtimed -p nteract-mcp
 
       - name: Rename binaries
         run: |
           cp target/x86_64-unknown-linux-gnu/release/runt runt-linux-x64
+          cp target/x86_64-unknown-linux-gnu/release/runtimed runtimed-linux-x64
+          cp target/x86_64-unknown-linux-gnu/release/nteract-mcp nteract-mcp-linux-x64
           chmod +x runt-linux-x64
+          chmod +x runtimed-linux-x64
+          chmod +x nteract-mcp-linux-x64
 
       - name: Upload Linux executables
         uses: actions/upload-artifact@v4
@@ -162,6 +166,8 @@ jobs:
           name: runt-linux-executables
           path: |
             runt-linux-x64
+            runtimed-linux-x64
+            nteract-mcp-linux-x64
 
   build-macos:
     name: Build macOS Executables
@@ -1194,12 +1200,18 @@ jobs:
         run: |
           CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
           CLI_NAME="runt"
+          DAEMON_NAME="runtimed"
+          MCP_NAME="nteract-mcp"
           if [ "$CHANNEL" = "nightly" ]; then
             CLI_NAME="runt-nightly"
+            DAEMON_NAME="runtimed-nightly"
+            MCP_NAME="nteract-mcp-nightly"
           fi
           mkdir -p release-assets
           # CLI binaries
           cp executables/runt-linux-x64 "release-assets/${CLI_NAME}-linux-x64"
+          cp executables/runtimed-linux-x64 "release-assets/${DAEMON_NAME}-linux-x64"
+          cp executables/nteract-mcp-linux-x64 "release-assets/${MCP_NAME}-linux-x64"
           cp executables/runt-darwin-arm64 "release-assets/${CLI_NAME}-darwin-arm64"
           cp executables/runt-darwin-x64 "release-assets/${CLI_NAME}-darwin-x64"
           # Notebook installers
@@ -1335,8 +1347,12 @@ jobs:
           RELEASE_INTRO: ${{ inputs.release_intro }}
         run: |
           CLI_NAME="runt"
+          DAEMON_NAME="runtimed"
+          MCP_NAME="nteract-mcp"
           if [ "$VERSION_SUFFIX" = "nightly" ]; then
             CLI_NAME="runt-nightly"
+            DAEMON_NAME="runtimed-nightly"
+            MCP_NAME="nteract-mcp-nightly"
           fi
           {
             echo "$RELEASE_INTRO"
@@ -1384,6 +1400,8 @@ jobs:
             echo '| Platform | Architecture | Download |'
             echo '|----------|--------------|----------|'
             echo "| Linux | x64 | \`${CLI_NAME}-linux-x64\` |"
+            echo "| Linux | x64 | \`${DAEMON_NAME}-linux-x64\` |"
+            echo "| Linux | x64 | \`${MCP_NAME}-linux-x64\` |"
             echo "| macOS | ARM64 | \`${CLI_NAME}-darwin-arm64\` |"
             echo "| macOS | x64 (Intel) | \`${CLI_NAME}-darwin-x64\` |"
             echo ''
@@ -1412,6 +1430,7 @@ jobs:
           prerelease: ${{ inputs.github_release_prerelease }}
           files: |
             ./release-assets/runt*-linux-x64
+            ./release-assets/nteract-mcp*-linux-x64
             ./release-assets/runt*-darwin-arm64
             ./release-assets/runt*-darwin-x64
             ./release-assets/nteract-${{ inputs.version_suffix }}-linux-x64.AppImage

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -134,6 +134,43 @@ jobs:
           "INSTALL_DIR=$installDir" | Out-File -Append -FilePath $env:GITHUB_ENV
           "RUNT=$installDir\runt.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
           "RUNTIMED=$installDir\runtimed.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
+          "MCP=$installDir\nteract-mcp.exe" | Out-File -Append -FilePath $env:GITHUB_ENV
+
+          $bootstrapLog = Join-Path $env:LOCALAPPDATA "nteract\install-bootstrap.log"
+          if (Test-Path $bootstrapLog) {
+            Write-Host "=== installer bootstrap log ==="
+            Get-Content $bootstrapLog
+          } else {
+            Write-Warning "Installer bootstrap log not found at $bootstrapLog"
+          }
+
+          $cliName = if ($env:RUNT_BUILD_CHANNEL -eq "nightly") { "runt-nightly" } else { "runt" }
+          $cmd = Get-Command $cliName -ErrorAction SilentlyContinue
+          if (-not $cmd) {
+            $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+            foreach ($entry in $userPath -split ';') {
+              if ($entry -and (Test-Path (Join-Path $entry "$cliName.cmd"))) {
+                $env:PATH = "$entry;$env:PATH"
+                $entry | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+                break
+              }
+            }
+            $cmd = Get-Command $cliName -ErrorAction SilentlyContinue
+          }
+          if (-not $cmd) {
+            Write-Error "$cliName was not discoverable after silent install"
+            exit 1
+          }
+          Write-Host "$cliName resolved to $($cmd.Source)"
+          "RUNT_CMD=$($cmd.Source)" | Out-File -Append -FilePath $env:GITHUB_ENV
+
+          $nbName = if ($env:RUNT_BUILD_CHANNEL -eq "nightly") { "nb-nightly" } else { "nb" }
+          $nbPath = Join-Path (Split-Path -Parent $cmd.Source) "$nbName.cmd"
+          if (-not (Test-Path $nbPath)) {
+            Write-Error "$nbName shim was not installed next to $cliName ($nbPath)"
+            exit 1
+          }
+          Write-Host "$nbName resolved to $nbPath"
 
       - name: runt --version
         shell: pwsh
@@ -143,6 +180,44 @@ jobs:
             exit 1
           }
           & $env:RUNT --version
+          & $env:RUNT_CMD --version
+
+      - name: Verify installer bootstrap
+        shell: pwsh
+        run: |
+          Write-Host "=== daemon status after installer ==="
+          $statusJson = & $env:RUNT_CMD daemon status --json
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Installed CLI could not read daemon status"
+            exit 1
+          }
+          Write-Host $statusJson
+          $status = $statusJson | ConvertFrom-Json
+          if ($status.installed -ne $true -or $status.running -ne $true) {
+            Write-Error "Installer did not leave the daemon installed and running"
+            exit 1
+          }
+          if (-not (Test-Path $env:MCP)) {
+            Write-Error "nteract-mcp.exe not found at $env:MCP"
+            exit 1
+          }
+          Write-Host "=== nteract-mcp startup probe ==="
+          $mcpOut = "$env:RUNNER_TEMP\nteract-mcp.stdout.log"
+          $mcpErr = "$env:RUNNER_TEMP\nteract-mcp.stderr.log"
+          $mcp = Start-Process -FilePath $env:MCP -WindowStyle Hidden -PassThru `
+            -RedirectStandardOutput $mcpOut -RedirectStandardError $mcpErr
+          Start-Sleep -Seconds 3
+          if ($mcp.HasExited -and $mcp.ExitCode -ne 0) {
+            Write-Host "--- nteract-mcp stdout ---"
+            if (Test-Path $mcpOut) { Get-Content $mcpOut }
+            Write-Host "--- nteract-mcp stderr ---"
+            if (Test-Path $mcpErr) { Get-Content $mcpErr }
+            Write-Error "nteract-mcp exited during startup probe"
+            exit $mcp.ExitCode
+          }
+          if (-not $mcp.HasExited) {
+            Stop-Process -Id $mcp.Id -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Set up Python for MCP smoke
         uses: actions/setup-python@v5
@@ -169,6 +244,12 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
+          Write-Host "=== Stopping installer-started daemon before controlled smoke daemon ==="
+          & $env:RUNT_CMD daemon stop
+          if ($LASTEXITCODE -ne 0) {
+            Write-Warning "daemon stop returned $LASTEXITCODE; continuing with controlled smoke start"
+          }
+
           $logOut = "$env:RUNNER_TEMP\runtimed.stdout.log"
           $logErr = "$env:RUNNER_TEMP\runtimed.stderr.log"
           $daemon = Start-Process -FilePath $env:RUNTIMED `
@@ -277,6 +358,8 @@ jobs:
             ${{ runner.temp }}\diag-post\*.tar.gz
             ${{ runner.temp }}\runtimed.stdout.log
             ${{ runner.temp }}\runtimed.stderr.log
+            ${{ runner.temp }}\nteract-mcp.stdout.log
+            ${{ runner.temp }}\nteract-mcp.stderr.log
           if-no-files-found: warn
           retention-days: 14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,6 +4475,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
+ "windows-sys 0.52.0",
  "wry",
 ]
 

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -60,6 +60,11 @@ tauri-plugin-webdriver = { version = "0.2", optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"
 
+# Windows CLI shim install writes HKCU\Environment\Path and broadcasts
+# WM_SETTINGCHANGE so new shells see the installed commands.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging"] }
+
 # Unix process group support for kernel cleanup
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process"] }

--- a/crates/notebook/nsis/bootstrap.nsh
+++ b/crates/notebook/nsis/bootstrap.nsh
@@ -1,0 +1,163 @@
+!define NTERACT_SHIM_MARKER "nteract-managed-cli-shim v1"
+!define NTERACT_HWND_BROADCAST 0xffff
+!define NTERACT_WM_SETTINGCHANGE 0x001A
+
+!macro NTERACT_SET_CHANNEL_VALUES
+  StrCpy $R9 "stable"
+  StrCpy $R8 "runt"
+  StrCpy $R7 "nb"
+  ${If} "${PRODUCTNAME}" == "nteract Nightly"
+    StrCpy $R9 "nightly"
+    StrCpy $R8 "runt-nightly"
+    StrCpy $R7 "nb-nightly"
+  ${EndIf}
+!macroend
+
+!macro NTERACT_APPEND_BOOTSTRAP_LOG TEXT
+  CreateDirectory "$LOCALAPPDATA\${PRODUCTNAME}"
+  FileOpen $R0 "$LOCALAPPDATA\${PRODUCTNAME}\install-bootstrap.log" a
+  ${IfNot} ${Errors}
+    FileWrite $R0 "${TEXT}$\r$\n"
+    FileClose $R0
+  ${EndIf}
+  DetailPrint "${TEXT}"
+!macroend
+
+!macro NTERACT_SELECT_CLI_DIR
+  StrCpy $R6 ""
+  StrCpy $R5 "$LOCALAPPDATA\Microsoft\WindowsApps"
+  ${If} ${FileExists} "$R5\*.*"
+    ReadEnvStr $R4 "PATH"
+    ${StrLoc} $R3 "$R4" "$R5" ">"
+    ${If} $R3 != ""
+      ClearErrors
+      FileOpen $R2 "$R5\.nteract-write-test.tmp" w
+      ${IfNot} ${Errors}
+        FileClose $R2
+        Delete "$R5\.nteract-write-test.tmp"
+        StrCpy $R6 "$R5"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R6 == ""
+    StrCpy $R6 "$PROFILE\.local\bin"
+    CreateDirectory "$R6"
+    ReadRegStr $R4 HKCU "Environment" "Path"
+    ${StrLoc} $R3 "$R4" "$R6" ">"
+    ${If} $R3 == ""
+      ${If} $R4 == ""
+        WriteRegExpandStr HKCU "Environment" "Path" "$R6"
+      ${Else}
+        WriteRegExpandStr HKCU "Environment" "Path" "$R4;$R6"
+      ${EndIf}
+      SendMessage ${NTERACT_HWND_BROADCAST} ${NTERACT_WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro NTERACT_WRITE_SHIM SHIM_PATH COMMAND_LINE
+  StrCpy $R4 "1"
+  ${If} ${FileExists} "${SHIM_PATH}"
+    FileOpen $R3 "${SHIM_PATH}" r
+    ${If} ${Errors}
+      StrCpy $R4 "0"
+    ${Else}
+      FileRead $R3 $R2
+      FileRead $R3 $R2
+      FileClose $R3
+      ${If} $R2 != "rem ${NTERACT_SHIM_MARKER}$\r$\n"
+      ${AndIf} $R2 != "rem ${NTERACT_SHIM_MARKER}$\n"
+        StrCpy $R4 "0"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R4 == "1"
+    ClearErrors
+    FileOpen $R3 "${SHIM_PATH}" w
+    ${If} ${Errors}
+      !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "Failed to open shim for writing: ${SHIM_PATH}"
+    ${Else}
+      FileWrite $R3 "@echo off$\r$\n"
+      FileWrite $R3 "rem ${NTERACT_SHIM_MARKER}$\r$\n"
+      FileWrite $R3 "${COMMAND_LINE}$\r$\n"
+      FileClose $R3
+      !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "Wrote shim: ${SHIM_PATH}"
+    ${EndIf}
+  ${Else}
+    !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "Skipped unmanaged shim: ${SHIM_PATH}"
+  ${EndIf}
+!macroend
+
+!macro NTERACT_DELETE_OWNED_SHIM SHIM_PATH
+  ${If} ${FileExists} "${SHIM_PATH}"
+    FileOpen $R3 "${SHIM_PATH}" r
+    ${IfNot} ${Errors}
+      FileRead $R3 $R2
+      FileRead $R3 $R2
+      FileClose $R3
+      ${If} $R2 == "rem ${NTERACT_SHIM_MARKER}$\r$\n"
+      ${OrIf} $R2 == "rem ${NTERACT_SHIM_MARKER}$\n"
+        Delete "${SHIM_PATH}"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro NTERACT_SET_CHANNEL_VALUES
+  ${If} ${FileExists} "$INSTDIR\uninstall.exe"
+    ; The Tauri template also passes /UPDATE for updater-driven uninstalls.
+    ; This registry flag covers the earlier pre-install phase where a prior
+    ; install already exists but the uninstaller has not been invoked yet.
+    WriteRegStr HKCU "Software\nteract\$R9\InstallState" "Updating" "1"
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  !insertmacro NTERACT_SET_CHANNEL_VALUES
+  CreateDirectory "$LOCALAPPDATA\${PRODUCTNAME}"
+  Delete "$LOCALAPPDATA\${PRODUCTNAME}\install-bootstrap.log"
+  !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "nteract installer bootstrap started"
+
+  !insertmacro NTERACT_SELECT_CLI_DIR
+  !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "CLI shim directory: $R6"
+  !insertmacro NTERACT_WRITE_SHIM "$R6\$R8.cmd" "$\"$INSTDIR\runt.exe$\" %*"
+  !insertmacro NTERACT_WRITE_SHIM "$R6\$R7.cmd" "$\"$INSTDIR\runt.exe$\" notebook %*"
+
+  nsExec::ExecToStack '"$INSTDIR\runt.exe" daemon doctor --fix'
+  Pop $R5
+  Pop $R4
+  !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "$R4"
+
+  ${If} $R5 != 0
+    !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "Daemon bootstrap failed with exit code $R5"
+    ${If} ${Silent}
+    ${OrIf} $PassiveMode = 1
+      SetErrorLevel 1
+      Abort "nteract bootstrap failed; see $LOCALAPPDATA\${PRODUCTNAME}\install-bootstrap.log"
+    ${Else}
+      MessageBox MB_ICONEXCLAMATION "nteract installed, but daemon setup failed. Details: $LOCALAPPDATA\${PRODUCTNAME}\install-bootstrap.log"
+    ${EndIf}
+  ${Else}
+    !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "Daemon bootstrap complete"
+  ${EndIf}
+
+  DeleteRegValue HKCU "Software\nteract\$R9\InstallState" "Updating"
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro NTERACT_SET_CHANNEL_VALUES
+  ReadRegStr $R6 HKCU "Software\nteract\$R9\InstallState" "Updating"
+  ${If} $UpdateMode = 1
+  ${OrIf} $R6 == "1"
+    DetailPrint "Skipping nteract daemon and shim removal during update"
+  ${Else}
+    nsExec::ExecToLog '"$INSTDIR\runt.exe" daemon uninstall'
+    !insertmacro NTERACT_DELETE_OWNED_SHIM "$LOCALAPPDATA\Microsoft\WindowsApps\$R8.cmd"
+    !insertmacro NTERACT_DELETE_OWNED_SHIM "$LOCALAPPDATA\Microsoft\WindowsApps\$R7.cmd"
+    !insertmacro NTERACT_DELETE_OWNED_SHIM "$PROFILE\.local\bin\$R8.cmd"
+    !insertmacro NTERACT_DELETE_OWNED_SHIM "$PROFILE\.local\bin\$R7.cmd"
+  ${EndIf}
+!macroend

--- a/crates/notebook/nsis/validate-bootstrap.nsi
+++ b/crates/notebook/nsis/validate-bootstrap.nsi
@@ -1,0 +1,32 @@
+Unicode true
+
+!include LogicLib.nsh
+!include StrFunc.nsh
+${StrLoc}
+
+!define PRODUCTNAME "nteract Nightly"
+!define MAINBINARYNAME "notebook"
+
+!include "bootstrap.nsh"
+
+Name "nteract NSIS bootstrap validation"
+OutFile "nsis-bootstrap-validation.exe"
+RequestExecutionLevel user
+
+Var PassiveMode
+Var UpdateMode
+
+Section "ValidateInstallHooks"
+  SetOutPath "$TEMP\nteract-bootstrap-validation"
+  StrCpy $INSTDIR "$TEMP\nteract-bootstrap-validation"
+  StrCpy $PassiveMode 1
+  StrCpy $UpdateMode 0
+  !insertmacro NSIS_HOOK_PREINSTALL
+  !insertmacro NSIS_HOOK_POSTINSTALL
+SectionEnd
+
+Section "ValidateUninstallHooks"
+  StrCpy $INSTDIR "$TEMP\nteract-bootstrap-validation"
+  StrCpy $UpdateMode 0
+  !insertmacro NSIS_HOOK_PREUNINSTALL
+SectionEnd

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -1,10 +1,10 @@
-//! CLI installation module for symlinking the bundled runt binary to PATH
-//! and creating the channel-specific notebook shorthand wrapper script.
+//! CLI installation module for putting the bundled runt binary on PATH and
+//! creating the channel-specific notebook shorthand wrapper.
 //!
 //! On Unix systems, we install to `~/.local/bin` (no admin privileges required)
 //! and create a symlink so the CLI automatically stays in sync when the app
-//! is updated. On Windows, we copy the binary since symlinks require admin
-//! and have compatibility issues.
+//! is updated. On Windows, we write small owned `.cmd` shims because symlinks
+//! require admin/Developer Mode and copied binaries drift across app upgrades.
 
 use runt_workspace::{cli_command_name, cli_notebook_alias_name};
 use std::fs;
@@ -13,8 +13,18 @@ use std::io::Write;
 use std::os::unix::fs::symlink;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "windows")]
+use std::os::windows::ffi::OsStrExt;
+#[cfg(any(target_os = "windows", test))]
+use std::path::Path;
 use std::path::PathBuf;
 use tauri::Manager;
+
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_CMD_SHIM_MARKER: &str = "nteract-managed-cli-shim v1";
+
+#[cfg(target_os = "windows")]
+const WINDOWS_REGISTRY_INSTALL_STATE_BASE: &str = "Software\\nteract";
 
 /// Legacy install directory — checked for backward compatibility detection only.
 #[cfg(unix)]
@@ -33,8 +43,47 @@ fn install_dir() -> PathBuf {
 
 #[cfg(target_os = "windows")]
 fn install_dir() -> PathBuf {
-    // Windows uses a different mechanism (App Paths registry or user PATH)
-    PathBuf::new()
+    windows_install_dir_for_install().unwrap_or_else(|e| {
+        log::warn!(
+            "[cli_install] Failed to choose Windows CLI install dir ({}), using fallback",
+            e
+        );
+        windows_fallback_cli_dir()
+    })
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_cmd_name(command_name: &str) -> String {
+    format!("{command_name}.cmd")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn cmd_escape_path(path: &Path) -> String {
+    // Batch files expand percent-delimited environment variables even inside
+    // quotes, so double literal percent signs from user/profile paths.
+    path.to_string_lossy().replace('%', "%%")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_runt_cmd_shim_contents(runt_path: &Path) -> String {
+    format!(
+        "@echo off\r\nrem {WINDOWS_CMD_SHIM_MARKER}\r\n\"{}\" %*\r\n",
+        cmd_escape_path(runt_path)
+    )
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_nb_cmd_shim_contents(runt_path: &Path) -> String {
+    format!(
+        "@echo off\r\nrem {WINDOWS_CMD_SHIM_MARKER}\r\n\"{}\" notebook %*\r\n",
+        cmd_escape_path(runt_path)
+    )
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_owned_windows_cmd_shim(contents: &str) -> bool {
+    contents.starts_with(&format!("@echo off\r\nrem {WINDOWS_CMD_SHIM_MARKER}\r\n"))
+        || contents.starts_with(&format!("@echo off\nrem {WINDOWS_CMD_SHIM_MARKER}\n"))
 }
 
 /// Get the path to the bundled runt binary.
@@ -269,6 +318,402 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
     }
 }
 
+#[cfg(target_os = "windows")]
+fn windows_apps_cli_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(windows_fallback_cli_dir)
+        .join("Microsoft")
+        .join("WindowsApps")
+}
+
+#[cfg(target_os = "windows")]
+fn windows_fallback_cli_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".local")
+        .join("bin")
+}
+
+#[cfg(target_os = "windows")]
+fn windows_candidate_cli_dirs() -> [PathBuf; 2] {
+    [windows_apps_cli_dir(), windows_fallback_cli_dir()]
+}
+
+#[cfg(target_os = "windows")]
+fn windows_install_dir_for_install() -> Result<PathBuf, String> {
+    let windows_apps = windows_apps_cli_dir();
+    if windows_apps.is_dir()
+        && effective_path_contains_dir(&windows_apps)
+        && directory_is_writable(&windows_apps)
+    {
+        return Ok(windows_apps);
+    }
+
+    let fallback = windows_fallback_cli_dir();
+    fs::create_dir_all(&fallback)
+        .map_err(|e| format!("Failed to create {}: {}", fallback.display(), e))?;
+    ensure_windows_user_path(&fallback)?;
+    Ok(fallback)
+}
+
+#[cfg(target_os = "windows")]
+fn effective_path_contains_dir(dir: &Path) -> bool {
+    std::env::var_os("PATH")
+        .map(|path| path_list_contains_dir(&path.to_string_lossy(), dir))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "windows")]
+fn directory_is_writable(dir: &Path) -> bool {
+    let probe = dir.join(format!(".nteract-write-test-{}.tmp", std::process::id()));
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+    {
+        Ok(_) => {
+            let _ = fs::remove_file(&probe);
+            true
+        }
+        Err(e) => {
+            log::debug!(
+                "[cli_install] Windows CLI dir {} is not writable: {}",
+                dir.display(),
+                e
+            );
+            false
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn normalize_windows_path_for_compare(path: &str) -> String {
+    let trimmed = path.trim().trim_matches('"').trim_end_matches(['\\', '/']);
+    trimmed.replace('/', "\\").to_ascii_lowercase()
+}
+
+#[cfg(target_os = "windows")]
+fn path_list_contains_dir(path_list: &str, dir: &Path) -> bool {
+    let expected = normalize_windows_path_for_compare(&dir.to_string_lossy());
+    path_list
+        .split(';')
+        .map(normalize_windows_path_for_compare)
+        .any(|entry| entry == expected)
+}
+
+#[cfg(target_os = "windows")]
+fn command_path(dir: &Path, command_name: &str) -> PathBuf {
+    dir.join(windows_cmd_name(command_name))
+}
+
+#[cfg(target_os = "windows")]
+fn check_windows_cmd_shim(path: &Path, expected_contents: &str) -> SymlinkStatus {
+    if !path.exists() {
+        return SymlinkStatus::NotInstalled;
+    }
+
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            if !is_owned_windows_cmd_shim(&contents) {
+                log::debug!(
+                    "[cli_install] Windows shim {} is not managed by nteract, skipping",
+                    path.display()
+                );
+                return SymlinkStatus::NotInstalled;
+            }
+            if contents == expected_contents {
+                SymlinkStatus::Current
+            } else {
+                SymlinkStatus::Stale
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "[cli_install] Failed to read Windows shim {}: {}",
+                path.display(),
+                e
+            );
+            SymlinkStatus::NotInstalled
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn write_owned_windows_cmd_shim(path: &Path, contents: &str) -> Result<(), String> {
+    if path.exists() {
+        let existing = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read existing {}: {}", path.display(), e))?;
+        if !is_owned_windows_cmd_shim(&existing) {
+            return Err(format!(
+                "{} already exists and is not managed by nteract",
+                path.display()
+            ));
+        }
+    }
+
+    fs::write(path, contents)
+        .map_err(|e| format!("Failed to write Windows shim {}: {}", path.display(), e))
+}
+
+#[cfg(target_os = "windows")]
+fn try_install_windows_cmd_shims(
+    bundled_runt: &Path,
+    runt_dest: &Path,
+    nb_dest: &Path,
+) -> Result<(), String> {
+    if let Some(parent) = runt_dest.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {}", parent.display(), e))?;
+    }
+    write_owned_windows_cmd_shim(runt_dest, &windows_runt_cmd_shim_contents(bundled_runt))?;
+    write_owned_windows_cmd_shim(nb_dest, &windows_nb_cmd_shim_contents(bundled_runt))?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_cli_currency_for_dir(
+    app: &tauri::AppHandle,
+    dir: &Path,
+) -> Option<(SymlinkStatus, SymlinkStatus)> {
+    let bundled = get_bundled_runt_path(app)?;
+    let runt_status = check_windows_cmd_shim(
+        &command_path(dir, cli_command_name()),
+        &windows_runt_cmd_shim_contents(&bundled),
+    );
+    let nb_status = check_windows_cmd_shim(
+        &command_path(dir, cli_notebook_alias_name()),
+        &windows_nb_cmd_shim_contents(&bundled),
+    );
+    Some((runt_status, nb_status))
+}
+
+#[cfg(target_os = "windows")]
+fn to_wide_null(value: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn read_user_path_registry_value() -> Result<String, String> {
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_SUCCESS};
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY_CURRENT_USER, KEY_READ,
+    };
+
+    let subkey = to_wide_null("Environment");
+    let value_name = to_wide_null("Path");
+    let mut key = 0;
+    let status =
+        unsafe { RegOpenKeyExW(HKEY_CURRENT_USER, subkey.as_ptr(), 0, KEY_READ, &mut key) };
+    if status == ERROR_FILE_NOT_FOUND {
+        return Ok(String::new());
+    }
+    if status != ERROR_SUCCESS {
+        return Err(format!("RegOpenKeyExW(HKCU\\Environment) failed: {status}"));
+    }
+
+    let mut byte_len = 0u32;
+    let status = unsafe {
+        RegQueryValueExW(
+            key,
+            value_name.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut byte_len,
+        )
+    };
+    if status == ERROR_FILE_NOT_FOUND {
+        unsafe {
+            RegCloseKey(key);
+        }
+        return Ok(String::new());
+    }
+    if status != ERROR_SUCCESS {
+        unsafe {
+            RegCloseKey(key);
+        }
+        return Err(format!(
+            "RegQueryValueExW(HKCU\\Environment\\Path) failed: {status}"
+        ));
+    }
+
+    let mut buffer = vec![0u16; (byte_len as usize + 1) / 2];
+    let status = unsafe {
+        RegQueryValueExW(
+            key,
+            value_name.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            buffer.as_mut_ptr().cast::<u8>(),
+            &mut byte_len,
+        )
+    };
+    unsafe {
+        RegCloseKey(key);
+    }
+    if status != ERROR_SUCCESS {
+        return Err(format!(
+            "RegQueryValueExW(HKCU\\Environment\\Path) failed: {status}"
+        ));
+    }
+
+    while buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    Ok(String::from_utf16_lossy(&buffer))
+}
+
+#[cfg(target_os = "windows")]
+fn write_user_path_registry_value(value: &str) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY_CURRENT_USER, KEY_SET_VALUE,
+        REG_EXPAND_SZ,
+    };
+
+    let subkey = to_wide_null("Environment");
+    let value_name = to_wide_null("Path");
+    let mut key = 0;
+    let status = unsafe {
+        RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            subkey.as_ptr(),
+            0,
+            std::ptr::null_mut(),
+            0,
+            KEY_SET_VALUE,
+            std::ptr::null(),
+            &mut key,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != ERROR_SUCCESS {
+        return Err(format!(
+            "RegCreateKeyExW(HKCU\\Environment) failed: {status}"
+        ));
+    }
+
+    let data = to_wide_null(value);
+    let status = unsafe {
+        RegSetValueExW(
+            key,
+            value_name.as_ptr(),
+            0,
+            REG_EXPAND_SZ,
+            data.as_ptr().cast::<u8>(),
+            (data.len() * std::mem::size_of::<u16>()) as u32,
+        )
+    };
+    unsafe {
+        RegCloseKey(key);
+    }
+    if status != ERROR_SUCCESS {
+        return Err(format!(
+            "RegSetValueExW(HKCU\\Environment\\Path) failed: {status}"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn broadcast_environment_change() {
+    use windows_sys::Win32::Foundation::{LPARAM, WPARAM};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SendMessageTimeoutW, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+    };
+
+    let environment = to_wide_null("Environment");
+    let mut result = 0usize;
+    unsafe {
+        SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            0 as WPARAM,
+            environment.as_ptr() as LPARAM,
+            SMTO_ABORTIFHUNG,
+            5000,
+            &mut result,
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn ensure_windows_user_path(bin_dir: &Path) -> Result<(), String> {
+    let current = read_user_path_registry_value()?;
+    if path_list_contains_dir(&current, bin_dir) {
+        return Ok(());
+    }
+
+    let bin_dir = bin_dir.to_string_lossy();
+    let updated = if current.trim().is_empty() {
+        bin_dir.to_string()
+    } else {
+        format!("{};{}", current.trim_end_matches(';'), bin_dir)
+    };
+    write_user_path_registry_value(&updated)?;
+    broadcast_environment_change();
+    log::info!("[cli_install] Added {} to HKCU Environment Path", bin_dir);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_install_state_key() -> String {
+    format!(
+        "{}\\{}\\InstallState",
+        WINDOWS_REGISTRY_INSTALL_STATE_BASE,
+        runt_workspace::channel_display_name()
+    )
+}
+
+#[cfg(target_os = "windows")]
+pub fn clear_windows_update_flag() {
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_SUCCESS};
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegDeleteValueW, RegOpenKeyExW, HKEY_CURRENT_USER, KEY_SET_VALUE,
+    };
+
+    let key_path = to_wide_null(&windows_install_state_key());
+    let value_name = to_wide_null("Updating");
+    let mut key = 0;
+    let status = unsafe {
+        RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            key_path.as_ptr(),
+            0,
+            KEY_SET_VALUE,
+            &mut key,
+        )
+    };
+    if status == ERROR_FILE_NOT_FOUND {
+        return;
+    }
+    if status != ERROR_SUCCESS {
+        log::debug!(
+            "[cli_install] Failed to open Windows install state key for cleanup: {}",
+            status
+        );
+        return;
+    }
+
+    let status = unsafe { RegDeleteValueW(key, value_name.as_ptr()) };
+    unsafe {
+        RegCloseKey(key);
+    }
+    if status != ERROR_SUCCESS && status != ERROR_FILE_NOT_FOUND {
+        log::debug!(
+            "[cli_install] Failed to clear Windows update flag: {}",
+            status
+        );
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn clear_windows_update_flag() {}
+
 /// Returns true if the app appears to be running from a temporary or
 /// ephemeral path. We must not rewrite CLI symlinks in this case because
 /// the path will disappear, leaving the symlinks broken.
@@ -305,20 +750,88 @@ fn is_ephemeral_path(app: &tauri::AppHandle) -> bool {
     ephemeral
 }
 
-/// Silently update the CLI installation if the symlinks are stale.
+/// Silently update the CLI installation if the installed command entrypoints
+/// are stale.
 ///
-/// Called on app launch. If the user has previously installed the CLI (symlink
-/// exists), this checks whether it still points to the current app bundle and
-/// re-runs `install_cli()` if not. Does nothing if the CLI was never installed.
+/// Called on app launch. On Unix, if the user has previously installed the CLI
+/// (symlink exists), this checks whether it still points to the current app
+/// bundle and re-runs `install_cli()` if not. On Windows, the installer should
+/// have created owned `.cmd` shims already; app launch repairs stale/missing
+/// shims so older installs and failed installer hooks still recover for UI use.
 ///
 /// Skips the check in dev mode (source builds) and on macOS if the app is
 /// running from a translocated path (e.g., directly from a DMG).
 pub fn ensure_cli_current(app: &tauri::AppHandle) {
-    #[cfg(not(unix))]
+    #[cfg(target_os = "windows")]
     {
-        let _ = app;
-        // On Windows, CLI install copies the binary — no symlink to check.
-        // A future enhancement could compare binary hashes.
+        if runt_workspace::is_dev_mode() {
+            log::debug!("[cli_install] Dev mode — skipping Windows CLI currency check");
+            clear_windows_update_flag();
+            return;
+        }
+
+        let Some(bundled_runt) = get_bundled_runt_path(app) else {
+            log::debug!("[cli_install] Cannot determine bundled runt path for Windows CLI check");
+            clear_windows_update_flag();
+            return;
+        };
+
+        let mut saw_blocking_conflict = false;
+        for dir in windows_candidate_cli_dirs() {
+            let Some((runt_status, nb_status)) = windows_cli_currency_for_dir(app, &dir) else {
+                continue;
+            };
+
+            let runt_path = command_path(&dir, cli_command_name());
+            let nb_path = command_path(&dir, cli_notebook_alias_name());
+            let runt_exists = fs::symlink_metadata(&runt_path).is_ok();
+            let nb_exists = fs::symlink_metadata(&nb_path).is_ok();
+            let runt_owned = runt_status != SymlinkStatus::NotInstalled || !runt_exists;
+            let nb_owned = nb_status != SymlinkStatus::NotInstalled || !nb_exists;
+
+            if runt_status == SymlinkStatus::Current && nb_status == SymlinkStatus::Current {
+                log::debug!(
+                    "[cli_install] Windows CLI shims current in {}",
+                    dir.display()
+                );
+                clear_windows_update_flag();
+                return;
+            }
+
+            if !runt_owned || !nb_owned {
+                log::info!(
+                    "[cli_install] Windows CLI shim path in {} is occupied by an unrelated command; skipping auto-repair",
+                    dir.display()
+                );
+                saw_blocking_conflict = true;
+                continue;
+            }
+
+            if runt_exists || nb_exists {
+                log::info!(
+                    "[cli_install] Windows CLI shims need update in {} (runt={:?}, nb={:?})",
+                    dir.display(),
+                    runt_status,
+                    nb_status
+                );
+                if let Err(e) = try_install_windows_cmd_shims(&bundled_runt, &runt_path, &nb_path) {
+                    log::warn!("[cli_install] Failed to repair Windows CLI shims: {}", e);
+                }
+                clear_windows_update_flag();
+                return;
+            }
+        }
+
+        if saw_blocking_conflict {
+            clear_windows_update_flag();
+            return;
+        }
+
+        log::info!("[cli_install] Windows CLI shims are missing; installing them for this app");
+        if let Err(e) = install_cli(app) {
+            log::warn!("[cli_install] Failed to install Windows CLI shims: {}", e);
+        }
+        clear_windows_update_flag();
     }
 
     #[cfg(unix)]
@@ -409,8 +922,19 @@ pub fn is_cli_installed() -> bool {
 pub fn is_cli_installed_local() -> bool {
     let cli_name = cli_command_name();
     let nb_name = cli_notebook_alias_name();
-    let dir = install_dir();
-    dir.join(cli_name).exists() && dir.join(nb_name).exists()
+
+    #[cfg(target_os = "windows")]
+    {
+        return windows_candidate_cli_dirs().iter().any(|dir| {
+            command_path(dir, cli_name).exists() && command_path(dir, nb_name).exists()
+        });
+    }
+
+    #[cfg(unix)]
+    {
+        let dir = install_dir();
+        dir.join(cli_name).exists() && dir.join(nb_name).exists()
+    }
 }
 
 /// Check if the CLI has a legacy install in `/usr/local/bin`.
@@ -428,7 +952,7 @@ pub fn is_cli_installed_legacy() -> bool {
     }
 }
 
-/// Install the CLI to `~/.local/bin` (no admin privileges needed).
+/// Install the CLI to the user-local command directory (no admin privileges needed).
 /// Returns Ok(()) on success, Err with message on failure.
 pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     let bundled_runt = get_bundled_runt_path(app)
@@ -439,8 +963,17 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     // Ensure ~/.local/bin exists
     fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {}: {}", dir.display(), e))?;
 
-    let runt_dest = dir.join(cli_command_name());
-    let nb_dest = dir.join(cli_notebook_alias_name());
+    #[cfg(target_os = "windows")]
+    let (runt_dest, nb_dest) = (
+        command_path(&dir, cli_command_name()),
+        command_path(&dir, cli_notebook_alias_name()),
+    );
+
+    #[cfg(unix)]
+    let (runt_dest, nb_dest) = (
+        dir.join(cli_command_name()),
+        dir.join(cli_notebook_alias_name()),
+    );
 
     try_install_direct(&bundled_runt, &runt_dest, &nb_dest)?;
 
@@ -454,9 +987,12 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     #[cfg(unix)]
     warn_legacy_cli_shadow();
 
-    // Ensure the user's shell RC has ~/.local/bin on PATH
-    if let Err(e) = ensure_shell_path(&dir) {
-        log::warn!("[cli_install] Shell PATH integration skipped: {}", e);
+    #[cfg(unix)]
+    {
+        // Ensure the user's shell RC has ~/.local/bin on PATH.
+        if let Err(e) = ensure_shell_path(&dir) {
+            log::warn!("[cli_install] Shell PATH integration skipped: {}", e);
+        }
     }
 
     Ok(())
@@ -499,31 +1035,31 @@ fn try_install_direct(
     runt_dest: &std::path::Path,
     nb_dest: &std::path::Path,
 ) -> Result<(), String> {
-    // Remove existing file/symlink if present
-    if runt_dest.exists() || runt_dest.is_symlink() {
-        fs::remove_file(runt_dest)
-            .map_err(|e| format!("Failed to remove existing {}: {}", cli_command_name(), e))?;
-    }
-
-    // On Unix, create a symlink so the CLI stays in sync when the app updates.
-    // On Windows, copy the binary since symlinks require admin and have issues.
     #[cfg(unix)]
     {
+        // Remove existing file/symlink if present. Unix install paths are the
+        // existing user-local/manual flow; ownership checks happen before
+        // auto-repair on app launch.
+        if runt_dest.exists() || runt_dest.is_symlink() {
+            fs::remove_file(runt_dest)
+                .map_err(|e| format!("Failed to remove existing {}: {}", cli_command_name(), e))?;
+        }
+
+        // Create a symlink so the CLI stays in sync when the app updates.
         symlink(bundled_runt, runt_dest).map_err(|e| format!("Failed to create symlink: {}", e))?;
+
+        // Create nb wrapper script.
+        create_nb_wrapper(nb_dest, cli_command_name())?;
     }
 
-    #[cfg(windows)]
-    {
-        fs::copy(bundled_runt, runt_dest).map_err(|e| format!("Failed to copy runt: {}", e))?;
-    }
-
-    // Create nb wrapper script
-    create_nb_wrapper(nb_dest, cli_command_name())?;
+    #[cfg(target_os = "windows")]
+    try_install_windows_cmd_shims(bundled_runt, runt_dest, nb_dest)?;
 
     Ok(())
 }
 
 /// Create the nb wrapper script
+#[cfg(unix)]
 fn create_nb_wrapper(nb_dest: &std::path::Path, cli_command: &str) -> Result<(), String> {
     let script = format!(
         r#"#!/bin/bash
@@ -560,6 +1096,7 @@ exec {} notebook "$@"
 /// Appends a PATH export to `~/.zshrc`, `~/.bashrc`, or fish config if
 /// `~/.local/bin` isn't already referenced. Idempotent — checks for the
 /// marker comment or an existing `.local/bin` PATH entry before appending.
+#[cfg(unix)]
 fn ensure_shell_path(bin_dir: &std::path::Path) -> Result<(), String> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let home = dirs::home_dir().ok_or("could not determine home directory")?;
@@ -846,10 +1383,7 @@ fn escalate_shell_command(shell_cmd: &str) -> Result<(), String> {
     Ok(())
 }
 
-// All tests below exercise Unix-only shell-script symlink paths. On
-// Windows the module would be empty and `use super::*;` resolves to
-// nothing, tripping clippy's `unused-imports` on `-D warnings`.
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -938,5 +1472,51 @@ mod tests {
         // A regular file (not a symlink) should be NotInstalled, not Stale
         assert!(file_path.exists());
         assert!(!file_path.is_symlink());
+    }
+
+    #[test]
+    fn windows_cmd_shim_invokes_absolute_runt_path() {
+        let runt = PathBuf::from(r"C:\Users\Alice\AppData\Local\nteract Nightly\runt.exe");
+
+        assert_eq!(
+            windows_runt_cmd_shim_contents(&runt),
+            "@echo off\r\nrem nteract-managed-cli-shim v1\r\n\"C:\\Users\\Alice\\AppData\\Local\\nteract Nightly\\runt.exe\" %*\r\n"
+        );
+    }
+
+    #[test]
+    fn windows_cmd_names_are_batch_files() {
+        assert_eq!(windows_cmd_name("runt-nightly"), "runt-nightly.cmd");
+        assert_eq!(windows_cmd_name("nb-nightly"), "nb-nightly.cmd");
+    }
+
+    #[test]
+    fn windows_nb_cmd_shim_invokes_notebook_mode_directly() {
+        let runt = PathBuf::from(r"C:\Users\Alice\AppData\Local\nteract Nightly\runt.exe");
+
+        assert_eq!(
+            windows_nb_cmd_shim_contents(&runt),
+            "@echo off\r\nrem nteract-managed-cli-shim v1\r\n\"C:\\Users\\Alice\\AppData\\Local\\nteract Nightly\\runt.exe\" notebook %*\r\n"
+        );
+    }
+
+    #[test]
+    fn windows_cmd_shim_escapes_percent_signs_in_paths() {
+        let runt = PathBuf::from(r"C:\Users\100% Real\AppData\Local\nteract Nightly\runt.exe");
+
+        assert!(windows_runt_cmd_shim_contents(&runt).contains(r"100%% Real"));
+    }
+
+    #[test]
+    fn windows_cmd_shim_ownership_requires_marker() {
+        assert!(is_owned_windows_cmd_shim(
+            "@echo off\r\nrem nteract-managed-cli-shim v1\r\n\"runt.exe\" %*\r\n"
+        ));
+        assert!(!is_owned_windows_cmd_shim(
+            "@echo off\r\n\"some-other-runt.exe\" %*\r\n"
+        ));
+        assert!(!is_owned_windows_cmd_shim(
+            "@echo off\r\n\"some-other-runt.exe\" %*\r\nrem nteract-managed-cli-shim v1\r\n"
+        ));
     }
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1245,7 +1245,7 @@ async fn run_upgrade(
     }
 
     // Step 5: Re-install CLI if it was previously installed (ensures Windows
-    // copies and Unix symlinks point at the new app bundle).
+    // shims and Unix symlinks point at the new app bundle).
     // Local installs: symlinks updated, legacy installs migrated to ~/.local/bin.
     if cli_install::is_cli_installed_local() || cli_install::is_cli_installed_legacy() {
         match cli_install::install_cli(&app) {
@@ -3794,7 +3794,7 @@ pub fn run(
                         }
                     };
 
-                // Check if CLI symlinks are current and silently update if stale.
+                // Check if CLI entrypoints are current and silently update if stale.
                 // This handles app reinstalls, bundle path changes, and channel switches.
                 cli_install::ensure_cli_current(&app_for_daemon);
 

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -42,7 +42,8 @@
     "windows": {
       "nsis": {
         "installerIcon": "icons/icon.ico",
-        "installMode": "currentUser"
+        "installMode": "currentUser",
+        "installerHooks": "nsis/bootstrap.nsh"
       }
     },
     "linux": {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2314,11 +2314,28 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                     std::env::current_exe().expect("Failed to get current executable path");
                 let exe_dir = current_exe.parent().unwrap();
                 let daemon_binary = runt_workspace::daemon_binary_basename();
-                exe_dir.join(if cfg!(windows) {
+                let channel_suffixed = exe_dir.join(if cfg!(windows) {
                     format!("{daemon_binary}.exe")
                 } else {
                     daemon_binary.to_string()
-                })
+                });
+
+                #[cfg(windows)]
+                {
+                    // Windows app bundles carry unsuffixed sidecars. The normal
+                    // installer path is `daemon doctor --fix`, which copies that
+                    // sidecar into the channel-suffixed service location. This
+                    // fallback keeps manual `runt daemon install` usable when the
+                    // user runs it before doctor has repaired the install.
+                    if !channel_suffixed.exists() {
+                        let unsuffixed = exe_dir.join("runtimed.exe");
+                        if unsuffixed.exists() {
+                            return unsuffixed;
+                        }
+                    }
+                }
+
+                channel_suffixed
             });
 
             if !source.exists() {

--- a/scripts/install-nightly-release
+++ b/scripts/install-nightly-release
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Install a published nteract nightly runtime stack on headless Linux.
+#
+# This is the release-artifact counterpart to scripts/install-nightly. It does
+# not build from source; it downloads or consumes already-built Linux binaries,
+# installs them under ~/.local/share/runt-nightly/bin, links the commands into
+# ~/.local/bin, writes the user systemd unit, and starts the daemon.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/install-nightly-release --tag v2.3.4-nightly.YYYYMMDDHHMM
+  scripts/install-nightly-release --from-dir /path/to/artifacts
+
+Options:
+  --tag <tag>          Download artifacts from a GitHub release tag.
+  --from-dir <dir>     Install artifacts from a local directory.
+  --repo <owner/repo>  GitHub repository for --tag (default: nteract/desktop).
+  --channel <name>     stable or nightly (default: nightly).
+  -h, --help           Show this help.
+
+Expected artifact names for nightly:
+  runt-nightly-linux-x64
+  runtimed-nightly-linux-x64
+  nteract-mcp-nightly-linux-x64
+USAGE
+}
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "install-nightly-release is Linux-only." >&2
+  exit 1
+fi
+
+REPO="nteract/desktop"
+CHANNEL="nightly"
+TAG=""
+FROM_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --from-dir)
+      FROM_DIR="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "$TAG" && -n "$FROM_DIR" ]]; then
+  echo "Use either --tag or --from-dir, not both." >&2
+  exit 2
+fi
+if [[ -z "$TAG" && -z "$FROM_DIR" ]]; then
+  echo "Missing --tag or --from-dir." >&2
+  usage >&2
+  exit 2
+fi
+if [[ "$CHANNEL" != "nightly" && "$CHANNEL" != "stable" ]]; then
+  echo "--channel must be stable or nightly." >&2
+  exit 2
+fi
+
+if [[ "$CHANNEL" == "nightly" ]]; then
+  CLI_NAME="runt-nightly"
+  DAEMON_NAME="runtimed-nightly"
+  MCP_NAME="nteract-mcp-nightly"
+else
+  CLI_NAME="runt"
+  DAEMON_NAME="runtimed"
+  MCP_NAME="nteract-mcp"
+fi
+
+INSTALL_DIR="$HOME/.local/share/$CLI_NAME/bin"
+LINK_DIR="$HOME/.local/bin"
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_UNIT="$DAEMON_NAME.service"
+DAEMON_JSON="$HOME/.cache/$CLI_NAME/daemon.json"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fetch_asset() {
+  local asset="$1"
+  local dest="$2"
+  if [[ -n "$FROM_DIR" ]]; then
+    local src="$FROM_DIR/$asset"
+    if [[ ! -f "$src" ]]; then
+      echo "Missing artifact: $src" >&2
+      exit 1
+    fi
+    cp "$src" "$dest"
+  else
+    local url="https://github.com/$REPO/releases/download/$TAG/$asset"
+    echo "Downloading $url"
+    curl --fail --location --show-error --silent "$url" --output "$dest"
+  fi
+  chmod 0755 "$dest"
+}
+
+atomic_install() {
+  local src="$1"
+  local dest="$2"
+  local tmp="$dest.new"
+  cp "$src" "$tmp"
+  chmod 0755 "$tmp"
+  mv -f "$tmp" "$dest"
+  echo "Installed $dest"
+}
+
+asset_for() {
+  printf '%s-linux-x64' "$1"
+}
+
+mkdir -p "$INSTALL_DIR" "$LINK_DIR" "$SERVICE_DIR"
+
+fetch_asset "$(asset_for "$CLI_NAME")" "$TMP_DIR/$CLI_NAME"
+fetch_asset "$(asset_for "$DAEMON_NAME")" "$TMP_DIR/$DAEMON_NAME"
+fetch_asset "$(asset_for "$MCP_NAME")" "$TMP_DIR/$MCP_NAME"
+
+atomic_install "$TMP_DIR/$CLI_NAME" "$INSTALL_DIR/$CLI_NAME"
+atomic_install "$TMP_DIR/$DAEMON_NAME" "$INSTALL_DIR/$DAEMON_NAME"
+atomic_install "$TMP_DIR/$MCP_NAME" "$INSTALL_DIR/$MCP_NAME"
+
+ln -sfn "$INSTALL_DIR/$CLI_NAME" "$LINK_DIR/$CLI_NAME"
+ln -sfn "$INSTALL_DIR/$MCP_NAME" "$LINK_DIR/$MCP_NAME"
+echo "Linked $LINK_DIR/$CLI_NAME -> $INSTALL_DIR/$CLI_NAME"
+echo "Linked $LINK_DIR/$MCP_NAME -> $INSTALL_DIR/$MCP_NAME"
+
+if ! PATH="$LINK_DIR:$PATH" command -v "$CLI_NAME" >/dev/null 2>&1; then
+  echo "Installed $CLI_NAME but could not resolve it on PATH." >&2
+  exit 1
+fi
+if [[ ":$PATH:" != *":$LINK_DIR:"* ]]; then
+  echo "Note: $LINK_DIR is not on this shell's PATH; new MCP hosts should include it." >&2
+fi
+
+cat > "$SERVICE_DIR/$SERVICE_UNIT" <<UNIT
+[Unit]
+Description=$DAEMON_NAME - Jupyter Runtime Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$INSTALL_DIR/$DAEMON_NAME
+Restart=on-failure
+RestartSec=5
+Environment=HOME=$HOME
+Environment=PATH=$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target
+UNIT
+echo "Wrote $SERVICE_DIR/$SERVICE_UNIT"
+
+systemctl --user daemon-reload
+systemctl --user enable "$SERVICE_UNIT" >/dev/null 2>&1
+systemctl --user restart "$SERVICE_UNIT"
+
+for _ in $(seq 1 20); do
+  sleep 0.5
+  if [[ -f "$DAEMON_JSON" ]] && jq -e .version "$DAEMON_JSON" >/dev/null 2>&1; then
+    version="$(jq -r .version "$DAEMON_JSON")"
+    echo "$CHANNEL release install complete - daemon running: version $version"
+    exit 0
+  fi
+done
+
+echo "Binaries installed and systemctl returned success, but $DAEMON_JSON" >&2
+echo "did not appear within 10s. Check: systemctl --user status $SERVICE_UNIT" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add Windows CLI shim installation/repair for `runt(-nightly)` and `nb(-nightly)` without clobbering unmanaged files
- add NSIS installer hooks that write shims, run `runt daemon doctor --fix`, log bootstrap output, and clean up owned shims on uninstall
- publish raw Linux daemon/MCP release binaries and add `scripts/install-nightly-release` for headless lab installs
- extend Windows smoke coverage to assert silent install leaves CLI, daemon, and MCP startup usable

## Verification
- `cargo test -p notebook windows_cmd --lib`
- `cargo test -p notebook nb_script --lib`
- `cargo check -p runt`
- `bash -n scripts/install-nightly-release`
- parsed `crates/notebook/tauri.conf.json`, `.github/workflows/smoke.yml`, and `.github/workflows/release-common.yml`
- `git diff --check`

Attempted `cargo check -p notebook --target x86_64-pc-windows-msvc --lib` from macOS, but it failed before reaching notebook code because the host lacks the Windows C headers/toolchain needed by `zstd-sys` (`stdlib.h` / `string.h` under `--target=x86_64-pc-windows-msvc`).
