### PR TITLE
fix(settings): persist daemon writes through json

### DIFF
--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -388,11 +388,27 @@ fn default_install_default_data_packages() -> bool {
 /// users would look like they had never consented, and their heartbeats
 /// would stop at the next app launch.
 ///
-/// Called once on daemon startup. Idempotent.
-pub fn backfill_telemetry_consent(settings: &mut SyncedSettings) {
+/// Called once on daemon startup. Idempotent. Returns `true` when the
+/// settings snapshot changed.
+pub fn backfill_telemetry_consent(settings: &mut SyncedSettings) -> bool {
     if !settings.telemetry_consent_recorded && settings.onboarding_completed {
         settings.telemetry_consent_recorded = true;
+        return true;
     }
+    false
+}
+
+/// Ensure an install ID exists in a materialized settings snapshot.
+///
+/// Returns the install ID and whether it had to be generated.
+pub fn ensure_install_id_in_settings(settings: &mut SyncedSettings) -> (String, bool) {
+    if !settings.install_id.is_empty() {
+        return (settings.install_id.clone(), false);
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    settings.install_id = id.clone();
+    (id, true)
 }
 
 /// Ensure an `install_id` exists in the settings doc, generating one if needed.
@@ -443,6 +459,35 @@ pub fn write_settings_schema() -> std::io::Result<()> {
     }
     let schema = generate_settings_schema().map_err(std::io::Error::other)?;
     std::fs::write(&path, format!("{schema}\n"))
+}
+
+/// Read canonical settings JSON into a materialized settings snapshot.
+///
+/// This intentionally routes through `SettingsDoc::from_json_value` so legacy
+/// values and field-level type mismatches keep the same tolerant migration
+/// behavior as daemon startup.
+pub fn read_synced_settings_json(path: &Path) -> std::io::Result<SyncedSettings> {
+    let contents = std::fs::read_to_string(path)?;
+    let json =
+        serde_json::from_str::<serde_json::Value>(&contents).map_err(std::io::Error::other)?;
+    Ok(SettingsDoc::from_json_value(&json).get_all())
+}
+
+/// Write a materialized settings snapshot to canonical settings JSON.
+pub fn write_synced_settings_json(path: &Path, settings: &SyncedSettings) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut json_value = serde_json::to_value(settings).map_err(std::io::Error::other)?;
+    if let Some(obj) = json_value.as_object_mut() {
+        obj.insert(
+            "$schema".to_string(),
+            serde_json::Value::String("./settings.schema.json".to_string()),
+        );
+    }
+    let json = serde_json::to_string_pretty(&json_value).map_err(std::io::Error::other)?;
+    std::fs::write(path, format!("{json}\n"))
 }
 
 /// Wrapper around an Automerge document storing application settings.
@@ -779,19 +824,8 @@ impl SettingsDoc {
     /// Injects a `$schema` key pointing to the companion schema file so editors
     /// can provide autocomplete and validation.
     pub fn save_json_mirror(&self, path: &Path) -> std::io::Result<()> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
         let settings = self.get_all();
-        let mut json_value = serde_json::to_value(&settings).map_err(std::io::Error::other)?;
-        if let Some(obj) = json_value.as_object_mut() {
-            obj.insert(
-                "$schema".to_string(),
-                serde_json::Value::String("./settings.schema.json".to_string()),
-            );
-        }
-        let json = serde_json::to_string_pretty(&json_value).map_err(std::io::Error::other)?;
-        std::fs::write(path, format!("{json}\n"))
+        write_synced_settings_json(path, &settings)
     }
 
     // ── Scalar accessors ─────────────────────────────────────────────
@@ -1505,7 +1539,7 @@ mod tests {
             telemetry_consent_recorded: false,
             ..Default::default()
         };
-        backfill_telemetry_consent(&mut s);
+        assert!(backfill_telemetry_consent(&mut s));
         assert!(s.telemetry_consent_recorded);
     }
 
