### PR TITLE
feat(pi): surface install hint when daemon is missing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,14 @@ concurrency:
   group: npm-publish-stable
   cancel-in-progress: false
 
+env:
+  # Bake the stable channel into the published binding. runt-workspace reads
+  # this at compile time via option_env!("RUNT_BUILD_CHANNEL") and falls back
+  # to Nightly when unset, so without this defaultSocketPath() in the
+  # published @runtimed/node would resolve under ~/.cache/runt-nightly. Source
+  # builds (no env) intentionally stay on the Nightly default.
+  RUNT_BUILD_CHANNEL: stable
+
 jobs:
   native:
     name: Native package (${{ matrix.target }})

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2015,7 +2015,9 @@ fn cmd_pi(pi_args: &[String]) {
     command.arg("--extension").arg(extension_path);
     command.args(pi_args);
     command.env("NTERACT_RUNTIMED_NODE_PATH", node_path);
-    command.env("NTERACT_SOCKET_PATH", socket_path);
+    // Socket selection flows through apply_worktree_env -> RUNTIMED_DEV +
+    // RUNTIMED_WORKSPACE_PATH, which runtimed-node's defaultSocketPath()
+    // resolves to the same per-worktree socket printed above.
     apply_worktree_env(&mut command, true);
 
     let status = command.status().unwrap_or_else(|e| {

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -7,8 +7,11 @@
  *
  * Config (env vars):
  *   NTERACT_RUNTIMED_NODE_PATH  override the runtimed-node package path.
- *   NTERACT_SOCKET_PATH         override the daemon socket path.
- *   NTERACT_CHANNEL             "stable" or "nightly" - picks the channel's socket.
+ *
+ * Daemon socket selection follows the runtimed-node contract:
+ * `RUNTIMED_SOCKET_PATH` overrides outright, `RUNTIMED_WORKSPACE_PATH` (or
+ * `RUNTIMED_DEV=1` plus a git checkout) selects the per-worktree dev daemon,
+ * otherwise the running channel is auto-detected.
  *
  * After editing, run `/reload` in pi.
  */
@@ -26,7 +29,6 @@ import { Type } from "typebox";
 
 type RuntimedNode = {
   defaultSocketPath(): string;
-  socketPathForChannel(channel: "stable" | "nightly"): string;
   PackageManager?: { Uv: "uv"; Conda: "conda"; Pixi: "pixi" };
   createNotebook(opts?: {
     runtime?: string;
@@ -136,22 +138,6 @@ function loadRuntimedNode(): RuntimedNode | null {
   return null;
 }
 
-function resolveSocketPath(rn: RuntimedNode): string {
-  if (process.env.NTERACT_SOCKET_PATH) return process.env.NTERACT_SOCKET_PATH;
-
-  const envChannel = process.env.NTERACT_CHANNEL;
-  if (envChannel === "stable" || envChannel === "nightly") {
-    return rn.socketPathForChannel(envChannel);
-  }
-
-  for (const channel of ["nightly", "stable"] as const) {
-    const socketPath = rn.socketPathForChannel(channel);
-    if (existsSync(socketPath)) return socketPath;
-  }
-
-  return rn.defaultSocketPath();
-}
-
 // --- bootstrap detection -----------------------------------------------------
 
 const INSTALL_HINT =
@@ -176,16 +162,15 @@ function findOnPath(cmd: string): string | undefined {
 function detectBootstrap(): BootstrapStatus {
   const rn = loadRuntimedNode();
   if (!rn) return { kind: "missing", reason: "binding" };
-  // Explicit socket override wins: assume the operator knows what they're doing.
-  if (process.env.NTERACT_SOCKET_PATH) return { kind: "ready", rn };
-  // Cache dir presence is a coarse "has this daemon ever run" check; the socket
-  // file itself only exists while the daemon is running, but the parent dir
-  // sticks around once any nteract install has touched the system.
-  const channels = ["nightly", "stable"] as const;
-  const sockets = channels.map((ch) => rn.socketPathForChannel(ch));
+  // defaultSocketPath() already honors RUNTIMED_SOCKET_PATH and the dev /
+  // worktree-aware resolution from runt-workspace, so this is the single point
+  // of truth. The socket file only exists while the daemon is running, but the
+  // parent cache dir survives shutdowns, so dir-existence covers "installed
+  // but stopped".
+  const socket = rn.defaultSocketPath();
   const installed =
-    sockets.some((s) => existsSync(s)) ||
-    sockets.some((s) => existsSync(path.dirname(s))) ||
+    existsSync(socket) ||
+    existsSync(path.dirname(socket)) ||
     Boolean(findOnPath("runt")) ||
     Boolean(findOnPath("runt-nightly"));
   return installed ? { kind: "ready", rn } : { kind: "missing", reason: "daemon" };
@@ -654,10 +639,11 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
       return opened;
     }
     opening = (async () => {
-      const socketPath = resolveSocketPath(rn);
+      // Omit socketPath so the binding resolves through defaultSocketPath(),
+      // which honors RUNTIMED_SOCKET_PATH / RUNTIMED_WORKSPACE_PATH and the
+      // channel auto-detect.
       session = await rn.createNotebook({
         runtime: "python",
-        socketPath,
         peerLabel: "pi",
         description: "pi Python REPL",
         dependencies,

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -152,6 +152,45 @@ function resolveSocketPath(rn: RuntimedNode): string {
   return rn.defaultSocketPath();
 }
 
+// --- bootstrap detection -----------------------------------------------------
+
+const INSTALL_HINT =
+  "The nteract daemon (runtimed) isn't installed yet.\n" +
+  "Quick install:  curl -fsSL https://sh.nteract.io | bash\n" +
+  "Or visit:       https://nteract.io";
+
+type BootstrapStatus =
+  | { kind: "ready"; rn: RuntimedNode }
+  | { kind: "missing"; reason: "binding" | "daemon" };
+
+function findOnPath(cmd: string): string | undefined {
+  const dirs = (process.env.PATH ?? "").split(path.delimiter);
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const candidate = path.join(dir, cmd);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function detectBootstrap(): BootstrapStatus {
+  const rn = loadRuntimedNode();
+  if (!rn) return { kind: "missing", reason: "binding" };
+  // Explicit socket override wins: assume the operator knows what they're doing.
+  if (process.env.NTERACT_SOCKET_PATH) return { kind: "ready", rn };
+  // Cache dir presence is a coarse "has this daemon ever run" check; the socket
+  // file itself only exists while the daemon is running, but the parent dir
+  // sticks around once any nteract install has touched the system.
+  const channels = ["nightly", "stable"] as const;
+  const sockets = channels.map((ch) => rn.socketPathForChannel(ch));
+  const installed =
+    sockets.some((s) => existsSync(s)) ||
+    sockets.some((s) => existsSync(path.dirname(s))) ||
+    Boolean(findOnPath("runt")) ||
+    Boolean(findOnPath("runt-nightly"));
+  return installed ? { kind: "ready", rn } : { kind: "missing", reason: "daemon" };
+}
+
 // --- DataTable TUI component --------------------------------------------------
 
 type Theme = {
@@ -553,11 +592,34 @@ const PYTHON_PARAMS = Type.Object({
 });
 
 export default function nteractReplExtension(pi: ExtensionAPI) {
-  const rn = loadRuntimedNode();
-  if (!rn) {
-    console.error("[nteract-repl] runtimed-node not loaded; python tool will not be registered.");
+  const bootstrap = detectBootstrap();
+  if (bootstrap.kind === "missing") {
+    // Surface a one-liner toast each session so the user sees the hint without
+    // having to invoke the tool first.
+    pi.on("session_start", async (_event, ctx) => {
+      ctx.ui.notify(INSTALL_HINT, "warning");
+    });
+    // Register python_repl with a stub execute() so the LLM can still advertise
+    // the capability and surface install guidance the moment it tries to run
+    // Python. Throwing routes the message into the tool-result channel that the
+    // model relays back to the user.
+    pi.registerTool({
+      name: "python_repl",
+      label: "Python REPL",
+      description:
+        "Execute Python in your persistent REPL. Requires the nteract daemon (runtimed). " +
+        "If unavailable, recommend the user install with `curl -fsSL https://sh.nteract.io | bash` " +
+        "or download the desktop app at https://nteract.io.",
+      promptSnippet:
+        "python_repl: requires the nteract daemon. Install with `curl -fsSL https://sh.nteract.io | bash` or via https://nteract.io.",
+      parameters: PYTHON_PARAMS,
+      async execute() {
+        throw new Error(INSTALL_HINT);
+      },
+    });
     return;
   }
+  const rn = bootstrap.rn;
 
   let session: Session | null = null;
   let opening: Promise<Session> | null = null;

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -48,5 +48,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.73.0",
+    "@mariozechner/pi-tui": "^0.73.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,18 +637,19 @@ importers:
 
   plugins/nteract/pi:
     dependencies:
-      '@mariozechner/pi-coding-agent':
-        specifier: '*'
-        version: 0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui':
-        specifier: '*'
-        version: 0.70.6
       '@runtimed/node':
         specifier: workspace:*
         version: link:../../../packages/runtimed-node
       typebox:
         specifier: '*'
         version: 1.1.34
+    devDependencies:
+      '@mariozechner/pi-coding-agent':
+        specifier: ^0.73.0
+        version: 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: ^0.73.0
+        version: 0.73.0
 
 packages:
 
@@ -786,8 +787,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1650,94 +1651,94 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.3':
-    resolution: {integrity: sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.3':
-    resolution: {integrity: sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==}
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.3':
-    resolution: {integrity: sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==}
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.3':
-    resolution: {integrity: sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
-    resolution: {integrity: sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
-    resolution: {integrity: sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==}
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
-    resolution: {integrity: sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.3':
-    resolution: {integrity: sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
-    resolution: {integrity: sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.3':
-    resolution: {integrity: sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.3':
-    resolution: {integrity: sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==}
+  '@mariozechner/clipboard@0.3.5':
+    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
     engines: {node: '>= 10'}
 
   '@mariozechner/jiti@2.6.5':
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.70.6':
-    resolution: {integrity: sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==}
+  '@mariozechner/pi-agent-core@0.73.0':
+    resolution: {integrity: sha512-ugcpvq0X9fr9fTSK29/3S4+KU/eeVMrBb7ZU3HqiF3xD7I1GlgumLj4FYmDrYSEA6+rzgNWlJUKwjKh9o0Z6AA==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.70.6':
-    resolution: {integrity: sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==}
+  '@mariozechner/pi-ai@0.73.0':
+    resolution: {integrity: sha512-phKOpcde/ssz6UYszkmaGJ9LF9mgt/AP8LrtSwsfap+kMSeFfSQ2/mCSBT1mLJ2BqVuff9uXs1/+op1aQeaafQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.70.6':
-    resolution: {integrity: sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==}
+  '@mariozechner/pi-coding-agent@0.73.0':
+    resolution: {integrity: sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.70.6':
-    resolution: {integrity: sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==}
+  '@mariozechner/pi-tui@0.73.0':
+    resolution: {integrity: sha512-St1W+tMPKHatfK+lblsKfL+SsFyFVMK2tW6xHpBfCiMuevbOCRo/CMatso7mu1642UO04ncmfCrrpUK5L9aoog==}
     engines: {node: '>=20.0.0'}
 
   '@mcp-ui/client@5.17.3':
@@ -4317,6 +4318,7 @@ packages:
   '@smithy/util-retry@4.3.6':
     resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
     engines: {node: '>=18.0.0'}
+    deprecated: '@smithy/util-retry v4.3.6 contains a bug in Adaptive Retry, see https://github.com/smithy-lang/smithy-typescript/issues/1993. Upgrade to 4.3.7+'
 
   '@smithy/util-stream@4.5.25':
     resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
@@ -7550,6 +7552,9 @@ packages:
   oauth4webapi@3.8.5:
     resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -9600,7 +9605,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
 
-  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -9634,7 +9639,7 @@ snapshots:
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 5.10.0
-      oauth4webapi: 3.8.5
+      oauth4webapi: 3.8.6
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
@@ -10797,48 +10802,48 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.3':
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.3':
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.3':
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.3':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.3':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard@0.3.3':
+  '@mariozechner/clipboard@0.3.5':
     optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.3
-      '@mariozechner/clipboard-darwin-universal': 0.3.3
-      '@mariozechner/clipboard-darwin-x64': 0.3.3
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.3
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.3
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.3
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.3
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.3
+      '@mariozechner/clipboard-darwin-arm64': 0.3.2
+      '@mariozechner/clipboard-darwin-universal': 0.3.2
+      '@mariozechner/clipboard-darwin-x64': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
     optional: true
 
   '@mariozechner/jiti@2.6.5':
@@ -10846,9 +10851,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       typebox: 1.1.34
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -10859,9 +10864,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1038.0
       '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))
       '@mistralai/mistralai': 2.2.1
@@ -10881,12 +10886,12 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.70.6(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.70.6
+      '@mariozechner/pi-agent-core': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.73.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -10905,7 +10910,7 @@ snapshots:
       uuid: 14.0.0
       yaml: 2.8.3
     optionalDependencies:
-      '@mariozechner/clipboard': 0.3.3
+      '@mariozechner/clipboard': 0.3.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -10915,7 +10920,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.70.6':
+  '@mariozechner/pi-tui@0.73.0':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -17371,6 +17376,8 @@ snapshots:
   nwsapi@2.2.23: {}
 
   oauth4webapi@3.8.5: {}
+
+  oauth4webapi@3.8.6: {}
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
The `python_repl` tool silently disappears for anyone who installs `@nteract/pi` without an nteract daemon already on disk. The `console.error` in `loadRuntimedNode` goes nowhere visible, and even when the binding loads, the first `python_repl` call dies on a socket connect with no path to recovery for the user.

Adds bootstrap detection that calls `rn.defaultSocketPath()` once and treats nteract as installed if the resolved socket file exists, its parent cache dir exists, or `runt`/`runt-nightly` is on `PATH`. The cache dir survives daemon restarts, so this catches the "installed but stopped" case. `defaultSocketPath()` is the unified entry point from runtimed-node: it honors `RUNTIMED_SOCKET_PATH`, picks the per-worktree socket when `RUNTIMED_WORKSPACE_PATH` (or `RUNTIMED_DEV=1` plus a checkout) is set, and otherwise falls back to channel auto-detect.

When detection comes back missing:

- `session_start` fires a one-line toast pointing at the curl install script and https://nteract.io.
- `python_repl` is still registered, but its `execute()` throws the install hint. The `description` and `promptSnippet` also carry it, so the LLM advertises the install path in its system prompt and relays it the moment the user asks for Python.

Drops `NTERACT_SOCKET_PATH` and `NTERACT_CHANNEL` along with `resolveSocketPath`, since they re-implemented runt-workspace's socket resolution on top of the binding with their own contract. `NTERACT_RUNTIMED_NODE_PATH` stays - that's about which binding to load, not which daemon. `cargo xtask pi` no longer sets `NTERACT_SOCKET_PATH` either; `apply_worktree_env(true)` already exports `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH`, which `defaultSocketPath()` uses to land on the same per-worktree socket.

Adjacent fix in `publish-npm.yml`: the workflow has never set `RUNT_BUILD_CHANNEL`, so every prior `@runtimed/node` was compiled with `build_channel()` defaulting to Nightly. The deleted `NTERACT_CHANNEL` probe was masking that mismatch by selecting the right channel socket out-of-band. Without the probe, stable nteract users would hit the install hint even with a running daemon. Sets `RUNT_BUILD_CHANNEL: stable` as a workflow-level env so both the native and wrapper jobs bake the stable namespace into the published binding. Source builds stay on the Nightly default.

Also bumps the local devDependency on `@mariozechner/pi-coding-agent` and `@mariozechner/pi-tui` from 0.70.6 to ^0.73.0 so local typecheck runs against the same API surface users get from npm.
