### PR TITLE
test(automerge-recovery): capture MissingOps fork_at edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "automerge-recovery"
+version = "0.1.0"
+dependencies = [
+ "automerge",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "automunge"
 version = "0.2.3"
 dependencies = [
@@ -4538,6 +4546,7 @@ name = "notebook-doc"
 version = "0.3.3"
 dependencies = [
  "automerge",
+ "automerge-recovery",
  "automunge",
  "ciborium",
  "hex",
@@ -4570,6 +4579,7 @@ name = "notebook-sync"
 version = "0.3.3"
 dependencies = [
  "automerge",
+ "automerge-recovery",
  "log",
  "notebook-doc",
  "notebook-protocol",
@@ -7037,6 +7047,7 @@ name = "runtime-doc"
 version = "0.2.3"
 dependencies = [
  "automerge",
+ "automerge-recovery",
  "automunge",
  "serde",
  "serde_json",
@@ -7053,6 +7064,7 @@ dependencies = [
  "anyhow",
  "async-rust-lsp",
  "automerge",
+ "automerge-recovery",
  "base64 0.22.1",
  "build-metadata",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/runt-workspace",
     "crates/kernel-launch",
     "crates/kernel-env",
+    "crates/automerge-recovery",
     "crates/notebook",
     "crates/automunge",
     "crates/notebook-wire",

--- a/crates/automerge-recovery/Cargo.toml
+++ b/crates/automerge-recovery/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "automerge-recovery"
+version = "0.1.0"
+edition.workspace = true
+description = "Small panic recovery helpers for Automerge operations"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+automerge = "0.8"
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -31,7 +31,7 @@ pub enum AutomergeOperationError {
     Automerge {
         label: String,
         #[source]
-        source: automerge::AutomergeError,
+        source: Box<automerge::AutomergeError>,
     },
     #[error(transparent)]
     Panic(#[from] AutomergeRecoveryError),
@@ -43,7 +43,7 @@ impl AutomergeOperationError {
     pub fn automerge(label: impl Into<String>, source: automerge::AutomergeError) -> Self {
         Self::Automerge {
             label: label.into(),
-            source,
+            source: Box::new(source),
         }
     }
 
@@ -86,16 +86,20 @@ mod tests {
 
     #[test]
     fn returns_normal_closure_value() {
-        let value = catch_automerge_panic("normal", || 42).unwrap();
-        assert_eq!(value, 42);
+        match catch_automerge_panic("normal", || 42) {
+            Ok(value) => assert_eq!(value, 42),
+            Err(error) => panic!("expected normal value, got {error}"),
+        }
     }
 
     #[test]
     fn captures_string_panic_payload() {
-        let error = catch_automerge_panic("string", || {
+        let error = match catch_automerge_panic("string", || {
             std::panic::panic_any("owned payload".to_string())
-        })
-        .unwrap_err();
+        }) {
+            Ok(_) => panic!("expected panic capture"),
+            Err(error) => error,
+        };
 
         assert_eq!(error.label, "string");
         assert_eq!(error.panic_message, "owned payload");
@@ -103,7 +107,10 @@ mod tests {
 
     #[test]
     fn captures_str_panic_payload() {
-        let error = catch_automerge_panic("str", || panic!("borrowed payload")).unwrap_err();
+        let error = match catch_automerge_panic("str", || panic!("borrowed payload")) {
+            Ok(_) => panic!("expected panic capture"),
+            Err(error) => error,
+        };
 
         assert_eq!(error.label, "str");
         assert_eq!(error.panic_message, "borrowed payload");
@@ -111,8 +118,10 @@ mod tests {
 
     #[test]
     fn captures_unknown_panic_payload() {
-        let error =
-            catch_automerge_panic("unknown", || std::panic::panic_any(17usize)).unwrap_err();
+        let error = match catch_automerge_panic("unknown", || std::panic::panic_any(17usize)) {
+            Ok(_) => panic!("expected panic capture"),
+            Err(error) => error,
+        };
 
         assert_eq!(error.label, "unknown");
         assert_eq!(error.panic_message, "unknown panic");

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -1,0 +1,120 @@
+//! Panic recovery helpers for Automerge operations.
+//!
+//! This crate intentionally depends only on `automerge` and error plumbing.
+//! Document-specific rebuild, peer-state reset, and retry policy belongs in the
+//! owning document crates.
+
+use std::any::Any;
+use std::panic::AssertUnwindSafe;
+
+/// Panic captured from an Automerge operation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("[{label}] automerge panicked: {panic_message}")]
+pub struct AutomergeRecoveryError {
+    pub label: String,
+    pub panic_message: String,
+}
+
+impl AutomergeRecoveryError {
+    pub fn new(label: impl Into<String>, panic_message: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            panic_message: panic_message.into(),
+        }
+    }
+}
+
+/// Error returned by document-level recovering Automerge operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AutomergeOperationError {
+    #[error("[{label}] automerge operation failed: {source}")]
+    Automerge {
+        label: String,
+        #[source]
+        source: automerge::AutomergeError,
+    },
+    #[error(transparent)]
+    Panic(#[from] AutomergeRecoveryError),
+    #[error("[{label}] failed to rebuild document after Automerge panic")]
+    RebuildFailed { label: String },
+}
+
+impl AutomergeOperationError {
+    pub fn automerge(label: impl Into<String>, source: automerge::AutomergeError) -> Self {
+        Self::Automerge {
+            label: label.into(),
+            source,
+        }
+    }
+
+    pub fn rebuild_failed(label: impl Into<String>) -> Self {
+        Self::RebuildFailed {
+            label: label.into(),
+        }
+    }
+}
+
+/// Convert a panic payload into stable human-readable text.
+pub fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+/// Catch a panic from an Automerge operation without exposing `catch_unwind` at call sites.
+pub fn catch_automerge_panic<T>(
+    label: impl Into<String>,
+    f: impl FnOnce() -> T,
+) -> Result<T, AutomergeRecoveryError> {
+    let label = label.into();
+    match std::panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(value) => Ok(value),
+        Err(payload) => Err(AutomergeRecoveryError::new(
+            label,
+            panic_payload_to_string(payload),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_normal_closure_value() {
+        let value = catch_automerge_panic("normal", || 42).unwrap();
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn captures_string_panic_payload() {
+        let error = catch_automerge_panic("string", || {
+            std::panic::panic_any("owned payload".to_string())
+        })
+        .unwrap_err();
+
+        assert_eq!(error.label, "string");
+        assert_eq!(error.panic_message, "owned payload");
+    }
+
+    #[test]
+    fn captures_str_panic_payload() {
+        let error = catch_automerge_panic("str", || panic!("borrowed payload")).unwrap_err();
+
+        assert_eq!(error.label, "str");
+        assert_eq!(error.panic_message, "borrowed payload");
+    }
+
+    #[test]
+    fn captures_unknown_panic_payload() {
+        let error =
+            catch_automerge_panic("unknown", || std::panic::panic_any(17usize)).unwrap_err();
+
+        assert_eq!(error.label, "unknown");
+        assert_eq!(error.panic_message, "unknown panic");
+    }
+}

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -83,6 +83,10 @@ pub fn catch_automerge_panic<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use automerge::{
+        sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, ChangeHash, ObjType,
+        ReadDoc, ROOT,
+    };
 
     #[test]
     fn returns_normal_closure_value() {
@@ -125,5 +129,146 @@ mod tests {
 
         assert_eq!(error.label, "unknown");
         assert_eq!(error.panic_message, "unknown panic");
+    }
+
+    #[test]
+    fn captures_real_missing_ops_panic_from_historical_fork_at() {
+        let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
+        let error = catch_automerge_panic("missing-ops-fork-at", || daemon.fork_at(&old_heads))
+            .expect_err("historical fork_at should trigger Automerge MissingOps panic");
+
+        assert!(error.panic_message.contains("MissingOps"));
+    }
+
+    #[test]
+    fn missing_ops_operation_matrix_identifies_fork_at_edge() {
+        let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
+        let current_heads = daemon.get_heads();
+
+        let get_changes =
+            catch_automerge_panic("missing-ops-get-changes", || daemon.get_changes(&old_heads));
+        assert!(get_changes.is_ok(), "get_changes should not panic");
+
+        let diff = catch_automerge_panic("missing-ops-diff", || {
+            daemon.diff(&old_heads, &current_heads)
+        });
+        assert!(diff.is_ok(), "diff should not panic");
+
+        let save_after =
+            catch_automerge_panic("missing-ops-save-after", || daemon.save_after(&old_heads));
+        assert!(save_after.is_ok(), "save_after should not panic");
+
+        let mut sync_state = sync::State::new();
+        let generate_sync_message = catch_automerge_panic("missing-ops-generate-sync", || {
+            daemon.sync().generate_sync_message(&mut sync_state)
+        });
+        assert!(
+            generate_sync_message.is_ok(),
+            "generate_sync_message should not panic"
+        );
+
+        let fork_at = catch_automerge_panic("missing-ops-fork-at", || daemon.fork_at(&old_heads));
+        assert!(fork_at.is_err(), "fork_at should expose the panic edge");
+    }
+
+    #[test]
+    fn save_load_rebuild_does_not_clear_historical_fork_at_panic() {
+        let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
+        let bytes = daemon.save();
+        let mut rebuilt = AutoCommit::load(&bytes).expect("saved bad doc should reload");
+
+        let fork_at = catch_automerge_panic("rebuilt-missing-ops-fork-at", || {
+            rebuilt.fork_at(&old_heads)
+        });
+        assert!(
+            fork_at.is_err(),
+            "save/load rebuild does not repair this fork_at edge"
+        );
+    }
+
+    fn build_missing_ops_historical_fork_doc() -> (AutoCommit, Vec<ChangeHash>) {
+        let mut daemon = AutoCommit::new();
+        daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+        let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+        daemon
+            .splice_text(&text, 0, 0, "# notebook cell\n")
+            .unwrap();
+        daemon.commit();
+
+        let mut peer = AutoCommit::new();
+        peer.set_actor(ActorId::from(b"wasm" as &[u8]));
+        let mut peer_sync = sync::State::new();
+        let mut daemon_sync = sync::State::new();
+        sync_docs_until_quiet(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+
+        let mut checkpoint_heads = Vec::new();
+
+        for i in 0..=200 {
+            let pos = peer.text(&text).unwrap().len();
+            peer.splice_text(
+                &text,
+                pos,
+                0,
+                &format!("{}", (b'a' + (i % 26) as u8) as char),
+            )
+            .unwrap();
+            peer.commit();
+
+            if i % 10 == 0 {
+                sync_one_message(&mut peer, &mut peer_sync, &mut daemon, &mut daemon_sync);
+
+                let mut fork = daemon.fork();
+                fork.set_actor(ActorId::from(format!("d:f{}", i).as_bytes()));
+                fork.put(ROOT, "exec_count", (i / 10) as i64).unwrap();
+                fork.commit();
+                daemon.merge(&mut fork).unwrap();
+
+                sync_one_message(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+            }
+
+            if i == 100 {
+                checkpoint_heads.push(daemon.get_heads());
+            }
+        }
+
+        let old_heads = checkpoint_heads.pop().unwrap();
+        (daemon, old_heads)
+    }
+
+    fn sync_docs_until_quiet(
+        left: &mut AutoCommit,
+        left_sync: &mut sync::State,
+        right: &mut AutoCommit,
+        right_sync: &mut sync::State,
+    ) {
+        for _ in 0..20 {
+            let mut progressed = false;
+            if let Some(msg) = left.sync().generate_sync_message(left_sync) {
+                right.sync().receive_sync_message(right_sync, msg).unwrap();
+                progressed = true;
+            }
+            if let Some(msg) = right.sync().generate_sync_message(right_sync) {
+                left.sync().receive_sync_message(left_sync, msg).unwrap();
+                progressed = true;
+            }
+            if !progressed {
+                break;
+            }
+        }
+    }
+
+    fn sync_one_message(
+        from: &mut AutoCommit,
+        from_sync: &mut sync::State,
+        to: &mut AutoCommit,
+        to_sync: &mut sync::State,
+    ) {
+        if let Some(msg) = from.sync().generate_sync_message(from_sync) {
+            to.sync().receive_sync_message(to_sync, msg).unwrap();
+        }
+        if let Some(msg) = to.sync().generate_sync_message(to_sync) {
+            from.sync().receive_sync_message(from_sync, msg).unwrap();
+        }
     }
 }

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 automerge = "0.8"
+automerge-recovery = { path = "../automerge-recovery" }
 ciborium = "0.2"
 loro_fractional_index = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -81,6 +81,7 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::{CommitOptions, Transactable};
 use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
 
 /// Re-export so downstream crates (runtimed-wasm) can set text encoding
 /// without depending on automerge directly.
@@ -335,6 +336,24 @@ impl NotebookDoc {
         other: &mut NotebookDoc,
     ) -> Result<Vec<automerge::ChangeHash>, AutomergeError> {
         self.doc.merge(&mut other.doc)
+    }
+
+    /// Merge another document's changes, rebuilding this document if Automerge panics.
+    pub fn merge_recovering(
+        &mut self,
+        other: &mut NotebookDoc,
+        label: &str,
+    ) -> Result<Vec<automerge::ChangeHash>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.doc.merge(&mut other.doc)) {
+            Ok(Ok(changes)) => Ok(changes),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 
     /// Fork the document, apply mutations on the fork, and merge back.
@@ -1995,6 +2014,26 @@ impl NotebookDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
+    /// Generate a sync message, recovering from Automerge panics by rebuilding
+    /// this doc, resetting peer sync state, and retrying once.
+    pub fn generate_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
+            Ok(message) => Ok(message),
+            Err(_err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
+                    .map_err(AutomergeOperationError::Panic)
+            }
+        }
+    }
+
     /// Receive and apply a sync message from a peer.
     pub fn receive_sync_message(
         &mut self,
@@ -2002,6 +2041,28 @@ impl NotebookDoc {
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
         self.doc.sync().receive_sync_message(peer_state, message)
+    }
+
+    /// Receive a sync message, recovering from Automerge panics by rebuilding
+    /// this doc and resetting peer sync state. A recovered panic is reported as
+    /// an error so callers do not treat the incoming message as applied.
+    pub fn receive_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 
     // ── Provenance queries ──────────────────────────────────────────
@@ -2748,6 +2809,32 @@ mod tests {
         assert_eq!(doc.schema_version(), Some(SCHEMA_VERSION));
         assert_eq!(doc.get_metadata("runtime"), None);
         assert!(doc.get_metadata_snapshot().is_none());
+    }
+
+    #[test]
+    fn recovering_sync_generation_preserves_actor_and_resets_peer_state() {
+        let mut doc = NotebookDoc::new_with_actor("test-notebook", "recovery-actor");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        let actor = doc.doc().get_actor().clone();
+        let mut peer_state = sync::State::new();
+
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "test-generate")
+            .unwrap()
+            .is_some());
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "test-generate")
+            .unwrap()
+            .is_none());
+
+        assert!(doc.rebuild_from_save());
+        peer_state = sync::State::new();
+
+        assert_eq!(doc.doc().get_actor(), &actor);
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "test-generate")
+            .unwrap()
+            .is_some());
     }
 
     #[test]

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -30,6 +30,7 @@ use automerge::{
     sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjType,
     ReadDoc, Value, ROOT,
 };
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
 use serde::{Deserialize, Serialize};
 
 // ── Snapshot types ───────────────────────────────────────────────────
@@ -296,6 +297,26 @@ impl PoolDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
+    /// Generate a sync message, recovering from Automerge panics by rebuilding
+    /// this doc, resetting peer sync state, and retrying once.
+    pub fn generate_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
+            Ok(message) => Ok(message),
+            Err(_err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
+                    .map_err(AutomergeOperationError::Panic)
+            }
+        }
+    }
+
     /// Receive a sync message from a client.
     ///
     /// **Read-only enforcement:** strips all `changes` from the client
@@ -313,6 +334,28 @@ impl PoolDoc {
             .sync()
             .receive_sync_message(peer_state, message)
             .map(|_| ())
+    }
+
+    /// Receive a sync message, recovering from Automerge panics by rebuilding
+    /// this doc and resetting peer sync state. A recovered panic is reported as
+    /// an error so callers do not treat the incoming message as applied.
+    pub fn receive_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 
     /// Round-trip save→load to rebuild internal automerge indices.
@@ -343,6 +386,48 @@ mod tests {
         assert_eq!(state.uv.pool_size, 0);
         assert_eq!(state.uv.error, None);
         assert_eq!(state.conda.available, 0);
+    }
+
+    #[test]
+    fn recovering_pool_sync_generation_preserves_actor_and_resets_peer_state() {
+        let mut doc = PoolDoc::new();
+        doc.doc_mut()
+            .set_actor(ActorId::from("pool-recovery".as_bytes()));
+        let actor = doc.doc().get_actor().clone();
+        doc.write_state(&PoolState {
+            uv: RuntimePoolState {
+                available: 1,
+                warming: 0,
+                pool_size: 2,
+                error: None,
+                failed_package: None,
+                error_kind: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
+            },
+            conda: RuntimePoolState::default(),
+            pixi: RuntimePoolState::default(),
+        })
+        .unwrap();
+        let mut peer_state = sync::State::new();
+
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "pool-test-generate")
+            .unwrap()
+            .is_some());
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "pool-test-generate")
+            .unwrap()
+            .is_none());
+
+        assert!(doc.rebuild_from_save());
+        peer_state = sync::State::new();
+
+        assert_eq!(doc.doc().get_actor(), &actor);
+        assert!(doc
+            .generate_sync_message_recovering(&mut peer_state, "pool-test-generate")
+            .unwrap()
+            .is_some());
     }
 
     #[test]

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 automerge = "0.8"
+automerge-recovery = { path = "../automerge-recovery" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
 notebook-protocol = { path = "../notebook-protocol" }

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -8,6 +8,7 @@
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::AutoCommit;
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
 use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::RuntimeStateDoc;
@@ -86,6 +87,35 @@ impl SharedDocState {
             .receive_sync_message(&mut self.peer_state, message)
     }
 
+    pub(crate) fn generate_sync_message_recovering(
+        &mut self,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.generate_sync_message()) {
+            Ok(message) => Ok(message),
+            Err(_err) => {
+                self.rebuild_doc();
+                catch_automerge_panic(label, || self.generate_sync_message())
+                    .map_err(AutomergeOperationError::Panic)
+            }
+        }
+    }
+
+    pub(crate) fn receive_sync_message_recovering(
+        &mut self,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.receive_sync_message(message)) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                self.rebuild_doc();
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
+    }
+
     // ── RuntimeStateDoc sync ────────────────────────────────────────
 
     /// Generate an outgoing sync reply for the RuntimeStateDoc.
@@ -94,6 +124,14 @@ impl SharedDocState {
             .doc_mut()
             .sync()
             .generate_sync_message(&mut self.state_peer_state)
+    }
+
+    pub(crate) fn generate_state_sync_message_recovering(
+        &mut self,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        self.state_doc
+            .generate_sync_message_recovering(&mut self.state_peer_state, label)
     }
 
     /// Apply an incoming RuntimeStateSync message from the daemon.
@@ -114,6 +152,21 @@ impl SharedDocState {
             .receive_sync_message(&mut self.state_peer_state, message)
     }
 
+    pub(crate) fn receive_state_sync_message_recovering(
+        &mut self,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.receive_state_sync_message(message)) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                self.rebuild_state_doc();
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
+    }
+
     /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
     ///
     /// Used after catching an automerge panic during `RuntimeStateSync`
@@ -127,6 +180,35 @@ impl SharedDocState {
             );
         }
         self.state_peer_state = sync::State::new();
+    }
+
+    fn rebuild_doc(&mut self) {
+        let actor = self.doc.get_actor().clone();
+        let pre_cell_count = notebook_doc::get_cells_from_doc(&self.doc).len();
+        let bytes = self.doc.save();
+        match AutoCommit::load(&bytes) {
+            Ok(mut doc) => {
+                let post_cell_count = notebook_doc::get_cells_from_doc(&doc).len();
+                if post_cell_count < pre_cell_count {
+                    warn!(
+                        "[notebook-sync] rebuild doc would lose cells ({} -> {}), resetting sync state only",
+                        pre_cell_count, post_cell_count
+                    );
+                    self.peer_state = sync::State::new();
+                    return;
+                }
+                doc.set_actor(actor);
+                self.doc = doc;
+                self.peer_state = sync::State::new();
+            }
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] failed to rebuild doc after panic: {}; resetting sync state only",
+                    e
+                );
+                self.peer_state = sync::State::new();
+            }
+        }
     }
 
     #[cfg(test)]

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -18,11 +18,11 @@
 //! via `DocHandle::with_doc`. This task is purely for network synchronization.
 
 use std::collections::HashMap;