@@ -1513,8 +1547,22 @@ mod tests {
     fn test_backfill_telemetry_consent_noop_for_fresh_installs() {
         let mut s = SyncedSettings::default();
         // onboarding_completed defaults to false
-        backfill_telemetry_consent(&mut s);
+        assert!(!backfill_telemetry_consent(&mut s));
         assert!(!s.telemetry_consent_recorded);
+    }
+
+    #[test]
+    fn test_ensure_install_id_in_settings_generates_once() {
+        let mut s = SyncedSettings::default();
+
+        let (id, generated) = ensure_install_id_in_settings(&mut s);
+        assert!(generated);
+        assert!(!id.is_empty());
+        assert_eq!(s.install_id, id);
+
+        let (again, generated) = ensure_install_id_in_settings(&mut s);
+        assert!(!generated);
+        assert_eq!(again, id);
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -30,7 +30,7 @@ use crate::connection::{self, Handshake};
 use crate::notebook_sync_server::{NotebookRooms, PathIndex};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
-use crate::settings_doc::SettingsDoc;
+use crate::settings_doc::{SettingsDoc, SyncedSettings};
 use crate::singleton::DaemonLock;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::trusted_packages::{log_store_unavailable, TrustedPackageStore};
@@ -1107,6 +1107,12 @@ pub struct DaemonAlreadyRunning {
     pub info: Box<DaemonInfo>,
 }
 
+pub(crate) struct SettingsJsonUpdate<T> {
+    pub value: T,
+    pub settings: SyncedSettings,
+    pub changed: bool,
+}
+
 impl Daemon {
     /// Get the daemon's Unix socket path.
     pub fn socket_path(&self) -> &PathBuf {
@@ -1116,6 +1122,49 @@ impl Daemon {
     /// Get the default Python environment type from settings.
     pub async fn default_python_env(&self) -> crate::settings_doc::PythonEnvType {
         self.settings.read().await.get_all().default_python_env
+    }
+
+    /// Mutate canonical `settings.json` first, then refresh the in-memory
+    /// Automerge projection used by settings sync.
+    ///
+    /// If the file is absent, the current in-memory projection seeds the new
+    /// JSON file. Invalid JSON is returned as an error and is never overwritten.
+    pub(crate) async fn update_settings_json<T>(
+        &self,
+        mutator: impl FnOnce(&mut SyncedSettings) -> T,
+    ) -> anyhow::Result<SettingsJsonUpdate<T>> {
+        let json_path = self.config.resolved_settings_json_path();
+        let update = {
+            let mut doc = self.settings.write().await;
+            let current = match crate::settings_doc::read_synced_settings_json(&json_path) {
+                Ok(settings) => settings,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => doc.get_all(),
+                Err(error) => return Err(error.into()),
+            };
+
+            let mut next = current.clone();
+            let value = mutator(&mut next);
+            if next == current {
+                return Ok(SettingsJsonUpdate {
+                    value,
+                    settings: next,
+                    changed: false,
+                });
+            }
+
+            crate::settings_doc::write_synced_settings_json(&json_path, &next)?;
+            *doc = SettingsDoc::from_synced_settings(&next);
+
+            SettingsJsonUpdate {
+                value,
+                settings: next,
+                changed: true,
+            }
+        };
+
+        let _ = self.settings_changed.send(());
+
+        Ok(update)
     }
 
     /// Get the default pixi packages from settings.
@@ -1258,15 +1307,20 @@ impl Daemon {
         // client happens to connect and trigger `persist_settings` in
         // `sync_server.rs` — a daemon that boots, runs briefly with no
         // settings-window interaction, and exits would drop the backfill.
-        if crate::settings_doc::backfill_telemetry_consent_in_doc(&mut settings) {
+        let mut startup_settings = settings.get_all();
+        if crate::settings_doc::backfill_telemetry_consent(&mut startup_settings) {
             tracing::info!(
                 "[settings] Backfilled telemetry_consent_recorded for an existing onboarded install"
             );
-            if let Err(e) = settings.save_json_mirror(&json_path) {
+            if let Err(e) =
+                crate::settings_doc::write_synced_settings_json(&json_path, &startup_settings)
+            {
                 tracing::warn!(
                     "[settings] Failed to persist backfilled settings.json: {}",
                     e
                 );
+            } else {
+                settings = SettingsDoc::from_synced_settings(&startup_settings);
             }
         }
 
@@ -5288,6 +5342,80 @@ mod tests {
         assert_eq!(
             legacy_settings_doc_path(&config),
             settings_json.with_file_name("settings.automerge")
+        );
+    }
+
+    #[tokio::test]
+    async fn update_settings_json_persists_refreshes_doc_and_broadcasts() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let mut settings_rx = daemon.settings_changed.subscribe();
+
+        let outcome = daemon
+            .update_settings_json(|settings| {
+                settings.theme = crate::settings_doc::ThemeMode::Dark;
+                "mutated"
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.value, "mutated");
+        assert!(outcome.changed);
+        assert_eq!(outcome.settings.theme, crate::settings_doc::ThemeMode::Dark);
+
+        let saved = crate::settings_doc::read_synced_settings_json(
+            &daemon.config.resolved_settings_json_path(),
+        )
+        .unwrap();
+        assert_eq!(saved.theme, crate::settings_doc::ThemeMode::Dark);
+        assert_eq!(
+            daemon.settings.read().await.get_all().theme,
+            crate::settings_doc::ThemeMode::Dark
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), settings_rx.recv())
+            .await
+            .expect("settings_changed should broadcast")
+            .expect("settings_changed channel should stay open");
+    }
+
+    #[tokio::test]
+    async fn update_settings_json_noop_does_not_broadcast() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let mut settings_rx = daemon.settings_changed.subscribe();
+
+        let outcome = daemon.update_settings_json(|_| ()).await.unwrap();
+
+        assert!(!outcome.changed);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), settings_rx.recv())
+                .await
+                .is_err(),
+            "no-op settings updates must not broadcast"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_settings_json_invalid_json_is_not_overwritten() {
+        let temp_dir = TempDir::new().unwrap();
+        let daemon = Daemon::new(lease_test_config(&temp_dir)).unwrap();
+        let settings_json_path = daemon.config.resolved_settings_json_path();
+        std::fs::write(&settings_json_path, "{ invalid json").unwrap();
+
+        let result = daemon
+            .update_settings_json(|settings| {
+                settings.theme = crate::settings_doc::ThemeMode::Dark;
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read_to_string(&settings_json_path).unwrap(),
+            "{ invalid json"
+        );
+        assert_ne!(
+            daemon.settings.read().await.get_all().theme,
+            crate::settings_doc::ThemeMode::Dark
         );
     }
 

--- a/crates/runtimed/src/daemon_telemetry.rs
+++ b/crates/runtimed/src/daemon_telemetry.rs
@@ -33,22 +33,21 @@ async fn daemon_heartbeat_loop(daemon: Arc<Daemon>) {
 }
 
 async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Client) {
-    let (settings, install_id, id_was_generated) = {
-        let mut settings_doc = daemon.settings.write().await;
-        let had_id = settings_doc
-            .get("install_id")
-            .map(|s| !s.is_empty())
-            .unwrap_or(false);
-        let id = runtimed_client::settings_doc::ensure_install_id(&mut settings_doc);
-        let generated = !had_id;
-        if generated {
-            persist_settings(&settings_doc, &daemon.config.resolved_settings_json_path());
+    let install_id_update = match daemon
+        .update_settings_json(runtimed_client::settings_doc::ensure_install_id_in_settings)
+        .await
+    {
+        Ok(update) => update,
+        Err(e) => {
+            tracing::warn!("[telemetry] failed to ensure install_id in settings.json: {e}");
+            return;
         }
-        let snapshot = settings_doc.get_all();
-        (snapshot, id, generated)
     };
+    let (install_id, id_was_generated) = install_id_update.value;
+    let install_id_was_persisted = install_id_update.changed;
+    let settings = install_id_update.settings;
 
-    if id_was_generated {
+    if id_was_generated && install_id_was_persisted {
         tracing::info!("[telemetry] generated install_id");
     }
 
@@ -88,15 +87,12 @@ async fn try_send_daemon_heartbeat(daemon: &Arc<Daemon>, client: &reqwest::Clien
     }
 
     // Update timestamp and persist to disk so it survives daemon restarts
+    if let Err(e) = daemon
+        .update_settings_json(|settings| {
+            settings.telemetry_last_daemon_ping_at = Some(now);
+        })
+        .await
     {
-        let mut settings_doc = daemon.settings.write().await;
-        settings_doc.put_u64("telemetry_last_daemon_ping_at", now);
-        persist_settings(&settings_doc, &daemon.config.resolved_settings_json_path());
-    }
-}
-
-fn persist_settings(doc: &runtimed_client::settings_doc::SettingsDoc, json_path: &std::path::Path) {
-    if let Err(e) = doc.save_json_mirror(json_path) {
-        tracing::warn!("[telemetry] failed to write settings.json: {e}");
+        tracing::warn!("[telemetry] failed to persist daemon heartbeat timestamp: {e}");
     }
 }


### PR DESCRIPTION
## Summary

- add canonical `settings.json` read/write helpers for materialized `SyncedSettings`
- route daemon-owned settings writes through JSON first, then refresh the in-memory `SettingsDoc` projection
- move startup telemetry-consent backfill and daemon heartbeat telemetry writes onto the JSON-first path
- broadcast `settings_changed` only when the persisted settings snapshot actually changes

## Tests

- `cargo test -p runtimed-client settings_doc`
- `cargo test -p runtimed update_settings_json`
- `cargo test -p runtimed --test integration test_settings_json_mirror_write_does_not_feedback_loop`
- `cargo test -p runtimed --test integration test_external_settings_json_edit_survives_settings_sync_ack`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo check --package runtimed`
- `cargo clippy -p runtimed-client -p runtimed --all-targets -- -D warnings`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` completed successfully with an existing TypeScript warning in `plugins/nteract/pi/extensions/repl.ts` about `new Array(singleArgument)`.
