### PR TITLE
fix(trust): show stale approval errors inline

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -251,6 +251,7 @@ function AppContent() {
     trustInfo,
     typosquatWarnings,
     loading: trustLoading,
+    approvalError,
     needsApproval,
     checkTrust,
     approveTrust,
@@ -1708,6 +1709,7 @@ function AppContent() {
           approveLabel={trustApproveLabel}
           approveOnlyLabel={trustApproveOnlyLabel}
           description={trustDialogDescription}
+          approvalError={approvalError}
         />
         <CrdtBridgeProvider
           getHandle={getHandle}

--- a/apps/notebook/src/components/TrustDialog.tsx
+++ b/apps/notebook/src/components/TrustDialog.tsx
@@ -25,6 +25,7 @@ interface TrustDialogProps {
   approveLabel?: string;
   approveOnlyLabel?: string;
   description?: string;
+  approvalError?: string | null;
 }
 
 /** Package list item with optional typosquat warning */
@@ -56,6 +57,7 @@ export function TrustDialog({
   approveLabel,
   approveOnlyLabel,
   description,
+  approvalError,
 }: TrustDialogProps) {
   const handleApprove = useCallback(async () => {
     const success = await onApprove();
@@ -112,6 +114,16 @@ export function TrustDialog({
         </DialogHeader>
 
         <div className="max-h-[300px] overflow-y-auto space-y-4">
+          {approvalError && (
+            <div
+              className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+              role="alert"
+            >
+              <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+              <p className="text-sm text-amber-800 dark:text-amber-200">{approvalError}</p>
+            </div>
+          )}
+
           {/* UV (PyPI) Dependencies */}
           {trustInfo && trustInfo.uv_dependencies.length > 0 && (
             <div>

--- a/apps/notebook/src/components/__tests__/trust-dialog.test.tsx
+++ b/apps/notebook/src/components/__tests__/trust-dialog.test.tsx
@@ -174,6 +174,20 @@ describe("TrustDialog", () => {
       );
       expect(screen.getByText(/dependencies have been modified/)).toBeInTheDocument();
     });
+
+    it("shows approval errors inline while keeping the dependency review visible", () => {
+      render(
+        <TrustDialog
+          {...defaultProps}
+          approvalError="Dependencies changed while the trust dialog was open. Review before approving."
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Dependencies changed while the trust dialog was open. Review before approving.",
+      );
+      expect(screen.getByText("requests")).toBeInTheDocument();
+    });
   });
 
   describe("button labels", () => {

--- a/apps/notebook/src/hooks/__tests__/useTrust.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useTrust.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { useTrust } from "../useTrust";
+
+const mocks = vi.hoisted(() => ({
+  approve: vi.fn(),
+  checkTyposquats: vi.fn().mockResolvedValue([]),
+  host: undefined as
+    | {
+        trust: { approve: ReturnType<typeof vi.fn> };
+        deps: { checkTyposquats: ReturnType<typeof vi.fn> };
+      }
+    | undefined,
+  uvDependencies: {
+    dependencies: ["requests"],
+  },
+  condaDependencies: {
+    dependencies: [],
+    channels: [],
+  },
+  pixiDeps: {
+    dependencies: [],
+    pypiDependencies: [],
+    channels: [],
+  },
+}));
+
+mocks.host = {
+  trust: {
+    approve: mocks.approve,
+  },
+  deps: {
+    checkTyposquats: mocks.checkTyposquats,
+  },
+};
+
+vi.mock("@nteract/notebook-host", () => ({
+  useNotebookHost: () => mocks.host,
+}));
+
+vi.mock("../../lib/runtime-state", () => ({
+  useRuntimeState: () => ({
+    trust: {
+      status: "untrusted",
+      needs_approval: true,
+    },
+  }),
+  useRuntimeStateLoaded: () => true,
+}));
+
+vi.mock("../useDependencies", () => ({
+  useDependencies: () => ({
+    dependencies: mocks.uvDependencies,
+  }),
+}));
+
+vi.mock("../useCondaDependencies", () => ({
+  useCondaDependencies: () => ({
+    dependencies: mocks.condaDependencies,
+  }),
+}));
+
+vi.mock("../../lib/notebook-metadata", () => ({
+  usePixiDeps: () => mocks.pixiDeps,
+}));
+
+describe("useTrust", () => {
+  it("surfaces approval failures and clears stale approval errors before retry", async () => {
+    mocks.approve
+      .mockRejectedValueOnce(
+        new Error("Dependencies changed while the trust dialog was open. Review before approving."),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useTrust());
+
+    await act(async () => {
+      await expect(result.current.approveTrust({ dependencyFingerprint: "deps-v1" })).resolves.toBe(
+        false,
+      );
+    });
+
+    expect(result.current.approvalError).toBe(
+      "Dependencies changed while the trust dialog was open. Review before approving.",
+    );
+
+    await act(async () => {
+      await expect(result.current.approveTrust({ dependencyFingerprint: "deps-v2" })).resolves.toBe(
+        true,
+      );
+    });
+    expect(result.current.approvalError).toBeNull();
+  });
+});

--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -34,6 +34,10 @@ export function useTrust() {
   const [typosquatWarnings, setTyposquatWarnings] = useState<TyposquatWarning[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Approval errors are shown inside TrustDialog. Keep them separate from
+  // generic trust-hook errors so typosquat-check failures do not appear as
+  // trust approval failures.
+  const [approvalError, setApprovalError] = useState<string | null>(null);
 
   // Compose TrustInfo from RuntimeStateDoc + dep hooks. Daemon is the sole
   // writer of `trust.status`; deps are synced via the notebook CRDT. No
@@ -107,6 +111,7 @@ export function useTrust() {
     async (options?: ApproveTrustOptions) => {
       setLoading(true);
       setError(null);
+      setApprovalError(null);
       try {
         await host.trust.approve({
           dependencyFingerprint: options?.dependencyFingerprint,
@@ -115,6 +120,7 @@ export function useTrust() {
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
         setError(message);
+        setApprovalError(message);
         logger.error("Failed to approve trust:", e);
         return false;
       } finally {
@@ -149,6 +155,7 @@ export function useTrust() {
     typosquatWarnings,
     loading,
     error,
+    approvalError,
     isTrusted,
     needsApproval,
     hasDependencies,


### PR DESCRIPTION
## Summary
- surface trust approval GuardRejected messages inline in the trust dialog
- keep the dialog open so users can review refreshed dependencies and retry approval
- add focused dialog and hook coverage for stale approval errors

## Test Plan
- pnpm exec vp test run apps/notebook/src/components/__tests__/trust-dialog.test.tsx apps/notebook/src/hooks/__tests__/useTrust.test.tsx
- pnpm exec vp test run packages/notebook-host/tests/tauri-host.test.ts
- pnpm exec vp check
- git diff --check