### PR TITLE
test(runtimed): cover headless trust and sync readiness

### DIFF
--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -642,4 +642,23 @@ mod tests {
     fn parse_whitespace_trimmed() {
         assert_eq!(parse_package_param("  ['pandas']  "), vec!["pandas"]);
     }
+
+    #[test]
+    fn approve_trust_params_accept_missing_fingerprint() {
+        let params: ApproveTrustParams = serde_json::from_value(serde_json::json!({})).unwrap();
+
+        assert_eq!(params.dependency_fingerprint, None);
+    }
+
+    #[test]
+    fn approve_trust_params_accept_supplied_fingerprint() {
+        let params: ApproveTrustParams =
+            serde_json::from_value(serde_json::json!({"dependency_fingerprint": "sha256:abc"}))
+                .unwrap();
+
+        assert_eq!(
+            params.dependency_fingerprint,
+            Some("sha256:abc".to_string())
+        );
+    }
 }

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -574,6 +574,69 @@ mod tests {
         .unwrap()
     }
 
+    fn registered_tool(name: &str) -> Tool {
+        all_tools()
+            .into_iter()
+            .find(|tool| tool.name == name)
+            .unwrap_or_else(|| panic!("missing registered tool: {name}"))
+    }
+
+    #[test]
+    fn approve_trust_tool_exposes_optional_fingerprint_schema() {
+        let tool = registered_tool("approve_trust");
+        let properties = tool
+            .input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .expect("approve_trust schema should expose properties");
+
+        assert!(properties.contains_key("dependency_fingerprint"));
+        let fingerprint_is_required = tool
+            .input_schema
+            .get("required")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|required| {
+                required
+                    .iter()
+                    .any(|field| field == "dependency_fingerprint")
+            });
+        assert!(!fingerprint_is_required);
+        assert!(tool
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .contains("dependency_fingerprint"));
+
+        let annotations = tool
+            .annotations
+            .expect("approve_trust should advertise safe mutation hints");
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn get_dependencies_tool_advertises_trust_metadata() {
+        let tool = registered_tool("get_dependencies");
+
+        assert!(tool
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .contains("dependency fingerprint"));
+        assert!(tool
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .contains("trust state"));
+
+        let annotations = tool
+            .annotations
+            .expect("get_dependencies should advertise read-only hints");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
     #[test]
     fn arg_bool_json_true() {
         let req = make_request(serde_json::json!({"flag": true}));

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1396,16 +1396,19 @@ async fn test_multiple_notebooks_concurrent_isolation() {
     let nb_c = nb_c.handle;
 
     assert!(
-        wait_for_session_ready(&nb_a, Duration::from_secs(2)).await,
-        "alpha notebook should reach session-ready state within 2s"
+        wait_for_session_ready(&nb_a, SESSION_READY_TIMEOUT).await,
+        "alpha notebook should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_session_ready(&nb_b, Duration::from_secs(2)).await,
-        "beta notebook should reach session-ready state within 2s"
+        wait_for_session_ready(&nb_b, SESSION_READY_TIMEOUT).await,
+        "beta notebook should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_session_ready(&nb_c, Duration::from_secs(2)).await,
-        "gamma notebook should reach session-ready state within 2s"
+        wait_for_session_ready(&nb_c, SESSION_READY_TIMEOUT).await,
+        "gamma notebook should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     // Add cells to each notebook
@@ -1442,32 +1445,38 @@ async fn test_multiple_notebooks_concurrent_isolation() {
     let handle_c = fresh_c.unwrap().handle;
 
     assert!(
-        wait_for_session_ready(&handle_a, Duration::from_secs(2)).await,
-        "alpha client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle_a, SESSION_READY_TIMEOUT).await,
+        "alpha client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_session_ready(&handle_b, Duration::from_secs(2)).await,
-        "beta client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle_b, SESSION_READY_TIMEOUT).await,
+        "beta client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_session_ready(&handle_c, Duration::from_secs(2)).await,
-        "gamma client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle_c, SESSION_READY_TIMEOUT).await,
+        "gamma client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     // Wait for initial sync to deliver the cells map before reading.
     // session_ready only guarantees status=Interactive, not that the
     // snapshot watch channel has published cells from the sync frames.
     assert!(
-        wait_for_cells_map(&handle_a, Duration::from_secs(2)).await,
-        "alpha sync did not deliver cells map within 2s"
+        wait_for_cells_map(&handle_a, SESSION_READY_TIMEOUT).await,
+        "alpha sync did not deliver cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_cells_map(&handle_b, Duration::from_secs(2)).await,
-        "beta sync did not deliver cells map within 2s"
+        wait_for_cells_map(&handle_b, SESSION_READY_TIMEOUT).await,
+        "beta sync did not deliver cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
     assert!(
-        wait_for_cells_map(&handle_c, Duration::from_secs(2)).await,
-        "gamma sync did not deliver cells map within 2s"
+        wait_for_cells_map(&handle_c, SESSION_READY_TIMEOUT).await,
+        "gamma sync did not deliver cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     let cells_a = handle_a.get_cells();
@@ -1833,8 +1842,9 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // mutate it. Otherwise `add_cell_after` panics with
     // `InvalidObjId("cells map not found")` — a flake under loaded CI.
     assert!(
-        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
-        "initial sync did not deliver the cells map within 2s"
+        wait_for_cells_map(&client2, SESSION_READY_TIMEOUT).await,
+        "initial sync did not deliver the cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2
@@ -1950,8 +1960,9 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     .unwrap()
     .handle;
     assert!(
-        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
-        "initial sync did not deliver the cells map within 2s"
+        wait_for_cells_map(&client2, SESSION_READY_TIMEOUT).await,
+        "initial sync did not deliver the cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
     client2.add_cell_after("bc-cell", "code", None).unwrap();
     client2.update_source("bc-cell", "x = 1").unwrap();
@@ -2106,8 +2117,9 @@ async fn test_pipe_mode_preserves_frame_order() {
     // mutate it. Otherwise `add_cell_after` panics with
     // `InvalidObjId("cells map not found")` — a flake under loaded CI.
     assert!(
-        wait_for_cells_map(&client2, Duration::from_secs(2)).await,
-        "initial sync did not deliver the cells map within 2s"
+        wait_for_cells_map(&client2, SESSION_READY_TIMEOUT).await,
+        "initial sync did not deliver the cells map within {:?}",
+        SESSION_READY_TIMEOUT
     );
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2
@@ -2412,8 +2424,9 @@ async fn test_create_notebook_with_deps() {
     let handle = result.handle;
 
     assert!(
-        wait_for_session_ready(&handle, Duration::from_secs(2)).await,
-        "client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     // Poll for metadata to arrive via Automerge sync
@@ -2485,8 +2498,9 @@ async fn test_create_notebook_with_explicit_manager_no_deps() {
     let handle = result.handle;
 
     assert!(
-        wait_for_session_ready(&handle, Duration::from_secs(2)).await,
-        "client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     // Poll for metadata to arrive via Automerge sync
@@ -2555,8 +2569,9 @@ async fn test_create_notebook_default_manager_with_deps() {
     let handle = result.handle;
 
     assert!(
-        wait_for_session_ready(&handle, Duration::from_secs(2)).await,
-        "client should reach session-ready state within 2s"
+        wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+        "client should reach session-ready state within {:?}",
+        SESSION_READY_TIMEOUT
     );
 
     // Poll for metadata to arrive via Automerge sync

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -230,6 +230,52 @@ class TestCreateNotebookValidation:
             client.create_notebook(working_dir=str(test_file))
 
 
+class _NotebookTrustSession:
+    notebook_id = "trust-notebook"
+
+    def __init__(self, fingerprint="sha256:current"):
+        self._fingerprint = fingerprint
+        self.approve_trust_calls = []
+
+    async def dependency_fingerprint(self):
+        return self._fingerprint
+
+    async def approve_trust(self, dependency_fingerprint=None):
+        self.approve_trust_calls.append(dependency_fingerprint)
+
+
+class TestNotebookTrustMethods:
+    """Notebook trust helpers delegate to the native session."""
+
+    @pytest.mark.asyncio
+    async def test_dependency_fingerprint_delegates_to_session(self):
+        from runtimed._notebook import Notebook
+
+        notebook = Notebook(_NotebookTrustSession("sha256:reviewed"))
+
+        assert await notebook.dependency_fingerprint() == "sha256:reviewed"
+
+    @pytest.mark.asyncio
+    async def test_dependency_fingerprint_allows_missing_metadata(self):
+        from runtimed._notebook import Notebook
+
+        notebook = Notebook(_NotebookTrustSession(None))
+
+        assert await notebook.dependency_fingerprint() is None
+
+    @pytest.mark.asyncio
+    async def test_approve_trust_passes_optional_fingerprint_to_session(self):
+        from runtimed._notebook import Notebook
+
+        session = _NotebookTrustSession()
+        notebook = Notebook(session)
+
+        await notebook.approve_trust()
+        await notebook.approve_trust("sha256:reviewed")
+
+        assert session.approve_trust_calls == [None, "sha256:reviewed"]
+
+
 class _ExecutionEntry:
     def __init__(self, status="queued", success=None, execution_count=None):
         self.status = status
@@ -269,11 +315,7 @@ class TestExecutionHandle:
         from runtimed._execution import Execution
 
         session = _ExecutionSession(
-            {
-                "exec-1": _ExecutionEntry(
-                    status="done", success=True, execution_count=12
-                )
-            }
+            {"exec-1": _ExecutionEntry(status="done", success=True, execution_count=12)}
         )
 
         execution = Execution(session, "cell-1", "exec-1")


### PR DESCRIPTION
## Summary
- Add MCP unit coverage for the `approve_trust` tool schema and mutation hints.
- Lock `get_dependencies` tool metadata to advertise dependency fingerprints and trust state.
- Add Python wrapper unit coverage for `Notebook.dependency_fingerprint()` and `Notebook.approve_trust()` delegation.
- Stabilize `runtimed` integration tests by using the existing session-readiness timeout for initial sync/cells-map gates that were still hard-coded to 2s.

## Validation
- `cargo xtask help`
- `cargo fmt -p runt-mcp`
- `cargo fmt -p runtimed`
- `cargo fmt --check -p runtimed`
- `cargo test -p runt-mcp trust --lib`
- `cargo test -p runt-mcp --lib`
- `cargo test -p runtimed --test integration test_pipe_mode_preserves_frame_order -- --nocapture`
- `cargo test -p runtimed --test integration pipe_mode -- --nocapture`
- `cargo test -p runtimed --test integration test_multiple_notebooks_concurrent_isolation -- --nocapture`
- `cargo test -p runtimed --test integration test_create_notebook -- --nocapture`
- `uv run --directory python/runtimed pytest tests/test_session_unit.py -k trust -v`
- `uv run --directory python/runtimed pytest tests/test_session_unit.py -v`
- `uv run --directory python/runtimed ruff check tests/test_session_unit.py`
- `uv run --directory python/runtimed ruff format --check tests/test_session_unit.py`
- `git diff --check`

## Local setup note
- Built gitignored wasm/plugin assets locally with `cargo xtask wasm` followed by `pnpm install --frozen-lockfile` and `cargo xtask renderer-plugins` so the `runtimed` integration target could compile.