### PR TITLE
pi extension: respect NTERACT_CHANNEL for socket discovery

### DIFF
--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -8,6 +8,7 @@
  * Config (env vars):
  *   NTERACT_RUNTIMED_NODE_PATH  override the runtimed-node package path.
  *   NTERACT_SOCKET_PATH         override the daemon socket path.
+ *   NTERACT_CHANNEL             "stable" or "nightly" - picks the channel's socket.
  *
  * After editing, run `/reload` in pi.
  */
@@ -123,6 +124,11 @@ function loadRuntimedNode(): RuntimedNode | null {
 
 function resolveSocketPath(rn: RuntimedNode): string {
   if (process.env.NTERACT_SOCKET_PATH) return process.env.NTERACT_SOCKET_PATH;
+
+  const envChannel = process.env.NTERACT_CHANNEL;
+  if (envChannel === "stable" || envChannel === "nightly") {
+    return rn.socketPathForChannel(envChannel);
+  }
 
   for (const channel of ["nightly", "stable"] as const) {
     const socketPath = rn.socketPathForChannel(channel);


### PR DESCRIPTION
`resolveSocketPath` in the pi extension now checks `NTERACT_CHANNEL` before probing for whichever daemon socket exists on disk. If set to `"stable"` or `"nightly"`, it calls `socketPathForChannel(channel)` directly. Without the env var, behavior is unchanged (nightly-then-stable existence check).

Motivated by pilab provisioning: we need pi talking to the nightly daemon on test boxes, but can't publish `@runtimed/node@next` without breaking OIDC provenance on `@latest`. The sandbox workaround uses `NTERACT_RUNTIMED_NODE_PATH` + `NTERACT_SOCKET_PATH` today. Once this lands, pilab can drop the explicit socket path and just set `NTERACT_CHANNEL=nightly`.

## Test plan

- [ ] `NTERACT_CHANNEL=nightly pi` connects to nightly daemon
- [ ] `NTERACT_CHANNEL=stable pi` connects to stable daemon
- [ ] Unset `NTERACT_CHANNEL` still probes nightly-then-stable (existing behavior)