-use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use automerge::{sync, AutoCommit, ChangeHash};
+use automerge::{sync, ChangeHash};
+use automerge_recovery::AutomergeOperationError;
 use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
@@ -44,42 +44,6 @@ const CONFIRM_SYNC_RETRY: Duration = Duration::from_millis(200);
 const STATE_SYNC_QUIET_TIMEOUT: Duration = Duration::from_millis(200);
 const STATE_SYNC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
 const MAINTENANCE_TICK: Duration = Duration::from_millis(50);
-
-/// Rebuild a `SharedDocState` after an automerge panic by round-tripping
-/// save→load to clear corrupted internal indices, then resetting the
-/// peer sync state to force a fresh handshake with the daemon.
-///
-/// Includes a defensive cell-count guard: if the rebuilt doc would have
-/// fewer cells than the original, the rebuild is skipped (only sync state
-/// is reset). This prevents silent cell loss when `save()` on a
-/// panic-corrupted doc drops ops from the serialized bytes.
-fn rebuild_shared_doc_state(state: &mut SharedDocState) {
-    let actor = state.doc.get_actor().clone();
-    let pre_cell_count = notebook_doc::get_cells_from_doc(&state.doc).len();
-    let bytes = state.doc.save();
-    match AutoCommit::load(&bytes) {
-        Ok(mut doc) => {
-            let post_cell_count = notebook_doc::get_cells_from_doc(&doc).len();
-            if post_cell_count < pre_cell_count {
-                warn!(
-                    "[notebook-sync] rebuild_shared_doc_state would lose cells \
-                     ({} → {}), keeping original doc and resetting sync state only",
-                    pre_cell_count, post_cell_count
-                );
-                state.peer_state = sync::State::new();
-                return;
-            }
-            doc.set_actor(actor);
-            state.doc = doc;
-            state.peer_state = sync::State::new();
-            info!("[notebook-sync] Rebuilt doc and reset sync state after automerge panic");
-        }
-        Err(e) => {
-            warn!("[notebook-sync] Failed to rebuild doc after panic: {}", e);
-            state.peer_state = sync::State::new();
-        }
-    }
-}
 
 /// Commands that require socket I/O (not document mutations).
 ///
