### PR TITLE
fix(runt-mcp): graceful session disconnect on SIGTERM

### DIFF
--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -122,6 +122,30 @@ impl NteractMcp {
     pub fn last_session_drop(&self) -> &Arc<RwLock<Option<SessionDropInfo>>> {
         &self.last_session_drop
     }
+
+    /// Explicitly drop the active session, closing the daemon peer connection
+    /// immediately.
+    ///
+    /// Call this before the process exits to trigger prompt session cleanup in
+    /// the daemon rather than relying on OS-level TCP connection close + the
+    /// 30s eviction delay. Dropping the `NotebookSession` closes its
+    /// `DocHandle` channels, which makes the sync task break out of its loop
+    /// and close the TCP writer — the daemon sees EOF and decrements the peer
+    /// count, starting the eviction timer right away.
+    ///
+    /// Without this, session cleanup depends on the tokio runtime tearing down
+    /// tasks in the right order during process exit, which is unreliable under
+    /// SIGTERM.
+    pub async fn shutdown(&self) {
+        let old = self.session.write().await.take();
+        if let Some(session) = old {
+            tracing::info!(
+                "[mcp] Shutdown: disconnecting session {}",
+                session.notebook_id
+            );
+            drop(session);
+        }
+    }
 }
 
 impl ServerHandler for NteractMcp {

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -123,24 +123,23 @@ impl NteractMcp {
         &self.last_session_drop
     }
 
-    /// Explicitly drop the active session, closing the daemon peer connection
-    /// immediately.
+    /// Disconnect this MCP process's peer from the active notebook session.
     ///
-    /// Call this before the process exits to trigger prompt session cleanup in
-    /// the daemon rather than relying on OS-level TCP connection close + the
-    /// 30s eviction delay. Dropping the `NotebookSession` closes its
-    /// `DocHandle` channels, which makes the sync task break out of its loop
-    /// and close the TCP writer — the daemon sees EOF and decrements the peer
-    /// count, starting the eviction timer right away.
+    /// This only drops **our** peer connection — it does NOT shut down the
+    /// kernel or evict the room. The daemon tracks `active_peers` per room
+    /// and only schedules eviction when the count hits zero. If other peers
+    /// (humans, other agents) are still connected, they are unaffected and
+    /// the room stays alive.
     ///
-    /// Without this, session cleanup depends on the tokio runtime tearing down
-    /// tasks in the right order during process exit, which is unreliable under
-    /// SIGTERM.
+    /// Call this before the process exits so the daemon sees a clean TCP
+    /// close immediately rather than waiting for the OS to reclaim the
+    /// socket (which delays the eviction timer start when we are the last
+    /// peer).
     pub async fn shutdown(&self) {
         let old = self.session.write().await.take();
         if let Some(session) = old {
             tracing::info!(
-                "[mcp] Shutdown: disconnecting session {}",
+                "[mcp] Shutdown: disconnecting our peer from session {}",
                 session.notebook_id
             );
             drop(session);

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -932,10 +932,18 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         }
     }
 
-    // Explicitly drop the notebook session before the process exits.
-    // This closes the DocHandle channels immediately, causing the sync task
-    // to shut down its TCP connection to the daemon. The daemon sees EOF
-    // and starts the eviction timer right away.
+    // Disconnect our peer from the notebook session before the process exits.
+    //
+    // This only drops OUR peer connection to the daemon — it does NOT shut
+    // down the kernel or evict the room. The daemon tracks `active_peers`
+    // per room and only starts the eviction timer when the count hits zero.
+    // If other peers (humans, other MCP agents) are still connected, the
+    // room and kernel stay alive.
+    //
+    // Why bother? Without an explicit drop, the OS reclaims the TCP socket
+    // on process exit, but the timing is non-deterministic (especially
+    // under SIGTERM where tokio runtime teardown order is unreliable). A
+    // clean disconnect lets the daemon decrement the peer count immediately.
     //
     // Runs on both normal exit (MCP client disconnect) and SIGTERM. On
     // daemon upgrade the std::process::exit() path skips this — the proxy
@@ -943,7 +951,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     let old = session_for_shutdown.write().await.take();
     if let Some(session) = old {
         tracing::info!(
-            "[mcp] Disconnecting session {} before exit",
+            "[mcp] Disconnecting our peer from session {} before exit",
             session.notebook_id
         );
         drop(session);

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -849,6 +849,7 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
 
     // Grab shared state handles before serving (serve consumes the server)
     let session = server.session().clone();
+    let session_for_shutdown = session.clone();
     let peer_label = server.peer_label_shared().clone();
     let last_session_drop = server.last_session_drop().clone();
 
@@ -882,6 +883,34 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         runtimed_client::telemetry::heartbeat_loop("mcp", "telemetry_last_mcp_ping_at").await;
     });
 
