### PR TITLE
fix(automerge): use nteract desktop patch fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,18 +602,17 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automerge"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aab56635599ee2e9df28d9ce180c155b8dbcdd96e4c3f62895fc6a44137d328"
+version = "0.9.0"
+source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
 dependencies = [
  "cfg-if",
  "flate2",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hex",
  "hexane",
  "itertools 0.14.0",
  "leb128",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash",
  "serde",
  "sha2 0.11.0",
@@ -3079,8 +3078,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4ecba0bb4e14df997df7cab6d1b584c6432d8865cf2adfced814706d715a7b"
+source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -4780,7 +4778,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7201,6 +7199,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "notebook-doc",
  "notebook-wire",
  "runtime-doc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 runtimelib = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64", default-features = false }
 jupyter-protocol = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64" }
 nbformat = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "4a605a43586e08de090bb1321b661b15c1e71962" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/crates/automerge-recovery/Cargo.toml
+++ b/crates/automerge-recovery/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -133,19 +133,17 @@ mod tests {
     }
 
     #[test]
-    fn captures_real_missing_ops_panic_from_historical_fork_at() {
+    fn historical_fork_at_missing_ops_regression_is_fixed_by_desktop_patch() {
         let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
-        let error =
-            match catch_automerge_panic("missing-ops-fork-at", || daemon.fork_at(&old_heads)) {
-                Ok(_) => panic!("historical fork_at should trigger Automerge MissingOps panic"),
-                Err(error) => error,
-            };
-
-        assert!(error.panic_message.contains("MissingOps"));
+        let fork_at = catch_automerge_panic("missing-ops-fork-at", || daemon.fork_at(&old_heads));
+        assert!(
+            fork_at.is_ok(),
+            "desktop-patched Automerge should not panic on historical fork_at"
+        );
     }
 
     #[test]
-    fn missing_ops_operation_matrix_identifies_fork_at_edge() {
+    fn missing_ops_operation_matrix_stays_non_panicking() {
         let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
         let current_heads = daemon.get_heads();
 
@@ -187,11 +185,11 @@ mod tests {
         );
 
         let fork_at = catch_automerge_panic("missing-ops-fork-at", || daemon.fork_at(&old_heads));
-        assert!(fork_at.is_err(), "fork_at should expose the panic edge");
+        assert!(fork_at.is_ok(), "fork_at should not panic");
     }
 
     #[test]
-    fn save_load_rebuild_does_not_clear_historical_fork_at_panic() {
+    fn save_load_rebuild_preserves_fixed_historical_fork_at_behavior() {
         let (mut daemon, old_heads) = build_missing_ops_historical_fork_doc();
         let bytes = daemon.save();
         let mut rebuilt = must(AutoCommit::load(&bytes), "saved bad doc should reload");
@@ -200,8 +198,8 @@ mod tests {
             rebuilt.fork_at(&old_heads)
         });
         assert!(
-            fork_at.is_err(),
-            "save/load rebuild does not repair this fork_at edge"
+            fork_at.is_ok(),
+            "desktop-patched Automerge should keep historical fork_at non-panicking after save/load"
         );
     }
 

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 serde_json = "1"
 
 [lints]

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
 ciborium = "0.2"
 loro_fractional_index = { workspace = true }

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -2513,7 +2513,7 @@ impl RuntimeStateDoc {
             need: message.need,
             have: message.have,
             changes: sync::ChunkList::empty(),
-            supported_capabilities: message.supported_capabilities,
+            flags: message.flags,
             version: message.version,
         };
         self.doc.sync().receive_sync_message(peer_state, filtered)?;

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -31,7 +31,7 @@ dirs = "6"
 base64 = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 uuid = { workspace = true }
-automerge = "0.8"
+automerge = { workspace = true }
 schemars = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -10,7 +10,7 @@ description = "WASM bindings for runtimed notebook document operations, compiled
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-automerge = "0.8"
+automerge = { workspace = true }
 notebook-doc = { path = "../notebook-doc" }
 notebook-wire = { path = "../notebook-wire" }
 runtime-doc = { path = "../runtime-doc" }
@@ -19,10 +19,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
 web-sys = { version = "0.3", features = ["console"] }
-# getrandom (both versions) stays to activate the wasm_js / js feature
-# for transitive crates. Removing either line breaks the wasm build
-# because uuid / rand can't find a browser RNG.
-getrandom = { version = "0.3", features = ["wasm_js"] }
+# getrandom stays to activate the wasm_js / js feature for transitive
+# crates. Removing these lines breaks the wasm build because uuid / rand
+# can't find a browser RNG.
+getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 console_error_panic_hook = "0.1"
 
@@ -33,10 +34,10 @@ wasm-bindgen-test = "0.3"
 wasm-opt = false
 
 [package.metadata.cargo-machete]
-# Both `getrandom` entries are here purely to activate the `wasm_js` /
-# `js` feature on the transitive dep so uuid / rand can find a browser
-# RNG. No direct code uses them; deleting either breaks the wasm build.
-ignored = ["getrandom", "getrandom_02"]
+# The `getrandom` entries are here purely to activate the `wasm_js` /
+# `js` feature on transitive deps so uuid / rand can find a browser RNG.
+# No direct code uses them; deleting them breaks the wasm build.
+ignored = ["getrandom", "getrandom_03", "getrandom_02"]
 
 [lints]
 workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -72,7 +72,7 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["tokio"] }
 
 # Automerge CRDT for settings sync
-automerge = "0.8"
+automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
 
 # Shared notebook document types (cell CRUD, metadata, sync)


### PR DESCRIPTION
## Summary

- Move Automerge to a single workspace dependency pinned to the nteract desktop patch fork commit.
- Migrate all direct workspace Automerge users to `workspace = true`.
- Update the Automerge 0.9 sync message field usage and wasm `getrandom` feature wiring.
- Reframe the recovery crate's historical MissingOps regression tests around the patched non-panicking behavior.

## Verification

- `cargo test -p automerge-recovery`
- `cargo test -p runtime-doc`
- `cargo test -p notebook-doc isolated_transaction`
- `cargo test -p notebook-doc rebuild_from_save`
- `cargo test -p notebook-sync runtime_state_sync_panic_is_caught_and_later_updates_still_apply`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo check --package runtimed`
- `cargo check -p runtimed-wasm --locked`
- `cargo xtask clippy`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py::TestExecuteCell::test_cell_execute_returns_execution_handle -q`

## Notes

- `cargo xtask lint --fix` still fails on the pre-existing long line at `python/runtimed/tests/test_daemon_integration.py:2929`.
- The first local attempt to run the Python integration test against an external dev daemon failed in module health check because that daemon had no available UV or conda pool environments. The integration-mode rerun spawned its own daemon and passed.
