### PR TITLE
fix(automerge-recovery): log when rebuild_from_save itself panics

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1180,7 +1180,7 @@ impl NotebookDoc {
     /// fewer cells, the rebuild is skipped to prevent silent cell loss when
     /// `save()` on a panic-corrupted doc drops ops from the serialized bytes.
     pub fn rebuild_from_save(&mut self) -> bool {
-        catch_automerge_panic("notebook-doc-rebuild-from-save", || {
+        match catch_automerge_panic("notebook-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let pre_cell_count = self.cell_count();
             let bytes = self.doc.save();
@@ -1190,7 +1190,7 @@ impl NotebookDoc {
                     if post_cell_count < pre_cell_count {
                         #[cfg(feature = "persistence")]
                         warn!(
-                            "[notebook-doc] rebuild_from_save would lose cells ({} → {}), skipping",
+                            "[notebook-doc] rebuild_from_save would lose cells ({} -> {}), skipping",
                             pre_cell_count, post_cell_count
                         );
                         return false;
@@ -1201,8 +1201,15 @@ impl NotebookDoc {
                 }
                 Err(_) => false,
             }
-        })
-        .unwrap_or_default()
+        }) {
+            Ok(rebuilt) => rebuilt,
+            Err(err) => {
+                #[cfg(feature = "persistence")]
+                log::error!("[notebook-doc] rebuild_from_save itself panicked: {}", err);
+                let _ = &err; // suppress unused warning when persistence is off
+                false
+            }
+        }
     }
 
     /// Save the document to a file.

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -358,9 +358,9 @@ impl PoolDoc {
         }
     }
 
-    /// Round-trip save→load to rebuild internal automerge indices.
+    /// Round-trip save->load to rebuild internal automerge indices.
     pub fn rebuild_from_save(&mut self) -> bool {
-        catch_automerge_panic("pool-doc-rebuild-from-save", || {
+        match catch_automerge_panic("pool-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let bytes = self.doc.save();
             match AutoCommit::load(&bytes) {
@@ -371,8 +371,15 @@ impl PoolDoc {
                 }
                 Err(_) => false,
             }
-        })
-        .unwrap_or_default()
+        }) {
+            Ok(rebuilt) => rebuilt,
+            Err(err) => {
+                #[cfg(feature = "persistence")]
+                log::error!("[pool-doc] rebuild_from_save itself panicked: {}", err);
+                let _ = &err; // suppress unused warning when persistence is off
+                false
+            }
+        }
     }
 }
 

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -534,7 +534,7 @@ impl RuntimeStateDoc {
     /// Used after catching an automerge panic (upstream MissingOps bug in
     /// `collector.rs`). See `NotebookDoc::rebuild_from_save` for details.
     pub fn rebuild_from_save(&mut self) -> bool {
-        catch_automerge_panic("runtime-state-doc-rebuild-from-save", || {
+        match catch_automerge_panic("runtime-state-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let bytes = self.doc.save();
             match AutoCommit::load(&bytes) {
@@ -545,8 +545,13 @@ impl RuntimeStateDoc {
                 }
                 Err(_) => false,
             }
-        })
-        .unwrap_or_default()
+        }) {
+            Ok(rebuilt) => rebuilt,
+            Err(err) => {
+                tracing::error!("[runtime-state] rebuild_from_save itself panicked: {}", err);
+                false
+            }
+        }
     }
 
     /// Compact the document if its serialized size exceeds `threshold` bytes.


### PR DESCRIPTION
## Summary

- Replaces `.unwrap_or_default()` with explicit match + error logging in all three `rebuild_from_save` methods (NotebookDoc, PoolDoc, RuntimeStateDoc)
- Previously, if `save()` or `load()` panicked during rebuild, `.unwrap_or_default()` would silently return `false`
- Now logs at `error!` level so the double-panic is visible in daemon logs
- Fixes emdash in doc comments

Follow-up to #2525. Identified during codex review as P2.2.

## Test plan

- [ ] No behavioral changes (logging only)
- [ ] CI passes (clippy, tests, WASM)