### PR TITLE
fix(automerge-recovery): return typed rebuild errors

### DIFF
--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -35,8 +35,12 @@ pub enum AutomergeOperationError {
     },
     #[error(transparent)]
     Panic(#[from] AutomergeRecoveryError),
-    #[error("[{label}] failed to rebuild document after Automerge panic")]
-    RebuildFailed { label: String },
+    #[error("[{label}] failed to rebuild document after Automerge panic: {source}")]
+    RebuildFailed {
+        label: String,
+        #[source]
+        source: AutomergeRebuildError,
+    },
 }
 
 impl AutomergeOperationError {
@@ -47,10 +51,37 @@ impl AutomergeOperationError {
         }
     }
 
-    pub fn rebuild_failed(label: impl Into<String>) -> Self {
+    pub fn rebuild_failed(label: impl Into<String>, source: AutomergeRebuildError) -> Self {
         Self::RebuildFailed {
             label: label.into(),
+            source,
         }
+    }
+}
+
+/// Error returned when save/load rebuild cannot safely replace a document.
+#[derive(Debug, thiserror::Error)]
+pub enum AutomergeRebuildError {
+    #[error(transparent)]
+    Panic(#[from] AutomergeRecoveryError),
+    #[error("load failed: {source}")]
+    Load {
+        #[source]
+        source: Box<automerge::AutomergeError>,
+    },
+    #[error("rebuilt notebook would lose cells ({before} -> {after})")]
+    CellLoss { before: usize, after: usize },
+}
+
+impl AutomergeRebuildError {
+    pub fn load(source: automerge::AutomergeError) -> Self {
+        Self::Load {
+            source: Box::new(source),
+        }
+    }
+
+    pub fn cell_loss(before: usize, after: usize) -> Self {
+        Self::CellLoss { before, after }
     }
 }
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -81,7 +81,7 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::{CommitOptions, Transactable};
 use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 
 /// Re-export so downstream crates (runtimed-wasm) can set text encoding
 /// without depending on automerge directly.
@@ -351,10 +351,11 @@ impl NotebookDoc {
             Ok(Ok(changes)) => Ok(changes),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                let self_rebuilt = self.rebuild_from_save();
-                let other_rebuilt = other.rebuild_from_save();
-                if !self_rebuilt || !other_rebuilt {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
+                }
+                if let Err(source) = other.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -420,8 +421,8 @@ impl NotebookDoc {
             (Ok(Ok(value)), None) => Ok(value),
             (Ok(Err(source)), None) => Err(AutomergeOperationError::automerge(label, source)),
             (Err(err), _) | (_, Some(err)) => {
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -1187,7 +1188,7 @@ impl NotebookDoc {
     /// Includes a defensive cell-count guard: if the rebuilt doc would have
     /// fewer cells, the rebuild is skipped to prevent silent cell loss when
     /// `save()` on a panic-corrupted doc drops ops from the serialized bytes.
-    pub fn rebuild_from_save(&mut self) -> bool {
+    pub fn rebuild_from_save(&mut self) -> Result<(), AutomergeRebuildError> {
         catch_automerge_panic("notebook-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let pre_cell_count = self.cell_count();
@@ -1201,16 +1202,18 @@ impl NotebookDoc {
                             "[notebook-doc] rebuild_from_save would lose cells ({} → {}), skipping",
                             pre_cell_count, post_cell_count
                         );
-                        return false;
+                        return Err(AutomergeRebuildError::cell_loss(
+                            pre_cell_count,
+                            post_cell_count,
+                        ));
                     }
                     doc.set_actor(actor);
                     self.doc = doc;
-                    true
+                    Ok(())
                 }
-                Err(_) => false,
+                Err(source) => Err(AutomergeRebuildError::load(source)),
             }
-        })
-        .unwrap_or_default()
+        })?
     }
 
     /// Save the document to a file.
