### PR TITLE
chore(deps): rename runtimelib to jupyter-zmq-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2162,7 +2162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2777,7 +2777,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3324,7 +3324,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3755,8 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "2.0.0"
-source = "git+https://github.com/runtimed/runtimed?rev=f982d30bc6c3ed699f7e0356703dea4f85ac7b64#f982d30bc6c3ed699f7e0356703dea4f85ac7b64"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f447d9d9ecd2619ed9df7c6a96095d813670325b80374909b635d7f2028368d1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3766,6 +3767,30 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "jupyter-zmq-client"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f00de3352a50889bb692b3c28db311df9109a3d524a0b47e48a9d45e100cb7"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "data-encoding",
+ "dirs",
+ "futures",
+ "glob",
+ "jupyter-protocol",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "zeromq",
 ]
 
 [[package]]
@@ -3832,7 +3857,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4295,7 +4320,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4399,7 +4424,8 @@ dependencies = [
 [[package]]
 name = "nbformat"
 version = "3.0.0"
-source = "git+https://github.com/runtimed/runtimed?rev=f982d30bc6c3ed699f7e0356703dea4f85ac7b64#f982d30bc6c3ed699f7e0356703dea4f85ac7b64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c06543f305caee515923b125a737c4d58079c063e25701f93f45077bb8d622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4668,7 +4694,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4778,7 +4804,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5144,7 +5170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6953,6 +6979,7 @@ dependencies = [
  "flate2",
  "futures",
  "jupyter-protocol",
+ "jupyter-zmq-client",
  "kernel-env",
  "libc",
  "notebook-doc",
@@ -6963,7 +6990,6 @@ dependencies = [
  "runt-mcp",
  "runt-workspace",
  "runtimed-client",
- "runtimelib",
  "serde",
  "serde_json",
  "tabled",
@@ -7076,6 +7102,7 @@ dependencies = [
  "hyper-util",
  "jiter",
  "jupyter-protocol",
+ "jupyter-zmq-client",
  "kernel-env",
  "kernel-launch",
  "libc",
@@ -7103,7 +7130,6 @@ dependencies = [
  "runt-workspace",
  "runtime-doc",
  "runtimed-client",
- "runtimelib",
  "rusqlite",
  "serde",
  "serde_json",
@@ -7213,29 +7239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "runtimelib"
-version = "2.0.0"
-source = "git+https://github.com/runtimed/runtimed?rev=f982d30bc6c3ed699f7e0356703dea4f85ac7b64#f982d30bc6c3ed699f7e0356703dea4f85ac7b64"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "data-encoding",
- "dirs",
- "futures",
- "glob",
- "jupyter-protocol",
- "serde",
- "serde_json",
- "shellexpand",
- "thiserror 2.0.18",
- "tokio",
- "uuid",
- "zeromq",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7304,7 +7307,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8073,7 +8076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8997,7 +9000,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10344,7 +10347,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11198,9 +11201,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeromq"
-version = "0.6.0-pre.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92d9897a1fefd826fbbfc98b11ef50aba2e37a425142163f1792744c701b6d2"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64", default-features = false }
-jupyter-protocol = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64" }
-nbformat = { git = "https://github.com/runtimed/runtimed", rev = "f982d30bc6c3ed699f7e0356703dea4f85ac7b64" }
+jupyter-zmq-client = { version = "1.0.0", default-features = false }
+jupyter-protocol = "2.0.1"
+nbformat = "3.0.0"
 automerge = { git = "https://github.com/nteract/automerge", rev = "4a605a43586e08de090bb1321b661b15c1e71962" }
 thiserror = "2"
 schemars = "1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fast, modern toolkit for Jupyter notebooks. Native desktop app with instant startup, realtime sync across windows and agents, and intelligent environment management.
 
-Built on [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
+Built on [jupyter-zmq-client](https://crates.io/crates/jupyter-zmq-client) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
 
 ## Install
 
@@ -195,7 +195,7 @@ cargo clippy --all-targets -- -D warnings               # Lint Rust
 The underlying Rust libraries are published to crates.io:
 
 - [`jupyter-protocol`](https://crates.io/crates/jupyter-protocol) — Jupyter messaging protocol
-- [`runtimelib`](https://crates.io/crates/runtimelib) — Jupyter kernel interactions over ZeroMQ
+- [`jupyter-zmq-client`](https://crates.io/crates/jupyter-zmq-client) - Jupyter kernel interactions over ZeroMQ
 - [`nbformat`](https://crates.io/crates/nbformat) — Notebook parsing
 
 ## Contributing

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,11 +78,11 @@ cargo xtask build
 
 ### Testing with local library changes
 
-To test against unpublished runtimelib/jupyter-protocol changes, add to the root `Cargo.toml`:
+To test against unpublished jupyter-zmq-client/jupyter-protocol changes, add to the root `Cargo.toml`:
 
 ```toml
 [patch.crates-io]
-runtimelib = { path = "../runtimed/crates/runtimelib" }
+jupyter-zmq-client = { path = "../runtimed/crates/jupyter-zmq-client" }
 jupyter-protocol = { path = "../runtimed/crates/jupyter-protocol" }
 ```
 

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -12,7 +12,7 @@ The daemon uses `tracing` with `tracing-subscriber` (layered subscribers for std
 use tracing::{debug, info, warn, error};
 ```
 
-Dependencies that use the `log` crate (runtimelib, automerge, etc.) are automatically bridged into the tracing subscriber via `tracing-log`.
+Dependencies that use the `log` crate (jupyter-zmq-client, automerge, etc.) are automatically bridged into the tracing subscriber via `tracing-log`.
 
 ### Tauri app (notebook crate)
 

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 jupyter-protocol = { workspace = true }
-runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
+jupyter-zmq-client = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 runtimed-client = { path = "../runtimed-client" }
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 runt-workspace = { path = "../runt-workspace" }

--- a/crates/runt/src/kernel_client.rs
+++ b/crates/runt/src/kernel_client.rs
@@ -9,7 +9,7 @@ use jupyter_protocol::{
 use petname::petname;
 use uuid::Uuid;
 
-use runtimelib::{
+use jupyter_zmq_client::{
     create_client_control_connection, create_client_iopub_connection,
     create_client_shell_connection_with_identity, create_client_stdin_connection_with_identity,
     peek_ports_with_listeners, peer_identity_for_session, runtime_dir, KernelspecDir, Result,

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -12,7 +12,7 @@ use tabled::{settings::Style, Table, Tabled};
 mod kernel_client;
 
 use crate::kernel_client::KernelClient;
-use runtimelib::{
+use jupyter_zmq_client::{
     create_client_heartbeat_connection, create_client_shell_connection_with_identity,
     find_kernelspec, peer_identity_for_session, runtime_dir, ConnectionInfo,
 };
@@ -1500,14 +1500,14 @@ async fn console(kernel_name: Option<&str>, cmd: Option<&str>, verbose: bool) ->
     let connection_info = client.connection_info();
     let session_id = client.session_id();
 
-    let identity = runtimelib::peer_identity_for_session(session_id)?;
-    let shell = runtimelib::create_client_shell_connection_with_identity(
+    let identity = jupyter_zmq_client::peer_identity_for_session(session_id)?;
+    let shell = jupyter_zmq_client::create_client_shell_connection_with_identity(
         connection_info,
         session_id,
         identity.clone(),
     )
     .await?;
-    let mut stdin_conn = runtimelib::create_client_stdin_connection_with_identity(
+    let mut stdin_conn = jupyter_zmq_client::create_client_stdin_connection_with_identity(
         connection_info,
         session_id,
         identity,
@@ -1516,7 +1516,7 @@ async fn console(kernel_name: Option<&str>, cmd: Option<&str>, verbose: bool) ->
     let (mut shell_writer, mut shell_reader) = shell.split();
 
     let mut iopub =
-        runtimelib::create_client_iopub_connection(connection_info, "", session_id).await?;
+        jupyter_zmq_client::create_client_iopub_connection(connection_info, "", session_id).await?;
 
     let kernel_name = connection_info
         .kernel_name

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -37,7 +37,7 @@ dirs = "6"
 # Jupyter kernel management
 jupyter-protocol = { workspace = true }
 nbformat = { workspace = true }
-runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
+jupyter-zmq-client = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 petname = "2"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -100,9 +100,11 @@ pub struct InterruptHandle {
 
 impl InterruptHandle {
     pub async fn interrupt(&self) -> Result<()> {
-        let mut control =
-            runtimelib::create_client_control_connection(&self.connection_info, &self.session_id)
-                .await?;
+        let mut control = jupyter_zmq_client::create_client_control_connection(
+            &self.connection_info,
+            &self.session_id,
+        )
+        .await?;
 
         let request: JupyterMessage = InterruptRequest {}.into();
         control.send(request).await?;
@@ -153,7 +155,7 @@ pub struct JupyterKernel {
     /// Path to the connection file.
     connection_file: Option<PathBuf>,
     /// Shell writer for sending execute requests.
-    shell_writer: Option<runtimelib::DealerSendConnection>,
+    shell_writer: Option<jupyter_zmq_client::DealerSendConnection>,
     /// IPC socket path prefix for cleanup (Unix only).
     #[cfg(unix)]
     ipc_prefix: Option<PathBuf>,
@@ -1001,7 +1003,7 @@ impl KernelConnection for JupyterKernel {
             iopub_endpoint,
             launch_started.elapsed().as_millis()
         );
-        let mut iopub = match runtimelib::create_client_iopub_connection(
+        let mut iopub = match jupyter_zmq_client::create_client_iopub_connection(
             &connection_info,
             "",
             &session_id,
@@ -2171,7 +2173,7 @@ impl KernelConnection for JupyterKernel {
 
         // ── Shell connection ─────────────────────────────────────────────
 
-        let identity = runtimelib::peer_identity_for_session(&session_id)?;
+        let identity = jupyter_zmq_client::peer_identity_for_session(&session_id)?;
         let shell_endpoint = connection_info.shell_url();
         let shell_connect_started = std::time::Instant::now();
         info!(
@@ -2180,7 +2182,7 @@ impl KernelConnection for JupyterKernel {
             shell_endpoint,
             launch_started.elapsed().as_millis()
         );
-        let mut shell = match runtimelib::create_client_shell_connection_with_identity(
+        let mut shell = match jupyter_zmq_client::create_client_shell_connection_with_identity(
             &connection_info,
             &session_id,
             identity,
@@ -2459,7 +2461,8 @@ impl KernelConnection for JupyterKernel {
 
                     let check = async {
                         let mut hb =
-                            runtimelib::create_client_heartbeat_connection(&hb_conn_info).await?;
+                            jupyter_zmq_client::create_client_heartbeat_connection(&hb_conn_info)
+                                .await?;
                         hb.single_heartbeat().await
                     };
 
@@ -2642,7 +2645,8 @@ impl KernelConnection for JupyterKernel {
             .ok_or_else(|| anyhow::anyhow!("No kernel running"))?;
 
         let mut control =
-            runtimelib::create_client_control_connection(connection_info, &self.session_id).await?;
+            jupyter_zmq_client::create_client_control_connection(connection_info, &self.session_id)
+                .await?;
 
         let request: JupyterMessage = InterruptRequest {}.into();
         control.send(request).await?;

--- a/docs/superpowers/specs/2026-04-13-nteract-dx-design.md
+++ b/docs/superpowers/specs/2026-04-13-nteract-dx-design.md
@@ -181,7 +181,7 @@ kernel.session.send(
 ```
 
 - Mirrors how ipykernel's own `publish_display_data` calls `Session.send` — `ident` is the IOPub topic (bytes), `parent` is the parent header dict.
-- No new transport: runtimelib already serializes trailing `buffers: Vec<Bytes>` as ZMQ frames on send (`RawMessage::from_jupyter_message`), and the receive side parses them back (`into_jupyter_message`). ipywidgets exercises this path today.
+- No new transport: jupyter-zmq-client already serializes trailing `buffers: Vec<Bytes>` as ZMQ frames on send (`RawMessage::from_jupyter_message`), and the receive side parses them back (`into_jupyter_message`). ipywidgets exercises this path today.
 
 ### Agent side: buffer preflight + ref MIME resolution
 


### PR DESCRIPTION
Tracks [runtimed/runtimed#306](https://github.com/runtimed/runtimed/pull/306). Renames the kernel client to `jupyter-zmq-client` (mirrors `jupyter-websocket-client`) and lifts the workspace off the `0.6.0-pre.2` zeromq prerelease.

## What moved

| Dep | Before | After |
|---|---|---|
| Kernel client | `runtimelib` (git rev `f982d30b`) | `jupyter-zmq-client = "1.0.0"` (crates.io) |
| Wire protocol | `jupyter-protocol` (git rev `f982d30b`) | `jupyter-protocol = "2.0.1"` (crates.io) |
| Notebook parser | `nbformat` (git rev `f982d30b`) | `nbformat = "3.0.0"` (crates.io) |
| Transport | `zeromq 0.6.0-pre.2` (transitive) | `zeromq 0.6.0` (transitive, stable) |

## Why direct, not via the shim

Upstream PR 306 leaves `runtimelib 3.0.0` in place as a deprecated `pub use jupyter_zmq_client::*` shim so external consumers keep compiling. We're an internal consumer with one workspace and three call sites, so we go straight to `jupyter-zmq-client` and skip the shim hop.

## Source diff is mechanical

Every `runtimelib::` becomes `jupyter_zmq_client::` and `use runtimelib::{...}` becomes `use jupyter_zmq_client::{...}`. No API drift. Three files touched: `crates/runtimed/src/jupyter_kernel.rs`, `crates/runt/src/main.rs`, `crates/runt/src/kernel_client.rs`.

## crates.io over git

The previous workspace pinned all three crates to a runtimed/runtimed git rev. PR 306 plus the four release commits behind it landed `jupyter-zmq-client 1.0.0`, `jupyter-protocol 2.0.1`, and `nbformat 3.0.0` on crates.io, so the git pin no longer earns its keep. Switching releases the rev pin and lets future bumps go through normal `cargo update`.

## Verification

- `cargo build -p runtimed -p runt` clean
- `cargo check --workspace --exclude runtimed-py` clean
- `cargo test -p runtimed --test tokio_mutex_lint` passes (load-bearing invariant)
- `cargo xtask lint --fix` clean (pre-existing repl.ts unicorn warning unrelated)

## Test plan

- [ ] CI green
- [ ] Smoke a kernel start + execute against the dev daemon (`up`, `create_notebook`, `execute_cell`)
