### PR TITLE
feat(runtime): add environment build decision state

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -23,6 +23,7 @@ import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatus
 import { DebugBanner } from "./components/DebugBanner";
 import { DenoDependencyHeader } from "./components/DenoDependencyHeader";
 import { DependencyHeader } from "./components/DependencyHeader";
+import { EnvBuildDecisionDialog } from "./components/EnvBuildDecisionDialog";
 import { GlobalFindBar } from "./components/GlobalFindBar";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
@@ -220,6 +221,8 @@ function AppContent() {
   const [dependencyHeaderOpen, setDependencyHeaderOpen] = useState(false);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
+  const [envBuildDialogOpen, setEnvBuildDialogOpen] = useState(false);
+  const [dismissedEnvBuildDetails, setDismissedEnvBuildDetails] = useState<string | null>(null);
   const [pendingTrustAction, setPendingTrustAction] = useState<PendingTrustAction | null>(null);
   const pendingTrustActionRef = useRef<PendingTrustAction | null>(null);
   const [trustActionNotice, setTrustActionNotice] = useState<string | null>(null);
@@ -399,6 +402,17 @@ function AppContent() {
     return () => clearTimeout(timeout);
   }, [kernelStatus, trustApprovalHandoffPending]);
 
+  useEffect(() => {
+    if (lifecycle.lifecycle !== "AwaitingEnvBuild") {
+      setEnvBuildDialogOpen(false);
+      setDismissedEnvBuildDetails(null);
+      return;
+    }
+    if (errorDetails !== dismissedEnvBuildDetails) {
+      setEnvBuildDialogOpen(true);
+    }
+  }, [dismissedEnvBuildDetails, errorDetails, lifecycle.lifecycle]);
+
   const { kernelStatus: displayKernelStatus, statusKey: displayStatusKey } =
     getTrustApprovalHandoffDisplayStatus({
       pending: trustApprovalHandoffPending,
@@ -520,7 +534,8 @@ function AppContent() {
   useEffect(() => {
     if (
       kernelStatus === KERNEL_STATUS.NOT_STARTED ||
-      kernelStatus === KERNEL_STATUS.AWAITING_TRUST
+      kernelStatus === KERNEL_STATUS.AWAITING_TRUST ||
+      kernelStatus === KERNEL_STATUS.AWAITING_ENV_BUILD
     ) {
       updateManager.reset();
     }
@@ -740,6 +755,7 @@ function AppContent() {
           setTrustActionNotice(response.reason);
           return false;
         }
+        envProgress.reset();
         return true;
       }
       // Untrusted - show dialog and mark pending start
@@ -748,7 +764,14 @@ function AppContent() {
       setTrustDialogOpen(true);
       return false;
     },
-    [sessionReady, checkTrust, launchKernel, setBlockedTrustAction, setTrustActionNotice],
+    [
+      sessionReady,
+      checkTrust,
+      launchKernel,
+      envProgress,
+      setBlockedTrustAction,
+      setTrustActionNotice,
+    ],
   );
 
   const performTrustedSyncDeps = useCallback(
@@ -1027,6 +1050,24 @@ function AppContent() {
     [setBlockedTrustAction],
   );
 
+  const handleEnvBuildDialogOpenChange = useCallback(
+    (open: boolean) => {
+      setEnvBuildDialogOpen(open);
+      if (!open) {
+        setDismissedEnvBuildDetails(errorDetails);
+      }
+    },
+    [errorDetails],
+  );
+
+  const handleEnvBuildRetry = useCallback(async () => {
+    setDismissedEnvBuildDetails(null);
+    const started = await tryStartKernel();
+    if (!started) {
+      setEnvBuildDialogOpen(true);
+    }
+  }, [tryStartKernel]);
+
   // Start kernel explicitly with pyproject.toml (user action from DependencyHeader)
   const handleStartKernelWithPyproject = useCallback(async () => {
     if (!sessionReady) {
@@ -1163,8 +1204,14 @@ function AppContent() {
       // Start kernel via daemon if not running or awaiting trust
       if (
         kernelStatus === KERNEL_STATUS.NOT_STARTED ||
-        kernelStatus === KERNEL_STATUS.AWAITING_TRUST
+        kernelStatus === KERNEL_STATUS.AWAITING_TRUST ||
+        kernelStatus === KERNEL_STATUS.AWAITING_ENV_BUILD
       ) {
+        if (kernelStatus === KERNEL_STATUS.AWAITING_ENV_BUILD) {
+          setDismissedEnvBuildDetails(null);
+          setEnvBuildDialogOpen(true);
+          return;
+        }
         const started = await tryStartKernel(captureRunAllTrustAction());
         if (!started) {
           logger.debug("[App] handleRunAllCells: kernel not started, skipping");
@@ -1710,6 +1757,12 @@ function AppContent() {
           approveOnlyLabel={trustApproveOnlyLabel}
           description={trustDialogDescription}
           approvalError={approvalError}
+        />
+        <EnvBuildDecisionDialog
+          open={envBuildDialogOpen}
+          onOpenChange={handleEnvBuildDialogOpenChange}
+          errorDetails={errorDetails}
+          onRetry={handleEnvBuildRetry}
         />
         <CrdtBridgeProvider
           getHandle={getHandle}

--- a/apps/notebook/src/components/EnvBuildDecisionDialog.tsx
+++ b/apps/notebook/src/components/EnvBuildDecisionDialog.tsx
@@ -1,0 +1,84 @@
+import { Copy, RotateCw, TerminalSquare } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { RuntimeDecisionDialog } from "./RuntimeDecisionDialog";
+
+interface EnvBuildDecisionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  errorDetails: string | null;
+  onRetry: () => void;
+}
+
+export function extractCondaEnvCreateCommand(details: string | null): string | null {
+  if (!details) return null;
+  const match = details.match(/conda env create -f .+$/m);
+  return match?.[0].trim() ?? null;
+}
+
+export function EnvBuildDecisionDialog({
+  open,
+  onOpenChange,
+  errorDetails,
+  onRetry,
+}: EnvBuildDecisionDialogProps) {
+  const [copied, setCopied] = useState(false);
+  const command = useMemo(() => extractCondaEnvCreateCommand(errorDetails), [errorDetails]);
+
+  const copyCommand = useCallback(async () => {
+    if (!command) return;
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+  }, [command]);
+
+  const retry = useCallback(() => {
+    setCopied(false);
+    onRetry();
+  }, [onRetry]);
+
+  return (
+    <RuntimeDecisionDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      testId="env-build-decision-dialog"
+      icon={<TerminalSquare className="size-5 text-amber-500" />}
+      title="Build environment.yml environment"
+      description="This notebook declares a conda environment that is not available on this machine."
+      footer={
+        <>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            data-testid="env-build-cancel-button"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={copyCommand}
+            disabled={!command}
+            data-testid="env-build-copy-button"
+          >
+            <Copy className="mr-2 size-4" />
+            {copied ? "Copied" : "Copy command"}
+          </Button>
+          <Button onClick={retry} data-testid="env-build-retry-button">
+            <RotateCw className="mr-2 size-4" />
+            Retry
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Build the declared environment in a terminal, then retry kernel launch.
+        </p>
+        {errorDetails && (
+          <pre className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words rounded-md border bg-muted/50 p-3 font-mono text-xs leading-relaxed">
+            {errorDetails}
+          </pre>
+        )}
+      </div>
+    </RuntimeDecisionDialog>
+  );
+}

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -18,11 +18,8 @@ import { Button } from "@/components/ui/button";
  * - Skip `runtime === "deno"`: toolbar renders the Deno
  *   "auto-install failed" prompt that already consumes it.
  *
- * Everything else — including `CondaEnvYmlMissing`, stderr tails from
- * generic subprocess crashes, env-build rate limits — falls through
- * to this banner. `CondaEnvYmlMissing`'s `error_details` carries the
- * conda env name + remediation command; surfacing that string in the
- * banner is a strict upgrade on the previous tooltip-only surface.
+ * Everything else — stderr tails from generic subprocess crashes,
+ * env-build rate limits — falls through to this banner.
  */
 export function shouldShowKernelLaunchErrorBanner(params: {
   lifecycle: RuntimeLifecycle;
@@ -33,6 +30,7 @@ export function shouldShowKernelLaunchErrorBanner(params: {
   if (params.lifecycle.lifecycle !== "Error") return false;
   if (!params.errorDetails || params.errorDetails.length === 0) return false;
   if (params.errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL) return false;
+  if (params.errorReason === KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING) return false;
   if (params.runtime === "deno") return false;
   return true;
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowDownToLine,
+  Copy,
   ChevronsRight,
   Code,
   Info,
@@ -23,6 +24,7 @@ import {
 } from "../lib/kernel-status";
 import type { KernelspecInfo } from "../types";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "./icons";
+import { extractCondaEnvCreateCommand } from "./EnvBuildDecisionDialog";
 
 /** Badge color variant for environment sources */
 type EnvBadgeVariant = "uv" | "conda" | "pixi";
@@ -82,12 +84,17 @@ export function NotebookToolbar({
   onRestartToUpdate,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
+  const [condaCommandCopied, setCondaCommandCopied] = useState(false);
 
   useEffect(() => {
     if (listKernelspecs) {
       listKernelspecs().then(setKernelspecs);
     }
   }, [listKernelspecs]);
+
+  useEffect(() => {
+    setCondaCommandCopied(false);
+  }, [kernelErrorMessage]);
 
   const handleStartKernel = useCallback(() => {
     // In daemon mode (no listKernelspecs), just call with empty name - backend auto-selects
@@ -127,6 +134,17 @@ export function NotebookToolbar({
     : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
       ? `Error \u2014 ${kernelErrorMessage}`
       : kernelStatusText;
+  const condaEnvCreateCommand = extractCondaEnvCreateCommand(kernelErrorMessage ?? null);
+  const showCondaEnvYmlMissingBanner =
+    runtime === "python" &&
+    lifecycle.lifecycle === "Error" &&
+    errorReason === KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING &&
+    !!kernelErrorMessage;
+  const copyCondaEnvCommand = useCallback(async () => {
+    if (!condaEnvCreateCommand) return;
+    await navigator.clipboard.writeText(condaEnvCreateCommand);
+    setCondaCommandCopied(true);
+  }, [condaEnvCreateCommand]);
 
   // Derive env manager label for the runtime pill (e.g. "uv", "conda", "pixi")
   const envManager: EnvBadgeVariant | null =
@@ -397,6 +415,14 @@ export function NotebookToolbar({
         errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL &&
         envSource &&
         renderMissingIpykernelPrompt(envSource)}
+      {showCondaEnvYmlMissingBanner && (
+        <CondaEnvYmlMissingBanner
+          details={kernelErrorMessage}
+          command={condaEnvCreateCommand}
+          copied={condaCommandCopied}
+          onCopyCommand={copyCondaEnvCommand}
+        />
+      )}
     </header>
   );
 }
@@ -445,6 +471,42 @@ function renderMissingIpykernelPrompt(envSource: string): ReactElement | null {
     );
   }
   return null;
+}
+
+function CondaEnvYmlMissingBanner({
+  details,
+  command,
+  copied,
+  onCopyCommand,
+}: {
+  details: string;
+  command: string | null;
+  copied: boolean;
+  onCopyCommand: () => void;
+}): ReactElement {
+  return (
+    <div className="border-t px-3 py-2" data-testid="conda-env-yml-missing-banner">
+      <div className="flex items-start justify-between gap-3 text-xs text-amber-800 dark:text-amber-300">
+        <div className="flex min-w-0 items-start gap-2">
+          <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span className="min-w-0">
+            <span className="font-medium">Conda environment not built.</span> <span>{details}</span>
+          </span>
+        </div>
+        {command && (
+          <button
+            type="button"
+            onClick={onCopyCommand}
+            className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-500/20 dark:text-amber-200"
+            data-testid="copy-conda-env-command"
+          >
+            <Copy className="h-3 w-3" />
+            {copied ? "Copied" : "Copy command"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function MissingIpykernelBanner({

--- a/apps/notebook/src/components/RuntimeDecisionDialog.tsx
+++ b/apps/notebook/src/components/RuntimeDecisionDialog.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface RuntimeDecisionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  description: ReactNode;
+  icon: ReactNode;
+  children: ReactNode;
+  footer: ReactNode;
+  testId?: string;
+}
+
+export function RuntimeDecisionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  icon,
+  children,
+  footer,
+  testId = "runtime-decision-dialog",
+}: RuntimeDecisionDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" showCloseButton={false} data-testid={testId}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {icon}
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {children}
+
+        <DialogFooter className="gap-2 sm:gap-0">{footer}</DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/notebook/src/components/TrustDialog.tsx
+++ b/apps/notebook/src/components/TrustDialog.tsx
@@ -1,15 +1,8 @@
 import { AlertTriangleIcon, PackageIcon, ShieldAlertIcon } from "lucide-react";
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import type { TrustInfo, TyposquatWarning } from "../hooks/useTrust";
+import { RuntimeDecisionDialog } from "./RuntimeDecisionDialog";
 
 interface TrustDialogProps {
   open: boolean;
@@ -96,114 +89,22 @@ export function TrustDialog({
   const isSignatureInvalid = trustInfo?.status === "signature_invalid";
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg" showCloseButton={false} data-testid="trust-dialog">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <ShieldAlertIcon className="size-5 text-amber-500" />
-            {isSignatureInvalid ? "Dependencies Modified" : "Review Dependencies"}
-          </DialogTitle>
-          <DialogDescription>
-            {description ??
-              (isSignatureInvalid
-                ? "This notebook's dependencies have been modified since you last approved them. Review and approve to continue."
-                : daemonMode
-                  ? "This notebook wants to install packages. Once approved, the kernel will start automatically."
-                  : "This notebook wants to install packages. Review them before running code.")}
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="max-h-[300px] overflow-y-auto space-y-4">
-          {approvalError && (
-            <div
-              className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
-              role="alert"
-            >
-              <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
-              <p className="text-sm text-amber-800 dark:text-amber-200">{approvalError}</p>
-            </div>
-          )}
-
-          {/* UV (PyPI) Dependencies */}
-          {trustInfo && trustInfo.uv_dependencies.length > 0 && (
-            <div>
-              <h4 className="text-sm font-medium text-muted-foreground mb-2">PyPI Packages</h4>
-              <div className="border rounded-md divide-y">
-                {trustInfo.uv_dependencies.map((pkg) => (
-                  <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Conda Dependencies */}
-          {trustInfo && trustInfo.conda_dependencies.length > 0 && (
-            <div>
-              <h4 className="text-sm font-medium text-muted-foreground mb-2">
-                Conda Packages
-                {trustInfo.conda_channels.length > 0 && (
-                  <span className="font-normal text-xs ml-2">
-                    ({trustInfo.conda_channels.join(", ")})
-                  </span>
-                )}
-              </h4>
-              <div className="border rounded-md divide-y">
-                {trustInfo.conda_dependencies.map((pkg) => (
-                  <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Pixi Dependencies */}
-          {trustInfo && trustInfo.pixi_dependencies.length > 0 && (
-            <div>
-              <h4 className="text-sm font-medium text-muted-foreground mb-2">
-                Pixi Packages
-                {trustInfo.pixi_channels.length > 0 && (
-                  <span className="font-normal text-xs ml-2">
-                    ({trustInfo.pixi_channels.join(", ")})
-                  </span>
-                )}
-              </h4>
-              <div className="border rounded-md divide-y">
-                {trustInfo.pixi_dependencies.map((pkg) => (
-                  <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Pixi PyPI Dependencies */}
-          {trustInfo && trustInfo.pixi_pypi_dependencies.length > 0 && (
-            <div>
-              <h4 className="text-sm font-medium text-muted-foreground mb-2">Pixi PyPI Packages</h4>
-              <div className="border rounded-md divide-y">
-                {trustInfo.pixi_pypi_dependencies.map((pkg) => (
-                  <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Typosquat Warning */}
-          {hasTyposquats && (
-            <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
-              <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
-              <div className="text-sm">
-                <p className="font-medium text-amber-800 dark:text-amber-200">
-                  Potential typosquatting detected
-                </p>
-                <p className="text-amber-700 dark:text-amber-300 mt-1">
-                  Some package names are similar to popular packages. Verify these are intentional
-                  before approving.
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <DialogFooter className="gap-2 sm:gap-0">
+    <RuntimeDecisionDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      testId="trust-dialog"
+      icon={<ShieldAlertIcon className="size-5 text-amber-500" />}
+      title={isSignatureInvalid ? "Dependencies Modified" : "Review Dependencies"}
+      description={
+        description ??
+        (isSignatureInvalid
+          ? "This notebook's dependencies have been modified since you last approved them. Review and approve to continue."
+          : daemonMode
+            ? "This notebook wants to install packages. Once approved, the kernel will start automatically."
+            : "This notebook wants to install packages. Review them before running code.")
+      }
+      footer={
+        <>
           <Button
             variant="outline"
             onClick={handleDecline}
@@ -227,8 +128,98 @@ export function TrustDialog({
               ? "Approving..."
               : (approveLabel ?? (daemonMode ? "Trust & Start" : "Trust & Install"))}
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </>
+      }
+    >
+      <div className="max-h-[300px] overflow-y-auto space-y-4">
+        {approvalError && (
+          <div
+            className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+            role="alert"
+          >
+            <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-800 dark:text-amber-200">{approvalError}</p>
+          </div>
+        )}
+
+        {/* UV (PyPI) Dependencies */}
+        {trustInfo && trustInfo.uv_dependencies.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">PyPI Packages</h4>
+            <div className="border rounded-md divide-y">
+              {trustInfo.uv_dependencies.map((pkg) => (
+                <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Conda Dependencies */}
+        {trustInfo && trustInfo.conda_dependencies.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              Conda Packages
+              {trustInfo.conda_channels.length > 0 && (
+                <span className="font-normal text-xs ml-2">
+                  ({trustInfo.conda_channels.join(", ")})
+                </span>
+              )}
+            </h4>
+            <div className="border rounded-md divide-y">
+              {trustInfo.conda_dependencies.map((pkg) => (
+                <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Pixi Dependencies */}
+        {trustInfo && trustInfo.pixi_dependencies.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              Pixi Packages
+              {trustInfo.pixi_channels.length > 0 && (
+                <span className="font-normal text-xs ml-2">
+                  ({trustInfo.pixi_channels.join(", ")})
+                </span>
+              )}
+            </h4>
+            <div className="border rounded-md divide-y">
+              {trustInfo.pixi_dependencies.map((pkg) => (
+                <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Pixi PyPI Dependencies */}
+        {trustInfo && trustInfo.pixi_pypi_dependencies.length > 0 && (
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">Pixi PyPI Packages</h4>
+            <div className="border rounded-md divide-y">
+              {trustInfo.pixi_pypi_dependencies.map((pkg) => (
+                <PackageItem key={pkg} pkg={pkg} warning={getWarning(pkg)} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Typosquat Warning */}
+        {hasTyposquats && (
+          <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <div className="text-sm">
+              <p className="font-medium text-amber-800 dark:text-amber-200">
+                Potential typosquatting detected
+              </p>
+              <p className="text-amber-700 dark:text-amber-300 mt-1">
+                Some package names are similar to popular packages. Verify these are intentional
+                before approving.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </RuntimeDecisionDialog>
   );
 }

--- a/apps/notebook/src/components/__tests__/env-build-decision-dialog.test.tsx
+++ b/apps/notebook/src/components/__tests__/env-build-decision-dialog.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { EnvBuildDecisionDialog, extractCondaEnvCreateCommand } from "../EnvBuildDecisionDialog";
+
+const DETAILS =
+  "environment.yml declares conda env 'analysis', which is not built on this machine. Run: conda env create -f /tmp/project/environment.yml";
+
+describe("extractCondaEnvCreateCommand", () => {
+  it("extracts only the terminal command from daemon details", () => {
+    expect(extractCondaEnvCreateCommand(DETAILS)).toBe(
+      "conda env create -f /tmp/project/environment.yml",
+    );
+  });
+
+  it("returns null when no command is present", () => {
+    expect(extractCondaEnvCreateCommand("environment missing")).toBeNull();
+  });
+
+  it("ignores text after the command line", () => {
+    expect(extractCondaEnvCreateCommand(`${DETAILS}\nNext step: restart the kernel`)).toBe(
+      "conda env create -f /tmp/project/environment.yml",
+    );
+  });
+});
+
+describe("EnvBuildDecisionDialog", () => {
+  it("renders the environment build decision details", () => {
+    render(
+      <EnvBuildDecisionDialog
+        open
+        onOpenChange={() => {}}
+        errorDetails={DETAILS}
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("env-build-decision-dialog")).toBeInTheDocument();
+    expect(screen.getByText("Build environment.yml environment")).toBeInTheDocument();
+    expect(screen.getByText(DETAILS)).toBeInTheDocument();
+  });
+
+  it("copies the extracted command", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <EnvBuildDecisionDialog
+        open
+        onOpenChange={() => {}}
+        errorDetails={DETAILS}
+        onRetry={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTestId("env-build-copy-button"));
+    expect(writeText).toHaveBeenCalledWith("conda env create -f /tmp/project/environment.yml");
+    expect(screen.getByText("Copied")).toBeInTheDocument();
+  });
+
+  it("invokes cancel and retry actions", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onRetry = vi.fn();
+
+    render(
+      <EnvBuildDecisionDialog
+        open
+        onOpenChange={onOpenChange}
+        errorDetails={DETAILS}
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.click(screen.getByTestId("env-build-cancel-button"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByTestId("env-build-retry-button"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables copy when details do not include a command", () => {
+    render(
+      <EnvBuildDecisionDialog
+        open
+        onOpenChange={() => {}}
+        errorDetails="environment.yml is missing a named env"
+        onRetry={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("env-build-copy-button")).toBeDisabled();
+  });
+});

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -132,10 +132,7 @@ describe("shouldShowKernelLaunchErrorBanner", () => {
     ).toBe(false);
   });
 
-  it("shows for CondaEnvYmlMissing — no dedicated UI exists yet", () => {
-    // Codex review on #2236: excluding this reason suppressed the only
-    // real rendered surface the daemon's `error_details` has.
-    // `environment.yml` unbuilt-env failures now use the generic banner.
+  it("hides for CondaEnvYmlMissing (toolbar and env-build dialog own that UX)", () => {
     expect(
       shouldShowKernelLaunchErrorBanner({
         lifecycle: ERROR,
@@ -144,7 +141,7 @@ describe("shouldShowKernelLaunchErrorBanner", () => {
         errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
         runtime: "python",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("hides for Deno runtime (toolbar renders its own install prompt)", () => {

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -46,6 +46,7 @@ const STATUS_KEY_FOR: Record<KernelStatus, RuntimeStatusKey> = {
   [KERNEL_STATUS.ERROR]: RUNTIME_STATUS.ERROR,
   [KERNEL_STATUS.SHUTDOWN]: RUNTIME_STATUS.SHUTDOWN,
   [KERNEL_STATUS.AWAITING_TRUST]: RUNTIME_STATUS.AWAITING_TRUST,
+  [KERNEL_STATUS.AWAITING_ENV_BUILD]: RUNTIME_STATUS.AWAITING_ENV_BUILD,
 };
 
 function propsForStatus(status: KernelStatus) {
@@ -468,6 +469,69 @@ describe("NotebookToolbar", () => {
       );
       expect(screen.queryByText(/ipykernel missing from/)).not.toBeInTheDocument();
       expect(screen.queryByText(/ipykernel not found/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("environment.yml missing conda env prompt", () => {
+    const errorLifecycle: RuntimeLifecycle = { lifecycle: "Error" };
+    const details =
+      "environment.yml declares conda env 'analysis', which is not built on this machine. Run: conda env create -f /tmp/project/environment.yml";
+
+    it("shows the conda env missing banner with daemon details", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          statusKey={RUNTIME_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING}
+          kernelErrorMessage={details}
+        />,
+      );
+
+      expect(screen.getByTestId("conda-env-yml-missing-banner")).toBeInTheDocument();
+      expect(screen.getByText(details)).toBeInTheDocument();
+    });
+
+    it("copies only the conda env create command", async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          statusKey={RUNTIME_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING}
+          kernelErrorMessage={details}
+        />,
+      );
+
+      await user.click(screen.getByTestId("copy-conda-env-command"));
+      expect(writeText).toHaveBeenCalledWith("conda env create -f /tmp/project/environment.yml");
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    });
+
+    it("does not show the banner outside the typed conda env error", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          statusKey={RUNTIME_STATUS.ERROR}
+          lifecycle={errorLifecycle}
+          errorReason={null}
+          kernelErrorMessage={details}
+        />,
+      );
+      expect(screen.queryByTestId("conda-env-yml-missing-banner")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/notebook/src/lib/__tests__/kernel-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/kernel-status.test.ts
@@ -28,8 +28,8 @@ describe("isKernelStatus", () => {
 });
 
 describe("KERNEL_STATUS", () => {
-  it("contains exactly seven statuses", () => {
-    expect(Object.keys(KERNEL_STATUS)).toHaveLength(7);
+  it("contains exactly eight statuses", () => {
+    expect(Object.keys(KERNEL_STATUS)).toHaveLength(8);
   });
 
   it("has expected values", () => {
@@ -40,6 +40,7 @@ describe("KERNEL_STATUS", () => {
     expect(KERNEL_STATUS.ERROR).toBe("error");
     expect(KERNEL_STATUS.SHUTDOWN).toBe("shutdown");
     expect(KERNEL_STATUS.AWAITING_TRUST).toBe("awaiting_trust");
+    expect(KERNEL_STATUS.AWAITING_ENV_BUILD).toBe("awaiting_env_build");
   });
 });
 
@@ -48,6 +49,11 @@ describe("getLifecycleLabel", () => {
     const cases: [RuntimeLifecycle, string | null, string][] = [
       [{ lifecycle: "NotStarted" }, null, RUNTIME_STATUS_LABELS[RUNTIME_STATUS.NOT_STARTED]],
       [{ lifecycle: "AwaitingTrust" }, null, RUNTIME_STATUS_LABELS[RUNTIME_STATUS.AWAITING_TRUST]],
+      [
+        { lifecycle: "AwaitingEnvBuild" },
+        null,
+        RUNTIME_STATUS_LABELS[RUNTIME_STATUS.AWAITING_ENV_BUILD],
+      ],
       [{ lifecycle: "Resolving" }, null, RUNTIME_STATUS_LABELS[RUNTIME_STATUS.RESOLVING]],
       [{ lifecycle: "PreparingEnv" }, null, RUNTIME_STATUS_LABELS[RUNTIME_STATUS.PREPARING_ENV]],
       [{ lifecycle: "Launching" }, null, RUNTIME_STATUS_LABELS[RUNTIME_STATUS.LAUNCHING]],

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -36,6 +36,7 @@ import {
 export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
   [RUNTIME_STATUS.NOT_STARTED]: "initializing",
   [RUNTIME_STATUS.AWAITING_TRUST]: "awaiting approval",
+  [RUNTIME_STATUS.AWAITING_ENV_BUILD]: "awaiting environment build",
   [RUNTIME_STATUS.RESOLVING]: "resolving environment",
   [RUNTIME_STATUS.PREPARING_ENV]: "preparing environment",
   [RUNTIME_STATUS.LAUNCHING]: "launching kernel",

--- a/crates/notebook/fixtures/env-build-decision/01-missing-named-env/awaiting-env-build.ipynb
+++ b/crates/notebook/fixtures/env-build-decision/01-missing-named-env/awaiting-env-build.ipynb
@@ -1,0 +1,39 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Missing named conda env\n",
+        "\n",
+        "This notebook should pause in the environment build decision state because `environment.yml` names an env that should not exist locally."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "print-env",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os, sys\n",
+        "print(sys.executable)\n",
+        "print(os.environ.get(\"CONDA_DEFAULT_ENV\"))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/env-build-decision/01-missing-named-env/environment.yml
+++ b/crates/notebook/fixtures/env-build-decision/01-missing-named-env/environment.yml
@@ -1,0 +1,8 @@
+name: nteract-qa-missing-env-alpha
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - ipykernel
+  - pandas
+  - matplotlib

--- a/crates/notebook/fixtures/env-build-decision/02-missing-named-env-yaml/awaiting-env-build-yaml.ipynb
+++ b/crates/notebook/fixtures/env-build-decision/02-missing-named-env-yaml/awaiting-env-build-yaml.ipynb
@@ -1,0 +1,38 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Missing named conda env with .yaml extension\n",
+        "\n",
+        "This exercises project-file detection for `environment.yaml`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "numpy-check",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "print(sys.version)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/env-build-decision/02-missing-named-env-yaml/environment.yaml
+++ b/crates/notebook/fixtures/env-build-decision/02-missing-named-env-yaml/environment.yaml
@@ -1,0 +1,7 @@
+name: nteract-qa-missing-env-beta
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - ipykernel
+  - numpy

--- a/crates/notebook/fixtures/env-build-decision/03-missing-named-env-with-pip/awaiting-env-build-pip.ipynb
+++ b/crates/notebook/fixtures/env-build-decision/03-missing-named-env-with-pip/awaiting-env-build-pip.ipynb
@@ -1,0 +1,38 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Missing named conda env with pip subsection\n",
+        "\n",
+        "This should still use the missing named-env decision state and preserve the create command."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "rich-check",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from rich import print\n",
+        "print({\"fixture\": \"pip-subsection\"})"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/env-build-decision/03-missing-named-env-with-pip/environment.yml
+++ b/crates/notebook/fixtures/env-build-decision/03-missing-named-env-with-pip/environment.yml
@@ -1,0 +1,9 @@
+name: nteract-qa-missing-env-pip
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - ipykernel
+  - pip
+  - pip:
+      - rich==13.9.4

--- a/crates/notebook/fixtures/env-build-decision/04-no-name-control/environment.yml
+++ b/crates/notebook/fixtures/env-build-decision/04-no-name-control/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - ipykernel
+  - six

--- a/crates/notebook/fixtures/env-build-decision/04-no-name-control/no-name-control.ipynb
+++ b/crates/notebook/fixtures/env-build-decision/04-no-name-control/no-name-control.ipynb
@@ -1,0 +1,38 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# No-name environment.yml control\n",
+        "\n",
+        "This env file intentionally has no `name` or `prefix`; it should not trigger the named missing-env decision dialog."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "control",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import sys\n",
+        "print(\"control\", sys.executable)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/env-build-decision/README.md
+++ b/crates/notebook/fixtures/env-build-decision/README.md
@@ -1,0 +1,20 @@
+# Environment Build Decision Fixtures
+
+These notebooks exercise the `environment.yml` missing-env UX.
+
+Open the notebooks with Cmd-O from a dev build of the notebook app.
+
+Expected behavior:
+
+- `01-missing-named-env/awaiting-env-build.ipynb`: shows the environment build decision dialog for `nteract-qa-missing-env-alpha`.
+- `02-missing-named-env-yaml/awaiting-env-build-yaml.ipynb`: shows the same decision flow, using `environment.yaml`.
+- `03-missing-named-env-with-pip/awaiting-env-build-pip.ipynb`: shows the same decision flow with a pip subsection.
+- `04-no-name-control/no-name-control.ipynb`: control case. The env file has no `name` or `prefix`, so it must not show the named missing-env dialog.
+
+Reset any created test envs before rerunning the missing-env cases:
+
+```bash
+conda env remove -n nteract-qa-missing-env-alpha -y || true
+conda env remove -n nteract-qa-missing-env-beta -y || true
+conda env remove -n nteract-qa-missing-env-pip -y || true
+```

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -8,7 +8,7 @@
 //! ```text
 //! ROOT/
 //!   kernel/
-//!     lifecycle: Str       ("NotStarted" | "AwaitingTrust" | "Resolving" | "PreparingEnv"
+//!     lifecycle: Str       ("NotStarted" | "AwaitingTrust" | "AwaitingEnvBuild" | "Resolving" | "PreparingEnv"
 //!                           | "Launching" | "Connecting" | "Running" | "Error" | "Shutdown")
 //!     activity: Str        ("" | "Unknown" | "Idle" | "Busy") — only meaningful when lifecycle == "Running"
 //!     error_reason: Str    ("" unless lifecycle == "Error")
@@ -891,9 +891,10 @@ impl RuntimeStateDoc {
     }
 
     /// Like [`set_lifecycle_with_error`] but also writes a free-form
-    /// `error_details` string alongside the typed reason. Use for errors
-    /// where the user-facing banner needs specifics that don't fit in
-    /// [`KernelErrorReason`] — e.g., the name of a missing conda env.
+    /// `error_details` string alongside the typed reason. Use for typed
+    /// failure or user-decision states where the UI needs specifics that
+    /// don't fit in [`KernelErrorReason`] — e.g., the name of a missing
+    /// conda env.
     ///
     /// - `Some(details)` records the explanation (non-empty recommended).
     /// - `None` clears `error_details` to `""`.
@@ -4958,6 +4959,7 @@ mod tests {
         let variants = [
             RuntimeLifecycle::NotStarted,
             RuntimeLifecycle::AwaitingTrust,
+            RuntimeLifecycle::AwaitingEnvBuild,
             RuntimeLifecycle::Resolving,
             RuntimeLifecycle::PreparingEnv,
             RuntimeLifecycle::Launching,
@@ -5035,6 +5037,7 @@ mod tests {
             RuntimeLifecycle::Resolving,
             RuntimeLifecycle::Running(KernelActivity::Busy),
             RuntimeLifecycle::Running(KernelActivity::Unknown),
+            RuntimeLifecycle::AwaitingEnvBuild,
             RuntimeLifecycle::Error,
             RuntimeLifecycle::Shutdown,
         ] {

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -252,6 +252,7 @@ pub enum RuntimeLifecycle {
     #[default]
     NotStarted,
     AwaitingTrust,
+    AwaitingEnvBuild,
     Resolving,
     PreparingEnv,
     Launching,
@@ -271,6 +272,7 @@ impl RuntimeLifecycle {
         match self {
             Self::NotStarted => "NotStarted",
             Self::AwaitingTrust => "AwaitingTrust",
+            Self::AwaitingEnvBuild => "AwaitingEnvBuild",
             Self::Resolving => "Resolving",
             Self::PreparingEnv => "PreparingEnv",
             Self::Launching => "Launching",
@@ -290,6 +292,7 @@ impl RuntimeLifecycle {
         match lifecycle {
             "NotStarted" => Some(Self::NotStarted),
             "AwaitingTrust" => Some(Self::AwaitingTrust),
+            "AwaitingEnvBuild" => Some(Self::AwaitingEnvBuild),
             "Resolving" => Some(Self::Resolving),
             "PreparingEnv" => Some(Self::PreparingEnv),
             "Launching" => Some(Self::Launching),
@@ -329,6 +332,7 @@ impl RuntimeLifecycle {
             "error" => Self::Error,
             "shutdown" => Self::Shutdown,
             "awaiting_trust" => Self::AwaitingTrust,
+            "awaiting_env_build" => Self::AwaitingEnvBuild,
             _ => Self::NotStarted,
         }
     }
@@ -345,6 +349,7 @@ impl RuntimeLifecycle {
         match self {
             Self::NotStarted => ("not_started", ""),
             Self::AwaitingTrust => ("awaiting_trust", ""),
+            Self::AwaitingEnvBuild => ("awaiting_env_build", ""),
             Self::Resolving => ("starting", "resolving"),
             Self::PreparingEnv => ("starting", "preparing_env"),
             Self::Launching => ("starting", "launching"),
@@ -438,6 +443,10 @@ mod tests {
             KernelErrorReason::MissingIpykernel.as_str(),
             "missing_ipykernel"
         );
+        assert_eq!(
+            KernelErrorReason::CondaEnvYmlMissing.as_str(),
+            "conda_env_yml_missing"
+        );
     }
 
     #[test]
@@ -445,6 +454,10 @@ mod tests {
         assert_eq!(
             KernelErrorReason::parse("missing_ipykernel"),
             Some(KernelErrorReason::MissingIpykernel)
+        );
+        assert_eq!(
+            KernelErrorReason::parse("conda_env_yml_missing"),
+            Some(KernelErrorReason::CondaEnvYmlMissing)
         );
         assert_eq!(KernelErrorReason::parse(""), None);
         assert_eq!(KernelErrorReason::parse("bogus"), None);
@@ -455,7 +468,10 @@ mod tests {
 
     #[test]
     fn error_reason_as_str_round_trips_through_parse() {
-        let reasons = [KernelErrorReason::MissingIpykernel];
+        let reasons = [
+            KernelErrorReason::MissingIpykernel,
+            KernelErrorReason::CondaEnvYmlMissing,
+        ];
         for r in reasons {
             assert_eq!(KernelErrorReason::parse(r.as_str()), Some(r));
         }
@@ -477,6 +493,7 @@ mod tests {
         use RuntimeLifecycle::*;
         assert_eq!(NotStarted.variant_str(), "NotStarted");
         assert_eq!(AwaitingTrust.variant_str(), "AwaitingTrust");
+        assert_eq!(AwaitingEnvBuild.variant_str(), "AwaitingEnvBuild");
         assert_eq!(Resolving.variant_str(), "Resolving");
         assert_eq!(PreparingEnv.variant_str(), "PreparingEnv");
         assert_eq!(Launching.variant_str(), "Launching");
@@ -493,6 +510,10 @@ mod tests {
         assert_eq!(
             RuntimeLifecycle::parse("AwaitingTrust", ""),
             Some(AwaitingTrust)
+        );
+        assert_eq!(
+            RuntimeLifecycle::parse("AwaitingEnvBuild", ""),
+            Some(AwaitingEnvBuild)
         );
         assert_eq!(RuntimeLifecycle::parse("Resolving", ""), Some(Resolving));
         assert_eq!(
@@ -554,6 +575,7 @@ mod tests {
         use RuntimeLifecycle::*;
         assert_eq!(NotStarted.to_legacy(), ("not_started", ""));
         assert_eq!(AwaitingTrust.to_legacy(), ("awaiting_trust", ""));
+        assert_eq!(AwaitingEnvBuild.to_legacy(), ("awaiting_env_build", ""));
         assert_eq!(Resolving.to_legacy(), ("starting", "resolving"));
         assert_eq!(PreparingEnv.to_legacy(), ("starting", "preparing_env"));
         assert_eq!(Launching.to_legacy(), ("starting", "launching"));

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -840,7 +840,7 @@ impl ExecutionResult {
 #[derive(Clone, Debug)]
 pub struct PyKernelState {
     /// Flat status string: "not_started", "starting", "idle", "busy",
-    /// "error", "shutdown", "awaiting_trust". Projected from
+    /// "error", "shutdown", "awaiting_trust", "awaiting_env_build". Projected from
     /// [`RuntimeLifecycle::to_legacy`] for callers that want a simple
     /// string bucket; use `lifecycle` for the full typed variant.
     pub status: String,
@@ -848,19 +848,22 @@ pub struct PyKernelState {
     /// "connecting". Only non-empty when `status == "starting"`.
     pub starting_phase: String,
     /// Typed lifecycle variant name: "NotStarted", "AwaitingTrust",
-    /// "Resolving", "PreparingEnv", "Launching", "Connecting", "Running",
-    /// "Error", "Shutdown". Paired with `activity` when "Running".
+    /// "AwaitingEnvBuild", "Resolving", "PreparingEnv", "Launching",
+    /// "Connecting", "Running", "Error", "Shutdown". Paired with
+    /// `activity` when "Running".
     pub lifecycle: String,
     /// Activity sub-state when `lifecycle == "Running"`: "Unknown",
     /// "Idle", "Busy". Empty string otherwise.
     pub activity: String,
-    /// Typed error reason when `lifecycle == "Error"`. `None` when the
-    /// CRDT key is absent (pre-migration doc); `Some("")` when the key is
-    /// scaffolded but no reason has been recorded.
+    /// Typed reason for lifecycle states that carry a specific cause
+    /// (`Error`, `AwaitingEnvBuild`). `None` when the CRDT key is absent
+    /// (pre-migration doc); `Some("")` when the key is scaffolded but no
+    /// reason has been recorded.
     pub error_reason: Option<String>,
-    /// Free-form details accompanying an error, shown to the user via
-    /// the frontend banner and surfaced to MCP tools. `None` when the
-    /// CRDT key is absent; `Some("")` when scaffolded but unset.
+    /// Free-form details accompanying an error or user-decision state,
+    /// shown to the user via the frontend banner/dialog and surfaced to MCP
+    /// tools. `None` when the CRDT key is absent; `Some("")` when scaffolded
+    /// but unset.
     pub error_details: Option<String>,
     /// Kernel display name (e.g. "charming-toucan")
     pub name: String,

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -285,7 +285,7 @@ fn hydrate_kernel_state(state: &mut SessionState) {
     };
     // A kernel is "usable" once it's running or mid-launch. That covers
     // every lifecycle variant except `NotStarted`, `AwaitingTrust`,
-    // `Error`, and `Shutdown`.
+    // `AwaitingEnvBuild`, `Error`, and `Shutdown`.
     let running = matches!(
         rs.kernel.lifecycle,
         RuntimeLifecycle::Running(_)
@@ -353,6 +353,7 @@ async fn ensure_create_runtime_ready(
             }
             RuntimeLifecycle::NotStarted
             | RuntimeLifecycle::AwaitingTrust
+            | RuntimeLifecycle::AwaitingEnvBuild
             | RuntimeLifecycle::Shutdown => {
                 if !forced_launch {
                     start_kernel(state, &runtime, "auto", None).await?;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -928,9 +928,9 @@ pub(crate) fn missing_conda_env_yml_name(
         }
     }
     // Declared but not built. Prefer the `name:` for display, fall back
-    // to the `prefix:` path, then to a placeholder if env.yml has
-    // neither (the kernel path's existing error handles the
-    // shape-broken case; we still want a useful banner).
+    // to the `prefix:` path. If env.yml has neither, leave it to the
+    // existing conda:env_yml launch path instead of inventing a fake
+    // named-env decision for an unnamed spec.
     let config = crate::project_file::parse_environment_yml(&detected.path).ok();
     if let Some(ref c) = config {
         if let Some(ref name) = c.name {
@@ -940,7 +940,7 @@ pub(crate) fn missing_conda_env_yml_name(
             return Some(prefix.display().to_string());
         }
     }
-    Some(String::from("(unnamed)"))
+    None
 }
 
 /// Check whether a notebook's inline dependency list exactly matches a
@@ -2572,14 +2572,14 @@ pub(crate) async fn auto_launch_kernel(
         }
     }
 
-    // #2157: If the detected project file is an environment.yml whose
-    // declared conda env isn't built on this machine, surface a typed
-    // error instead of spawning a runtime agent that would die with
+    // #2157/#2170: If the detected project file is an environment.yml whose
+    // declared conda env isn't built on this machine, surface an explicit
+    // awaiting-user-decision lifecycle instead of spawning a runtime agent that would die with
     // "could not resolve conda environment prefix". Silent fallback to
     // a pool env was rejected as user-hostile: env.yml users expect
     // their declared deps to be installed, and a pool env lacks them.
-    // Writing Error + details gives the frontend enough to render a
-    // specific banner and MCP tools enough to report the miss.
+    // Writing AwaitingEnvBuild + details gives the frontend enough to
+    // render a cohesive decision dialog and MCP tools enough to report the miss.
     if let Some(ref detected) = detected_project_file {
         if let Some(env_name) = missing_conda_env_yml_name(detected) {
             let yml_path = detected.path.display().to_string();
@@ -2590,7 +2590,7 @@ pub(crate) async fn auto_launch_kernel(
             warn!("[notebook-sync] {}", details);
             if let Err(e) = room.state.with_doc(|sd| {
                 sd.set_lifecycle_with_error_details(
-                    &RuntimeLifecycle::Error,
+                    &RuntimeLifecycle::AwaitingEnvBuild,
                     Some(runtime_doc::KernelErrorReason::CondaEnvYmlMissing),
                     Some(&details),
                 )
@@ -3039,6 +3039,203 @@ pub(crate) async fn auto_launch_kernel(
             }
         } else {
             (pooled_env, None)
+        }
+    } else if matches!(env_source, EnvSource::EnvYml) {
+        let yml_path = detected_project_file
+            .as_ref()
+            .filter(|d| d.kind == crate::project_file::ProjectFileKind::EnvironmentYml)
+            .map(|d| d.path.clone())
+            .or_else(|| {
+                notebook_path_opt.as_ref().and_then(|p| {
+                    crate::project_file::find_nearest_project_file(
+                        p,
+                        &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                    )
+                    .map(|d| d.path)
+                })
+            });
+
+        let Some(yml_path) = yml_path else {
+            warn!("[notebook-sync] conda:env_yml but no environment.yml found");
+            reset_starting_state(room, None).await;
+            return;
+        };
+
+        let detected_yml = crate::project_file::DetectedProjectFile {
+            path: yml_path.clone(),
+            kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+        };
+        if let Some(env_name) = missing_conda_env_yml_name(&detected_yml) {
+            let details = format!(
+                "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
+                env_name,
+                yml_path.display()
+            );
+            warn!("[notebook-sync] {}", details);
+            if let Err(e) = room.state.with_doc(|sd| {
+                sd.set_lifecycle_with_error_details(
+                    &RuntimeLifecycle::AwaitingEnvBuild,
+                    Some(KernelErrorReason::CondaEnvYmlMissing),
+                    Some(&details),
+                )
+            }) {
+                warn!("[runtime-state] {}", e);
+            }
+            return;
+        }
+
+        let env_config = match crate::project_file::parse_environment_yml(&yml_path) {
+            Ok(config) => config,
+            Err(e) => {
+                error!("[notebook-sync] Failed to parse environment.yml: {}", e);
+                reset_starting_state(room, None).await;
+                return;
+            }
+        };
+
+        let conda_prefix = if let Some(ref prefix) = env_config.prefix {
+            prefix.clone()
+        } else if let Some(ref name) = env_config.name {
+            crate::project_file::find_named_conda_env(name)
+                .unwrap_or_else(|| crate::project_file::default_conda_envs_dir().join(name))
+        } else {
+            let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
+            let conda_deps_tmp = kernel_env::CondaDependencies {
+                dependencies: env_config.dependencies.clone(),
+                channels: env_config.channels.clone(),
+                python: env_config.python.clone(),
+                env_id: None,
+            };
+            cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
+        };
+
+        let mut all_deps = env_config.dependencies.clone();
+        if let Some(crdt_deps) = metadata_snapshot.as_ref().and_then(get_inline_conda_deps) {
+            let base_names: std::collections::HashSet<String> = all_deps
+                .iter()
+                .map(|d| notebook_doc::metadata::extract_package_name(d).to_lowercase())
+                .collect();
+            for dep in &crdt_deps {
+                let name = notebook_doc::metadata::extract_package_name(dep).to_lowercase();
+                if !base_names.contains(&name) {
+                    all_deps.push(dep.clone());
+                }
+            }
+        }
+
+        let base_names: std::collections::HashSet<String> = all_deps
+            .iter()
+            .map(|d| notebook_doc::metadata::extract_package_name(d).to_lowercase())
+            .collect();
+        if !base_names.contains("ipykernel") {
+            all_deps.push("ipykernel".to_string());
+        }
+
+        let channels = if env_config.channels.is_empty() {
+            vec!["conda-forge".to_string()]
+        } else {
+            env_config.channels.clone()
+        };
+
+        let env_name_display = env_config.name.as_deref().unwrap_or("<unnamed>");
+        info!(
+            "[notebook-sync] conda:env_yml: env '{}' at {:?} with {} deps",
+            env_name_display,
+            conda_prefix,
+            all_deps.len()
+        );
+
+        let conda_deps = kernel_env::CondaDependencies {
+            dependencies: all_deps,
+            channels,
+            python: env_config.python.clone(),
+            env_id: None,
+        };
+
+        let python_path = crate::project_file::conda_python_path(&conda_prefix);
+        if python_path.exists() {
+            let conda_env = kernel_env::CondaEnvironment {
+                env_path: conda_prefix.clone(),
+                python_path: python_path.clone(),
+            };
+            progress_handler.on_progress(
+                "conda",
+                kernel_env::EnvProgressPhase::Installing {
+                    total: conda_deps.dependencies.len(),
+                },
+            );
+            if let Err(e) = kernel_env::conda::sync_dependencies(&conda_env, &conda_deps).await {
+                warn!(
+                    "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
+                    e
+                );
+            }
+            let env = Some(crate::PooledEnv {
+                env_type: crate::EnvType::Conda,
+                venv_path: conda_prefix,
+                python_path,
+                prewarmed_packages: vec![],
+            });
+            (
+                env,
+                metadata_snapshot.as_ref().and_then(get_inline_conda_deps),
+            )
+        } else {
+            let parent = conda_prefix
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("/tmp"));
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                error!(
+                    "[notebook-sync] Failed to create conda envs directory {:?}: {}",
+                    parent, e
+                );
+                reset_starting_state(room, None).await;
+                return;
+            }
+
+            match kernel_env::conda::prepare_environment_in(
+                &conda_deps,
+                parent,
+                progress_handler.clone(),
+            )
+            .await
+            {
+                Ok(prepared) => {
+                    let final_prefix = if prepared.env_path != conda_prefix {
+                        match tokio::fs::rename(&prepared.env_path, &conda_prefix).await {
+                            Ok(()) => conda_prefix.clone(),
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync] Failed to rename {:?} -> {:?}: {}, using hash path",
+                                    prepared.env_path, conda_prefix, e
+                                );
+                                prepared.env_path
+                            }
+                        }
+                    } else {
+                        prepared.env_path
+                    };
+                    let python = crate::project_file::conda_python_path(&final_prefix);
+                    let env = Some(crate::PooledEnv {
+                        env_type: crate::EnvType::Conda,
+                        venv_path: final_prefix,
+                        python_path: python,
+                        prewarmed_packages: vec![],
+                    });
+                    (
+                        env,
+                        metadata_snapshot.as_ref().and_then(get_inline_conda_deps),
+                    )
+                }
+                Err(e) => {
+                    error!(
+                        "[notebook-sync] Failed to create conda env '{}' from environment.yml: {}",
+                        env_name_display, e
+                    );
+                    reset_starting_state(room, None).await;
+                    return;
+                }
+            }
         }
     } else if matches!(env_source, EnvSource::Inline(PackageManager::Pixi)) {
         // pixi exec handles its own env caching — just extract deps for the -w flags

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5968,6 +5968,26 @@ fn test_missing_conda_env_yml_name_skips_non_envyml() {
     assert_eq!(missing_conda_env_yml_name(&detected), None);
 }
 
+#[test]
+fn test_missing_conda_env_yml_name_skips_unnamed_envyml() {
+    let tmp = tempfile::tempdir().unwrap();
+    let yml_path = tmp.path().join("environment.yml");
+    std::fs::write(
+        &yml_path,
+        "channels:\n  - conda-forge\ndependencies:\n  - python\n  - ipykernel\n",
+    )
+    .unwrap();
+    let detected = crate::project_file::DetectedProjectFile {
+        path: yml_path,
+        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+    };
+    assert_eq!(
+        missing_conda_env_yml_name(&detected),
+        None,
+        "unnamed environment.yml should not enter the named-env build decision flow",
+    );
+}
+
 /// Codex P2 on #2167: `prefix:` pointing at a non-existent path must
 /// be reported as missing so `auto_launch_kernel` surfaces the typed
 /// error instead of letting the runtime agent die with the generic

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -18,10 +18,11 @@ use crate::notebook_sync_server::{
     acquire_prewarmed_env_with_capture, build_launched_config, captured_env_for_runtime,
     captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
     extract_pixi_toml_deps, get_inline_conda_channels, get_inline_conda_deps, get_inline_uv_deps,
-    get_inline_uv_prerelease, promote_inline_deps_to_project, publish_kernel_state_presence,
-    reset_starting_state, reset_starting_state_with_outcome, resolve_metadata_snapshot,
-    send_runtime_agent_request, try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps,
-    unified_env_on_disk, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
+    get_inline_uv_prerelease, missing_conda_env_yml_name, promote_inline_deps_to_project,
+    publish_kernel_state_presence, reset_starting_state, reset_starting_state_with_outcome,
+    resolve_metadata_snapshot, send_runtime_agent_request, try_conda_pool_for_inline_deps,
+    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
+    ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -107,6 +108,7 @@ pub(crate) async fn handle(
                             | RuntimeLifecycle::Error
                             | RuntimeLifecycle::Shutdown
                             | RuntimeLifecycle::NotStarted
+                            | RuntimeLifecycle::AwaitingEnvBuild
                     ) {
                         return lc;
                     }
@@ -127,7 +129,7 @@ pub(crate) async fn handle(
             }
         }
         _ => {
-            // Not_started / Error / Shutdown / AwaitingTrust — already
+            // NotStarted / Error / Shutdown / AwaitingTrust / AwaitingEnvBuild — already
             // claimed above by writing Resolving; fall through.
         }
     }
@@ -871,6 +873,29 @@ pub(crate) async fn handle(
         if let Some(ref yml) = yml_path {
             match crate::project_file::parse_environment_yml(yml) {
                 Ok(env_config) => {
+                    let detected_yml = crate::project_file::DetectedProjectFile {
+                        path: yml.clone(),
+                        kind: crate::project_file::ProjectFileKind::EnvironmentYml,
+                    };
+                    if let Some(env_name) = missing_conda_env_yml_name(&detected_yml) {
+                        let details = format!(
+                            "environment.yml declares conda env '{}', which is not built on this machine. Run: conda env create -f {}",
+                            env_name,
+                            yml.display()
+                        );
+                        warn!("[notebook-sync] {}", details);
+                        if let Err(e) = room.state.with_doc(|sd| {
+                            sd.set_lifecycle_with_error_details(
+                                &RuntimeLifecycle::AwaitingEnvBuild,
+                                Some(KernelErrorReason::CondaEnvYmlMissing),
+                                Some(&details),
+                            )
+                        }) {
+                            warn!("[runtime-state] {}", e);
+                        }
+                        return NotebookResponse::Error { error: details };
+                    }
+
                     // Resolve the conda prefix: prefix: → direct path,
                     // name: → search standard dirs, create if not found.
                     let conda_prefix = if let Some(ref prefix) = env_config.prefix {

--- a/packages/runtimed/src/derived-state.ts
+++ b/packages/runtimed/src/derived-state.ts
@@ -10,7 +10,7 @@ import type { QueueEntry, RuntimeState } from "./runtime-state";
 // ── Kernel status ───────────────────────────────────────────────────
 
 /**
- * Compressed seven-state status vocabulary for UI-level conditionals.
+ * Compressed status vocabulary for UI-level conditionals.
  *
  * `KERNEL_STATUS` groups the full [`RuntimeLifecycle`] union into buckets
  * that map cleanly onto common UI predicates: a single "starting" bucket
@@ -28,6 +28,7 @@ export const KERNEL_STATUS = {
   ERROR: "error",
   SHUTDOWN: "shutdown",
   AWAITING_TRUST: "awaiting_trust",
+  AWAITING_ENV_BUILD: "awaiting_env_build",
 } as const;
 
 export type KernelStatus = (typeof KERNEL_STATUS)[keyof typeof KERNEL_STATUS];
@@ -198,7 +199,8 @@ export function deriveEnvSyncState(state: RuntimeState): EnvSyncState | null {
     (lc === "NotStarted" && !state.kernel.env_source) ||
     lc === "Shutdown" ||
     lc === "Error" ||
-    lc === "AwaitingTrust"
+    lc === "AwaitingTrust" ||
+    lc === "AwaitingEnvBuild"
   ) {
     return null;
   }
@@ -232,6 +234,8 @@ export function lifecycleToLegacyStatus(lc: RuntimeState["kernel"]["lifecycle"])
       return KERNEL_STATUS.NOT_STARTED;
     case "AwaitingTrust":
       return KERNEL_STATUS.AWAITING_TRUST;
+    case "AwaitingEnvBuild":
+      return KERNEL_STATUS.AWAITING_ENV_BUILD;
     case "Resolving":
     case "PreparingEnv":
     case "Launching":
@@ -260,12 +264,13 @@ export function lifecycleToLegacyStatus(lc: RuntimeState["kernel"]["lifecycle"])
  *
  * Use this for CSS classes, icon tables, label tables, and any other
  * lookup keyed on "what is the runtime doing right now." Use
- * [`KERNEL_STATUS`] when the simpler seven-bucket shape matches your
+ * [`KERNEL_STATUS`] when the simpler bucket shape matches your
  * UI predicate.
  */
 export const RUNTIME_STATUS = {
   NOT_STARTED: "not_started",
   AWAITING_TRUST: "awaiting_trust",
+  AWAITING_ENV_BUILD: "awaiting_env_build",
   RESOLVING: "resolving",
   PREPARING_ENV: "preparing_env",
   LAUNCHING: "launching",
@@ -291,6 +296,8 @@ export function runtimeStatusKey(lc: RuntimeState["kernel"]["lifecycle"]): Runti
       return RUNTIME_STATUS.NOT_STARTED;
     case "AwaitingTrust":
       return RUNTIME_STATUS.AWAITING_TRUST;
+    case "AwaitingEnvBuild":
+      return RUNTIME_STATUS.AWAITING_ENV_BUILD;
     case "Resolving":
       return RUNTIME_STATUS.RESOLVING;
     case "PreparingEnv":
@@ -332,6 +339,8 @@ export function statusKeyToLegacyStatus(key: RuntimeStatusKey): KernelStatus {
       return KERNEL_STATUS.NOT_STARTED;
     case RUNTIME_STATUS.AWAITING_TRUST:
       return KERNEL_STATUS.AWAITING_TRUST;
+    case RUNTIME_STATUS.AWAITING_ENV_BUILD:
+      return KERNEL_STATUS.AWAITING_ENV_BUILD;
     case RUNTIME_STATUS.RESOLVING:
     case RUNTIME_STATUS.PREPARING_ENV:
     case RUNTIME_STATUS.LAUNCHING:

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -55,6 +55,7 @@ export const KERNEL_ERROR_REASON = {
 export type RuntimeLifecycle =
   | { lifecycle: "NotStarted" }
   | { lifecycle: "AwaitingTrust" }
+  | { lifecycle: "AwaitingEnvBuild" }
   | { lifecycle: "Resolving" }
   | { lifecycle: "PreparingEnv" }
   | { lifecycle: "Launching" }
@@ -67,14 +68,15 @@ export interface KernelState {
   /** Typed lifecycle. The authoritative view of kernel state. */
   lifecycle: RuntimeLifecycle;
   /**
-   * Human-readable reason populated when `lifecycle.lifecycle === "Error"`.
+   * Typed reason populated for lifecycle states that carry a specific cause
+   * such as `Error` or `AwaitingEnvBuild`.
    * `null` when the kernel map is absent; empty string when scaffolded but
    * unset. Most consumers can treat both as "no reason."
    */
   error_reason: string | null;
   /**
-   * Free-form details accompanying an error, shown to the user via the
-   * banner. Carries specifics that don't fit in the typed
+   * Free-form details accompanying an error or user-decision state, shown
+   * to the user via the banner/dialog. Carries specifics that don't fit in the typed
    * `error_reason` enum — e.g., the name of a conda env declared in
    * environment.yml that isn't built on this machine, with a suggested
    * remediation command. `null`/empty when absent or unset.

--- a/python/runtimed/src/runtimed/_constants.py
+++ b/python/runtimed/src/runtimed/_constants.py
@@ -54,6 +54,7 @@ class KERNEL_ERROR_REASON:
 KernelStatusKey = Literal[
     "not_started",
     "awaiting_trust",
+    "awaiting_env_build",
     "starting",
     "idle",
     "busy",
@@ -78,6 +79,7 @@ class KERNEL_STATUS:
 
     NOT_STARTED: Final[KernelStatusKey] = "not_started"
     AWAITING_TRUST: Final[KernelStatusKey] = "awaiting_trust"
+    AWAITING_ENV_BUILD: Final[KernelStatusKey] = "awaiting_env_build"
     STARTING: Final[KernelStatusKey] = "starting"
     IDLE: Final[KernelStatusKey] = "idle"
     BUSY: Final[KernelStatusKey] = "busy"

--- a/python/runtimed/src/runtimed/_internals.pyi
+++ b/python/runtimed/src/runtimed/_internals.pyi
@@ -255,9 +255,10 @@ class KernelState:
 
     @property
     def status(self) -> str:
-        """Flat status bucket: "not_started", "awaiting_trust", "starting",
-        "idle", "busy", "error", "shutdown". Projected from the typed
-        lifecycle for callers that want a simple string."""
+        """Flat status bucket: "not_started", "awaiting_trust",
+        "awaiting_env_build", "starting", "idle", "busy", "error",
+        "shutdown". Projected from the typed lifecycle for callers that want
+        a simple string."""
         ...
     @property
     def starting_phase(self) -> str:
@@ -267,8 +268,9 @@ class KernelState:
     @property
     def lifecycle(self) -> str:
         """Typed lifecycle variant name: "NotStarted", "AwaitingTrust",
-        "Resolving", "PreparingEnv", "Launching", "Connecting", "Running",
-        "Error", "Shutdown". Paired with `activity` when "Running"."""
+        "AwaitingEnvBuild", "Resolving", "PreparingEnv", "Launching",
+        "Connecting", "Running", "Error", "Shutdown". Paired with
+        `activity` when "Running"."""
         ...
     @property
     def activity(self) -> str:
@@ -277,14 +279,15 @@ class KernelState:
         ...
     @property
     def error_reason(self) -> str | None:
-        """Typed error reason when lifecycle == "Error". None when the
-        CRDT key is absent; empty string when scaffolded but unset."""
+        """Typed reason for lifecycle states that carry a specific cause
+        such as "Error" or "AwaitingEnvBuild". None when the CRDT key is
+        absent; empty string when scaffolded but unset."""
         ...
     @property
     def error_details(self) -> str | None:
-        """Free-form error details accompanying error_reason. None when
-        the CRDT key is absent; empty string when scaffolded but unset.
-        Carries specifics that don't fit the typed reason enum — e.g.,
+        """Free-form details accompanying an error or user-decision state.
+        None when the CRDT key is absent; empty string when scaffolded but
+        unset. Carries specifics that don't fit the typed reason enum — e.g.,
         the name of a missing conda env plus a remediation command."""
         ...
     @property

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2667,8 +2667,8 @@ class TestTrustApproval:
     async def test_envyml_missing_env_surfaces_error_state(self, client, tmp_path):
         """#2157: when environment.yml declares a conda env that isn't built
         on this machine, the daemon must set RuntimeStateDoc lifecycle to
-        Error with a typed reason and descriptive details — NOT silently
-        fall back to a pool env, and NOT leave the kernel stuck in
+        AwaitingEnvBuild with a typed reason and descriptive details — NOT
+        silently fall back to a pool env, and NOT leave the kernel stuck in
         `initializing` forever.
         """
         import asyncio
@@ -2705,24 +2705,27 @@ class TestTrustApproval:
         notebook = Notebook(session)
 
         # Poll briefly for the daemon to detect the miss and write the
-        # error lifecycle. Auto-launch runs in a spawned task, so the
+        # awaiting-env-build lifecycle. Auto-launch runs in a spawned task, so the
         # state might lag the open_notebook response.
         deadline = asyncio.get_event_loop().time() + 5.0
         kernel_state = None
         while asyncio.get_event_loop().time() < deadline:
             kernel_state = notebook.runtime.kernel
             lifecycle = kernel_state.lifecycle
-            # RuntimeLifecycle serializes as {"lifecycle": "Error"} or the
+            # RuntimeLifecycle serializes as {"lifecycle": "AwaitingEnvBuild"} or the
             # typed enum depending on binding — match both shapes.
-            if getattr(lifecycle, "lifecycle", None) == "Error" or str(lifecycle) == "Error":
+            if (
+                getattr(lifecycle, "lifecycle", None) == "AwaitingEnvBuild"
+                or str(lifecycle) == "AwaitingEnvBuild"
+            ):
                 break
             await asyncio.sleep(0.1)
 
         assert kernel_state is not None
         lifecycle = kernel_state.lifecycle
         lifecycle_tag = getattr(lifecycle, "lifecycle", None) or str(lifecycle)
-        assert lifecycle_tag == "Error", (
-            f"expected lifecycle=Error after env.yml miss; got {lifecycle_tag!r}"
+        assert lifecycle_tag == "AwaitingEnvBuild", (
+            f"expected lifecycle=AwaitingEnvBuild after env.yml miss; got {lifecycle_tag!r}"
         )
         assert kernel_state.error_reason == KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING
         details = kernel_state.error_details or ""

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -182,6 +182,7 @@ class TestKernelStatusConstants:
         """Each constant matches the exact wire string the daemon writes."""
         assert runtimed.KERNEL_STATUS.NOT_STARTED == "not_started"
         assert runtimed.KERNEL_STATUS.AWAITING_TRUST == "awaiting_trust"
+        assert runtimed.KERNEL_STATUS.AWAITING_ENV_BUILD == "awaiting_env_build"
         assert runtimed.KERNEL_STATUS.STARTING == "starting"
         assert runtimed.KERNEL_STATUS.IDLE == "idle"
         assert runtimed.KERNEL_STATUS.BUSY == "busy"
@@ -206,6 +207,10 @@ class TestKernelErrorReasonConstants:
         # The TS mirror lives in packages/runtimed/src/runtime-state.ts;
         # both ends must serialise to the same CRDT value.
         assert runtimed.KERNEL_ERROR_REASON.MISSING_IPYKERNEL == "missing_ipykernel"
+
+    def test_conda_env_yml_missing_value(self):
+        """``CONDA_ENV_YML_MISSING`` matches the Rust enum's wire string."""
+        assert runtimed.KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING == "conda_env_yml_missing"
 
 
 class TestCreateNotebookValidation:


### PR DESCRIPTION
## Summary

- Add a dedicated `AwaitingEnvBuild` runtime lifecycle for missing `environment.yml` conda environments.
- Surface missing-env remediation through a toolbar banner and a shared runtime decision dialog shell.
- Keep automatic env building deferred while preserving manual `conda env create -f ...` copy/retry affordances.

## Details

This implements the immediate missing-env UX for `conda_env_yml_missing` and adds the foundation layer for future environment build decisions. The trust dialog now uses a shared runtime decision shell, while `TrustDialog` keeps its existing public props stable.

The daemon now reports missing `environment.yml` conda envs as `AwaitingEnvBuild` instead of generic launch `Error`, and the lifecycle/status shape is mirrored through Rust, TypeScript, and Python-facing constants/types.

## Validation

- `cargo test -p runtime-doc`
- `pnpm test:run`
- `.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -v`
- `cargo check -p runtimed -p runtimed-py`
- `cargo xtask lint`
- `cargo xtask clippy`

## Notes

I attempted `cargo xtask integration test_envyml_missing_env_surfaces_error_state`, but the integration harness failed in shared setup before reaching the target test because the `uv:prewarmed` health-check kernel launch timed out.