### PR TITLE
fix(installer): add Win32_Security to windows-sys features

### DIFF
--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -61,9 +61,12 @@ tauri-plugin-webdriver = { version = "0.2", optional = true }
 cocoa = "0.26"
 
 # Windows CLI shim install writes HKCU\Environment\Path and broadcasts
-# WM_SETTINGCHANGE so new shells see the installed commands.
+# WM_SETTINGCHANGE so new shells see the installed commands. The Reg* APIs we
+# call (RegCreateKeyExW, RegSetValueExW, ...) take a SECURITY_ATTRIBUTES
+# pointer, so the windows-sys symbols are gated on the `Win32_Security` feature
+# in addition to `Win32_System_Registry` itself.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging"] }
 
 # Unix process group support for kernel cleanup
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## Why

#2306 merged before the Windows release build was exercised. Last night's nightly run [25023406493](https://github.com/nteract/desktop/actions/runs/25023406493) hit:

```
error[E0432]: unresolved import `windows_sys::Win32::System::Registry::RegCreateKeyExW`
```

`windows-sys` 0.52 gates `RegCreateKeyExW` on `Win32_Foundation` AND `Win32_Security` (it takes a `SECURITY_ATTRIBUTES` pointer). The merged feature list had `Win32_Foundation` + `Win32_System_Registry` + `Win32_UI_WindowsAndMessaging` but missed `Win32_Security`.

Verified directly against the registry source:

```
$ grep -A0 "fn RegCreateKeyExW" .../windows-sys-0.52.0/src/Windows/Win32/System/Registry/mod.rs
... #[doc = "Required features: `\"Win32_Foundation\"`, `\"Win32_Security\"`"] fn RegCreateKeyExW(...)
```

All other Reg* APIs the new code uses (`RegOpenKeyExW`, `RegQueryValueExW`, `RegSetValueExW`, `RegCloseKey`, `RegDeleteValueW`) require only `Win32_Foundation`, so a single feature add is sufficient.

## What

One line change in `crates/notebook/Cargo.toml`: add `Win32_Security` to the windows-sys features list.

No runtime behavior change. The registry write path was already authored to call `RegCreateKeyExW` with a null `SECURITY_ATTRIBUTES`; this PR only unblocks compilation.

## Verification

- Local `cargo check -p notebook --lib` on Windows Server 2022 with the chocolatey rust-ms toolchain
- CI Windows build pending; local check passes