### PR TITLE
fix(installer): break the daemon out of the parent's Job Object

### DIFF
--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -770,32 +770,39 @@ Set WshShell = Nothing
         use std::os::windows::ffi::OsStrExt;
         use windows_sys::Win32::Foundation::CloseHandle;
         use windows_sys::Win32::System::Threading::{
-            CreateProcessW, CREATE_NO_WINDOW, DETACHED_PROCESS, PROCESS_INFORMATION, STARTUPINFOW,
+            CreateProcessW, CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW, DETACHED_PROCESS,
+            PROCESS_INFORMATION, STARTUPINFOW,
         };
 
-        // The daemon runs forever. The standard `Command::new(...).spawn()`
-        // path on Windows calls `CreateProcessW` with `bInheritHandles=TRUE`
-        // (Rust's default), which duplicates *every* inheritable handle in
-        // this process's table into the child - not just stdio. That bites
-        // when this process was launched by NSIS's `nsExec::ExecToStack` to
-        // run `runt daemon doctor --fix`: NSIS hands the child stdout/stderr
-        // pipes that are marked inheritable so they propagate through stdio.
-        // When `runt` then spawns the daemon with `bInheritHandles=TRUE`,
-        // those pipes get duplicated *again* into the daemon's handle table.
-        // `runt` exits, releasing its copies, but the daemon keeps the
-        // duplicates open forever, so `nsExec::ExecToStack` never sees EOF
-        // on the read pipe and the silent installer hangs at `Install
-        // silently` until the runner times out (see runs 25025820384 and
-        // 25025909072).
+        // The daemon runs forever. Two things go wrong with the default
+        // `Command::new(...).spawn()` path on Windows:
         //
-        // Redirecting stdio to NUL via `Stdio::null()` does not fix this:
-        // the *original* pipe handles in this process are still inheritable
-        // and `bInheritHandles=TRUE` still duplicates them.
+        // 1. CreateProcessW defaults to `bInheritHandles=TRUE`, which
+        //    duplicates every inheritable handle from the parent into the
+        //    child - not just stdio. We don't want any of that to leak.
         //
-        // Bypass `std::process::Command` and call `CreateProcessW` directly
-        // with `bInheritHandles=FALSE`. The daemon needs no inherited
-        // handles - logging goes to a file (see runtimed::main), and stdio
-        // is unused.
+        // 2. The new process is implicitly added to the parent's Job
+        //    Object. PowerShell's `Start-Process -Wait` (and CI runners
+        //    that wrap each step in a Job to track step descendants) wait
+        //    for *every* process in the Job to exit. With the daemon in
+        //    the Job, `Start-Process -Wait` blocks forever - this is the
+        //    actual mechanism behind the silent-install hangs in
+        //    runs 25025820384, 25025909072, and 25031947609. (Verified
+        //    locally with `IsProcessInJob` on the running daemon.)
+        //
+        // Bypass `std::process::Command` and call `CreateProcessW` directly:
+        //   - bInheritHandles=FALSE   (no handle leakage)
+        //   - DETACHED_PROCESS        (no inherited console)
+        //   - CREATE_NO_WINDOW        (no new visible window)
+        //   - CREATE_BREAKAWAY_FROM_JOB (escape the parent's Job Object)
+        //
+        // CREATE_BREAKAWAY_FROM_JOB requires the parent Job to have set
+        // JOB_OBJECT_LIMIT_BREAKAWAY_OK. PowerShell's Start-Process and
+        // GitHub Actions' step Jobs both set it, but if a future caller
+        // creates a stricter Job and the spawn fails with ACCESS_DENIED
+        // we retry without the flag - the daemon still starts, the
+        // -Wait caller still hangs, but at least we don't fail the
+        // common cases that don't use a strict Job at all.
         // lpApplicationName: NUL-terminated UTF-16 path to the binary, no
         // surrounding quotes (Windows does not parse application-name).
         let app_name: Vec<u16> = self
@@ -826,23 +833,53 @@ Set WshShell = Nothing
         // owned by this stack frame and live through the call. &si and &mut pi
         // point at correctly-initialized POD structs (see above). All pointer
         // arguments documented as nullable (security attrs, environment,
