### PR TITLE
perf(runtimed): isolate pool warming in subprocess

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -277,6 +277,7 @@ struct PackageInstallError {
 ///
 /// UV outputs errors in various formats. This function tries to extract
 /// the package name that caused the failure.
+#[cfg(test)]
 fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
     // Pattern 1: "No solution found when resolving dependencies:
     //   ╰─▶ Because foo was not found..."
@@ -327,60 +328,6 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
     }
 
     None
-}
-
-fn uv_pip_install_args(python_path: &Path, packages: &[String], offline: bool) -> Vec<String> {
-    let mut args = vec![
-        "pip".to_string(),
-        "install".to_string(),
-        "--link-mode".to_string(),
-        "hardlink".to_string(),
-        "--python".to_string(),
-        python_path.to_string_lossy().to_string(),
-    ];
-    if offline {
-        args.push("--offline".to_string());
-    }
-    args.extend(packages.iter().cloned());
-    args
-}
-
-const UV_OFFLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-const UV_ONLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
-
-enum UvInstallAttempt {
-    Completed(std::process::Output),
-    SpawnError(std::io::Error),
-    Timeout,
-}
-
-async fn run_uv_pip_install(
-    uv_path: &Path,
-    install_args: &[String],
-    timeout: std::time::Duration,
-) -> UvInstallAttempt {
-    let mut command = tokio::process::Command::new(uv_path);
-    command
-        .args(install_args)
-        .kill_on_drop(true)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    match tokio::time::timeout(timeout, command.output()).await {
-        Ok(Ok(output)) => UvInstallAttempt::Completed(output),
-        Ok(Err(e)) => UvInstallAttempt::SpawnError(e),
-        Err(_) => UvInstallAttempt::Timeout,
-    }
-}
-
-/// Outcome of a warmup script execution.
-enum WarmupOutcome {
-    /// Warmup succeeded — environment is ready.
-    Ok,
-    /// Warmup timed out.
-    Timeout,
-    /// Warmup script failed (import error or process failure).
-    ImportError(String),
 }
 
 /// Spawn background deletion of environment directories.
@@ -520,6 +467,7 @@ fn expected_pool_package_hash(env_type: EnvType, packages: &[String]) -> String 
     hex::encode(hasher.finalize())
 }
 
+#[cfg(test)]
 async fn write_pool_package_hash(
     env_root: &Path,
     env_type: EnvType,
@@ -4499,321 +4447,65 @@ impl Daemon {
         }
     }
 
