### PR TITLE
docs(automerge): refresh transaction and recovery guidance

### DIFF
--- a/.claude/rules/crdt-mutations.md
+++ b/.claude/rules/crdt-mutations.md
@@ -102,6 +102,6 @@ The bridge uses `externalChangeAnnotation` to prevent echo: inbound changes are 
 
 4. **Do not bypass the bridge for source text.** The CodeMirror bridge handles character-level sync. Using `update_source` (Myers diff) from the UI would conflict with the bridge's splice tracking.
 
-5. **Do not mutate the doc directly after an async gap.** If you read doc state, await something, then write back, use `NotebookDoc::fork()` before the async work and `merge()` after. For synchronous blocks, use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` for the full pattern.
+5. **Do not mutate the doc directly after an async gap.** If you read doc state, await something, then write back, prefer `NotebookDoc::transact_at_heads_recovering(...)` with heads captured before the await. Use `fork_with_actor(...)` + `merge_recovering(...)` only when a forked document must cross the async gap. For synchronous blocks, use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` for the full pattern.
 
 6. **Do not `put_object()` at a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` from different actors create two distinct Map objects -- an Automerge conflict. One wins; the loser's children become invisible. Document structure must be created by exactly one peer (the daemon). Other peers receive it via sync. This is why `bootstrap()` only seeds `schema_version`, not the full skeleton.

--- a/.claude/skills/automerge-document-model/SKILL.md
+++ b/.claude/skills/automerge-document-model/SKILL.md
@@ -193,8 +193,11 @@ Creates a new document containing only changes up to `heads`:
 3. Extracts changes for those hashes and applies them
 
 **Much more expensive than fork()** — it doesn't clone; it replays
-changes from scratch. Used for time-travel views. nteract avoids this
-in production paths due to automerge/automerge#1327.
+changes from scratch. Use it for time-travel views and diagnostics, not
+as the default async mutation primitive. The pinned nteract Automerge
+0.9 desktop patch fixes the historical MissingOps/fork_at regression
+that previously made this path unsafe, but document-owned transaction
+helpers are still preferred for writes at captured heads.
 
 ### merge(other)
 
@@ -209,11 +212,13 @@ pub fn merge(&mut self, other: &mut Self) -> Result<Vec<ChangeHash>, AutomergeEr
 Merge extracts changes from `other` that `self` doesn't have and applies
 them. After merge, `self` contains all ops from both documents.
 
-**The DuplicateSeqNumber trap:** If two forks share the same ActorId
-(because `fork()` clones the actor and the caller forgot to change it),
-both will produce changes with the same `(actor, seq)` pair. The second
-merge returns `DuplicateSeqNumber`. nteract's `fork_with_actor()` exists
-specifically to prevent this.
+**The DuplicateSeqNumber trap:** Automerge forks receive a new random
+actor by default. If callers override that and force two concurrent
+forks to share the same ActorId, both can produce changes with the same
+`(actor, seq)` pair. The second merge returns `DuplicateSeqNumber`.
+nteract's `fork_with_actor()` exists for the cases where we need a
+specific actor for attribution/filtering; the caller must choose an actor
+that is not used by another concurrent fork.
 
 ## The AutoCommit Wrapper
 
@@ -245,9 +250,10 @@ incremental materialization. `diff_incremental()` returns patches and
 advances the cursor. This is how nteract's WASM side computes
 `CellChangeset` — by diffing the PatchLog after receiving sync frames.
 
-## Why #1187 Panics Happen
+## Historical #1187 / #1327 Panic Class
 
-The panic occurs in `BatchApply::apply()` during `PatchLog::migrate_actors()`:
+Older Automerge builds could panic in `BatchApply::apply()` during
+`PatchLog::migrate_actors()`:
 
 1. **Setup:** Two peers sync concurrently. Peer A introduces actor X;
    Peer B introduces actor Y.
@@ -268,10 +274,14 @@ The panic occurs in `BatchApply::apply()` during `PatchLog::migrate_actors()`:
 - The ChangeGraph is rebuilt from column metadata
 - `sync::State::new()` starts a fresh sync handshake
 
-**Why catch_unwind is needed:** The panic happens inside `receive_sync_message`
-→ `load_incremental` → `apply_changes` → `BatchApply::apply`. Since this
-is an automerge bug (not a logic error in nteract), catching and rebuilding
-is the correct workaround until upstream fixes the actor migration logic.
+**Current nteract status:** the workspace uses a pinned nteract Automerge
+0.9 desktop patch that covers the historical MissingOps/fork_at regression,
+and notebook-doc now has `transact_at_heads_recovering(...)` for writes
+against captured heads. We still keep document-level panic recovery around
+Automerge receive/generate/merge/transaction boundaries as a containment
+layer: catch while the document lock/owner still holds the guard, rebuild
+from save/load if needed, reset that peer's `sync::State`, and do not treat
+panic recovery as normal control flow.
 
 ## Document Size Factors
 
@@ -320,11 +330,35 @@ doc.fork_and_merge(|fork| {
 });
 ```
 
-Safe for synchronous blocks — actor collision is harmless because
-merge completes before any concurrent fork exists. No unique actor
-needed.
+Safe for synchronous blocks: the helper creates, mutates, and merges the
+fork before returning. Do not force a shared actor inside the closure
+unless that actor cannot overlap with another concurrent fork.
 
-### fork_with_actor for Async Mutations
+### transact_at_heads_recovering for Async Notebook Mutations
+
+```rust
+let baseline_heads = doc.get_heads();
+// ... async work ...
+doc.transact_at_heads_recovering(
+    &baseline_heads,
+    Some("runtimed:formatter"),
+    "formatter-transaction",
+    |doc| {
+        doc.update_source(cell_id, formatted)?;
+        Ok(())
+    },
+)?;
+```
+
+Preferred for notebook-doc async writes that can be expressed as a
+mutation against a captured baseline. The helper uses Automerge's
+isolate/integrate transaction path, restores the original actor, and
+keeps panic recovery inside the document boundary. Because the live doc
+owns the actor sequence, repeated historical transactions can use one
+stable actor without the duplicate-sequence risk that independent forks
+have.
+
+### fork_with_actor for Async Forks
 
 ```rust
 let mut fork = doc.fork_with_actor("runtimed:iopub:kernel-abc");
@@ -333,8 +367,9 @@ fork.set_outputs(cell_id, outputs);
 doc.merge(&mut fork)?;
 ```
 
