### PR TITLE
fix(sync): avoid idle disconnects for live peers

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -190,7 +190,12 @@ export function useAutomergeNotebook() {
 
     const handle = NotebookHandle.create_empty_with_actor(`human:${sessionIdRef.current}`);
 
-    handleRef.current?.free();
+    const previousHandle = handleRef.current;
+    if (previousHandle) {
+      setNotebookHandle(null);
+      handleRef.current = null;
+      previousHandle.free();
+    }
     handleRef.current = handle;
     handle.set_mime_priority(DEFAULT_MIME_PRIORITY);
     let initialBlobPort = getBlobPort();

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -5,44 +5,11 @@ import { logger } from "../lib/logger";
 import {
   encode_cursor_presence,
   encode_focus_presence,
+  encode_heartbeat_presence,
   encode_selection_presence,
 } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
-
-function encodeCborText(value: string): Uint8Array {
-  const bytes = new TextEncoder().encode(value);
-  if (bytes.length < 24) {
-    return new Uint8Array([0x60 + bytes.length, ...bytes]);
-  }
-  if (bytes.length <= 0xff) {
-    return new Uint8Array([0x78, bytes.length, ...bytes]);
-  }
-  if (bytes.length <= 0xffff) {
-    return new Uint8Array([0x79, bytes.length >> 8, bytes.length & 0xff, ...bytes]);
-  }
-  throw new Error("presence heartbeat peer_id is too long");
-}
-
-function encodeHeartbeatPresence(peerId: string): Uint8Array {
-  const typeKey = encodeCborText("type");
-  const typeValue = encodeCborText("heartbeat");
-  const peerIdKey = encodeCborText("peer_id");
-  const peerIdValue = encodeCborText(peerId);
-  const payload = new Uint8Array(
-    1 + typeKey.length + typeValue.length + peerIdKey.length + peerIdValue.length,
-  );
-  let offset = 0;
-  payload[offset++] = 0xa2;
-  payload.set(typeKey, offset);
-  offset += typeKey.length;
-  payload.set(typeValue, offset);
-  offset += typeValue.length;
-  payload.set(peerIdKey, offset);
-  offset += peerIdKey.length;
-  payload.set(peerIdValue, offset);
-  return payload;
-}
 
 // ── Hook ─────────────────────────────────────────────────────────────
 
@@ -73,7 +40,7 @@ export function usePresence(
       if (!transport.connected) return;
       let payload: Uint8Array;
       try {
-        payload = encodeHeartbeatPresence(peerId);
+        payload = encode_heartbeat_presence(peerId);
       } catch (e) {
         logger.warn("[presence] encode heartbeat failed:", e);
         return;

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -1,5 +1,5 @@
 import { useNotebookHost } from "@nteract/notebook-host";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { sendPresenceFrame } from "runtimed";
 import { logger } from "../lib/logger";
 import {
@@ -7,6 +7,42 @@ import {
   encode_focus_presence,
   encode_selection_presence,
 } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+function encodeCborText(value: string): Uint8Array {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.length < 24) {
+    return new Uint8Array([0x60 + bytes.length, ...bytes]);
+  }
+  if (bytes.length <= 0xff) {
+    return new Uint8Array([0x78, bytes.length, ...bytes]);
+  }
+  if (bytes.length <= 0xffff) {
+    return new Uint8Array([0x79, bytes.length >> 8, bytes.length & 0xff, ...bytes]);
+  }
+  throw new Error("presence heartbeat peer_id is too long");
+}
+
+function encodeHeartbeatPresence(peerId: string): Uint8Array {
+  const typeKey = encodeCborText("type");
+  const typeValue = encodeCborText("heartbeat");
+  const peerIdKey = encodeCborText("peer_id");
+  const peerIdValue = encodeCborText(peerId);
+  const payload = new Uint8Array(
+    1 + typeKey.length + typeValue.length + peerIdKey.length + peerIdValue.length,
+  );
+  let offset = 0;
+  payload[offset++] = 0xa2;
+  payload.set(typeKey, offset);
+  offset += typeKey.length;
+  payload.set(typeValue, offset);
+  offset += typeValue.length;
+  payload.set(peerIdKey, offset);
+  offset += peerIdKey.length;
+  payload.set(peerIdValue, offset);
+  return payload;
+}
 
 // ── Hook ─────────────────────────────────────────────────────────────
 
@@ -29,6 +65,28 @@ export function usePresence(
 ) {
   const host = useNotebookHost();
   const transport = host.transport;
+
+  useEffect(() => {
+    if (!peerId) return;
+
+    const sendHeartbeat = () => {
+      if (!transport.connected) return;
+      let payload: Uint8Array;
+      try {
+        payload = encodeHeartbeatPresence(peerId);
+      } catch (e) {
+        logger.warn("[presence] encode heartbeat failed:", e);
+        return;
+      }
+      sendPresenceFrame(transport, payload).catch((e: unknown) =>
+        logger.debug("[presence] send heartbeat failed:", e),
+      );
+    };
+
+    sendHeartbeat();
+    const interval = window.setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [peerId, transport]);
 
   const setCursor = useCallback(
     (cellId: string, line: number, column: number) => {

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -29,36 +29,15 @@ export function setMetadataTransport(transport: NotebookTransport | null): void 
   _transport = transport;
 }
 
-function clearHandleAfterWasmError(context: string, error: unknown): void {
-  logger.warn(`[notebook-metadata] ${context} failed; clearing WASM handle:`, error);
-  _handle = null;
-  _snapshotCache = null;
-  _fingerprint = null;
-}
-
 /**
  * Read the current metadata snapshot from the WASM handle as a typed object.
  * Returns null if no handle is set or the WASM method returns a non-object.
  */
 function readSnapshot(): NotebookMetadataSnapshot | null {
-  try {
-    const raw = _handle?.get_metadata_snapshot();
-    return raw && typeof raw === "object"
-      ? (raw as NotebookMetadataSnapshot)
-      : null;
-  } catch (error) {
-    clearHandleAfterWasmError("get_metadata_snapshot", error);
-    return null;
-  }
-}
-
-function readFingerprint(): string | null {
-  try {
-    return _handle?.get_metadata_fingerprint() ?? null;
-  } catch (error) {
-    clearHandleAfterWasmError("get_metadata_fingerprint", error);
-    return null;
-  }
+  const raw = _handle?.get_metadata_snapshot();
+  return raw && typeof raw === "object"
+    ? (raw as NotebookMetadataSnapshot)
+    : null;
 }
 
 /**
@@ -73,7 +52,7 @@ function readFingerprint(): string | null {
  * during high-frequency output streaming.
  */
 export function notifyMetadataChanged(): void {
-  const newFingerprint = readFingerprint();
+  const newFingerprint = _handle?.get_metadata_fingerprint() ?? null;
   if (newFingerprint === _fingerprint) return;
   _fingerprint = newFingerprint;
   _snapshotCache = readSnapshot();
@@ -87,7 +66,7 @@ export function notifyMetadataChanged(): void {
  * itself changed and the old fingerprint is meaningless.
  */
 function forceNotifyMetadataChanged(): void {
-  _fingerprint = readFingerprint();
+  _fingerprint = _handle?.get_metadata_fingerprint() ?? null;
   _snapshotCache = readSnapshot();
   for (const cb of _subscribers) cb();
 }
@@ -148,12 +127,7 @@ export function useDetectRuntime(): "python" | "deno" | null {
   // Subscribe to metadata changes so we re-render when the doc updates.
   useSyncExternalStore(subscribe, getSnapshot);
   if (!_handle) return null;
-  try {
-    return (_handle.detect_runtime() as "python" | "deno") ?? null;
-  } catch (error) {
-    clearHandleAfterWasmError("detect_runtime", error);
-    return null;
-  }
+  return (_handle.detect_runtime() as "python" | "deno") ?? null;
 }
 
 /**

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -29,15 +29,36 @@ export function setMetadataTransport(transport: NotebookTransport | null): void 
   _transport = transport;
 }
 
+function clearHandleAfterWasmError(context: string, error: unknown): void {
+  logger.warn(`[notebook-metadata] ${context} failed; clearing WASM handle:`, error);
+  _handle = null;
+  _snapshotCache = null;
+  _fingerprint = null;
+}
+
 /**
  * Read the current metadata snapshot from the WASM handle as a typed object.
  * Returns null if no handle is set or the WASM method returns a non-object.
  */
 function readSnapshot(): NotebookMetadataSnapshot | null {
-  const raw = _handle?.get_metadata_snapshot();
-  return raw && typeof raw === "object"
-    ? (raw as NotebookMetadataSnapshot)
-    : null;
+  try {
+    const raw = _handle?.get_metadata_snapshot();
+    return raw && typeof raw === "object"
+      ? (raw as NotebookMetadataSnapshot)
+      : null;
+  } catch (error) {
+    clearHandleAfterWasmError("get_metadata_snapshot", error);
+    return null;
+  }
+}
+
+function readFingerprint(): string | null {
+  try {
+    return _handle?.get_metadata_fingerprint() ?? null;
+  } catch (error) {
+    clearHandleAfterWasmError("get_metadata_fingerprint", error);
+    return null;
+  }
 }
 
 /**
@@ -52,7 +73,7 @@ function readSnapshot(): NotebookMetadataSnapshot | null {
  * during high-frequency output streaming.
  */
 export function notifyMetadataChanged(): void {
-  const newFingerprint = _handle?.get_metadata_fingerprint() ?? null;
+  const newFingerprint = readFingerprint();
   if (newFingerprint === _fingerprint) return;
   _fingerprint = newFingerprint;
   _snapshotCache = readSnapshot();
@@ -66,7 +87,7 @@ export function notifyMetadataChanged(): void {
  * itself changed and the old fingerprint is meaningless.
  */
 function forceNotifyMetadataChanged(): void {
-  _fingerprint = _handle?.get_metadata_fingerprint() ?? null;
+  _fingerprint = readFingerprint();
   _snapshotCache = readSnapshot();
   for (const cb of _subscribers) cb();
 }
@@ -127,7 +148,12 @@ export function useDetectRuntime(): "python" | "deno" | null {
   // Subscribe to metadata changes so we re-render when the doc updates.
   useSyncExternalStore(subscribe, getSnapshot);
   if (!_handle) return null;
-  return (_handle.detect_runtime() as "python" | "deno") ?? null;
+  try {
+    return (_handle.detect_runtime() as "python" | "deno") ?? null;
+  } catch (error) {
+    clearHandleAfterWasmError("detect_runtime", error);
+    return null;
+  }
 }
 
 /**

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -44,6 +44,8 @@ const CONFIRM_SYNC_RETRY: Duration = Duration::from_millis(200);
 const STATE_SYNC_QUIET_TIMEOUT: Duration = Duration::from_millis(200);
 const STATE_SYNC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
 const MAINTENANCE_TICK: Duration = Duration::from_millis(50);
+const CLIENT_HEARTBEAT_INTERVAL: Duration =
+    Duration::from_millis(notebook_doc::presence::DEFAULT_HEARTBEAT_MS);
 
 /// Commands that require socket I/O (not document mutations).
 ///
@@ -233,6 +235,8 @@ where
     let mut reactor = SyncReactor::new(doc, snapshot_tx, runtime_state_tx, status_tx, broadcast_tx);
     let mut maintenance = tokio::time::interval(MAINTENANCE_TICK);
     maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut heartbeat = tokio::time::interval(CLIENT_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         reactor.state.loop_count += 1;
@@ -240,15 +244,20 @@ where
         // Keep the inbound frame pump hot. Commands must only register work
         // and write immediate outbound frames; waits resolve from the normal
         // frame path so the daemon never backs up behind a command subloop.
+        // The heartbeat tick sits ahead of the frame pump so a busy inbound
+        // stream cannot starve the daemon idle-deadline refresh.
         enum SelectResult {
             Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
             Changed(Option<()>),
             Command(Option<SyncCommand>),
             Maintenance,
+            Heartbeat,
         }
 
         let select_result = tokio::select! {
             biased;
+
+            _ = heartbeat.tick() => SelectResult::Heartbeat,
 
             // Incoming frame from daemon (cancel-safe: actor owns read_exact)
             frame = framed_reader.recv() => SelectResult::Frame(frame),
@@ -335,6 +344,16 @@ where
                     break;
                 }
             }
+
+            SelectResult::Heartbeat => {
+                if let Err(e) = send_client_heartbeat(&mut writer).await {
+                    warn!(
+                        "[notebook-sync] Failed to send heartbeat for {}: {}",
+                        reactor.io.notebook_id, e
+                    );
+                    break;
+                }
+            }
         }
     }
 
@@ -345,6 +364,14 @@ where
         "[notebook-sync] Stopped for {} after {} loop iterations",
         reactor.io.notebook_id, reactor.state.loop_count
     );
+}
+
+async fn send_client_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<(), SyncError> {
+    let payload = notebook_doc::presence::encode_heartbeat("local")
+        .map_err(|e| SyncError::Protocol(format!("encode heartbeat: {e}")))?;
+    connection::send_typed_frame(writer, NotebookFrameType::Presence, &payload)
+        .await
+        .map_err(SyncError::Io)
 }
 
 // =========================================================================

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2092,6 +2092,12 @@ pub fn encode_focus_presence(
         .map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Encode a heartbeat as a presence frame payload (CBOR).
+#[wasm_bindgen]
+pub fn encode_heartbeat_presence(peer_id: &str) -> Result<Vec<u8>, JsError> {
+    presence::encode_heartbeat(peer_id).map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Encode a clear-channel message as a presence frame payload (CBOR).
 /// Removes a single presence channel (e.g. cursor or selection) for this peer.
 #[wasm_bindgen]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1484,16 +1484,16 @@ impl Daemon {
     /// any inbound frames before the daemon forcibly disconnects it.
     ///
     /// This is a safety net for orphaned connections (e.g. a proxy process that
-    /// exited without cleanly closing its socket). In production the MCP child
-    /// sends periodic Automerge sync and presence frames, so a healthy peer
-    /// never hits this. In test mode the timeout is shorter to keep tests fast.
+    /// exited without cleanly closing its socket). Keep this long enough that
+    /// quiet notebook and MCP sessions are not treated as dead just because a
+    /// human stepped away. In test mode the timeout is shorter to keep tests fast.
     pub fn idle_peer_timeout(&self) -> std::time::Duration {
         if self.config.room_eviction_delay_ms.is_some() {
             // Tests: 30 seconds
             return std::time::Duration::from_secs(30);
         }
-        // Production: 5 minutes
-        std::time::Duration::from_secs(300)
+        // Production: 1 hour
+        std::time::Duration::from_secs(60 * 60)
     }
 
     /// Run the daemon server.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -65,6 +65,10 @@ pub struct DaemonConfig {
     /// Override for room eviction delay (milliseconds). Used in tests.
     /// If None, uses the user's `keep_alive_secs` setting.
     pub room_eviction_delay_ms: Option<u64>,
+    /// Override for idle peer timeout (milliseconds). Used in tests.
+    /// If None, uses the production default or the shorter test default when
+    /// `room_eviction_delay_ms` is set.
+    pub idle_peer_timeout_ms: Option<u64>,
     /// Maximum age (in seconds) for content-addressed cached environments.
     /// Environments older than this are evicted by the GC loop.
     pub env_cache_max_age_secs: u64,
@@ -105,6 +109,7 @@ impl Default for DaemonConfig {
             max_age_secs: 172800, // 2 days
             lock_dir: None,
             room_eviction_delay_ms: None,
+            idle_peer_timeout_ms: None,
             env_cache_max_age_secs: 86400, // 1 day
             env_cache_max_count: 10,
             use_preferred_blob_port: true,
@@ -1484,16 +1489,19 @@ impl Daemon {
     /// any inbound frames before the daemon forcibly disconnects it.
     ///
     /// This is a safety net for orphaned connections (e.g. a proxy process that
-    /// exited without cleanly closing its socket). Keep this long enough that
-    /// quiet notebook and MCP sessions are not treated as dead just because a
-    /// human stepped away. In test mode the timeout is shorter to keep tests fast.
+    /// exited without cleanly closing its socket). Live clients send request
+    /// frames on activity and presence heartbeats while idle. In test mode the
+    /// timeout is shorter to keep tests fast.
     pub fn idle_peer_timeout(&self) -> std::time::Duration {
+        if let Some(ms) = self.config.idle_peer_timeout_ms {
+            return std::time::Duration::from_millis(ms);
+        }
         if self.config.room_eviction_delay_ms.is_some() {
             // Tests: 30 seconds
             return std::time::Duration::from_secs(30);
         }
-        // Production: 1 hour
-        std::time::Duration::from_secs(60 * 60)
+        // Production: 5 minutes
+        std::time::Duration::from_secs(300)
     }
 
     /// Run the daemon server.

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -155,8 +155,9 @@ where
     let mut framed_reader = connection::FramedReader::spawn(reader, 16);
 
     // Idle peer timeout: disconnect peers that stop sending inbound frames.
-    // This is the safety net for orphaned connections where the remote process
-    // exited without closing its socket (e.g. proxy runtime teardown race).
+    // This is a coarse orphan guard for processes that died without closing
+    // their socket; live notebook and MCP peers send presence/request/sync
+    // traffic often enough to keep the deadline fresh.
     let idle_peer_timeout = daemon.idle_peer_timeout();
     let idle_deadline = tokio::time::sleep(idle_peer_timeout);
     tokio::pin!(idle_deadline);
@@ -189,8 +190,6 @@ where
             }
 
             // Idle peer timeout: no inbound frames within the deadline.
-            // Fires when the remote peer is an orphan (process exited without
-            // closing the socket) or genuinely idle beyond the configured limit.
             _ = &mut idle_deadline => {
                 warn!(
                     "[notebook-sync] Idle peer timeout for {} (peer_id={}, no inbound frames for {:?})",
@@ -206,18 +205,7 @@ where
                     Some(Err(e)) => return Err(e.into()),
                     None => return Ok(()), // clean EOF
                 };
-                // Reset idle deadline only for frames that represent genuine
-                // client intent — Request (tool calls) and Presence (cursor/focus).
-                // Automerge sync and state sync frames are reflexive: the daemon
-                // sends changes, the client ACKs. That loop would keep an orphan
-                // peer alive forever because daemon-side writes trigger client
-                // responses indefinitely.
-                if matches!(
-                    frame.frame_type,
-                    NotebookFrameType::Request | NotebookFrameType::Presence
-                ) {
-                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
-                }
+                idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 let notebook_doc_effects = match handle_notebook_doc_frame(

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -154,10 +154,9 @@ where
     // arm wins mid-payload (see issue + production diagnostics).
     let mut framed_reader = connection::FramedReader::spawn(reader, 16);
 
-    // Idle peer timeout: disconnect peers that stop sending inbound frames.
-    // This is a coarse orphan guard for processes that died without closing
-    // their socket; live notebook and MCP peers send presence/request/sync
-    // traffic often enough to keep the deadline fresh.
+    // Idle peer timeout: disconnect peers that stop sending client intent.
+    // Automerge/state sync frames are reflexive, so they do not prove the
+    // peer process is still healthy. Requests and presence heartbeats do.
     let idle_peer_timeout = daemon.idle_peer_timeout();
     let idle_deadline = tokio::time::sleep(idle_peer_timeout);
     tokio::pin!(idle_deadline);
@@ -205,7 +204,16 @@ where
                     Some(Err(e)) => return Err(e.into()),
                     None => return Ok(()), // clean EOF
                 };
-                idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
+                // Reset only for frames that represent genuine client intent.
+                // Automerge sync and state sync frames can be reflexive: daemon
+                // writes trigger client ACKs, which can keep an orphan peer
+                // alive forever if they refresh this deadline.
+                if matches!(
+                    frame.frame_type,
+                    NotebookFrameType::Request | NotebookFrameType::Presence
+                ) {
+                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
+                }
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
                                 let notebook_doc_effects = match handle_notebook_doc_frame(

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2728,3 +2728,50 @@ async fn test_create_notebook_default_manager_with_deps() {
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
+
+/// The Rust notebook-sync client sends presence heartbeats while idle so
+/// long-lived MCP/Python sessions are not mistaken for orphaned peers.
+#[tokio::test(start_paused = true)]
+async fn test_notebook_sync_heartbeat_keeps_idle_peer_connected() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    config.idle_peer_timeout_ms = Some(20_000);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "heartbeat-peer",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .expect("client should connect");
+    let client = result.handle;
+    assert_session_ready(&client, "heartbeat client").await;
+
+    // The daemon timeout is 20s and notebook-sync heartbeats every 15s.
+    // Advancing past the timeout proves the background heartbeat refreshed
+    // the daemon deadline without any tool call or document mutation.
+    tokio::time::advance(Duration::from_secs(35)).await;
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        client.status().connection,
+        notebook_sync::status::ConnectionState::Connected,
+        "notebook-sync heartbeat should keep an idle peer connected past idle_peer_timeout"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}


### PR DESCRIPTION
## Summary

- send canonical `notebook-doc` presence heartbeats from open notebook windows
- send the same idle heartbeat from Rust `notebook-sync` clients so MCP/Python sessions also prove liveness while quiet
- keep the daemon idle-peer guard at 5 minutes and reset it only on Request/Presence frames, preserving the #2549 orphan cleanup behavior
- clear the metadata handle before freeing the prior WASM handle during reconnect bootstrap

## Verification

- `cargo xtask wasm runtimed`
- `cargo check -p notebook-sync`
- `cargo check -p runtimed-wasm`
- `cargo test -p runtimed --test integration test_notebook_sync_heartbeat_keeps_idle_peer_connected -- --nocapture`
- `cargo check -p runtimed`
- `pnpm -C apps/notebook exec tsc -b`
- `cargo xtask lint --fix`

Note: the lint pass still reports the pre-existing `plugins/nteract/pi/extensions/repl.ts:217` `eslint-plugin-unicorn(no-new-array)` warning, but exits successfully.
