### PR TITLE
fix(installer): detach Windows daemon spawn so the NSIS installer can return

### DIFF
--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -42,7 +42,10 @@ smappservice-rs = "0.1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
+# Win32_System_Threading: CreateProcessW with bInheritHandles=FALSE (the
+# daemon spawn path - prevents pipe handles inherited from a captured-stdout
+# parent like NSIS's nsExec::ExecToStack from leaking into the daemon).
+windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -42,10 +42,10 @@ smappservice-rs = "0.1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-# Win32_System_Threading: CreateProcessW with bInheritHandles=FALSE (the
-# daemon spawn path - prevents pipe handles inherited from a captured-stdout
-# parent like NSIS's nsExec::ExecToStack from leaking into the daemon).
-windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Threading"] }
+# Win32_System_Threading: CreateProcessW for the daemon spawn path. windows-sys
+# 0.52 gates that symbol on Win32_Security as well (CreateProcessW takes
+# *const SECURITY_ATTRIBUTES for lpProcessAttributes / lpThreadAttributes).
+windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -767,28 +767,70 @@ Set WshShell = Nothing
 
     #[cfg(target_os = "windows")]
     fn start_windows(&self) -> ServiceResult<()> {
-        use std::os::windows::process::CommandExt;
-        use std::process::Stdio;
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            CreateProcessW, CREATE_NO_WINDOW, DETACHED_PROCESS, PROCESS_INFORMATION, STARTUPINFOW,
+        };
 
-        // The daemon runs forever. If we let it inherit the spawning process's
-        // stdio, any caller that captures our output via a pipe (NSIS
-        // `nsExec::ExecToStack` during installer post-install, parent shells
-        // running `runt daemon doctor --fix`, CI runners with stdout
-        // redirected) will hang waiting for EOF on a pipe the daemon is still
-        // holding open. Detach: redirect stdio to NUL and use
-        // DETACHED_PROCESS|CREATE_NO_WINDOW so the child never gets a console
-        // either. Daemon logs already go to a file (see runtimed::main),
-        // so killing stderr here doesn't lose anything.
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        // The daemon runs forever. The standard `Command::new(...).spawn()`
+        // path on Windows calls `CreateProcessW` with `bInheritHandles=TRUE`
+        // (Rust's default), which duplicates *every* inheritable handle in
+        // this process's table into the child - not just stdio. That bites
+        // when this process was launched by NSIS's `nsExec::ExecToStack` to
+        // run `runt daemon doctor --fix`: NSIS hands the child stdout/stderr
+        // pipes that are marked inheritable so they propagate through stdio.
+        // When `runt` then spawns the daemon with `bInheritHandles=TRUE`,
+        // those pipes get duplicated *again* into the daemon's handle table.
+        // `runt` exits, releasing its copies, but the daemon keeps the
+        // duplicates open forever, so `nsExec::ExecToStack` never sees EOF
+        // on the read pipe and the silent installer hangs at `Install
+        // silently` until the runner times out (see runs 25025820384 and
+        // 25025909072).
+        //
+        // Redirecting stdio to NUL via `Stdio::null()` does not fix this:
+        // the *original* pipe handles in this process are still inheritable
+        // and `bInheritHandles=TRUE` still duplicates them.
+        //
+        // Bypass `std::process::Command` and call `CreateProcessW` directly
+        // with `bInheritHandles=FALSE`. The daemon needs no inherited
+        // handles - logging goes to a file (see runtimed::main), and stdio
+        // is unused.
+        let mut cmd_line: Vec<u16> = std::iter::once(b'"' as u16)
+            .chain(self.config.binary_path.as_os_str().encode_wide())
+            .chain(std::iter::once(b'"' as u16))
+            .chain(std::iter::once(0))
+            .collect();
 
