### PR TITLE
fix(runtimed): catch_unwind for Automerge panics in runtime agent sync

### DIFF
--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -1,3 +1,4 @@
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 
@@ -87,6 +88,126 @@ impl RuntimeStateHandle {
             let _ = self.changed_tx.send(());
         }
         Ok(())
+    }
+
+    /// Apply an inbound sync message with panic recovery.
+    ///
+    /// Automerge 0.8 can panic with PatchLogMismatch during
+    /// `receive_sync_message` when concurrent sync messages interleave
+    /// actor table mutations (upstream bug automerge/automerge#1187).
+    /// This method catches the panic inside the mutex guard (before the
+    /// guard drops, so poison never occurs), rebuilds the doc via
+    /// save/load, and resets `peer_state` for a fresh handshake.
+    ///
+    /// `sync_op` receives `(&mut RuntimeStateDoc, &mut sync::State)` and
+    /// should call whichever receive variant is needed (e.g.,
+    /// `receive_sync_message`, `receive_sync_message_with_changes`, or
+    /// `receive_sync_and_foreign_comms`). On panic recovery, the closure's
+    /// return value is lost and `Ok(None)` is returned.
+    pub fn receive_sync_recovering<F, T>(
+        &self,
+        peer_state: &mut automerge::sync::State,
+        sync_op: F,
+    ) -> Result<Option<T>, RuntimeStateError>
+    where
+        F: FnOnce(
+            &mut RuntimeStateDoc,
+            &mut automerge::sync::State,
+        ) -> Result<T, RuntimeStateError>,
+    {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        let heads_before = sd.get_heads();
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| sync_op(&mut sd, peer_state)));
+        match result {
+            Ok(Ok(val)) => {
+                if sd.get_heads() != heads_before {
+                    let _ = self.changed_tx.send(());
+                }
+                Ok(Some(val))
+            }
+            Ok(Err(e)) => {
+                if sd.get_heads() != heads_before {
+                    let _ = self.changed_tx.send(());
+                }
+                Err(e)
+            }
+            Err(panic_payload) => {
+                let msg = crate::panic_payload_to_string(panic_payload);
+                tracing::error!(
+                    "[runtime-state] Automerge panicked during receive_sync \
+                     (upstream bug automerge/automerge#1187): {}",
+                    msg
+                );
+                sd.rebuild_from_save();
+                *peer_state = automerge::sync::State::new();
+                Ok(None)
+            }
+        }
+    }
+
+    /// Generate an outbound sync message with panic recovery.
+    ///
+    /// Same recovery strategy as `receive_sync_recovering`: on panic,
+    /// rebuilds via save/load and resets `peer_state`. Returns `None`
+    /// both when there is nothing to send and on panic recovery.
+    pub fn generate_sync_recovering(
+        &self,
+        peer_state: &mut automerge::sync::State,
+    ) -> Option<Vec<u8>> {
+        let mut sd = match self.doc.lock() {
+            Ok(guard) => guard,
+            Err(_) => return None,
+        };
+        match std::panic::catch_unwind(AssertUnwindSafe(|| {
+            sd.generate_sync_message(peer_state).map(|msg| msg.encode())
+        })) {
+            Ok(encoded) => encoded,
+            Err(panic_payload) => {
+                let msg = crate::panic_payload_to_string(panic_payload);
+                tracing::error!(
+                    "[runtime-state] Automerge panicked during generate_sync_message \
+                     (upstream bug automerge/automerge#1187): {}",
+                    msg
+                );
+                sd.rebuild_from_save();
+                *peer_state = automerge::sync::State::new();
+                None
+            }
+        }
+    }
+
+    /// Generate a bounded sync message with panic recovery.
+    ///
+    /// Compacts the doc if the encoded message exceeds `max_encoded_bytes`.
+    /// On panic, rebuilds and resets peer state.
+    pub fn generate_sync_bounded_recovering(
+        &self,
+        peer_state: &mut automerge::sync::State,
+        max_encoded_bytes: usize,
+    ) -> Option<Vec<u8>> {
+        let mut sd = match self.doc.lock() {
+            Ok(guard) => guard,
+            Err(_) => return None,
+        };
+        match std::panic::catch_unwind(AssertUnwindSafe(|| {
+            sd.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
+        })) {
+            Ok(encoded) => encoded,
+            Err(panic_payload) => {
+                let msg = crate::panic_payload_to_string(panic_payload);
+                tracing::error!(
+                    "[runtime-state] Automerge panicked during generate_sync_message_bounded \
+                     (upstream bug automerge/automerge#1187): {}",
+                    msg
+                );
+                sd.rebuild_from_save();
+                *peer_state = automerge::sync::State::new();
+                None
+            }
+        }
     }
 
     /// Read-only access. No notification.

--- a/crates/runtime-doc/src/lib.rs
+++ b/crates/runtime-doc/src/lib.rs
@@ -9,3 +9,14 @@ pub use error::RuntimeStateError;
 pub use handle::RuntimeStateHandle;
 pub use projection::{diff_executions, ExecutionTransition, ExecutionTransitionKind};
 pub use types::*;
