### PR TITLE
fix(kernel-env): scope daemon-created conda:env_yml envs by project dir

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1050,8 +1050,93 @@ pub async fn sync_dependencies(
         },
     );
 
+    // Post-install verification: confirm every requested package is present
+    // in conda-meta. The rattler Installer performs a transactional unlink-then-
+    // link sequence; if it fails mid-transaction the prefix can be left without
+    // packages that were previously installed. Catching this here prevents the
+    // caller from launching a kernel against an inconsistent env.
+    let missing = verify_packages_installed(&env.env_path, &deps.dependencies);
+    if !missing.is_empty() {
+        return Err(anyhow!(
+            "Post-sync verification failed: packages missing from conda-meta after install: [{}]",
+            missing.join(", ")
+        ));
+    }
+
     info!("Conda dependencies synced successfully");
     Ok(())
+}
+
+/// Verify that every package name in `required` has a corresponding
+/// `<name>-*.json` entry in the env's `conda-meta/` directory.
+///
+/// Returns the list of package names that are missing. An empty vec means
+/// all required packages are present.
+///
+/// Used as a post-install gate: the rattler Installer's transactional
+/// unlink-then-link can leave the prefix inconsistent if it fails between
+/// the two phases. Checking conda-meta after install catches this before
+/// the kernel launches against a broken env.
+pub fn verify_packages_installed(env_path: &std::path::Path, required: &[String]) -> Vec<String> {
+    /// Extract the bare package name from a conda spec like "numpy>=1.24"
+    /// or "conda-forge::scipy". Mirrors notebook_doc::metadata::extract_package_name
+    /// without pulling in that crate dependency.
+    fn extract_pkg_name(spec: &str) -> String {
+        let spec = spec.trim();
+        // Strip conda channel qualifier (e.g. "conda-forge::numpy" -> "numpy")
+        let spec = spec.rsplit_once("::").map_or(spec, |(_, name)| name);
+        spec.split(&['>', '<', '=', '!', '~', '[', ';', '@', ' '][..])
+            .next()
+            .unwrap_or(spec)
+            .to_lowercase()
+    }
+
+    let meta_dir = env_path.join("conda-meta");
+    let installed_names: std::collections::HashSet<String> = match std::fs::read_dir(&meta_dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let fname = e.file_name();
+                let fname = fname.to_string_lossy().to_string();
+                if !fname.ends_with(".json") || fname == "history" {
+                    return None;
+                }
+                // conda-meta filenames: <name>-<version>-<build>.json
+                // Split on '-' from the right: the last two segments are
+                // build and version; everything before is the package name.
+                let stem = fname.strip_suffix(".json")?;
+                let mut parts: Vec<&str> = stem.rsplitn(3, '-').collect();
+                parts.reverse();
+                if parts.len() >= 3 {
+                    Some(parts[0].to_lowercase())
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        Err(_) => std::collections::HashSet::new(),
+    };
+
+    required
+        .iter()
+        .filter_map(|spec| {
+            let name = extract_pkg_name(spec);
+            // Skip base packages that are always present; the caller may have
+            // included them in the dep list but they aren't user-visible if missing.
+            if name == "ipykernel"
+                || name == "ipywidgets"
+                || name == "anywidget"
+                || name == "nbformat"
+            {
+                return None;
+            }
+            if installed_names.contains(&name) {
+                None
+            } else {
+                Some(name)
+            }
+        })
+        .collect()
 }
 
 /// No-op cleanup (cached environments are kept for reuse).

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1040,21 +1040,8 @@ pub(crate) fn missing_conda_env_yml_decision(
     }
 
     let config = crate::project_file::parse_environment_yml(&detected.path).ok()?;
-    let conda_prefix = if let Some(ref prefix) = config.prefix {
-        prefix.clone()
-    } else if let Some(ref name) = config.name {
-        crate::project_file::find_named_conda_env(name)
-            .unwrap_or_else(|| crate::project_file::default_conda_envs_dir().join(name))
-    } else {
-        let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
-        let conda_deps_tmp = kernel_env::CondaDependencies {
-            dependencies: config.dependencies.clone(),
-            channels: config.channels.clone(),
-            python: config.python.clone(),
-            env_id: None,
-        };
-        cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp))
-    };
+    let (conda_prefix, _is_daemon_owned) =
+        crate::project_file::resolve_conda_env_yml_prefix(&config, &detected.path);
 
     if crate::project_file::conda_python_path(&conda_prefix).exists() {
         return None;
@@ -3202,31 +3189,11 @@ pub(crate) async fn auto_launch_kernel(
             }
         };
 