-Required when the fork crosses an `.await` — another fork might exist
-concurrently, and shared actors cause DuplicateSeqNumber on merge.
+Use this when the worker must carry an editable fork across an `.await`.
+Another fork might exist concurrently, so shared actors cause
+DuplicateSeqNumber on merge.
 
 ## Decision Framework
 
@@ -342,12 +377,13 @@ concurrently, and shared actors cause DuplicateSeqNumber on merge.
 |-----------|----------|
 | Need to recover from corrupted indices | `save()` → `load()` round-trip (rebuilds OpSet from columns) |
 | Need to check if peer has specific changes | `change_graph.has_change(&hash)` (O(1) hash lookup) |
-| Need document at earlier point | `fork_at(heads)` — expensive, avoid in hot paths |
-| Need concurrent async mutations | `fork_with_actor()` — unique actor per concurrent fork |
-| Need synchronous batch mutation | `fork_and_merge()` — shared actor is safe |
+| Need document at earlier point | `fork_at(heads)` — expensive, OK for views/diagnostics |
+| Need async notebook write from captured heads | `transact_at_heads_recovering()` — preferred historical mutation helper |
+| Need concurrent async fork | `fork_with_actor()` — unique actor per concurrent fork |
+| Need synchronous batch mutation | `fork_and_merge()` |
 | Need to shrink document bytes | `save()` uses columnar + DEFLATE; no history compaction available |
 | Need to understand document size | Count ops, actors, tombstones; save() gives compressed size |
-| Debugging a panic in apply | Check actor table ordering; likely #1187-class bug; catch_unwind + rebuild |
+| Debugging a panic in apply | Check actor table ordering; document-level catch/rebuild/reset contains the failure |
 | Need incremental save for wire | `save_after(heads)` for changes since last sync point |
 
 ## Key Source Files
@@ -359,10 +395,10 @@ concurrently, and shared actors cause DuplicateSeqNumber on merge.
 | `automerge/src/change.rs` | `Change` struct, actor_id/seq/deps/hash accessors |
 | `automerge/src/change_graph.rs` | `ChangeGraph` DAG, heads, clock computation, causal queries |
 | `automerge/src/op_set2/op_set.rs` | `OpSet` columnar storage, actor table, object index |
-| `automerge/src/op_set2/change/batch.rs` | `BatchApply::apply`, actor migration, the #1187 panic site |
-| `automerge/src/patches/patch_log.rs` | `PatchLog`, `migrate_actors` — the function that panics |
+| `automerge/src/op_set2/change/batch.rs` | `BatchApply::apply`, actor migration, historical #1187 panic site |
+| `automerge/src/patches/patch_log.rs` | `PatchLog`, `migrate_actors` |
 | `automerge/src/types.rs` | `OpId`, `ActorId`, `ObjId`, `ElemId`, `OpType` |
 | `automerge/src/storage/` | Columnar encoding, Document format, change parsing |
-| `notebook-doc/src/lib.rs` | nteract's `NotebookDoc` wrapper: fork/merge/save/load/rebuild |
+| `notebook-doc/src/lib.rs` | nteract's `NotebookDoc` wrapper: transactions, fork/merge, save/load/rebuild |
 | `notebook-sync/src/shared.rs` | `SharedDocState`, `rebuild_state_doc`, dual-doc management |
-| `notebook-sync/src/sync_task.rs` | catch_unwind guards, `rebuild_shared_doc_state` with cell-count guard |
+| `notebook-sync/src/sync_task.rs` | Calls into document-owned recovery helpers from the biased sync loop |

