### PR TITLE
fix(runt-mcp): report package_manager as "deno" for Deno notebooks

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -582,8 +582,19 @@ pub async fn create_notebook(
             let peer_label = server.get_peer_label().await;
             crate::presence::announce(&result.handle, &peer_label).await;
 
-            let pkg_manager: notebook_protocol::connection::PackageManager = explicit_pkg_manager
-                .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle));
+            // For Deno notebooks, there's no Python package manager — deps use
+            // Deno-native imports (npm: specifiers, URL imports). We skip
+            // detect_package_manager() which would fall back to "uv" since the
+            // Deno env_source hasn't propagated to the CRDT yet at this point.
+            let is_deno = runtime.eq_ignore_ascii_case("deno");
+            let pkg_manager: Option<notebook_protocol::connection::PackageManager> = if is_deno {
+                None
+            } else {
+                Some(
+                    explicit_pkg_manager
+                        .unwrap_or_else(|| super::deps::detect_package_manager(&result.handle)),
+                )
+            };
 
             let session = NotebookSession {
                 handle: result.handle,
@@ -605,7 +616,11 @@ pub async fn create_notebook(
             let all_deps = {
                 let guard = server.session.read().await;
                 guard.as_ref().map_or_else(Vec::new, |s| {
-                    super::deps::get_deps_for_manager_pub(&s.handle, &pkg_manager)
+                    if let Some(ref pm) = pkg_manager {
+                        super::deps::get_deps_for_manager_pub(&s.handle, pm)
+                    } else {
+                        Vec::new() // Deno: no Python deps
+                    }
                 })
             };
 
@@ -621,7 +636,10 @@ pub async fn create_notebook(
                 "runtime": runtime_info,
                 "dependencies": all_deps,
                 "added_dependencies": deps,
-                "package_manager": pkg_manager.as_str(),
+                "package_manager": match pkg_manager {
+                    Some(ref pm) => pm.as_str(),
+                    None => "deno",
+                },
                 "ephemeral": ephemeral,
                 "project_context": project_context,
             });


### PR DESCRIPTION
## Summary

- `create_notebook(runtime="deno")` was incorrectly reporting `package_manager: "uv"` in the MCP response. This confused agents into thinking they could use `add_dependency` / `get_dependencies` on Deno notebooks.
- Root cause: the Deno kernel's `env_source` hasn't propagated to the CRDT at response time, so `detect_package_manager()` fell through all checks to the `Uv` default.
- Fix: skip `detect_package_manager()` entirely for Deno notebooks. Report `package_manager: "deno"` and empty deps list. Deno dependencies use native imports (`npm:` specifiers, URL imports), not Python package managers.

## Context

Found during live Deno notebook testing. The `read_runtime_info()` path (used by `connect_notebook` / `open_notebook`) already handles Deno correctly (lines 203-204 in session.rs set `package_manager: "deno"` when `EnvSource::Deno`). Only `create_notebook` was broken because it builds the response before the runtime state has synced.

## Test plan

- [x] `cargo test -p runt-mcp` — 112 tests pass
- [x] `cargo clippy -p runt-mcp` — clean
- [x] `cargo xtask lint --fix` — clean
- [ ] Manual: `create_notebook(runtime="deno")` should return `package_manager: "deno"`