### PR TITLE
fix(kernel-env): abort kernel launch when conda env sync fails

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3353,10 +3353,20 @@ pub(crate) async fn auto_launch_kernel(
             )
             .await
             {
-                warn!(
-                    "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
-                    e
-                );
+                let details = format!("conda:env_yml sync into existing env failed: {}", e);
+                error!("[notebook-sync] {}", details);
+                if let Err(e) = room.state.with_doc(|sd| {
+                    sd.set_lifecycle_with_error_details(
+                        &RuntimeLifecycle::Error,
+                        Some(KernelErrorReason::CondaEnvBuildFailed),
+                        Some(&details),
+                    )?;
+                    sd.clear_env_progress()?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
+                }
+                return;
             }
             // The banner stays lit until a terminal phase is written. Emit Ready so
             // it clears whether the sync completed or we fell through to the existing env.

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1084,10 +1084,21 @@ pub(crate) async fn handle(
                         )
                         .await
                         {
-                            warn!(
-                                "[notebook-sync] conda:env_yml sync into existing env failed: {}, continuing with existing env",
-                                e
-                            );
+                            let details =
+                                format!("conda:env_yml sync into existing env failed: {}", e);
+                            error!("[notebook-sync] {}", details);
+                            reset_starting_state_with_outcome(
+                                room,
+                                None,
+                                ResetOutcome::Error {
+                                    reason: Some(
+                                        runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
+                                    ),
+                                    details: &details,
+                                },
+                            )
+                            .await;
+                            return NotebookResponse::Error { error: details };
                         }
                         // Terminal phase so the banner clears. Matches the env_yml path in
                         // notebook_sync_server::metadata::auto_launch_kernel.


### PR DESCRIPTION
## Summary

- When `sync_dependencies` fails for a `conda:env_yml` environment, abort the kernel launch instead of continuing with a broken env
- Both launch paths (LaunchKernel RPC and auto_launch_kernel) now set `CondaEnvBuildFailed` error lifecycle so the user sees a clear error banner
- Previously the daemon logged a warning and launched the kernel anyway, leading to confusing missing-package errors

Split from #2504 - this is the uncontroversial abort-on-failure fix. The project-scoped env isolation (preventing cross-notebook clobbering) is tracked separately in #2513.

## Test plan

- [ ] `cargo check --package runtimed` passes
- [ ] `cargo xtask lint --fix` clean
- [ ] CI green
- [ ] Verify that a conda env sync failure surfaces as an error banner (not a silently broken kernel)