-        // Track whether the env is daemon-owned (safe to auto-rebuild)
-        // vs. user-managed (prefix: field or pre-existing named env).
-        let (conda_prefix, is_daemon_owned_env) = if let Some(ref prefix) = env_config.prefix {
-            (prefix.clone(), false) // User-specified path — never auto-delete
-        } else if let Some(ref name) = env_config.name {
-            match crate::project_file::find_named_conda_env(name) {
-                Some(found) => (found, false), // Pre-existing user env — never auto-delete
-                None => (
-                    crate::project_file::default_conda_envs_dir().join(name),
-                    true,
-                ),
-            }
-        } else {
-            let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
-            let conda_deps_tmp = kernel_env::CondaDependencies {
-                dependencies: env_config.dependencies.clone(),
-                channels: env_config.channels.clone(),
-                python: env_config.python.clone(),
-                env_id: None,
-            };
-            (
-                cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp)),
-                true,
-            )
-        };
+        // Resolve conda prefix: daemon-created envs are scoped by project
+        // directory so different projects with the same env name get isolated
+        // prefixes (prevents concurrent clobbering).
+        let (conda_prefix, is_daemon_owned_env) =
+            crate::project_file::resolve_conda_env_yml_prefix(&env_config, &yml_path);
 
         let mut all_deps = env_config.dependencies.clone();
         if let Some(crdt_deps) = metadata_snapshot.as_ref().and_then(get_inline_conda_deps) {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3320,10 +3320,20 @@ pub(crate) async fn auto_launch_kernel(
             )
             .await
             {
-                warn!(
-                    "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
-                    e
-                );
+                let details = format!("conda:env_yml sync into existing env failed: {}", e);
+                error!("[notebook-sync] {}", details);
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::CondaEnvBuildFailed),
+                        Some(&details),
+                    )?;
+                    sd.clear_env_progress()?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
             }
             // The banner stays lit until a terminal phase is written. Emit Ready so
             // it clears whether the sync completed or we fell through to the existing env.

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -759,18 +759,17 @@ mod tests {
             resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
         let (prefix2, _) =
             resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
-        assert_eq!(prefix1, prefix2, "same project dir must produce same prefix");
+        assert_eq!(
+            prefix1, prefix2,
+            "same project dir must produce same prefix"
+        );
     }
 
     #[test]
     fn test_resolve_conda_env_yml_prefix_no_name_no_prefix() {
         // No name or prefix: should use hash-based path
         let temp = TempDir::new().unwrap();
-        write_file(
-            temp.path(),
-            "environment.yml",
-            "dependencies:\n  - numpy\n",
-        );
+        write_file(temp.path(), "environment.yml", "dependencies:\n  - numpy\n");
         let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
         let (prefix, is_daemon_owned) =
             resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -206,6 +206,73 @@ pub fn default_conda_envs_dir() -> PathBuf {
         .join("envs")
 }
 
+/// Resolve the conda prefix for a daemon-created `conda:env_yml` environment.
+///
+/// When the daemon needs to create a new named env (not pre-existing on the
+/// system), the path is scoped to the project directory so that different
+/// projects using the same `name:` field in their `environment.yaml` get
+/// isolated prefixes. Without this, concurrent notebooks sharing the same
+/// env name but different dep sets can clobber each other - the rattler
+/// Installer removes packages not in the current notebook's specs.
+///
+/// Returns `(prefix_path, is_daemon_owned)`.
+///
+/// - `prefix:` field -> use that path directly (user-managed)
+/// - `name:` found on system -> use that path (user-managed)
+/// - `name:` not found -> daemon-owned, project-scoped cache path
+/// - no name or prefix -> hash-based cache path (daemon-owned)
+pub fn resolve_conda_env_yml_prefix(
+    env_config: &EnvironmentYmlConfig,
+    yml_path: &Path,
+) -> (PathBuf, bool) {
+    if let Some(ref prefix) = env_config.prefix {
+        // Explicit prefix: path from environment.yml - user-managed
+        (prefix.clone(), false)
+    } else if let Some(ref name) = env_config.name {
+        match find_named_conda_env(name) {
+            Some(found) => (found, false), // Pre-existing user env
+            None => {
+                // Daemon-created: scope by project dir so different projects
+                // with the same env name get isolated prefixes.
+                let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
+                let project_hash = compute_project_scope_hash(yml_path);
+                (cache_dir.join(format!("{}-{}", name, project_hash)), true)
+            }
+        }
+    } else {
+        // No name or prefix - use a hash-based env in cache
+        let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
+        let conda_deps_tmp = kernel_env::CondaDependencies {
+            dependencies: env_config.dependencies.clone(),
+            channels: env_config.channels.clone(),
+            python: env_config.python.clone(),
+            env_id: None,
+        };
+        (
+            cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp)),
+            true,
+        )
+    }
+}
+
+/// Compute a short hash that scopes a conda env to its project directory.
+///
+/// Uses the canonical parent directory of the environment.yaml file as the
+/// scope key - two environment.yaml files in the same directory get the same
+/// hash, different directories get different hashes even with identical
+/// content.
+fn compute_project_scope_hash(yml_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let canonical = yml_path
+        .parent()
+        .and_then(|p| p.canonicalize().ok())
+        .unwrap_or_else(|| yml_path.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let hash = hasher.finalize();
+    hex::encode(hash)[..12].to_string()
+}
+
 /// Get the python path within a conda prefix.
 pub fn conda_python_path(prefix: &Path) -> PathBuf {
     #[cfg(target_os = "windows")]
@@ -625,5 +692,94 @@ mod tests {
         assert_eq!(python, PathBuf::from("/opt/conda/envs/test/bin/python"));
         #[cfg(target_os = "windows")]
         assert_eq!(python, PathBuf::from("/opt/conda/envs/test/python.exe"));
+    }
+
+    #[test]
+    fn test_resolve_conda_env_yml_prefix_with_prefix_field() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "environment.yml",
+            "prefix: /custom/path\ndependencies:\n  - numpy\n",
+        );
+        let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
+        let (prefix, is_daemon_owned) =
+            resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
+        assert_eq!(prefix, PathBuf::from("/custom/path"));
+        assert!(!is_daemon_owned);
+    }
+
+    #[test]
+    fn test_resolve_conda_env_yml_prefix_daemon_created_scoped_by_project() {
+        // Two different project dirs with the same env name should get
+        // different daemon-owned prefixes (project-scoped isolation).
+        let temp1 = TempDir::new().unwrap();
+        let temp2 = TempDir::new().unwrap();
+        let yml_content = "name: shared-env\ndependencies:\n  - numpy\n";
+        write_file(temp1.path(), "environment.yml", yml_content);
+        write_file(temp2.path(), "environment.yml", yml_content);
+
+        let config1 = parse_environment_yml(&temp1.path().join("environment.yml")).unwrap();
+        let config2 = parse_environment_yml(&temp2.path().join("environment.yml")).unwrap();
+        let (prefix1, owned1) =
+            resolve_conda_env_yml_prefix(&config1, &temp1.path().join("environment.yml"));
+        let (prefix2, owned2) =
+            resolve_conda_env_yml_prefix(&config2, &temp2.path().join("environment.yml"));
+
+        assert!(owned1, "daemon-created envs should be daemon-owned");
+        assert!(owned2, "daemon-created envs should be daemon-owned");
+        assert_ne!(
+            prefix1, prefix2,
+            "different project dirs must get different prefixes"
+        );
+        // Both should start with the env name
+        let name1 = prefix1.file_name().unwrap().to_string_lossy();
+        let name2 = prefix2.file_name().unwrap().to_string_lossy();
+        assert!(
+            name1.starts_with("shared-env-"),
+            "prefix should start with env name"
+        );
+        assert!(
+            name2.starts_with("shared-env-"),
+            "prefix should start with env name"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conda_env_yml_prefix_same_dir_same_hash() {
+        // Same project dir should produce the same prefix
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "environment.yml",
+            "name: myenv\ndependencies:\n  - numpy\n",
+        );
+        let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
+        let (prefix1, _) =
+            resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
+        let (prefix2, _) =
+            resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
+        assert_eq!(prefix1, prefix2, "same project dir must produce same prefix");
+    }
+
+    #[test]
+    fn test_resolve_conda_env_yml_prefix_no_name_no_prefix() {
+        // No name or prefix: should use hash-based path
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "environment.yml",
+            "dependencies:\n  - numpy\n",
+        );
+        let config = parse_environment_yml(&temp.path().join("environment.yml")).unwrap();
+        let (prefix, is_daemon_owned) =
+            resolve_conda_env_yml_prefix(&config, &temp.path().join("environment.yml"));
+        assert!(is_daemon_owned);
+        // Should be under the cache dir
+        let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
+        assert!(
+            prefix.starts_with(&cache_dir),
+            "no-name prefix should be under cache dir"
+        );
     }
 }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1059,10 +1059,21 @@ pub(crate) async fn handle(
                         )
                         .await
                         {
-                            warn!(
-                                "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
-                                e
-                            );
+                            let details =
+                                format!("conda:env_yml sync into existing env failed: {}", e);
+                            error!("[notebook-sync] {}", details);
+                            reset_starting_state_with_outcome(
+                                room,
+                                None,
+                                ResetOutcome::Error {
+                                    reason: Some(
+                                        runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
+                                    ),
+                                    details: &details,
+                                },
+                            )
+                            .await;
+                            return NotebookResponse::Error { error: details };
                         }
                         // Terminal phase so the banner clears. Matches the env_yml path in
                         // notebook_sync_server::metadata::auto_launch_kernel.

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -924,38 +924,13 @@ pub(crate) async fn handle(
                         }
                     }
 
