### PR TITLE
fix(runtime-doc): propagate transaction rebuild errors

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -579,8 +579,8 @@ impl RuntimeStateDoc {
             (Ok(Ok(value)), None) => Ok(value),
             (Ok(Err(source)), None) => Err(source),
             (Err(err), _) | (_, Some(err)) => {
-                if !self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label).into());
+                if let Err(source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(label, source).into());
                 }
                 Err(AutomergeOperationError::Panic(err).into())
             }
@@ -4168,7 +4168,7 @@ mod tests {
 
         doc.transact_at_heads_recovering(
             &heads,
-            Some("rt:kernel:coalesce"),
+            Some("rt:kernel:shared"),
             "test-runtime-transaction-compose",
             |doc| {
                 doc.create_execution("exec-1", "cell-1")?;


### PR DESCRIPTION
## Summary

- Fix `RuntimeStateDoc::transact_at_heads_recovering` after #2532 changed `rebuild_from_save` to return typed rebuild errors.
- Remove the stale `rt:kernel:coalesce` actor label from the runtime transaction unit test.

## Audit Notes

- Current `origin/main` included #2532 but `cargo check -p runtime-doc` failed because one runtime-doc call site still treated `rebuild_from_save()` as `bool`.
- The production comm coalescer is already using the base kernel actor through transactions; no production `:coalesce` actor label remains.
- Remaining `:iopub` and `:shell` actors are still attached to true async fork paths.

## Verification

- `cargo check -p runtime-doc`
- `cargo check --package runtimed`
- `cargo test -p automerge-recovery`
- `cargo test -p runtime-doc isolated_transaction`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo clippy -p automerge-recovery -p runtime-doc -p runtimed --all-targets -- -D warnings`