-    /// Create a single Conda environment using rattler and add it to the pool.
+    /// Create a single Conda environment via subprocess and add it to the pool.
     async fn create_conda_env(self: &Arc<Self>) {
-        use rattler::{default_cache_dir, install::Installer};
-        use rattler_conda_types::{
-            Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions,
-            Platform,
-        };
-        use rattler_solve::{resolvo, SolverImpl, SolverTask};
-
         let temp_id = format!("{}{}", crate::POOL_PREFIX_CONDA, uuid::Uuid::new_v4());
         let env_path = self.config.cache_dir.join(&temp_id);
 
-        // Register warming path before creating the directory so GC won't
-        // delete it while packages are being installed.
-        self.conda_pool
-            .lock()
-            .await
-            .register_warming_path(env_path.clone());
-
-        // Guard rolls back pool accounting on panic or early exit.
-        let mut guard = WarmingGuard::new(self.clone(), env_path.clone(), PoolKind::Conda);
-
-        #[cfg(target_os = "windows")]
-        let python_path = env_path.join("python.exe");
-        #[cfg(not(target_os = "windows"))]
-        let python_path = env_path.join("bin").join("python");
-
-        info!("[runtimed] Creating Conda environment at {:?}", env_path);
-
-        // Ensure cache directory exists
-        if let Err(e) = tokio::fs::create_dir_all(&self.config.cache_dir).await {
-            error!("[runtimed] Failed to create cache dir: {}", e);
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Failed to create cache dir: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Setup channel configuration
-        let channel_config = ChannelConfig::default_with_root_dir(self.config.cache_dir.clone());
-
-        // Parse channels
-        let channels = match Channel::from_str("conda-forge", &channel_config) {
-            Ok(ch) => vec![ch],
-            Err(e) => {
-                error!("[runtimed] Failed to parse conda-forge channel: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to parse conda-forge channel: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        // Read default conda packages from synced settings
-        let (extra_conda_packages, install_default_data_packages) = {
+        let conda_install_packages = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            (
-                synced.conda.default_packages,
+            conda_prewarmed_packages(
+                &synced.conda.default_packages,
                 synced.install_default_data_packages,
             )
         };
 
-        if !extra_conda_packages.is_empty() {
-            info!(
-                "[runtimed] Including default conda packages: {:?}",
-                extra_conda_packages
-            );
-        }
+        self.conda_pool
+            .lock()
+            .await
+            .register_warming_path(env_path.clone());
+        let mut guard = WarmingGuard::new(self.clone(), env_path.clone(), PoolKind::Conda);
 
-        // Build specs: python + notebook essentials + user-configured defaults
-        let conda_install_packages =
-            conda_prewarmed_packages(&extra_conda_packages, install_default_data_packages);
+        info!("[runtimed] Creating Conda environment at {:?}", env_path);
 
-        let match_spec_options = ParseMatchSpecOptions::strict();
-        let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
-            let mut specs = vec![MatchSpec::from_str("python>=3.13", match_spec_options)?];
-            specs.push(MatchSpec::from_str("python-gil", match_spec_options)?);
-            for pkg in &conda_install_packages {
-                specs.push(MatchSpec::from_str(pkg, match_spec_options)?);
-            }
-            Ok(specs)
-        })() {
-            Ok(s) => s,
-            Err(e) => {
-                error!("[runtimed] Failed to parse match specs: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to parse match specs: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        // Find rattler cache directory
-        let rattler_cache_dir = match default_cache_dir() {
-            Ok(dir) => dir,
-            Err(e) => {
-                error!(
-                    "[runtimed] Could not determine rattler cache directory: {}",
-                    e
-                );
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!(
-                            "Could not determine rattler cache directory: {}",
-                            e
-                        ),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        if let Err(e) = rattler_cache::ensure_cache_dir(&rattler_cache_dir) {
-            error!("[runtimed] Could not create rattler cache directory: {}", e);
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Could not create rattler cache directory: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Create HTTP client
-        let download_client = match reqwest::Client::builder().build() {
-            Ok(c) => reqwest_middleware::ClientBuilder::new(c).build(),
-            Err(e) => {
-                error!("[runtimed] Failed to create HTTP client: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to create HTTP client: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        let install_platform = Platform::current();
-        let platforms = vec![install_platform, Platform::NoArch];
-        let progress_handler = Arc::new(kernel_env::LogHandler);
-
-        info!("[runtimed] Resolving conda repodata from cache or conda-forge...");
-        let repo_data = match kernel_env::repodata::query_repodata_offline_first(
-            channels.clone(),
-            platforms,
-            specs.clone(),
-            &rattler_cache_dir,
-            download_client.clone(),
-            progress_handler,
-            "conda",
-        )
-        .await
+        match self
+            .spawn_warm_env(
+                EnvType::Conda,
+                &env_path,
+                &conda_install_packages,
+                &["conda-forge".to_string()],
+            )
+            .await
         {
-            Ok(data) => data,
-            Err(e) => {
-                error!("[runtimed] Failed to fetch repodata: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to fetch repodata: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        info!("[runtimed] Repodata fetched, solving dependencies...");
-
-        // Detect virtual packages
-        let virtual_packages = match rattler_virtual_packages::VirtualPackage::detect(
-            &rattler_virtual_packages::VirtualPackageOverrides::default(),
-        ) {
-            Ok(vps) => vps
-                .iter()
-                .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
-                .collect::<Vec<_>>(),
-            Err(e) => {
-                error!("[runtimed] Failed to detect virtual packages: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to detect virtual packages: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        // Solve dependencies
-        let solver_task = SolverTask {
-            virtual_packages,
-            specs,
-            ..SolverTask::from_iter(&repo_data)
-        };
-
-        let required_packages = match resolvo::Solver.solve(solver_task) {
-            Ok(result) => result.records,
-            Err(e) => {
-                error!("[runtimed] Failed to solve dependencies: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to solve dependencies: {}", e),
-                        error_kind: "invalid_package".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        };
-
-        info!(
-            "[runtimed] Solved: {} packages to install",
-            required_packages.len()
-        );
-
-        // Install packages
-        let install_result = Installer::new()
-            .with_download_client(download_client)
-            .with_target_platform(install_platform)
-            .install(&env_path, required_packages)
-            .await;
-
-        if let Err(e) = install_result {
-            error!("[runtimed] Failed to install packages: {}", e);
-            tokio::fs::remove_dir_all(&env_path).await.ok();
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Failed to install packages: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Verify python exists
-        if !python_path.exists() {
-            error!(
-                "[runtimed] Python not found at {:?} after install",
-                python_path
-            );
-            tokio::fs::remove_dir_all(&env_path).await.ok();
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Python not found at {:?} after install", python_path),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Vendor the single-file nteract_kernel_launcher module into
-        // site-packages so `python -m nteract_kernel_launcher` resolves for
-        // pool-served conda envs. Without this, bootstrap_dx kernels die with
-        // ModuleNotFoundError at launch. Run before warmup so .pyc is built
-        // with the launcher present.
-        if let Err(e) = kernel_env::launcher::vendor_into_venv(&python_path).await {
-            error!(
-                "[runtimed] Failed to vendor nteract_kernel_launcher into conda pool env at {:?}: {}",
-                python_path, e
-            );
-            let _ = tokio::fs::remove_dir_all(&env_path).await;
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Failed to vendor nteract_kernel_launcher: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Run warmup script
-        let warmup_outcome = self
-            .warmup_conda_env(&python_path, &env_path, &conda_install_packages)
-            .await;
-
-        match warmup_outcome {
-            WarmupOutcome::Ok => {
-                if let Err(e) =
-                    write_pool_package_hash(&env_path, EnvType::Conda, &conda_install_packages)
-                        .await
-                {
-                    warn!(
-                        "[runtimed] Failed to write Conda pool package marker for {:?}: {}",
-                        env_path, e
-                    );
-                }
+            Ok(result) if result.success => {
+                let default_python_path = || {
+                    #[cfg(target_os = "windows")]
+                    {
+                        env_path.join("python.exe")
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        env_path.join("bin").join("python")
+                    }
+                };
+                let (venv_path, python_path) = match Self::validated_warm_env_paths(
+                    result,
+                    env_path.clone(),
+                    default_python_path(),
+                ) {
+                    Ok(paths) => paths,
+                    Err(error) => {
+                        guard.fail_with(Some(error)).await;
+                        return;
+                    }
+                };
                 guard.commit();
                 let retired_to_delete = {
                     let mut pool = self.conda_pool.lock().await;
                     pool.add(PooledEnv {
                         env_type: EnvType::Conda,
-                        venv_path: env_path.clone(),
+                        venv_path,
                         python_path,
                         prewarmed_packages: conda_install_packages,
                     });
@@ -4822,7 +4514,6 @@ impl Daemon {
                 if !retired_to_delete.is_empty() {
                     spawn_env_deletions(retired_to_delete);
                 }
-
                 {
                     let pool = self.conda_pool.lock().await;
                     info!(
@@ -4834,93 +4525,18 @@ impl Daemon {
                 }
                 self.update_pool_doc().await;
             }
-            WarmupOutcome::Timeout => {
-                let _ = tokio::fs::remove_dir_all(&env_path).await;
+            Ok(result) => {
+                guard.fail_with(Some(Self::warm_env_failure(result))).await;
+            }
+            Err(e) => {
+                error!("[runtimed] Conda warm-env subprocess failed: {}", e);
                 guard
                     .fail_with(Some(PackageInstallError {
                         failed_package: None,
-                        error_message: "Conda warmup timed out".into(),
-                        error_kind: "timeout".to_string(),
+                        error_message: e,
+                        error_kind: "setup_failed".to_string(),
                     }))
                     .await;
-            }
-            WarmupOutcome::ImportError(msg) => {
-                let _ = tokio::fs::remove_dir_all(&env_path).await;
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!(
-                            "Conda warmup failed: {}",
-                            msg.chars().take(200).collect::<String>()
-                        ),
-                        error_kind: "import_error".to_string(),
-                    }))
-                    .await;
-            }
-        }
-    }
-
-    /// Warm up a conda environment by running Python to trigger .pyc compilation.
-    async fn warmup_conda_env(
-        &self,
-        python_path: &PathBuf,
-        env_path: &PathBuf,
-        extra_packages: &[String],
-    ) -> WarmupOutcome {
-        let site_packages = {
-            let lib_dir = env_path.join("lib");
-            std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
-                entries.flatten().find_map(|entry| {
-                    let path = entry.path();
-                    let name = path.file_name()?.to_str()?;
-                    if name.starts_with("python") {
-                        let sp = path.join("site-packages");
-                        sp.is_dir().then(|| sp.to_string_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                })
-            })
-        };
-        let warmup_script = kernel_env::warmup::build_warmup_command(
-            extra_packages,
-            true,
-            site_packages.as_deref(),
-        );
-
-        let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(180),
-            tokio::process::Command::new(python_path)
-                .args(["-c", &warmup_script])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await;
-
-        match warmup_result {
-            Ok(Ok(output)) if output.status.success() => {
-                // Create marker file
-                tokio::fs::write(env_path.join(".warmed"), "").await.ok();
-                info!("[runtimed] Conda warmup complete for {:?}", env_path);
-                WarmupOutcome::Ok
-            }
-            Ok(Ok(output)) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                error!(
-                    "[runtimed] Conda warmup failed for {:?}: {}",
-                    env_path,
-                    stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
-                );
-                WarmupOutcome::ImportError(stderr.to_string())
-            }
-            Ok(Err(e)) => {
-                error!("[runtimed] Failed to run conda warmup: {}", e);
-                WarmupOutcome::ImportError(e.to_string())
-            }
-            Err(_) => {
-                error!("[runtimed] Conda warmup timed out (180s)");
-                WarmupOutcome::Timeout
             }
         }
     }
@@ -4931,94 +4547,84 @@ impl Daemon {
         self.create_conda_env().await;
     }
 
-    /// Create a pixi environment using rattler (no subprocess).
-    ///
-    /// Creates a pixi-compatible project directory with ipykernel and default
-    /// packages, solved and installed via rattler. Replaces the old
-    /// `pixi init` + `pixi add` subprocess approach.
+    /// Create a pixi environment via subprocess and add it to the pool.
     async fn create_pixi_env(self: &Arc<Self>) {
         let cache_dir = self.config.cache_dir.clone();
         let env_id = uuid::Uuid::new_v4().to_string();
         let project_dir = cache_dir.join(format!("{}{}", crate::POOL_PREFIX_PIXI, env_id));
 
-        // Register warming path before creating the directory so GC won't
-        // delete it while packages are being installed.
+        let packages = {
+            let settings = self.settings.read().await;
+            let synced = settings.get_all();
+            pixi_prewarmed_packages(
+                &synced.pixi.default_packages,
+                synced.install_default_data_packages,
+            )
+        };
+
         self.pixi_pool
             .lock()
             .await
             .register_warming_path(project_dir.clone());
-
-        // Guard rolls back pool accounting on panic or early exit.
         let mut guard = WarmingGuard::new(self.clone(), project_dir.clone(), PoolKind::Pixi);
 
         info!("[runtimed] Creating Pixi environment at {:?}", project_dir);
 
-        // Build package list
-        let packages = {
-            let settings = self.settings.read().await;
-            let synced = settings.get_all();
-            let pixi_defaults = synced.pixi.default_packages;
-            let install_default_data_packages = synced.install_default_data_packages;
-            if !pixi_defaults.is_empty() {
-                info!(
-                    "[runtimed] Including default pixi packages: {:?}",
-                    pixi_defaults
-                );
-            }
-            pixi_prewarmed_packages(&pixi_defaults, install_default_data_packages)
-        };
-        let prewarmed_packages = packages.clone();
-
-        // Create environment using rattler (pixi-compatible layout)
-        let handler = std::sync::Arc::new(kernel_env::LogHandler);
-        match kernel_env::pixi::create_pixi_environment(
-            &project_dir,
-            &packages,
-            &["conda-forge".to_string()],
-            handler.clone(),
-        )
-        .await
+        match self
+            .spawn_warm_env(
+                EnvType::Pixi,
+                &project_dir,
+                &packages,
+                &["conda-forge".to_string()],
+            )
+            .await
         {
-            Ok(env) => {
-                // Warm up the environment (.pyc compilation)
-                if let Err(e) =
-                    kernel_env::pixi::warmup_environment(&env, &prewarmed_packages).await
-                {
-                    warn!("[runtimed] Pixi warmup failed (non-fatal): {}", e);
-                }
-
-                info!("[runtimed] Pixi environment ready at {:?}", env.project_dir);
-                if let Err(e) =
-                    write_pool_package_hash(&project_dir, EnvType::Pixi, &prewarmed_packages).await
-                {
-                    warn!(
-                        "[runtimed] Failed to write Pixi pool package marker for {:?}: {}",
-                        project_dir, e
-                    );
-                }
+            Ok(result) if result.success => {
+                let (venv_path, python_path) = match Self::validated_warm_env_paths(
+                    result,
+                    project_dir.join(".pixi/envs/default"),
+                    project_dir.join(".pixi/envs/default/bin/python"),
+                ) {
+                    Ok(paths) => paths,
+                    Err(error) => {
+                        guard.fail_with(Some(error)).await;
+                        return;
+                    }
+                };
                 guard.commit();
                 let retired_to_delete = {
                     let mut pool = self.pixi_pool.lock().await;
                     pool.add(PooledEnv {
                         env_type: EnvType::Pixi,
-                        venv_path: env.venv_path,
-                        python_path: env.python_path,
-                        prewarmed_packages,
+                        venv_path,
+                        python_path,
+                        prewarmed_packages: packages,
                     });
                     pool.retired_paths_after_replacement()
                 };
                 if !retired_to_delete.is_empty() {
                     spawn_env_deletions(retired_to_delete);
                 }
+                {
+                    let pool = self.pixi_pool.lock().await;
+                    info!(
+                        "[runtimed] Pixi environment ready at {:?} (pool: {}/{})",
+                        project_dir,
+                        pool.stats().0,
+                        pool.target()
+                    );
+                }
                 self.update_pool_doc().await;
             }
+            Ok(result) => {
+                guard.fail_with(Some(Self::warm_env_failure(result))).await;
+            }
             Err(e) => {
-                error!("[runtimed] Pixi environment creation failed: {}", e);
-                let _ = tokio::fs::remove_dir_all(&project_dir).await;
+                error!("[runtimed] Pixi warm-env subprocess failed: {}", e);
                 guard
                     .fail_with(Some(PackageInstallError {
-                        error_message: format!("{}", e),
                         failed_package: None,
+                        error_message: e,
                         error_kind: "setup_failed".to_string(),
                     }))
                     .await;
@@ -5097,327 +4703,213 @@ impl Daemon {
         self.pool_ready_pixi.notify_waiters();
     }
 
-    /// Create a single UV environment and add it to the pool.
-    async fn create_uv_env(self: &Arc<Self>) {
-        // Get uv path (cached via OnceCell, so this is instant after initial bootstrap)
-        let uv_path = match kernel_launch::tools::get_uv_path().await {
-            Ok(path) => path,
-            Err(e) => {
-                error!("[runtimed] Failed to get uv path: {}", e);
-                self.uv_pool
-                    .lock()
-                    .await
-                    .warming_failed_with_error(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to get uv path: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }));
-                self.update_pool_doc().await;
-                return;
-            }
+    fn warm_env_failure(result: crate::warm_env::WarmEnvResult) -> PackageInstallError {
+        PackageInstallError {
+            failed_package: result.failed_package,
+            error_message: result
+                .error
+                .filter(|message| !message.is_empty())
+                .unwrap_or_else(|| "warm-env subprocess reported failure".to_string()),
+            error_kind: result
+                .error_kind
+                .filter(|kind| !kind.is_empty())
+                .unwrap_or_else(|| "setup_failed".to_string()),
+        }
+    }
+
+    fn validated_warm_env_paths(
+        result: crate::warm_env::WarmEnvResult,
+        default_venv_path: PathBuf,
+        default_python_path: PathBuf,
+    ) -> Result<(PathBuf, PathBuf), PackageInstallError> {
+        let venv_path = result.venv_path.unwrap_or(default_venv_path);
+        let python_path = result.python_path.unwrap_or(default_python_path);
+
+        if !venv_path.exists() {
+            return Err(PackageInstallError {
+                failed_package: None,
+                error_message: format!("warm-env returned missing environment path: {venv_path:?}"),
+                error_kind: "setup_failed".to_string(),
+            });
+        }
+
+        if !python_path.exists() {
+            return Err(PackageInstallError {
+                failed_package: None,
+                error_message: format!("warm-env returned missing Python path: {python_path:?}"),
+                error_kind: "setup_failed".to_string(),
+            });
+        }
+
+        Ok((venv_path, python_path))
+    }
+
+    /// Spawn a `runtimed warm-env` subprocess and parse its JSON result.
+    ///
+    /// Config is sent as a single JSON object on the child's stdin.
+    /// The child writes newline-delimited JSON events (progress + result) on
+    /// stdout. A 10-minute overall timeout kills the child if it hangs.
+    async fn spawn_warm_env(
+        &self,
+        env_type: EnvType,
+        env_dir: &Path,
+        packages: &[String],
+        channels: &[String],
+    ) -> Result<crate::warm_env::WarmEnvResult, String> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let exe = match std::env::current_exe() {
+            Ok(e) => e,
+            Err(e) => return Err(format!("Failed to get current exe: {e}")),
         };
 
+        let type_str = match env_type {
+            EnvType::Uv => "uv",
+            EnvType::Conda => "conda",
+            EnvType::Pixi => "pixi",
+        };
+
+        let config = crate::warm_env::WarmEnvConfig {
+            env_type,
+            env_dir: env_dir.to_path_buf(),
+            packages: packages.to_vec(),
+            channels: channels.to_vec(),
+        };
+        let config_json = serde_json::to_string(&config)
+            .map_err(|e| format!("Failed to serialize warm-env config: {e}"))?;
+
+        let mut child = tokio::process::Command::new(&exe)
+            .arg("warm-env")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("Failed to spawn warm-env: {e}"))?;
+
+        // Write config to stdin and close it so the child can proceed.
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| "Failed to open subprocess stdin".to_string())?;
+            stdin
+                .write_all(config_json.as_bytes())
+                .await
+                .map_err(|e| format!("Failed to write config to warm-env stdin: {e}"))?;
+            // stdin is dropped here, closing the pipe
+        }
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Failed to capture subprocess stdout".to_string())?;
+
+        let mut lines = tokio::io::BufReader::new(stdout).lines();
+        let mut last_result: Option<crate::warm_env::WarmEnvResult> = None;
+
+        let timeout = std::time::Duration::from_secs(600);
+        let read_result = tokio::time::timeout(timeout, async {
+            while let Ok(Some(line)) = lines.next_line().await {
+                match serde_json::from_str::<crate::warm_env::WarmEnvEvent>(&line) {
+                    Ok(crate::warm_env::WarmEnvEvent::Progress { phase, detail }) => {
+                        debug!("[runtimed] warm-env {type_str}: [{phase}] {detail}");
+                    }
+                    Ok(crate::warm_env::WarmEnvEvent::Result(result)) => {
+                        last_result = Some(result);
+                    }
+                    Err(e) => {
+                        debug!("[runtimed] warm-env {type_str}: unparseable line: {e}");
+                    }
+                }
+            }
+        })
+        .await;
+
+        if read_result.is_err() {
+            // Kill before waiting — don't block on a wedged child.
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err("warm-env subprocess timed out after 10 minutes".to_string());
+        }
+
+        let status = child.wait().await;
+
+        if let Some(result) = last_result {
+            // Treat non-zero exit as failure even if the child emitted a
+            // success result (it may have crashed during teardown).
+            if let Ok(s) = &status {
+                if !s.success() && result.success {
+                    return Err(format!(
+                        "warm-env {type_str} emitted success but exited with {s}"
+                    ));
+                }
+            }
+            return Ok(result);
+        }
+
+        match status {
+            Ok(s) if s.success() => Err("warm-env exited 0 but no result event on stdout".into()),
+            Ok(s) => Err(format!("warm-env exited with status {s}")),
+            Err(e) => Err(format!("Failed to wait on warm-env: {e}")),
+        }
+    }
+
+    /// Create a single UV environment and add it to the pool.
+    async fn create_uv_env(self: &Arc<Self>) {
         let temp_id = format!("{}{}", crate::POOL_PREFIX_UV, uuid::Uuid::new_v4());
         let venv_path = self.config.cache_dir.join(&temp_id);
 
-        // Register warming path before creating the directory so GC won't
-        // delete it while packages are being installed.
+        // Read packages from settings before spawning
+        let install_packages = {
+            let settings = self.settings.read().await;
+            let synced = settings.get_all();
+            uv_prewarmed_packages(
+                &synced.uv.default_packages,
+                synced.install_default_data_packages,
+            )
+        };
+
         self.uv_pool
             .lock()
             .await
             .register_warming_path(venv_path.clone());
-
-        // Guard rolls back pool accounting on panic or early exit.
         let mut guard = WarmingGuard::new(self.clone(), venv_path.clone(), PoolKind::Uv);
-
-        #[cfg(target_os = "windows")]
-        let python_path = venv_path.join("Scripts").join("python.exe");
-        #[cfg(not(target_os = "windows"))]
-        let python_path = venv_path.join("bin").join("python");
 
         info!("[runtimed] Creating UV environment at {:?}", venv_path);
 
-        // Ensure cache directory exists
-        if let Err(e) = tokio::fs::create_dir_all(&self.config.cache_dir).await {
-            error!("[runtimed] Failed to create cache dir: {}", e);
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Failed to create cache dir: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Create venv (60 second timeout)
-        let venv_result = tokio::time::timeout(
-            std::time::Duration::from_secs(60),
-            tokio::process::Command::new(&uv_path)
-                .arg("venv")
-                .arg(&venv_path)
-                .arg("--python")
-                .arg("3.13")
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await;
-
-        match venv_result {
-            Ok(Ok(output)) if output.status.success() => {}
-            Ok(Ok(output)) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                error!("[runtimed] Failed to create venv: {}", stderr);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to create venv: {}", stderr),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-            Ok(Err(e)) => {
-                error!("[runtimed] Failed to create venv: {}", e);
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: format!("Failed to create venv: {}", e),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-            Err(_) => {
-                error!("[runtimed] Timeout creating venv");
-                tokio::fs::remove_dir_all(&venv_path).await.ok();
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: "Timeout creating venv after 60 seconds".to_string(),
-                        error_kind: "timeout".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        }
-
-        // Read default uv packages from synced settings
-        let (user_default_packages, install_default_data_packages) = {
-            let settings = self.settings.read().await;
-            let synced = settings.get_all();
-            let configured = synced.uv.default_packages;
-            if !configured.is_empty() {
-                info!("[runtimed] Including default uv packages: {:?}", configured);
-            }
-            (configured, synced.install_default_data_packages)
-        };
-        let install_packages =
-            uv_prewarmed_packages(&user_default_packages, install_default_data_packages);
-
-        // Install packages (180 second timeout per attempt). Try uv's cache
-        // first so offline users with cached wheels do not take the network
-        // path just to warm a background pool entry.
-        let offline_install_args = uv_pip_install_args(&python_path, &install_packages, true);
-        let install_result = match run_uv_pip_install(
-            &uv_path,
-            &offline_install_args,
-            UV_OFFLINE_INSTALL_TIMEOUT,
-        )
-        .await
+        match self
+            .spawn_warm_env(EnvType::Uv, &venv_path, &install_packages, &[])
+            .await
         {
-            UvInstallAttempt::Completed(output) if output.status.success() => {
-                info!("[runtimed] UV packages installed from local cache (offline mode)");
-                UvInstallAttempt::Completed(output)
-            }
-            UvInstallAttempt::Completed(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                info!(
-                    "[runtimed] UV offline install missed cache, falling back to network-capable install: {}",
-                    stderr.lines().take(3).collect::<Vec<_>>().join(" ")
-                );
-                let install_args = uv_pip_install_args(&python_path, &install_packages, false);
-                run_uv_pip_install(&uv_path, &install_args, UV_ONLINE_INSTALL_TIMEOUT).await
-            }
-            UvInstallAttempt::SpawnError(e) => {
-                warn!(
-                    "[runtimed] Failed to run uv offline install, falling back to network-capable install: {}",
-                    e
-                );
-                let install_args = uv_pip_install_args(&python_path, &install_packages, false);
-                run_uv_pip_install(&uv_path, &install_args, UV_ONLINE_INSTALL_TIMEOUT).await
-            }
-            UvInstallAttempt::Timeout => {
-                warn!(
-                    "[runtimed] UV offline install timed out, falling back to network-capable install"
-                );
-                let install_args = uv_pip_install_args(&python_path, &install_packages, false);
-                run_uv_pip_install(&uv_path, &install_args, UV_ONLINE_INSTALL_TIMEOUT).await
-            }
-        };
-
-        match install_result {
-            UvInstallAttempt::Completed(output) if output.status.success() => {}
-            UvInstallAttempt::Completed(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let parsed_error = parse_uv_error(&stderr);
-
-                if let Some(ref err) = parsed_error {
-                    if let Some(pkg) = &err.failed_package {
-                        // Check if this is a user-specified package (not ipykernel/ipywidgets/anywidget)
-                        let is_user_package = user_default_packages
-                            .iter()
-                            .any(|configured| configured == pkg);
-
-                        if is_user_package {
-                            error!(
-                                "[runtimed] Failed to install user package '{}' from default_packages setting. \
-                                 Check uv.default_packages in settings for typos.",
-                                pkg
-                            );
-                        } else {
-                            error!(
-                                "[runtimed] Failed to install package '{}': {}",
-                                pkg,
-                                stderr.lines().take(3).collect::<Vec<_>>().join(" ")
-                            );
-                        }
-                    } else {
-                        error!(
-                            "[runtimed] Package installation failed: {}",
-                            stderr.lines().take(5).collect::<Vec<_>>().join(" ")
-                        );
+            Ok(result) if result.success => {
+                let default_python_path = || {
+                    #[cfg(target_os = "windows")]
+                    {
+                        venv_path.join("Scripts").join("python.exe")
                     }
-                } else {
-                    error!(
-                        "[runtimed] Package installation failed: {}",
-                        stderr.lines().take(5).collect::<Vec<_>>().join(" ")
-                    );
-                }
-
-                tokio::fs::remove_dir_all(&venv_path).await.ok();
-                guard.fail_with(parsed_error).await;
-                return;
-            }
-            UvInstallAttempt::SpawnError(e) => {
-                error!("[runtimed] Failed to run uv pip install: {}", e);
-                tokio::fs::remove_dir_all(&venv_path).await.ok();
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: e.to_string(),
-                        error_kind: "setup_failed".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-            UvInstallAttempt::Timeout => {
-                error!("[runtimed] Timeout installing packages (180s)");
-                tokio::fs::remove_dir_all(&venv_path).await.ok();
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: "Timeout after 180 seconds".to_string(),
-                        error_kind: "timeout".to_string(),
-                    }))
-                    .await;
-                return;
-            }
-        }
-
-        // Vendor the single-file nteract_kernel_launcher module into
-        // site-packages so `python -m nteract_kernel_launcher` resolves for
-        // pool-served UV envs. Without this, bootstrap_dx kernels die with
-        // ModuleNotFoundError at launch. Run before warmup so .pyc is built
-        // with the launcher present.
-        if let Err(e) = kernel_env::launcher::vendor_into_venv(&python_path).await {
-            error!(
-                "[runtimed] Failed to vendor nteract_kernel_launcher into UV pool env at {:?}: {}",
-                python_path, e
-            );
-            let _ = tokio::fs::remove_dir_all(&venv_path).await;
-            guard
-                .fail_with(Some(PackageInstallError {
-                    failed_package: None,
-                    error_message: format!("Failed to vendor nteract_kernel_launcher: {}", e),
-                    error_kind: "setup_failed".to_string(),
-                }))
-                .await;
-            return;
-        }
-
-        // Warm up the environment (30 second timeout)
-        let site_packages = {
-            let lib_dir = venv_path.join("lib");
-            std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
-                entries.flatten().find_map(|entry| {
-                    let path = entry.path();
-                    let name = path.file_name()?.to_str()?;
-                    if name.starts_with("python") {
-                        let sp = path.join("site-packages");
-                        sp.is_dir().then(|| sp.to_string_lossy().into_owned())
-                    } else {
-                        None
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        venv_path.join("bin").join("python")
                     }
-                })
-            })
-        };
-        let warmup_script = kernel_env::warmup::build_warmup_command(
-            &install_packages,
-            false,
-            site_packages.as_deref(),
-        );
-
-        let warmup_result = tokio::time::timeout(
-            std::time::Duration::from_secs(180),
-            tokio::process::Command::new(&python_path)
-                .args(["-c", &warmup_script])
-                .output(),
-        )
-        .await;
-
-        let warmup_outcome = match warmup_result {
-            Ok(Ok(output)) if output.status.success() => {
-                // Create marker file
-                tokio::fs::write(venv_path.join(".warmed"), "").await.ok();
-                WarmupOutcome::Ok
-            }
-            Ok(Ok(output)) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                error!(
-                    "[runtimed] UV warmup failed, NOT adding to pool: {}",
-                    stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
-                );
-                WarmupOutcome::ImportError(stderr.to_string())
-            }
-            Ok(Err(e)) => {
-                error!("[runtimed] Failed to run UV warmup: {}", e);
-                WarmupOutcome::ImportError(e.to_string())
-            }
-            Err(_) => {
-                error!("[runtimed] UV warmup timed out, NOT adding to pool (180s)");
-                WarmupOutcome::Timeout
-            }
-        };
-
-        match warmup_outcome {
-            WarmupOutcome::Ok => {
-                info!("[runtimed] UV environment ready at {:?}", venv_path);
-                if let Err(e) =
-                    write_pool_package_hash(&venv_path, EnvType::Uv, &install_packages).await
-                {
-                    warn!(
-                        "[runtimed] Failed to write UV pool package marker for {:?}: {}",
-                        venv_path, e
-                    );
-                }
+                };
+                let (venv_path, python_path) = match Self::validated_warm_env_paths(
+                    result,
+                    venv_path.clone(),
+                    default_python_path(),
+                ) {
+                    Ok(paths) => paths,
+                    Err(error) => {
+                        guard.fail_with(Some(error)).await;
+                        return;
+                    }
+                };
                 guard.commit();
                 let retired_to_delete = {
                     let mut pool = self.uv_pool.lock().await;
                     pool.add(PooledEnv {
                         env_type: EnvType::Uv,
-                        venv_path,
+                        venv_path: venv_path.clone(),
                         python_path,
                         prewarmed_packages: install_packages,
                     });
@@ -5426,28 +4918,27 @@ impl Daemon {
                 if !retired_to_delete.is_empty() {
                     spawn_env_deletions(retired_to_delete);
                 }
+                {
+                    let pool = self.uv_pool.lock().await;
+                    info!(
+                        "[runtimed] UV environment ready at {:?} (pool: {}/{})",
+                        venv_path,
+                        pool.stats().0,
+                        pool.target()
+                    );
+                }
                 self.update_pool_doc().await;
             }
-            WarmupOutcome::Timeout => {
-                let _ = tokio::fs::remove_dir_all(&venv_path).await;
-                guard
-                    .fail_with(Some(PackageInstallError {
-                        failed_package: None,
-                        error_message: "UV warmup timed out".into(),
-                        error_kind: "timeout".to_string(),
-                    }))
-                    .await;
+            Ok(result) => {
+                guard.fail_with(Some(Self::warm_env_failure(result))).await;
             }
-            WarmupOutcome::ImportError(msg) => {
-                let _ = tokio::fs::remove_dir_all(&venv_path).await;
+            Err(e) => {
+                error!("[runtimed] UV warm-env subprocess failed: {}", e);
                 guard
                     .fail_with(Some(PackageInstallError {
                         failed_package: None,
-                        error_message: format!(
-                            "UV warmup failed: {}",
-                            msg.chars().take(200).collect::<String>()
-                        ),
-                        error_kind: "import_error".to_string(),
+                        error_message: e,
+                        error_kind: "setup_failed".to_string(),
                     }))
                     .await;
             }
@@ -6438,53 +5929,6 @@ mod tests {
     }
 
     #[test]
-    fn test_uv_pip_install_args_offline_first_shape() {
-        let packages = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
-        let args = uv_pip_install_args(Path::new("/tmp/env/bin/python"), &packages, true);
-
-        assert_eq!(
-            args,
-            vec![
-                "pip",
-                "install",
-                "--link-mode",
-                "hardlink",
-                "--python",
-                "/tmp/env/bin/python",
-                "--offline",
-                "ipykernel",
-                "ipywidgets",
-            ]
-        );
-    }
-
-    #[test]
-    fn test_uv_pip_install_args_online_fallback_shape() {
-        let packages = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
-        let args = uv_pip_install_args(Path::new("/tmp/env/bin/python"), &packages, false);
-
-        assert_eq!(
-            args,
-            vec![
-                "pip",
-                "install",
-                "--link-mode",
-                "hardlink",
-                "--python",
-                "/tmp/env/bin/python",
-                "ipykernel",
-                "ipywidgets",
-            ]
-        );
-        assert!(!args.iter().any(|arg| arg == "--offline"));
-    }
-
-    #[test]
-    fn test_uv_offline_probe_has_shorter_timeout_than_online_fallback() {
-        assert!(UV_OFFLINE_INSTALL_TIMEOUT < UV_ONLINE_INSTALL_TIMEOUT);
-    }
-
-    #[test]
     fn test_collect_blob_hashes_display_data() {
         let manifest = serde_json::json!({
             "output_type": "display_data",
@@ -7108,6 +6552,50 @@ mod tests {
         manual.update(b"ipykernel\n");
 
         assert_eq!(hash, hex::encode(manual.finalize()));
+    }
+
+    #[test]
+    fn test_validated_warm_env_paths_rejects_missing_python() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_path = temp_dir.path().join("env");
+        let python_path = env_path.join("bin").join("python");
+        std::fs::create_dir_all(&env_path).unwrap();
+
+        let result = crate::warm_env::WarmEnvResult {
+            success: true,
+            python_path: Some(python_path.clone()),
+            venv_path: Some(env_path.clone()),
+            error: None,
+            error_kind: None,
+            failed_package: None,
+        };
+
+        let error = Daemon::validated_warm_env_paths(result, env_path, python_path)
+            .expect_err("missing Python path should not be accepted");
+        assert_eq!(error.error_kind, "setup_failed");
+        assert!(error.error_message.contains("missing Python path"));
+    }
+
+    #[test]
+    fn test_validated_warm_env_paths_accepts_existing_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_path = temp_dir.path().join("env");
+        let python_path = env_path.join("bin").join("python");
+        std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
+        std::fs::write(&python_path, "").unwrap();
+
+        let result = crate::warm_env::WarmEnvResult {
+            success: true,
+            python_path: Some(python_path.clone()),
+            venv_path: Some(env_path.clone()),
+            error: None,
+            error_kind: None,
+            failed_package: None,
+        };
+
+        let paths = Daemon::validated_warm_env_paths(result, env_path.clone(), python_path.clone())
+            .expect("existing helper paths should be accepted");
+        assert_eq!(paths, (env_path, python_path));
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -53,6 +53,8 @@ pub mod terminal_size;
 pub(crate) mod trusted_packages;
 pub mod user_error;
 pub(crate) mod uv_project;
+#[doc(hidden)]
+pub mod warm_env;
 
 pub fn trusted_packages_db_path() -> std::path::PathBuf {
     runtimed_client::daemon_base_dir().join("trusted-packages.sqlite")

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -138,6 +138,11 @@ enum Commands {
         #[arg(long)]
         blob_root: PathBuf,
     },
+
+    /// Warm a pool environment (internal, spawned by daemon warming loops).
+    /// Reads JSON config from stdin, writes JSON events to stdout.
+    #[command(hide = true, name = "warm-env")]
+    WarmEnv,
 }
 
 /// Get a log path that works even when HOME is not set.
@@ -417,6 +422,10 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("[runtime-agent] Fatal: {}", e);
             e
         }),
+        Some(Commands::WarmEnv) => {
+            runtimed::warm_env::run().await;
+            Ok(())
+        }
     }
 }
 

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -1,0 +1,863 @@
+//! Subprocess entry point for pool environment warming.
+//!
+//! The `warm-env` subcommand runs as a short-lived child process spawned by the
+//! daemon's warming loops. It creates one environment (UV, Conda, or Pixi),
+//! writes structured JSON events to stdout, and exits. All of rattler's
+//! in-process memory is reclaimed by the OS when the process exits.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, warn};
+
+use crate::EnvType;
+
+// -- IPC protocol --------------------------------------------------------
+//
+// stdin:  single JSON object (WarmEnvConfig) - all arguments for the run
+// stdout: newline-delimited JSON events (WarmEnvEvent) - progress + result
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WarmEnvConfig {
+    pub env_type: EnvType,
+    pub env_dir: PathBuf,
+    pub packages: Vec<String>,
+    #[serde(default)]
+    pub channels: Vec<String>,
+}
+
+// -- stdout events -------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum WarmEnvEvent {
+    Progress { phase: String, detail: String },
+    Result(WarmEnvResult),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WarmEnvResult {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub venv_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_package: Option<String>,
+}
+
+// -- helpers --------------------------------------------------------------
+
+fn emit(event: &WarmEnvEvent) {
+    if let Ok(json) = serde_json::to_string(event) {
+        println!("{json}");
+        let mut stdout = std::io::stdout();
+        let _ = std::io::Write::flush(&mut stdout);
+    }
+}
+
+fn progress(phase: &str, detail: &str) {
+    emit(&WarmEnvEvent::Progress {
+        phase: phase.into(),
+        detail: detail.into(),
+    });
+}
+
+fn success_result(python_path: PathBuf, venv_path: PathBuf) -> WarmEnvResult {
+    WarmEnvResult {
+        success: true,
+        python_path: Some(python_path),
+        venv_path: Some(venv_path),
+        error: None,
+        error_kind: None,
+        failed_package: None,
+    }
+}
+
+fn failure_result(
+    error: String,
+    error_kind: &str,
+    failed_package: Option<String>,
+) -> WarmEnvResult {
+    WarmEnvResult {
+        success: false,
+        python_path: None,
+        venv_path: None,
+        error: Some(error),
+        error_kind: Some(error_kind.into()),
+        failed_package,
+    }
+}
+
+fn emit_success(python_path: PathBuf, venv_path: PathBuf) {
+    emit(&WarmEnvEvent::Result(success_result(
+        python_path,
+        venv_path,
+    )));
+}
+
+fn emit_failure(error: String, error_kind: &str, failed_package: Option<String>) {
+    emit(&WarmEnvEvent::Result(failure_result(
+        error,
+        error_kind,
+        failed_package,
+    )));
+}
+
+// -- package hash (shared with daemon's find_existing_environments) -------
+
+const POOL_PACKAGE_HASH_FILE: &str = ".runt-pool-packages.sha256";
+const POOL_PACKAGE_HASH_VERSION: &str = "v1";
+
+fn expected_pool_package_hash(env_type: EnvType, packages: &[String]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut sorted = packages.to_vec();
+    sorted.sort();
+
+    let mut hasher = Sha256::new();
+    hasher.update(POOL_PACKAGE_HASH_VERSION.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(env_type.to_string().as_bytes());
+    hasher.update(b"\n");
+    hasher.update(std::env::consts::OS.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(std::env::consts::ARCH.as_bytes());
+    hasher.update(b"\n");
+    for package in sorted {
+        hasher.update(package.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex::encode(hasher.finalize())
+}
+
+async fn write_pool_package_hash(
+    env_root: &Path,
+    env_type: EnvType,
+    packages: &[String],
+) -> std::io::Result<()> {
+    tokio::fs::write(
+        env_root.join(POOL_PACKAGE_HASH_FILE),
+        expected_pool_package_hash(env_type, packages),
+    )
+    .await
+}
+
+// -- site-packages discovery ----------------------------------------------
+
+fn find_site_packages(env_path: &Path) -> Option<String> {
+    let lib_dir = env_path.join("lib");
+    std::fs::read_dir(&lib_dir).ok().and_then(|entries| {
+        entries.flatten().find_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            if name.starts_with("python") {
+                let sp = path.join("site-packages");
+                sp.is_dir().then(|| sp.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        })
+    })
+}
+
+// -- UV env creation ------------------------------------------------------
+
+const UV_OFFLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const UV_ONLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+fn uv_pip_install_args(python_path: &Path, packages: &[String], offline: bool) -> Vec<String> {
+    let mut args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--link-mode".to_string(),
+        "hardlink".to_string(),
+        "--python".to_string(),
+        python_path.to_string_lossy().to_string(),
+    ];
+    if offline {
+        args.push("--offline".to_string());
+    }
+    args.extend(packages.iter().cloned());
+    args
+}
+
+enum UvInstallAttempt {
+    Completed(std::process::Output),
+    SpawnError(std::io::Error),
+    Timeout,
+}
+
+async fn run_uv_pip_install(
+    uv_path: &Path,
+    install_args: &[String],
+    timeout: std::time::Duration,
+) -> UvInstallAttempt {
+    let mut command = tokio::process::Command::new(uv_path);
+    command
+        .args(install_args)
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match tokio::time::timeout(timeout, command.output()).await {
+        Ok(Ok(output)) => UvInstallAttempt::Completed(output),
+        Ok(Err(e)) => UvInstallAttempt::SpawnError(e),
+        Err(_) => UvInstallAttempt::Timeout,
+    }
+}
+
+fn parse_uv_error(stderr: &str) -> Option<(String, String, Option<String>)> {
+    let stderr_lower = stderr.to_lowercase();
+    let pkg_patterns = [
+        (r"package `([^`]+)`", '`'),
+        (r"package '([^']+)'", '\''),
+        (r"because ([a-z0-9_-]+) was not found", ' '),
+        (r"no matching distribution found for ([a-z0-9_-]+)", ' '),
+        (r"failed to download `([^`]+)`", '`'),
+        (r"failed to download '([^']+)'", '\''),
+    ];
+
+    for (pattern, _) in &pkg_patterns {
+        if let Ok(re) = regex::Regex::new(pattern) {
+            if let Some(caps) = re.captures(&stderr_lower) {
+                if let Some(pkg) = caps.get(1) {
+                    let package_name = pkg.as_str().to_string();
+                    if package_name != "ipykernel"
+                        && package_name != "ipywidgets"
+                        && package_name != "anywidget"
+                    {
+                        return Some((
+                            stderr.to_string(),
+                            "invalid_package".to_string(),
+                            Some(package_name),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if stderr.contains("error") || stderr.contains("failed") || stderr.contains("not found") {
+        return Some((stderr.to_string(), "setup_failed".to_string(), None));
+    }
+
+    None
+}
+
+async fn create_uv(env_dir: &Path, packages: &[String]) {
+    progress("bootstrap", "getting uv path");
+    let uv_path = match kernel_launch::tools::get_uv_path().await {
+        Ok(path) => path,
+        Err(e) => {
+            emit_failure(format!("Failed to get uv path: {e}"), "setup_failed", None);
+            return;
+        }
+    };
+
+    #[cfg(target_os = "windows")]
+    let python_path = env_dir.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_dir.join("bin").join("python");
+
+    if let Some(parent) = env_dir.parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            emit_failure(
+                format!("Failed to create cache dir: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    }
+
+    // Create venv
+    progress("venv", "creating virtual environment");
+    let venv_result = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        tokio::process::Command::new(&uv_path)
+            .arg("venv")
+            .arg(env_dir)
+            .arg("--python")
+            .arg("3.13")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match venv_result {
+        Ok(Ok(output)) if output.status.success() => {}
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            emit_failure(
+                format!("Failed to create venv: {stderr}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+        Ok(Err(e)) => {
+            emit_failure(format!("Failed to create venv: {e}"), "setup_failed", None);
+            return;
+        }
+        Err(_) => {
+            emit_failure(
+                "Timeout creating venv after 60 seconds".into(),
+                "timeout",
+                None,
+            );
+            return;
+        }
+    }
+
+    // Install packages (offline-first, fallback to network)
+    progress("installing", &format!("{} packages", packages.len()));
+    let offline_args = uv_pip_install_args(&python_path, packages, true);
+    let install_result =
+        match run_uv_pip_install(&uv_path, &offline_args, UV_OFFLINE_INSTALL_TIMEOUT).await {
+            UvInstallAttempt::Completed(output) if output.status.success() => {
+                info!("[warm-env] UV packages installed from local cache (offline mode)");
+                UvInstallAttempt::Completed(output)
+            }
+            UvInstallAttempt::Completed(_)
+            | UvInstallAttempt::SpawnError(_)
+            | UvInstallAttempt::Timeout => {
+                let args = uv_pip_install_args(&python_path, packages, false);
+                run_uv_pip_install(&uv_path, &args, UV_ONLINE_INSTALL_TIMEOUT).await
+            }
+        };
+
+    match install_result {
+        UvInstallAttempt::Completed(output) if output.status.success() => {}
+        UvInstallAttempt::Completed(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if let Some((error, kind, pkg)) = parse_uv_error(&stderr) {
+                cleanup_and_fail(env_dir, error, &kind, pkg).await;
+            } else {
+                cleanup_and_fail(env_dir, stderr.to_string(), "setup_failed", None).await;
+            }
+            return;
+        }
+        UvInstallAttempt::SpawnError(e) => {
+            cleanup_and_fail(env_dir, e.to_string(), "setup_failed", None).await;
+            return;
+        }
+        UvInstallAttempt::Timeout => {
+            cleanup_and_fail(env_dir, "Timeout after 180 seconds".into(), "timeout", None).await;
+            return;
+        }
+    }
+
+    // Vendor kernel launcher
+    progress("vendor", "vendoring kernel launcher");
+    if let Err(e) = kernel_env::launcher::vendor_into_venv(&python_path).await {
+        cleanup_and_fail(
+            env_dir,
+            format!("Failed to vendor nteract_kernel_launcher: {e}"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
+    // Warmup (.pyc compilation)
+    progress("warming", "compiling .pyc files");
+    let site_packages = find_site_packages(env_dir);
+    let warmup_script =
+        kernel_env::warmup::build_warmup_command(packages, false, site_packages.as_deref());
+
+    let warmup_result = tokio::time::timeout(
+        std::time::Duration::from_secs(180),
+        tokio::process::Command::new(&python_path)
+            .args(["-c", &warmup_script])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match warmup_result {
+        Ok(Ok(output)) if output.status.success() => {
+            tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
+        }
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            cleanup_and_fail(
+                env_dir,
+                format!(
+                    "UV warmup failed: {}",
+                    stderr.chars().take(200).collect::<String>()
+                ),
+                "import_error",
+                None,
+            )
+            .await;
+            return;
+        }
+        Ok(Err(e)) => {
+            cleanup_and_fail(
+                env_dir,
+                format!("UV warmup failed: {e}"),
+                "import_error",
+                None,
+            )
+            .await;
+            return;
+        }
+        Err(_) => {
+            cleanup_and_fail(env_dir, "UV warmup timed out".into(), "timeout", None).await;
+            return;
+        }
+    }
+
+    // Write package hash marker
+    if let Err(e) = write_pool_package_hash(env_dir, EnvType::Uv, packages).await {
+        warn!("[warm-env] Failed to write UV pool package marker: {e}");
+    }
+    emit_success(python_path, env_dir.to_path_buf());
+}
+
+// -- Conda env creation ---------------------------------------------------
+
+async fn create_conda(env_dir: &Path, packages: &[String], channels: &[String]) {
+    use rattler::install::Installer;
+    use rattler_conda_types::{
+        Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
+    };
+    use rattler_solve::{resolvo, SolverImpl, SolverTask};
+
+    #[cfg(target_os = "windows")]
+    let python_path = env_dir.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_dir.join("bin").join("python");
+
+    if let Some(parent) = env_dir.parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            emit_failure(
+                format!("Failed to create cache dir: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    }
+
+    // Setup channel configuration
+    let cache_dir = env_dir.parent().unwrap_or(env_dir).to_path_buf();
+    let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
+
+    progress("channels", "parsing channels");
+    let channel_names = if channels.is_empty() {
+        vec!["conda-forge".to_string()]
+    } else {
+        channels.to_vec()
+    };
+    let channels = match channel_names
+        .iter()
+        .map(|channel| Channel::from_str(channel, &channel_config))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(channels) => channels,
+        Err(e) => {
+            emit_failure(
+                format!("Failed to parse conda channel: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    // Build specs
+    progress("specs", "building dependency specs");
+    let match_spec_options = ParseMatchSpecOptions::strict();
+    let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
+        let mut specs = vec![MatchSpec::from_str("python>=3.13", match_spec_options)?];
+        specs.push(MatchSpec::from_str("python-gil", match_spec_options)?);
+        for pkg in packages {
+            specs.push(MatchSpec::from_str(pkg, match_spec_options)?);
+        }
+        Ok(specs)
+    })() {
+        Ok(s) => s,
+        Err(e) => {
+            emit_failure(
+                format!("Failed to parse match specs: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    // Rattler cache
+    let rattler_cache_dir = match rattler::default_cache_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            emit_failure(
+                format!("Could not determine rattler cache directory: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+    if let Err(e) = rattler_cache::ensure_cache_dir(&rattler_cache_dir) {
+        emit_failure(
+            format!("Could not create rattler cache directory: {e}"),
+            "setup_failed",
+            None,
+        );
+        return;
+    }
+
+    // HTTP client
+    let download_client = match reqwest::Client::builder().build() {
+        Ok(c) => reqwest_middleware::ClientBuilder::new(c).build(),
+        Err(e) => {
+            emit_failure(
+                format!("Failed to create HTTP client: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    let install_platform = Platform::current();
+    let platforms = vec![install_platform, Platform::NoArch];
+    let progress_handler = std::sync::Arc::new(kernel_env::LogHandler);
+
+    // Fetch repodata
+    progress("resolving", "fetching repodata from cache or conda-forge");
+    let repo_data = match kernel_env::repodata::query_repodata_offline_first(
+        channels,
+        platforms,
+        specs.clone(),
+        &rattler_cache_dir,
+        download_client.clone(),
+        progress_handler,
+        "conda",
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(e) => {
+            emit_failure(
+                format!("Failed to fetch repodata: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    // Detect virtual packages
+    let virtual_packages = match rattler_virtual_packages::VirtualPackage::detect(
+        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+    ) {
+        Ok(vps) => vps
+            .iter()
+            .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            emit_failure(
+                format!("Failed to detect virtual packages: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    // Solve
+    progress("resolving", "solving dependencies");
+    let solver_task = SolverTask {
+        virtual_packages,
+        specs,
+        ..SolverTask::from_iter(&repo_data)
+    };
+    let required_packages = match resolvo::Solver.solve(solver_task) {
+        Ok(result) => result.records,
+        Err(e) => {
+            emit_failure(
+                format!("Failed to solve dependencies: {e}"),
+                "invalid_package",
+                None,
+            );
+            return;
+        }
+    };
+
+    // Install
+    progress(
+        "installing",
+        &format!("{} packages", required_packages.len()),
+    );
+    if let Err(e) = Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform)
+        .install(env_dir, required_packages)
+        .await
+    {
+        cleanup_and_fail(
+            env_dir,
+            format!("Failed to install packages: {e}"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
+    // Verify python
+    if !python_path.exists() {
+        cleanup_and_fail(
+            env_dir,
+            format!("Python not found at {python_path:?} after install"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
+    // Vendor kernel launcher
+    progress("vendor", "vendoring kernel launcher");
+    if let Err(e) = kernel_env::launcher::vendor_into_venv(&python_path).await {
+        cleanup_and_fail(
+            env_dir,
+            format!("Failed to vendor nteract_kernel_launcher: {e}"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
+    // Warmup
+    progress("warming", "compiling .pyc files");
+    let site_packages = find_site_packages(env_dir);
+    let warmup_script =
+        kernel_env::warmup::build_warmup_command(packages, true, site_packages.as_deref());
+
+    let warmup_result = tokio::time::timeout(
+        std::time::Duration::from_secs(180),
+        tokio::process::Command::new(&python_path)
+            .args(["-c", &warmup_script])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await;
+
+    match warmup_result {
+        Ok(Ok(output)) if output.status.success() => {
+            tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
+        }
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            cleanup_and_fail(
+                env_dir,
+                format!(
+                    "Conda warmup failed: {}",
+                    stderr.chars().take(200).collect::<String>()
+                ),
+                "import_error",
+                None,
+            )
+            .await;
+            return;
+        }
+        Ok(Err(e)) => {
+            cleanup_and_fail(
+                env_dir,
+                format!("Conda warmup failed: {e}"),
+                "import_error",
+                None,
+            )
+            .await;
+            return;
+        }
+        Err(_) => {
+            cleanup_and_fail(env_dir, "Conda warmup timed out".into(), "timeout", None).await;
+            return;
+        }
+    }
+
+    if let Err(e) = write_pool_package_hash(env_dir, EnvType::Conda, packages).await {
+        warn!("[warm-env] Failed to write Conda pool package marker: {e}");
+    }
+    emit_success(python_path, env_dir.to_path_buf());
+}
+
+// -- Pixi env creation ----------------------------------------------------
+
+async fn create_pixi(project_dir: &Path, packages: &[String], channels: &[String]) {
+    if let Some(parent) = project_dir.parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            emit_failure(
+                format!("Failed to create cache dir: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    }
+
+    progress("creating", "creating pixi environment");
+    let handler = std::sync::Arc::new(kernel_env::LogHandler);
+    let channel_list: Vec<String> = if channels.is_empty() {
+        vec!["conda-forge".to_string()]
+    } else {
+        channels.to_vec()
+    };
+
+    match kernel_env::pixi::create_pixi_environment(project_dir, packages, &channel_list, handler)
+        .await
+    {
+        Ok(env) => {
+            progress("warming", "compiling .pyc files");
+            if let Err(e) = kernel_env::pixi::warmup_environment(&env, packages).await {
+                warn!("[warm-env] Pixi warmup failed (non-fatal): {e}");
+            }
+
+            if let Err(e) = write_pool_package_hash(project_dir, EnvType::Pixi, packages).await {
+                warn!("[warm-env] Failed to write Pixi pool package marker: {e}");
+            }
+            emit_success(env.python_path, env.venv_path);
+        }
+        Err(e) => {
+            cleanup_and_fail(
+                project_dir,
+                format!("Pixi environment creation failed: {e}"),
+                "setup_failed",
+                None,
+            )
+            .await;
+        }
+    }
+}
+
+// -- cleanup helper -------------------------------------------------------
+
+async fn cleanup_and_fail(
+    env_dir: &Path,
+    error: String,
+    error_kind: &str,
+    failed_package: Option<String>,
+) {
+    error!("[warm-env] {error}");
+    let _ = tokio::fs::remove_dir_all(env_dir).await;
+    emit_failure(error, error_kind, failed_package);
+}
+
+// -- entry point ----------------------------------------------------------
+
+pub async fn run() {
+    use tokio::io::AsyncReadExt;
+
+    let mut input = String::new();
+    if let Err(e) = tokio::io::stdin().read_to_string(&mut input).await {
+        emit_failure(
+            format!("Failed to read config from stdin: {e}"),
+            "setup_failed",
+            None,
+        );
+        return;
+    }
+
+    let config: WarmEnvConfig = match serde_json::from_str(&input) {
+        Ok(c) => c,
+        Err(e) => {
+            emit_failure(
+                format!("Invalid config JSON on stdin: {e}"),
+                "setup_failed",
+                None,
+            );
+            return;
+        }
+    };
+
+    match config.env_type {
+        EnvType::Uv => create_uv(&config.env_dir, &config.packages).await,
+        EnvType::Conda => create_conda(&config.env_dir, &config.packages, &config.channels).await,
+        EnvType::Pixi => create_pixi(&config.env_dir, &config.packages, &config.channels).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warm_env_result_success_roundtrip() {
+        let result = WarmEnvResult {
+            success: true,
+            python_path: Some(PathBuf::from("/env/bin/python")),
+            venv_path: Some(PathBuf::from("/env")),
+            error: None,
+            error_kind: None,
+            failed_package: None,
+        };
+        let event = WarmEnvEvent::Result(result);
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: WarmEnvEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WarmEnvEvent::Result(r) => {
+                assert!(r.success);
+                assert_eq!(r.python_path.unwrap(), PathBuf::from("/env/bin/python"));
+            }
+            _ => panic!("expected Result variant"),
+        }
+    }
+
+    #[test]
+    fn warm_env_result_failure_roundtrip() {
+        let result = WarmEnvResult {
+            success: false,
+            python_path: None,
+            venv_path: None,
+            error: Some("bad package".into()),
+            error_kind: Some("invalid_package".into()),
+            failed_package: Some("bogus-pkg".into()),
+        };
+        let event = WarmEnvEvent::Result(result);
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: WarmEnvEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            WarmEnvEvent::Result(r) => {
+                assert!(!r.success);
+                assert_eq!(r.failed_package.unwrap(), "bogus-pkg");
+            }
+            _ => panic!("expected Result variant"),
+        }
+    }
+
+    #[test]
+    fn warm_env_config_roundtrip() {
+        let config = WarmEnvConfig {
+            env_type: EnvType::Conda,
+            env_dir: PathBuf::from("/cache/pool-conda-abc"),
+            packages: vec!["numpy>=1.20,<2".into(), "pandas".into()],
+            channels: vec!["conda-forge".into()],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: WarmEnvConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.packages, config.packages);
+        assert_eq!(parsed.channels, config.channels);
+    }
+
+    #[test]
+    fn package_hash_deterministic() {
+        let h1 = expected_pool_package_hash(EnvType::Uv, &["b".into(), "a".into()]);
+        let h2 = expected_pool_package_hash(EnvType::Uv, &["a".into(), "b".into()]);
+        assert_eq!(h1, h2, "hash should be order-independent");
+    }
+}

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -55,8 +55,9 @@ pub struct WarmEnvResult {
 
 fn emit(event: &WarmEnvEvent) {
     if let Ok(json) = serde_json::to_string(event) {
-        println!("{json}");
         let mut stdout = std::io::stdout();
+        let _ = std::io::Write::write_all(&mut stdout, json.as_bytes());
+        let _ = std::io::Write::write_all(&mut stdout, b"\n");
         let _ = std::io::Write::flush(&mut stdout);
     }
 }
@@ -859,5 +860,78 @@ mod tests {
         let h1 = expected_pool_package_hash(EnvType::Uv, &["b".into(), "a".into()]);
         let h2 = expected_pool_package_hash(EnvType::Uv, &["a".into(), "b".into()]);
         assert_eq!(h1, h2, "hash should be order-independent");
+    }
+
+    #[test]
+    fn parse_uv_error_package_not_found() {
+        let stderr = r#"error: No solution found when resolving dependencies:
+  Because Because scitkit-learn was not found in the package registry and you require scitkit-learn, we can conclude that your requirements are unsatisfiable."#;
+
+        let result = parse_uv_error(stderr).expect("expected package parse error");
+        assert_eq!(result.1, "invalid_package");
+        assert_eq!(result.2, Some("scitkit-learn".to_string()));
+    }
+
+    #[test]
+    fn parse_uv_error_backtick_format() {
+        let result = parse_uv_error("error: Package `nonexistent-pkg` not found in registry")
+            .expect("expected package parse error");
+        assert_eq!(result.1, "invalid_package");
+        assert_eq!(result.2, Some("nonexistent-pkg".to_string()));
+    }
+
+    #[test]
+    fn parse_uv_error_no_matching_distribution() {
+        let result = parse_uv_error("error: No matching distribution found for bad-package-name")
+            .expect("expected package parse error");
+        assert_eq!(result.1, "invalid_package");
+        assert_eq!(result.2, Some("bad-package-name".to_string()));
+    }
+
+    #[test]
+    fn parse_uv_error_generic_error() {
+        let result = parse_uv_error("error: Failed to resolve dependencies")
+            .expect("expected generic error");
+        assert_eq!(result.1, "setup_failed");
+        assert_eq!(result.2, None);
+        assert!(result.0.contains("error"));
+    }
+
+    #[test]
+    fn parse_uv_error_no_error() {
+        assert!(parse_uv_error("Successfully installed packages").is_none());
+    }
+
+    #[test]
+    fn uv_pip_install_args_offline_first_shape() {
+        let args = uv_pip_install_args(
+            Path::new("/tmp/env/bin/python"),
+            &["ipykernel".into(), "numpy>=2".into()],
+            true,
+        );
+
+        assert_eq!(args[0], "pip");
+        assert_eq!(args[1], "install");
+        assert!(args.contains(&"--link-mode".to_string()));
+        assert!(args.contains(&"hardlink".to_string()));
+        assert!(args.contains(&"--python".to_string()));
+        assert!(args.contains(&"/tmp/env/bin/python".to_string()));
+        assert!(args.contains(&"--offline".to_string()));
+        assert!(args.ends_with(&["ipykernel".to_string(), "numpy>=2".to_string()]));
+    }
+
+    #[test]
+    fn uv_pip_install_args_online_fallback_shape() {
+        let args = uv_pip_install_args(Path::new("/tmp/env/bin/python"), &["pandas".into()], false);
+
+        assert!(!args.contains(&"--offline".to_string()));
+        assert!(args.contains(&"--link-mode".to_string()));
+        assert!(args.contains(&"hardlink".to_string()));
+        assert!(args.ends_with(&["pandas".to_string()]));
+    }
+
+    #[test]
+    fn uv_offline_probe_has_shorter_timeout_than_online_fallback() {
+        assert!(UV_OFFLINE_INSTALL_TIMEOUT < UV_ONLINE_INSTALL_TIMEOUT);
     }
 }


### PR DESCRIPTION
## Summary

- move environment pool creation into a `runtimed warm-env` helper subprocess so UV/Conda/Pixi warming memory is reclaimed on helper exit
- keep daemon-side pool accounting, replacement, retirement, and PoolDoc updates in the daemon process
- harden the helper IPC by validating returned paths, preserving existing pool-ready log strings, honoring Conda channels, and flushing JSON progress events

## Notes

This is a cleaner take on #2515. It omits the investigation docs from the implementation PR and includes fixes for issues found while inspecting the first pass:

- the original PR changed `UV environment ready at ...` to `UV environment ready: ...`, which broke the Python integration harness readiness detector
- the helper accepted Conda channels but ignored them
- the daemon accepted successful helper results without checking that the reported environment and Python paths existed

## Verification

- `cargo check -p runtimed --lib`
- `cargo check -p runtimed --bin runtimed`
- `cargo test -p runtimed --lib validated_warm_env_paths`
- `cargo xtask lint --fix`