@@ -518,61 +482,39 @@ impl SyncReactor {
                     }
                 };
 
-                // Apply and generate ack — lock held only for Automerge operations.
-                //
-                // The receive_sync_message call is wrapped in catch_unwind because
-                // automerge 0.7 has a known panic in BatchApply::apply when the
-                // internal patch log actor table gets out of order during concurrent
-                // sync (automerge/automerge#1187). Without catch_unwind, the panic
-                // poisons the Mutex and renders the session permanently unusable.
-                // By catching it, the MutexGuard drops normally and subsequent
-                // operations can still succeed.
+                // Apply and generate ack while the mutex guard is alive so panic
+                // recovery can rebuild the document without poisoning the mutex.
                 let ack_bytes = {
                     let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
-                    let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.receive_sync_message(msg)
-                    }));
-                    match recv_result {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
+                    match state.receive_sync_message_recovering(msg, "notebook-sync-receive") {
+                        Ok(()) => {}
+                        Err(AutomergeOperationError::Panic(e)) => {
+                            warn!(
+                                "[notebook-sync] Recovered from sync panic for {}: {}",
+                                self.io.notebook_id, e
+                            );
+                        }
+                        Err(AutomergeOperationError::RebuildFailed { label }) => {
+                            warn!(
+                                "[notebook-sync] Failed to rebuild after sync panic for {}: {}",
+                                self.io.notebook_id, label
+                            );
+                        }
+                        Err(e) => {
                             warn!(
                                 "[notebook-sync] Failed to apply sync message for {}: {}",
                                 self.io.notebook_id, e
                             );
                             return;
                         }
-                        Err(panic_payload) => {
-                            let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
-                                s.as_str()
-                            } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                                s
-                            } else {
-                                "unknown panic"
-                            };
-                            warn!(
-                                "[notebook-sync] Automerge panicked during sync for {} \
-                             (upstream bug automerge/automerge#1187): {}",
-                                self.io.notebook_id, msg
-                            );
-                            // Rebuild doc via save→load to clear corrupted indices,
-                            // then reset peer state to force a fresh sync handshake.
-                            rebuild_shared_doc_state(&mut state);
-                            return;
-                        }
                     }
