### PR TITLE
test(bindings): add coverage for public binding crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,6 +388,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --verbose
 
+      - name: Run binding crate tests
+        run: cargo test -p runtimed-node -p nteract-mcp --verbose
+
   build:
     name: ${{ matrix.platform.name }}
     needs: [changes, build-ui]
@@ -742,6 +745,19 @@ jobs:
           cd crates/runtimed-py && \
             VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
             uv run --directory ../../python/runtimed maturin develop
+
+      - name: Run runtimed-py Rust unit tests
+        run: |
+          PYTHON="${GITHUB_WORKSPACE}/.venv/bin/python"
+          PYTHON_LIB_DIR="$("${PYTHON}" - <<'PY'
+          import sysconfig
+          print(sysconfig.get_config_var("LIBDIR") or "")
+          PY
+          )"
+          export PYO3_PYTHON="${PYTHON}"
+          export LD_LIBRARY_PATH="${PYTHON_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+          export DYLD_LIBRARY_PATH="${PYTHON_LIB_DIR}:${DYLD_LIBRARY_PATH:-}"
+          cargo test -p runtimed-py --lib --no-default-features --verbose
 
       - name: Run integration tests
         timeout-minutes: 30

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -17,13 +17,22 @@ use rmcp::ServiceExt;
 use runt_mcp_proxy::{McpProxy, ProxyConfig};
 use tracing::{error, info, warn};
 
