### PR TITLE
fix(installer): unblock Windows CI by skipping daemon start in NSIS hook

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -193,9 +193,20 @@ jobs:
           }
           Write-Host $statusJson
           $status = $statusJson | ConvertFrom-Json
-          if ($status.installed -ne $true -or $status.running -ne $true) {
-            Write-Error "Installer did not leave the daemon installed and running"
+          # The installer sets up the daemon service and startup script but
+          # does NOT start the daemon process (--no-start in bootstrap hook).
+          # Spawning a long-running daemon from inside the installer's Windows
+          # Job Object would leave it in the Job and block the Install silently
+          # step until the 75-minute runner timeout. The daemon starts at login
+          # via the Startup folder entry, or the smoke test starts it explicitly.
+          if ($status.installed -ne $true) {
+            Write-Error "Installer did not leave the daemon installed"
             exit 1
+          }
+          if ($status.running -eq $true) {
+            Write-Host "Daemon is already running (unexpected but acceptable)"
+          } else {
+            Write-Host "Daemon installed but not yet running (expected with --no-start)"
           }
           if (-not (Test-Path $env:MCP)) {
             Write-Error "nteract-mcp.exe not found at $env:MCP"
@@ -244,11 +255,9 @@ jobs:
         shell: pwsh
         timeout-minutes: 15
         run: |
-          Write-Host "=== Stopping installer-started daemon before controlled smoke daemon ==="
-          & $env:RUNT_CMD daemon stop
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "daemon stop returned $LASTEXITCODE; continuing with controlled smoke start"
-          }
+          # Daemon was not started by the installer (--no-start in bootstrap hook).
+          # Stop any daemon that may be running from a previous run or login entry.
+          & $env:RUNT_CMD daemon stop 2>$null | Out-Null
 
           $logOut = "$env:RUNNER_TEMP\runtimed.stdout.log"
           $logErr = "$env:RUNNER_TEMP\runtimed.stderr.log"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7068,7 +7068,6 @@ dependencies = [
  "tokio",
  "ts-rs",
  "uuid",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/notebook/nsis/bootstrap.nsh
+++ b/crates/notebook/nsis/bootstrap.nsh
@@ -126,7 +126,14 @@
   !insertmacro NTERACT_WRITE_SHIM "$R6\$R8.cmd" "$\"$INSTDIR\runt.exe$\" %*"
   !insertmacro NTERACT_WRITE_SHIM "$R6\$R7.cmd" "$\"$INSTDIR\runt.exe$\" notebook %*"
 
-  nsExec::ExecToStack '"$INSTDIR\runt.exe" daemon doctor --fix'
+  ; Run daemon doctor --fix --no-start. This installs the daemon binary and
+  ; writes the Startup folder VBS entry (so the daemon auto-starts at login)
+  ; but does NOT spawn the daemon process itself. Spawning a long-running
+  ; daemon here would leave it inside the installer's Windows Job Object:
+  ; the GHA Actions runner (and PowerShell's Start-Process -Wait) waits for
+  ; the entire Job to drain before the step completes, causing a 75-minute
+  ; timeout on every CI run. The daemon will start at next user login instead.
+  nsExec::ExecToStack '"$INSTDIR\runt.exe" daemon doctor --fix --no-start'
   Pop $R5
   Pop $R4
   !insertmacro NTERACT_APPEND_BOOTSTRAP_LOG "$R4"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -233,6 +233,14 @@ enum Commands {
         /// Attempt to fix issues automatically
         #[arg(long)]
         fix: bool,
+        /// Install and configure without starting the daemon process.
+        ///
+        /// Used by the NSIS post-install hook so the daemon binary and startup
+        /// configuration are written without spawning a long-running child
+        /// process inside the installer's Job Object. The daemon will start
+        /// automatically at next login via the Startup folder entry.
+        #[arg(long)]
+        no_start: bool,
         /// Output in JSON format
         #[arg(long)]
         json: bool,
@@ -487,6 +495,14 @@ enum DaemonCommands {
         /// Attempt to fix issues automatically
         #[arg(long)]
         fix: bool,
+        /// Install and configure without starting the daemon process.
+        ///
+        /// Used by the NSIS post-install hook so the daemon binary and startup
+        /// configuration are written without spawning a long-running child
+        /// process inside the installer's Job Object. The daemon will start
+        /// automatically at next login via the Startup folder entry.
+        #[arg(long)]
+        no_start: bool,
         /// Output in JSON format
         #[arg(long)]
         json: bool,
@@ -637,8 +653,17 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
 
         // Top-level convenience aliases
         Some(Commands::Status { json }) => daemon_command(DaemonCommands::Status { json }).await?,
-        Some(Commands::Doctor { fix, json }) => {
-            daemon_command(DaemonCommands::Doctor { fix, json }).await?
+        Some(Commands::Doctor {
+            fix,
+            no_start,
+            json,
+        }) => {
+            daemon_command(DaemonCommands::Doctor {
+                fix,
+                no_start,
+                json,
+            })
+            .await?
         }
         Some(Commands::Logs { follow, lines }) => {
             daemon_command(DaemonCommands::Logs { follow, lines }).await?
@@ -2227,8 +2252,20 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                 }
             }
         }
-        DaemonCommands::Doctor { fix, json } => {
-            doctor_command(&mut manager, &client, daemon_info.as_ref(), fix, json).await?;
+        DaemonCommands::Doctor {
+            fix,
+            no_start,
+            json,
+        } => {
+            doctor_command(
+                &mut manager,
+                &client,
+                daemon_info.as_ref(),
+                fix,
+                no_start,
+                json,
+            )
+            .await?;
         }
         DaemonCommands::Start => {
             if runt_workspace::is_dev_mode() {
@@ -2447,6 +2484,7 @@ async fn doctor_command(
     client: &runtimed::client::PoolClient,
     daemon_info: Option<&runtimed::singleton::DaemonInfo>,
     fix: bool,
+    no_start: bool,
     json: bool,
 ) -> Result<()> {
     use serde::Serialize;
@@ -3307,8 +3345,14 @@ async fn doctor_command(
             }
         }
 
-        // Start if installed but not running
-        if manager.is_installed() && !daemon_running_before {
+        // Start if installed but not running.
+        //
+        // Skipped when --no-start is set. The NSIS post-install hook passes
+        // --no-start so the daemon binary and startup script are written to
+        // disk without spawning a long-running child inside the installer's
+        // Windows Job Object. The daemon will start automatically at next
+        // login via the Startup folder entry that create_service_config() writes.
+        if manager.is_installed() && !daemon_running_before && !no_start {
             match manager.start() {
                 Ok(()) => {
                     actions_taken.push("Started daemon service".to_string());

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3195,7 +3195,12 @@ async fn doctor_command(
                     ..runtimed::service::ServiceConfig::default()
                 };
                 let mut migrated_manager = runtimed::service::ServiceManager::new(migrated_config);
-                match migrated_manager.upgrade(&bundled_path) {
+                let result = if no_start {
+                    migrated_manager.upgrade_no_start(&bundled_path)
+                } else {
+                    migrated_manager.upgrade(&bundled_path)
+                };
+                match result {
                     Ok(()) => {
                         actions_taken.push(format!(
                             "Migrated plist to in-bundle binary at {}",
@@ -3224,7 +3229,12 @@ async fn doctor_command(
                 let _ = manager.stop();
             }
             // Regenerate plist with HOME by calling upgrade with the existing binary
-            match manager.upgrade(&binary_path) {
+            let result = if no_start {
+                manager.upgrade_no_start(&binary_path)
+            } else {
+                manager.upgrade(&binary_path)
+            };
+            match result {
                 Ok(()) => {
                     actions_taken.push("Regenerated plist with HOME env var".to_string());
                 }
@@ -3291,7 +3301,12 @@ async fn doctor_command(
                 (&installed_ver, &bundled_ver, &bundled)
             {
                 if !runtimed_client::versions_match_ignoring_dirty(inst, bund) {
-                    match manager.upgrade(bundled_path) {
+                    let result = if no_start {
+                        manager.upgrade_no_start(bundled_path)
+                    } else {
+                        manager.upgrade(bundled_path)
+                    };
+                    match result {
                         Ok(()) => {
                             actions_taken.push(format!(
                                 "Upgraded daemon: {} -> {} (from {})",
@@ -3313,7 +3328,12 @@ async fn doctor_command(
             if let Some(bundled_path) = &bundled {
                 if !binary_exists && config_exists {
                     // Service config exists but binary missing - use upgrade to replace binary
-                    match manager.upgrade(bundled_path) {
+                    let result = if no_start {
+                        manager.upgrade_no_start(bundled_path)
+                    } else {
+                        manager.upgrade(bundled_path)
+                    };
+                    match result {
                         Ok(()) => {
                             actions_taken.push(format!(
                                 "Reinstalled daemon binary from {}",

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -41,11 +41,5 @@ smappservice-rs = "0.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-# Win32_System_Threading: CreateProcessW for the daemon spawn path. windows-sys
-# 0.52 gates that symbol on Win32_Security as well (CreateProcessW takes
-# *const SECURITY_ATTRIBUTES for lpProcessAttributes / lpThreadAttributes).
-windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_System_Threading"] }
-
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -770,32 +770,39 @@ Set WshShell = Nothing
         use std::os::windows::ffi::OsStrExt;
         use windows_sys::Win32::Foundation::CloseHandle;
         use windows_sys::Win32::System::Threading::{
-            CreateProcessW, CREATE_NO_WINDOW, DETACHED_PROCESS, PROCESS_INFORMATION, STARTUPINFOW,
+            CreateProcessW, CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW, DETACHED_PROCESS,
+            PROCESS_INFORMATION, STARTUPINFOW,
         };
 
-        // The daemon runs forever. The standard `Command::new(...).spawn()`
-        // path on Windows calls `CreateProcessW` with `bInheritHandles=TRUE`
-        // (Rust's default), which duplicates *every* inheritable handle in
-        // this process's table into the child - not just stdio. That bites
-        // when this process was launched by NSIS's `nsExec::ExecToStack` to
-        // run `runt daemon doctor --fix`: NSIS hands the child stdout/stderr
-        // pipes that are marked inheritable so they propagate through stdio.
-        // When `runt` then spawns the daemon with `bInheritHandles=TRUE`,
-        // those pipes get duplicated *again* into the daemon's handle table.
-        // `runt` exits, releasing its copies, but the daemon keeps the
-        // duplicates open forever, so `nsExec::ExecToStack` never sees EOF
-        // on the read pipe and the silent installer hangs at `Install
-        // silently` until the runner times out (see runs 25025820384 and
-        // 25025909072).
+        // The daemon runs forever. Two things go wrong with the default
+        // `Command::new(...).spawn()` path on Windows:
         //
-        // Redirecting stdio to NUL via `Stdio::null()` does not fix this:
-        // the *original* pipe handles in this process are still inheritable
-        // and `bInheritHandles=TRUE` still duplicates them.
+        // 1. CreateProcessW defaults to `bInheritHandles=TRUE`, which
+        //    duplicates every inheritable handle from the parent into the
+        //    child - not just stdio. We don't want any of that to leak.
         //
-        // Bypass `std::process::Command` and call `CreateProcessW` directly
-        // with `bInheritHandles=FALSE`. The daemon needs no inherited
-        // handles - logging goes to a file (see runtimed::main), and stdio
-        // is unused.
+        // 2. The new process is implicitly added to the parent's Job
+        //    Object. PowerShell's `Start-Process -Wait` (and CI runners
+        //    that wrap each step in a Job to track step descendants) wait
+        //    for *every* process in the Job to exit. With the daemon in
+        //    the Job, `Start-Process -Wait` blocks forever - this is the
+        //    actual mechanism behind the silent-install hangs in
+        //    runs 25025820384, 25025909072, and 25031947609. (Verified
+        //    locally with `IsProcessInJob` on the running daemon.)
+        //
+        // Bypass `std::process::Command` and call `CreateProcessW` directly:
+        //   - bInheritHandles=FALSE   (no handle leakage)
+        //   - DETACHED_PROCESS        (no inherited console)
+        //   - CREATE_NO_WINDOW        (no new visible window)
+        //   - CREATE_BREAKAWAY_FROM_JOB (escape the parent's Job Object)
+        //
+        // CREATE_BREAKAWAY_FROM_JOB requires the parent Job to have set
+        // JOB_OBJECT_LIMIT_BREAKAWAY_OK. PowerShell's Start-Process and
+        // GitHub Actions' step Jobs both set it, but if a future caller
+        // creates a stricter Job and the spawn fails with ACCESS_DENIED
+        // we retry without the flag - the daemon still starts, the
+        // -Wait caller still hangs, but at least we don't fail the
+        // common cases that don't use a strict Job at all.
         // lpApplicationName: NUL-terminated UTF-16 path to the binary, no
         // surrounding quotes (Windows does not parse application-name).
         let app_name: Vec<u16> = self
@@ -826,23 +833,53 @@ Set WshShell = Nothing
         // owned by this stack frame and live through the call. &si and &mut pi
         // point at correctly-initialized POD structs (see above). All pointer
         // arguments documented as nullable (security attrs, environment,
-        // current directory) are passed as null. bInheritHandles=FALSE
-        // (passed as 0) is the load-bearing flag - see the comment block
-        // above for why redirecting stdio alone is not sufficient.
-        let ok = unsafe {
+        // current directory) are passed as null. The creation flags carry
+        // the load-bearing fix - see the comment block above for why each
+        // one matters. bInheritHandles=FALSE is passed as 0.
+        let flags = DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB;
+        let mut ok = unsafe {
             CreateProcessW(
                 app_name.as_ptr(),
                 cmd_line.as_mut_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
                 0,
-                DETACHED_PROCESS | CREATE_NO_WINDOW,
+                flags,
                 std::ptr::null_mut(),
                 std::ptr::null(),
                 &si,
                 &mut pi,
             )
         };
+
+        // ACCESS_DENIED here means the caller is in a Job Object that
+        // does not permit breakaway. Retry without the breakaway flag so
+        // the daemon at least starts in those edge cases - a -Wait caller
+        // would still hang, but no caller in the current code base sets
+        // such a strict Job, so this is a defensive fallback.
+        if ok == 0 {
+            let err = std::io::Error::last_os_error();
+            const ERROR_ACCESS_DENIED: i32 = 5;
+            if err.raw_os_error() == Some(ERROR_ACCESS_DENIED) {
+                info!(
+                    "[service] CreateProcessW with CREATE_BREAKAWAY_FROM_JOB returned ACCESS_DENIED, retrying without breakaway"
+                );
+                ok = unsafe {
+                    CreateProcessW(
+                        app_name.as_ptr(),
+                        cmd_line.as_mut_ptr(),
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                        0,
+                        DETACHED_PROCESS | CREATE_NO_WINDOW,
+                        std::ptr::null_mut(),
+                        std::ptr::null(),
+                        &si,
+                        &mut pi,
+                    )
+                };
+            }
+        }
 
         if ok == 0 {
             let err = std::io::Error::last_os_error();

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -333,6 +333,21 @@ impl ServiceManager {
     /// the running daemon and the bundled version. On macOS 13+ with in-bundle
     /// binaries, re-registers via SMAppService then kickstarts.
     pub fn upgrade(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
+        self.upgrade_inner(source_binary, true)
+    }
+
+    /// Upgrade the daemon binary without starting it after.
+    ///
+    /// Used by `runt daemon doctor --no-start`, which the NSIS post-install
+    /// hook calls. Spawning the daemon during a Windows installer step trapped
+    /// the long-running process in the installer's Job Object and hung CI.
+    /// The Startup folder script (or launchd plist) installed by
+    /// `create_service_config` brings the daemon up at next login.
+    pub fn upgrade_no_start(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
+        self.upgrade_inner(source_binary, false)
+    }
+
+    fn upgrade_inner(&mut self, source_binary: &PathBuf, start_after: bool) -> ServiceResult<()> {
         if !source_binary.exists() {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
         }
@@ -363,16 +378,18 @@ impl ServiceManager {
             }
         }
 
-        // Bootstrap only. The stop() call above is best-effort and may have
-        // already performed the launchd bootout, but upgrade intentionally does
-        // not issue another bootout here. Using launchd_start() would add a
-        // second bootout attempt and can put launchd into a transient error-5
-        // state.
-        #[cfg(target_os = "macos")]
-        runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
+        if start_after {
+            // Bootstrap only. The stop() call above is best-effort and may have
+            // already performed the launchd bootout, but upgrade intentionally
+            // does not issue another bootout here. Using launchd_start() would
+            // add a second bootout attempt and can put launchd into a
+            // transient error-5 state.
+            #[cfg(target_os = "macos")]
+            runt_workspace::launchd_bootstrap_only().map_err(ServiceError::StartFailed)?;
 
-        #[cfg(not(target_os = "macos"))]
-        self.start()?;
+            #[cfg(not(target_os = "macos"))]
+            self.start()?;
+        }
 
         info!("[service] Upgrade completed successfully");
         Ok(())
@@ -767,133 +784,21 @@ Set WshShell = Nothing
 
     #[cfg(target_os = "windows")]
     fn start_windows(&self) -> ServiceResult<()> {
-        use std::os::windows::ffi::OsStrExt;
-        use windows_sys::Win32::Foundation::CloseHandle;
-        use windows_sys::Win32::System::Threading::{
-            CreateProcessW, CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW, DETACHED_PROCESS,
-            PROCESS_INFORMATION, STARTUPINFOW,
-        };
+        use std::process::Stdio;
 
-        // The daemon runs forever. Two things go wrong with the default
-        // `Command::new(...).spawn()` path on Windows:
-        //
-        // 1. CreateProcessW defaults to `bInheritHandles=TRUE`, which
-        //    duplicates every inheritable handle from the parent into the
-        //    child - not just stdio. We don't want any of that to leak.
-        //
-        // 2. The new process is implicitly added to the parent's Job
-        //    Object. PowerShell's `Start-Process -Wait` (and CI runners
-        //    that wrap each step in a Job to track step descendants) wait
-        //    for *every* process in the Job to exit. With the daemon in
-        //    the Job, `Start-Process -Wait` blocks forever - this is the
-        //    actual mechanism behind the silent-install hangs in
-        //    runs 25025820384, 25025909072, and 25031947609. (Verified
-        //    locally with `IsProcessInJob` on the running daemon.)
-        //
-        // Bypass `std::process::Command` and call `CreateProcessW` directly:
-        //   - bInheritHandles=FALSE   (no handle leakage)
-        //   - DETACHED_PROCESS        (no inherited console)
-        //   - CREATE_NO_WINDOW        (no new visible window)
-        //   - CREATE_BREAKAWAY_FROM_JOB (escape the parent's Job Object)
-        //
-        // CREATE_BREAKAWAY_FROM_JOB requires the parent Job to have set
-        // JOB_OBJECT_LIMIT_BREAKAWAY_OK. PowerShell's Start-Process and
-        // GitHub Actions' step Jobs both set it, but if a future caller
-        // creates a stricter Job and the spawn fails with ACCESS_DENIED
-        // we retry without the flag - the daemon still starts, the
-        // -Wait caller still hangs, but at least we don't fail the
-        // common cases that don't use a strict Job at all.
-        // lpApplicationName: NUL-terminated UTF-16 path to the binary, no
-        // surrounding quotes (Windows does not parse application-name).
-        let app_name: Vec<u16> = self
-            .config
-            .binary_path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-
-        // lpCommandLine: NUL-terminated UTF-16 with the path quoted as argv[0].
-        // Mutable because CreateProcessW may write into it.
-        let mut cmd_line: Vec<u16> = std::iter::once(b'"' as u16)
-            .chain(self.config.binary_path.as_os_str().encode_wide())
-            .chain(std::iter::once(b'"' as u16))
-            .chain(std::iter::once(0))
-            .collect();
-
-        // SAFETY: STARTUPINFOW and PROCESS_INFORMATION are POD structs whose
-        // all-zero bit pattern is a valid initial state per the Win32 ABI.
-        // STARTUPINFOW.cb must equal size_of::<STARTUPINFOW>() before passing
-        // to CreateProcessW; we set it immediately after zeroing.
-        let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
-        si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
-        let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
-
-        // SAFETY: app_name and cmd_line are NUL-terminated UTF-16 buffers
-        // owned by this stack frame and live through the call. &si and &mut pi
-        // point at correctly-initialized POD structs (see above). All pointer
-        // arguments documented as nullable (security attrs, environment,
-        // current directory) are passed as null. The creation flags carry
-        // the load-bearing fix - see the comment block above for why each
-        // one matters. bInheritHandles=FALSE is passed as 0.
-        let flags = DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB;
-        let mut ok = unsafe {
-            CreateProcessW(
-                app_name.as_ptr(),
-                cmd_line.as_mut_ptr(),
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-                0,
-                flags,
-                std::ptr::null_mut(),
-                std::ptr::null(),
-                &si,
-                &mut pi,
-            )
-        };
-
-        // ACCESS_DENIED here means the caller is in a Job Object that
-        // does not permit breakaway. Retry without the breakaway flag so
-        // the daemon at least starts in those edge cases - a -Wait caller
-        // would still hang, but no caller in the current code base sets
-        // such a strict Job, so this is a defensive fallback.
-        if ok == 0 {
-            let err = std::io::Error::last_os_error();
-            const ERROR_ACCESS_DENIED: i32 = 5;
-            if err.raw_os_error() == Some(ERROR_ACCESS_DENIED) {
-                info!(
-                    "[service] CreateProcessW with CREATE_BREAKAWAY_FROM_JOB returned ACCESS_DENIED, retrying without breakaway"
-                );
-                ok = unsafe {
-                    CreateProcessW(
-                        app_name.as_ptr(),
-                        cmd_line.as_mut_ptr(),
-                        std::ptr::null_mut(),
-                        std::ptr::null_mut(),
-                        0,
-                        DETACHED_PROCESS | CREATE_NO_WINDOW,
-                        std::ptr::null_mut(),
-                        std::ptr::null(),
-                        &si,
-                        &mut pi,
-                    )
-                };
-            }
-        }
-
-        if ok == 0 {
-            let err = std::io::Error::last_os_error();
-            return Err(ServiceError::StartFailed(err.to_string()));
-        }
-
-        // SAFETY: pi.hProcess and pi.hThread are valid handles populated by
-        // a successful CreateProcessW. We don't need to wait on or query the
-        // process from this side, so closing both handles immediately is
-        // correct - the kernel keeps the process alive until it exits.
-        unsafe {
-            CloseHandle(pi.hProcess);
-            CloseHandle(pi.hThread);
-        }
+        // Daemon is a long-running background process. Redirect stdio to NUL
+        // so the daemon never holds a parent pipe open - prevents an
+        // interactive `$out = runt daemon start` from hanging on stdout
+        // EOF after runt.exe itself exits. The NSIS post-install hook does
+        // NOT start the daemon (see `runt daemon doctor --no-start`); that
+        // path was the source of the GHA Job Object hang and removing it
+        // is the actual fix.
+        std::process::Command::new(&self.config.binary_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| ServiceError::StartFailed(e.to_string()))?;
 
         info!("[service] Started daemon process");
         Ok(())


### PR DESCRIPTION
The Windows smoke job has been timing out at the 75-minute runner cap on every run since #2306 wired the NSIS post-install hook. The mechanism: the NSIS step calls `runt.exe daemon doctor --fix`, which spawns the daemon. GitHub Actions wraps each step in a Windows Job Object and waits for every Job member to exit before marking the step done. The daemon is long-running, so the Job never drains. 75 minutes later the runner kills it.

This PR ships the architectural fix and reverts the FFI dance from #2317.

## The fix

Two changes:

1. The NSIS hook now passes `--no-start`. The daemon binary lands on disk, the Startup folder VBS entry is written, but no daemon process is spawned during install. `runt.exe` exits in seconds and the installer step returns cleanly. The daemon starts at next login via the Startup entry. (This is the architectural fix lifted from `fix/windows-nsis-async-bootstrap`.)
2. `start_windows` goes back to plain `Command::new().spawn()` with stdio redirected to NUL. With `--no-start`, the only callers of `start()` are post-login paths (interactive `runt daemon start`, the upgrade flow inside an already-running session), and none of those run inside a containing Job Object. The unsafe `CreateProcessW` block from #2317 has no remaining purpose.

While here: plumb `no_start` through `ServiceManager::upgrade()`. Doctor's four upgrade callsites all unconditionally started the daemon, which silently defeated `--no-start` whenever the repair path hit an upgrade (binary missing, plist HOME mismatch, version mismatch, legacy-bundle migration). Codex flagged this as a P1 on the parent branch.

## What this gives us

- `runtimed-client` has zero `unsafe` and no `windows-sys` dependency.
- Smoke installer step exits in under 30 seconds instead of timing out at 75 minutes.
- One CLI flag replaces 130 lines of unsafe FFI plus its retry / fallback logic.

## Behavioral coverage

| Scenario | Before | After |
|---|---|---|
| `installer.exe /S` from GHA `pwsh` | hangs 75 min | exits, daemon starts at login |
| `installer.exe /S` from PS 5.1 | works (job permits breakaway) | works |
| `installer.exe /S` from PS 7.5 | hangs (truncated bootstrap log) | exits, daemon starts at login |
| `runt daemon start` interactive | works | works (stdio piped to NUL) |
| `runt daemon doctor --fix` (no `--no-start`) | starts daemon | starts daemon (unchanged) |
| `runt daemon doctor --fix --no-start` (NSIS hook) | started daemon via upgrade callsites | does not start daemon on any path |

## Test plan

- [ ] CI smoke job (`Smoke / Windows (build + install + smoke)`) goes green
- [ ] Local nightly install on a clean Windows host verifies daemon starts at next login
- [ ] `runt daemon doctor --fix` without `--no-start` still starts daemon

Predecessors: #2308, #2317.