-                    // Guard generate_sync_message — the collector can also panic
-                    // with MissingOps even after a successful receive.
-                    match std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.generate_sync_message().map(|msg| msg.encode())
-                    })) {
-                        Ok(bytes) => bytes,
-                        Err(_) => {
+                    match state.generate_sync_message_recovering("notebook-sync-reply") {
+                        Ok(message) => message.map(|msg| msg.encode()),
+                        Err(e) => {
                             warn!(
-                            "[notebook-sync] Automerge panicked in generate_sync_message for {} \
-                             (upstream MissingOps bug)",
-                            self.io.notebook_id
-                        );
-                            rebuild_shared_doc_state(&mut state);
+                                "[notebook-sync] Failed to generate sync reply for {}: {}",
+                                self.io.notebook_id, e
+                            );
                             None
                         }
                     }
@@ -698,58 +640,43 @@ impl SyncReactor {
                     }
                 };
 
-                // Apply and generate reply — same pattern as AutomergeSync.
-                //
-                // Wrapped in catch_unwind because automerge 0.7 can panic in
-                // receive_sync_message / generate_sync_message on the state
-                // doc under the same concurrent-sync conditions that trigger
-                // the notebook doc panic (automerge/automerge#1187). Without
-                // catch_unwind, the panic kills the sync task, which closes
-                // the socket and causes the MCP connection to drop — any
-                // locally-pending notebook mutations (e.g. a cell creation)
-                // that hadn't been synced yet are lost on reconnect.
+                // Apply and generate reply while the mutex guard is alive so
+                // recovery can rebuild the RuntimeStateDoc without poisoning it.
                 let (reply_bytes, runtime_state) = {
                     let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
-                    let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.receive_state_sync_message(msg)
-                    }));
-                    match recv_result {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
+                    match state
+                        .receive_state_sync_message_recovering(msg, "runtime-state-sync-receive")
+                    {
+                        Ok(()) => {}
+                        Err(AutomergeOperationError::Panic(e)) => {
+                            warn!(
+                                "[notebook-sync] Recovered from RuntimeStateSync panic for {}: {}",
+                                self.io.notebook_id, e
+                            );
+                        }
+                        Err(AutomergeOperationError::RebuildFailed { label }) => {
+                            warn!(
+                                "[notebook-sync] Failed to rebuild after RuntimeStateSync panic for {}: {}",
+                                self.io.notebook_id, label
+                            );
+                        }
+                        Err(e) => {
                             warn!(
                                 "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
                                 self.io.notebook_id, e
                             );
                             return;
                         }
-                        Err(panic_payload) => {
-                            let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
-                                s.as_str()
-                            } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                                s
-                            } else {
-                                "unknown panic"
-                            };
-                            warn!(
-                                "[notebook-sync] Automerge panicked during RuntimeStateSync for {} \
-                                 (upstream bug automerge/automerge#1187): {}",
-                                self.io.notebook_id, msg
-                            );
-                            state.rebuild_state_doc();
-                            return;
-                        }
                     };