@@ -2101,8 +2104,8 @@ impl NotebookDoc {
             Ok(message) => Ok(message),
             Err(_err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 catch_automerge_panic(label, || self.generate_sync_message(peer_state))
                     .map_err(AutomergeOperationError::Panic)
@@ -2133,8 +2136,8 @@ impl NotebookDoc {
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -2903,7 +2906,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        assert!(doc.rebuild_from_save());
+        assert!(doc.rebuild_from_save().is_ok());
         peer_state = sync::State::new();
 
         assert_eq!(doc.doc().get_actor(), &actor);

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -351,10 +351,12 @@ impl NotebookDoc {
             Ok(Ok(changes)) => Ok(changes),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                if let Err(source) = self.rebuild_from_save() {
+                let self_rebuilt = self.rebuild_from_save();
+                let other_rebuilt = other.rebuild_from_save();
+                if let Err(source) = self_rebuilt {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                if let Err(source) = other.rebuild_from_save() {
+                if let Err(source) = other_rebuilt {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -30,7 +30,7 @@ use automerge::{
     sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjType,
     ReadDoc, Value, ROOT,
 };
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 use serde::{Deserialize, Serialize};
 
 // ── Snapshot types ───────────────────────────────────────────────────
@@ -308,8 +308,8 @@ impl PoolDoc {
             Ok(message) => Ok(message),
             Err(_err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 catch_automerge_panic(label, || self.generate_sync_message(peer_state))
                     .map_err(AutomergeOperationError::Panic)
@@ -350,8 +350,8 @@ impl PoolDoc {
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -359,7 +359,7 @@ impl PoolDoc {
     }
 
     /// Round-trip save→load to rebuild internal automerge indices.
-    pub fn rebuild_from_save(&mut self) -> bool {
+    pub fn rebuild_from_save(&mut self) -> Result<(), AutomergeRebuildError> {
         catch_automerge_panic("pool-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let bytes = self.doc.save();
@@ -367,12 +367,11 @@ impl PoolDoc {
                 Ok(mut doc) => {
                     doc.set_actor(actor);
                     self.doc = doc;
-                    true
+                    Ok(())
                 }
-                Err(_) => false,
+                Err(source) => Err(AutomergeRebuildError::load(source)),
             }
-        })
-        .unwrap_or_default()
+        })?
     }
 }
 
@@ -423,7 +422,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        assert!(doc.rebuild_from_save());
+        assert!(doc.rebuild_from_save().is_ok());
         peer_state = sync::State::new();
 
         assert_eq!(doc.doc().get_actor(), &actor);

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -8,7 +8,7 @@
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::AutoCommit;
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::RuntimeStateDoc;
@@ -94,8 +94,8 @@ impl SharedDocState {
         match catch_automerge_panic(label, || self.generate_sync_message()) {
             Ok(message) => Ok(message),
             Err(_err) => {
-                if !self.rebuild_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_doc() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 catch_automerge_panic(label, || self.generate_sync_message())
                     .map_err(AutomergeOperationError::Panic)
@@ -112,8 +112,8 @@ impl SharedDocState {
             Ok(Ok(())) => Ok(()),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                if !self.rebuild_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_doc() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -165,8 +165,8 @@ impl SharedDocState {
             Ok(Ok(())) => Ok(()),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                if !self.rebuild_state_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_state_doc() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -178,19 +178,20 @@ impl SharedDocState {
     /// Used after catching an automerge panic during `RuntimeStateSync`
     /// processing — the same recovery pattern as `rebuild_doc` for the
     /// notebook doc, but targeting the state doc.
-    pub fn rebuild_state_doc(&mut self) -> bool {
+    pub fn rebuild_state_doc(&mut self) -> Result<(), AutomergeRebuildError> {
         let rebuilt = self.state_doc.rebuild_from_save();
-        if !rebuilt {
+        if let Err(err) = &rebuilt {
             warn!(
-                "[notebook-sync] Failed to rebuild RuntimeStateDoc after panic; \
-                 resetting state sync protocol only"
+                "[notebook-sync] Failed to rebuild RuntimeStateDoc after panic: {}; \
+                 resetting state sync protocol only",
+                err
             );
         }
         self.state_peer_state = sync::State::new();
         rebuilt
     }
 
-    fn rebuild_doc(&mut self) -> bool {
+    fn rebuild_doc(&mut self) -> Result<(), AutomergeRebuildError> {
         let rebuilt = catch_automerge_panic("notebook-sync-rebuild-doc", || {
             let actor = self.doc.get_actor().clone();
             let pre_cell_count = notebook_doc::get_cells_from_doc(&self.doc).len();
@@ -203,18 +204,21 @@ impl SharedDocState {
                             "[notebook-sync] rebuild doc would lose cells ({} -> {}), resetting sync state only",
                             pre_cell_count, post_cell_count
                         );
-                        return false;
+                        return Err(AutomergeRebuildError::cell_loss(
+                            pre_cell_count,
+                            post_cell_count,
+                        ));
                     }
                     doc.set_actor(actor);
                     self.doc = doc;
-                    true
+                    Ok(())
                 }
                 Err(e) => {
                     warn!(
                         "[notebook-sync] failed to rebuild doc after panic: {}; resetting sync state only",
                         e
                     );
-                    false
+                    Err(AutomergeRebuildError::load(e))
                 }
             }
         });
@@ -227,7 +231,7 @@ impl SharedDocState {
                     "[notebook-sync] panic while rebuilding doc after panic: {}; resetting sync state only",
                     e
                 );
-                false
+                Err(e.into())
             }
         }
     }
@@ -259,7 +263,7 @@ mod tests {
             "peer state should suppress duplicate messages before rebuild"
         );
 
-        state.rebuild_state_doc();
+        assert!(state.rebuild_state_doc().is_ok());
 
         let runtime_state = state.state_doc.read_state();
         assert!(

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -494,10 +494,10 @@ impl SyncReactor {
                                 self.io.notebook_id, e
                             );
                         }
-                        Err(AutomergeOperationError::RebuildFailed { label }) => {
+                        Err(AutomergeOperationError::RebuildFailed { label, source }) => {
                             warn!(
-                                "[notebook-sync] Failed to rebuild after sync panic for {}: {}",
-                                self.io.notebook_id, label
+                                "[notebook-sync] Failed to rebuild after sync panic for {}: {}: {}",
+                                self.io.notebook_id, label, source
                             );
                             return;
                         }
@@ -655,10 +655,10 @@ impl SyncReactor {
                                 self.io.notebook_id, e
                             );
                         }
-                        Err(AutomergeOperationError::RebuildFailed { label }) => {
+                        Err(AutomergeOperationError::RebuildFailed { label, source }) => {
                             warn!(
-                                "[notebook-sync] Failed to rebuild after RuntimeStateSync panic for {}: {}",
-                                self.io.notebook_id, label
+                                "[notebook-sync] Failed to rebuild after RuntimeStateSync panic for {}: {}: {}",
+                                self.io.notebook_id, label, source
                             );
                             return;
                         }
@@ -1404,7 +1404,7 @@ mod tests {
                 reactor.handle_incoming_frame(&frame, &mut writer).await;
 
                 if !later_update_sent {
-                    daemon_state.rebuild_state_doc();
+                    let _ = daemon_state.rebuild_state_doc();
                     daemon_state
                         .state_doc
                         .create_execution_with_source("exec-2", "cell-2", "y = 2", 2)

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -503,10 +503,12 @@ impl RuntimeStateDoc {
             Ok(Ok(changes)) => Ok(changes),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                if let Err(source) = self.rebuild_from_save() {
+                let self_rebuilt = self.rebuild_from_save();
+                let other_rebuilt = other.rebuild_from_save();
+                if let Err(source) = self_rebuilt {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                if let Err(source) = other.rebuild_from_save() {
+                if let Err(source) = other_rebuilt {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -87,7 +87,7 @@ use automerge::{
     transaction::{CommitOptions, Transactable},
     ActorId, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -503,10 +503,11 @@ impl RuntimeStateDoc {
             Ok(Ok(changes)) => Ok(changes),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
-                let self_rebuilt = self.rebuild_from_save();
-                let other_rebuilt = other.rebuild_from_save();
-                if !self_rebuilt || !other_rebuilt {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
+                }
+                if let Err(source) = other.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -532,7 +533,7 @@ impl RuntimeStateDoc {
     /// Used as a containment step after catching an Automerge panic inside a
     /// document-owned recovery boundary. See `NotebookDoc::rebuild_from_save`
     /// for the notebook-doc variant with a cell-count guard.
-    pub fn rebuild_from_save(&mut self) -> bool {
+    pub fn rebuild_from_save(&mut self) -> Result<(), AutomergeRebuildError> {
         catch_automerge_panic("runtime-state-doc-rebuild-from-save", || {
             let actor = self.doc.get_actor().clone();
             let bytes = self.doc.save();
@@ -540,12 +541,11 @@ impl RuntimeStateDoc {
                 Ok(mut doc) => {
                     doc.set_actor(actor);
                     self.doc = doc;
-                    true
+                    Ok(())
                 }
-                Err(_) => false,
+                Err(source) => Err(AutomergeRebuildError::load(source)),
             }
-        })
-        .unwrap_or_default()
+        })?
     }
 
     /// Compact the document if its serialized size exceeds `threshold` bytes.
@@ -2421,8 +2421,8 @@ impl RuntimeStateDoc {
             Ok(message) => Ok(message),
             Err(_err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 catch_automerge_panic(label, || self.generate_sync_message(peer_state))
                     .map_err(AutomergeOperationError::Panic)
@@ -2454,8 +2454,11 @@ impl RuntimeStateDoc {
             encoded.len(),
             max_encoded_bytes,
         );
-        if !self.rebuild_from_save() {
-            tracing::warn!("[runtime-state] Compaction failed during bounded sync generation");
+        if let Err(err) = self.rebuild_from_save() {
+            tracing::warn!(
+                "[runtime-state] Compaction failed during bounded sync generation: {}",
+                err
+            );
             return Some(encoded);
         }
         *peer_state = sync::State::new();
@@ -2479,8 +2482,8 @@ impl RuntimeStateDoc {
             Ok(message) => Ok(message),
             Err(_err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 catch_automerge_panic(label, || {
                     self.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
@@ -2532,8 +2535,8 @@ impl RuntimeStateDoc {
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -2574,8 +2577,8 @@ impl RuntimeStateDoc {
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }
@@ -2712,8 +2715,8 @@ impl RuntimeStateDoc {
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label));
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
                 Err(AutomergeOperationError::Panic(err))
             }

--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -170,7 +170,13 @@ impl RuntimeStateHandle {
         }) {
             Ok(()) => Ok(()),
             Err(err) => {
-                sd.rebuild_from_save();
+                if let Err(source) = sd.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        "runtime-state-handle-test",
+                        source,
+                    )
+                    .into());
+                }
                 Err(AutomergeOperationError::Panic(err).into())
             }
         }

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -182,11 +182,17 @@ impl KernelState {
                     sd.set_queue(None, &doc_queued)?;
                     match sd.trim_executions(MAX_EXECUTION_ENTRIES) {
                         Ok(trimmed) if trimmed > 0 => {
-                            sd.rebuild_from_save();
-                            debug!(
-                                "[kernel-state] Compacted RuntimeStateDoc after trimming {} executions",
-                                trimmed
-                            );
+                            match sd.rebuild_from_save() {
+                                Ok(()) => {
+                                    debug!(
+                                        "[kernel-state] Compacted RuntimeStateDoc after trimming {} executions",
+                                        trimmed
+                                    );
+                                }
+                                Err(err) => {
+                                    warn!("[runtime-state] Failed to compact RuntimeStateDoc: {}", err);
+                                }
+                            }
                         }
                         Err(e) => {
                             warn!("[runtime-state] {}", e);

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2926,7 +2926,8 @@ class TestTrustApproval:
         # Both are valid: the key invariant is that the daemon does NOT
         # silently fall back to a pool env.
         assert lifecycle_tag in ("AwaitingEnvBuild", "PreparingEnv"), (
-            f"expected lifecycle=AwaitingEnvBuild or PreparingEnv after env.yml; got {lifecycle_tag!r}"
+            "expected lifecycle=AwaitingEnvBuild or PreparingEnv after env.yml; "
+            f"got {lifecycle_tag!r}"
         )
         if lifecycle_tag == "AwaitingEnvBuild":
             assert kernel_state.error_reason == KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING


### PR DESCRIPTION
## Summary

- replace boolean Automerge rebuild reporting with typed `AutomergeRebuildError` values
- carry rebuild failure causes through `AutomergeOperationError::RebuildFailed`
- update recovery callers to match on rebuild errors instead of silently defaulting
- preserve merge recovery semantics by attempting rebuild on both documents before returning a rebuild failure
- wrap one pre-existing Python assertion so the required lint gate passes

Supersedes the split follow-up shape in #2527 and #2528 with a single recovery outcome contract.

## Verification

- `cargo test -p automerge-recovery`
- `cargo check -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed`
- `cargo test -p notebook-sync runtime_state_sync_panic_is_caught_and_later_updates_still_apply`
- `cargo test -p notebook-doc recovering_sync_generation_preserves_actor_and_resets_peer_state`
- `cargo test -p notebook-doc recovering_pool_sync_generation_preserves_actor_and_resets_peer_state`
- `cargo check -p notebook-doc -p runtime-doc` after review fix
- `cargo xtask lint --fix`

## External review

- Pi via Bedrock Claude Opus 4.6 found one confirmed merge-recovery regression; fixed in `bd81fb73`
- Pi via Bedrock Claude Opus 4.6 rerun reported no actionable findings
