### PR TITLE
refactor(runtime-doc): transact synchronous iopub writes

### DIFF
--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -85,6 +85,26 @@ impl RuntimeStateHandle {
         Ok(())
     }
 
+    /// Run a document-owned transaction at the current heads.
+    ///
+    /// Use this for synchronous writes that previously forked only to assign
+    /// an actor. The handle owns locking and change notification; Automerge
+    /// owns the actor sequence on the live document.
+    pub fn transact_at_current_heads<F, T>(
+        &self,
+        actor: Option<&str>,
+        label: &str,
+        f: F,
+    ) -> Result<T, RuntimeStateError>
+    where
+        F: FnOnce(&mut RuntimeStateDoc) -> Result<T, RuntimeStateError>,
+    {
+        self.with_doc(|sd| {
+            let heads = sd.get_heads();
+            sd.transact_at_heads_recovering(&heads, actor, label, f)
+        })
+    }
+
     pub fn generate_sync_message_recovering(
         &self,
         peer_state: &mut sync::State,
@@ -259,6 +279,31 @@ mod tests {
         fork.set_lifecycle(&idle()).unwrap();
         handle.merge(&mut fork).unwrap();
         assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn transact_at_current_heads_notifies_with_stable_actor() {
+        let handle = make_handle();
+        let mut rx = handle.subscribe();
+
+        handle
+            .transact_at_current_heads(Some("rt:kernel:test"), "handle-transaction-a", |sd| {
+                sd.create_execution("exec-a", "cell-a")?;
+                Ok(())
+            })
+            .unwrap();
+        handle
+            .transact_at_current_heads(Some("rt:kernel:test"), "handle-transaction-b", |sd| {
+                sd.create_execution("exec-b", "cell-b")?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_ok());
+        let state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(state.executions["exec-a"].cell_id, "cell-a");
+        assert_eq!(state.executions["exec-b"].cell_id, "cell-b");
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1078,11 +1078,11 @@ impl KernelConnection for JupyterKernel {
         let iopub_comm_seq = comm_seq.clone();
         let iopub_stream_terminals = stream_terminals.clone();
         let state_for_iopub = shared.state.clone();
-        // IOPub and shell still create true async forks, so they keep distinct
-        // task actors until those paths move to transactions. Transactional
-        // comm coalescing uses the base kernel actor because Automerge keeps
-        // the live document's actor sequence linear.
+        // Display updates still mutate a fork across an async manifest helper,
+        // so IOPub keeps a task actor for that path. Synchronous IOPub writes
+        // use transactions with the base kernel actor.
         let iopub_actor_id = format!("{kernel_actor_id}:iopub");
+        let iopub_kernel_actor_id = kernel_actor_id.clone();
 
         // Create coalescing channel early so the IOPub task can capture the sender.
         let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
@@ -1368,51 +1368,36 @@ impl KernelConnection for JupyterKernel {
                                                 String::new()
                                             };
 
-                                        let mut fork = match state_for_iopub.fork(&iopub_actor_id) {
-                                            Ok(f) => f,
+                                        let upsert_result = match state_for_iopub
+                                            .transact_at_current_heads(
+                                                Some(&iopub_kernel_actor_id),
+                                                "runtime-state-iopub-stream-transaction",
+                                                |sd| {
+                                                    Ok(sd.upsert_stream_output(
+                                                        &eid,
+                                                        stream_name,
+                                                        &manifest_json,
+                                                        known_state.as_ref(),
+                                                    )?)
+                                                },
+                                            ) {
+                                            Ok(result) => result,
                                             Err(e) => {
-                                                warn!("[runtime-state] fork: {}", e);
+                                                warn!("[runtime-state] {}", e);
                                                 continue;
                                             }
                                         };
 
-                                        let upsert_result = fork.upsert_stream_output(
+                                        let (_updated, output_index) = upsert_result;
+                                        let mut terminals = iopub_stream_terminals.lock().await;
+                                        terminals.set_output_state(
                                             &eid,
                                             stream_name,
-                                            &manifest_json,
-                                            known_state.as_ref(),
+                                            StreamOutputState {
+                                                index: output_index,
+                                                blob_hash: blob_hash.clone(),
+                                            },
                                         );
-
-                                        let merge_ok = match state_for_iopub.merge(&mut fork) {
-                                            Ok(()) => true,
-                                            Err(e) => {
-                                                warn!("[runtime-state] merge: {}", e);
-                                                false
-                                            }
-                                        };
-
-                                        if merge_ok {
-                                            match &upsert_result {
-                                                Ok((_updated, output_index)) => {
-                                                    let mut terminals =
-                                                        iopub_stream_terminals.lock().await;
-                                                    terminals.set_output_state(
-                                                        &eid,
-                                                        stream_name,
-                                                        StreamOutputState {
-                                                            index: *output_index,
-                                                            blob_hash: blob_hash.clone(),
-                                                        },
-                                                    );
-                                                }
-                                                Err(e) => {
-                                                    warn!(
-                                                    "[jupyter-kernel] Failed to upsert stream output: {}",
-                                                    e
-                                                );
-                                                }
-                                            }
-                                        }
                                     }
                                 }
 
@@ -1571,25 +1556,24 @@ impl KernelConnection for JupyterKernel {
                                                 }
                                             };
 
-                                            let mut fork =
-                                                match state_for_iopub.fork(&iopub_actor_id) {
-                                                    Ok(f) => f,
-                                                    Err(e) => {
-                                                        warn!("[runtime-state] fork: {}", e);
-                                                        continue;
-                                                    }
-                                                };
-
-                                            if let Err(e) = fork.append_output(&eid, &manifest_json)
+                                            if let Err(e) = state_for_iopub
+                                                .transact_at_current_heads(
+                                                    Some(&iopub_kernel_actor_id),
+                                                    "runtime-state-iopub-output-transaction",
+                                                    |sd| {
+                                                        if let Err(e) = sd
+                                                            .append_output(&eid, &manifest_json)
+                                                        {
+                                                            warn!(
+                                                                "[jupyter-kernel] Failed to append output to state doc: {}",
+                                                                e
+                                                            );
+                                                        }
+                                                        Ok(())
+                                                    },
+                                                )
                                             {
-                                                warn!(
-                                                "[jupyter-kernel] Failed to append output to state doc: {}",
-                                                e
-                                            );
-                                            }
-
-                                            if let Err(e) = state_for_iopub.merge(&mut fork) {
-                                                warn!("[runtime-state] merge: {}", e);
+                                                warn!("[runtime-state] {}", e);
                                             }
                                         }
 
@@ -1809,25 +1793,24 @@ impl KernelConnection for JupyterKernel {
                                                 }
                                             };
 
-                                            let mut fork =
-                                                match state_for_iopub.fork(&iopub_actor_id) {
-                                                    Ok(f) => f,
-                                                    Err(e) => {
-                                                        warn!("[runtime-state] fork: {}", e);
-                                                        continue;
-                                                    }
-                                                };
-
-                                            if let Err(e) = fork.append_output(&eid, &manifest_json)
+                                            if let Err(e) = state_for_iopub
+                                                .transact_at_current_heads(
+                                                    Some(&iopub_kernel_actor_id),
+                                                    "runtime-state-iopub-error-transaction",
+                                                    |sd| {
+                                                        if let Err(e) = sd
+                                                            .append_output(&eid, &manifest_json)
+                                                        {
+                                                            warn!(
+                                                                "[jupyter-kernel] Failed to append error output to state doc: {}",
+                                                                e
+                                                            );
+                                                        }
+                                                        Ok(())
+                                                    },
+                                                )
                                             {
-                                                warn!(
-                                                "[jupyter-kernel] Failed to append error output to state doc: {}",
-                                                e
-                                            );
-                                            }
-
-                                            if let Err(e) = state_for_iopub.merge(&mut fork) {
-                                                warn!("[runtime-state] merge: {}", e);
+                                                warn!("[runtime-state] {}", e);
                                             }
                                         }
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1373,12 +1373,21 @@ impl KernelConnection for JupyterKernel {
                                                 Some(&iopub_kernel_actor_id),
                                                 "runtime-state-iopub-stream-transaction",
                                                 |sd| {
-                                                    Ok(sd.upsert_stream_output(
+                                                    match sd.upsert_stream_output(
                                                         &eid,
                                                         stream_name,
                                                         &manifest_json,
                                                         known_state.as_ref(),
-                                                    )?)
+                                                    ) {
+                                                        Ok(result) => Ok(result),
+                                                        Err(e) => {
+                                                            warn!(
+                                                                "[jupyter-kernel] Failed to upsert stream output: {}",
+                                                                e
+                                                            );
+                                                            Err(e.into())
+                                                        }
+                                                    }
                                                 },
                                             ) {
                                             Ok(result) => result,
@@ -1561,6 +1570,10 @@ impl KernelConnection for JupyterKernel {
                                                     Some(&iopub_kernel_actor_id),
                                                     "runtime-state-iopub-output-transaction",
                                                     |sd| {
+                                                        // Preserve the old fork+merge behavior:
+                                                        // append errors are logged but do not
+                                                        // turn the transaction into a recovery
+                                                        // failure.
                                                         if let Err(e) = sd
                                                             .append_output(&eid, &manifest_json)
                                                         {
@@ -1798,6 +1811,10 @@ impl KernelConnection for JupyterKernel {
                                                     Some(&iopub_kernel_actor_id),
                                                     "runtime-state-iopub-error-transaction",
                                                     |sd| {
+                                                        // Preserve the old fork+merge behavior:
+                                                        // append errors are logged but do not
+                                                        // turn the transaction into a recovery
+                                                        // failure.
                                                         if let Err(e) = sd
                                                             .append_output(&eid, &manifest_json)
                                                         {


### PR DESCRIPTION
## Summary

- Add `RuntimeStateHandle::transact_at_current_heads` so synchronous runtime-state writes can use document-owned transactions without repeating lock/head/notify plumbing.
- Move IOPub stream, display/execute-result append, and error append writes from `fork(&iopub_actor_id)` + `merge` to transactions using the base kernel actor.
- Leave the remaining IOPub display-update fork and shell fork in place because those are still true async fork paths.

## Audit Notes

- Remaining `:iopub` use: display-update path mutates a fork across `update_output_by_display_id_with_manifests(...).await`.
- Remaining `:shell` use: shell page payload append path still forks after async manifest creation.
- No production `:coalesce` actor remains.

## Verification

- `cargo xtask lint --fix`
- `cargo check --package runtimed`
- `cargo test -p runtime-doc transact_at_current_heads_notifies_with_stable_actor`
- `cargo test -p runtime-doc isolated_transaction`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo clippy -p runtime-doc -p runtimed --all-targets -- -D warnings`

## Notes

`cargo xtask lint --fix` passed and reported one existing JS lint warning in `plugins/nteract/pi/extensions/repl.ts`.
