### PR TITLE
fix(pi): spawn node subscriptions on napi runtime

### DIFF
--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -414,6 +414,13 @@ impl EventSubscription {
     }
 }
 
+fn spawn_event_task<F>(future: F) -> tokio::task::JoinHandle<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    napi::bindgen_prelude::spawn(future)
+}
+
 fn json_callback(callback: Function<'_, (String,), ()>) -> Result<JsonCallback> {
     callback
         .build_threadsafe_function::<String>()
@@ -453,7 +460,7 @@ impl Session {
         };
         let mut rx = handle.subscribe_runtime_state();
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             emit_json(&tsfn, &*rx.borrow_and_update());
             while rx.changed().await.is_ok() {
                 emit_json(&tsfn, &*rx.borrow_and_update());
@@ -480,7 +487,7 @@ impl Session {
         };
         let mut rx = handle.subscribe_runtime_state();
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             let mut prev = rx.borrow_and_update().executions.clone();
             while rx.changed().await.is_ok() {
                 let curr = rx.borrow_and_update().executions.clone();
@@ -521,7 +528,7 @@ impl Session {
             )
         };
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             let fallback_cell_id = cell_id.unwrap_or_default();
             let mut watcher =
                 notebook_sync::ExecutionWatcher::new(&handle, fallback_cell_id, execution_id);
@@ -566,7 +573,7 @@ impl Session {
         };
         let mut rx = handle.subscribe();
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             while rx.changed().await.is_ok() {
                 let _ = tsfn.call("null".to_string(), ThreadsafeFunctionCallMode::NonBlocking);
             }
@@ -588,7 +595,7 @@ impl Session {
                 .resubscribe()
         };
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             while let Some(broadcast) = rx.recv().await {
                 emit_json(&tsfn, &broadcast);
             }
@@ -614,7 +621,7 @@ impl Session {
         };
         let mut rx = handle.subscribe_status();
         let tsfn = json_callback(callback)?;
-        let task = tokio::spawn(async move {
+        let task = spawn_event_task(async move {
             emit_json(&tsfn, &*rx.borrow_and_update());
             while rx.changed().await.is_ok() {
                 emit_json(&tsfn, &*rx.borrow_and_update());

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -414,6 +414,10 @@ impl EventSubscription {
     }
 }
 
+/// Spawns subscription watchers on the napi-managed Tokio runtime.
+///
+/// The `Session.on*` methods are synchronous N-API entry points, so they cannot
+/// rely on an ambient Tokio task context being present on the calling thread.
 fn spawn_event_task<F>(future: F) -> tokio::task::JoinHandle<()>
 where
     F: std::future::Future<Output = ()> + Send + 'static,

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -77,7 +77,7 @@ type CellResult = {
   executionCount?: number;
   status: string; // "done" | "error" | "timeout" | "kernel_error"
   success: boolean;
-  outputs: JsOutput[];
+  outputs?: JsOutput[];
 };
 
 type QueuedExecution = {
@@ -340,17 +340,18 @@ function formatResult(result: CellResult): {
   content: (TextContent | ImageContent)[];
   isError: boolean;
 } {
+  const outputs = result.outputs ?? [];
   const isError =
     result.status === "error" ||
     result.status === "kernel_error" ||
     result.status === "kernel_failed" ||
-    result.outputs.some((o) => o.outputType === "error");
+    outputs.some((o) => o.outputType === "error");
 
   const parts: (TextContent | ImageContent)[] = [];
   const header = `cell ${result.cellId} [${result.executionCount ?? "?"}] ${result.status}`;
   const textChunks: string[] = [];
 
-  for (const o of result.outputs) {
+  for (const o of outputs) {
     switch (o.outputType) {
       case "stream": {
         const prefix = o.name === "stderr" ? "[stderr] " : "";
@@ -419,7 +420,7 @@ function formatResult(result: CellResult): {
 }
 
 function findParquetBlobPath(result: CellResult): string | undefined {
-  for (const o of result.outputs) {
+  for (const o of result.outputs ?? []) {
     if (!o.blobPathsJson) continue;
     try {
       const paths = JSON.parse(o.blobPathsJson);


### PR DESCRIPTION
## Summary

- Spawn runtimed-node event subscription tasks on napi-rs's runtime instead of ambient `tokio::spawn`.
- Allow the Pi REPL formatter to handle streaming progress snapshots before `outputs` are present.
- Document why synchronous N-API subscription entry points must use the napi-managed Tokio runtime.

## Repro

On `pilab4`, nightly `5bff4230` aborted in `crates/runtimed-node/src/session.rs:456` when the JS wrapper eagerly subscribed to runtime state after `createNotebook()`. Calling the native binding directly succeeded, which isolated the crash to the wrapper/subscription path.

## Verification

- `cargo check -p runtimed-node`
- `cargo fmt -p runtimed-node --check`
- `git diff --check -- crates/runtimed-node/src/session.rs plugins/nteract/pi/extensions/repl.ts`
- Local wrapper repro: `createNotebook()` returned a wrapped `Session`, runtime-state subscription emitted, no abort.
- Local Pi extension harness ran Python and returned `hello from pi` plus `2`.
- Local Pi extension harness ran the happy matplotlib plot and returned one `image/png`.

## External review

- Claude Bedrock Opus 4.6 reviewed `main...HEAD` twice.
- First pass: two low-severity maintainability notes; documented the napi runtime helper.
- Second pass: clear, no actionable findings.

## Notes

The PR remains draft pending GitHub CI.
