### PR TITLE
docs(settings): document json authority

### DIFF
--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -286,7 +286,7 @@ const isDark = await browser.execute(() => {
 
 ### Daemon-Independent Testing
 
-Some features interact with the global runtimed daemon (Automerge-based settings sync). If the daemon is running, it may override default values on mount. If it's not running, the app falls back to localStorage.
+Some features interact with the global runtimed daemon (settings sync backed by canonical `settings.json`). If the daemon is running, it may override default values on mount. If it's not running, the app falls back to localStorage.
 
 **The rule: never assert initial state. Always click first, then assert the result.**
 

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -308,7 +308,7 @@ The diagrams show two main layers:
 
 1. **Frontend** (blue) — React hooks that invoke Tauri commands, listen for typed notebook frames, and project daemon-authored runtime state from RuntimeStateDoc. `useDaemonKernel.ts` handles kernel actions and ephemeral runtime events. Output **rendering** is driven by RuntimeStateDoc manifests (`materialize-cells.ts`, `notebook-outputs.ts`, and `manifest-resolution.ts`), not output broadcasts.
 
-2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: metadata inline deps first, then PEP 723 cell metadata (`uv:pep723`), then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
+2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: metadata inline deps first, then PEP 723 cell metadata (`uv:pep723`), then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs Automerge sync streams for notebook state and for the live projection of canonical `settings.json`.
 
 3. **External Tools** (grey) — `uv` for pip-compatible package management, `rattler` for conda solving/installing, and `deno` for TypeScript notebooks.
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -59,6 +59,9 @@ The notebook app communicates with runtimed over a Unix socket (named pipe on Wi
 4. **Broadcasts** — JSON messages the daemon pushes to all connected clients for ephemeral comm messages and environment progress
 5. **Presence and session control** — binary presence updates plus daemon-originated readiness/status frames
 
+Settings sync is a special Automerge stream: the Automerge document is the live
+transport/projection, while `settings.json` remains the durable settings store.
+
 ## Connection Topology
 
 ```
@@ -112,7 +115,7 @@ the same OS user and holding the socket path can intentionally use the daemon.
 | Handshake | Authority exposed |
 |-----------|-------------------|
 | `Pool` | Pool status, environment claims/returns, daemon status/admin requests including shutdown |
-| `SettingsSync` | Read/write access to the user's synced settings document |
+| `SettingsSync` | Read/write sync access to the live projection of canonical `settings.json`; successful client changes are persisted by the daemon |
 | `NotebookSync` | Peer access to a notebook room and its runtime-state sync |
 | `OpenNotebook` | Load or create a file-backed notebook from a path |
 | `CreateNotebook` | Create an untitled or ephemeral notebook room |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -79,12 +79,32 @@ Execution is CRDT-driven — the coordinator writes execution entries (with sour
 | Info file (legacy) | Pre-socket discovery fallback | `~/Library/Caches/<cache_namespace>/daemon.json` (macOS) / `~/.cache/<cache_namespace>/daemon.json` (Linux) |
 | Environments | Prewarmed venvs | `~/Library/Caches/<cache_namespace>/envs/` (macOS) / `~/.cache/<cache_namespace>/envs/` (Linux) |
 | Blob store | Content-addressed outputs | `~/Library/Caches/<cache_namespace>/blobs/` (macOS) / `~/.cache/<cache_namespace>/blobs/` (Linux) |
+| Settings | Canonical user settings JSON + schema | Channel config namespace via `settings_json_path()` and `settings_schema_path()` |
 | Notebook docs | Persisted Automerge docs | `~/Library/Caches/<cache_namespace>/notebook-docs/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/` (Linux) |
 | Snapshots | Pre-delete safety copies | `~/Library/Caches/<cache_namespace>/notebook-docs/snapshots/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/snapshots/` (Linux) |
 
 `<cache_namespace>` is `runt` for stable builds and `runt-nightly` for nightly builds. Source builds default to nightly unless `RUNT_BUILD_CHANNEL=stable`.
 
 **Daemon discovery is socket-first.** Clients connect to the socket and send a `GetDaemonInfo` request; the daemon answers from live state. The on-disk `daemon.json` exists only as a fallback for older daemons that don't recognise the request — it will be removed once every daemon in the wild speaks `GetDaemonInfo`. New code should not depend on `daemon.json`. See `crates/runtimed-client/src/singleton.rs::query_daemon_info`.
+
+## Settings Authority
+
+`settings.json` is the durable source of truth for user settings. The Automerge
+`SettingsDoc` is a live sync projection used for cross-window settings updates
+over the `SettingsSync` channel.
+
+Daemon-owned settings writes mutate and persist `SyncedSettings` JSON first,
+then refresh the projection and broadcast `settings_changed` only when the saved
+snapshot changes. Client-originated sync edits are accepted through
+`SettingsDoc` and written to `settings.json` only after the daemon proves the
+sync message applied. Mirror writes from daemon sync must not feed back through
+the file watcher as a second settings broadcast.
+
+External `settings.json` edits are authoritative. The file watcher applies them
+to the in-memory projection and broadcasts the resulting settings change. If
+Automerge sync recovery is needed, rebuild the projection from `settings.json`;
+if that JSON is invalid, keep the last-known-good in-memory snapshot for sync
+continuity and never overwrite the file as part of recovery.
 
 ## Security Model
 
@@ -292,7 +312,7 @@ crates/runtimed-client/
 ├── src/output_resolver.rs       # Shared Rust manifest resolution
 ├── src/resolved_output.rs       # Output resolution types
 ├── src/protocol.rs              # Client-side protocol helpers and typed request wrappers
-├── src/settings_doc.rs          # Settings Automerge document, schema, migration
+├── src/settings_doc.rs          # Settings JSON schema, materialization, and sync projection
 ├── src/singleton.rs             # File-based daemon discovery/locking helpers
 ├── src/sync_client.rs           # Settings sync client library
 └── src/service.rs               # Cross-platform service install/uninstall helpers

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1,9 +1,10 @@
-//! Automerge-backed settings document for cross-window sync.
+//! Automerge projection for cross-window settings sync.
 //!
-//! Wraps an Automerge `AutoCommit` document with typed accessors for
-//! application settings. The daemon holds the live copy; each connected
-//! notebook window holds a local replica that syncs over the Automerge sync
-//! protocol. On disk, `settings.json` is canonical.
+//! `settings.json` is the durable source of truth. `SettingsDoc` wraps an
+//! Automerge `AutoCommit` document as the live projection that the daemon and
+//! notebook windows use to exchange settings changes over the sync protocol.
+//! Daemon-owned writes mutate and persist canonical JSON first, then refresh
+//! this projection; successful client sync writes are mirrored back to JSON.
 //!
 //! The document uses nested maps for environment-specific settings:
 //!

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -1,8 +1,10 @@
 //! Automerge sync protocol handler for settings synchronization.
 //!
 //! Handles a single client connection that has already been routed by the
-//! daemon's unified socket. Exchanges Automerge sync messages to keep a
-//! shared settings document in sync across all notebook windows.
+//! daemon's unified socket. The durable settings state is canonical
+//! `settings.json`; this handler exchanges Automerge sync messages for the
+//! live `SettingsDoc` projection, persists successfully applied client changes
+//! back to JSON, and rebuilds the projection from JSON during recovery.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

- document that `settings.json` is the durable settings authority
- describe `SettingsDoc` as the live Automerge projection/sync transport
- clarify daemon recovery behavior: rebuild from JSON, keep last-known-good only in memory when JSON is invalid, and never rewrite invalid user JSON during recovery

## Verification

- `cargo xtask lint --fix`
- `git diff --check`
