### PR TITLE
fix(settings): recover sync from canonical json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7124,6 +7124,7 @@ name = "runtimed-client"
 version = "2.4.3"
 dependencies = [
  "automerge",
+ "automerge-recovery",
  "base64 0.22.1",
  "build-metadata",
  "chrono",

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -32,6 +32,7 @@ base64 = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 uuid = { workspace = true }
 automerge = { workspace = true }
+automerge-recovery = { path = "../automerge-recovery" }
 schemars = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -20,11 +20,14 @@
 //! ```
 
 use std::path::Path;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::Transactable;
 use automerge::{AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
+use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRecoveryError};
 use log::info;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -450,6 +453,11 @@ pub struct SettingsDoc {
     doc: AutoCommit,
 }
 
+#[cfg(debug_assertions)]
+static PANIC_ON_NEXT_GENERATE_SYNC_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(debug_assertions)]
+static PANIC_ON_NEXT_RECEIVE_SYNC_CALLS: AtomicUsize = AtomicUsize::new(0);
+
 impl SettingsDoc {
     /// Create a new empty settings document with defaults.
     pub fn new() -> Self {
@@ -458,6 +466,14 @@ impl SettingsDoc {
 
         // Root-level scalars (Automerge stores strings; enums are serialized via Display)
         let _ = doc.put(automerge::ROOT, "theme", defaults.theme.to_string());
+        let _ = doc.put(
+            automerge::ROOT,
+            "color_theme",
+            match defaults.color_theme {
+                ColorTheme::Classic => "classic",
+                ColorTheme::Cream => "cream",
+            },
+        );
         let _ = doc.put(
             automerge::ROOT,
             "default_runtime",
@@ -500,6 +516,11 @@ impl SettingsDoc {
             let _ = doc.put_object(&conda_id, "default_packages", ObjType::List);
         }
 
+        // Nested pixi map with empty package list
+        if let Ok(pixi_id) = doc.put_object(automerge::ROOT, "pixi", ObjType::Map) {
+            let _ = doc.put_object(&pixi_id, "default_packages", ObjType::List);
+        }
+
         Self { doc }
     }
 
@@ -520,7 +541,7 @@ impl SettingsDoc {
                 {
                     Some(json) => {
                         info!("[settings] Loaded canonical settings from {:?}", json_path);
-                        return Self::from_json(&json);
+                        return Self::from_json_value(&json);
                     }
                     None => {
                         log::warn!(
@@ -565,12 +586,15 @@ impl SettingsDoc {
         settings
     }
 
-    /// Create a settings document from parsed JSON (for migration from settings.json).
-    fn from_json(json: &serde_json::Value) -> Self {
+    /// Create a settings document from parsed canonical settings JSON.
+    pub fn from_json_value(json: &serde_json::Value) -> Self {
         let mut settings = Self::new();
 
         if let Some(theme) = json.get("theme").and_then(|v| v.as_str()) {
             settings.put("theme", theme);
+        }
+        if let Some(color_theme) = json.get("color_theme").and_then(|v| v.as_str()) {
+            settings.put("color_theme", color_theme);
         }
         if let Some(runtime) = json.get("default_runtime").and_then(|v| v.as_str()) {
             settings.put("default_runtime", runtime);
@@ -659,7 +683,18 @@ impl SettingsDoc {
             settings.put_list("conda.default_packages", &conda_packages);
         }
 
+        let pixi_packages = Self::extract_packages_from_json(json, "pixi");
+        if !pixi_packages.is_empty() {
+            settings.put_list("pixi.default_packages", &pixi_packages);
+        }
+
         settings
+    }
+
+    /// Create a settings document from a materialized settings snapshot.
+    pub fn from_synced_settings(settings: &SyncedSettings) -> Self {
+        let json = serde_json::to_value(settings).unwrap_or_else(|_| serde_json::Value::Null);
+        Self::from_json_value(&json)
     }
 
     /// Extract packages from a nested JSON key (e.g. `uv.default_packages`).
@@ -1059,6 +1094,19 @@ impl SettingsDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
+    /// Generate a sync message while capturing Automerge panics at the document boundary.
+    pub fn generate_sync_message_recovering(
+        &mut self,
+        label: impl Into<String>,
+        peer_state: &mut sync::State,
+    ) -> Result<Option<sync::Message>, AutomergeRecoveryError> {
+        catch_automerge_panic(label, || {
+            #[cfg(debug_assertions)]
+            Self::panic_if_requested(&PANIC_ON_NEXT_GENERATE_SYNC_CALLS, "generate sync");
+            self.generate_sync_message(peer_state)
+        })
+    }
+
     /// Receive and apply a sync message from a peer.
     pub fn receive_sync_message(
         &mut self,
@@ -1066,6 +1114,25 @@ impl SettingsDoc {
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
         self.doc.sync().receive_sync_message(peer_state, message)
+    }
+
+    /// Receive a sync message while capturing Automerge panics at the document boundary.
+    pub fn receive_sync_message_recovering(
+        &mut self,
+        label: impl Into<String>,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<(), AutomergeOperationError> {
+        let label = label.into();
+        match catch_automerge_panic(label.clone(), || {
+            #[cfg(debug_assertions)]
+            Self::panic_if_requested(&PANIC_ON_NEXT_RECEIVE_SYNC_CALLS, "receive sync");
+            self.receive_sync_message(peer_state, message)
+        }) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+            Err(error) => Err(AutomergeOperationError::Panic(error)),
+        }
     }
 
     /// Current document heads. Used to detect whether a sync exchange
@@ -1087,7 +1154,12 @@ impl SettingsDoc {
         let mut changed = false;
 
         // Scalar fields — only update if present in JSON and different
-        for key in &["theme", "default_runtime", "default_python_env"] {
+        for key in &[
+            "theme",
+            "color_theme",
+            "default_runtime",
+            "default_python_env",
+        ] {
             if let Some(value) = json.get(key).and_then(|v| v.as_str()) {
                 let current = self.get(key);
                 if current.as_deref() != Some(value) {
@@ -1115,6 +1187,15 @@ impl SettingsDoc {
             let conda_packages = Self::extract_packages_from_json(json, "conda");
             if self.get_list("conda.default_packages") != conda_packages {
                 self.put_list("conda.default_packages", &conda_packages);
+                changed = true;
+            }
+        }
+
+        // Pixi packages
+        if json.get("pixi").is_some() {
+            let pixi_packages = Self::extract_packages_from_json(json, "pixi");
+            if self.get_list("pixi.default_packages") != pixi_packages {
+                self.put_list("pixi.default_packages", &pixi_packages);
                 changed = true;
             }
         }
@@ -1248,6 +1329,30 @@ impl SettingsDoc {
 
         changed
     }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn __panic_on_next_generate_sync_calls_for_test(count: usize) {
+        PANIC_ON_NEXT_GENERATE_SYNC_CALLS.store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn __panic_on_next_receive_sync_calls_for_test(count: usize) {
+        PANIC_ON_NEXT_RECEIVE_SYNC_CALLS.store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(debug_assertions)]
+    fn panic_if_requested(counter: &AtomicUsize, operation: &str) {
+        if counter
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            panic!("injected settings {operation} panic");
+        }
+    }
 }
 
 impl Default for SettingsDoc {
@@ -1326,6 +1431,7 @@ mod tests {
         assert_eq!(settings.pixi_pool_size, DEFAULT_POOL_SIZE);
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
+        assert!(settings.pixi.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
     }
 
@@ -1914,11 +2020,13 @@ mod tests {
         let json = serde_json::json!({
             "uv": { "default_packages": ["numpy", "pandas"] },
             "conda": { "default_packages": ["scipy"] },
+            "pixi": { "default_packages": ["polars"] },
         });
         let changed = doc.apply_json_changes(&json);
         assert!(changed);
         assert_eq!(doc.get_list("uv.default_packages"), vec!["numpy", "pandas"]);
         assert_eq!(doc.get_list("conda.default_packages"), vec!["scipy"]);
+        assert_eq!(doc.get_list("pixi.default_packages"), vec!["polars"]);
     }
 
     #[test]
@@ -2063,12 +2171,85 @@ mod tests {
             "keep_alive_secs": null
         });
 
-        let doc = SettingsDoc::from_json(&json);
+        let doc = SettingsDoc::from_json_value(&json);
         let settings = doc.get_all();
 
         // Should be MAX_KEEP_ALIVE_SECS, not the default 30s
         assert_eq!(settings.keep_alive_secs, MAX_KEEP_ALIVE_SECS);
         assert_eq!(settings.theme, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn test_from_json_value_imports_color_theme_and_pixi_packages() {
+        let json = serde_json::json!({
+            "theme": "dark",
+            "color_theme": "cream",
+            "pixi": { "default_packages": ["numpy", "polars"] },
+        });
+
+        let doc = SettingsDoc::from_json_value(&json);
+        let settings = doc.get_all();
+
+        assert_eq!(settings.theme, ThemeMode::Dark);
+        assert_eq!(settings.color_theme, ColorTheme::Cream);
+        assert_eq!(
+            settings.pixi.default_packages,
+            vec!["numpy".to_string(), "polars".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_from_synced_settings_round_trips_pixi_packages() {
+        let settings = SyncedSettings {
+            color_theme: ColorTheme::Cream,
+            pixi: PixiDefaults {
+                default_packages: vec!["numpy".to_string(), "polars".to_string()],
+            },
+            ..SyncedSettings::default()
+        };
+
+        let doc = SettingsDoc::from_synced_settings(&settings);
+        assert_eq!(doc.get_all(), settings);
+    }
+
+    #[test]
+    fn test_recovering_generate_sync_catches_injected_panic() {
+        let mut doc = SettingsDoc::new();
+        let mut peer_state = sync::State::new();
+
+        SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
+        let error = doc
+            .generate_sync_message_recovering("settings-test-generate", &mut peer_state)
+            .expect_err("injected panic should be captured");
+
+        assert_eq!(error.label, "settings-test-generate");
+        assert!(error.panic_message.contains("generate sync"));
+    }
+
+    #[test]
+    fn test_recovering_receive_sync_catches_injected_panic() {
+        let mut sender = SettingsDoc::new();
+        sender.put("theme", "dark");
+        let mut sender_state = sync::State::new();
+        let message = sender
+            .generate_sync_message(&mut sender_state)
+            .expect("sender should generate sync message");
+
+        let mut receiver = SettingsDoc::new();
+        let mut receiver_state = sync::State::new();
+
+        SettingsDoc::__panic_on_next_receive_sync_calls_for_test(1);
+        let error = receiver
+            .receive_sync_message_recovering("settings-test-receive", &mut receiver_state, message)
+            .expect_err("injected panic should be captured");
+
+        match error {
+            AutomergeOperationError::Panic(error) => {
+                assert_eq!(error.label, "settings-test-receive");
+                assert!(error.panic_message.contains("receive sync"));
+            }
+            other => panic!("expected panic recovery error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -693,7 +693,7 @@ impl SettingsDoc {
 
     /// Create a settings document from a materialized settings snapshot.
     pub fn from_synced_settings(settings: &SyncedSettings) -> Self {
-        let json = serde_json::to_value(settings).unwrap_or_else(|_| serde_json::Value::Null);
+        let json = serde_json::to_value(settings).unwrap_or(serde_json::Value::Null);
         Self::from_json_value(&json)
     }
 

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -693,7 +693,10 @@ impl SettingsDoc {
 
     /// Create a settings document from a materialized settings snapshot.
     pub fn from_synced_settings(settings: &SyncedSettings) -> Self {
-        let json = serde_json::to_value(settings).unwrap_or(serde_json::Value::Null);
+        let json = match serde_json::to_value(settings) {
+            Ok(json) => json,
+            Err(error) => unreachable!("SyncedSettings serializes: {error}"),
+        };
         Self::from_json_value(&json)
     }
 

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -202,6 +202,9 @@ fn recover_settings_doc_reset_peer_and_retry_generate(
         "[sync] Rebuilding settings doc from JSON after Automerge panic: {}",
         error
     );
+    // A receive-side panic means we cannot prove the inbound client edit
+    // applied cleanly. Rebuild from durable JSON truth and resync the peer
+    // instead of replaying the same sync message into a recovered document.
     recover_settings_doc_from_json_or_snapshot(doc, json_path, fallback);
     *peer_state = sync::State::new();
 

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -173,6 +173,9 @@ fn apply_incoming_settings_sync_frame(
             })
         }
         Err(AutomergeOperationError::Panic(error)) => {
+            // We cannot prove the inbound client edit applied cleanly after a
+            // receive-side panic. Rebuild from durable JSON truth and resync
+            // instead of replaying the same message into a recovered document.
             let reply = recover_settings_doc_reset_peer_and_retry_generate(
                 doc,
                 peer_state,
@@ -202,9 +205,6 @@ fn recover_settings_doc_reset_peer_and_retry_generate(
         "[sync] Rebuilding settings doc from JSON after Automerge panic: {}",
         error
     );
-    // A receive-side panic means we cannot prove the inbound client edit
-    // applied cleanly. Rebuild from durable JSON truth and resync the peer
-    // instead of replaying the same sync message into a recovered document.
     recover_settings_doc_from_json_or_snapshot(doc, json_path, fallback);
     *peer_state = sync::State::new();
 

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -8,12 +8,13 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use automerge::sync;
+use automerge_recovery::{AutomergeOperationError, AutomergeRecoveryError};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
 use crate::connection;
-use crate::settings_doc::SettingsDoc;
+use crate::settings_doc::{SettingsDoc, SyncedSettings};
 
 /// Check if an error is just a normal connection close.
 pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {
@@ -56,8 +57,12 @@ where
     {
         let encoded = {
             let mut doc = settings.write().await;
-            doc.generate_sync_message(&mut peer_state)
-                .map(|msg| msg.encode())
+            generate_settings_sync_frame(
+                &mut doc,
+                &mut peer_state,
+                &json_path,
+                "settings-sync-initial-generate",
+            )?
         };
         if let Some(data) = encoded {
             connection::send_frame(&mut writer, &data).await?;
@@ -74,25 +79,22 @@ where
                         let message = sync::Message::decode(&data)
                             .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
 
-                        let mut doc = settings.write().await;
-                        // Compare heads before/after so pure acks or duplicate
-                        // messages don't fire `settings_changed`. Without this
-                        // the pool warming loops wake up on every sync-protocol
-                        // round-trip, which thrashes the pools when several
-                        // per-`invoke` clients land back-to-back (#2120).
-                        let before = doc.heads();
-                        doc.receive_sync_message(&mut peer_state, message)?;
-                        let after = doc.heads();
-                        let doc_changed = before != after;
+                        let outcome = {
+                            let mut doc = settings.write().await;
+                            apply_incoming_settings_sync_frame(
+                                &mut doc,
+                                &mut peer_state,
+                                message,
+                                &json_path,
+                            )?
+                        };
 
-                        if doc_changed {
-                            persist_settings(&doc, &json_path);
+                        if outcome.broadcast_changed {
                             let _ = changed_tx.send(());
                         }
 
-                        // Send our response
-                        if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                            connection::send_frame(&mut writer, &reply.encode()).await?;
+                        if let Some(reply) = outcome.reply {
+                            connection::send_frame(&mut writer, &reply).await?;
                         }
                     }
                     None => {
@@ -104,18 +106,275 @@ where
 
             // Another peer changed settings -- push update to this client
             _ = changed_rx.recv() => {
-                let mut doc = settings.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    connection::send_frame(&mut writer, &msg.encode()).await?;
+                let encoded = {
+                    let mut doc = settings.write().await;
+                    generate_settings_sync_frame(
+                        &mut doc,
+                        &mut peer_state,
+                        &json_path,
+                        "settings-sync-broadcast-generate",
+                    )?
+                };
+                if let Some(msg) = encoded {
+                    connection::send_frame(&mut writer, &msg).await?;
                 }
             }
         }
     }
 }
 
+struct IncomingSettingsSyncOutcome {
+    reply: Option<Vec<u8>>,
+    broadcast_changed: bool,
+}
+
+fn generate_settings_sync_frame(
+    doc: &mut SettingsDoc,
+    peer_state: &mut sync::State,
+    json_path: &Path,
+    label: &'static str,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let fallback = doc.get_all();
+    match doc.generate_sync_message_recovering(label, peer_state) {
+        Ok(message) => Ok(message.map(|msg| msg.encode())),
+        Err(error) => recover_settings_doc_reset_peer_and_retry_generate(
+            doc, peer_state, json_path, &fallback, label, error,
+        ),
+    }
+}
+
+fn apply_incoming_settings_sync_frame(
+    doc: &mut SettingsDoc,
+    peer_state: &mut sync::State,
+    message: sync::Message,
+    json_path: &Path,
+) -> anyhow::Result<IncomingSettingsSyncOutcome> {
+    let fallback = doc.get_all();
+
+    // Compare heads before/after so pure acks or duplicate messages don't fire
+    // `settings_changed`. Without this the pool warming loops wake up on every
+    // sync-protocol round-trip, which thrashes the pools when several
+    // per-`invoke` clients land back-to-back (#2120).
+    let before = doc.heads();
+    match doc.receive_sync_message_recovering("settings-sync-receive", peer_state, message) {
+        Ok(()) => {
+            let after = doc.heads();
+            let doc_changed = before != after;
+
+            if doc_changed {
+                persist_settings(doc, json_path);
+            }
+
+            let reply =
+                generate_settings_sync_frame(doc, peer_state, json_path, "settings-sync-reply")?;
+            Ok(IncomingSettingsSyncOutcome {
+                reply,
+                broadcast_changed: doc_changed,
+            })
+        }
+        Err(AutomergeOperationError::Panic(error)) => {
+            let reply = recover_settings_doc_reset_peer_and_retry_generate(
+                doc,
+                peer_state,
+                json_path,
+                &fallback,
+                "settings-sync-receive-recovery-generate",
+                error,
+            )?;
+            Ok(IncomingSettingsSyncOutcome {
+                reply,
+                broadcast_changed: false,
+            })
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn recover_settings_doc_reset_peer_and_retry_generate(
+    doc: &mut SettingsDoc,
+    peer_state: &mut sync::State,
+    json_path: &Path,
+    fallback: &SyncedSettings,
+    retry_label: &'static str,
+    error: AutomergeRecoveryError,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    warn!(
+        "[sync] Rebuilding settings doc from JSON after Automerge panic: {}",
+        error
+    );
+    recover_settings_doc_from_json_or_snapshot(doc, json_path, fallback);
+    *peer_state = sync::State::new();
+
+    doc.generate_sync_message_recovering(retry_label, peer_state)
+        .map(|message| message.map(|msg| msg.encode()))
+        .map_err(|retry_error| {
+            anyhow::anyhow!(
+                "[sync] settings sync recovery retry failed after Automerge panic: {}",
+                retry_error
+            )
+        })
+}
+
+fn recover_settings_doc_from_json_or_snapshot(
+    doc: &mut SettingsDoc,
+    json_path: &Path,
+    fallback: &SyncedSettings,
+) {
+    match load_settings_doc_from_json(json_path) {
+        Ok(recovered) => {
+            *doc = recovered;
+        }
+        Err(error) => {
+            warn!(
+                "[sync] Failed to reload canonical settings.json during recovery: {}; using last-known-good settings snapshot",
+                error
+            );
+            *doc = SettingsDoc::from_synced_settings(fallback);
+        }
+    }
+}
+
+fn load_settings_doc_from_json(json_path: &Path) -> anyhow::Result<SettingsDoc> {
+    let contents = std::fs::read_to_string(json_path)?;
+    let json = serde_json::from_str::<serde_json::Value>(&contents)?;
+    Ok(SettingsDoc::from_json_value(&json))
+}
+
 /// Persist the settings document to the canonical JSON file.
 fn persist_settings(doc: &SettingsDoc, json_path: &Path) {
     if let Err(e) = doc.save_json_mirror(json_path) {
         warn!("[sync] Failed to write settings.json: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings_doc::{ColorTheme, SyncedSettings, ThemeMode};
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn write_settings_json(path: &Path, settings: &SyncedSettings) {
+        let json = serde_json::to_string_pretty(settings).expect("settings serialize");
+        std::fs::write(path, json).expect("settings write");
+    }
+
+    #[test]
+    #[serial(settings_sync_panic_hooks)]
+    fn generate_panic_rebuilds_from_canonical_json_and_retries() {
+        let tmp = TempDir::new().expect("temp dir");
+        let json_path = tmp.path().join("settings.json");
+        let canonical = SyncedSettings {
+            theme: ThemeMode::Dark,
+            color_theme: ColorTheme::Cream,
+            ..SyncedSettings::default()
+        };
+        write_settings_json(&json_path, &canonical);
+
+        let mut doc = SettingsDoc::new();
+        doc.put("theme", "light");
+        let mut peer_state = sync::State::new();
+
+        SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
+        let frame = generate_settings_sync_frame(
+            &mut doc,
+            &mut peer_state,
+            &json_path,
+            "settings-test-generate",
+        )
+        .expect("recovery should retry generate");
+
+        assert!(frame.is_some());
+        assert_eq!(doc.get_all(), canonical);
+    }
+
+    #[test]
+    #[serial(settings_sync_panic_hooks)]
+    fn receive_panic_does_not_persist_or_broadcast_client_edit() {
+        let tmp = TempDir::new().expect("temp dir");
+        let json_path = tmp.path().join("settings.json");
+        let canonical = SyncedSettings::default();
+        write_settings_json(&json_path, &canonical);
+
+        let mut server = SettingsDoc::from_synced_settings(&canonical);
+        let mut server_peer_state = sync::State::new();
+
+        let mut client = SettingsDoc::new();
+        client.put("theme", "dark");
+        let mut client_state = sync::State::new();
+        let message = client
+            .generate_sync_message(&mut client_state)
+            .expect("client should generate settings edit");
+
+        SettingsDoc::__panic_on_next_receive_sync_calls_for_test(1);
+        let outcome = apply_incoming_settings_sync_frame(
+            &mut server,
+            &mut server_peer_state,
+            message,
+            &json_path,
+        )
+        .expect("receive panic should recover to canonical settings");
+
+        assert!(outcome.reply.is_some());
+        assert!(!outcome.broadcast_changed);
+        assert_eq!(server.get_all(), canonical);
+
+        let saved = std::fs::read_to_string(&json_path).expect("settings read");
+        let saved: SyncedSettings = serde_json::from_str(&saved).expect("settings parse");
+        assert_eq!(saved.theme, ThemeMode::System);
+    }
+
+    #[test]
+    #[serial(settings_sync_panic_hooks)]
+    fn invalid_json_recovery_keeps_last_known_good_and_file_contents() {
+        let tmp = TempDir::new().expect("temp dir");
+        let json_path = tmp.path().join("settings.json");
+        std::fs::write(&json_path, "{ invalid json").expect("settings write");
+
+        let snapshot = SyncedSettings {
+            theme: ThemeMode::Dark,
+            color_theme: ColorTheme::Cream,
+            ..SyncedSettings::default()
+        };
+        let mut doc = SettingsDoc::from_synced_settings(&snapshot);
+        let mut peer_state = sync::State::new();
+
+        SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
+        let frame = generate_settings_sync_frame(
+            &mut doc,
+            &mut peer_state,
+            &json_path,
+            "settings-test-generate-invalid-json",
+        )
+        .expect("invalid JSON should fall back to last-known-good snapshot");
+
+        assert!(frame.is_some());
+        assert_eq!(doc.get_all(), snapshot);
+        assert_eq!(
+            std::fs::read_to_string(&json_path).expect("settings read"),
+            "{ invalid json"
+        );
+    }
+
+    #[test]
+    #[serial(settings_sync_panic_hooks)]
+    fn repeated_generate_panic_after_recovery_returns_error() {
+        let tmp = TempDir::new().expect("temp dir");
+        let json_path = tmp.path().join("settings.json");
+        write_settings_json(&json_path, &SyncedSettings::default());
+
+        let mut doc = SettingsDoc::new();
+        let mut peer_state = sync::State::new();
+
+        SettingsDoc::__panic_on_next_generate_sync_calls_for_test(2);
+        let error = generate_settings_sync_frame(
+            &mut doc,
+            &mut peer_state,
+            &json_path,
+            "settings-test-repeated-generate",
+        )
+        .expect_err("second generate panic should close this sync path");
+
+        assert!(error.to_string().contains("recovery retry failed"));
     }
 }


### PR DESCRIPTION
## Summary

- treat daemon settings sync panics as recoverable transport failures by rebuilding `SettingsDoc` from canonical `settings.json`
- reset the affected peer sync state and retry outbound settings sync once
- keep last-known-good in-memory settings when `settings.json` is invalid, without rewriting the file
- fill JSON authority gaps for `color_theme` and `pixi.default_packages`

## Tests

- `cargo test -p runtimed-client settings_doc`
- `cargo test -p runtimed sync_server::tests`
- `cargo test -p runtimed --test integration test_external_settings_json_edit_survives_settings_sync_ack`
- `cargo test -p runtimed --test integration test_settings_json_mirror_write_does_not_feedback_loop`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo check --package runtimed`
- `cargo clippy -p runtimed-client -p runtimed --all-targets -- -D warnings`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` completed successfully with an existing TypeScript warning in `plugins/nteract/pi/extensions/repl.ts` about `new Array(singleArgument)`.