--- a/.claude/skills/automerge-sync/SKILL.md
+++ b/.claude/skills/automerge-sync/SKILL.md
@@ -5,15 +5,15 @@ description: >
   debugging sync failures, changing reconnection logic, adding new sync
   streams, or reasoning about why peers converge (or don't). Covers
   sync::State lifecycle, bloom filters, in-flight suppression, and the
-  nteract catch_unwind recovery pattern.
+  nteract document-level recovery pattern.
 ---
 
 # Automerge Sync Internals
 
 Use this skill when working on sync behavior: reconnection, peer state,
-convergence bugs, new frame types, or catch_unwind recovery. This encodes
-knowledge from reading the actual automerge sync implementation, not just
-the docs.
+convergence bugs, new frame types, or document-level Automerge recovery.
+This encodes knowledge from reading the actual automerge sync implementation,
+not just the docs.
 
 ## How Automerge Sync Actually Works
 
@@ -148,39 +148,23 @@ while the daemon carries `pool_peer_state` in the peer loop.
 The mutex is `std::sync::Mutex` (not tokio), never held across `.await`.
 Recovery from mutex poisoning: `unwrap_or_else(|e| e.into_inner())`.
 
-### catch_unwind Recovery Pattern
+### Document-Level Recovery Pattern
 
-automerge 0.7 has a known panic in `BatchApply::apply` when the internal
-patch log actor table gets out of order during concurrent sync
-(automerge/automerge#1187). Both sync handlers use the same pattern:
+The workspace uses a pinned nteract Automerge 0.9 desktop patch that fixes
+the historical MissingOps/fork_at regression, but Automerge is still treated
+as a fallible boundary in user-facing sync paths. Recovery must live inside
+the document owner while the mutex/guard is still held; catching outside the
+document helper can poison the mutex before rebuild runs.
 
 ```rust
-// Step 1: catch_unwind around receive_sync_message
-let recv_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-    state.receive_sync_message(msg)
-}));
-match recv_result {
-    Ok(Ok(())) => {}
-    Ok(Err(e)) => { warn!(...); return; }
-    Err(_panic) => {
-        rebuild_shared_doc_state(&mut state);
-        return;
-    }
-}
+// receive panic: rebuild document, reset this peer state, do not claim applied
+state.receive_sync_message_recovering(msg, "notebook-sync-receive");
 
-// Step 2: catch_unwind around generate_sync_message (can also panic)
-match std::panic::catch_unwind(AssertUnwindSafe(|| {
-    state.generate_sync_message().map(|msg| msg.encode())
-})) {
-    Ok(bytes) => bytes,
-    Err(_) => {
-        rebuild_shared_doc_state(&mut state);
-        None
-    }
-}
+// generate panic: rebuild document, reset this peer state, retry once
+let bytes = state.generate_sync_message_recovering("notebook-sync-outbound");
 ```
 
-**Rebuild for notebook doc** (`rebuild_shared_doc_state`):
+**Rebuild for notebook doc** (`SharedDocState::rebuild_doc`):
 1. `save()` the doc to bytes
 2. `AutoCommit::load()` from those bytes (clears corrupted indices)
 3. **Cell-count guard:** if rebuilt doc has fewer cells, skip rebuild
@@ -262,17 +246,18 @@ The sync task must keep draining incoming frames. Any command handler that
 blocks waiting for a specific response starves broadcasts, state sync,
 and sync replies. Use waiters/pending-request registration instead.
 
-### 4. Forgetting catch_unwind on new sync handlers
+### 4. Bypassing document-level recovery on new sync handlers
 
 If you add a new Automerge sync stream (e.g., PoolStateSync `0x06`),
-it needs the same catch_unwind + rebuild pattern. Any `receive_sync_message`
-or `generate_sync_message` call on a concurrently-synced document is
-vulnerable to automerge#1187.
+it needs document-owned receive/generate helpers with panic capture,
+rebuild, peer `sync::State` reset, and generate retry semantics. Do not
+call `receive_sync_message` or `generate_sync_message` directly from a
+task loop that can lose the document guard before recovery runs.
 
 ### 5. Skipping the cell-count guard
 
 `save()` on a panic-corrupted doc may drop ops, producing fewer cells.
-The guard in `rebuild_shared_doc_state` prevents silent cell loss by
+The guard in `SharedDocState::rebuild_doc` prevents silent cell loss by
 falling back to sync-state-only reset when the rebuilt doc has fewer cells.
 
 ### 6. Holding the mutex across I/O
@@ -350,7 +335,7 @@ wait (see #2457 for the ordering rationale).
 | `automerge/src/sync/bloom.rs` | `BloomFilter`, 1% FP rate params |
 | `automerge-repo/.../DocSynchronizer.ts` | Per-peer `#syncStates`, `beginSync` encode/decode hack |
 | `samod/subduction-sans-io/src/engine.rs` | `handle_connection_lost` -- simplest correct reconnection |
-| `crates/notebook-sync/src/sync_task.rs` | Biased select, catch_unwind, rebuild |
+| `crates/notebook-sync/src/sync_task.rs` | Biased select, document recovery calls |
 | `crates/notebook-sync/src/shared.rs` | `SharedDocState`, dual sync states |
 | `crates/notebook-sync/src/handle.rs` | `send_request_after_heads`, `current_heads_hex`, `confirm_sync` |
 | `crates/runtimed/src/notebook_sync_server/peer_writer.rs` | `wait_for_required_heads`, daemon-side causal gate |
@@ -365,7 +350,7 @@ When you need to decide how to handle sync state:
 | Transport disconnect + reconnect | Reset sync::State (new() or encode/decode round-trip) |
 | automerge panic caught | Rebuild doc (save/load), reset sync::State |
 | Local mutation happened | Do nothing -- next generate_sync_message handles it |
-| Adding a new sync stream | New frame type, new sync::State field, catch_unwind guard |
+| Adding a new sync stream | New frame type, new sync::State field, document-owned recovery helper |
 | Peer lost all data (empty heads) | Already handled -- receive_sync_message resets sent_hashes |
 | Switching read-only to read-write | set_read_only() handles reset + SyncReset flag |
 | Need daemon to see edits before executing | Use `required_heads` (not confirm_sync) |

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -127,19 +127,25 @@ Prefer these over `get_cells()` which materializes everything.
 
 ```rust
 // Fork BEFORE async work — captures the baseline
-let fork = {
+let baseline_heads = {
     let mut doc = room.doc.write().await;
-    doc.fork()
+    doc.get_heads()
 };
 
 // Async work happens here (ruff, network, etc.)
 let result = do_async_work().await;
 
-// Apply on fork, then merge back
-let mut fork = fork;
-fork.update_source(&cell_id, &result).ok();
+// Apply against the captured baseline after reacquiring the live doc
 let mut doc = room.doc.write().await;
-doc.merge(&mut fork).ok();
+doc.transact_at_heads_recovering(
+    &baseline_heads,
+    Some("runtimed:formatter"),
+    "formatter-transaction",
+    |doc| {
+        doc.update_source(&cell_id, &result)?;
+        Ok(())
+    },
+).ok();
 ```
 
 For synchronous mutation blocks (no `.await` between fork and merge), prefer the helpers:
@@ -149,9 +155,9 @@ doc.fork_and_merge(|fork| {
 });
 ```
 
-Do not use `fork_at(...)` in current daemon code paths. The file watcher now compares against `last_save_sources` and uses `fork()` at current heads because `fork_at(...)` can trigger automerge/automerge#1327 on complex text histories.
+Use `fork_with_actor(...)` + `merge_recovering(...)` only when the async worker must carry an editable fork across the `.await`. Do not use `fork_at(...)` for historical writes; keep it for views/diagnostics and prefer document-owned transaction helpers.
 
-Key methods on `NotebookDoc`: `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
+Key methods on `NotebookDoc`: `get_heads()`, `transact_at_heads_recovering(...)`, `fork_with_actor(...)`, `merge_recovering(...)`, `fork_and_merge(f)`.
 
 All async CRDT mutation paths in the daemon are now protected — see #1216.
 

--- a/.claude/skills/sync-protocol-patterns/SKILL.md
+++ b/.claude/skills/sync-protocol-patterns/SKILL.md
@@ -147,7 +147,8 @@ connection. Daemon as authoritative server, clients as syncing peers.
 **Where nteract is ahead:**
 - `required_heads` is a clean causal ordering primitive that neither
   automerge-repo nor samod has in exactly this form
-- The catch_unwind + rebuild pattern handles automerge bugs gracefully
+- Document-owned Automerge recovery helpers rebuild and reset peer sync
+  state without poisoning shared locks
 - Per-cell O(1) WASM accessors avoid full-doc materialization
 
 **Where nteract could learn from upstream:**
@@ -210,14 +211,15 @@ If you need to add a new Automerge-synced document to the protocol
      sync state directly; daemon carries `pool_peer_state` in the peer
      loop. Choose this when sync-task's biased select isn't the right
      priority model for the new stream
-3. **Add catch_unwind guards** for both receive and generate paths
-4. **Add a rebuild function** following the save→load→reset pattern
+3. **Add document-owned recovery helpers** for both receive and generate paths
+4. **Add a rebuild function** following the save→load→reset pattern, plus
+   peer `sync::State` reset and generate retry semantics where appropriate
 5. **Update the biased select loop** (SharedDocState pattern) or the
    relevant owner's frame handler (separate ownership)
 6. **Consider subscription scope** — does every peer need this stream,
    or only specific consumers?
-7. **Test with concurrent mutation** — the automerge#1187 panic only
-   manifests under concurrent sync, so single-peer tests miss it
+7. **Test with concurrent mutation** — actor/heads bugs only manifest under
+   concurrent sync or historical-head writes, so single-peer tests miss them
 
 ## Design Decision Checklist
 

--- a/.codex/skills/nteract-automerge-protocol/SKILL.md
+++ b/.codex/skills/nteract-automerge-protocol/SKILL.md
@@ -43,7 +43,7 @@ Before changing code, answer these in notes or in your head:
 - Do not write to the CRDT in response to a daemon broadcast that mirrors a daemon-authored CRDT change.
 - Keep sync state per remote peer. Automerge `sync::State` tracks `shared_heads`, `last_sent_heads`, `their_heads`, `their_need`, `their_have`, `sent_hashes`, `in_flight`, and capabilities; sharing it across peers causes duplicate, missing, or suppressed sync messages.
 - Respect Automerge's in-flight behavior. `generate_sync_message` may return `None` while an earlier message is unacknowledged; flushing code must not assume every local mutation immediately yields bytes.
-- Prefer narrow transactions and explicit mutation APIs. For async work, fork before the await and merge after; for synchronous blocks use the local fork-and-merge helpers if available.
+- Prefer narrow transactions and explicit mutation APIs. For notebook-doc async work, capture heads before the await and use `transact_at_heads_recovering(...)` after reacquiring the document. Use `fork_with_actor(...)` + `merge_recovering(...)` only when a forked document must cross the await; for synchronous blocks use local fork-and-merge helpers.
 - Never independently `put_object` into shared structural keys from multiple actors. Concurrent object creation at the same key creates conflicts and can hide child data.
 - Use Automerge heads/change hashes for convergence checks, not JSON equality of materialized projections.
 

--- a/.codex/skills/nteract-daemon-dev/SKILL.md
+++ b/.codex/skills/nteract-daemon-dev/SKILL.md
@@ -23,7 +23,7 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 - Let the human launch the notebook GUI from their own terminal.
 - If a test or script depends on notebook execution, blob resolution, or MCP server behavior, confirm it is pointed at the worktree daemon first.
 - Use `default_socket_path()` for the current process. Reach for `socket_path_for_channel(...)` only when you intentionally need stable/nightly discovery that ignores `RUNTIMED_SOCKET_PATH`.
-- **Any daemon code that reads CRDT state, does async work, then writes back must use `fork()` + `merge()`.** For synchronous blocks use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` and `.codex/skills/nteract-notebook-sync/references/crdt-ownership.md`.
+- **Any daemon code that reads CRDT state, does async work, then writes back must reconcile against the pre-await heads.** Prefer `NotebookDoc::transact_at_heads_recovering(...)` for notebook-doc writes; use `fork_with_actor(...)` + `merge_recovering(...)` only when an editable fork must cross the await. For synchronous blocks use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` and `.codex/skills/nteract-notebook-sync/references/crdt-ownership.md`.
 
 ## Quick Start
 

--- a/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
+++ b/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
@@ -15,13 +15,14 @@
 
 ## Fork+Merge for Daemon Async Mutations
 
-Any daemon code that reads from the CRDT doc, does async work (subprocess, I/O, network), then writes back **must** use `fork()` + `merge()`. Direct mutation after an async gap can silently overwrite concurrent edits.
+Any daemon code that reads from the CRDT doc, does async work (subprocess, I/O, network), then writes back **must** reconcile against the pre-await document state. Direct mutation after an async gap can silently overwrite concurrent edits.
 
-- **Async pattern:** `fork()` before the `.await`, mutate the fork, `merge()` after. The fork must be created *before* async work starts.
+- **Preferred async notebook-doc pattern:** capture heads before the `.await`, then use `doc.transact_at_heads_recovering(...)` after reacquiring the live doc.
+- **Forked async pattern:** when a worker must carry an editable document through the `.await`, use `fork_with_actor(...)` before the async work, mutate the fork, then `merge_recovering(...)` after.
 - **Sync pattern:** `doc.fork_and_merge(|fork| { ... })` — handles fork/merge ordering automatically.
-- **Historic save comparison:** compare against `last_save_sources`, then `fork()` at current heads and `merge()`. Avoid `fork_at(...)` in current daemon paths because of automerge/automerge#1327.
+- **Historic save comparison:** compare against `last_save_sources`, then use a transaction or forked merge against the live doc. Do not use `fork_at(...)` for historical writes; keep it for views/diagnostics.
 
-Key methods on `NotebookDoc`: `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
+Key methods on `NotebookDoc`: `get_heads()`, `transact_at_heads_recovering(...)`, `fork_with_actor(...)`, `merge_recovering(...)`, `fork_and_merge(f)`.
 
 ## Common review questions
 
@@ -29,4 +30,4 @@ Key methods on `NotebookDoc`: `fork()`, `get_heads()`, `merge()`, `fork_and_merg
 - Is this change re-writing daemon-authored state from the frontend?
 - Is the change on the local-mutation path, inbound sync path, or both?
 - Does the sync rollback or retry logic preserve convergence if delivery fails?
-- Does this code read doc state, await something, then write back? If so, is it using fork+merge?
+- Does this code read doc state, await something, then write back? If so, is it using a historical transaction or forked merge?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@
 This is a map. Subsystem details live in `contributing/`, auto-loaded rules live in `.claude/rules/`, and operational recipes live in `.claude/skills/` and `.codex/skills/`. Run `cargo xtask help` for build commands.
 
 Claude-specific skills live in `.claude/skills/`. Use when the task matches:
-- `automerge-sync` for sync protocol internals, reconnection, peer state lifecycle, in-flight suppression, catch_unwind recovery, and convergence debugging
+- `automerge-sync` for sync protocol internals, reconnection, peer state lifecycle, in-flight suppression, document-level recovery, and convergence debugging
 - `mcp-session-lifecycle` for MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, and room eviction
 - `sync-protocol-patterns` for higher-level protocol design: comparing automerge-repo/samod/nteract architectures, adding new sync streams, heads tracking patterns, and connection lifecycle decisions
-- `automerge-document-model` for Automerge internals: OpSet, ChangeGraph, actor tables, save/load lifecycle, fork/merge semantics, #1187 panic root cause, and document size reasoning
+- `automerge-document-model` for Automerge internals: OpSet, ChangeGraph, actor tables, save/load lifecycle, transaction/fork/merge semantics, actor-stream invariants, and document size reasoning
 - `execution-pipeline` for end-to-end cell execution: required_heads → ExecuteCell → CellQueued → RuntimeStateDoc polling → output-sync grace → output resolution. Use when debugging missing outputs, execution timeouts, or stale results
 
 Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ strip = "debuginfo"
 lto = true
 codegen-units = 1
 # Keep unwinding so catch_unwind guards work in release — both runtimed
-# (spawn_supervised task recovery) and runt (automerge sync panic
-# recovery, automerge/automerge#1187). The binary size cost is ~2-5%
-# but prevents silent process death on shared notebooks.
+# (spawn_supervised task recovery) and document-owned Automerge recovery.
+# The binary size cost is ~2-5% but prevents silent process death on
+# shared notebooks.
 panic = "unwind"

--- a/contributing/crdt-mutation-guide.md
+++ b/contributing/crdt-mutation-guide.md
@@ -97,19 +97,46 @@ The bridge uses `externalChangeAnnotation` to prevent echo: inbound changes are 
 
 4. **Don't bypass the bridge for source text.** The CodeMirror bridge handles character-level sync. Using `update_source` (Myers diff) from the UI would conflict with the bridge's splice tracking.
 
-5. **Don't mutate the doc directly after an async gap.** If you read doc state, await something (subprocess, network, I/O), then write back, use `fork()` + `merge()` instead. Direct mutation after an async gap overwrites concurrent edits. See below.
+5. **Don't mutate the doc directly after an async gap.** If you read doc state, await something (subprocess, network, I/O), then write back, use a document-owned reconciliation helper. Prefer `NotebookDoc::transact_at_heads_recovering(...)` when the write can be expressed against captured baseline heads. Use `fork_with_actor(...)` + `merge_recovering(...)` only when you must carry a forked document through the async work. Direct mutation after an async gap overwrites concurrent edits. See below.
 
 6. **Don't `put_object()` at a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` calls from different Automerge actors create two *distinct* Map objects at the same key — an Automerge conflict. One wins; the loser's children (cells, deps, etc.) become invisible. Document structure (Maps, Lists at well-known keys like `cells` and `metadata`) must be created by exactly one peer — the daemon, in `new_inner()`. All other peers receive it via Automerge sync. This is why `NotebookDoc::bootstrap()` only seeds `schema_version` (a scalar), not the full document skeleton.
 
-## Fork+Merge for Async Mutations (Daemon-Side)
+## Async Mutations (Daemon-Side)
 
-When daemon code needs to read from the CRDT, do async work, and write results back, it **must** fork the doc before the async work and merge afterward. This treats the daemon's changes as concurrent with any edits that arrived during the async gap.
+When daemon code needs to read from the CRDT, do async work, and write results back, it **must** reconcile against the document state that existed before the async gap. The preferred notebook-doc pattern is a historical transaction: capture heads before the await, re-acquire the document lock after the await, then run `NotebookDoc::transact_at_heads_recovering(...)`.
+
+```rust
+// 1. Capture baseline heads BEFORE async work.
+let baseline_heads = {
+    let mut doc = room.doc.write().await;
+    doc.get_heads()
+};
+
+// 2. Do async work.
+let result = expensive_subprocess().await;
+
+// 3. Re-acquire the live doc and apply the mutation at the baseline view.
+let mut doc = room.doc.write().await;
+doc.transact_at_heads_recovering(
+    &baseline_heads,
+    Some("runtimed:formatter"),
+    "formatter-transaction",
+    |doc| {
+        doc.update_source(&cell_id, &result)?;
+        Ok(())
+    },
+)?;
+```
+
+This uses Automerge's isolate/integrate transaction path under the document helper. The live document owns the actor sequence, so repeated transactions can share one stable actor without creating duplicate `(actor, seq)` changes. The helper also keeps panic capture and rebuild inside the document boundary.
+
+Use `fork_with_actor(...)` + `merge_recovering(...)` when the async worker genuinely needs an editable fork before the await. The fork must use an actor that cannot overlap with another concurrent fork from the same parent.
 
 ```rust
 // 1. Fork BEFORE async work
 let fork = {
     let mut doc = room.doc.write().await;
-    doc.fork()
+    doc.fork_with_actor("runtimed:external-worker")
 };
 
 // 2. Do async work
@@ -119,12 +146,17 @@ let result = expensive_subprocess().await;
 let mut fork = fork;
 fork.update_source(&cell_id, &result).ok();
 let mut doc = room.doc.write().await;
-doc.merge(&mut fork).ok();
+doc.merge_recovering(&mut fork, "external-worker-merge").ok();
 ```
 
-**Why this matters:** Without fork+merge, the async gap is a data loss window. If a user types while ruff formats, or another peer edits while the file watcher processes, the write-back silently overwrites those changes. Fork+merge lets Automerge's text CRDT compose both sets of changes.
+**Why this matters:** Without transaction/fork reconciliation, the async gap is a data loss window. If a user types while ruff formats, or another peer edits while the file watcher processes, the write-back silently overwrites those changes. Historical transactions and fork+merge both let Automerge compose the daemon write with concurrent text CRDT changes.
 
-**Do not use `fork_at(heads)` / `fork_at_and_merge(...)` in daemon mutation paths right now.** `fork_at(...)` currently triggers automerge/automerge#1327 (`MissingOps` in the change collector) on documents with interleaved text splices and merges. For file-watcher and other external-content merges, compare against the saved-on-disk baseline (`last_save_sources`), then `fork()` at current heads and `merge()`.
+Do not use `fork_at(heads)` as the historical write primitive. The old
+MissingOps panic is covered by the pinned nteract Automerge 0.9 desktop patch,
+but `fork_at` still builds a separate historical document with its own actor
+stream and should be reserved for views/diagnostics. Use document-owned
+transaction helpers for historical writes so actor sequencing, restoration,
+integration, and panic recovery stay centralized.
 
 ### Helpers for Synchronous Blocks
 
@@ -139,7 +171,7 @@ doc.fork_and_merge(|fork| {
 
 ```
 
-These encapsulate the fork-before/merge-after pattern. For **async** work between fork and merge, use `fork()` and `merge()` directly — the fork must be created before the `.await` and merged after.
+These encapsulate the fork-before/merge-after pattern for synchronous edits. For **async** notebook-doc writes, prefer `transact_at_heads_recovering(...)`; if a fork must cross the `.await`, create it before the async work with `fork_with_actor(...)` and merge it after with `merge_recovering(...)`.
 
 ### Adoption Status
 
@@ -147,12 +179,12 @@ All async CRDT mutation paths in the daemon are now protected:
 
 | Path | Protection |
 |------|-----------|
-| ExecuteCell / RunAllCells formatting | `fork()` before `tokio::spawn`, merge in task |
+| ExecuteCell / RunAllCells formatting | `transact_at_heads_recovering(...)` against captured format heads |
 | `format_notebook_cells` (Cmd+S) | `fork()` before format loop, merge after |
-| File watcher source updates | Compare against `last_save_sources`, then `fork()` + merge |
-| File watcher order-changed rebuild | Compare against `last_save_sources`, then `fork()` + merge |
+| File watcher source updates | Compare against `last_save_sources`, then `fork_with_actor(...)` + `merge_recovering(...)` |
+| File watcher order-changed rebuild | Compare against `last_save_sources`, then `fork_with_actor(...)` + `merge_recovering(...)` |
 | `UpdateDisplayData` IOPub | `fork()` before blob I/O, merge after |
-| `process_markdown_assets` | `fork()` before async resolution, merge after |
+| `process_markdown_assets` | `transact_at_heads_recovering(...)` against captured metadata heads |
 | `handle_sync_environment` | Fresh read (no CRDT write, only in-memory state) |
 
 ## Future Direction

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -223,7 +223,11 @@ The notebook document is a CRDT shared between two peers:
 - **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, compiled to WASM and loaded in the webview. Cell mutations (add, delete, edit source) happen instantly in the local WASM document.
 - **Daemon** — `NotebookDoc` from `crates/notebook-doc`. The canonical document used for kernel execution, output writing, and persistence.
 
-Both sides use the same Rust `automerge = "0.7"` crate, which guarantees schema compatibility (the JS `@automerge/automerge` package uses different CRDT types for string fields).
+Both sides use the workspace Rust `automerge` dependency from the pinned
+`nteract/automerge` desktop patch commit. Keeping the daemon and WASM peer on
+that one Rust crate is the compatibility contract; the frontend does not use the
+JS `@automerge/automerge` package for notebook state because its CRDT/string
+types and release cadence are a separate compatibility surface.
 
 ### Sync flow
 

--- a/crates/automunge/src/lib.rs
+++ b/crates/automunge/src/lib.rs
@@ -4,9 +4,9 @@
 //! documents. Used by both `notebook-doc` (NotebookDoc) and `runtime-doc`
 //! (RuntimeStateDoc) to avoid duplicating these helpers across crates.
 //!
-//! Named after automorph (codeberg.org/dpp/automorph), which we may adopt
-//! when it ships automerge 0.8 support. Until then, this is the single
-//! source of truth for JSON/Automerge conversion.
+//! Named after automorph (codeberg.org/dpp/automorph), which we may adopt if it
+//! can cover the workspace Automerge API we need. Until then, this is the
+//! single source of truth for JSON/Automerge conversion.
 
 use automerge::{transaction::Transactable, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -282,14 +282,14 @@ impl NotebookDoc {
         }
     }
 
-    /// Fork the document and set a distinct actor ID on the fork in one step.
+    /// Fork the document and set a caller-chosen actor ID on the fork.
     ///
-    /// Forks inherit the parent's actor ID, and Automerge tracks ops by
-    /// `(actor, seq)`. Two concurrent forks that share an actor will each
-    /// produce ops at seq `N`, `N+1`, …; the first merge lands and the
-    /// second returns `DuplicateSeqNumber` — silently dropping writes if
-    /// the error is ignored. See the regression test
-    /// `merging_two_forks_with_shared_actor_returns_duplicate_seq_error`
+    /// Automerge forks receive a new random actor by default because an actor
+    /// ID identifies one linear stream of changes. If two concurrent forks are
+    /// forced to share an actor, they can each produce ops at seq `N`, `N+1`,
+    /// …; the first merge lands and the second returns `DuplicateSeqNumber`,
+    /// silently dropping writes if the error is ignored. See the regression
+    /// test `merging_two_forks_with_shared_actor_returns_duplicate_seq_error`
     /// in `runtime_state.rs`.
     ///
     /// Use this for any fork whose merge crosses an `.await` point. The
@@ -303,10 +303,10 @@ impl NotebookDoc {
     /// sites where concurrent forks from the same logical task can
     /// overlap across the async gap.
     ///
+    /// For notebook writes that can be expressed after the async work, prefer
+    /// [`transact_at_heads_recovering`](Self::transact_at_heads_recovering).
     /// For synchronous fork+merge blocks, use
-    /// [`fork_and_merge`](Self::fork_and_merge) — actor collisions are
-    /// harmless there because the merge completes before any other fork
-    /// of the same parent can exist.
+    /// [`fork_and_merge`](Self::fork_and_merge).
     pub fn fork_with_actor(&mut self, actor: impl AsRef<str>) -> Self {
         let mut fork = self.fork();
         fork.set_actor(actor.as_ref());
@@ -1168,13 +1168,13 @@ impl NotebookDoc {
         self.doc.save()
     }
 
-    /// Round-trip save→load to rebuild internal automerge indices.
+    /// Round-trip save→load to rebuild internal Automerge indices.
     ///
-    /// Used after catching an automerge panic (upstream MissingOps bug in
-    /// `collector.rs`). `save()` serializes via `op_set.export()` (safe),
-    /// and `load()` reconstructs all internal data structures from scratch.
-    /// This is the document-level equivalent of automerge-repo's
-    /// `decodeSyncState(encodeSyncState(state))` round-trip hack.
+    /// Used as a containment step after catching an Automerge panic inside a
+    /// document-owned recovery boundary. `save()` serializes via
+    /// `op_set.export()` and `load()` reconstructs internal data structures
+    /// from scratch. This is separate from peer recovery, which resets that
+    /// peer's `sync::State` so the next message starts from a fresh handshake.
     ///
     /// Includes a defensive cell-count guard: if the rebuilt doc would have
     /// fewer cells, the rebuild is skipped to prevent silent cell loss when

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -176,8 +176,8 @@ impl SharedDocState {
     /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
     ///
     /// Used after catching an automerge panic during `RuntimeStateSync`
-    /// processing — the same recovery pattern as `rebuild_shared_doc_state`
-    /// for the notebook doc, but targeting the state doc.
+    /// processing — the same recovery pattern as `rebuild_doc` for the
+    /// notebook doc, but targeting the state doc.
     pub fn rebuild_state_doc(&mut self) -> bool {
         let rebuilt = self.state_doc.rebuild_from_save();
         if !rebuilt {

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -442,23 +442,23 @@ impl RuntimeStateDoc {
     /// Automerge fork. Changes made on the fork are independent of the
     /// original — call [`merge`](Self::merge) to reconcile them.
     ///
-    /// **Important:** Forks inherit the parent's actor ID. Call
-    /// [`set_actor`](Self::set_actor) on the fork to assign a distinct
-    /// identity (e.g., `"runtimed:state:cell-error"`) before making any
-    /// mutations to avoid `DuplicateSeqNumber` errors on merge.
+    /// Automerge forks receive a new random actor by default. Set a stable
+    /// actor only when downstream filtering or attribution requires it, and do
+    /// not reuse that actor for concurrent forks that can both write before
+    /// merging.
     pub fn fork(&mut self) -> Self {
         Self {
             doc: self.doc.fork(),
         }
     }
 
-    /// Fork the document and set a distinct actor ID on the fork in one step.
+    /// Fork the document and set a caller-chosen actor ID on the fork.
     ///
-    /// Forks inherit the parent's actor ID, and Automerge tracks ops by
-    /// `(actor, seq)`. Two concurrent forks that share an actor will
-    /// each produce ops at seq `N`, `N+1`, …; the first merge lands and
-    /// the second returns `DuplicateSeqNumber` — silently dropping
-    /// writes if the error is ignored. The regression test
+    /// Automerge forks receive a new random actor by default because an actor
+    /// ID identifies one linear stream of changes. If two concurrent forks are
+    /// forced to share an actor, they can each produce ops at seq `N`, `N+1`,
+    /// …; the first merge lands and the second returns `DuplicateSeqNumber`,
+    /// silently dropping writes if the error is ignored. The regression test
     /// [`merging_two_forks_with_shared_actor_returns_duplicate_seq_error`]
     /// pins this invariant.
     ///
@@ -475,9 +475,7 @@ impl RuntimeStateDoc {
     /// overlap across the async gap.
     ///
     /// For synchronous fork+merge blocks, use
-    /// [`fork_and_merge`](Self::fork_and_merge) — actor collisions are
-    /// harmless there because the merge completes before any other
-    /// fork of the same parent can exist.
+    /// [`fork_and_merge`](Self::fork_and_merge).
     pub fn fork_with_actor(&mut self, actor: impl AsRef<str>) -> Self {
         let mut fork = self.fork();
         fork.set_actor(actor.as_ref());
@@ -529,10 +527,11 @@ impl RuntimeStateDoc {
         let _ = self.merge(&mut fork);
     }
 
-    /// Round-trip save→load to rebuild internal automerge indices.
+    /// Round-trip save→load to rebuild internal Automerge indices.
     ///
-    /// Used after catching an automerge panic (upstream MissingOps bug in
-    /// `collector.rs`). See `NotebookDoc::rebuild_from_save` for details.
+    /// Used as a containment step after catching an Automerge panic inside a
+    /// document-owned recovery boundary. See `NotebookDoc::rebuild_from_save`
+    /// for the notebook-doc variant with a cell-count guard.
     pub fn rebuild_from_save(&mut self) -> bool {
         catch_automerge_panic("runtime-state-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
@@ -3945,7 +3944,7 @@ mod tests {
         let mut doc = RuntimeStateDoc::new();
         let mut fork = doc.fork();
 
-        // Fork inherits parent actor — must set a distinct one
+        // Fork receives an actor distinct from the parent.
         fork.set_actor("runtimed:state:cell-error");
 
         // Verify the fork's actor is different from the parent

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -49,7 +49,7 @@ impl RuntimeStateHandle {
         result
     }
 
-    /// Fork at current heads for async work. Never uses fork_at (automerge#1327).
+    /// Fork at current heads for async runtime-state work.
     pub fn fork(&self, actor_label: &str) -> Result<RuntimeStateDoc, RuntimeStateError> {
         let mut sd = self
             .doc

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1,9 +1,9 @@
 //! WASM bindings for runtimed notebook document operations.
 //!
-//! Compiled from the same `automerge = "0.7"` crate as the daemon,
-//! guaranteeing wire-compatible sync messages. The frontend imports
-//! this WASM module instead of `@automerge/automerge` to avoid
-//! version mismatch issues that produce phantom cells.
+//! Compiled from the same workspace `automerge` dependency as the daemon,
+//! guaranteeing wire-compatible sync messages. The frontend imports this WASM
+//! module instead of `@automerge/automerge` to avoid version mismatch issues
+//! that produce phantom cells.
 
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
@@ -155,11 +155,12 @@ pub enum FrameEvent {
     },
     /// Sync error recovered — doc rebuilt and sync state normalized.
     ///
-    /// Emitted when `receive_sync_message` fails (e.g. automerge MissingOps
-    /// bug). The WASM layer automatically rebuilds the doc via save→load and
-    /// normalizes sync state via encode→decode round-trip (preserving
-    /// `shared_heads`, clearing transient state). The optional `reply`
-    /// contains a fresh sync message to restart negotiation.
+    /// Emitted when `receive_sync_message` fails or an Automerge operation
+    /// panics inside the WASM recovery boundary. The WASM layer automatically
+    /// rebuilds the doc via save→load and normalizes sync state via
+    /// encode→decode round-trip (preserving `shared_heads`, clearing transient
+    /// state). The optional `reply` contains a fresh sync message to restart
+    /// negotiation.
     SyncError {
         /// True if the document advanced before the error (partial apply).
         /// When true, the SyncEngine should trigger a full materialization

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -2479,9 +2479,9 @@ impl KernelConnection for JupyterKernel {
         // Coalesced comm writes must carry the kernel actor ID so the
         // runtime agent's actor filter in `receive_sync_and_foreign_comms`
         // recognizes them as self-authored echoes and doesn't forward
-        // them back to the kernel. Without this, writes inherit the
-        // doc's default actor (`runtimed:state`) and the filter lets
-        // them through, re-triggering the amplification loop.
+        // them back to the kernel. Without this, fork writes use an
+        // unrelated actor and the filter lets them through, re-triggering
+        // the amplification loop.
         let coalesce_actor_id = format!("{kernel_actor_id}:coalesce");
         let coalesce_panic_cmd_tx = cmd_tx.clone();
         let comm_coalesce_task = spawn_supervised(

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1196,10 +1196,11 @@ pub(crate) async fn apply_ipynb_changes(
     // cell list. Use fork + merge so the structural rebuild from disk
     // composes with concurrent CRDT changes rather than overwriting them.
     //
-    // We use fork() (at current heads) instead of fork_at(save_heads)
-    // because fork_at triggers an automerge bug (MissingOps panic in
-    // the change collector) when the document has a complex history of
-    // interleaved text splices and merges. See automerge/automerge#1327.
+    // This path still uses a current-head fork because the file watcher
+    // compares disk content against `last_save_sources` rather than mutating a
+    // historical document clone. New historical writes should prefer
+    // `transact_at_heads_recovering` so actor restoration and panic recovery
+    // stay document-owned.
     if order_changed || no_common_cells {
         debug!(
             "[notebook-watch] {} — rebuilding cell list",
@@ -1409,8 +1410,9 @@ pub(crate) async fn apply_ipynb_changes(
 
         // For source updates on existing cells, use fork + merge so that
         // external edits compose with concurrent CRDT changes rather than
-        // overwriting them. We use fork() instead of fork_at(save_heads)
-        // to avoid the automerge MissingOps bug (automerge/automerge#1327).
+        // overwriting them. This path uses a current-head fork because source
+        // comparison is anchored on `last_save_sources`; new historical writes
+        // should prefer `transact_at_heads_recovering`.
         //
         // Source comparison uses last_save_sources (what we wrote to disk)
         // instead of the live CRDT (which may have progressed with new user


### PR DESCRIPTION
## Summary

- Refresh Automerge docs after the 0.9 desktop-patch migration.
- Document the actor-stream invariant: an actor ID is one linear change stream, and forks get random actors by default.
- Reframe async CRDT mutation guidance around captured heads and `transact_at_heads_recovering(...)`.
- Keep `fork_at(...)` positioned for historical views/diagnostics, not historical writes.
- Update panic recovery guidance to document-owned recovery helpers that rebuild and reset peer sync state inside the document boundary.

## Verification

- `cargo fmt --check`
- `git diff --check`
- Stale-reference sweep with `rg` for old Automerge versions, fork inheritance, old `fork_at` MissingOps guidance, and old sync `catch_unwind` wording

## Notes

- `cargo xtask lint --fix` still fails on the pre-existing long line at `python/runtimed/tests/test_daemon_integration.py:2929`.
- This sweep incorporates the guidance from automerge/automerge#1367: concurrent branches need distinct actors; same-logical-actor historical work should use isolated transactions rather than `fork_at` plus actor reset.