+
+/// Extract a human-readable message from a panic payload.
+pub(crate) fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -135,6 +135,35 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
+/// Run a sync operation on a NotebookDoc with panic recovery.
+///
+/// On success, returns the closure's value. On panic (automerge#1187 /
+/// MissingOps), rebuilds the doc via save/load and resets `sync_state`
+/// for a fresh handshake. Returns `None` on recovery.
+///
+/// The caller must already hold the `RwLock<NotebookDoc>` write guard.
+/// catch_unwind runs inside the guard so the lock is never poisoned.
+pub(crate) fn doc_sync_recovering<T>(
+    label: &str,
+    doc: &mut crate::notebook_doc::NotebookDoc,
+    sync_state: &mut automerge::sync::State,
+    f: impl FnOnce(&mut crate::notebook_doc::NotebookDoc, &mut automerge::sync::State) -> T,
+) -> Option<T> {
+    match std::panic::catch_unwind(AssertUnwindSafe(|| f(doc, sync_state))) {
+        Ok(val) => Some(val),
+        Err(payload) => {
+            let msg = crate::task_supervisor::panic_payload_to_string(payload);
+            tracing::error!(
+                "[{label}] Automerge panicked during NotebookDoc sync \
+                 (upstream bug automerge/automerge#1187): {msg}"
+            );
+            doc.rebuild_from_save();
+            *sync_state = automerge::sync::State::new();
+            None
+        }
+    }
+}
+
 /// A message sent through the runtime agent channel.
 pub enum RuntimeAgentMessage {
     /// Fire-and-forget command - no response expected.

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
 use notebook_protocol::protocol::RuntimeAgentResponse;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::peer_runtime_sync::{persist_terminal_execution_records, runtime_file_save_fingerprint};
 use super::peer_writer::spawn_peer_writer;
@@ -68,8 +68,18 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let doc_sync_msg = {
         let mut doc = room.doc.write().await;
         // Generate our sync message (full doc state for fresh peer)
-        doc.generate_sync_message(&mut doc_sync_state)
-            .map(|msg| msg.encode())
+        match super::catch_automerge_panic("peer-runtime-agent-doc-init", || {
+            doc.generate_sync_message(&mut doc_sync_state)
+                .map(|msg| msg.encode())
+        }) {
+            Ok(msg) => msg,
+            Err(panic_msg) => {
+                error!("[notebook-sync] {}", panic_msg);
+                doc.rebuild_from_save();
+                doc_sync_state = automerge::sync::State::new();
+                None
+            }
+        }
     };
     if let Some(encoded) = doc_sync_msg {
         if let Err(e) =
@@ -83,16 +93,28 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
     // Uses bounded generation to compact if oversized (same 80 MiB threshold).
     let mut state_sync_state = automerge::sync::State::new();
-    let state_sync_msg = room
-        .state
-        .with_doc(|sd| {
-            Ok(sd.generate_sync_message_bounded_encoded(
-                &mut state_sync_state,
-                STATE_SYNC_COMPACT_THRESHOLD,
-            ))
-        })
-        .ok()
-        .flatten();
+    let state_sync_msg = match super::catch_automerge_panic("peer-runtime-agent-state-init", || {
+        room.state
+            .with_doc(|sd| {
+                Ok(sd.generate_sync_message_bounded_encoded(
+                    &mut state_sync_state,
+                    STATE_SYNC_COMPACT_THRESHOLD,
+                ))
+            })
+            .ok()
+            .flatten()
+    }) {
+        Ok(msg) => msg,
+        Err(panic_msg) => {
+            error!("[notebook-sync] {}", panic_msg);
+            let _ = room.state.with_doc(|sd| {
+                sd.rebuild_from_save();
+                Ok(())
+            });
+            state_sync_state = automerge::sync::State::new();
+            None
+        }
+    };
     if let Some(encoded) = state_sync_msg {
         if let Err(e) =
             send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await
@@ -183,18 +205,42 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     NotebookFrameType::AutomergeSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                             let mut doc = room.doc.write().await;
-                            if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
-                                let _ = room.broadcasts.changed_tx.send(());
+                            match super::catch_automerge_panic(
+                                "peer-runtime-agent-doc",
+                                || doc.receive_sync_message(&mut doc_sync_state, msg),
+                            ) {
+                                Ok(Ok(_)) => {
+                                    let _ = room.broadcasts.changed_tx.send(());
+                                }
+                                Ok(Err(e)) => {
+                                    warn!("[notebook-sync] Agent doc sync receive failed: {}", e);
+                                }
+                                Err(panic_msg) => {
+                                    error!("[notebook-sync] {}", panic_msg);
+                                    doc.rebuild_from_save();
+                                    doc_sync_state = automerge::sync::State::new();
+                                }
                             }
                             // Send sync reply
-                            if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
-                                let encoded = reply.encode();
-                                if let Err(e) = agent_writer.send_frame(
-                                    NotebookFrameType::AutomergeSync,
-                                    encoded,
-                                ) {
-                                    warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
-                                    break;
+                            match super::catch_automerge_panic(
+                                "peer-runtime-agent-doc",
+                                || doc.generate_sync_message(&mut doc_sync_state),
+                            ) {
+                                Ok(Some(reply)) => {
+                                    let encoded = reply.encode();
+                                    if let Err(e) = agent_writer.send_frame(
+                                        NotebookFrameType::AutomergeSync,
+                                        encoded,
+                                    ) {
+                                        warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
+                                        break;
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(panic_msg) => {
+                                    error!("[notebook-sync] {}", panic_msg);
+                                    doc.rebuild_from_save();
+                                    doc_sync_state = automerge::sync::State::new();
                                 }
                             }
                         }
@@ -203,29 +249,48 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                             let mut state_changed = false;
                             let mut runtime_file_dirty = false;
-                            let reply_encoded = room.state.with_doc(|sd| {
-                                let before = runtime_file_save_fingerprint(sd);
-                                if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                    &mut state_sync_state, msg,
-                                ) {
-                                    if changed {
-                                        state_changed = true;
-                                        if runtime_file_save_fingerprint(sd) != before {
-                                            runtime_file_dirty = true;
+                            // Wrapped in catch_automerge_panic: both
+                            // receive_sync_message_with_changes and
+                            // generate_sync_message can trigger the
+                            // PatchLog/MissingOps panic (automerge#1187).
+                            let reply_result = super::catch_automerge_panic(
+                                "peer-runtime-agent-state",
+                                || {
+                                    room.state.with_doc(|sd| {
+                                        let before = runtime_file_save_fingerprint(sd);
+                                        if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                            &mut state_sync_state, msg,
+                                        ) {
+                                            if changed {
+                                                state_changed = true;
+                                                if runtime_file_save_fingerprint(sd) != before {
+                                                    runtime_file_dirty = true;
+                                                }
+                                            }
                                         }
-                                        // Notification handled by with_doc heads check
+                                        Ok(sd.generate_sync_message(&mut state_sync_state)
+                                            .map(|reply| reply.encode()))
+                                    }).ok().flatten()
+                                },
+                            );
+                            match reply_result {
+                                Ok(Some(encoded)) => {
+                                    if let Err(e) = agent_writer.send_frame(
+                                        NotebookFrameType::RuntimeStateSync,
+                                        encoded,
+                                    ) {
+                                        warn!("[notebook-sync] Failed to queue state sync reply to runtime agent: {}", e);
+                                        break;
                                     }
                                 }
-                                Ok(sd.generate_sync_message(&mut state_sync_state)
-                                    .map(|reply| reply.encode()))
-                            }).ok().flatten();
-                            if let Some(encoded) = reply_encoded {
-                                if let Err(e) = agent_writer.send_frame(
-                                    NotebookFrameType::RuntimeStateSync,
-                                    encoded,
-                                ) {
-                                    warn!("[notebook-sync] Failed to queue state sync reply to runtime agent: {}", e);
-                                    break;
+                                Ok(None) => {}
+                                Err(panic_msg) => {
+                                    error!("[notebook-sync] {}", panic_msg);
+                                    let _ = room.state.with_doc(|sd| {
+                                        sd.rebuild_from_save();
+                                        Ok(())
+                                    });
+                                    state_sync_state = automerge::sync::State::new();
                                 }
                             }
                             if state_changed {
@@ -261,14 +326,25 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             _ = changed_rx.recv() => {
                 while changed_rx.try_recv().is_ok() {}
                 let mut doc = room.doc.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut doc_sync_state) {
-                    let encoded = msg.encode();
-                    if let Err(e) = agent_writer.send_frame(
-                        NotebookFrameType::AutomergeSync,
-                        encoded,
-                    ) {
-                        warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
-                        break;
+                match super::catch_automerge_panic(
+                    "peer-runtime-agent-doc-outbound",
+                    || doc.generate_sync_message(&mut doc_sync_state),
+                ) {
+                    Ok(Some(msg)) => {
+                        let encoded = msg.encode();
+                        if let Err(e) = agent_writer.send_frame(
+                            NotebookFrameType::AutomergeSync,
+                            encoded,
+                        ) {
+                            warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
+                            break;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(panic_msg) => {
+                        error!("[notebook-sync] {}", panic_msg);
+                        doc.rebuild_from_save();
+                        doc_sync_state = automerge::sync::State::new();
                     }
                 }
             }
@@ -276,17 +352,33 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             // RuntimeStateDoc changes → sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
-                let encoded = room.state.with_doc(|sd| {
-                    Ok(sd.generate_sync_message(&mut state_sync_state)
-                        .map(|msg| msg.encode()))
-                }).ok().flatten();
-                if let Some(encoded) = encoded {
-                    if let Err(e) = agent_writer.send_frame(
-                        NotebookFrameType::RuntimeStateSync,
-                        encoded,
-                    ) {
-                        warn!("[notebook-sync] Failed to queue state sync to runtime agent: {}", e);
-                        break;
+                let reply_result = super::catch_automerge_panic(
+                    "peer-runtime-agent-state-outbound",
+                    || {
+                        room.state.with_doc(|sd| {
+                            Ok(sd.generate_sync_message(&mut state_sync_state)
+                                .map(|msg| msg.encode()))
+                        }).ok().flatten()
+                    },
+                );
+                match reply_result {
+                    Ok(Some(encoded)) => {
+                        if let Err(e) = agent_writer.send_frame(
+                            NotebookFrameType::RuntimeStateSync,
+                            encoded,
+                        ) {
+                            warn!("[notebook-sync] Failed to queue state sync to runtime agent: {}", e);
+                            break;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(panic_msg) => {
+                        error!("[notebook-sync] {}", panic_msg);
+                        let _ = room.state.with_doc(|sd| {
+                            sd.rebuild_from_save();
+                            Ok(())
+                        });
+                        state_sync_state = automerge::sync::State::new();
                     }
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
 use notebook_protocol::protocol::RuntimeAgentResponse;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use super::peer_runtime_sync::{persist_terminal_execution_records, runtime_file_save_fingerprint};
 use super::peer_writer::spawn_peer_writer;
@@ -32,9 +32,9 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     // Frames are received on a dedicated task so the busy `select!`
-    // below stays cancel-safe — `recv_typed_frame`'s internal
+    // below stays cancel-safe -- `recv_typed_frame`'s internal
     // `read_exact` calls would otherwise drop bytes mid-read whenever
-    // another arm wins, desyncing the runtime-agent ↔ daemon stream.
+    // another arm wins, desyncing the runtime-agent <-> daemon stream.
     let mut framed_reader = FramedReader::spawn(reader, 16);
 
     info!(
@@ -42,14 +42,14 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         notebook_id, runtime_agent_id
     );
 
-    // Validate provenance — reject stale agents.
+    // Validate provenance -- reject stale agents.
     // None means no agent is expected (room was reset or no spawn in progress),
     // so reject unconditionally. Only the exact current agent ID is accepted.
     {
         let expected = room.current_runtime_agent_id.read().await;
         match expected.as_deref() {
             Some(expected_id) if expected_id == runtime_agent_id => {
-                // Match — this is the agent we're waiting for.
+                // Match -- this is the agent we're waiting for.
             }
             other => {
                 warn!(
@@ -67,19 +67,13 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let mut doc_sync_state = automerge::sync::State::new();
     let doc_sync_msg = {
         let mut doc = room.doc.write().await;
-        // Generate our sync message (full doc state for fresh peer)
-        match super::catch_automerge_panic("peer-runtime-agent-doc-init", || {
-            doc.generate_sync_message(&mut doc_sync_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(msg) => msg,
-            Err(panic_msg) => {
-                error!("[notebook-sync] {}", panic_msg);
-                doc.rebuild_from_save();
-                doc_sync_state = automerge::sync::State::new();
-                None
-            }
-        }
+        super::doc_sync_recovering(
+            "peer-runtime-agent-doc-init",
+            &mut doc,
+            &mut doc_sync_state,
+            |d, ss| d.generate_sync_message(ss).map(|msg| msg.encode()),
+        )
+        .flatten()
     };
     if let Some(encoded) = doc_sync_msg {
         if let Err(e) =
@@ -93,28 +87,9 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
     // Uses bounded generation to compact if oversized (same 80 MiB threshold).
     let mut state_sync_state = automerge::sync::State::new();
-    let state_sync_msg = match super::catch_automerge_panic("peer-runtime-agent-state-init", || {
-        room.state
-            .with_doc(|sd| {
-                Ok(sd.generate_sync_message_bounded_encoded(
-                    &mut state_sync_state,
-                    STATE_SYNC_COMPACT_THRESHOLD,
-                ))
-            })
-            .ok()
-            .flatten()
-    }) {
-        Ok(msg) => msg,
-        Err(panic_msg) => {
-            error!("[notebook-sync] {}", panic_msg);
-            let _ = room.state.with_doc(|sd| {
-                sd.rebuild_from_save();
-                Ok(())
-            });
-            state_sync_state = automerge::sync::State::new();
-            None
-        }
-    };
+    let state_sync_msg = room
+        .state
+        .generate_sync_bounded_recovering(&mut state_sync_state, STATE_SYNC_COMPACT_THRESHOLD);
     if let Some(encoded) = state_sync_msg {
         if let Err(e) =
             send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await
@@ -136,11 +111,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
 
     // ── 4. Signal connected ─────────────────────────────────────────
     // Provenance is already set by the spawn site (before spawn).
-    // We do NOT re-set it here — doing so after the async sync work above
+    // We do NOT re-set it here -- doing so after the async sync work above
     // would create a window where a newer spawn's provenance could be
     // clobbered by this (potentially stale) connect handler.
     //
-    // take() ensures at most one signal per spawn generation — a stale
+    // take() ensures at most one signal per spawn generation -- a stale
     // runtime agent that passes provenance finds None here (no-op).
     if let Some(tx) = room.pending_runtime_agent_connect_tx.lock().await.take() {
         let _ = tx.send(());
@@ -205,92 +180,65 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     NotebookFrameType::AutomergeSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                             let mut doc = room.doc.write().await;
-                            match super::catch_automerge_panic(
-                                "peer-runtime-agent-doc",
-                                || doc.receive_sync_message(&mut doc_sync_state, msg),
-                            ) {
-                                Ok(Ok(_)) => {
-                                    let _ = room.broadcasts.changed_tx.send(());
-                                }
-                                Ok(Err(e)) => {
-                                    warn!("[notebook-sync] Agent doc sync receive failed: {}", e);
-                                }
-                                Err(panic_msg) => {
-                                    error!("[notebook-sync] {}", panic_msg);
-                                    doc.rebuild_from_save();
-                                    doc_sync_state = automerge::sync::State::new();
-                                }
+                            // Receive + reply via centralized doc recovery helper
+                            let received = super::doc_sync_recovering(
+                                "peer-runtime-agent-doc-recv",
+                                &mut doc,
+                                &mut doc_sync_state,
+                                |d, ss| d.receive_sync_message(ss, msg),
+                            );
+                            if let Some(Ok(_)) = received {
+                                let _ = room.broadcasts.changed_tx.send(());
                             }
-                            // Send sync reply
-                            match super::catch_automerge_panic(
-                                "peer-runtime-agent-doc",
-                                || doc.generate_sync_message(&mut doc_sync_state),
+                            // Generate reply
+                            if let Some(Some(reply)) = super::doc_sync_recovering(
+                                "peer-runtime-agent-doc-reply",
+                                &mut doc,
+                                &mut doc_sync_state,
+                                |d, ss| d.generate_sync_message(ss),
                             ) {
-                                Ok(Some(reply)) => {
-                                    let encoded = reply.encode();
-                                    if let Err(e) = agent_writer.send_frame(
-                                        NotebookFrameType::AutomergeSync,
-                                        encoded,
-                                    ) {
-                                        warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
-                                        break;
-                                    }
-                                }
-                                Ok(None) => {}
-                                Err(panic_msg) => {
-                                    error!("[notebook-sync] {}", panic_msg);
-                                    doc.rebuild_from_save();
-                                    doc_sync_state = automerge::sync::State::new();
+                                let encoded = reply.encode();
+                                if let Err(e) = agent_writer.send_frame(
+                                    NotebookFrameType::AutomergeSync,
+                                    encoded,
+                                ) {
+                                    warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
+                                    break;
                                 }
                             }
                         }
                     }
                     NotebookFrameType::RuntimeStateSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                            // Receive via centralized handle recovery.
+                            // The closure captures mutable flags for post-lock work.
                             let mut state_changed = false;
                             let mut runtime_file_dirty = false;
-                            // Wrapped in catch_automerge_panic: both
-                            // receive_sync_message_with_changes and
-                            // generate_sync_message can trigger the
-                            // PatchLog/MissingOps panic (automerge#1187).
-                            let reply_result = super::catch_automerge_panic(
-                                "peer-runtime-agent-state",
-                                || {
-                                    room.state.with_doc(|sd| {
-                                        let before = runtime_file_save_fingerprint(sd);
-                                        if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                            &mut state_sync_state, msg,
-                                        ) {
-                                            if changed {
-                                                state_changed = true;
-                                                if runtime_file_save_fingerprint(sd) != before {
-                                                    runtime_file_dirty = true;
-                                                }
+                            let _ = room.state.receive_sync_recovering(
+                                &mut state_sync_state,
+                                |sd, ss| {
+                                    let before = runtime_file_save_fingerprint(sd);
+                                    if let Ok(changed) = sd.receive_sync_message_with_changes(ss, msg) {
+                                        if changed {
+                                            state_changed = true;
+                                            if runtime_file_save_fingerprint(sd) != before {
+                                                runtime_file_dirty = true;
                                             }
                                         }
-                                        Ok(sd.generate_sync_message(&mut state_sync_state)
-                                            .map(|reply| reply.encode()))
-                                    }).ok().flatten()
+                                    }
+                                    Ok(())
                                 },
                             );
-                            match reply_result {
-                                Ok(Some(encoded)) => {
-                                    if let Err(e) = agent_writer.send_frame(
-                                        NotebookFrameType::RuntimeStateSync,
-                                        encoded,
-                                    ) {
-                                        warn!("[notebook-sync] Failed to queue state sync reply to runtime agent: {}", e);
-                                        break;
-                                    }
-                                }
-                                Ok(None) => {}
-                                Err(panic_msg) => {
-                                    error!("[notebook-sync] {}", panic_msg);
-                                    let _ = room.state.with_doc(|sd| {
-                                        sd.rebuild_from_save();
-                                        Ok(())
-                                    });
-                                    state_sync_state = automerge::sync::State::new();
+                            // Generate reply via centralized handle recovery
+                            if let Some(encoded) = room.state.generate_sync_recovering(
+                                &mut state_sync_state,
+                            ) {
+                                if let Err(e) = agent_writer.send_frame(
+                                    NotebookFrameType::RuntimeStateSync,
+                                    encoded,
+                                ) {
+                                    warn!("[notebook-sync] Failed to queue state sync reply to runtime agent: {}", e);
+                                    break;
                                 }
                             }
                             if state_changed {
@@ -322,63 +270,39 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                 }
             }
 
-            // NotebookDoc changes (from other peers) → sync to runtime agent
+            // NotebookDoc changes (from other peers) -> sync to runtime agent
             _ = changed_rx.recv() => {
                 while changed_rx.try_recv().is_ok() {}
                 let mut doc = room.doc.write().await;
-                match super::catch_automerge_panic(
+                if let Some(Some(msg)) = super::doc_sync_recovering(
                     "peer-runtime-agent-doc-outbound",
-                    || doc.generate_sync_message(&mut doc_sync_state),
+                    &mut doc,
+                    &mut doc_sync_state,
+                    |d, ss| d.generate_sync_message(ss),
                 ) {
-                    Ok(Some(msg)) => {
-                        let encoded = msg.encode();
-                        if let Err(e) = agent_writer.send_frame(
-                            NotebookFrameType::AutomergeSync,
-                            encoded,
-                        ) {
-                            warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
-                            break;
-                        }
-                    }
-                    Ok(None) => {}
-                    Err(panic_msg) => {
-                        error!("[notebook-sync] {}", panic_msg);
-                        doc.rebuild_from_save();
-                        doc_sync_state = automerge::sync::State::new();
+                    let encoded = msg.encode();
+                    if let Err(e) = agent_writer.send_frame(
+                        NotebookFrameType::AutomergeSync,
+                        encoded,
+                    ) {
+                        warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
+                        break;
                     }
                 }
             }
 
-            // RuntimeStateDoc changes → sync to runtime agent
+            // RuntimeStateDoc changes -> sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
-                let reply_result = super::catch_automerge_panic(
-                    "peer-runtime-agent-state-outbound",
-                    || {
-                        room.state.with_doc(|sd| {
-                            Ok(sd.generate_sync_message(&mut state_sync_state)
-                                .map(|msg| msg.encode()))
-                        }).ok().flatten()
-                    },
-                );
-                match reply_result {
-                    Ok(Some(encoded)) => {
-                        if let Err(e) = agent_writer.send_frame(
-                            NotebookFrameType::RuntimeStateSync,
-                            encoded,
-                        ) {
-                            warn!("[notebook-sync] Failed to queue state sync to runtime agent: {}", e);
-                            break;
-                        }
-                    }
-                    Ok(None) => {}
-                    Err(panic_msg) => {
-                        error!("[notebook-sync] {}", panic_msg);
-                        let _ = room.state.with_doc(|sd| {
-                            sd.rebuild_from_save();
-                            Ok(())
-                        });
-                        state_sync_state = automerge::sync::State::new();
+                if let Some(encoded) = room.state.generate_sync_recovering(
+                    &mut state_sync_state,
+                ) {
+                    if let Err(e) = agent_writer.send_frame(
+                        NotebookFrameType::RuntimeStateSync,
+                        encoded,
+                    ) {
+                        warn!("[notebook-sync] Failed to queue state sync to runtime agent: {}", e);
+                        break;
                     }
                 }
             }
@@ -442,7 +366,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             let mut tx_guard = room.runtime_agent_request_tx.lock().await;
             *tx_guard = None;
         }
-        // No need to signal "disconnected" — the oneshot was consumed on
+        // No need to signal "disconnected" -- the oneshot was consumed on
         // connect. If the runtime agent dies before connecting, the oneshot
         // sender is dropped when pending_runtime_agent_connect_tx is replaced
         // by the next spawn, which resolves the receiver with Err.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -30,7 +30,6 @@
 //! 6. On shutdown or daemon disconnect, runtime agent exits
 
 use std::collections::{HashMap, HashSet};
-use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -335,28 +334,15 @@ pub async fn run_runtime_agent(
                             // and forward frontend-originated comm state changes to kernel
                             NotebookFrameType::RuntimeStateSync => {
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
-                                    // Apply sync and extract data we need for async
-                                    // work, all in one lock acquisition.
-                                    //
-                                    // Wrapped in catch_unwind because automerge 0.8 can
-                                    // panic with PatchLogMismatch in BatchApply::apply
-                                    // when concurrent sync messages interleave actor
-                                    // table mutations (automerge/automerge#1187). Without
-                                    // catch_unwind the panic kills the entire runtime
-                                    // agent process, taking the kernel with it. By
-                                    // catching it, we rebuild the doc via save/load
-                                    // (clearing corrupted indices) and reset sync state
-                                    // to force a fresh handshake.
-                                    let sync_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                                        ctx.state.with_doc(|sd| {
-                                            // Snapshot comm state before applying sync so we can
-                                            // detect frontend-originated widget state changes.
+                                    // Apply sync with centralized panic recovery
+                                    // (automerge/automerge#1187). On panic, the handle
+                                    // rebuilds the doc and resets sync state internally.
+                                    let sync_result = ctx.state.receive_sync_recovering(
+                                        &mut coordinator_sync_state,
+                                        |sd, _peer_state| {
                                             let comms_before = sd.read_state().comms;
-
-                                            // Per-change actor filter: diff comm state against a
-                                            // foreign-only view of the post-sync doc.
                                             match sd.receive_sync_and_foreign_comms(
-                                                &mut coordinator_sync_state,
+                                                _peer_state,
                                                 msg,
                                                 |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
                                             ) {
@@ -385,31 +371,11 @@ pub async fn run_runtime_agent(
                                                     Ok(None)
                                                 }
                                             }
-                                        })
-                                    }));
-                                    let sync_result = match sync_result {
-                                        Ok(inner) => inner,
-                                        Err(panic_payload) => {
-                                            let msg = crate::task_supervisor::panic_payload_to_string(panic_payload);
-                                            error!(
-                                                "[runtime-agent] Automerge panicked during RuntimeStateSync \
-                                                 (upstream bug automerge/automerge#1187): {}",
-                                                msg
-                                            );
-                                            // Rebuild doc via save/load to clear corrupted
-                                            // indices, then reset sync state for a fresh
-                                            // handshake.
-                                            let _ = ctx.state.with_doc(|sd| {
-                                                sd.rebuild_from_save();
-                                                Ok(())
-                                            });
-                                            coordinator_sync_state = automerge::sync::State::new();
-                                            Ok(None)
-                                        }
-                                    };
+                                        },
+                                    ).ok().flatten();
 
                                     // Async work outside the lock
-                                    if let Ok(Some((queued, comm_updates))) = sync_result {
+                                    if let Some(Some((queued, comm_updates))) = sync_result {
                                         if !comm_updates.is_empty() {
                                             if let Some(ref mut k) = kernel {
                                                 for (comm_id, delta) in &comm_updates {
@@ -450,37 +416,15 @@ pub async fn run_runtime_agent(
                                         }
                                     }
 
-                                    // Send sync reply -- also wrapped in catch_unwind
-                                    // because generate_sync_message can trigger the
-                                    // same PatchLog/MissingOps panics.
-                                    let reply_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                                        ctx.state.with_doc(|sd| {
-                                            Ok(sd.generate_sync_message(&mut coordinator_sync_state)
-                                                .map(|reply| reply.encode()))
-                                        }).ok().flatten()
-                                    }));
-                                    match reply_result {
-                                        Ok(Some(encoded)) => {
-                                            let _ = send_typed_frame(
-                                                &mut writer,
-                                                NotebookFrameType::RuntimeStateSync,
-                                                &encoded,
-                                            ).await;
-                                        }
-                                        Ok(None) => {}
-                                        Err(panic_payload) => {
-                                            let msg = crate::task_supervisor::panic_payload_to_string(panic_payload);
-                                            error!(
-                                                "[runtime-agent] Automerge panicked during generate_sync_message \
-                                                 (upstream bug automerge/automerge#1187): {}",
-                                                msg
-                                            );
-                                            let _ = ctx.state.with_doc(|sd| {
-                                                sd.rebuild_from_save();
-                                                Ok(())
-                                            });
-                                            coordinator_sync_state = automerge::sync::State::new();
-                                        }
+                                    // Send sync reply via centralized recovering API
+                                    if let Some(encoded) = ctx.state.generate_sync_recovering(
+                                        &mut coordinator_sync_state,
+                                    ) {
+                                        let _ = send_typed_frame(
+                                            &mut writer,
+                                            NotebookFrameType::RuntimeStateSync,
+                                            &encoded,
+                                        ).await;
                                     }
                                 }
                             }
@@ -578,11 +522,9 @@ pub async fn run_runtime_agent(
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
 
-                let encoded = ctx.state.with_doc(|sd| {
-                    Ok(sd.generate_sync_message(&mut coordinator_sync_state)
-                        .map(|msg| msg.encode()))
-                }).ok().flatten();
-                if let Some(encoded) = encoded {
+                if let Some(encoded) = ctx.state.generate_sync_recovering(
+                    &mut coordinator_sync_state,
+                ) {
                     if let Err(e) = send_typed_frame(
                         &mut writer,
                         NotebookFrameType::RuntimeStateSync,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -30,6 +30,7 @@
 //! 6. On shutdown or daemon disconnect, runtime agent exits
 
 use std::collections::{HashMap, HashSet};
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -336,44 +337,76 @@ pub async fn run_runtime_agent(
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                                     // Apply sync and extract data we need for async
                                     // work, all in one lock acquisition.
-                                    let sync_result = ctx.state.with_doc(|sd| {
-                                        // Snapshot comm state before applying sync so we can
-                                        // detect frontend-originated widget state changes.
-                                        let comms_before = sd.read_state().comms;
+                                    //
+                                    // Wrapped in catch_unwind because automerge 0.8 can
+                                    // panic with PatchLogMismatch in BatchApply::apply
+                                    // when concurrent sync messages interleave actor
+                                    // table mutations (automerge/automerge#1187). Without
+                                    // catch_unwind the panic kills the entire runtime
+                                    // agent process, taking the kernel with it. By
+                                    // catching it, we rebuild the doc via save/load
+                                    // (clearing corrupted indices) and reset sync state
+                                    // to force a fresh handshake.
+                                    let sync_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                                        ctx.state.with_doc(|sd| {
+                                            // Snapshot comm state before applying sync so we can
+                                            // detect frontend-originated widget state changes.
+                                            let comms_before = sd.read_state().comms;
 
-                                        // Per-change actor filter: diff comm state against a
-                                        // foreign-only view of the post-sync doc.
-                                        match sd.receive_sync_and_foreign_comms(
-                                            &mut coordinator_sync_state,
-                                            msg,
-                                            |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
-                                        ) {
-                                            Ok(view) if !view.applied_actors.is_empty() => {
-                                                let queued = sd.get_queued_executions();
-                                                let comm_updates = match view.foreign_comms {
-                                                    Some(foreign_comms) => {
-                                                        diff_comm_state(&comms_before, &foreign_comms)
-                                                    }
-                                                    None => {
-                                                        debug!(
-                                                            "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
-                                                            view.applied_actors.len()
-                                                        );
-                                                        Vec::new()
-                                                    }
-                                                };
-                                                Ok(Some((queued, comm_updates)))
+                                            // Per-change actor filter: diff comm state against a
+                                            // foreign-only view of the post-sync doc.
+                                            match sd.receive_sync_and_foreign_comms(
+                                                &mut coordinator_sync_state,
+                                                msg,
+                                                |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                                            ) {
+                                                Ok(view) if !view.applied_actors.is_empty() => {
+                                                    let queued = sd.get_queued_executions();
+                                                    let comm_updates = match view.foreign_comms {
+                                                        Some(foreign_comms) => {
+                                                            diff_comm_state(&comms_before, &foreign_comms)
+                                                        }
+                                                        None => {
+                                                            debug!(
+                                                                "[runtime-agent] Skipping comm forward: {} applied change(s) were all self-kernel echoes",
+                                                                view.applied_actors.len()
+                                                            );
+                                                            Vec::new()
+                                                        }
+                                                    };
+                                                    Ok(Some((queued, comm_updates)))
+                                                }
+                                                Ok(_) => Ok(None),
+                                                Err(e) => {
+                                                    warn!(
+                                                        "[runtime-agent] Failed to apply RuntimeStateSync: {}",
+                                                        e
+                                                    );
+                                                    Ok(None)
+                                                }
                                             }
-                                            Ok(_) => Ok(None),
-                                            Err(e) => {
-                                                warn!(
-                                                    "[runtime-agent] Failed to apply RuntimeStateSync: {}",
-                                                    e
-                                                );
-                                                Ok(None)
-                                            }
+                                        })
+                                    }));
+                                    let sync_result = match sync_result {
+                                        Ok(inner) => inner,
+                                        Err(panic_payload) => {
+                                            let msg = crate::task_supervisor::panic_payload_to_string(panic_payload);
+                                            error!(
+                                                "[runtime-agent] Automerge panicked during RuntimeStateSync \
+                                                 (upstream bug automerge/automerge#1187): {}",
+                                                msg
+                                            );
+                                            // Rebuild doc via save/load to clear corrupted
+                                            // indices, then reset sync state for a fresh
+                                            // handshake.
+                                            let _ = ctx.state.with_doc(|sd| {
+                                                sd.rebuild_from_save();
+                                                Ok(())
+                                            });
+                                            coordinator_sync_state = automerge::sync::State::new();
+                                            Ok(None)
                                         }
-                                    });
+                                    };
 
                                     // Async work outside the lock
                                     if let Ok(Some((queued, comm_updates))) = sync_result {
@@ -417,17 +450,37 @@ pub async fn run_runtime_agent(
                                         }
                                     }
 
-                                    // Send sync reply
-                                    let reply_encoded = ctx.state.with_doc(|sd| {
-                                        Ok(sd.generate_sync_message(&mut coordinator_sync_state)
-                                            .map(|reply| reply.encode()))
-                                    }).ok().flatten();
-                                    if let Some(encoded) = reply_encoded {
-                                        let _ = send_typed_frame(
-                                            &mut writer,
-                                            NotebookFrameType::RuntimeStateSync,
-                                            &encoded,
-                                        ).await;
+                                    // Send sync reply -- also wrapped in catch_unwind
+                                    // because generate_sync_message can trigger the
+                                    // same PatchLog/MissingOps panics.
+                                    let reply_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                                        ctx.state.with_doc(|sd| {
+                                            Ok(sd.generate_sync_message(&mut coordinator_sync_state)
+                                                .map(|reply| reply.encode()))
+                                        }).ok().flatten()
+                                    }));
+                                    match reply_result {
+                                        Ok(Some(encoded)) => {
+                                            let _ = send_typed_frame(
+                                                &mut writer,
+                                                NotebookFrameType::RuntimeStateSync,
+                                                &encoded,
+                                            ).await;
+                                        }
+                                        Ok(None) => {}
+                                        Err(panic_payload) => {
+                                            let msg = crate::task_supervisor::panic_payload_to_string(panic_payload);
+                                            error!(
+                                                "[runtime-agent] Automerge panicked during generate_sync_message \
+                                                 (upstream bug automerge/automerge#1187): {}",
+                                                msg
+                                            );
+                                            let _ = ctx.state.with_doc(|sd| {
+                                                sd.rebuild_from_save();
+                                                Ok(())
+                                            });
+                                            coordinator_sync_state = automerge::sync::State::new();
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

- Centralizes Automerge panic recovery (upstream [automerge/automerge#1187](https://github.com/automerge/automerge/issues/1187)) behind doc-level APIs instead of ad-hoc catch_unwind at each call site
- `RuntimeStateHandle` gains `receive_sync_recovering()`, `generate_sync_recovering()`, and `generate_sync_bounded_recovering()` that catch panics inside the mutex guard (preventing poison), rebuild via save/load, and reset sync state
- `doc_sync_recovering()` helper in `notebook_sync_server/mod.rs` provides the same pattern for NotebookDoc (tokio RwLock, guard held by caller)
- All sync paths in `runtime_agent.rs` and `peer_runtime_agent.rs` now use these centralized APIs

## Context

Automerge 0.8's `PatchLog::migrate_actors()` can panic when concurrent sync messages interleave actor table mutations. The `.unwrap()` at `batch.rs:807` is an upstream bug (confirmed by automerge maintainer, unfixed in 0.9.0). Without recovery, the panic kills the runtime agent process, taking the kernel and leaving cells queued forever.

This was observed in 5 concurrent runtime agents during batch gremlin startup, all hitting PatchLogMismatch within 11 seconds.

## Changes

**`runtime-doc/src/handle.rs`** (centralized API):
- `receive_sync_recovering()`: catch_unwind inside mutex guard, rebuild_from_save + reset peer_state on panic
- `generate_sync_recovering()`: same pattern for outbound sync
- `generate_sync_bounded_recovering()`: bounded variant with recovery

**`runtime-doc/src/lib.rs`**:
- `panic_payload_to_string()` utility (moved from task_supervisor, crate-local)

**`notebook_sync_server/mod.rs`**:
- `doc_sync_recovering()`: shared helper for NotebookDoc sync with rebuild + sync state reset

**`runtime_agent.rs`**:
- Inbound RuntimeStateSync uses `receive_sync_recovering()`
- Reply generation uses `generate_sync_recovering()`
- Outbound state_changed_rx arm uses `generate_sync_recovering()` (was previously unprotected)
- Removed direct `std::panic::catch_unwind` and `AssertUnwindSafe` usage

**`peer_runtime_agent.rs`**:
- All sync operations use centralized APIs: `doc_sync_recovering()` for NotebookDoc, `receive_sync_recovering()`/`generate_sync_recovering()`/`generate_sync_bounded_recovering()` for RuntimeStateDoc
- Replaced all `catch_automerge_panic` usage with the new helpers

## Test plan

- [x] `cargo check --package runtimed --package runtime-doc` passes
- [x] `cargo xtask clippy` passes
- [x] `cargo xtask lint --fix` clean (Rust)
- [ ] CI green
- [ ] Nightly install + gremlin suite confirms runtime agents survive concurrent startup