-        std::process::Command::new(&self.config.binary_path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
-            .spawn()
-            .map_err(|e| ServiceError::StartFailed(e.to_string()))?;
+        let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
+        si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+
+        let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+
+        let ok = unsafe {
+            CreateProcessW(
+                std::ptr::null(),
+                cmd_line.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0, // bInheritHandles = FALSE
+                DETACHED_PROCESS | CREATE_NO_WINDOW,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &si,
+                &mut pi,
+            )
+        };
+
+        if ok == 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(ServiceError::StartFailed(err.to_string()));
+        }
+
+        unsafe {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+        }
 
         info!("[service] Started daemon process");
         Ok(())

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -767,8 +767,26 @@ Set WshShell = Nothing
 
     #[cfg(target_os = "windows")]
     fn start_windows(&self) -> ServiceResult<()> {
-        // Start the daemon directly
+        use std::os::windows::process::CommandExt;
+        use std::process::Stdio;
+
+        // The daemon runs forever. If we let it inherit the spawning process's
+        // stdio, any caller that captures our output via a pipe (NSIS
+        // `nsExec::ExecToStack` during installer post-install, parent shells
+        // running `runt daemon doctor --fix`, CI runners with stdout
+        // redirected) will hang waiting for EOF on a pipe the daemon is still
+        // holding open. Detach: redirect stdio to NUL and use
+        // DETACHED_PROCESS|CREATE_NO_WINDOW so the child never gets a console
+        // either. Daemon logs already go to a file (see runtimed::main),
+        // so killing stderr here doesn't lose anything.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
         std::process::Command::new(&self.config.binary_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW)
             .spawn()
             .map_err(|e| ServiceError::StartFailed(e.to_string()))?;
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -796,24 +796,46 @@ Set WshShell = Nothing
         // with `bInheritHandles=FALSE`. The daemon needs no inherited
         // handles - logging goes to a file (see runtimed::main), and stdio
         // is unused.
+        // lpApplicationName: NUL-terminated UTF-16 path to the binary, no
+        // surrounding quotes (Windows does not parse application-name).
+        let app_name: Vec<u16> = self
+            .config
+            .binary_path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        // lpCommandLine: NUL-terminated UTF-16 with the path quoted as argv[0].
+        // Mutable because CreateProcessW may write into it.
         let mut cmd_line: Vec<u16> = std::iter::once(b'"' as u16)
             .chain(self.config.binary_path.as_os_str().encode_wide())
             .chain(std::iter::once(b'"' as u16))
             .chain(std::iter::once(0))
             .collect();
 
+        // SAFETY: STARTUPINFOW and PROCESS_INFORMATION are POD structs whose
+        // all-zero bit pattern is a valid initial state per the Win32 ABI.
+        // STARTUPINFOW.cb must equal size_of::<STARTUPINFOW>() before passing
+        // to CreateProcessW; we set it immediately after zeroing.
         let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
         si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
-
         let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
 
+        // SAFETY: app_name and cmd_line are NUL-terminated UTF-16 buffers
+        // owned by this stack frame and live through the call. &si and &mut pi
+        // point at correctly-initialized POD structs (see above). All pointer
+        // arguments documented as nullable (security attrs, environment,
+        // current directory) are passed as null. bInheritHandles=FALSE
+        // (passed as 0) is the load-bearing flag - see the comment block
+        // above for why redirecting stdio alone is not sufficient.
         let ok = unsafe {
             CreateProcessW(
-                std::ptr::null(),
+                app_name.as_ptr(),
                 cmd_line.as_mut_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
-                0, // bInheritHandles = FALSE
+                0,
                 DETACHED_PROCESS | CREATE_NO_WINDOW,
                 std::ptr::null_mut(),
                 std::ptr::null(),
@@ -827,6 +849,10 @@ Set WshShell = Nothing
             return Err(ServiceError::StartFailed(err.to_string()));
         }
 
+        // SAFETY: pi.hProcess and pi.hThread are valid handles populated by
+        // a successful CreateProcessW. We don't need to wait on or query the
+        // process from this side, so closing both handles immediately is
+        // correct - the kernel keeps the process alive until it exits.
         unsafe {
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);


### PR DESCRIPTION
## Why

The Windows leg of the post-merge `Smoke` workflow has been timing out at the 1h15m runner cap. Two affected runs:

- [25025820384](https://github.com/nteract/desktop/actions/runs/25025820384) — manual dispatch on PR #2307 branch
- [25025909072](https://github.com/nteract/desktop/actions/runs/25025909072) — push-to-main after #2307 merged

Both got as far as `Installing ...\nteract_2.3.5_x64-setup.exe` and then no further output. Linux leg passes in ~5 min.

## Diagnosis

`crates/runtimed-client/src/service.rs:start_windows()` spawned `runtimed.exe` with `std::process::Command::spawn()`, which on Windows calls `CreateProcessW` with `bInheritHandles=TRUE`. That duplicates **every** inheritable handle in the parent's table into the child - not just stdio.

The break chain:

1. NSIS post-install hook calls `nsExec::ExecToStack '"$INSTDIR\runt.exe" daemon doctor --fix'`. NSIS creates pipes with `bInheritHandle=TRUE` so it can hand them to runt as stdio.
2. `runt.exe` inherits the inheritable pipe handles from NSIS as its stdin/stdout/stderr.
3. `runt daemon doctor --fix` → `Service::install` → `Service::start` → `start_windows`.
4. `start_windows` calls `Command::spawn()`, which calls `CreateProcessW` with `bInheritHandles=TRUE`. Even with stdio overridden, the original inheritable pipe handles in `runt.exe`'s table are duplicated into `runtimed.exe`.
5. `runt.exe` exits, releasing its handle copies. `runtimed.exe` keeps the duplicates open for its lifetime.
6. `nsExec::ExecToStack` blocks forever waiting for EOF on the read pipe.

## Fix

Bypass `std::process::Command` and call `CreateProcessW` directly with `bInheritHandles=FALSE`. With that flag the daemon inherits no handles at all, breaking the deadlock chain regardless of what inheritable handles the parent happened to be holding. Combined with `DETACHED_PROCESS | CREATE_NO_WINDOW`, the daemon also gets no console.

The daemon needs no inherited handles - logging goes to a file (`runtimed::main` opens its own log writer), and the daemon doesn't read stdin or write stdout/stderr to anything load-bearing.

Adds `Win32_System_Threading` to the existing `windows-sys` feature list in `crates/runtimed-client/Cargo.toml`.

Why the simpler `Stdio::null()` approach in the first cut wasn't enough: `Stdio::null()` opens fresh NUL handles for the child's stdio, but it doesn't disable handle inheritance. With `bInheritHandles=TRUE`, the original inheritable pipe handles in the parent still propagate to the child - they just aren't wired to STD_*_HANDLE. They sit in the daemon's handle table keeping the pipe open. Setting `bInheritHandles=FALSE` is the only way to stop that.

## Verification

Smoke workflow dispatched against this branch: [run 25031455231](https://github.com/nteract/desktop/actions/runs/25031455231). The previous two attempts on this surface both timed out at `Install silently`; this run reaching `Verify installer bootstrap` is the proof point.
