### PR TITLE
ci(windows): install tauri cli from release asset

### DIFF
--- a/.github/actions/install-tauri-cli/action.yml
+++ b/.github/actions/install-tauri-cli/action.yml
@@ -1,0 +1,19 @@
+name: Install Tauri CLI
+description: Install cargo-tauri on Windows via upstream release asset with source-build fallback.
+
+inputs:
+  version:
+    description: Tauri CLI version to install.
+    required: false
+    default: "2.11.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Tauri CLI
+      shell: pwsh
+      env:
+        TAURI_CLI_VERSION: ${{ inputs.version }}
+      run: |
+        Set-ExecutionPolicy Unrestricted -Scope Process -Force
+        ./scripts/ci/install-tauri-cli.ps1

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -104,15 +104,38 @@ jobs:
         if: runner.os != 'Windows'
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-      - name: Install cargo-binstall (Windows)
+      - name: Install tauri-cli (Unix)
+        if: runner.os != 'Windows'
+        run: cargo binstall tauri-cli --no-confirm --locked --force
+
+      - name: Install tauri-cli (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Set-ExecutionPolicy Unrestricted -Scope Process -Force
-          iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
-
-      - name: Install tauri-cli
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+          $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
+          $version = "2.11.0"
+          $target = "x86_64-pc-windows-msvc"
+          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
+          $cargoBin = Join-Path $cargoHome "bin"
+          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+          Add-Content -Path $env:GITHUB_PATH -Value $cargoBin
+          $env:PATH = "$cargoBin;$env:PATH"
+          $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+          try {
+            $url = "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v$version/cargo-tauri-$target.zip"
+            $zip = Join-Path $tmp "cargo-tauri.zip"
+            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+            Expand-Archive -Path $zip -DestinationPath $tmp -Force
+            Copy-Item -Path (Join-Path $tmp "cargo-tauri.exe") -Destination (Join-Path $cargoBin "cargo-tauri.exe") -Force
+          } catch {
+            Write-Warning "Direct Tauri CLI download failed: $_"
+            cargo install tauri-cli --version $version --locked --force
+          } finally {
+            Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+          }
+          cargo tauri --version
 
       - name: Bake PR + commit into version
         id: version

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -652,12 +652,17 @@ jobs:
 
       - name: Install cargo-binstall
         shell: pwsh
+        env:
+          BINSTALL_VERSION: v1.18.1
         run: |
           Set-ExecutionPolicy Unrestricted -Scope Process -Force
           iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
-      - name: Install Tauri CLI and trusted-signing-cli
-        run: cargo binstall tauri-cli trusted-signing-cli --no-confirm --locked --force
+      - name: Install Tauri CLI
+        uses: ./.github/actions/install-tauri-cli
+
+      - name: Install trusted-signing-cli
+        run: cargo binstall trusted-signing-cli --no-confirm --locked --force
 
       - name: Set version in tauri.conf.json
         shell: pwsh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -53,14 +53,8 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
-      - name: Install cargo-binstall
-        shell: pwsh
-        run: |
-          Set-ExecutionPolicy Unrestricted -Scope Process -Force
-          iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
-
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       # Build the MCP output widget HTML. runt-mcp's include_str! needs it
       # before we compile the Rust binaries.

--- a/scripts/ci/install-tauri-cli.ps1
+++ b/scripts/ci/install-tauri-cli.ps1
@@ -1,0 +1,54 @@
+param(
+  [string]$Version = $env:TAURI_CLI_VERSION
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+if (-not $Version) {
+  $Version = "2.11.0"
+}
+
+$procArch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
+switch ($procArch) {
+  "AMD64" { $target = "x86_64-pc-windows-msvc" }
+  "ARM64" { $target = "aarch64-pc-windows-msvc" }
+  default { throw "Unsupported Windows processor architecture: $procArch" }
+}
+
+$cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
+$cargoBin = Join-Path $cargoHome "bin"
+New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
+
+if ($env:GITHUB_PATH) {
+  Add-Content -Path $env:GITHUB_PATH -Value $cargoBin
+}
+$env:PATH = "$cargoBin;$env:PATH"
+
+$assetName = "cargo-tauri-$target.zip"
+$url = "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v$Version/$assetName"
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+try {
+  $zip = Join-Path $tmp $assetName
+  Write-Host "Installing Tauri CLI v$Version for $target from $url"
+  Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
+
+  $cargoTauri = Get-ChildItem -Path $tmp -Filter "cargo-tauri.exe" -Recurse | Select-Object -First 1
+  if (-not $cargoTauri) {
+    throw "Downloaded archive did not contain cargo-tauri.exe"
+  }
+
+  Copy-Item -Path $cargoTauri.FullName -Destination (Join-Path $cargoBin "cargo-tauri.exe") -Force
+  Write-Host "Installed cargo-tauri.exe to $cargoBin"
+} catch {
+  Write-Warning "Direct Tauri CLI download failed: $_"
+  Write-Host "Falling back to cargo install tauri-cli --version $Version"
+  cargo install tauri-cli --version $Version --locked --force
+} finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+cargo tauri --version


### PR DESCRIPTION
## Summary

- add a Windows-only Tauri CLI installer that downloads the upstream `cargo-tauri` release asset directly
- fall back to `cargo install tauri-cli --version 2.11.0 --locked --force` if the direct asset install fails
- use the deterministic installer in Windows smoke and Windows release packaging
- keep PR binary generation compatible with older checked-out PR heads by inlining the Windows install there

## Verification

- `actionlint .github/workflows/smoke.yml .github/workflows/pr-binary-generation.yml .github/workflows/release-common.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/smoke.yml .github/workflows/pr-binary-generation.yml .github/workflows/release-common.yml .github/actions/install-tauri-cli/action.yml`
- `git diff --check`

## Notes

- The Windows release job still needs `cargo-binstall` for `trusted-signing-cli`, so that bootstrap is pinned to `v1.18.1`.
- I could not execute the PowerShell helper locally because this machine does not have `pwsh`.