-                    // Resolve the conda prefix: prefix: → direct path,
-                    // name: → search standard dirs, create if not found.
-                    // Track whether the env is daemon-owned (safe to
-                    // auto-rebuild) vs. user-managed (prefix: field or
-                    // pre-existing named env).
-                    let (conda_prefix, is_daemon_owned_env) = if let Some(ref prefix) =
-                        env_config.prefix
-                    {
-                        // Explicit prefix: path from environment.yml — user-managed
-                        (prefix.clone(), false)
-                    } else if let Some(ref name) = env_config.name {
-                        match crate::project_file::find_named_conda_env(name) {
-                            Some(found) => (found, false), // Pre-existing user env
-                            None => (
-                                crate::project_file::default_conda_envs_dir().join(name),
-                                true,
-                            ),
-                        }
-                    } else {
-                        // No name or prefix — use a hash-based env in cache
-                        let cache_dir = crate::paths::default_cache_dir().join("conda-envs");
-                        let conda_deps_tmp = kernel_env::CondaDependencies {
-                            dependencies: env_config.dependencies.clone(),
-                            channels: env_config.channels.clone(),
-                            python: env_config.python.clone(),
-                            env_id: None,
-                        };
-                        (
-                            cache_dir.join(kernel_env::conda::compute_env_hash(&conda_deps_tmp)),
-                            true,
-                        )
-                    };
+                    // Resolve the conda prefix: prefix: -> direct path,
+                    // name: -> search standard dirs, create if not found.
+                    // Daemon-created envs are scoped by project directory so
+                    // different projects with the same env name get isolated
+                    // prefixes (prevents concurrent clobbering).
+                    let (conda_prefix, is_daemon_owned_env) =
+                        crate::project_file::resolve_conda_env_yml_prefix(&env_config, yml);
 
                     // Merge env.yml deps with any CRDT notebook deps (additive)
                     let mut all_deps = env_config.dependencies.clone();


### PR DESCRIPTION
## Summary

- Scope daemon-created `conda:env_yml` envs by project directory to prevent cross-notebook clobbering
- Extract `resolve_conda_env_yml_prefix()` as single source of truth for conda prefix resolution (3 call sites consolidated)
- When two notebooks share the same `name:` in environment.yaml but have different deps, they now get isolated prefixes (`{name}-{project_hash}`)

**Note:** The abort-on-sync-failure fix has been split into #2514 (uncontroversial, can merge independently). This PR contains only the project-scoped isolation approach, which needs the product discussion in #2513.

See #2513 for the full product framing and alternative approaches.

## Test plan

- [x] `cargo check --package runtimed` passes
- [x] `cargo xtask lint --fix` clean
- [x] CI green
- [x] 4 unit tests covering prefix resolution (prefix field, project scoping, same-dir stability, no-name fallback)