### PR TITLE
refactor(automerge): use transactions for notebook server writes

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -292,10 +292,15 @@ impl NotebookDoc {
     /// test `merging_two_forks_with_shared_actor_returns_duplicate_seq_error`
     /// in `runtime_state.rs`.
     ///
-    /// Use this for any fork whose merge crosses an `.await` point. The
-    /// `actor` argument is set verbatim — the caller controls whether
-    /// the actor is stable per task (e.g. `"rt:kernel:abc:iopub"`) or
-    /// unique per fork (e.g. `format!("runtimed:assets:{}", Uuid::new_v4())`).
+    /// Prefer
+    /// [`transact_at_heads_recovering`](Self::transact_at_heads_recovering)
+    /// when the writes can be computed after async work and applied at a
+    /// captured baseline. A transaction keeps actor sequencing on the live
+    /// document and avoids creating a second document that must later merge.
+    ///
+    /// If a true fork must cross an `.await` point, the `actor` argument is
+    /// set verbatim. The caller controls whether the actor is stable per task
+    /// (e.g. `"rt:kernel:abc:iopub"`) or unique per fork.
     ///
     /// Prefer a stable per-task actor for long-running loops that fork
     /// many times in sequence — each unique actor consumes space in
@@ -303,8 +308,6 @@ impl NotebookDoc {
     /// sites where concurrent forks from the same logical task can
     /// overlap across the async gap.
     ///
-    /// For notebook writes that can be expressed after the async work, prefer
-    /// [`transact_at_heads_recovering`](Self::transact_at_heads_recovering).
     /// For synchronous fork+merge blocks, use
     /// [`fork_and_merge`](Self::fork_and_merge).
     pub fn fork_with_actor(&mut self, actor: impl AsRef<str>) -> Self {
@@ -423,10 +426,10 @@ impl NotebookDoc {
 
     /// Fork the document, apply mutations on the fork, and merge back.
     ///
-    /// This is the preferred way to apply mutations that should compose
-    /// with concurrent edits rather than overwriting them. The closure
-    /// receives a forked doc; any mutations on it are merged back after
-    /// the closure returns.
+    /// This is only for synchronous compatibility with older call sites.
+    /// Prefer [`transact_at_heads_recovering`](Self::transact_at_heads_recovering)
+    /// for new document-owned mutation helpers, especially when the mutation
+    /// is based on heads captured before async work.
     ///
     /// ```ignore
     /// doc.fork_and_merge(|fork| {
@@ -435,9 +438,10 @@ impl NotebookDoc {
     /// });
     /// ```
     ///
-    /// For async work between fork and merge, use [`fork`](Self::fork)
-    /// and [`merge`](Self::merge) directly — the fork must be created
-    /// before the `.await` and merged after.
+    /// Do not use this as the default async mutation pattern. Capture heads
+    /// before the await and call
+    /// [`transact_at_heads_recovering`](Self::transact_at_heads_recovering)
+    /// when applying the computed writes.
     pub fn fork_and_merge<F>(&mut self, f: F)
     where
         F: FnOnce(&mut NotebookDoc),

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -370,6 +370,10 @@ impl NotebookDoc {
     /// historical view. The live document owns the actor sequence, so repeated
     /// isolated transactions can share one stable actor without producing
     /// duplicate sequence numbers.
+    ///
+    /// The closure is invoked exactly once. Prepare non-deterministic values
+    /// before calling this method if they need to be reused outside the
+    /// transaction; the helper does not retry conflicts by re-running `f`.
     pub fn transact_at_heads_recovering<F, T>(
         &mut self,
         heads: &[automerge::ChangeHash],

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1176,9 +1176,9 @@ pub(crate) async fn apply_ipynb_changes(
     // Detect wholesale file replacement: the current doc has cells, the
     // external file has cells, but they share zero cell IDs. This happens
     // when an external process (e.g. an AI agent) writes a completely new
-    // notebook to the same path. Route through the rebuild path which is
-    // atomic (fork → delete all → re-add all → merge) rather than the
-    // incremental path which mixes direct mutations with fork+merge.
+    // notebook to the same path. Route through the rebuild path so the cell
+    // list is replaced atomically instead of trying to infer an incremental
+    // edit script across unrelated IDs.
     let no_common_cells = !current_ids.is_empty()
         && !external_ids.is_empty()
         && !current_ids.iter().any(|id| external_map.contains_key(id));
@@ -1193,14 +1193,10 @@ pub(crate) async fn apply_ipynb_changes(
     }
 
     // If order changed or the file was wholesale-replaced, rebuild the
-    // cell list. Use fork + merge so the structural rebuild from disk
-    // composes with concurrent CRDT changes rather than overwriting them.
-    //
-    // This path still uses a current-head fork because the file watcher
-    // compares disk content against `last_save_sources` rather than mutating a
-    // historical document clone. New historical writes should prefer
-    // `transact_at_heads_recovering` so actor restoration and panic recovery
-    // stay document-owned.
+    // cell list as a document-owned transaction. The baseline is the current
+    // live document because the file watcher compares disk content against
+    // `last_save_sources`; using a transaction avoids minting a parallel fork
+    // actor while keeping actor restoration and panic recovery document-owned.
     if order_changed || no_common_cells {
         debug!(
             "[notebook-watch] {} — rebuilding cell list",
@@ -1215,86 +1211,103 @@ pub(crate) async fn apply_ipynb_changes(
         // saved_sources `.await`s (deadlock prevention).
         let deferred_executions = {
             let mut doc = room.doc.write().await;
-            // Synchronous fork+merge inside the write guard — no `.await`
-            // between fork and merge. A stable actor is safe here because
-            // no other fork of this doc can exist concurrently.
-            let mut fork = doc.fork_with_actor("runtimed:filesystem");
+            let current_execution_ids: HashMap<String, String> = current_cells
+                .iter()
+                .filter_map(|cell| {
+                    doc.get_execution_id(&cell.id)
+                        .map(|execution_id| (cell.id.clone(), execution_id))
+                })
+                .collect();
+            let heads = doc.get_heads();
 
-            // Delete all current cells and re-add in external order on the fork
-            for cell in &current_cells {
-                let _ = fork.delete_cell(&cell.id);
-            }
+            match doc.transact_at_heads_recovering(
+                &heads,
+                Some("runtimed:filesystem"),
+                "file-watcher-order-transaction",
+                |doc| {
+                    // Delete all current cells and re-add in external order.
+                    for cell in &current_cells {
+                        let _ = doc.delete_cell(&cell.id);
+                    }
 
-            let mut deferred: Vec<DeferredExecution> = Vec::new();
+                    let mut deferred: Vec<DeferredExecution> = Vec::new();
 
-            for (index, ext_cell) in external_cells.iter().enumerate() {
-                if fork
-                    .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
-                    .is_ok()
-                {
-                    let _ = fork.update_source(&ext_cell.id, &ext_cell.source);
+                    for (index, ext_cell) in external_cells.iter().enumerate() {
+                        if doc
+                            .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
+                            .is_ok()
+                        {
+                            let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
 
-                    // For existing cells with running kernel: preserve current execution_id
-                    // (outputs live in RuntimeStateDoc, keyed by execution_id)
-                    // For new cells: defer state_doc writes until after doc lock is released
-                    if has_running_kernel {
-                        if let Some(_current) = current_map.get(ext_cell.id.as_str()) {
-                            // Existing cell - preserve in-progress state (execution_id stays)
-                            // execution_count is in RuntimeStateDoc via execution_id
-                            if let Some(eid) = doc.get_execution_id(&ext_cell.id) {
-                                let _ = fork.set_execution_id(&ext_cell.id, Some(&eid));
+                            // For existing cells with running kernel: preserve current execution_id
+                            // (outputs live in RuntimeStateDoc, keyed by execution_id)
+                            // For new cells: defer state_doc writes until after doc lock is released
+                            if has_running_kernel {
+                                if current_map.contains_key(ext_cell.id.as_str()) {
+                                    // Existing cell - preserve in-progress state (execution_id stays)
+                                    // execution_count is in RuntimeStateDoc via execution_id
+                                    if let Some(eid) = current_execution_ids.get(&ext_cell.id) {
+                                        let _ =
+                                            doc.set_execution_id(&ext_cell.id, Some(eid.as_str()));
+                                    }
+                                } else {
+                                    // New cell - collect for deferred state_doc write
+                                    let ext_outputs = converted_outputs
+                                        .get(ext_cell.id.as_str())
+                                        .map(|v| v.as_slice())
+                                        .unwrap_or(&[]);
+                                    let parsed_ec: Option<i64> =
+                                        ext_cell.execution_count.parse().ok();
+                                    if !ext_outputs.is_empty() || parsed_ec.is_some() {
+                                        let synthetic_eid = uuid::Uuid::new_v4().to_string();
+                                        let _ = doc
+                                            .set_execution_id(&ext_cell.id, Some(&synthetic_eid));
+                                        deferred.push(DeferredExecution {
+                                            synthetic_eid,
+                                            cell_id: ext_cell.id.clone(),
+                                            outputs: ext_outputs,
+                                            execution_count: parsed_ec,
+                                        });
+                                    }
+                                }
+                            } else {
+                                let ext_outputs = converted_outputs
+                                    .get(ext_cell.id.as_str())
+                                    .map(|v| v.as_slice())
+                                    .unwrap_or(&[]);
+                                let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
+                                if !ext_outputs.is_empty() || parsed_ec.is_some() {
+                                    let synthetic_eid = uuid::Uuid::new_v4().to_string();
+                                    let _ =
+                                        doc.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
+                                    deferred.push(DeferredExecution {
+                                        synthetic_eid,
+                                        cell_id: ext_cell.id.clone(),
+                                        outputs: ext_outputs,
+                                        execution_count: parsed_ec,
+                                    });
+                                }
                             }
-                        } else {
-                            // New cell - collect for deferred state_doc write
-                            let ext_outputs = converted_outputs
+                            let ext_assets = converted_assets
                                 .get(ext_cell.id.as_str())
-                                .map(|v| v.as_slice())
-                                .unwrap_or(&[]);
-                            let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
-                            if !ext_outputs.is_empty() || parsed_ec.is_some() {
-                                let synthetic_eid = uuid::Uuid::new_v4().to_string();
-                                let _ = fork.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
-                                deferred.push(DeferredExecution {
-                                    synthetic_eid,
-                                    cell_id: ext_cell.id.clone(),
-                                    outputs: ext_outputs,
-                                    execution_count: parsed_ec,
-                                });
-                            }
-                        }
-                    } else {
-                        let ext_outputs = converted_outputs
-                            .get(ext_cell.id.as_str())
-                            .map(|v| v.as_slice())
-                            .unwrap_or(&[]);
-                        let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
-                        if !ext_outputs.is_empty() || parsed_ec.is_some() {
-                            let synthetic_eid = uuid::Uuid::new_v4().to_string();
-                            let _ = fork.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
-                            deferred.push(DeferredExecution {
-                                synthetic_eid,
-                                cell_id: ext_cell.id.clone(),
-                                outputs: ext_outputs,
-                                execution_count: parsed_ec,
-                            });
+                                .unwrap_or(&empty_assets);
+                            let _ = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets);
+                            let ext_attachments = converted_attachments
+                                .get(ext_cell.id.as_str())
+                                .unwrap_or(&empty_attachments);
+                            let _ = doc.set_cell_attachments(&ext_cell.id, ext_attachments);
                         }
                     }
-                    let ext_assets = converted_assets
-                        .get(ext_cell.id.as_str())
-                        .unwrap_or(&empty_assets);
-                    let _ = fork.set_cell_resolved_assets(&ext_cell.id, ext_assets);
-                    let ext_attachments = converted_attachments
-                        .get(ext_cell.id.as_str())
-                        .unwrap_or(&empty_attachments);
-                    let _ = fork.set_cell_attachments(&ext_cell.id, ext_attachments);
+
+                    Ok(deferred)
+                },
+            ) {
+                Ok(deferred) => deferred,
+                Err(e) => {
+                    warn!("[file-watcher] order transaction failed: {}", e);
+                    Vec::new()
                 }
             }
-
-            if let Err(e) = doc.merge_recovering(&mut fork, "file-watcher-order-merge") {
-                warn!("[file-watcher] order merge failed: {}", e);
-            }
-
-            deferred
         }; // doc guard dropped here
 
         // Apply deferred state_doc writes
@@ -1399,182 +1412,177 @@ pub(crate) async fn apply_ipynb_changes(
     // across `.await`).
     let (changed, deferred_execs) = {
         let mut doc = room.doc.write().await;
-        let mut changed = false;
+        let heads = doc.get_heads();
+        match doc.transact_at_heads_recovering(
+            &heads,
+            Some("runtimed:filesystem"),
+            "file-watcher-update-transaction",
+            |doc| {
+                let mut changed = false;
 
-        for cell_id in cells_to_delete {
-            debug!("[notebook-watch] Deleting cell: {}", cell_id);
-            if let Ok(true) = doc.delete_cell(&cell_id) {
-                changed = true;
-            }
-        }
-
-        // For source updates on existing cells, use fork + merge so that
-        // external edits compose with concurrent CRDT changes rather than
-        // overwriting them. This path uses a current-head fork because source
-        // comparison is anchored on `last_save_sources`; new historical writes
-        // should prefer `transact_at_heads_recovering`.
-        //
-        // Source comparison uses last_save_sources (what we wrote to disk)
-        // instead of the live CRDT (which may have progressed with new user
-        // typing since the save). This prevents the file watcher from
-        // treating our own autosave as an "external change" and overwriting
-        // the user's recent edits. Only genuine external changes (git pull,
-        // external editor) — where the disk content differs from what we
-        // last saved — trigger a source update.
-        // Synchronous fork+merge inside the write guard — a stable actor
-        // is safe here because no other fork of this doc can exist
-        // concurrently.
-        let mut source_fork = Some(doc.fork_with_actor("runtimed:filesystem"));
-
-        let mut deferred_execs: Vec<DeferredExecution> = Vec::new();
-        // Track cells whose execution_id should be cleared (no new outputs)
-        let mut clear_execution_ids: Vec<String> = Vec::new();
-
-        // Process external cells in order (add new or update existing)
-        for (index, ext_cell) in external_cells.iter().enumerate() {
-            if let Some(current_cell) = current_map.get(ext_cell.id.as_str()) {
-                // Cell exists — check if source genuinely changed externally.
-                // Compare disk content against what we last saved, NOT the live
-                // CRDT. If disk matches our last save, the change is from our
-                // own autosave and should be ignored (the CRDT may have
-                // progressed with new typing since then).
-                let saved_source = saved_sources_snapshot.get(ext_cell.id.as_str());
-                let is_external_change = match saved_source {
-                    Some(saved) => ext_cell.source != *saved,
-                    None => current_cell.source != ext_cell.source,
-                };
-
-                if is_external_change {
-                    debug!("[notebook-watch] Updating source for cell: {}", ext_cell.id);
-                    if let Some(ref mut fork) = source_fork {
-                        let _ = fork.update_source(&ext_cell.id, &ext_cell.source);
-                        changed = true;
-                    } else if let Ok(true) = doc.update_source(&ext_cell.id, &ext_cell.source) {
+                for cell_id in cells_to_delete {
+                    debug!("[notebook-watch] Deleting cell: {}", cell_id);
+                    if let Ok(true) = doc.delete_cell(&cell_id) {
                         changed = true;
                     }
                 }
 
-                // Update cell type if changed
-                if current_cell.cell_type != ext_cell.cell_type {
-                    debug!(
-                        "[notebook-watch] Cell type changed for {}: {} -> {}",
-                        ext_cell.id, current_cell.cell_type, ext_cell.cell_type
-                    );
-                    // Cell type changes require recreating the cell (rare case)
-                    // For now, just log - full support would need more work
-                }
+                // Source comparison uses last_save_sources (what we wrote to disk)
+                // instead of the live CRDT (which may have progressed with new user
+                // typing since the save). This prevents the file watcher from
+                // treating our own autosave as an "external change" and overwriting
+                // the user's recent edits. Only genuine external changes (git pull,
+                // external editor) — where the disk content differs from what we
+                // last saved — trigger a source update.
+                let mut deferred_execs: Vec<DeferredExecution> = Vec::new();
+                // Track cells whose execution_id should be cleared (no new outputs)
+                let mut clear_execution_ids: Vec<String> = Vec::new();
 
-                // Preserve outputs and execution_count if kernel is running
-                if !has_running_kernel {
-                    let ext_outputs = converted_outputs
-                        .get(ext_cell.id.as_str())
-                        .map(|v| v.as_slice())
-                        .unwrap_or(&[]);
-                    let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
+                // Process external cells in order (add new or update existing)
+                for (index, ext_cell) in external_cells.iter().enumerate() {
+                    if let Some(current_cell) = current_map.get(ext_cell.id.as_str()) {
+                        // Cell exists — check if source genuinely changed externally.
+                        // Compare disk content against what we last saved, NOT the live
+                        // CRDT. If disk matches our last save, the change is from our
+                        // own autosave and should be ignored (the CRDT may have
+                        // progressed with new typing since then).
+                        let saved_source = saved_sources_snapshot.get(ext_cell.id.as_str());
+                        let is_external_change = match saved_source {
+                            Some(saved) => ext_cell.source != *saved,
+                            None => current_cell.source != ext_cell.source,
+                        };
 
-                    // Compare external outputs and execution_count against
-                    // pre-snapshotted RuntimeStateDoc state
-                    let current_eid = doc.get_execution_id(&ext_cell.id);
-                    let (current_outputs, current_ec) = current_execution_state
-                        .get(ext_cell.id.as_str())
-                        .cloned()
-                        .unwrap_or((Vec::new(), None));
+                        if is_external_change {
+                            debug!("[notebook-watch] Updating source for cell: {}", ext_cell.id);
+                            if doc.update_source(&ext_cell.id, &ext_cell.source).is_ok() {
+                                changed = true;
+                            }
+                        }
 
-                    let outputs_changed = current_outputs.as_slice() != ext_outputs;
-                    let ec_changed = current_ec != parsed_ec;
-
-                    if outputs_changed || ec_changed {
-                        if !ext_outputs.is_empty() || parsed_ec.is_some() {
+                        // Update cell type if changed
+                        if current_cell.cell_type != ext_cell.cell_type {
                             debug!(
-                                "[notebook-watch] Updating outputs/execution_count for cell: {}",
-                                ext_cell.id
+                                "[notebook-watch] Cell type changed for {}: {} -> {}",
+                                ext_cell.id, current_cell.cell_type, ext_cell.cell_type
                             );
-                            let synthetic_eid = uuid::Uuid::new_v4().to_string();
-                            let _ = doc.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
-                            deferred_execs.push(DeferredExecution {
-                                synthetic_eid,
-                                cell_id: ext_cell.id.clone(),
-                                outputs: ext_outputs,
-                                execution_count: parsed_ec,
-                            });
+                            // Cell type changes require recreating the cell (rare case)
+                            // For now, just log - full support would need more work
+                        }
+
+                        // Preserve outputs and execution_count if kernel is running
+                        if !has_running_kernel {
+                            let ext_outputs = converted_outputs
+                                .get(ext_cell.id.as_str())
+                                .map(|v| v.as_slice())
+                                .unwrap_or(&[]);
+                            let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
+
+                            // Compare external outputs and execution_count against
+                            // pre-snapshotted RuntimeStateDoc state
+                            let current_eid = doc.get_execution_id(&ext_cell.id);
+                            let (current_outputs, current_ec) = current_execution_state
+                                .get(ext_cell.id.as_str())
+                                .cloned()
+                                .unwrap_or((Vec::new(), None));
+
+                            let outputs_changed = current_outputs.as_slice() != ext_outputs;
+                            let ec_changed = current_ec != parsed_ec;
+
+                            if outputs_changed || ec_changed {
+                                if !ext_outputs.is_empty() || parsed_ec.is_some() {
+                                    debug!(
+                                        "[notebook-watch] Updating outputs/execution_count for cell: {}",
+                                        ext_cell.id
+                                    );
+                                    let synthetic_eid = uuid::Uuid::new_v4().to_string();
+                                    let _ =
+                                        doc.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
+                                    deferred_execs.push(DeferredExecution {
+                                        synthetic_eid,
+                                        cell_id: ext_cell.id.clone(),
+                                        outputs: ext_outputs,
+                                        execution_count: parsed_ec,
+                                    });
+                                    changed = true;
+                                } else if current_eid.is_some() {
+                                    clear_execution_ids.push(ext_cell.id.clone());
+                                    changed = true;
+                                }
+                            }
+                        }
+
+                        let ext_assets = converted_assets
+                            .get(ext_cell.id.as_str())
+                            .unwrap_or(&empty_assets);
+                        if current_cell.resolved_assets != *ext_assets {
+                            if let Ok(true) = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets)
+                            {
+                                changed = true;
+                            }
+                        }
+                        let ext_attachments = converted_attachments
+                            .get(ext_cell.id.as_str())
+                            .unwrap_or(&empty_attachments);
+                        if current_cell.attachments != *ext_attachments {
+                            if let Ok(true) = doc.set_cell_attachments(&ext_cell.id, ext_attachments)
+                            {
+                                changed = true;
+                            }
+                        }
+                    } else {
+                        // New cell - add it
+                        // New cells don't have any in-progress state, so always use external values
+                        debug!(
+                            "[notebook-watch] Adding new cell at index {}: {}",
+                            index, ext_cell.id
+                        );
+                        if doc
+                            .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
+                            .is_ok()
+                        {
                             changed = true;
-                        } else if current_eid.is_some() {
-                            clear_execution_ids.push(ext_cell.id.clone());
-                            changed = true;
+                            let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
+                            let ext_outputs = converted_outputs
+                                .get(ext_cell.id.as_str())
+                                .map(|v| v.as_slice())
+                                .unwrap_or(&[]);
+                            let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
+                            if !ext_outputs.is_empty() || parsed_ec.is_some() {
+                                let synthetic_eid = uuid::Uuid::new_v4().to_string();
+                                let _ = doc.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
+                                deferred_execs.push(DeferredExecution {
+                                    synthetic_eid,
+                                    cell_id: ext_cell.id.clone(),
+                                    outputs: ext_outputs,
+                                    execution_count: parsed_ec,
+                                });
+                            }
+                            let ext_assets = converted_assets
+                                .get(ext_cell.id.as_str())
+                                .unwrap_or(&empty_assets);
+                            let _ = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets);
+                            let ext_attachments = converted_attachments
+                                .get(ext_cell.id.as_str())
+                                .unwrap_or(&empty_attachments);
+                            let _ = doc.set_cell_attachments(&ext_cell.id, ext_attachments);
                         }
                     }
                 }
 
-                let ext_assets = converted_assets
-                    .get(ext_cell.id.as_str())
-                    .unwrap_or(&empty_assets);
-                if current_cell.resolved_assets != *ext_assets {
-                    if let Ok(true) = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets) {
-                        changed = true;
-                    }
+                // Apply clear_execution_ids before integrating the transaction.
+                for cell_id in &clear_execution_ids {
+                    let _ = doc.set_execution_id(cell_id, None);
                 }
-                let ext_attachments = converted_attachments
-                    .get(ext_cell.id.as_str())
-                    .unwrap_or(&empty_attachments);
-                if current_cell.attachments != *ext_attachments {
-                    if let Ok(true) = doc.set_cell_attachments(&ext_cell.id, ext_attachments) {
-                        changed = true;
-                    }
-                }
-            } else {
-                // New cell - add it
-                // New cells don't have any in-progress state, so always use external values
-                debug!(
-                    "[notebook-watch] Adding new cell at index {}: {}",
-                    index, ext_cell.id
-                );
-                if doc
-                    .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
-                    .is_ok()
-                {
-                    changed = true;
-                    let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
-                    let ext_outputs = converted_outputs
-                        .get(ext_cell.id.as_str())
-                        .map(|v| v.as_slice())
-                        .unwrap_or(&[]);
-                    let parsed_ec: Option<i64> = ext_cell.execution_count.parse().ok();
-                    if !ext_outputs.is_empty() || parsed_ec.is_some() {
-                        let synthetic_eid = uuid::Uuid::new_v4().to_string();
-                        let _ = doc.set_execution_id(&ext_cell.id, Some(&synthetic_eid));
-                        deferred_execs.push(DeferredExecution {
-                            synthetic_eid,
-                            cell_id: ext_cell.id.clone(),
-                            outputs: ext_outputs,
-                            execution_count: parsed_ec,
-                        });
-                    }
-                    let ext_assets = converted_assets
-                        .get(ext_cell.id.as_str())
-                        .unwrap_or(&empty_assets);
-                    let _ = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets);
-                    let ext_attachments = converted_attachments
-                        .get(ext_cell.id.as_str())
-                        .unwrap_or(&empty_attachments);
-                    let _ = doc.set_cell_attachments(&ext_cell.id, ext_attachments);
-                }
+
+                Ok((changed, deferred_execs))
+            },
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                warn!("[file-watcher] update transaction failed: {}", e);
+                (false, Vec::new())
             }
         }
-
-        // Apply clear_execution_ids before merge
-        for cell_id in &clear_execution_ids {
-            let _ = doc.set_execution_id(cell_id, None);
-        }
-
-        // Merge source fork back — source changes from disk compose with
-        // post-save CRDT changes via Automerge's text CRDT merge.
-        if let Some(ref mut fork) = source_fork {
-            if let Err(e) = doc.merge_recovering(fork, "file-watcher-source-merge") {
-                warn!("[file-watcher] source merge failed: {}", e);
-            }
-        }
-
-        (changed, deferred_execs)
     }; // doc guard dropped here
 
     // Apply deferred state_doc writes

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1305,6 +1305,8 @@ pub(crate) async fn apply_ipynb_changes(
                 Ok(deferred) => deferred,
                 Err(e) => {
                     warn!("[file-watcher] order transaction failed: {}", e);
+                    // Do not create RuntimeStateDoc executions for cells that
+                    // failed to commit to the notebook doc.
                     Vec::new()
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -4690,22 +4690,27 @@ pub(crate) async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, 
         }
     }
 
-    let formatted_count = formatted_updates.len();
-    if formatted_count > 0 {
+    let mut formatted_count = 0;
+    if !formatted_updates.is_empty() {
         let mut doc = room.doc.write().await;
         match doc.transact_at_heads_recovering(
             &baseline_heads,
             Some(&formatter_actor(&runtime)),
             "save-format-transaction",
             |doc| {
+                let mut applied = 0;
                 let mut changed = false;
                 for (cell_id, fmt) in &formatted_updates {
-                    changed |= doc.update_source(cell_id, fmt)?;
+                    if let Ok(cell_changed) = doc.update_source(cell_id, fmt) {
+                        applied += 1;
+                        changed |= cell_changed;
+                    }
                 }
-                Ok(changed)
+                Ok((applied, changed))
             },
         ) {
-            Ok(changed) => {
+            Ok((applied, changed)) => {
+                formatted_count = applied;
                 if changed {
                     let _ = room.broadcasts.changed_tx.send(());
                 }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -989,9 +989,17 @@ async fn resign_trusted_snapshot(room: &NotebookRoom) -> Result<bool, String> {
 
     auto_sign_in_place(&mut snapshot)?;
 
-    doc.fork_and_merge(|fork| {
-        let _ = fork.set_metadata_snapshot(&snapshot);
-    });
+    let heads = doc.get_heads();
+    doc.transact_at_heads_recovering(
+        &heads,
+        Some("runtimed:metadata"),
+        "metadata-resign-transaction",
+        |doc| {
+            doc.set_metadata_snapshot(&snapshot)?;
+            Ok(())
+        },
+    )
+    .map_err(|e| format!("write trust signature: {}", e))?;
     drop(doc);
 
     // Persist the new signature to disk so reopening after a restart keeps
@@ -1326,7 +1334,8 @@ pub(crate) enum CapturedEnvRuntime {
 ///   overwritten only if empty (the brand-new notebook case). Existing
 ///   non-empty deps are left alone so user-edited lists aren't clobbered.
 ///
-/// Uses `fork_and_merge` per the async-CRDT-mutation rule.
+/// Uses a document-owned transaction so metadata writes keep one stable
+/// runtimed actor and still inherit Automerge recovery handling.
 ///
 /// Returns `true` if any field was updated.
 pub(crate) async fn capture_env_into_metadata(
@@ -1335,50 +1344,62 @@ pub(crate) async fn capture_env_into_metadata(
     user_defaults: &[String],
     env_id: &str,
 ) -> bool {
-    let mut changed = false;
     let mut doc = room.doc.write().await;
-    doc.fork_and_merge(|fork| {
-        let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
+    let heads = doc.get_heads();
+    let changed = match doc.transact_at_heads_recovering(
+        &heads,
+        Some("runtimed:metadata"),
+        "metadata-capture-env-transaction",
+        |doc| {
+            let mut changed = false;
+            let mut snap = doc.get_metadata_snapshot().unwrap_or_default();
 
-        if snap.runt.env_id.is_none() {
-            snap.runt.env_id = Some(env_id.to_string());
-            changed = true;
-        }
+            if snap.runt.env_id.is_none() {
+                snap.runt.env_id = Some(env_id.to_string());
+                changed = true;
+            }
 
-        match runtime {
-            CapturedEnvRuntime::Uv => {
-                let uv =
-                    snap.runt
-                        .uv
-                        .get_or_insert_with(|| notebook_doc::metadata::UvInlineMetadata {
+            match runtime {
+                CapturedEnvRuntime::Uv => {
+                    let uv = snap.runt.uv.get_or_insert_with(|| {
+                        notebook_doc::metadata::UvInlineMetadata {
                             dependencies: Vec::new(),
                             requires_python: None,
                             prerelease: None,
-                        });
-                if uv.dependencies.is_empty() && !user_defaults.is_empty() {
-                    uv.dependencies = user_defaults.to_vec();
-                    changed = true;
-                }
-            }
-            CapturedEnvRuntime::Conda => {
-                let conda = snap.runt.conda.get_or_insert_with(|| {
-                    notebook_doc::metadata::CondaInlineMetadata {
-                        dependencies: Vec::new(),
-                        channels: vec!["conda-forge".to_string()],
-                        python: None,
+                        }
+                    });
+                    if uv.dependencies.is_empty() && !user_defaults.is_empty() {
+                        uv.dependencies = user_defaults.to_vec();
+                        changed = true;
                     }
-                });
-                if conda.dependencies.is_empty() && !user_defaults.is_empty() {
-                    conda.dependencies = user_defaults.to_vec();
-                    changed = true;
+                }
+                CapturedEnvRuntime::Conda => {
+                    let conda = snap.runt.conda.get_or_insert_with(|| {
+                        notebook_doc::metadata::CondaInlineMetadata {
+                            dependencies: Vec::new(),
+                            channels: vec!["conda-forge".to_string()],
+                            python: None,
+                        }
+                    });
+                    if conda.dependencies.is_empty() && !user_defaults.is_empty() {
+                        conda.dependencies = user_defaults.to_vec();
+                        changed = true;
+                    }
                 }
             }
-        }
 
-        if changed {
-            let _ = fork.set_metadata_snapshot(&snap);
+            if changed {
+                doc.set_metadata_snapshot(&snap)?;
+            }
+            Ok(changed)
+        },
+    ) {
+        Ok(changed) => changed,
+        Err(e) => {
+            warn!("[notebook-sync] metadata capture transaction failed: {}", e);
+            false
         }
-    });
+    };
     drop(doc);
     if changed {
         // Notify the autosave debouncer so the capture lands in the .ipynb
@@ -1445,43 +1466,58 @@ pub(crate) async fn flush_launched_deps_to_metadata(
         return false;
     };
 
-    let mut changed = false;
     let mut doc = room.doc.write().await;
-    doc.fork_and_merge(|fork| {
-        let mut snap = fork.get_metadata_snapshot().unwrap_or_default();
-        match runtime {
-            CapturedEnvRuntime::Uv => {
-                let uv =
-                    snap.runt
-                        .uv
-                        .get_or_insert_with(|| notebook_doc::metadata::UvInlineMetadata {
+    let heads = doc.get_heads();
+    let changed = match doc.transact_at_heads_recovering(
+        &heads,
+        Some("runtimed:metadata"),
+        "metadata-flush-deps-transaction",
+        |doc| {
+            let mut changed = false;
+            let mut snap = doc.get_metadata_snapshot().unwrap_or_default();
+            match runtime {
+                CapturedEnvRuntime::Uv => {
+                    let uv = snap.runt.uv.get_or_insert_with(|| {
+                        notebook_doc::metadata::UvInlineMetadata {
                             dependencies: Vec::new(),
                             requires_python: None,
                             prerelease: None,
-                        });
-                if uv.dependencies != new_deps {
-                    uv.dependencies = new_deps.clone();
-                    changed = true;
-                }
-            }
-            CapturedEnvRuntime::Conda => {
-                let conda = snap.runt.conda.get_or_insert_with(|| {
-                    notebook_doc::metadata::CondaInlineMetadata {
-                        dependencies: Vec::new(),
-                        channels: vec!["conda-forge".to_string()],
-                        python: None,
+                        }
+                    });
+                    if uv.dependencies != new_deps {
+                        uv.dependencies = new_deps.clone();
+                        changed = true;
                     }
-                });
-                if conda.dependencies != new_deps {
-                    conda.dependencies = new_deps.clone();
-                    changed = true;
+                }
+                CapturedEnvRuntime::Conda => {
+                    let conda = snap.runt.conda.get_or_insert_with(|| {
+                        notebook_doc::metadata::CondaInlineMetadata {
+                            dependencies: Vec::new(),
+                            channels: vec!["conda-forge".to_string()],
+                            python: None,
+                        }
+                    });
+                    if conda.dependencies != new_deps {
+                        conda.dependencies = new_deps.clone();
+                        changed = true;
+                    }
                 }
             }
+            if changed {
+                doc.set_metadata_snapshot(&snap)?;
+            }
+            Ok(changed)
+        },
+    ) {
+        Ok(changed) => changed,
+        Err(e) => {
+            warn!(
+                "[notebook-sync] metadata deps flush transaction failed: {}",
+                e
+            );
+            false
         }
-        if changed {
-            let _ = fork.set_metadata_snapshot(&snap);
-        }
-    });
+    };
     drop(doc);
     changed
 }
@@ -4630,51 +4666,56 @@ pub(crate) async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, 
         }
     };
 
-    // Get all code cells
-    let cells: Vec<(String, String)> = {
-        let doc = room.doc.read().await;
-        doc.get_cells()
+    // Capture the code cells and heads before formatting so the eventual
+    // writes are applied as an isolated transaction at this baseline.
+    let (cells, baseline_heads) = {
+        let mut doc = room.doc.write().await;
+        let cells: Vec<(String, String)> = doc
+            .get_cells()
             .into_iter()
             .filter(|cell| cell.cell_type == "code" && !cell.source.trim().is_empty())
             .map(|cell| (cell.id, cell.source))
-            .collect()
+            .collect();
+        (cells, doc.get_heads())
     };
 
     if cells.is_empty() {
         return Ok(0);
     }
 
-    // Fork BEFORE formatting so the baseline is the pre-format doc state.
-    // Formatting ops on the fork are concurrent with any user edits on the
-    // live doc, and Automerge's text CRDT merges them cleanly.
-    let mut fork = {
-        let mut doc = room.doc.write().await;
-        doc.fork_with_actor(format!(
-            "{}:{}",
-            formatter_actor(&runtime),
-            uuid::Uuid::new_v4()
-        ))
-    };
-
-    let mut formatted_count = 0;
+    let mut formatted_updates: Vec<(String, String)> = Vec::new();
     for (cell_id, source) in cells {
         if let Some(fmt) = format_source(&source, &runtime).await {
-            if fork.update_source(&cell_id, &fmt).is_ok() {
-                formatted_count += 1;
-            }
+            formatted_updates.push((cell_id, fmt));
         }
     }
 
+    let formatted_count = formatted_updates.len();
     if formatted_count > 0 {
         let mut doc = room.doc.write().await;
-        if let Err(e) = doc.merge_recovering(&mut fork, "save-format-merge") {
-            warn!("[format] merge failed: {}", e);
+        match doc.transact_at_heads_recovering(
+            &baseline_heads,
+            Some(&formatter_actor(&runtime)),
+            "save-format-transaction",
+            |doc| {
+                let mut changed = false;
+                for (cell_id, fmt) in &formatted_updates {
+                    changed |= doc.update_source(cell_id, fmt)?;
+                }
+                Ok(changed)
+            },
+        ) {
+            Ok(changed) => {
+                if changed {
+                    let _ = room.broadcasts.changed_tx.send(());
+                }
+                info!(
+                    "[format] Formatted {} code cells (runtime: {})",
+                    formatted_count, runtime
+                );
+            }
+            Err(e) => warn!("[format] transaction failed: {}", e),
         }
-        let _ = room.broadcasts.changed_tx.send(());
-        info!(
-            "[format] Formatted {} code cells (runtime: {})",
-            formatted_count, runtime
-        );
     }
 
     Ok(formatted_count)


### PR DESCRIPTION
## Summary

- Convert notebook file-watcher structural rebuilds and incremental source updates from fork/merge to `NotebookDoc::transact_at_heads_recovering`.
- Convert save-format writes and metadata update helpers to document-owned transactions with stable runtimed actors.
- Update `NotebookDoc` API docs so new async mutation guidance prefers captured heads plus transactions over forks.

## Why

The recent Automerge work centralized panic recovery and moved us onto the fork that supports isolated transactions. This follow-up audits production notebook-server writes that were still minting fork actors for work that can now be applied at captured heads on the live document. That keeps actor sequencing on one document, reduces duplicate-actor risk, and keeps recovery inside the document boundary.

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo check --package runtimed`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo test -p runtimed notebook_sync_server::tests::test_apply_ipynb_changes`
- `cargo test -p runtimed capture_`
- `cargo test -p runtimed format_notebook_cells`
- `cargo test -p notebook-doc isolated_transaction`
- `cargo xtask clippy`
- `cargo clippy -p runtimed --all-targets -- -D warnings`
- Claude Bedrock Opus 4.6 review pass after follow-ups: no actionable findings remain.

## Known Issue

- `cargo xtask lint --fix` still fails on the pre-existing long line at `python/runtimed/tests/test_daemon_integration.py:2929`.
