### PR TITLE
feat(notebook): add iframe output height toggle

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,11 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff } from "lucide-react";
+import {
+  ChevronRight,
+  Code2,
+  EyeOff,
+  SquareDashedMousePointer,
+  SquareMousePointer,
+} from "lucide-react";
 import {
   lazy,
   memo,
@@ -13,7 +19,7 @@ import {
 } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
-import { OutputArea } from "@/components/cell/OutputArea";
+import { anyOutputNeedsIsolation, OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -116,6 +122,7 @@ export const CodeCell = memo(function CodeCell({
   const isGroupExecuting = useIsGroupExecuting(hiddenGroupCellIds);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+  const [isIframeOutputExpanded, setIsIframeOutputExpanded] = useState(false);
   const presence = usePresenceContext();
   const { extension: crdtBridgeExt, bridge } = useCrdtBridge(cell.id);
   // Subscribe to outputs via the per-execution / per-output stores rather
@@ -125,6 +132,7 @@ export const CodeCell = memo(function CodeCell({
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
+  const hasConstrainedIframeOutput = anyOutputNeedsIsolation(outputs);
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -135,6 +143,12 @@ export const CodeCell = memo(function CodeCell({
   // Fully collapsed when source is hidden AND there's nothing else to show
   // (outputs explicitly hidden, or no outputs at all).
   const bothHidden = isSourceHidden && (isOutputsHidden || outputs.length === 0);
+
+  useEffect(() => {
+    if (!hasConstrainedIframeOutput || isOutputsHidden || outputs.length === 0) {
+      setIsIframeOutputExpanded(false);
+    }
+  }, [hasConstrainedIframeOutput, isOutputsHidden, outputs.length]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -388,20 +402,51 @@ export const CodeCell = memo(function CodeCell({
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
               onIframeMouseDown={onFocus}
+              expandIframeOutputs={isIframeOutputExpanded}
             />
           )
         }
         outputRightGutterContent={
-          onToggleOutputsHidden && outputs.length > 0 && !isOutputsHidden ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => onToggleOutputsHidden(true)}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
-              title="Hide outputs"
-            >
-              <EyeOff className="h-3.5 w-3.5" />
-            </button>
+          outputs.length > 0 &&
+          !isOutputsHidden &&
+          (hasConstrainedIframeOutput || onToggleOutputsHidden) ? (
+            <>
+              {hasConstrainedIframeOutput && (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-pressed={isIframeOutputExpanded}
+                  onClick={() => {
+                    setIsIframeOutputExpanded((expanded) => !expanded);
+                    onFocus();
+                  }}
+                  className={cn(
+                    "flex items-center justify-center rounded border p-1 transition-colors",
+                    isIframeOutputExpanded
+                      ? "border-ring/40 bg-accent text-foreground"
+                      : "border-transparent text-muted-foreground/40 hover:text-foreground",
+                  )}
+                  title={isIframeOutputExpanded ? "Constrain output height" : "Expand output"}
+                >
+                  {isIframeOutputExpanded ? (
+                    <SquareMousePointer className="h-3.5 w-3.5" />
+                  ) : (
+                    <SquareDashedMousePointer className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              )}
+              {onToggleOutputsHidden && (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={() => onToggleOutputsHidden(true)}
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+                  title="Hide outputs"
+                >
+                  <EyeOff className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </>
           ) : undefined
         }
         hideOutput={outputs.length === 0 || bothHidden}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -409,9 +409,7 @@ export const CodeCell = memo(function CodeCell({
           )
         }
         outputRightGutterContent={
-          outputs.length > 0 &&
-          !isOutputsHidden &&
-          (hasIsolatedOutput || onToggleOutputsHidden) ? (
+          outputs.length > 0 && !isOutputsHidden && (hasIsolatedOutput || onToggleOutputsHidden) ? (
             <>
               {hasIsolatedOutput && (
                 <button

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -132,7 +132,9 @@ export const CodeCell = memo(function CodeCell({
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
-  const hasConstrainedIframeOutput = anyOutputNeedsIsolation(outputs);
+  // CodeCell leaves OutputArea in its default `isolated="auto"` mode, so this
+  // matches whether the output row will render in the isolated iframe.
+  const hasIsolatedOutput = anyOutputNeedsIsolation(outputs);
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -145,10 +147,10 @@ export const CodeCell = memo(function CodeCell({
   const bothHidden = isSourceHidden && (isOutputsHidden || outputs.length === 0);
 
   useEffect(() => {
-    if (!hasConstrainedIframeOutput || isOutputsHidden || outputs.length === 0) {
+    if (!hasIsolatedOutput || isOutputsHidden || outputs.length === 0) {
       setIsIframeOutputExpanded(false);
     }
-  }, [hasConstrainedIframeOutput, isOutputsHidden, outputs.length]);
+  }, [hasIsolatedOutput, isOutputsHidden, outputs.length]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -409,9 +411,9 @@ export const CodeCell = memo(function CodeCell({
         outputRightGutterContent={
           outputs.length > 0 &&
           !isOutputsHidden &&
-          (hasConstrainedIframeOutput || onToggleOutputsHidden) ? (
+          (hasIsolatedOutput || onToggleOutputsHidden) ? (
             <>
-              {hasConstrainedIframeOutput && (
+              {hasIsolatedOutput && (
                 <button
                   type="button"
                   tabIndex={-1}
@@ -421,10 +423,10 @@ export const CodeCell = memo(function CodeCell({
                     onFocus();
                   }}
                   className={cn(
-                    "flex items-center justify-center rounded border p-1 transition-colors",
+                    "flex items-center justify-center rounded p-1 transition-colors",
                     isIframeOutputExpanded
-                      ? "border-ring/40 bg-accent text-foreground"
-                      : "border-transparent text-muted-foreground/40 hover:text-foreground",
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground/40 hover:text-foreground",
                   )}
                   title={isIframeOutputExpanded ? "Constrain output height" : "Expand output"}
                 >

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -138,7 +138,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 {/* Output row right gutter — always rendered as spacer for consistent width */}
                 <div
                   className={cn(
-                    "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
+                    "sticky top-2 flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
                     outputRightGutterContent && "opacity-100 transition-opacity duration-150",
                     outputRightGutterContent &&
                       "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -47,6 +47,11 @@ interface OutputAreaProps {
    */
   maxHeight?: number;
   /**
+   * When true, isolated iframe outputs grow to their full rendered height
+   * instead of using the output max-height cap.
+   */
+  expandIframeOutputs?: boolean;
+  /**
    * Additional CSS classes for the container.
    */
   className?: string;
@@ -149,7 +154,7 @@ function outputNeedsIsolation(
  * Check if any outputs in the array need iframe isolation.
  * If any output needs isolation, ALL outputs should go to the iframe.
  */
-function anyOutputNeedsIsolation(
+export function anyOutputNeedsIsolation(
   outputs: JupyterOutput[],
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {
@@ -246,6 +251,7 @@ export function OutputArea({
   collapsed = false,
   onToggleCollapse,
   maxHeight,
+  expandIframeOutputs = false,
   className,
   renderers,
   priority = DEFAULT_PRIORITY,
@@ -558,6 +564,7 @@ export function OutputArea({
                 colorTheme={colorTheme}
                 minHeight={24}
                 maxHeight={maxHeight ?? 2000}
+                autoHeight={expandIframeOutputs}
                 allowWheelBoundaryScroll
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   CommBridgeManager,
   type IframeToParentMessage,
@@ -20,6 +20,32 @@ import { cn } from "@/lib/utils";
 
 const handleIframeError = (err: { message: string; stack?: string }) =>
   console.error("[OutputArea] iframe error:", err);
+
+const DEFAULT_OUTPUT_WELL_VIEWPORT_RATIO = 0.75;
+const MIN_OUTPUT_WELL_HEIGHT = 360;
+
+function getDefaultOutputWellMaxHeight(): number {
+  if (typeof window === "undefined") return 720;
+  return Math.max(
+    MIN_OUTPUT_WELL_HEIGHT,
+    Math.floor(window.innerHeight * DEFAULT_OUTPUT_WELL_VIEWPORT_RATIO),
+  );
+}
+
+function useDefaultOutputWellMaxHeight(): number {
+  const [height, setHeight] = useState(getDefaultOutputWellMaxHeight);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setHeight(getDefaultOutputWellMaxHeight());
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return height;
+}
 
 import type { JupyterOutput } from "./jupyter-output";
 // Re-export so existing imports continue to work.
@@ -274,6 +300,7 @@ export function OutputArea({
 
   const darkMode = useDarkMode();
   const colorTheme = useColorTheme();
+  const defaultOutputWellMaxHeight = useDefaultOutputWellMaxHeight();
   const maxHeightStyle = useMemo(
     () => (maxHeight ? { maxHeight: `${maxHeight}px` } : undefined),
     [maxHeight],
@@ -291,6 +318,11 @@ export function OutputArea({
   const shouldIsolate =
     outputs.length > 0 &&
     (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
+  const shouldConstrainIsolatedOutput = shouldIsolate && !expandIframeOutputs;
+  const isolatedOutputWellMaxHeight = maxHeight ?? defaultOutputWellMaxHeight;
+  const isolatedOutputWellStyle = shouldConstrainIsolatedOutput
+    ? { maxHeight: `${isolatedOutputWellMaxHeight}px` }
+    : undefined;
 
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
@@ -552,8 +584,12 @@ export function OutputArea({
       {!collapsed && (
         <div
           id={id}
-          className={cn("space-y-2", maxHeight && "overflow-y-auto")}
-          style={maxHeightStyle}
+          className={cn(
+            "space-y-2",
+            !shouldIsolate && maxHeight && "overflow-y-auto",
+            shouldConstrainIsolatedOutput && "overflow-y-auto overscroll-contain",
+          )}
+          style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
         >
           {/* Preloaded or active isolated frame */}
           {(shouldIsolate || showPreloadedIframe) && (
@@ -563,8 +599,8 @@ export function OutputArea({
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 minHeight={24}
-                maxHeight={maxHeight ?? 2000}
-                autoHeight={expandIframeOutputs}
+                maxHeight={isolatedOutputWellMaxHeight}
+                autoHeight={shouldIsolate}
                 allowWheelBoundaryScroll
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -587,7 +587,7 @@ export function OutputArea({
           className={cn(
             "space-y-2",
             !shouldIsolate && maxHeight && "overflow-y-auto",
-            shouldConstrainIsolatedOutput && "overflow-y-auto overscroll-contain",
+            shouldConstrainIsolatedOutput && "overflow-y-auto",
           )}
           style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
         >

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -34,8 +34,8 @@ vi.mock("@/components/isolated", async () => {
 
   const MockIsolatedFrame = React.forwardRef<
     typeof mockFrameHandle,
-    { allowWheelBoundaryScroll?: boolean; onReady?: () => void }
-  >(function MockIsolatedFrame({ allowWheelBoundaryScroll, onReady }, ref) {
+    { allowWheelBoundaryScroll?: boolean; autoHeight?: boolean; onReady?: () => void }
+  >(function MockIsolatedFrame({ allowWheelBoundaryScroll, autoHeight, onReady }, ref) {
     React.useImperativeHandle(ref, () => mockFrameHandle);
 
     React.useEffect(() => {
@@ -45,6 +45,7 @@ vi.mock("@/components/isolated", async () => {
     return (
       <div
         data-allow-wheel-boundary-scroll={String(allowWheelBoundaryScroll)}
+        data-auto-height={String(autoHeight)}
         data-testid="isolated-frame"
       />
     );
@@ -120,5 +121,13 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
     );
+  });
+
+  it("can expand isolated iframe outputs past the default height cap", () => {
+    const { getByTestId } = render(
+      <OutputArea outputs={makeMarkdownOutput()} isolated expandIframeOutputs />,
+    );
+
+    expect(getByTestId("isolated-frame").getAttribute("data-auto-height")).toBe("true");
   });
 });

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -69,6 +69,10 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
 
 describe("OutputArea iframe theme sync", () => {
   beforeEach(() => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
     mockDarkMode = false;
     mockColorTheme = undefined;
     mockFrameHandle.send.mockClear();
@@ -123,11 +127,25 @@ describe("OutputArea iframe theme sync", () => {
     );
   });
 
-  it("can expand isolated iframe outputs past the default height cap", () => {
-    const { getByTestId } = render(
+  it("constrains isolated iframe outputs to a viewport-sized output well by default", () => {
+    const { container, getByTestId } = render(
+      <OutputArea outputs={makeMarkdownOutput()} isolated />,
+    );
+
+    const outputContent = container.querySelector('[data-slot="output-area"] > div');
+
+    expect(getByTestId("isolated-frame").getAttribute("data-auto-height")).toBe("true");
+    expect(outputContent?.getAttribute("class") ?? "").toContain("overflow-y-auto");
+    expect((outputContent as HTMLElement | null)?.style.maxHeight).toBe("600px");
+  });
+
+  it("can expand isolated iframe outputs past the default output well cap", () => {
+    const { container, getByTestId } = render(
       <OutputArea outputs={makeMarkdownOutput()} isolated expandIframeOutputs />,
     );
 
     expect(getByTestId("isolated-frame").getAttribute("data-auto-height")).toBe("true");
+    const outputContent = container.querySelector('[data-slot="output-area"] > div') as HTMLElement;
+    expect(outputContent.style.maxHeight).toBe("");
   });
 });

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { NTERACT_RENDERER_READY, NTERACT_THEME } from "../rpc-methods";
+import { NTERACT_RENDERER_READY, NTERACT_RESIZE, NTERACT_THEME } from "../rpc-methods";
 
 const { MockJsonRpcTransport } = vi.hoisted(() => {
   class MockJsonRpcTransport {
@@ -89,6 +89,31 @@ describe("IsolatedFrame theme updates", () => {
         isDark: false,
         colorTheme: "cream",
       });
+    });
+  });
+
+  it("re-applies the last measured content height when autoHeight changes", async () => {
+    const { container, rerender } = render(
+      <IsolatedFrame darkMode={false} maxHeight={2000} autoHeight={false} />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    act(() => {
+      transport.notificationHandlers.get(NTERACT_RESIZE)?.({ height: 2600 });
+    });
+
+    expect(iframe.style.height).toBe("2000px");
+
+    rerender(<IsolatedFrame darkMode={false} maxHeight={2000} autoHeight />);
+
+    await waitFor(() => {
+      expect(iframe.style.height).toBe("2600px");
     });
   });
 });

--- a/src/components/isolated/__tests__/scroll-boundary.test.ts
+++ b/src/components/isolated/__tests__/scroll-boundary.test.ts
@@ -85,6 +85,33 @@ describe("scroll-boundary", () => {
     expect(scrollContainer.scrollBy).not.toHaveBeenCalled();
   });
 
+  it("scrolls the next ancestor when the nearest scroll ancestor is at a boundary", () => {
+    const notebookScroller = document.createElement("div");
+    notebookScroller.style.overflowY = "auto";
+    setScrollMetrics(notebookScroller, 2000, 600);
+    notebookScroller.scrollTop = 200;
+    notebookScroller.scrollBy = vi.fn();
+
+    const outputWell = document.createElement("div");
+    outputWell.style.overflowY = "auto";
+    setScrollMetrics(outputWell, 1000, 400);
+    outputWell.scrollTop = 600;
+    outputWell.scrollBy = vi.fn();
+
+    const iframe = document.createElement("iframe");
+    outputWell.appendChild(iframe);
+    notebookScroller.appendChild(outputWell);
+    document.body.appendChild(notebookScroller);
+
+    scrollFrameWheelBoundary(iframe, { deltaY: 160 });
+
+    expect(outputWell.scrollBy).not.toHaveBeenCalled();
+    expect(notebookScroller.scrollBy).toHaveBeenCalledWith({
+      top: 160,
+      behavior: "auto",
+    });
+  });
+
   it("falls back to the owning window when no scroll ancestor exists", () => {
     const iframe = document.createElement("iframe");
     document.body.appendChild(iframe);

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -313,6 +313,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     // Use ref to track ready state for send callback (avoids stale closure)
     const isReadyRef = useRef(false);
     const [height, setHeight] = useState(minHeight);
+    const measuredHeightRef = useRef(minHeight);
     // Track if content has been rendered (for revealOnRender mode)
     const [isContentRendered, setIsContentRendered] = useState(false);
     // Track if the iframe is reloading (DOM move caused browser to tear down)
@@ -353,6 +354,22 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
     allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
+
+    const applyMeasuredHeight = useCallback(
+      (contentHeight: number) => {
+        measuredHeightRef.current = contentHeight;
+        const newHeight = autoHeight
+          ? Math.max(minHeight, contentHeight)
+          : Math.max(minHeight, Math.min(maxHeight, contentHeight));
+        setHeight(newHeight);
+        onResizeRef.current?.(newHeight);
+      },
+      [autoHeight, maxHeight, minHeight],
+    );
+
+    useEffect(() => {
+      applyMeasuredHeight(measuredHeightRef.current);
+    }, [applyMeasuredHeight]);
 
     // Create blob URL on mount (only once, with initial darkMode)
     useEffect(() => {
@@ -525,22 +542,14 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               transport.onNotification(NTERACT_RESIZE, (params) => {
                 const p = params as { height?: number };
                 if (p.height != null) {
-                  const newHeight = autoHeight
-                    ? Math.max(minHeight, p.height)
-                    : Math.max(minHeight, Math.min(maxHeight, p.height));
-                  setHeight(newHeight);
-                  onResizeRef.current?.(newHeight);
+                  applyMeasuredHeight(p.height);
                 }
               });
               transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {
                 const p = params as { height?: number };
                 if (p.height != null) {
                   setIsContentRendered(true);
-                  const newHeight = autoHeight
-                    ? Math.max(minHeight, p.height)
-                    : Math.max(minHeight, Math.min(maxHeight, p.height));
-                  setHeight(newHeight);
-                  onResizeRef.current?.(newHeight);
+                  applyMeasuredHeight(p.height);
                 }
               });
               transport.onNotification(NTERACT_LINK_CLICK, (params) => {
@@ -625,11 +634,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
           case "resize":
             if (data.payload?.height != null) {
-              const newHeight = autoHeight
-                ? Math.max(minHeight, data.payload.height)
-                : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
-              setHeight(newHeight);
-              onResizeRef.current?.(newHeight);
+              applyMeasuredHeight(data.payload.height);
             }
             break;
 
@@ -637,11 +642,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             // Content has been rendered - reveal iframe if in revealOnRender mode
             if (data.payload?.height != null) {
               setIsContentRendered(true);
-              const newHeight = autoHeight
-                ? Math.max(minHeight, data.payload.height)
-                : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
-              setHeight(newHeight);
-              onResizeRef.current?.(newHeight);
+              applyMeasuredHeight(data.payload.height);
             }
             break;
 
@@ -681,7 +682,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
       window.addEventListener("message", handleMessage);
       return () => window.removeEventListener("message", handleMessage);
-    }, [initialContent, minHeight, maxHeight, autoHeight]);
+    }, [initialContent, applyMeasuredHeight]);
 
     // Clean up JSON-RPC transport on unmount
     useEffect(() => {

--- a/src/components/isolated/scroll-boundary.ts
+++ b/src/components/isolated/scroll-boundary.ts
@@ -43,6 +43,19 @@ export function findVerticalScrollAncestor(start: Element | null): HTMLElement |
   return null;
 }
 
+function findVerticalScrollConsumer(start: Element | null, deltaY: number): HTMLElement | null {
+  let element = start instanceof HTMLElement ? start : (start?.parentElement ?? null);
+
+  while (element) {
+    if (canScrollVertically(element) && canConsumeScrollDelta(element, deltaY)) {
+      return element;
+    }
+    element = element.parentElement;
+  }
+
+  return null;
+}
+
 export function scrollFrameWheelBoundary(
   iframe: HTMLIFrameElement | null,
   params: NteractWheelBoundaryParams,
@@ -54,11 +67,8 @@ export function scrollFrameWheelBoundary(
     return;
   }
 
-  const scrollTarget = findVerticalScrollAncestor(iframe?.parentElement ?? null);
+  const scrollTarget = findVerticalScrollConsumer(iframe?.parentElement ?? null, deltaY);
   if (scrollTarget) {
-    if (!canConsumeScrollDelta(scrollTarget, deltaY)) {
-      return;
-    }
     scrollTarget.scrollBy({ top: deltaY, behavior: "auto" });
     return;
   }


### PR DESCRIPTION
## Summary

- Add a per-cell gutter toggle for expanding iframe-isolated outputs beyond the default height cap.
- Reuse the prior output-well icon family with constrained and expanded states.
- Thread an `expandIframeOutputs` prop through `OutputArea` to switch isolated frames from capped height to `autoHeight`.
- Keep output gutter controls sticky in tall output rows so the expand control remains reachable near the cutoff.
- Re-apply the iframe's last measured content height when switching between capped and expanded modes.
- Constrain tall isolated outputs with a viewport-sized parent output well so the default state scrolls instead of clipping iframe content.
- Chain wheel scrolling from a saturated output well to the notebook scroller.

## Verification

- `pnpm test:run src/components/isolated/__tests__/scroll-boundary.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm -C apps/notebook exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vp check apps/notebook/src/components/CodeCell.tsx src/components/cell/OutputArea.tsx src/components/isolated/scroll-boundary.ts src/components/isolated/__tests__/scroll-boundary.test.ts src/components/isolated/isolated-frame.tsx src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask clippy`
- `git diff --check -- apps/notebook/src/components/CodeCell.tsx src/components/cell/CellContainer.tsx src/components/cell/OutputArea.tsx src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/isolated-frame.tsx src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
