### PR TITLE
fix(daemon): prevent orphan kernel leak from stale peer connections

### DIFF
--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -311,6 +311,12 @@ async fn main() -> ExitCode {
         }
     }
 
+    // Shut down the child process before exiting. Without this, the Tokio
+    // runtime teardown races the `wait_for_child` detached task — if the
+    // runtime drops first, the child survives as an orphan, holding its
+    // daemon peer connection open and preventing room eviction.
+    proxy_ref.shutdown_child().await;
+
     ExitCode::SUCCESS
 }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -734,6 +734,24 @@ impl McpProxy {
         self.state.read().await.last_restart_time
     }
 
+    /// Explicitly shut down the child process before the proxy exits.
+    ///
+    /// Without this, Tokio runtime teardown races the detached `wait_for_child`
+    /// task — if the runtime drops first, the `shutdown_tx` signal from
+    /// `ManagedChildTransport::Drop` is never processed and the child survives
+    /// as an orphan, holding its daemon peer connection open and preventing room
+    /// eviction.
+    pub async fn shutdown_child(&self) {
+        let old = {
+            let mut state = self.state.write().await;
+            state.child_client.take()
+        };
+        if let Some(child) = old {
+            info!("Shutting down child process before proxy exit");
+            let _ = child.cancel().await;
+        }
+    }
+
     // ── Internal helpers ──────────────────────────────────────────────
 
     async fn try_forward_tool_call(

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1426,6 +1426,22 @@ impl Daemon {
         std::time::Duration::from_secs(secs)
     }
 
+    /// Idle peer timeout — how long a connected peer can go without sending
+    /// any inbound frames before the daemon forcibly disconnects it.
+    ///
+    /// This is a safety net for orphaned connections (e.g. a proxy process that
+    /// exited without cleanly closing its socket). In production the MCP child
+    /// sends periodic Automerge sync and presence frames, so a healthy peer
+    /// never hits this. In test mode the timeout is shorter to keep tests fast.
+    pub fn idle_peer_timeout(&self) -> std::time::Duration {
+        if self.config.room_eviction_delay_ms.is_some() {
+            // Tests: 30 seconds
+            return std::time::Duration::from_secs(30);
+        }
+        // Production: 5 minutes
+        std::time::Duration::from_secs(300)
+    }
+
     /// Run the daemon server.
     pub async fn run(self: Arc<Self>) -> anyhow::Result<()> {
         // Platform-specific setup

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -154,6 +154,13 @@ where
     // arm wins mid-payload (see issue + production diagnostics).
     let mut framed_reader = connection::FramedReader::spawn(reader, 16);
 
+    // Idle peer timeout: disconnect peers that stop sending inbound frames.
+    // This is the safety net for orphaned connections where the remote process
+    // exited without closing its socket (e.g. proxy runtime teardown race).
+    let idle_peer_timeout = daemon.idle_peer_timeout();
+    let idle_deadline = tokio::time::sleep(idle_peer_timeout);
+    tokio::pin!(idle_deadline);
+
     // Steady state: exchange client frames and broadcast room changes.
     loop {
         tokio::select! {
@@ -181,6 +188,17 @@ where
                 };
             }
 
+            // Idle peer timeout: no inbound frames within the deadline.
+            // Fires when the remote peer is an orphan (process exited without
+            // closing the socket) or genuinely idle beyond the configured limit.
+            _ = &mut idle_deadline => {
+                warn!(
+                    "[notebook-sync] Idle peer timeout for {} (peer_id={}, no inbound frames for {:?})",
+                    notebook_id, peer_id, idle_peer_timeout
+                );
+                return Ok(());
+            }
+
             // Incoming message from this client (cancel-safe via FramedReader actor)
             maybe_frame = framed_reader.recv() => {
                 let frame = match maybe_frame {
@@ -188,6 +206,8 @@ where
                     Some(Err(e)) => return Err(e.into()),
                     None => return Ok(()), // clean EOF
                 };
+                // Reset idle deadline — this peer is alive.
+                idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 let notebook_doc_effects = match handle_notebook_doc_frame(

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -206,8 +206,18 @@ where
                     Some(Err(e)) => return Err(e.into()),
                     None => return Ok(()), // clean EOF
                 };
-                // Reset idle deadline — this peer is alive.
-                idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
+                // Reset idle deadline only for frames that represent genuine
+                // client intent — Request (tool calls) and Presence (cursor/focus).
+                // Automerge sync and state sync frames are reflexive: the daemon
+                // sends changes, the client ACKs. That loop would keep an orphan
+                // peer alive forever because daemon-side writes trigger client
+                // responses indefinitely.
+                if matches!(
+                    frame.frame_type,
+                    NotebookFrameType::Request | NotebookFrameType::Presence
+                ) {
+                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
+                }
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 let notebook_doc_effects = match handle_notebook_doc_frame(


### PR DESCRIPTION
## Summary

- **Belt**: `nteract-mcp` now explicitly shuts down its child process before exiting, preventing Tokio runtime teardown from racing the detached `wait_for_child` task that would otherwise leave `runt-nightly mcp` alive as an orphan.
- **Suspenders**: Daemon-side idle peer timeout (5 min production, 30s test) disconnects any peer that hasn't sent inbound frames, catching edge cases where the proxy-side fix can't fire (SIGKILL, OOM, etc).
- Together these ensure `active_peers` accurately reflects live peers, so room eviction (and kernel shutdown) always fires after all clients disconnect.

## Root cause

When `nteract-mcp` exits, `ManagedChildTransport::Drop` sends a `shutdown_tx` signal. But the receiver lives in a detached Tokio task — if the runtime shuts down before the task processes the signal, the child (`runt-nightly mcp`) survives as an orphan. It holds its daemon Unix socket open, keeping `active_peers > 0` and permanently preventing room eviction + kernel shutdown.

## State invariant

`active_peers` accurately reflects the count of live, communicating peers. The idle timeout adds a transition from `connected+idle → disconnected` after the configured duration, ensuring room eviction eventually fires even when socket close notifications are lost.

## Test plan

- [x] `cargo xtask lint --fix` — all checks passed
- [x] `cargo test -p runtimed --test tokio_mutex_lint` — no mutex guards across await
- [x] `cargo test -p runtimed --test integration` — 36/37 pass (1 pre-existing failure unrelated to this change)
- [x] `cargo test -p runt-mcp-proxy` — 94/94 pass
- [ ] Gremlin suite re-run to confirm no orphaned sessions after completion