### PR TITLE
fix(notebook): gate relay frames per bootstrap generation

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -223,6 +223,14 @@ export function useAutomergeNotebook() {
     return true;
   }, []);
 
+  const notifyRelayReady = useCallback(
+    (generation?: number) =>
+      host.relay
+        .notifySyncReady(generation)
+        .catch((e: unknown) => logger.warn("[automerge-notebook] Failed to signal sync ready:", e)),
+    [host.relay],
+  );
+
   // ── Lifecycle (single effect) ──────────────────────────────────────
 
   useEffect(() => {
@@ -242,13 +250,6 @@ export function useAutomergeNotebook() {
 
     // Start the engine (subscribes to transport frames).
     engine.start();
-
-    // Signal the Rust relay that the JS frame listener is active.
-    // The relay buffers daemon frames until this fires, preventing
-    // frame loss during WASM init (see #1421).
-    host.relay.notifySyncReady().catch((e: unknown) => {
-      logger.warn("[automerge-notebook] Failed to signal sync ready:", e);
-    });
 
     // ── Subscribe to SyncEngine observables ───────────────────────
 
@@ -376,21 +377,35 @@ export function useAutomergeNotebook() {
     // ── Bootstrap ─────────────────────────────────────────────────
 
     setIsLoading(true);
-    void bootstrap(() => cancelled).catch((error) => {
-      logger.error("[automerge-notebook] Bootstrap failed", error);
-      if (!cancelled) {
-        setLoadError(error instanceof Error ? error.message : String(error));
-        setIsLoading(false);
-      }
-    });
+    void host.daemon
+      .getReadyInfo()
+      .catch(() => null)
+      .then((readyInfo) =>
+        bootstrap(() => cancelled).then((bootstrapped) => ({ bootstrapped, readyInfo })),
+      )
+      .then((bootstrapped) => {
+        if (!bootstrapped.bootstrapped || cancelled) return;
+        // Signal the Rust relay only after the WASM handle exists and the
+        // bootstrap reset has run. Otherwise buffered daemon frames can mark
+        // the session interactive, then resetForBootstrap() emits pending
+        // afterward with no later status frame to recover.
+        return notifyRelayReady(bootstrapped.readyInfo?.sync_generation);
+      })
+      .catch((error) => {
+        logger.error("[automerge-notebook] Bootstrap failed", error);
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : String(error));
+          setIsLoading(false);
+        }
+      });
 
     // ── Daemon lifecycle ─────────────────────────────────────────
 
-    const lifecycleSub = new Observable<void>((subscriber) =>
-      host.daemonEvents.onReadyLive(() => subscriber.next()),
+    const lifecycleSub = new Observable<{ sync_generation?: number }>((subscriber) =>
+      host.daemonEvents.onReadyLive((payload) => subscriber.next(payload)),
     )
       .pipe(
-        switchMap(() => {
+        switchMap((readyPayload) => {
           logger.info("[automerge-notebook] daemon:ready — re-bootstrapping");
           refreshBlobPort();
           resetNotebookCells();
@@ -402,9 +417,18 @@ export function useAutomergeNotebook() {
           setIsLoading(true);
           setLoadError(null);
           return from(
-            bootstrap(() => cancelled).catch((err: unknown) => {
-              logger.error("[automerge-notebook] lifecycle bootstrap failed:", err);
-            }),
+            bootstrap(() => cancelled)
+              .then((bootstrapped) => {
+                if (!bootstrapped || cancelled) return;
+                return notifyRelayReady(readyPayload.sync_generation);
+              })
+              .catch((err: unknown) => {
+                logger.error("[automerge-notebook] lifecycle bootstrap failed:", err);
+                if (!cancelled) {
+                  setLoadError(err instanceof Error ? err.message : String(err));
+                  setIsLoading(false);
+                }
+              }),
           );
         }),
       )
@@ -445,7 +469,7 @@ export function useAutomergeNotebook() {
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [bootstrap, host, materializeCells, refreshCanAcceptCellMutations]);
+  }, [bootstrap, host, materializeCells, notifyRelayReady, refreshCanAcceptCellMutations]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -169,8 +169,9 @@ struct DaemonStatusState(Arc<Mutex<Option<runtimed::client::DaemonProgress>>>);
 /// This prevents frame loss when the JS `SyncEngine` hasn't subscribed yet
 /// (race between relay start and `engine.start()` + `webview.listen()`).
 ///
-/// On the first connection the relay blocks until the JS calls `notify_sync_ready`.
-/// On reconnection the flag is already `true`, so frames flow immediately.
+/// Each relay generation blocks until the JS calls `notify_sync_ready` after
+/// completing that generation's WASM bootstrap/reset. This keeps buffered
+/// daemon frames from being applied to a stale or not-yet-reset handle.
 ///
 /// Also caches the most-recent `daemon:ready` payload per window so that
 /// `notify_sync_ready` can re-emit it for late-mounted JS listeners. Tauri
@@ -179,45 +180,90 @@ struct DaemonStatusState(Arc<Mutex<Option<runtimed::client::DaemonProgress>>>);
 /// Re-emitting on sync-ready closes that race.
 #[derive(Clone, Default)]
 struct SyncReadyState {
-    senders: Arc<Mutex<HashMap<String, tokio::sync::watch::Sender<bool>>>>,
+    gates: Arc<Mutex<HashMap<String, SyncReadyGate>>>,
     last_ready: Arc<Mutex<HashMap<String, DaemonReadyPayload>>>,
 }
 
+struct SyncReadyGate {
+    generation: u64,
+    tx: tokio::sync::watch::Sender<bool>,
+}
+
 impl SyncReadyState {
+    /// Prepare a fresh relay generation for a window.
+    ///
+    /// The frontend SyncEngine listener may survive reconnects, but the WASM
+    /// handle and bootstrap status do not. Reset the gate for every relay
+    /// generation so frames flow only after JS has rebuilt the handle and
+    /// emitted its pending session status for that generation.
+    fn reset_for_generation(&self, label: &str, generation: u64) {
+        let mut gates = match self.gates.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
+        };
+        match gates.get_mut(label) {
+            Some(gate) => {
+                gate.generation = generation;
+                let _ = gate.tx.send(false);
+            }
+            None => {
+                gates.insert(
+                    label.to_string(),
+                    SyncReadyGate {
+                        generation,
+                        tx: tokio::sync::watch::channel(false).0,
+                    },
+                );
+            }
+        }
+    }
+
     /// Mark a window's relay as ready to emit frames.
     ///
     /// If the relay hasn't subscribed yet (JS signaled before the Rust
     /// connection finished), creates the entry pre-seeded to `true` so
     /// the later `subscribe()` picks it up immediately.
-    fn set_ready(&self, label: &str) {
-        let mut senders = match self.senders.lock() {
+    fn set_ready(&self, label: &str, generation: Option<u64>) -> bool {
+        let mut gates = match self.gates.lock() {
             Ok(s) => s,
             Err(e) => e.into_inner(),
         };
-        match senders.get(label) {
-            Some(tx) => {
-                let _ = tx.send(true);
+        match gates.get_mut(label) {
+            Some(gate) if generation == Some(gate.generation) => {
+                let _ = gate.tx.send(true);
+                true
             }
+            Some(_) => false,
             None => {
                 // Pre-seed: JS signaled before the relay subscribed.
-                senders.insert(label.to_string(), tokio::sync::watch::channel(true).0);
+                gates.insert(
+                    label.to_string(),
+                    SyncReadyGate {
+                        generation: generation.unwrap_or(0),
+                        tx: tokio::sync::watch::channel(true).0,
+                    },
+                );
+                true
             }
         }
     }
 
     /// Get a receiver for the readiness flag, creating the entry if needed.
     ///
-    /// The receiver starts at the sender's current value: `false` on first
-    /// connection, `true` on reconnection (since the JS listener persists).
+    /// The receiver starts at the sender's current value. `setup_sync_receivers`
+    /// resets it to `false` for each relay generation before subscribing.
     fn subscribe(&self, label: &str) -> tokio::sync::watch::Receiver<bool> {
-        let mut senders = match self.senders.lock() {
+        let mut gates = match self.gates.lock() {
             Ok(s) => s,
             Err(e) => e.into_inner(),
         };
-        let tx = senders
+        let gate = gates
             .entry(label.to_string())
-            .or_insert_with(|| tokio::sync::watch::channel(false).0);
-        tx.subscribe()
+            .or_insert_with(|| SyncReadyGate {
+                generation: 0,
+                tx: tokio::sync::watch::channel(false).0,
+            });
+        gate.tx.subscribe()
     }
 
     /// Record the most-recent `daemon:ready` payload for this window, so
@@ -280,6 +326,10 @@ use tauri::{RunEvent, WindowEvent};
 #[derive(Clone, Serialize)]
 struct DaemonReadyPayload {
     notebook_id: String,
+    /// Current Tauri relay generation for this window. Frontend bootstrap uses
+    /// this as an acknowledgement token so a stale bootstrap cannot release a
+    /// newer relay generation.
+    sync_generation: u64,
     cell_count: usize,
     needs_trust_approval: bool,
     /// Whether this notebook is in-memory only (no on-disk path).
@@ -461,6 +511,7 @@ async fn initialize_notebook_sync_open(
 
     let ready_payload = DaemonReadyPayload {
         notebook_id: info.notebook_id.clone(),
+        sync_generation: current_generation,
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
         ephemeral: info.ephemeral,
@@ -535,6 +586,7 @@ async fn initialize_notebook_sync_create(
 
     let ready_payload = DaemonReadyPayload {
         notebook_id: info.notebook_id.clone(),
+        sync_generation: current_generation,
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
         ephemeral: info.ephemeral,
@@ -597,6 +649,7 @@ async fn initialize_notebook_sync_attach(
     // the payload with sensible defaults for an ephemeral clone.
     let ready_payload = DaemonReadyPayload {
         notebook_id: notebook_id.clone(),
+        sync_generation: current_generation,
         cell_count: 0,
         needs_trust_approval: false,
         ephemeral: true,
@@ -654,13 +707,11 @@ async fn setup_sync_receivers(
     let notebook_id_for_relay = notebook_id.clone();
     let sync_generation_for_cleanup = sync_generation.clone();
 
-    // Subscribe to the per-window readiness gate. On the first connection this
-    // starts at `false` (relay waits until JS calls `notify_sync_ready`). On
-    // reconnection the flag is already `true` so the relay proceeds immediately.
-    let mut ready_rx = window
-        .app_handle()
-        .state::<SyncReadyState>()
-        .subscribe(window.label());
+    // Subscribe to the per-window readiness gate. Every relay generation starts
+    // paused until the frontend has completed its matching WASM bootstrap.
+    let sync_ready = window.app_handle().state::<SyncReadyState>();
+    sync_ready.reset_for_generation(window.label(), current_generation);
+    let mut ready_rx = sync_ready.subscribe(window.label());
 
     tokio::spawn(async move {
         // Wait for the frontend SyncEngine to signal readiness. Daemon frames
@@ -771,7 +822,10 @@ async fn setup_sync_receivers(
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_commit_hash, next_available_sample_path, reopen_action, ReopenAction};
+    use super::{
+        extract_commit_hash, next_available_sample_path, reopen_action, ReopenAction,
+        SyncReadyState,
+    };
     use tempfile::TempDir;
 
     #[test]
@@ -816,6 +870,43 @@ mod tests {
     #[test]
     fn reopen_action_ignores_reopen_events_when_a_window_is_visible() {
         assert_eq!(reopen_action(true, 1), None);
+    }
+
+    #[test]
+    fn sync_ready_rejects_stale_generation_ack() {
+        let sync_ready = SyncReadyState::default();
+        sync_ready.reset_for_generation("notebook-1", 1);
+        assert!(sync_ready.set_ready("notebook-1", Some(1)));
+
+        sync_ready.reset_for_generation("notebook-1", 2);
+        assert!(
+            !sync_ready.set_ready("notebook-1", Some(1)),
+            "old bootstrap ack must not release a newer relay generation"
+        );
+
+        let rx = sync_ready.subscribe("notebook-1");
+        assert!(
+            !*rx.borrow(),
+            "stale ready ack should leave the newer relay generation gated"
+        );
+        assert!(sync_ready.set_ready("notebook-1", Some(2)));
+        assert!(*rx.borrow());
+    }
+
+    #[test]
+    fn sync_ready_rejects_missing_generation_for_active_gate() {
+        let sync_ready = SyncReadyState::default();
+        sync_ready.reset_for_generation("notebook-1", 3);
+
+        assert!(
+            !sync_ready.set_ready("notebook-1", None),
+            "generation-less ready ack must not bypass an active relay gate"
+        );
+
+        let rx = sync_ready.subscribe("notebook-1");
+        assert!(!*rx.borrow());
+        assert!(sync_ready.set_ready("notebook-1", Some(3)));
+        assert!(*rx.borrow());
     }
 }
 
@@ -2573,12 +2664,24 @@ async fn reconnect_to_daemon(
 /// Called once after `engine.start()` in `useAutomergeNotebook`. On
 /// reconnection the flag persists, so the new relay proceeds immediately.
 #[tauri::command]
-fn notify_sync_ready(window: tauri::Window, sync_ready: tauri::State<'_, SyncReadyState>) {
-    info!(
-        "[notebook-sync] Frontend sync ready for '{}'",
-        window.label()
-    );
-    sync_ready.set_ready(window.label());
+fn notify_sync_ready(
+    window: tauri::Window,
+    sync_ready: tauri::State<'_, SyncReadyState>,
+    generation: Option<u64>,
+) {
+    if sync_ready.set_ready(window.label(), generation) {
+        info!(
+            "[notebook-sync] Frontend sync ready for '{}'{}",
+            window.label(),
+            generation.map_or_else(String::new, |g| format!(" (gen {g})"))
+        );
+    } else {
+        warn!(
+            "[notebook-sync] Ignoring stale frontend sync ready for '{}'{}",
+            window.label(),
+            generation.map_or_else(String::new, |g| format!(" (gen {g})"))
+        );
+    }
     // Note: we do NOT re-emit `daemon:ready` here. `notifySyncReady()` is
     // called from `useAutomergeNotebook`, whose useEffect runs BEFORE the
     // App.tsx useEffects that subscribe to `host.daemonEvents.onReady(...)`.

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -178,8 +178,8 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   };
 
   const relay: HostRelay = {
-    async notifySyncReady() {
-      await invoke("notify_sync_ready");
+    async notifySyncReady(generation?: number) {
+      await invoke("notify_sync_ready", { generation });
     },
   };
 

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -68,6 +68,8 @@ export interface TyposquatWarning {
 
 export interface DaemonReadyPayload {
   notebook_id?: string;
+  /** Tauri relay generation used to acknowledge the matching frontend bootstrap. */
+  sync_generation?: number;
   cell_count?: number;
   needs_trust_approval?: boolean;
   /** In-memory-only notebook (no on-disk path). Drives the always-dirty asterisk. */
@@ -168,7 +170,7 @@ export interface HostRelay {
    * `notify_sync_ready` Tauri command. No-op in hosts where the main
    * process doesn't buffer (e.g., a browser-served host).
    */
-  notifySyncReady(): Promise<void>;
+  notifySyncReady(generation?: number): Promise<void>;
 }
 
 /**

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -29,6 +29,7 @@ vi.mock("@tauri-apps/api/core", () => ({
       case "get_daemon_ready_info":
         return Promise.resolve({
           notebook_id: "nb-1",
+          sync_generation: 3,
           cell_count: 2,
           needs_trust_approval: false,
           ephemeral: true,
@@ -301,6 +302,7 @@ describe("createTauriHost()", () => {
     // Mock returns the canned ready info (ephemeral=true, runtime=python).
     expect(received).toContainEqual({
       notebook_id: "nb-1",
+      sync_generation: 3,
       cell_count: 2,
       needs_trust_approval: false,
       ephemeral: true,
@@ -341,8 +343,9 @@ describe("createTauriHost()", () => {
 
   it("relay.notifySyncReady invokes notify_sync_ready (not on daemonEvents)", async () => {
     const host = createTauriHost({ transport: stubTransport });
-    await host.relay.notifySyncReady();
+    await host.relay.notifySyncReady(7);
     expect(capturedInvokes.at(-1)?.cmd).toBe("notify_sync_ready");
+    expect(capturedInvokes.at(-1)?.args).toEqual({ generation: 7 });
     // Sanity: subscribe-only namespace shouldn't have the outbound method.
     expect(
       (host.daemonEvents as unknown as { notifySyncReady?: unknown }).notifySyncReady,


### PR DESCRIPTION
## Summary

- Reset the Tauri relay readiness gate for every notebook sync generation instead of keeping it sticky after the first `notify_sync_ready`.
- Notify the relay only after the frontend has created the WASM handle and run `resetForBootstrap()`, including daemon reconnect rebootstrap.
- Fixes the canary ordering where buffered `SessionStatus` frames could mark the session interactive and then get overwritten back to pending by a late bootstrap reset.

## Canary Evidence

- Failing run inspected: https://github.com/nteract/desktop/actions/runs/25278810476
- Deno failure root cause: daemon launched the Deno kernel successfully, but frontend session status stayed pending after `notebook interactive` was processed before `Resetting for bootstrap`.
- Untitled pyproject failure root cause: daemon launched the Python kernel successfully, but the execute request never reached the daemon after the same frontend bootstrap ordering race.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `pnpm test:run packages/notebook-host/tests/tauri-host.test.ts`
- `cargo test -p notebook sync_ready_`
- `cargo check -p notebook --features e2e-webdriver,tauri/custom-protocol`
- `cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/10-deno.ipynb e2e/specs/deno.spec.js`
- `cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/pyproject-project e2e/specs/untitled-pyproject.spec.js`

## Review

- Claude Bedrock review found stale-bootstrap and stale-generation acknowledgement races; both were fixed by carrying `sync_generation` through the ready payload and storing the active generation inside the relay gate.
- The active gate now rejects stale or missing-generation acknowledgements, with Rust unit coverage for both cases.