-        // current directory) are passed as null. bInheritHandles=FALSE
-        // (passed as 0) is the load-bearing flag - see the comment block
-        // above for why redirecting stdio alone is not sufficient.
-        let ok = unsafe {
+        // current directory) are passed as null. The creation flags carry
+        // the load-bearing fix - see the comment block above for why each
+        // one matters. bInheritHandles=FALSE is passed as 0.
+        let flags = DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB;
+        let mut ok = unsafe {
             CreateProcessW(
                 app_name.as_ptr(),
                 cmd_line.as_mut_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 0,
-                DETACHED_PROCESS | CREATE_NO_WINDOW,
+                flags,
                 std::ptr::null_mut(),
                 std::ptr::null(),
                 &si,
                 &mut pi,
             )
         };
+
+        // ACCESS_DENIED here means the caller is in a Job Object that
+        // does not permit breakaway. Retry without the breakaway flag so
+        // the daemon at least starts in those edge cases - a -Wait caller
+        // would still hang, but no caller in the current code base sets
+        // such a strict Job, so this is a defensive fallback.
+        if ok == 0 {
+            let err = std::io::Error::last_os_error();
+            const ERROR_ACCESS_DENIED: i32 = 5;
+            if err.raw_os_error() == Some(ERROR_ACCESS_DENIED) {
+                info!(
+                    "[service] CreateProcessW with CREATE_BREAKAWAY_FROM_JOB returned ACCESS_DENIED, retrying without breakaway"
+                );
+                ok = unsafe {
+                    CreateProcessW(
+                        app_name.as_ptr(),
+                        cmd_line.as_mut_ptr(),
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                        0,
+                        DETACHED_PROCESS | CREATE_NO_WINDOW,
+                        std::ptr::null_mut(),
+                        std::ptr::null(),
+                        &si,
+                        &mut pi,
+                    )
+                };
+            }
+        }
 
         if ok == 0 {
             let err = std::io::Error::last_os_error();


### PR DESCRIPTION
## Why

#2308 fixed handle inheritance, which was a real bug, but it did not fix the silent-install hang. Verified on a clean Windows host: with `-Wait`, the post-#2308 installer still hangs indefinitely; the only surviving process is `runtimed.exe`, and `IsProcessInJob` returns `TRUE`.

The actual mechanism is **Job Object containment**, not pipe handles. PowerShell's `Start-Process -Wait` (which is what GitHub Actions' `Install silently` step uses, and what GHA wraps every step in for descendant tracking) wraps the child in a Windows Job Object and waits for *every* process in the Job to exit before returning. The default `CreateProcessW` puts the new daemon in the parent's Job, so the daemon's lifetime keeps the Job populated and `-Wait` waits forever - which is what the runner timeout was hitting.

## What

Add `CREATE_BREAKAWAY_FROM_JOB` to the daemon spawn flags. Falls back to a non-breakaway spawn on `ACCESS_DENIED` so the daemon still starts in the rare case where a future caller wraps the spawn in a strict Job that disallows breakaway.

## Verification

Direct test on a clean Windows host. A standalone Rust binary (`spawn-test`) is launched under `Start-Process -Wait -NoNewWindow` (which puts it in PowerShell's Job) and spawns the existing nightly daemon with the two flag sets:

```
mode=none:       self_in_job=true   child_in_job=true    ← daemon stuck in PowerShell's job
mode=breakaway:  self_in_job=true   child_in_job=false   ← daemon escaped, -Wait can return
```

PowerShell's `Start-Process` Job permits breakaway, so the new flag is sufficient and the fallback path is rarely hit.

CI smoke dispatched against this branch: [run 25034437945](https://github.com/nteract/desktop/actions/runs/25034437945). The post-#2308 manual smoke ([25031947609](https://github.com/nteract/desktop/actions/runs/25031947609)) hung at `Install silently` for the full 1h15m runner timeout; this run reaching `Verify installer bootstrap` is the proof point.
