### PR TITLE
refactor(automerge): prune stale recovery paths

### DIFF
--- a/crates/runtime-doc/src/handle.rs
+++ b/crates/runtime-doc/src/handle.rs
@@ -11,7 +11,7 @@ use crate::{ForeignSyncView, RuntimeStateDoc, RuntimeStateError};
 ///
 /// Mutations go through `with_doc` for synchronous document-owned writes.
 /// Use RuntimeStateDoc transactions inside `with_doc` when applying writes at
-/// captured heads; keep `fork`/`merge` for true async fork work.
+/// captured heads.
 /// Notification is automatic via heads comparison. Clone is cheap.
 ///
 /// Uses `std::sync::Mutex`, not `tokio::sync::RwLock`. Automerge writes are
@@ -49,40 +49,6 @@ impl RuntimeStateHandle {
             let _ = self.changed_tx.send(());
         }
         result
-    }
-
-    /// Fork at current heads for async runtime-state work.
-    pub fn fork(&self, actor_label: &str) -> Result<RuntimeStateDoc, RuntimeStateError> {
-        let mut sd = self
-            .doc
-            .lock()
-            .map_err(|_| RuntimeStateError::LockPoisoned)?;
-        Ok(sd.fork_with_actor(actor_label))
-    }
-
-    /// Merge a fork back. Notifies if heads changed.
-    ///
-    /// If merge panics (Automerge's apply path is not transactional),
-    /// catches the unwind and rebuilds the doc via save/load to restore
-    /// a consistent state. The fork's writes are lost but the session
-    /// continues.
-    pub fn merge(&self, fork: &mut RuntimeStateDoc) -> Result<(), RuntimeStateError> {
-        let mut sd = self
-            .doc
-            .lock()
-            .map_err(|_| RuntimeStateError::LockPoisoned)?;
-        let heads_before = sd.get_heads();
-        match sd.merge_recovering(fork, "runtime-state-merge") {
-            Ok(_) => {}
-            Err(err) => {
-                tracing::warn!("[runtime-state] {}", err);
-                return Err(err.into());
-            }
-        }
-        if sd.get_heads() != heads_before {
-            let _ = self.changed_tx.send(());
-        }
-        Ok(())
     }
 
     /// Run a document-owned transaction at the current heads.
@@ -220,10 +186,6 @@ mod tests {
         RuntimeLifecycle::Running(KernelActivity::Busy)
     }
 
-    fn idle() -> RuntimeLifecycle {
-        RuntimeLifecycle::Running(KernelActivity::Idle)
-    }
-
     #[test]
     fn with_doc_notifies_on_change() {
         let handle = make_handle();
@@ -269,16 +231,6 @@ mod tests {
             handle.read(|sd| sd.read_state().kernel.lifecycle).unwrap(),
             busy()
         );
-    }
-
-    #[test]
-    fn fork_and_merge_notifies() {
-        let handle = make_handle();
-        let mut rx = handle.subscribe();
-        let mut fork = handle.fork("test-fork").unwrap();
-        fork.set_lifecycle(&idle()).unwrap();
-        handle.merge(&mut fork).unwrap();
-        assert!(rx.try_recv().is_ok());
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -153,14 +153,12 @@ pub enum FrameEvent {
         #[serde(default)]
         output_changeset: OutputChangeset,
     },
-    /// Sync error recovered — doc rebuilt and sync state normalized.
+    /// Sync apply error recovered — doc rebuilt and sync state normalized.
     ///
-    /// Emitted when `receive_sync_message` fails or an Automerge operation
-    /// panics inside the WASM recovery boundary. The WASM layer automatically
-    /// rebuilds the doc via save→load and normalizes sync state via
-    /// encode→decode round-trip (preserving `shared_heads`, clearing transient
-    /// state). The optional `reply` contains a fresh sync message to restart
-    /// negotiation.
+    /// Emitted when `receive_sync_message` returns an error. The WASM layer
+    /// rebuilds the doc via save→load and normalizes sync state via encode→decode
+    /// round-trip (preserving `shared_heads`, clearing transient state). The
+    /// optional `reply` contains a fresh sync message to restart negotiation.
     SyncError {
         /// True if the document advanced before the error (partial apply).
         /// When true, the SyncEngine should trigger a full materialization

--- a/crates/runtimed/src/requests/guarded.rs
+++ b/crates/runtimed/src/requests/guarded.rs
@@ -5,8 +5,6 @@ use std::str::FromStr;
 use automerge::ChangeHash;
 use notebook_doc::{diff::DocChangeset, NotebookDoc};
 
-use automerge_recovery::catch_automerge_panic;
-
 use crate::notebook_sync_server::{check_and_update_trust_state, NotebookRoom};
 use crate::protocol::NotebookResponse;
 
@@ -148,10 +146,11 @@ fn diff_from_observed_heads(
     observed: &[ChangeHash],
 ) -> GuardResult<DocChangeset> {
     let current = doc.get_heads();
-    catch_automerge_panic("guarded-action-diff", || {
-        notebook_doc::diff::diff_doc(doc.doc_mut(), observed, &current)
-    })
-    .map_err(|_| rejected("Notebook state changed unexpectedly. Review before running again."))
+    Ok(notebook_doc::diff::diff_doc(
+        doc.doc_mut(),
+        observed,
+        &current,
+    ))
 }
 
 fn parse_heads(heads: &[String]) -> GuardResult<Vec<ChangeHash>> {


### PR DESCRIPTION
## Summary

- remove the unused `RuntimeStateHandle::fork` / `merge` surface now that runtime-state writes go through transactions
- stop wrapping guarded `diff_doc(...)` in a panic catcher that had no document-owned recovery policy
- correct the WASM sync error comment so it describes `receive_sync_message` error recovery, not panic recovery

## Verification

- `cargo fmt --all --check`
- `cargo check -p runtime-doc -p runtimed -p runtimed-wasm`
- `cargo test -p runtime-doc handle::tests -- --nocapture`
- `cargo test -p runtimed guarded -- --nocapture`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` still reports the existing JS warning in `plugins/nteract/pi/extensions/repl.ts` for `new Array(singleArgument)`, but exits successfully.

## Follow-up

Settings sync still uses raw Automerge sync helpers and should be treated as a separate decision because it crosses the `runtimed-client` API surface.
