### PR TITLE
feat(runt): add config show and config path subcommands

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -437,7 +437,12 @@ enum EnvCommands {
 /// Settings subcommands
 #[derive(Subcommand)]
 enum ConfigCommands {
-    /// List all current settings
+    /// Show all current settings (default)
+    Show,
+    /// Print the settings file path
+    Path,
+    /// Alias for `show`
+    #[command(hide = true)]
     List,
     /// Get a specific setting value
     Get {
@@ -4530,11 +4535,13 @@ async fn config_command(command: Option<ConfigCommands>) -> Result<()> {
     let settings_path = runt_workspace::settings_json_path();
 
     match command {
-        None | Some(ConfigCommands::List) => {
-            // Print all settings as pretty JSON
+        None | Some(ConfigCommands::Show) | Some(ConfigCommands::List) => {
             let settings = read_settings_from_file(&settings_path)?;
             let json = serde_json::to_string_pretty(&settings)?;
             println!("{json}");
+        }
+        Some(ConfigCommands::Path) => {
+            println!("{}", settings_path.display());
         }
         Some(ConfigCommands::Get { key }) => {
             validate_config_key(&key)?;


### PR DESCRIPTION
Splits `runt config` into explicit subcommands so the JSON blob and the file path are independently addressable.

- `runt config` / `runt config show` - prints settings JSON (existing behavior, unchanged)
- `runt config path` - prints the settings file path, nothing else
- `runt config list` - hidden alias for `show`

`config path` is useful for scripting (`$EDITOR $(runt config path)`) and for quickly finding which file you're looking at across stable/nightly channels.

```
$ runt config path
/Users/kyle/.config/nteract-nightly/settings.json
```
