### PR TITLE
docs(automerge-recovery): explain why receive_*_recovering methods do not retry

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2114,6 +2114,12 @@ impl NotebookDoc {
     /// Receive a sync message, recovering from Automerge panics by rebuilding
     /// this doc and resetting peer sync state. A recovered panic is reported as
     /// an error so callers do not treat the incoming message as applied.
+    ///
+    /// Unlike `generate_sync_message_recovering`, this does not retry after
+    /// rebuild. The inbound `sync::Message` is moved into `receive_sync_message`
+    /// and consumed by Automerge's apply path, so it cannot be replayed. The
+    /// caller's next outbound sync (via the generate path) will trigger a fresh
+    /// handshake from the rebuilt state.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -339,6 +339,12 @@ impl PoolDoc {
     /// Receive a sync message, recovering from Automerge panics by rebuilding
     /// this doc and resetting peer sync state. A recovered panic is reported as
     /// an error so callers do not treat the incoming message as applied.
+    ///
+    /// Unlike `generate_sync_message_recovering`, this does not retry after
+    /// rebuild. The inbound `sync::Message` is moved into `receive_sync_message`
+    /// and consumed by Automerge's apply path, so it cannot be replayed. The
+    /// caller's next outbound sync (via the generate path) will trigger a fresh
+    /// handshake from the rebuilt state.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -103,6 +103,9 @@ impl SharedDocState {
         }
     }
 
+    /// No retry after rebuild: the inbound `sync::Message` is consumed by the
+    /// failed attempt and cannot be replayed. The next outbound sync triggers a
+    /// fresh handshake from the rebuilt state.
     pub(crate) fn receive_sync_message_recovering(
         &mut self,
         message: sync::Message,
@@ -156,6 +159,9 @@ impl SharedDocState {
             .receive_sync_message(&mut self.state_peer_state, message)
     }
 
+    /// No retry after rebuild: the inbound `sync::Message` is consumed by the
+    /// failed attempt and cannot be replayed. The next outbound sync triggers a
+    /// fresh handshake from the rebuilt state.
     pub(crate) fn receive_state_sync_message_recovering(
         &mut self,
         message: sync::Message,

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -2522,6 +2522,12 @@ impl RuntimeStateDoc {
 
     /// Receive a read-only sync message, recovering from Automerge panics by
     /// rebuilding this doc and resetting peer sync state.
+    ///
+    /// Unlike `generate_sync_message_recovering`, this does not retry after
+    /// rebuild. The inbound `sync::Message` is moved into `receive_sync_message`
+    /// and consumed by Automerge's apply path, so it cannot be replayed. The
+    /// caller's next outbound sync (via the generate path) will trigger a fresh
+    /// handshake from the rebuilt state.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2562,6 +2568,10 @@ impl RuntimeStateDoc {
 
     /// Receive a writable sync message, recovering from Automerge panics by
     /// rebuilding this doc and resetting peer sync state.
+    ///
+    /// No retry after rebuild: the inbound `sync::Message` is consumed by the
+    /// failed attempt and cannot be replayed. See
+    /// `receive_sync_message_recovering` for details.
     pub fn receive_sync_message_with_changes_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2696,6 +2706,10 @@ impl RuntimeStateDoc {
     /// Receive a writable sync message and compute a foreign-actor comm view,
     /// recovering from Automerge panics by rebuilding this doc and resetting
     /// peer sync state.
+    ///
+    /// No retry after rebuild: the inbound `sync::Message` is consumed by the
+    /// failed attempt and cannot be replayed. See
+    /// `receive_sync_message_recovering` for details.
     pub fn receive_sync_and_foreign_comms_recovering<F>(
         &mut self,
         peer_state: &mut sync::State,


### PR DESCRIPTION
## Summary

- Adds doc comments to all `receive_*_recovering` methods explaining why they do not retry after rebuild, unlike their `generate_*_recovering` counterparts
- The inbound `sync::Message` is moved into the apply path and consumed by Automerge, so it cannot be replayed after a panic+rebuild
- The caller's next outbound sync triggers a fresh handshake from the rebuilt state, which is the correct recovery path

Follow-up to #2525. Identified during codex review as P2.1.

## Test plan

- [ ] Doc-only change, no behavioral changes
- [ ] CI passes (clippy, tests)