-                    let reply_bytes = match std::panic::catch_unwind(AssertUnwindSafe(|| {
-                        state.generate_state_sync_message().map(|msg| msg.encode())
-                    })) {
-                        Ok(bytes) => bytes,
-                        Err(_) => {
+                    let reply_bytes = match state
+                        .generate_state_sync_message_recovering("runtime-state-sync-reply")
+                    {
+                        Ok(message) => message.map(|msg| msg.encode()),
+                        Err(e) => {
                             warn!(
-                                "[notebook-sync] Automerge panicked in generate_state_sync_message \
-                                 for {} (upstream MissingOps bug)",
-                                self.io.notebook_id
+                                "[notebook-sync] Failed to generate RuntimeStateSync reply for {}: {}",
+                                self.io.notebook_id, e
                             );
-                            state.rebuild_state_doc();
                             None
                         }
                     };
@@ -1039,7 +966,10 @@ async fn send_doc_sync_message<W: AsyncWrite + Unpin>(
 ) -> Result<bool, SyncError> {
     let msg_bytes = {
         let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-        state.generate_sync_message().map(|msg| msg.encode())
+        state
+            .generate_sync_message_recovering("notebook-sync-outbound")
+            .map_err(|e| SyncError::Protocol(e.to_string()))?
+            .map(|msg| msg.encode())
     };
 
     if let Some(bytes) = msg_bytes {
@@ -1066,7 +996,10 @@ async fn send_state_sync_message<W: AsyncWrite + Unpin>(
 ) -> Result<(), SyncError> {
     let msg_bytes = {
         let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-        state.generate_state_sync_message().map(|msg| msg.encode())
+        state
+            .generate_state_sync_message_recovering("runtime-state-sync-outbound")
+            .map_err(|e| SyncError::Protocol(e.to_string()))?
+            .map(|msg| msg.encode())
     };
 
     if let Some(bytes) = msg_bytes {
@@ -1168,6 +1101,7 @@ fn apply_sync_status(
 mod tests {
     use super::*;
 
+    use automerge::AutoCommit;
     use notebook_protocol::connection::send_typed_json_frame;
     use notebook_protocol::protocol::{
         InitialLoadPhaseWire, NotebookDocPhaseWire, NotebookRequestEnvelope,
@@ -1424,13 +1358,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn runtime_state_sync_panic_is_caught_and_later_updates_still_apply() {
-        // Probe for a known recovery gap: catching an inbound RuntimeStateSync
-        // panic keeps the task alive, but the daemon peer state can still
-        // believe the client received the dropped change. A fuller fix likely
-        // needs a runtime-state peer reset/rejoin path, not just catch_unwind.
-        // Remove #[ignore] once that peer reset/rejoin path exists.
+        // Recovery resets the runtime-state peer state. After the daemon peer
+        // also rejoins with fresh sync state, later updates still apply.
         let mut reactor = test_reactor();
         {
             let mut state = reactor.io.doc.lock().unwrap();
@@ -1472,6 +1402,7 @@ mod tests {
                 reactor.handle_incoming_frame(&frame, &mut writer).await;
 
                 if !later_update_sent {
+                    daemon_state.rebuild_state_doc();
                     daemon_state
                         .state_doc
                         .create_execution_with_source("exec-2", "cell-2", "y = 2", 2)

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 automerge = "0.8"
+automerge-recovery = { path = "../automerge-recovery" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 automunge = { path = "../automunge" }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -87,6 +87,7 @@ use automerge::{
     transaction::{CommitOptions, Transactable},
     ActorId, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -492,6 +493,24 @@ impl RuntimeStateDoc {
         other: &mut RuntimeStateDoc,
     ) -> Result<Vec<automerge::ChangeHash>, AutomergeError> {
         self.doc.merge(&mut other.doc)
+    }
+
+    /// Merge another runtime-state document, rebuilding this document if Automerge panics.
+    pub fn merge_recovering(
+        &mut self,
+        other: &mut RuntimeStateDoc,
+        label: &str,
+    ) -> Result<Vec<automerge::ChangeHash>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.doc.merge(&mut other.doc)) {
+            Ok(Ok(changes)) => Ok(changes),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 
     /// Fork, apply mutations on the fork, and merge back.
@@ -2387,6 +2406,26 @@ impl RuntimeStateDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
+    /// Generate a sync message, recovering from Automerge panics by rebuilding
+    /// this doc, resetting peer sync state, and retrying once.
+    pub fn generate_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
+            Ok(message) => Ok(message),
+            Err(_err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
+                    .map_err(AutomergeOperationError::Panic)
+            }
+        }
+    }
+
     /// Generate a sync message, compacting the doc if the encoded message
     /// would exceed `max_encoded_bytes`.
     ///
@@ -2422,6 +2461,31 @@ impl RuntimeStateDoc {
             .map(|m| m.encode())
     }
 
+    /// Generate a bounded encoded sync message, recovering from Automerge panics
+    /// by rebuilding this doc, resetting peer sync state, and retrying once.
+    pub fn generate_sync_message_bounded_encoded_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        max_encoded_bytes: usize,
+        label: &str,
+    ) -> Result<Option<Vec<u8>>, AutomergeOperationError> {
+        match catch_automerge_panic(label, || {
+            self.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
+        }) {
+            Ok(message) => Ok(message),
+            Err(_err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                catch_automerge_panic(label, || {
+                    self.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
+                })
+                .map_err(AutomergeOperationError::Panic)
+            }
+        }
+    }
+
     /// Receive a sync message with change stripping (read-only enforcement).
     ///
     /// The daemon is the sole authority for runtime state. Any changes a
@@ -2451,6 +2515,27 @@ impl RuntimeStateDoc {
         Ok(())
     }
 
+    /// Receive a read-only sync message, recovering from Automerge panics by
+    /// rebuilding this doc and resetting peer sync state.
+    pub fn receive_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
+    }
+
     /// Receive a sync message accepting client writes.
     ///
     /// Unlike `receive_sync_message()` which strips client changes, this
@@ -2468,6 +2553,29 @@ impl RuntimeStateDoc {
         self.doc.sync().receive_sync_message(peer_state, message)?;
         let heads_after = self.doc.get_heads();
         Ok(heads_before != heads_after)
+    }
+
+    /// Receive a writable sync message, recovering from Automerge panics by
+    /// rebuilding this doc and resetting peer sync state.
+    pub fn receive_sync_message_with_changes_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<bool, AutomergeOperationError> {
+        match catch_automerge_panic(label, || {
+            self.receive_sync_message_with_changes(peer_state, message)
+        }) {
+            Ok(Ok(changed)) => Ok(changed),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 
     /// Apply a sync message and return both the list of applied-change
@@ -2578,6 +2686,34 @@ impl RuntimeStateDoc {
             applied_actors,
             foreign_comms: Some(foreign_comms),
         })
+    }
+
+    /// Receive a writable sync message and compute a foreign-actor comm view,
+    /// recovering from Automerge panics by rebuilding this doc and resetting
+    /// peer sync state.
+    pub fn receive_sync_and_foreign_comms_recovering<F>(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        is_foreign: F,
+        label: &str,
+    ) -> Result<ForeignSyncView, AutomergeOperationError>
+    where
+        F: Fn(&ActorId) -> bool,
+    {
+        match catch_automerge_panic(label, || {
+            self.receive_sync_and_foreign_comms(peer_state, message, is_foreign)
+        }) {
+            Ok(Ok(view)) => Ok(view),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(err) => {
+                *peer_state = sync::State::new();
+                if !self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label));
+                }
+                Err(AutomergeOperationError::Panic(err))
+            }
+        }
     }
 }
 

--- a/crates/runtime-doc/src/error.rs
+++ b/crates/runtime-doc/src/error.rs
@@ -9,7 +9,13 @@ pub enum RuntimeStateError {
     #[error("automerge: {0}")]
     Automerge(#[from] AutomergeError),
     #[error("automerge recovery: {0}")]
-    AutomergeRecovery(#[from] automerge_recovery::AutomergeOperationError),
+    AutomergeRecovery(Box<automerge_recovery::AutomergeOperationError>),
     #[error("RuntimeStateDoc mutex poisoned")]
     LockPoisoned,
+}
+
+impl From<automerge_recovery::AutomergeOperationError> for RuntimeStateError {
+    fn from(error: automerge_recovery::AutomergeOperationError) -> Self {
+        Self::AutomergeRecovery(Box::new(error))
+    }
 }

--- a/crates/runtime-doc/src/error.rs
+++ b/crates/runtime-doc/src/error.rs
@@ -8,6 +8,8 @@ pub enum RuntimeStateError {
     InvalidProgressShape,
     #[error("automerge: {0}")]
     Automerge(#[from] AutomergeError),
+    #[error("automerge recovery: {0}")]
+    AutomergeRecovery(#[from] automerge_recovery::AutomergeOperationError),
     #[error("RuntimeStateDoc mutex poisoned")]
     LockPoisoned,
 }

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -1,7 +1,11 @@
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 
-use crate::{RuntimeStateDoc, RuntimeStateError};
+use automerge::sync;
+#[cfg(test)]
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
+
+use crate::{ForeignSyncView, RuntimeStateDoc, RuntimeStateError};
 
 /// Handle to a per-notebook RuntimeStateDoc.
 ///
@@ -66,27 +70,76 @@ impl RuntimeStateHandle {
             .lock()
             .map_err(|_| RuntimeStateError::LockPoisoned)?;
         let heads_before = sd.get_heads();
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sd.merge(fork))) {
-            Ok(Ok(_)) => {}
-            Ok(Err(e)) => {
-                // Normal error: doc is unchanged (error fires before mutation).
-                return Err(e.into());
-            }
-            Err(_panic) => {
-                // Panic during apply: doc may be half-merged. Rebuild from save.
-                tracing::warn!(
-                    "[runtime-state] merge panicked, rebuilding from save to restore consistency"
-                );
-                sd.rebuild_from_save();
-                return Err(RuntimeStateError::MissingScaffold(
-                    "merge panicked, rebuilt from save",
-                ));
+        match sd.merge_recovering(fork, "runtime-state-merge") {
+            Ok(_) => {}
+            Err(err) => {
+                tracing::warn!("[runtime-state] {}", err);
+                return Err(err.into());
             }
         }
         if sd.get_heads() != heads_before {
             let _ = self.changed_tx.send(());
         }
         Ok(())
+    }
+
+    pub fn generate_sync_message_recovering(
+        &self,
+        peer_state: &mut sync::State,
+        label: &str,
+    ) -> Result<Option<sync::Message>, RuntimeStateError> {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        sd.generate_sync_message_recovering(peer_state, label)
+            .map_err(Into::into)
+    }
+
+    pub fn generate_sync_message_bounded_encoded_recovering(
+        &self,
+        peer_state: &mut sync::State,
+        max_encoded_bytes: usize,
+        label: &str,
+    ) -> Result<Option<Vec<u8>>, RuntimeStateError> {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        sd.generate_sync_message_bounded_encoded_recovering(peer_state, max_encoded_bytes, label)
+            .map_err(Into::into)
+    }
+
+    pub fn receive_sync_message_with_changes_recovering(
+        &self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<bool, RuntimeStateError> {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        sd.receive_sync_message_with_changes_recovering(peer_state, message, label)
+            .map_err(Into::into)
+    }
+
+    pub fn receive_sync_and_foreign_comms_recovering<F>(
+        &self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        is_foreign: F,
+        label: &str,
+    ) -> Result<ForeignSyncView, RuntimeStateError>
+    where
+        F: Fn(&automerge::ActorId) -> bool,
+    {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        sd.receive_sync_and_foreign_comms_recovering(peer_state, message, is_foreign, label)
+            .map_err(Into::into)
     }
 
     /// Read-only access. No notification.
@@ -104,6 +157,23 @@ impl RuntimeStateHandle {
     /// Subscribe to change notifications.
     pub fn subscribe(&self) -> broadcast::Receiver<()> {
         self.changed_tx.subscribe()
+    }
+
+    #[cfg(test)]
+    fn recover_injected_panic_for_test(&self) -> Result<(), RuntimeStateError> {
+        let mut sd = self
+            .doc
+            .lock()
+            .map_err(|_| RuntimeStateError::LockPoisoned)?;
+        match catch_automerge_panic("runtime-state-handle-test", || {
+            panic!("injected runtime-state panic")
+        }) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                sd.rebuild_from_save();
+                Err(AutomergeOperationError::Panic(err).into())
+            }
+        }
     }
 }
 
@@ -156,6 +226,21 @@ mod tests {
             .unwrap();
         assert!(rx.try_recv().is_ok());
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn recovery_panic_inside_handle_does_not_poison_mutex() {
+        let handle = make_handle();
+        let err = handle
+            .recover_injected_panic_for_test()
+            .expect_err("injected panic should be reported");
+        assert!(err.to_string().contains("injected runtime-state panic"));
+
+        handle.with_doc(|sd| sd.set_lifecycle(&busy())).unwrap();
+        assert_eq!(
+            handle.read(|sd| sd.read_state().kernel.lifecycle).unwrap(),
+            busy()
+        );
     }
 
     #[test]

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -73,6 +73,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 
 # Automerge CRDT for settings sync
 automerge = "0.8"
+automerge-recovery = { path = "../automerge-recovery" }
 
 # Shared notebook document types (cell CRUD, metadata, sync)
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -560,15 +560,11 @@ where
                 doc.set_cell_attachments(&cell.id, attachment_refs)
                     .map_err(|e| format!("Failed to set attachments for {}: {}", cell.id, e))?;
             }
-            match catch_automerge_panic("streaming-load-cells", || {
-                doc.generate_sync_message(peer_state).map(|m| m.encode())
-            }) {
-                Ok(encoded) => encoded,
+            match doc.generate_sync_message_recovering(peer_state, "streaming-load-cells") {
+                Ok(message) => message.map(|m| m.encode()),
                 Err(e) => {
-                    warn!("{}", e);
-                    doc.rebuild_from_save();
-                    *peer_state = sync::State::new();
-                    doc.generate_sync_message(peer_state).map(|m| m.encode())
+                    warn!("[streaming-load] cell sync generation failed: {}", e);
+                    None
                 }
             }
         };
@@ -678,15 +674,11 @@ where
             if let Err(e) = doc.set_metadata_snapshot(&meta) {
                 warn!("[streaming-load] Failed to set metadata: {}", e);
             }
-            match catch_automerge_panic("streaming-load-meta", || {
-                doc.generate_sync_message(peer_state).map(|m| m.encode())
-            }) {
-                Ok(encoded) => encoded,
+            match doc.generate_sync_message_recovering(peer_state, "streaming-load-meta") {
+                Ok(message) => message.map(|m| m.encode()),
                 Err(e) => {
-                    warn!("{}", e);
-                    doc.rebuild_from_save();
-                    *peer_state = sync::State::new();
-                    doc.generate_sync_message(peer_state).map(|m| m.encode())
+                    warn!("[streaming-load] metadata sync generation failed: {}", e);
+                    None
                 }
             }
         };
@@ -1297,11 +1289,8 @@ pub(crate) async fn apply_ipynb_changes(
                 }
             }
 
-            if let Err(e) =
-                catch_automerge_panic("file-watcher-order-merge", || doc.merge(&mut fork))
-            {
-                warn!("{}", e);
-                doc.rebuild_from_save();
+            if let Err(e) = doc.merge_recovering(&mut fork, "file-watcher-order-merge") {
+                warn!("[file-watcher] order merge failed: {}", e);
             }
 
             deferred
@@ -1578,9 +1567,8 @@ pub(crate) async fn apply_ipynb_changes(
         // Merge source fork back — source changes from disk compose with
         // post-save CRDT changes via Automerge's text CRDT merge.
         if let Some(ref mut fork) = source_fork {
-            if let Err(e) = catch_automerge_panic("file-watcher-source-merge", || doc.merge(fork)) {
-                warn!("{}", e);
-                doc.rebuild_from_save();
+            if let Err(e) = doc.merge_recovering(fork, "file-watcher-source-merge") {
+                warn!("[file-watcher] source merge failed: {}", e);
             }
         }
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -669,9 +669,8 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
 
     let persist_bytes = {
         let mut doc = room.doc.write().await;
-        if let Err(e) = catch_automerge_panic("metadata-merge", || doc.merge(&mut fork)) {
-            warn!("{}", e);
-            doc.rebuild_from_save();
+        if let Err(e) = doc.merge_recovering(&mut fork, "metadata-merge") {
+            warn!("[metadata] merge failed: {}", e);
         }
         doc.save()
     };
@@ -4648,9 +4647,8 @@ pub(crate) async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, 
 
     if formatted_count > 0 {
         let mut doc = room.doc.write().await;
-        if let Err(e) = catch_automerge_panic("save-format-merge", || doc.merge(&mut fork)) {
-            warn!("{}", e);
-            doc.rebuild_from_save();
+        if let Err(e) = doc.merge_recovering(&mut fork, "save-format-merge") {
+            warn!("[format] merge failed: {}", e);
         }
         let _ = room.broadcasts.changed_tx.send(());
         info!(

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -25,7 +25,6 @@
 //! - Multiple windows share the same kernel
 
 use std::collections::HashMap;
-use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -113,27 +112,6 @@ const KERNEL_BROADCAST_CAPACITY: usize = 256;
 /// If the encoded message exceeds this, compact before sending. Leaves
 /// 20 MiB headroom under the 100 MiB frame limit.
 const STATE_SYNC_COMPACT_THRESHOLD: usize = 80 * 1024 * 1024;
-
-/// Catch panics from automerge internal operations.
-///
-/// Automerge 0.7.4 (and 0.8.0) has a known bug where the change collector
-/// panics with `MissingOps` when internal op-set indices become inconsistent
-/// (see `op_set2/change/collector.rs:761`). This affects `generate_sync_message`,
-/// `fork_at`, `merge`, and `get_changes`.
-///
-/// After catching a panic, callers should call `rebuild_from_save()` on the
-/// affected doc to round-trip save->load and rebuild clean internal indices.
-pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Result<T, String> {
-    match std::panic::catch_unwind(AssertUnwindSafe(f)) {
-        Ok(val) => Ok(val),
-        Err(payload) => {
-            let msg = crate::task_supervisor::panic_payload_to_string(payload);
-            Err(format!(
-                "[{label}] automerge panicked (upstream bug, see automerge collector.rs MissingOps): {msg}"
-            ))
-        }
-    }
-}
 
 /// A message sent through the runtime agent channel.
 pub enum RuntimeAgentMessage {

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -3,7 +3,6 @@ use tracing::warn;
 
 use crate::connection::NotebookFrameType;
 
-use super::catch_automerge_panic;
 use super::peer_writer::PeerWriter;
 use super::{
     check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
@@ -27,19 +26,10 @@ pub(super) async fn handle_notebook_doc_frame(
 
         let heads_before = doc.get_heads();
 
-        let recv_result = catch_automerge_panic("doc-receive-sync", || {
-            doc.receive_sync_message(peer_state, message)
-        });
-        match recv_result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!("[notebook-sync] receive_sync_message error: {}", e);
-                return Ok(NotebookDocFrameOutcome::Skipped);
-            }
+        match doc.receive_sync_message_recovering(peer_state, message, "doc-receive-sync") {
+            Ok(()) => {}
             Err(e) => {
-                warn!("{}", e);
-                doc.rebuild_from_save();
-                *peer_state = sync::State::new();
+                warn!("[notebook-sync] receive_sync_message error: {}", e);
                 return Ok(NotebookDocFrameOutcome::Skipped);
             }
         }
@@ -52,20 +42,11 @@ pub(super) async fn handle_notebook_doc_frame(
         // Notify other peers in this room.
         let _ = room.broadcasts.changed_tx.send(());
 
-        let encoded = match catch_automerge_panic("doc-sync-reply", || {
-            doc.generate_sync_message(peer_state)
-                .map(|reply| reply.encode())
-        }) {
-            Ok(encoded) => encoded,
+        let encoded = match doc.generate_sync_message_recovering(peer_state, "doc-sync-reply") {
+            Ok(message) => message.map(|reply| reply.encode()),
             Err(e) => {
-                warn!("{}", e);
-                *peer_state = sync::State::new();
-                if doc.rebuild_from_save() {
-                    doc.generate_sync_message(peer_state)
-                        .map(|reply| reply.encode())
-                } else {
-                    None
-                }
+                warn!("[notebook-sync] doc sync reply failed: {}", e);
+                None
             }
         };
 
@@ -117,20 +98,11 @@ pub(super) async fn forward_notebook_doc_broadcast(
 ) -> anyhow::Result<()> {
     let encoded = {
         let mut doc = room.doc.write().await;
-        match catch_automerge_panic("doc-broadcast", || {
-            doc.generate_sync_message(peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
+        match doc.generate_sync_message_recovering(peer_state, "doc-broadcast") {
+            Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
-                warn!("{}", e);
-                *peer_state = sync::State::new();
-                if doc.rebuild_from_save() {
-                    doc.generate_sync_message(peer_state)
-                        .map(|msg| msg.encode())
-                } else {
-                    None
-                }
+                warn!("[notebook-sync] doc broadcast failed: {}", e);
+                None
             }
         }
     };
@@ -151,17 +123,11 @@ pub(super) async fn queue_doc_sync(
 ) -> anyhow::Result<()> {
     let encoded = {
         let mut doc = room.doc.write().await;
-        match catch_automerge_panic("broadcast-doc-changes", || {
-            doc.generate_sync_message(peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
+        match doc.generate_sync_message_recovering(peer_state, "broadcast-doc-changes") {
+            Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
-                warn!("{}", e);
-                doc.rebuild_from_save();
-                *peer_state = sync::State::new();
-                doc.generate_sync_message(peer_state)
-                    .map(|msg| msg.encode())
+                warn!("[notebook-sync] queue doc sync failed: {}", e);
+                None
             }
         }
     };

--- a/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
@@ -7,7 +7,6 @@ use tracing::{debug, warn};
 
 use crate::connection::{self, NotebookFrameType};
 
-use super::catch_automerge_panic;
 use super::peer_writer::PeerWriter;
 
 pub(super) async fn send_initial_pool_sync<W>(
@@ -20,19 +19,11 @@ where
 {
     let initial_pool_encoded = {
         let mut pool_doc = daemon.pool_doc.write().await;
-        match catch_automerge_panic("initial-pool-sync", || {
-            pool_doc
-                .generate_sync_message(pool_peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
+        match pool_doc.generate_sync_message_recovering(pool_peer_state, "initial-pool-sync") {
+            Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
-                warn!("{}", e);
-                pool_doc.rebuild_from_save();
-                *pool_peer_state = sync::State::new();
-                pool_doc
-                    .generate_sync_message(pool_peer_state)
-                    .map(|msg| msg.encode())
+                warn!("[notebook-sync] initial pool sync failed: {}", e);
+                None
             }
         }
     };
@@ -53,19 +44,14 @@ pub(super) async fn handle_pool_state_frame(
     let reply_encoded = {
         let mut pool_doc = daemon.pool_doc.write().await;
 
-        let recv_result = catch_automerge_panic("pool-receive-sync", || {
-            pool_doc.receive_sync_message(pool_peer_state, message)
-        });
-        match recv_result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
-                warn!("[notebook-sync] pool receive_sync_message error: {}", e);
-                return Ok(false);
-            }
+        match pool_doc.receive_sync_message_recovering(
+            pool_peer_state,
+            message,
+            "pool-receive-sync",
+        ) {
+            Ok(()) => {}
             Err(e) => {
-                warn!("{}", e);
-                pool_doc.rebuild_from_save();
-                *pool_peer_state = sync::State::new();
+                warn!("[notebook-sync] pool receive_sync_message error: {}", e);
                 return Ok(false);
             }
         }
@@ -125,19 +111,11 @@ fn generate_pool_sync_message(
     pool_peer_state: &mut sync::State,
     label: &str,
 ) -> Option<Vec<u8>> {
-    match catch_automerge_panic(label, || {
-        pool_doc
-            .generate_sync_message(pool_peer_state)
-            .map(|msg| msg.encode())
-    }) {
-        Ok(encoded) => encoded,
+    match pool_doc.generate_sync_message_recovering(pool_peer_state, label) {
+        Ok(message) => message.map(|msg| msg.encode()),
         Err(e) => {
-            warn!("{}", e);
-            pool_doc.rebuild_from_save();
-            *pool_peer_state = sync::State::new();
-            pool_doc
-                .generate_sync_message(pool_peer_state)
-                .map(|msg| msg.encode())
+            warn!("[notebook-sync] pool sync generation failed: {}", e);
+            None
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -68,8 +68,18 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let doc_sync_msg = {
         let mut doc = room.doc.write().await;
         // Generate our sync message (full doc state for fresh peer)
-        doc.generate_sync_message(&mut doc_sync_state)
-            .map(|msg| msg.encode())
+        match doc
+            .generate_sync_message_recovering(&mut doc_sync_state, "peer-runtime-agent-doc-init")
+        {
+            Ok(message) => message.map(|msg| msg.encode()),
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] runtime-agent initial doc sync failed: {}",
+                    e
+                );
+                None
+            }
+        }
     };
     if let Some(encoded) = doc_sync_msg {
         if let Err(e) =
@@ -85,12 +95,11 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     let mut state_sync_state = automerge::sync::State::new();
     let state_sync_msg = room
         .state
-        .with_doc(|sd| {
-            Ok(sd.generate_sync_message_bounded_encoded(
-                &mut state_sync_state,
-                STATE_SYNC_COMPACT_THRESHOLD,
-            ))
-        })
+        .generate_sync_message_bounded_encoded_recovering(
+            &mut state_sync_state,
+            STATE_SYNC_COMPACT_THRESHOLD,
+            "peer-runtime-agent-state-init",
+        )
         .ok()
         .flatten();
     if let Some(encoded) = state_sync_msg {
@@ -183,18 +192,36 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     NotebookFrameType::AutomergeSync => {
                         if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                             let mut doc = room.doc.write().await;
-                            if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
-                                let _ = room.broadcasts.changed_tx.send(());
+                            match doc.receive_sync_message_recovering(
+                                &mut doc_sync_state,
+                                msg,
+                                "peer-runtime-agent-doc",
+                            ) {
+                                Ok(()) => {
+                                    let _ = room.broadcasts.changed_tx.send(());
+                                }
+                                Err(e) => {
+                                    warn!("[notebook-sync] Agent doc sync receive failed: {}", e);
+                                }
                             }
                             // Send sync reply
-                            if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
-                                let encoded = reply.encode();
-                                if let Err(e) = agent_writer.send_frame(
-                                    NotebookFrameType::AutomergeSync,
-                                    encoded,
-                                ) {
-                                    warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
-                                    break;
+                            match doc.generate_sync_message_recovering(
+                                &mut doc_sync_state,
+                                "peer-runtime-agent-doc-reply",
+                            ) {
+                                Ok(Some(reply)) => {
+                                    let encoded = reply.encode();
+                                    if let Err(e) = agent_writer.send_frame(
+                                        NotebookFrameType::AutomergeSync,
+                                        encoded,
+                                    ) {
+                                        warn!("[notebook-sync] Failed to queue doc sync reply to runtime agent: {}", e);
+                                        break;
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    warn!("[notebook-sync] Agent doc sync reply failed: {}", e);
                                 }
                             }
                         }
@@ -205,18 +232,32 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                             let mut runtime_file_dirty = false;
                             let reply_encoded = room.state.with_doc(|sd| {
                                 let before = runtime_file_save_fingerprint(sd);
-                                if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                    &mut state_sync_state, msg,
+                                match sd.receive_sync_message_with_changes_recovering(
+                                    &mut state_sync_state,
+                                    msg,
+                                    "peer-runtime-agent-state",
                                 ) {
-                                    if changed {
-                                        state_changed = true;
-                                        if runtime_file_save_fingerprint(sd) != before {
-                                            runtime_file_dirty = true;
+                                    Ok(changed) => {
+                                        if changed {
+                                            state_changed = true;
+                                            if runtime_file_save_fingerprint(sd) != before {
+                                                runtime_file_dirty = true;
+                                            }
+                                            // Notification handled by with_doc heads check
                                         }
-                                        // Notification handled by with_doc heads check
+                                    }
+                                    Err(e) => {
+                                        warn!("[notebook-sync] Agent state sync receive failed: {}", e);
+                                        return Ok(None);
                                     }
                                 }
-                                Ok(sd.generate_sync_message(&mut state_sync_state)
+                                Ok(sd
+                                    .generate_sync_message_recovering(
+                                        &mut state_sync_state,
+                                        "peer-runtime-agent-state-reply",
+                                    )
+                                    .ok()
+                                    .flatten()
                                     .map(|reply| reply.encode()))
                             }).ok().flatten();
                             if let Some(encoded) = reply_encoded {
@@ -261,14 +302,23 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             _ = changed_rx.recv() => {
                 while changed_rx.try_recv().is_ok() {}
                 let mut doc = room.doc.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut doc_sync_state) {
-                    let encoded = msg.encode();
-                    if let Err(e) = agent_writer.send_frame(
-                        NotebookFrameType::AutomergeSync,
-                        encoded,
-                    ) {
-                        warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
-                        break;
+                match doc.generate_sync_message_recovering(
+                    &mut doc_sync_state,
+                    "peer-runtime-agent-doc-outbound",
+                ) {
+                    Ok(Some(msg)) => {
+                        let encoded = msg.encode();
+                        if let Err(e) = agent_writer.send_frame(
+                            NotebookFrameType::AutomergeSync,
+                            encoded,
+                        ) {
+                            warn!("[notebook-sync] Failed to queue doc sync to runtime agent: {}", e);
+                            break;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        warn!("[notebook-sync] Agent outbound doc sync failed: {}", e);
                     }
                 }
             }
@@ -276,10 +326,15 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             // RuntimeStateDoc changes → sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
-                let encoded = room.state.with_doc(|sd| {
-                    Ok(sd.generate_sync_message(&mut state_sync_state)
-                        .map(|msg| msg.encode()))
-                }).ok().flatten();
+                let encoded = room
+                    .state
+                    .generate_sync_message_recovering(
+                        &mut state_sync_state,
+                        "peer-runtime-agent-state-outbound",
+                    )
+                    .ok()
+                    .flatten()
+                    .map(|msg| msg.encode());
                 if let Some(encoded) = encoded {
                     if let Err(e) = agent_writer.send_frame(
                         NotebookFrameType::RuntimeStateSync,

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -6,7 +6,6 @@ use tracing::{debug, warn};
 
 use crate::connection::NotebookFrameType;
 
-use super::catch_automerge_panic;
 use super::peer_writer::PeerWriter;
 use super::NotebookRoom;
 
@@ -82,19 +81,14 @@ pub(super) async fn handle_runtime_state_frame(
         .state
         .with_doc(|state_doc| {
             let before = runtime_file_save_fingerprint(state_doc);
-            let recv_result = catch_automerge_panic("state-receive-sync", || {
-                state_doc.receive_sync_message_with_changes(state_peer_state, message)
-            });
-            let had_changes = match recv_result {
-                Ok(Ok(changed)) => changed,
-                Ok(Err(e)) => {
-                    warn!("[notebook-sync] state receive_sync_message error: {}", e);
-                    return Ok(None);
-                }
+            let had_changes = match state_doc.receive_sync_message_with_changes_recovering(
+                state_peer_state,
+                message,
+                "state-receive-sync",
+            ) {
+                Ok(changed) => changed,
                 Err(e) => {
-                    warn!("{}", e);
-                    state_doc.rebuild_from_save();
-                    *state_peer_state = sync::State::new();
+                    warn!("[notebook-sync] state receive_sync_message error: {}", e);
                     return Ok(None);
                 }
             };
@@ -188,19 +182,14 @@ fn generate_runtime_state_sync_message(
     state_peer_state: &mut sync::State,
     label: &str,
 ) -> Option<Vec<u8>> {
-    match catch_automerge_panic(label, || {
-        state_doc
-            .generate_sync_message(state_peer_state)
-            .map(|msg| msg.encode())
-    }) {
-        Ok(encoded) => encoded,
+    match state_doc.generate_sync_message_recovering(state_peer_state, label) {
+        Ok(message) => message.map(|msg| msg.encode()),
         Err(e) => {
-            warn!("{}", e);
-            state_doc.rebuild_from_save();
-            *state_peer_state = sync::State::new();
-            state_doc
-                .generate_sync_message(state_peer_state)
-                .map(|msg| msg.encode())
+            warn!(
+                "[notebook-sync] runtime state sync generation failed: {}",
+                e
+            );
+            None
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -7,9 +7,7 @@ use tracing::{info, warn};
 
 use crate::connection::{self, NotebookFrameType};
 
-use super::{
-    catch_automerge_panic, streaming_load_cells, NotebookRoom, STATE_SYNC_COMPACT_THRESHOLD,
-};
+use super::{streaming_load_cells, NotebookRoom, STATE_SYNC_COMPACT_THRESHOLD};
 
 pub(crate) async fn send_session_status<W>(
     writer: &mut W,
@@ -70,22 +68,11 @@ where
     // holding the write lock across async I/O.
     let initial_encoded = {
         let mut doc = room.doc.write().await;
-        match catch_automerge_panic("initial-doc-sync", || {
-            doc.generate_sync_message(&mut sync_state.peer_state)
-                .map(|msg| msg.encode())
-        }) {
-            Ok(encoded) => encoded,
+        match doc.generate_sync_message_recovering(&mut sync_state.peer_state, "initial-doc-sync") {
+            Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
-                warn!("{}", e);
-                sync_state.peer_state = sync::State::new();
-                if doc.rebuild_from_save() {
-                    doc.generate_sync_message(&mut sync_state.peer_state)
-                        .map(|msg| msg.encode())
-                } else {
-                    // Cell-count guard prevented rebuild — skip sync message,
-                    // fresh peer_state will trigger full re-sync on next exchange
-                    None
-                }
+                warn!("[notebook-sync] initial doc sync failed: {}", e);
+                None
             }
         }
     };
@@ -119,20 +106,15 @@ where
             if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
                 info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
             }
-            match catch_automerge_panic("initial-state-sync", || {
-                state_doc.generate_sync_message_bounded_encoded(
-                    state_peer_state,
-                    STATE_SYNC_COMPACT_THRESHOLD,
-                )
-            }) {
+            match state_doc.generate_sync_message_bounded_encoded_recovering(
+                state_peer_state,
+                STATE_SYNC_COMPACT_THRESHOLD,
+                "initial-state-sync",
+            ) {
                 Ok(encoded) => Ok(encoded),
                 Err(e) => {
-                    warn!("{}", e);
-                    state_doc.rebuild_from_save();
-                    *state_peer_state = sync::State::new();
-                    Ok(state_doc
-                        .generate_sync_message(state_peer_state)
-                        .map(|msg| msg.encode()))
+                    warn!("[notebook-sync] initial runtime state sync failed: {}", e);
+                    Ok(None)
                 }
             }
         })

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -6,7 +6,7 @@ use runtime_doc::RuntimeLifecycle;
 use tracing::warn;
 
 use crate::notebook_sync_server::{
-    catch_automerge_panic, detect_room_runtime, format_source, formatter_actor, NotebookRoom,
+    detect_room_runtime, format_source, formatter_actor, NotebookRoom,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -94,11 +94,8 @@ async fn handle_inner(
                         ));
                         if fork.update_source(&cell_id_clone, &formatted).is_ok() {
                             let mut doc = room_clone.doc.write().await;
-                            if let Err(e) =
-                                catch_automerge_panic("format-merge", || doc.merge(&mut fork))
-                            {
-                                warn!("{}", e);
-                                doc.rebuild_from_save();
+                            if let Err(e) = doc.merge_recovering(&mut fork, "format-merge") {
+                                warn!("[format] merge failed: {}", e);
                             }
                             let _ = room_clone.broadcasts.changed_tx.send(());
                         }

--- a/crates/runtimed/src/requests/guarded.rs
+++ b/crates/runtimed/src/requests/guarded.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 use automerge::ChangeHash;
 use notebook_doc::{diff::DocChangeset, NotebookDoc};
 
-use crate::notebook_sync_server::{
-    catch_automerge_panic, check_and_update_trust_state, NotebookRoom,
-};
+use automerge_recovery::catch_automerge_panic;
+
+use crate::notebook_sync_server::{check_and_update_trust_state, NotebookRoom};
 use crate::protocol::NotebookResponse;
 
 #[derive(Debug)]

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -343,10 +343,11 @@ pub async fn run_runtime_agent(
 
                                         // Per-change actor filter: diff comm state against a
                                         // foreign-only view of the post-sync doc.
-                                        match sd.receive_sync_and_foreign_comms(
+                                        match sd.receive_sync_and_foreign_comms_recovering(
                                             &mut coordinator_sync_state,
                                             msg,
                                             |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                                            "runtime-agent-state-receive",
                                         ) {
                                             Ok(view) if !view.applied_actors.is_empty() => {
                                                 let queued = sd.get_queued_executions();
@@ -418,10 +419,15 @@ pub async fn run_runtime_agent(
                                     }
 
                                     // Send sync reply
-                                    let reply_encoded = ctx.state.with_doc(|sd| {
-                                        Ok(sd.generate_sync_message(&mut coordinator_sync_state)
-                                            .map(|reply| reply.encode()))
-                                    }).ok().flatten();
+                                    let reply_encoded = ctx
+                                        .state
+                                        .generate_sync_message_recovering(
+                                            &mut coordinator_sync_state,
+                                            "runtime-agent-state-reply",
+                                        )
+                                        .ok()
+                                        .flatten()
+                                        .map(|reply| reply.encode());
                                     if let Some(encoded) = reply_encoded {
                                         let _ = send_typed_frame(
                                             &mut writer,
@@ -525,10 +531,15 @@ pub async fn run_runtime_agent(
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
 
-                let encoded = ctx.state.with_doc(|sd| {
-                    Ok(sd.generate_sync_message(&mut coordinator_sync_state)
-                        .map(|msg| msg.encode()))
-                }).ok().flatten();
+                let encoded = ctx
+                    .state
+                    .generate_sync_message_recovering(
+                        &mut coordinator_sync_state,
+                        "runtime-agent-state-outbound",
+                    )
+                    .ok()
+                    .flatten()
+                    .map(|msg| msg.encode());
                 if let Some(encoded) = encoded {
                     if let Err(e) = send_typed_frame(
                         &mut writer,


### PR DESCRIPTION
## Summary

- stack on #2525 and rebase the investigation branch onto current `main`
- add a real `automerge 0.8.0` `MissingOps` panic reproducer to `automerge-recovery`
- classify the reproduced bad document shape: `fork_at(old_heads)` panics, while `get_changes`, `diff`, `save_after`, and `generate_sync_message` do not in this case
- document that save/load rebuild does not repair this specific `fork_at` edge

## Verification

```sh
cargo test -p automerge-recovery
```

Result: 7 passed.

## Notes

This is an investigation branch, not a replacement for #2525. The main result so far is that the known upstream `MissingOps` repro is specifically a historical `fork_at` edge. The repo currently has no production `fork_at(` calls; the file watcher paths already avoid it.
