### PR TITLE
ci(smoke): drop broken nteract-mcp startup probe

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -212,23 +212,13 @@ jobs:
             Write-Error "nteract-mcp.exe not found at $env:MCP"
             exit 1
           }
-          Write-Host "=== nteract-mcp startup probe ==="
-          $mcpOut = "$env:RUNNER_TEMP\nteract-mcp.stdout.log"
-          $mcpErr = "$env:RUNNER_TEMP\nteract-mcp.stderr.log"
-          $mcp = Start-Process -FilePath $env:MCP -WindowStyle Hidden -PassThru `
-            -RedirectStandardOutput $mcpOut -RedirectStandardError $mcpErr
-          Start-Sleep -Seconds 3
-          if ($mcp.HasExited -and $mcp.ExitCode -ne 0) {
-            Write-Host "--- nteract-mcp stdout ---"
-            if (Test-Path $mcpOut) { Get-Content $mcpOut }
-            Write-Host "--- nteract-mcp stderr ---"
-            if (Test-Path $mcpErr) { Get-Content $mcpErr }
-            Write-Error "nteract-mcp exited during startup probe"
-            exit $mcp.ExitCode
-          }
-          if (-not $mcp.HasExited) {
-            Stop-Process -Id $mcp.Id -Force -ErrorAction SilentlyContinue
-          }
+          # No standalone startup probe: nteract-mcp is a JSON-RPC stdio
+          # server with no boot phase. It reads stdin for an `initialize`
+          # request and exits with `connection closed` if stdin EOFs first.
+          # `Start-Process -RedirectStandardOutput` doesn't pipe stdin from
+          # the parent, so a bare-launch probe always fails. The "Run daemon
+          # and smoke" step below exercises the same binary end-to-end with
+          # a real MCP client, which is the test we actually want.
 
       - name: Set up Python for MCP smoke
         uses: actions/setup-python@v5


### PR DESCRIPTION
After #2323 unhooked the Windows install hang, run [25058685926](https://github.com/nteract/desktop/actions/runs/25058685926) finally got past the 75-minute cap on `Install silently` (8 seconds now) and surfaced the next layer of breakage: the `nteract-mcp` startup probe at the end of `Verify installer bootstrap`.

## What's broken

The probe runs:

```powershell
$mcp = Start-Process -FilePath $env:MCP -WindowStyle Hidden -PassThru `
  -RedirectStandardOutput $mcpOut -RedirectStandardError $mcpErr
Start-Sleep -Seconds 3
if ($mcp.HasExited -and $mcp.ExitCode -ne 0) { ... fail ... }
```

`nteract-mcp` is a JSON-RPC stdio server with no boot phase. It immediately reads stdin for an `initialize` request and exits with `connection closed: initialize request` if stdin EOFs first. `Start-Process -RedirectStandardOutput` does not pipe stdin from the parent, so the child saw stdin EOF and exited non-zero before the 3-second sleep finished. The CI log confirms it:

```
ERROR nteract_mcp: Failed to start MCP server: connection closed: initialize request
```

The probe was added in #2306 but never actually ran on a push event because every push since has timed out at the install step.

## Why drop instead of fix

A bare-launch probe of an MCP server can't pass without a JSON-RPC client connected to stdin. Reinventing one in PowerShell would duplicate the existing `Run daemon and smoke (single step)` job, which already drives `nteract-mcp` end-to-end with a real Python MCP client. Easier to delete the dead test. The binary-existence check (`Test-Path $env:MCP`) stays.

## Test plan

- [ ] Run goes green on push to main