+fn selected_build_channel(channel: &str) -> runt_workspace::BuildChannel {
+    if channel.eq_ignore_ascii_case("nightly") {
+        runt_workspace::BuildChannel::Nightly
+    } else {
+        runt_workspace::BuildChannel::Stable
+    }
+}
+
+fn runt_binary_name_for_channel(channel: &str) -> &'static str {
+    runt_workspace::cli_command_name_for(selected_build_channel(channel))
+}
+
 /// Find the `runt` or `runt-nightly` binary on PATH or in platform-specific locations.
 fn find_runt_binary(channel: &str) -> Option<PathBuf> {
-    let binary_name = if channel == "nightly" {
-        runt_workspace::cli_command_name_for(runt_workspace::BuildChannel::Nightly)
-    } else {
-        runt_workspace::cli_command_name_for(runt_workspace::BuildChannel::Stable)
-    };
+    let build_channel = selected_build_channel(channel);
+    let binary_name = runt_workspace::cli_command_name_for(build_channel);
 
     // 1. Check PATH via `which`
     let which_cmd = if cfg!(target_os = "windows") {
@@ -123,6 +132,36 @@ fn find_runt_binary(channel: &str) -> Option<PathBuf> {
     None
 }
 
+fn child_env_for_channel(channel: &str) -> HashMap<String, String> {
+    HashMap::from([("NTERACT_CHANNEL".to_string(), channel.to_string())])
+}
+
+fn proxy_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|d| {
+        let dir = d.join(runt_workspace::cache_namespace()).join("proxy");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    })
+}
+
+fn proxy_config_for_channel(channel: String) -> ProxyConfig {
+    let child_env = child_env_for_channel(&channel);
+    let binary_name = runt_binary_name_for_channel(&channel);
+    let channel_for_resolve = channel.clone();
+    ProxyConfig {
+        resolve_child_command: Box::new(move || {
+            find_runt_binary(&channel_for_resolve).ok_or_else(|| {
+                format!("{binary_name} no longer found on PATH or in known install locations")
+            })
+        }),
+        child_args: vec!["mcp".to_string()],
+        child_env,
+        server_name: runt_workspace::desktop_product_name().to_string(),
+        cache_dir: proxy_cache_dir(),
+        monitor_poll_interval_ms: 500,
+    }
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     // Log to stderr (MCP uses stdout for transport)
@@ -141,7 +180,7 @@ async fn main() -> ExitCode {
     let channel = std::env::var("NTERACT_CHANNEL")
         .unwrap_or_else(|_| runt_workspace::channel_display_name().to_string());
     let app_name = runt_workspace::desktop_display_name();
-    let binary_name = runt_workspace::cli_command_name();
+    let binary_name = runt_binary_name_for_channel(&channel);
 
     info!(
         "nteract-mcp starting (channel={channel}, compiled={})",
@@ -163,10 +202,6 @@ async fn main() -> ExitCode {
     }
     info!("Validated {binary_name} is available");
 
-    // Build child environment
-    let mut child_env = HashMap::new();
-    child_env.insert("NTERACT_CHANNEL".to_string(), channel.clone());
-
     // Pass resolution as a closure so the proxy re-discovers the binary
     // on every child restart. This is the core upgrade mechanism: the user
     // upgrades the nteract app (new runt binary), and the proxy picks it up
@@ -176,23 +211,7 @@ async fn main() -> ExitCode {
     // (`runt mcp` stamps the daemon version into `ServerInfo.title`), so the
     // proxy no longer opens its own daemon socket — that used to drag the
     // full runtimed-client compile graph into every MCP process.
-    let channel_for_resolve = channel.clone();
-    let config = ProxyConfig {
-        resolve_child_command: Box::new(move || {
-            find_runt_binary(&channel_for_resolve).ok_or_else(|| {
-                format!("{binary_name} no longer found on PATH or in known install locations")
-            })
-        }),
-        child_args: vec!["mcp".to_string()],
-        child_env,
-        server_name: runt_workspace::desktop_product_name().to_string(),
-        cache_dir: dirs::cache_dir().map(|d| {
-            let dir = d.join(runt_workspace::cache_namespace()).join("proxy");
-            let _ = std::fs::create_dir_all(&dir);
-            dir
-        }),
-        monitor_poll_interval_ms: 500,
-    };
+    let config = proxy_config_for_channel(channel.clone());
 
     let proxy = McpProxy::new(config, None);
 
@@ -250,4 +269,50 @@ async fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_name_selects_the_expected_child_binary() {
+        assert_eq!(runt_binary_name_for_channel("stable"), "runt");
+        assert_eq!(runt_binary_name_for_channel("nightly"), "runt-nightly");
+        assert_eq!(runt_binary_name_for_channel("NIGHTLY"), "runt-nightly");
+        assert_eq!(runt_binary_name_for_channel("future"), "runt");
+    }
+
+    #[test]
+    fn child_env_is_limited_to_the_channel_contract() {
+        let env = child_env_for_channel("stable");
+        assert_eq!(env.len(), 1);
+        assert_eq!(env.get("NTERACT_CHANNEL"), Some(&"stable".to_string()));
+        assert!(!env.contains_key("RUNTIMED_DEV"));
+        assert!(!env.contains_key("RUNTIMED_WORKSPACE_PATH"));
+        assert!(!env.contains_key("RUNTIMED_SOCKET_PATH"));
+    }
+
+    #[test]
+    fn proxy_config_uses_the_resilient_runt_mcp_child_contract() {
+        let config = proxy_config_for_channel("nightly".to_string());
+
+        assert_eq!(config.child_args, vec!["mcp".to_string()]);
+        assert_eq!(
+            config.child_env.get("NTERACT_CHANNEL"),
+            Some(&"nightly".to_string())
+        );
+        assert_eq!(config.server_name, runt_workspace::desktop_product_name());
+        assert_eq!(config.monitor_poll_interval_ms, 500);
+    }
+
+    #[test]
+    fn proxy_cache_dir_is_under_the_channel_cache_namespace() {
+        let Some(dir) = proxy_cache_dir() else {
+            return;
+        };
+
+        let suffix = PathBuf::from(runt_workspace::cache_namespace()).join("proxy");
+        assert!(dir.ends_with(suffix));
+    }
 }

--- a/crates/runtimed-node/src/parquet.rs
+++ b/crates/runtimed-node/src/parquet.rs
@@ -44,8 +44,12 @@ pub fn summarize_parquet(base64_data: String) -> napi::Result<ParquetSummaryResu
         .decode(&base64_data)
         .map_err(|e| napi::Error::from_reason(format!("Invalid base64: {e}")))?;
 
-    let summary = parquet_summary::summarize_parquet(&bytes)
-        .map_err(|e| napi::Error::from_reason(format!("Parquet error: {e}")))?;
+    summarize_parquet_bytes(&bytes).map_err(napi::Error::from_reason)
+}
+
+fn summarize_parquet_bytes(bytes: &[u8]) -> Result<ParquetSummaryResult, String> {
+    let summary =
+        parquet_summary::summarize_parquet(bytes).map_err(|e| format!("Parquet error: {e}"))?;
 
     let columns = summary
         .columns
@@ -78,14 +82,22 @@ pub fn read_parquet_rows(
         .decode(&base64_data)
         .map_err(|e| napi::Error::from_reason(format!("Invalid base64: {e}")))?;
 
-    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes.clone()))
-        .map_err(|e| napi::Error::from_reason(format!("Parquet error: {e}")))?;
+    read_parquet_rows_bytes(bytes, offset, limit).map_err(napi::Error::from_reason)
+}
+
+fn read_parquet_rows_bytes(
+    bytes: Vec<u8>,
+    offset: i64,
+    limit: i64,
+) -> Result<ParquetRowPage, String> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+        .map_err(|e| format!("Parquet error: {e}"))?;
 
     let schema = builder.schema().clone();
     let columns: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
     let reader = builder
         .build()
-        .map_err(|e| napi::Error::from_reason(format!("Parquet reader error: {e}")))?;
+        .map_err(|e| format!("Parquet reader error: {e}"))?;
 
     let offset = offset.max(0) as usize;
     let limit = limit.max(0) as usize;
@@ -94,8 +106,7 @@ pub fn read_parquet_rows(
     let mut row_idx: usize = 0;
 
     for batch in reader {
-        let batch =
-            batch.map_err(|e| napi::Error::from_reason(format!("Batch read error: {e}")))?;
+        let batch = batch.map_err(|e| format!("Batch read error: {e}"))?;
         let batch_rows = batch.num_rows();
         total_rows += batch_rows;
 
@@ -198,6 +209,110 @@ fn array_value_to_string(array: &dyn Array, idx: usize) -> String {
             // Fallback: use Arrow's built-in display
             arrow::util::display::array_value_to_string(array, idx)
                 .unwrap_or_else(|_| "?".to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use arrow::array::{BooleanArray, Float64Array, Int32Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    fn sample_parquet_bytes() -> Vec<u8> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("label", DataType::Utf8, true),
+            Field::new("score", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("alpha"), None, Some("gamma")])),
+                Arc::new(Float64Array::from(vec![1.25, 2.5, 3.75])),
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+            ],
+        )
+        .expect("record batch");
+
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut writer =
+                ArrowWriter::try_new(&mut cursor, schema, None).expect("parquet writer");
+            writer.write(&batch).expect("write batch");
+            writer.close().expect("close writer");
+        }
+        cursor.into_inner()
+    }
+
+    #[test]
+    fn summarize_parquet_reports_rows_bytes_and_columns() {
+        let bytes = sample_parquet_bytes();
+        let summary = summarize_parquet_bytes(&bytes).expect("summary");
+
+        assert_eq!(summary.num_rows, 3);
+        assert!(summary.num_bytes > 0);
+        assert_eq!(
+            summary
+                .columns
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["id", "label", "score", "flag"]
+        );
+        assert_eq!(summary.columns[1].data_type, "string");
+        assert_eq!(summary.columns[1].null_count, 1);
+        assert!(serde_json::from_str::<serde_json::Value>(&summary.columns[0].stats_json).is_ok());
+    }
+
+    #[test]
+    fn read_parquet_rows_paginates_and_formats_values_for_js() {
+        let page = read_parquet_rows_bytes(sample_parquet_bytes(), 1, 2).expect("rows");
+
+        assert_eq!(page.columns, vec!["id", "label", "score", "flag"]);
+        assert_eq!(page.total_rows, 3);
+        assert_eq!(page.offset, 1);
+        assert_eq!(
+            page.rows,
+            vec![
+                vec![
+                    "2".to_string(),
+                    "null".to_string(),
+                    "2.5000".to_string(),
+                    "false".to_string()
+                ],
+                vec![
+                    "3".to_string(),
+                    "gamma".to_string(),
+                    "3.7500".to_string(),
+                    "true".to_string()
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn read_parquet_rows_clamps_negative_offset_and_limit() {
+        let page = read_parquet_rows_bytes(sample_parquet_bytes(), -10, -1).expect("rows");
+
+        assert_eq!(page.total_rows, 3);
+        assert_eq!(page.offset, 0);
+        assert!(page.rows.is_empty());
+    }
+
+    #[test]
+    fn invalid_parquet_bytes_report_a_parquet_error() {
+        match summarize_parquet_bytes(b"not parquet") {
+            Ok(_) => panic!("invalid parquet bytes should fail"),
+            Err(err) => assert!(err.contains("Parquet error")),
         }
     }
 }

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -552,6 +552,13 @@ enum DataValueJson {
 }
 
 fn to_js_output(o: runtimed_client::resolved_output::Output) -> napi::Result<JsOutput> {
+    js_output_from_resolved_output(o)
+        .map_err(|e| napi::Error::from_reason(format!("Failed to serialize output data: {e}")))
+}
+
+fn js_output_from_resolved_output(
+    o: runtimed_client::resolved_output::Output,
+) -> serde_json::Result<JsOutput> {
     let data_json = match o.data {
         Some(d) => {
             let map: std::collections::HashMap<String, DataValueJson> = d
@@ -568,22 +575,15 @@ fn to_js_output(o: runtimed_client::resolved_output::Output) -> napi::Result<JsO
                     (k, dv)
                 })
                 .collect();
-            Some(serde_json::to_string(&map).map_err(|e| {
-                napi::Error::from_reason(format!("Failed to serialize output data: {e}"))
-            })?)
+            Some(serde_json::to_string(&map)?)
         }
         None => None,
     };
-    let blob_urls_json = o
-        .blob_urls
-        .map(|m| serde_json::to_string(&m))
-        .transpose()
-        .map_err(|e| napi::Error::from_reason(format!("Failed to serialize blob_urls: {e}")))?;
+    let blob_urls_json = o.blob_urls.map(|m| serde_json::to_string(&m)).transpose()?;
     let blob_paths_json = o
         .blob_paths
         .map(|m| serde_json::to_string(&m))
-        .transpose()
-        .map_err(|e| napi::Error::from_reason(format!("Failed to serialize blob_paths: {e}")))?;
+        .transpose()?;
     Ok(JsOutput {
         output_type: o.output_type,
         name: o.name,
@@ -596,4 +596,106 @@ fn to_js_output(o: runtimed_client::resolved_output::Output) -> napi::Result<JsO
         blob_urls_json,
         blob_paths_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use runtimed_client::resolved_output::{DataValue as SharedDataValue, Output as SharedOutput};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn resolve_socket_path_prefers_explicit_override() {
+        let path = resolve_socket_path(Some("/tmp/runtimed-node-test.sock".to_string()));
+        assert_eq!(path, PathBuf::from("/tmp/runtimed-node-test.sock"));
+    }
+
+    #[test]
+    fn to_js_output_preserves_output_fields_and_typed_data_contract() {
+        let data = HashMap::from([
+            (
+                "text/plain".to_string(),
+                SharedDataValue::Text("hello".to_string()),
+            ),
+            (
+                "image/png".to_string(),
+                SharedDataValue::Binary(vec![0, 1, 2, 255]),
+            ),
+            (
+                "application/json".to_string(),
+                SharedDataValue::Json(json!({"ok": true, "n": 3})),
+            ),
+        ]);
+        let mut output = SharedOutput::execute_result(data, 7);
+        output.blob_urls = Some(HashMap::from([(
+            "image/png".to_string(),
+            "http://localhost:9999/blob/abc".to_string(),
+        )]));
+        output.blob_paths = Some(HashMap::from([(
+            "image/png".to_string(),
+            "/tmp/blobs/ab/abc".to_string(),
+        )]));
+
+        let js_output = js_output_from_resolved_output(output).expect("output serializes");
+
+        assert_eq!(js_output.output_type, "execute_result");
+        assert_eq!(js_output.execution_count, Some(7));
+
+        let data_json: serde_json::Value =
+            serde_json::from_str(js_output.data_json.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            data_json["text/plain"],
+            json!({"type": "text", "value": "hello"})
+        );
+        assert_eq!(
+            data_json["image/png"],
+            json!({"type": "binary", "value": "AAEC/w=="})
+        );
+        assert_eq!(
+            data_json["application/json"],
+            json!({"type": "json", "value": {"ok": true, "n": 3}})
+        );
+
+        let blob_urls: serde_json::Value =
+            serde_json::from_str(js_output.blob_urls_json.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            blob_urls,
+            json!({"image/png": "http://localhost:9999/blob/abc"})
+        );
+
+        let blob_paths: serde_json::Value =
+            serde_json::from_str(js_output.blob_paths_json.as_deref().unwrap()).unwrap();
+        assert_eq!(blob_paths, json!({"image/png": "/tmp/blobs/ab/abc"}));
+    }
+
+    #[test]
+    fn to_js_output_keeps_kernel_error_shape_stable() {
+        let output = SharedOutput::error(
+            "ValueError",
+            "bad value",
+            vec![
+                "Traceback line 1".to_string(),
+                "Traceback line 2".to_string(),
+            ],
+        );
+
+        let js_output = js_output_from_resolved_output(output).expect("error output serializes");
+
+        assert_eq!(js_output.output_type, "error");
+        assert_eq!(js_output.ename.as_deref(), Some("ValueError"));
+        assert_eq!(js_output.evalue.as_deref(), Some("bad value"));
+        assert_eq!(
+            js_output.traceback,
+            Some(vec![
+                "Traceback line 1".to_string(),
+                "Traceback line 2".to_string()
+            ])
+        );
+        assert!(js_output.data_json.is_none());
+        assert!(js_output.blob_urls_json.is_none());
+        assert!(js_output.blob_paths_json.is_none());
+    }
 }

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -11,8 +11,12 @@ publish = false
 name = "_internals"
 crate-type = ["cdylib"]
 
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.28", features = ["abi3-py39"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 runtimed-client = { path = "../runtimed-client" }
 notebook-doc = { path = "../notebook-doc" }

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1148,3 +1148,180 @@ impl From<runtime_doc::RuntimeState> for PyRuntimeState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use runtime_doc::{
+        CommDocEntry, EnvState, ExecutionState, KernelActivity, KernelState, ProjectContext,
+        QueueEntry, QueueState as RuntimeQueueState, RuntimeLifecycle, RuntimeState,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn output_data_preserves_mime_typed_values_before_python_projection() {
+        let output = Output::display_data(HashMap::from([
+            (
+                "text/plain".to_string(),
+                DataValue::Text("hello".to_string()),
+            ),
+            (
+                "image/png".to_string(),
+                DataValue::Binary(vec![0, 1, 2, 255]),
+            ),
+            (
+                "application/json".to_string(),
+                DataValue::Json(json!({"ok": true, "items": [1, 2]})),
+            ),
+        ]));
+
+        let data = output.data.as_ref().expect("data");
+
+        let DataValue::Text(text) = &data["text/plain"] else {
+            panic!("text/plain should stay text");
+        };
+        assert_eq!(text, "hello");
+
+        let DataValue::Binary(image) = &data["image/png"] else {
+            panic!("image/png should stay raw binary");
+        };
+        assert_eq!(image, &[0, 1, 2, 255]);
+
+        let DataValue::Json(json_value) = &data["application/json"] else {
+            panic!("application/json should stay structured JSON");
+        };
+        assert_eq!(json_value["items"], json!([1, 2]));
+    }
+
+    #[test]
+    fn execution_result_helpers_split_stream_display_and_error_outputs() {
+        let result = ExecutionResult {
+            cell_id: "cell-1".to_string(),
+            outputs: vec![
+                Output::stream("stdout", "alpha"),
+                Output::stream("stdout", " beta"),
+                Output::stream("stderr", "warning"),
+                Output::execute_result(
+                    HashMap::from([("text/plain".to_string(), DataValue::Text("42".to_string()))]),
+                    4,
+                ),
+                Output::error("ValueError", "bad value", vec!["trace".to_string()]),
+            ],
+            success: false,
+            execution_count: Some(4),
+        };
+
+        assert_eq!(result.stdout(), "alpha beta");
+        assert_eq!(result.stderr(), "warning");
+        assert_eq!(result.display_data().len(), 1);
+        assert_eq!(result.error().unwrap().ename.as_deref(), Some("ValueError"));
+        assert_eq!(
+            result.__repr__(),
+            "ExecutionResult(cell=cell-1, status=error, outputs=5)"
+        );
+    }
+
+    #[test]
+    fn runtime_state_conversion_preserves_queue_executions_and_widget_state() {
+        let mut executions = HashMap::new();
+        executions.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "done".to_string(),
+                execution_count: Some(12),
+                success: Some(true),
+                outputs: vec![json!({"output_type": "stream", "name": "stdout"})],
+                source: Some("print('ok')".to_string()),
+                seq: Some(7),
+            },
+        );
+
+        let mut comms = HashMap::new();
+        comms.insert(
+            "comm-1".to_string(),
+            CommDocEntry {
+                target_name: "jupyter.widget".to_string(),
+                model_module: "@jupyter-widgets/controls".to_string(),
+                model_name: "IntSliderModel".to_string(),
+                state: json!({"value": 42, "description": "answer"}),
+                outputs: vec![json!({"output_type": "display_data"})],
+                seq: 9,
+                capture_msg_id: String::new(),
+            },
+        );
+
+        let runtime = RuntimeState {
+            kernel: KernelState {
+                name: "kernel-a".to_string(),
+                language: "python".to_string(),
+                env_source: "uv:prewarmed".to_string(),
+                lifecycle: RuntimeLifecycle::Running(KernelActivity::Busy),
+                error_reason: Some(String::new()),
+                error_details: Some(String::new()),
+                ..KernelState::default()
+            },
+            queue: RuntimeQueueState {
+                executing: Some(QueueEntry {
+                    cell_id: "cell-1".to_string(),
+                    execution_id: "exec-1".to_string(),
+                }),
+                queued: vec![QueueEntry {
+                    cell_id: "cell-2".to_string(),
+                    execution_id: "exec-2".to_string(),
+                }],
+            },
+            env: EnvState {
+                in_sync: false,
+                added: vec!["pandas".to_string()],
+                removed: vec!["numpy".to_string()],
+                channels_changed: true,
+                deno_changed: true,
+                prewarmed_packages: vec!["ipykernel".to_string()],
+            },
+            last_saved: Some("2026-04-27T12:00:00Z".to_string()),
+            executions,
+            comms,
+            project_context: ProjectContext::NotFound {
+                observed_at: "2026-04-27T12:01:00Z".to_string(),
+            },
+            ..RuntimeState::default()
+        };
+
+        let py_state = PyRuntimeState::from(runtime);
+
+        assert_eq!(py_state.kernel.status, "busy");
+        assert_eq!(py_state.kernel.lifecycle, "Running");
+        assert_eq!(py_state.kernel.activity, "Busy");
+        assert_eq!(py_state.kernel.name, "kernel-a");
+        assert_eq!(py_state.kernel.language, "python");
+        assert_eq!(py_state.kernel.env_source, "uv:prewarmed");
+        assert_eq!(
+            py_state.queue.executing.as_ref().unwrap().execution_id,
+            "exec-1"
+        );
+        assert_eq!(py_state.queue.queued[0].cell_id, "cell-2");
+        assert!(!py_state.env.in_sync);
+        assert_eq!(py_state.env.added, vec!["pandas".to_string()]);
+        assert_eq!(
+            py_state.env.prewarmed_packages,
+            vec!["ipykernel".to_string()]
+        );
+        assert_eq!(
+            py_state.executions["exec-1"].__repr__(),
+            "ExecutionState(cell_id=cell-1, status=done, success=Some(true))"
+        );
+        assert_eq!(py_state.comms["comm-1"].model_name, "IntSliderModel");
+        assert_eq!(
+            py_state.comms["comm-1"].outputs,
+            vec!["{\"output_type\":\"display_data\"}".to_string()]
+        );
+
+        let project_context: serde_json::Value =
+            serde_json::from_str(&py_state.project_context_json).unwrap();
+        assert_eq!(project_context["state"], "NotFound");
+        assert_eq!(project_context["observed_at"], "2026-04-27T12:01:00Z");
+    }
+}

--- a/crates/runtimed-py/src/output_resolver.rs
+++ b/crates/runtimed-py/src/output_resolver.rs
@@ -50,3 +50,76 @@ pub async fn resolve_cell_outputs(
         .map(convert_output)
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use runtimed_client::resolved_output as shared_output;
+    use serde_json::json;
+
+    #[test]
+    fn convert_output_preserves_typed_data_and_blob_metadata() {
+        let output = shared_output::Output {
+            output_type: "execute_result".to_string(),
+            name: None,
+            text: None,
+            data: Some(HashMap::from([
+                (
+                    "text/plain".to_string(),
+                    shared_output::DataValue::Text("hello".to_string()),
+                ),
+                (
+                    "image/png".to_string(),
+                    shared_output::DataValue::Binary(vec![0, 1, 2, 255]),
+                ),
+                (
+                    "application/json".to_string(),
+                    shared_output::DataValue::Json(json!({"ok": true})),
+                ),
+            ])),
+            ename: None,
+            evalue: None,
+            traceback: None,
+            execution_count: Some(7),
+            blob_urls: Some(HashMap::from([(
+                "image/png".to_string(),
+                "http://127.0.0.1/blob/image".to_string(),
+            )])),
+            blob_paths: Some(HashMap::from([(
+                "image/png".to_string(),
+                "/tmp/runt/blob-image".to_string(),
+            )])),
+        };
+
+        let converted = convert_output(output);
+
+        assert_eq!(converted.output_type, "execute_result");
+        assert_eq!(converted.execution_count, Some(7));
+        assert_eq!(
+            converted.blob_urls.unwrap()["image/png"],
+            "http://127.0.0.1/blob/image"
+        );
+        assert_eq!(
+            converted.blob_paths.unwrap()["image/png"],
+            "/tmp/runt/blob-image"
+        );
+
+        let data = converted.data.unwrap();
+        let DataValue::Text(text) = &data["text/plain"] else {
+            panic!("text/plain should convert to text");
+        };
+        assert_eq!(text, "hello");
+
+        let DataValue::Binary(bytes) = &data["image/png"] else {
+            panic!("image/png should convert to binary");
+        };
+        assert_eq!(bytes, &[0, 1, 2, 255]);
+
+        let DataValue::Json(value) = &data["application/json"] else {
+            panic!("application/json should convert to JSON");
+        };
+        assert_eq!(value["ok"], true);
+    }
+}

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -230,5 +230,131 @@ class TestCreateNotebookValidation:
             client.create_notebook(working_dir=str(test_file))
 
 
+class _ExecutionEntry:
+    def __init__(self, status="queued", success=None, execution_count=None):
+        self.status = status
+        self.success = success
+        self.execution_count = execution_count
+
+
+class _RuntimeState:
+    def __init__(self, executions):
+        self.executions = executions
+
+
+class _ExecutionSession:
+    def __init__(self, executions=None, state_error=None):
+        self._executions = executions or {}
+        self._state_error = state_error
+        self.wait_calls = []
+        self.interrupted = False
+
+    def get_runtime_state_sync(self):
+        if self._state_error is not None:
+            raise self._state_error
+        return _RuntimeState(self._executions)
+
+    async def wait_for_execution(self, cell_id, execution_id, timeout_secs):
+        self.wait_calls.append((cell_id, execution_id, timeout_secs))
+        return "execution-result"
+
+    async def interrupt(self):
+        self.interrupted = True
+
+
+class TestExecutionHandle:
+    """Execution handle state reads without a live daemon."""
+
+    def test_execution_properties_read_runtime_state_entry(self):
+        from runtimed._execution import Execution
+
+        session = _ExecutionSession(
+            {
+                "exec-1": _ExecutionEntry(
+                    status="done", success=True, execution_count=12
+                )
+            }
+        )
+
+        execution = Execution(session, "cell-1", "exec-1")
+
+        assert execution.execution_id == "exec-1"
+        assert execution.cell_id == "cell-1"
+        assert execution.status == "done"
+        assert execution.success is True
+        assert execution.execution_count == 12
+        assert execution.done is True
+        assert "status=done" in repr(execution)
+
+    def test_execution_properties_degrade_to_unknown_when_state_is_missing(self):
+        from runtimed._execution import Execution
+
+        execution = Execution(_ExecutionSession({}), "cell-1", "missing")
+
+        assert execution.status == "unknown"
+        assert execution.success is None
+        assert execution.execution_count is None
+        assert execution.done is False
+
+    def test_execution_properties_degrade_to_unknown_when_state_read_fails(self):
+        from runtimed._execution import Execution
+
+        execution = Execution(
+            _ExecutionSession(state_error=RuntimeError("runtime unavailable")),
+            "cell-1",
+            "exec-1",
+        )
+
+        assert execution.status == "unknown"
+        assert execution.success is None
+        assert execution.execution_count is None
+
+    @pytest.mark.asyncio
+    async def test_result_delegates_to_session_without_requeueing(self):
+        from runtimed._execution import Execution
+
+        session = _ExecutionSession({"exec-1": _ExecutionEntry(status="done")})
+        execution = Execution(session, "cell-1", "exec-1")
+
+        result = await execution.result(timeout_secs=12.5)
+
+        assert result == "execution-result"
+        assert session.wait_calls == [("cell-1", "exec-1", 12.5)]
+
+    @pytest.mark.asyncio
+    async def test_await_execution_is_result_shorthand(self):
+        from runtimed._execution import Execution
+
+        session = _ExecutionSession({"exec-1": _ExecutionEntry(status="done")})
+        execution = Execution(session, "cell-1", "exec-1")
+
+        assert await execution == "execution-result"
+        assert session.wait_calls == [("cell-1", "exec-1", 60.0)]
+
+    @pytest.mark.asyncio
+    async def test_cancel_interrupts_the_session(self):
+        from runtimed._execution import Execution
+
+        session = _ExecutionSession({"exec-1": _ExecutionEntry(status="running")})
+        execution = Execution(session, "cell-1", "exec-1")
+
+        await execution.cancel()
+
+        assert session.interrupted is True
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out_with_current_status(self):
+        from runtimed._execution import Execution
+
+        execution = Execution(
+            _ExecutionSession({"exec-1": _ExecutionEntry(status="running")}),
+            "cell-1",
+            "exec-1",
+        )
+
+        with pytest.raises(TimeoutError, match="status=running"):
+            await execution.wait(timeout_secs=0.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- add Rust unit coverage for runtimed-node output/parquet binding contracts
- add nteract-mcp sidecar config tests
- add runtimed-py Rust/Python unit coverage for output, runtime-state, resolver, and Execution handle contracts
- add explicit CI steps for binding crate tests

## Verification
- cargo test -p runtimed-node -p nteract-mcp --verbose
- cargo test -p runtimed-py --lib --no-default-features --verbose
- cargo check -p runtimed-py --verbose
- uv run --directory python/runtimed pytest tests/test_session_unit.py -v
- cargo clippy -p runtimed-node -p nteract-mcp --all-targets -- -D warnings
- cargo clippy -p runtimed-py --lib --no-default-features -- -D warnings
- cargo fmt --check -p nteract-mcp -p runtimed-node -p runtimed-py
- git diff --check