+    // Listen for SIGTERM so we can drop the session cleanly before exit.
+    // Without this, SIGTERM from the gremlin harness (or systemd, or the
+    // proxy) terminates the process immediately — the daemon only learns
+    // the peer is gone when the OS reclaims the TCP socket, which delays
+    // the eviction timer start.
+    let sigterm = async {
+        #[cfg(unix)]
+        {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sig) => {
+                    sig.recv().await;
+                }
+                Err(e) => {
+                    tracing::warn!("[mcp] Failed to register SIGTERM handler: {e}");
+                    // Fall back to never resolving — the other select arms
+                    // handle shutdown, and SIGTERM will use the default
+                    // handler (immediate process termination).
+                    std::future::pending::<()>().await;
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            // On non-Unix, never resolve — the other select arms handle shutdown.
+            std::future::pending::<()>().await;
+        }
+    };
+
     tokio::select! {
         result = handle.waiting() => {
             // MCP client disconnected — normal shutdown
@@ -898,6 +927,26 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             std::process::exit(code);
         }
+        _ = sigterm => {
+            tracing::info!("[mcp] Received SIGTERM, shutting down gracefully");
+        }
+    }
+
+    // Explicitly drop the notebook session before the process exits.
+    // This closes the DocHandle channels immediately, causing the sync task
+    // to shut down its TCP connection to the daemon. The daemon sees EOF
+    // and starts the eviction timer right away.
+    //
+    // Runs on both normal exit (MCP client disconnect) and SIGTERM. On
+    // daemon upgrade the std::process::exit() path skips this — the proxy
+    // will re-establish the session on the new child anyway.
+    let old = session_for_shutdown.write().await.take();
+    if let Some(session) = old {
+        tracing::info!(
+            "[mcp] Disconnecting session {} before exit",
+            session.notebook_id
+        );
+        drop(session);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- **Adds SIGTERM signal handling** to the `runt mcp` process so ephemeral notebook sessions are cleanly disconnected before exit, allowing the daemon to start its eviction timer immediately rather than waiting for OS-level TCP cleanup.
- **Adds explicit session drop** after the MCP transport closes (normal exit path), ensuring the daemon peer is disconnected even if the MCP client disconnects without a clean shutdown.
- **Adds `NteractMcp::shutdown()` method** for structured session teardown.

## Motivation

Gremlin baseline runs showed 22/39 gremlins reporting orphan kernel sessions. Investigation traced the root cause to `runt mcp` processes exiting on SIGTERM (sent by the gremlin harness) without any session cleanup — the default SIGTERM handler kills the process immediately, and tokio runtime teardown order is unreliable for async cleanup. The daemon then must wait for OS TCP socket cleanup before detecting the peer disconnect and starting its 30s eviction timer.

While analysis showed the majority of "orphan" reports are measurement artifacts from concurrent batch execution (gremlins see each other's sessions), the lack of graceful shutdown is a real issue that delays kernel cleanup and could cause genuine leaks under edge conditions (e.g., half-open TCP connections).

## Changes

### `crates/runt/src/main.rs`
- Register a `SIGTERM` handler using `tokio::signal::unix::signal`
- Add it as a third arm in the `tokio::select!` loop alongside MCP transport close and daemon-watch
- After the select completes (any arm), explicitly take and drop the `NotebookSession` to disconnect from the daemon

### `crates/runt-mcp/src/lib.rs`
- Add `NteractMcp::shutdown()` async method that takes the session lock, extracts the session, and drops it with logging

## Test plan

- [x] `cargo test -p runt-mcp` — 112 tests pass
- [x] `cargo xtask lint --fix` — clean
- [x] `cargo clippy -p runt -p runt-mcp` — clean
- [x] `./scripts/install-nightly` — installed, daemon status shows matching SHA
- [ ] Gremlin suite re-run to validate reduced orphan count