### PR TITLE
fix: keep idle notebook windows alive and survive daemon disconnect

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -190,6 +190,10 @@ export function useAutomergeNotebook() {
 
     const handle = NotebookHandle.create_empty_with_actor(`human:${sessionIdRef.current}`);
 
+    // Drop the metadata module's reference BEFORE freeing the prior handle.
+    // Renders that fire during the await below (e.g. the daemon-disconnect
+    // re-bootstrap) must not call into a freed wasm-bindgen pointer.
+    setNotebookHandle(null);
     handleRef.current?.free();
     handleRef.current = handle;
     handle.set_mime_priority(DEFAULT_MIME_PRIORITY);

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -1,12 +1,21 @@
 import { useNotebookHost } from "@nteract/notebook-host";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { sendPresenceFrame } from "runtimed";
 import { logger } from "../lib/logger";
 import {
   encode_cursor_presence,
   encode_focus_presence,
+  encode_heartbeat_presence,
   encode_selection_presence,
 } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+
+/**
+ * Heartbeat interval in milliseconds. Matches the Rust-side
+ * `notebook_doc::presence::DEFAULT_HEARTBEAT_MS` so room presence TTL
+ * pruning (3× heartbeat) and the daemon's 300s idle-peer timeout both
+ * stay comfortably ahead of an idle but live notebook window.
+ */
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 // ── Hook ─────────────────────────────────────────────────────────────
 
@@ -89,6 +98,28 @@ export function usePresence(
     },
     [peerId, peerLabel, actorLabel, transport],
   );
+
+  // Periodic heartbeats keep the daemon's idle-peer timeout from disconnecting
+  // a quiet but live window. Cursor/selection/focus frames already reset the
+  // timer on user activity; this covers the no-activity case.
+  useEffect(() => {
+    if (!peerId) return;
+    const send = () => {
+      let payload: Uint8Array;
+      try {
+        payload = encode_heartbeat_presence(peerId);
+      } catch (e) {
+        logger.warn("[presence] encode heartbeat failed:", e);
+        return;
+      }
+      sendPresenceFrame(transport, payload).catch((e: unknown) =>
+        logger.warn("[presence] send heartbeat failed:", e),
+      );
+    };
+    send();
+    const id = setInterval(send, HEARTBEAT_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [peerId, transport]);
 
   return {
     /** Set the local cursor position (fire-and-forget). */

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -21,8 +21,9 @@ use automerge::AutoCommit;
 use log::{debug, info};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 
 use notebook_protocol::connection::{
     self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
@@ -392,6 +393,7 @@ where
     let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
     let (changed_tx, changed_rx) = mpsc::unbounded_channel();
     let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
+    let heartbeat_cmd_tx = cmd_tx.clone();
     let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
 
     let handle = DocHandle::new(
@@ -428,7 +430,59 @@ where
         );
     });
 
+    spawn_presence_heartbeat(heartbeat_cmd_tx, presence_heartbeat_interval());
+
     Ok((handle, broadcast_rx.into()))
+}
+
+/// Default heartbeat interval for full-peer client connections (15s).
+///
+/// Matches `notebook_doc::presence::DEFAULT_HEARTBEAT_MS` so room presence TTL
+/// pruning (3× heartbeat) and the daemon's idle-peer timeout both stay
+/// comfortably ahead of an idle-but-live MCP or Python client.
+fn presence_heartbeat_interval() -> Duration {
+    Duration::from_millis(notebook_doc::presence::DEFAULT_HEARTBEAT_MS)
+}
+
+/// Spawn a background task that sends a heartbeat presence frame at `interval`.
+///
+/// The desktop frontend is a relay peer and runs its own heartbeat in
+/// `apps/notebook/src/hooks/usePresence.ts`. This covers everyone else who
+/// connects via `build_and_spawn` (runt-mcp, runtimed-py, integration tests):
+/// without it, a quiet but live MCP session gets disconnected after the
+/// daemon's idle-peer timeout.
+///
+/// The task exits on the first send failure - which fires when the sync
+/// task drops `cmd_rx` after the user drops their `DocHandle`.
+fn spawn_presence_heartbeat(cmd_tx: mpsc::Sender<sync_task::SyncCommand>, interval: Duration) {
+    let payload = match notebook_doc::presence::encode_heartbeat("local") {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug!("[notebook-sync] heartbeat encode failed: {e}");
+            return;
+        }
+    };
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if cmd_tx
+                .send(sync_task::SyncCommand::SendPresence {
+                    data: payload.clone(),
+                    reply: reply_tx,
+                })
+                .await
+                .is_err()
+            {
+                return;
+            }
+            // Drain the reply so the oneshot doesn't leak; ignore the result.
+            let _ = reply_rx.await;
+        }
+    });
 }
 
 // =========================================================================

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -21,9 +21,8 @@ use automerge::AutoCommit;
 use log::{debug, info};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
     self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
@@ -393,7 +392,6 @@ where
     let (status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
     let (changed_tx, changed_rx) = mpsc::unbounded_channel();
     let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
-    let heartbeat_cmd_tx = cmd_tx.clone();
     let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
 
     let handle = DocHandle::new(
@@ -430,59 +428,7 @@ where
         );
     });
 
-    spawn_presence_heartbeat(heartbeat_cmd_tx, presence_heartbeat_interval());
-
     Ok((handle, broadcast_rx.into()))
-}
-
-/// Default heartbeat interval for full-peer client connections (15s).
-///
-/// Matches `notebook_doc::presence::DEFAULT_HEARTBEAT_MS` so room presence TTL
-/// pruning (3× heartbeat) and the daemon's idle-peer timeout both stay
-/// comfortably ahead of an idle-but-live MCP or Python client.
-fn presence_heartbeat_interval() -> Duration {
-    Duration::from_millis(notebook_doc::presence::DEFAULT_HEARTBEAT_MS)
-}
-
-/// Spawn a background task that sends a heartbeat presence frame at `interval`.
-///
-/// The desktop frontend is a relay peer and runs its own heartbeat in
-/// `apps/notebook/src/hooks/usePresence.ts`. This covers everyone else who
-/// connects via `build_and_spawn` (runt-mcp, runtimed-py, integration tests):
-/// without it, a quiet but live MCP session gets disconnected after the
-/// daemon's idle-peer timeout.
-///
-/// The task exits on the first send failure - which fires when the sync
-/// task drops `cmd_rx` after the user drops their `DocHandle`.
-fn spawn_presence_heartbeat(cmd_tx: mpsc::Sender<sync_task::SyncCommand>, interval: Duration) {
-    let payload = match notebook_doc::presence::encode_heartbeat("local") {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            debug!("[notebook-sync] heartbeat encode failed: {e}");
-            return;
-        }
-    };
-
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            ticker.tick().await;
-            let (reply_tx, reply_rx) = oneshot::channel();
-            if cmd_tx
-                .send(sync_task::SyncCommand::SendPresence {
-                    data: payload.clone(),
-                    reply: reply_tx,
-                })
-                .await
-                .is_err()
-            {
-                return;
-            }
-            // Drain the reply so the oneshot doesn't leak; ignore the result.
-            let _ = reply_rx.await;
-        }
-    });
 }
 
 // =========================================================================

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -44,6 +44,11 @@ const CONFIRM_SYNC_RETRY: Duration = Duration::from_millis(200);
 const STATE_SYNC_QUIET_TIMEOUT: Duration = Duration::from_millis(200);
 const STATE_SYNC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
 const MAINTENANCE_TICK: Duration = Duration::from_millis(50);
+/// Idle presence heartbeat sent by full-peer clients (runt-mcp, runtimed-py,
+/// integration tests) so the daemon's idle-peer timeout never fires on a
+/// quiet but live session. Matches `presence::DEFAULT_HEARTBEAT_MS`.
+const CLIENT_HEARTBEAT_INTERVAL: Duration =
+    Duration::from_millis(notebook_doc::presence::DEFAULT_HEARTBEAT_MS);
 
 /// Commands that require socket I/O (not document mutations).
 ///
@@ -233,6 +238,8 @@ where
     let mut reactor = SyncReactor::new(doc, snapshot_tx, runtime_state_tx, status_tx, broadcast_tx);
     let mut maintenance = tokio::time::interval(MAINTENANCE_TICK);
     maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut heartbeat = tokio::time::interval(CLIENT_HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         reactor.state.loop_count += 1;
@@ -240,15 +247,20 @@ where
         // Keep the inbound frame pump hot. Commands must only register work
         // and write immediate outbound frames; waits resolve from the normal
         // frame path so the daemon never backs up behind a command subloop.
+        // The heartbeat tick sits ahead of the frame pump so a busy inbound
+        // stream cannot starve the daemon idle-deadline refresh.
         enum SelectResult {
             Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
             Changed(Option<()>),
             Command(Option<SyncCommand>),
             Maintenance,
+            Heartbeat,
         }
 
         let select_result = tokio::select! {
             biased;
+
+            _ = heartbeat.tick() => SelectResult::Heartbeat,
 
             // Incoming frame from daemon (cancel-safe: actor owns read_exact)
             frame = framed_reader.recv() => SelectResult::Frame(frame),
@@ -335,6 +347,16 @@ where
                     break;
                 }
             }
+
+            SelectResult::Heartbeat => {
+                if let Err(e) = send_client_heartbeat(&mut writer).await {
+                    warn!(
+                        "[notebook-sync] Failed to send heartbeat for {}: {}",
+                        reactor.io.notebook_id, e
+                    );
+                    break;
+                }
+            }
         }
     }
 
@@ -345,6 +367,14 @@ where
         "[notebook-sync] Stopped for {} after {} loop iterations",
         reactor.io.notebook_id, reactor.state.loop_count
     );
+}
+
+async fn send_client_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<(), SyncError> {
+    let payload = notebook_doc::presence::encode_heartbeat("local")
+        .map_err(|e| SyncError::Protocol(format!("encode heartbeat: {e}")))?;
+    connection::send_typed_frame(writer, NotebookFrameType::Presence, &payload)
+        .await
+        .map_err(SyncError::Io)
 }
 
 // =========================================================================

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2092,6 +2092,16 @@ pub fn encode_focus_presence(
         .map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Encode a heartbeat as a presence frame payload (CBOR).
+///
+/// The desktop client sends these on a fixed interval so the daemon's
+/// idle-peer timeout (which only resets on Request and Presence frames)
+/// does not fire on a quiet but live notebook window.
+#[wasm_bindgen]
+pub fn encode_heartbeat_presence(peer_id: &str) -> Result<Vec<u8>, JsError> {
+    presence::encode_heartbeat(peer_id).map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Encode a clear-channel message as a presence frame payload (CBOR).
 /// Removes a single presence channel (e.g. cursor or selection) for this peer.
 #[wasm_bindgen]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -65,6 +65,9 @@ pub struct DaemonConfig {
     /// Override for room eviction delay (milliseconds). Used in tests.
     /// If None, uses the user's `keep_alive_secs` setting.
     pub room_eviction_delay_ms: Option<u64>,
+    /// Override for idle peer timeout (milliseconds).
+    /// If None: 300s production, 30s when `room_eviction_delay_ms` is set.
+    pub idle_peer_timeout_ms: Option<u64>,
     /// Maximum age (in seconds) for content-addressed cached environments.
     /// Environments older than this are evicted by the GC loop.
     pub env_cache_max_age_secs: u64,
@@ -105,6 +108,7 @@ impl Default for DaemonConfig {
             max_age_secs: 172800, // 2 days
             lock_dir: None,
             room_eviction_delay_ms: None,
+            idle_peer_timeout_ms: None,
             env_cache_max_age_secs: 86400, // 1 day
             env_cache_max_count: 10,
             use_preferred_blob_port: true,
@@ -1488,6 +1492,9 @@ impl Daemon {
     /// sends periodic Automerge sync and presence frames, so a healthy peer
     /// never hits this. In test mode the timeout is shorter to keep tests fast.
     pub fn idle_peer_timeout(&self) -> std::time::Duration {
+        if let Some(ms) = self.config.idle_peer_timeout_ms {
+            return std::time::Duration::from_millis(ms);
+        }
         if self.config.room_eviction_delay_ms.is_some() {
             // Tests: 30 seconds
             return std::time::Duration::from_secs(30);

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2730,17 +2730,17 @@ async fn test_create_notebook_default_manager_with_deps() {
 }
 
 /// `notebook-sync::connect` clients (runt-mcp, runtimed-py, integration tests)
-/// get an auto-heartbeat task spawned in `build_and_spawn`. A quiet but live
-/// peer must survive past the daemon's idle_peer_timeout solely on that
-/// background traffic; otherwise headless MCP and Python sessions regress to
-/// the original "kicked after 5 minutes of silence" failure that the desktop
-/// hook fixes only for the webview.
-#[tokio::test]
+/// get an auto-heartbeat that fires from `sync_task::run`'s biased select. A
+/// quiet but live peer must survive past the daemon's idle_peer_timeout solely
+/// on that traffic; otherwise headless MCP and Python sessions regress to the
+/// original "kicked after 5 minutes of silence" failure that the desktop hook
+/// fixes only for the webview.
+#[tokio::test(start_paused = true)]
 async fn test_auto_heartbeat_keeps_idle_peer_connected() {
     let temp_dir = TempDir::new().unwrap();
     let mut config = test_config(&temp_dir);
     // Sit just above the 15s default heartbeat interval so the second tick
-    // lands in time to reset the deadline without dragging the test past 30s.
+    // lands in time to reset the deadline.
     config.idle_peer_timeout_ms = Some(20_000);
     let socket_path = config.socket_path.clone();
 
@@ -2766,10 +2766,13 @@ async fn test_auto_heartbeat_keeps_idle_peer_connected() {
     let client = result.handle;
     assert_session_ready(&client, "heartbeat client").await;
 
-    // Send nothing from the test. Auto-heartbeats from build_and_spawn fire at
-    // t≈0 and t≈15s; without them the 20s idle deadline would have expired by
-    // the 22s mark.
-    sleep(Duration::from_secs(22)).await;
+    // Advance virtual time past the 20s daemon timeout. With heartbeats
+    // disabled the deadline would have expired by t=20s; with the auto-
+    // heartbeat firing every 15s from sync_task's biased select arm, the
+    // peer stays Connected at t=35s.
+    tokio::time::advance(Duration::from_secs(35)).await;
+    tokio::task::yield_now().await;
+
     assert_eq!(
         client.status().connection,
         notebook_sync::ConnectionState::Connected,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2729,17 +2729,19 @@ async fn test_create_notebook_default_manager_with_deps() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
-/// Heartbeat presence frames must keep a quiet but live peer connected past
-/// the daemon's `idle_peer_timeout`. Without this the desktop client - which
-/// only sends Presence on cursor/focus events - gets kicked after 5 minutes
-/// of no typing and the WASM frontend trips a stale-handle render during the
-/// daemon-disconnect re-bootstrap.
+/// `notebook-sync::connect` clients (runt-mcp, runtimed-py, integration tests)
+/// get an auto-heartbeat task spawned in `build_and_spawn`. A quiet but live
+/// peer must survive past the daemon's idle_peer_timeout solely on that
+/// background traffic; otherwise headless MCP and Python sessions regress to
+/// the original "kicked after 5 minutes of silence" failure that the desktop
+/// hook fixes only for the webview.
 #[tokio::test]
-async fn test_heartbeat_keeps_idle_peer_connected() {
+async fn test_auto_heartbeat_keeps_idle_peer_connected() {
     let temp_dir = TempDir::new().unwrap();
     let mut config = test_config(&temp_dir);
-    // Compress the timeout so the test runs in seconds, not 30s.
-    config.idle_peer_timeout_ms = Some(1500);
+    // Sit just above the 15s default heartbeat interval so the second tick
+    // lands in time to reset the deadline without dragging the test past 30s.
+    config.idle_peer_timeout_ms = Some(20_000);
     let socket_path = config.socket_path.clone();
 
     let daemon = Daemon::new(config).unwrap();
@@ -2764,51 +2766,14 @@ async fn test_heartbeat_keeps_idle_peer_connected() {
     let client = result.handle;
     assert_session_ready(&client, "heartbeat client").await;
 
-    // Drive heartbeats every 500ms (3× under the 1500ms timeout) for ~3.5s.
-    // That's well past the timeout — if the daemon were resetting the deadline
-    // only on Request frames the connection would have died by ~1.5s.
-    let heartbeat_handle = client.clone();
-    let heartbeats = tokio::spawn(async move {
-        for _ in 0..7 {
-            let payload = notebook_doc::presence::encode_heartbeat("heartbeat-peer")
-                .expect("encode heartbeat");
-            heartbeat_handle
-                .send_presence(payload)
-                .await
-                .expect("send heartbeat");
-            sleep(Duration::from_millis(500)).await;
-        }
-    });
-
-    sleep(Duration::from_millis(3500)).await;
+    // Send nothing from the test. Auto-heartbeats from build_and_spawn fire at
+    // t≈0 and t≈15s; without them the 20s idle deadline would have expired by
+    // the 22s mark.
+    sleep(Duration::from_secs(22)).await;
     assert_eq!(
         client.status().connection,
-        notebook_sync::status::ConnectionState::Connected,
-        "heartbeats should keep the peer Connected past idle_peer_timeout"
-    );
-
-    heartbeats.await.expect("heartbeat task should finish");
-
-    // Stop heartbeats. Now the deadline runs to completion and the daemon
-    // disconnects. The DocHandle observes the close and flips to Disconnected.
-    let mut status_rx = client.subscribe_status();
-    let disconnect_deadline = Duration::from_millis(3500);
-    let disconnect_observed = tokio::time::timeout(disconnect_deadline, async {
-        loop {
-            if status_rx.borrow().connection == notebook_sync::status::ConnectionState::Disconnected
-            {
-                return;
-            }
-            if status_rx.changed().await.is_err() {
-                return;
-            }
-        }
-    })
-    .await;
-    assert!(
-        disconnect_observed.is_ok(),
-        "peer should disconnect once heartbeats stop (status={:?})",
-        client.status()
+        notebook_sync::ConnectionState::Connected,
+        "auto-heartbeat should keep the peer Connected past idle_peer_timeout"
     );
 
     pool_client.shutdown().await.ok();

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2728,3 +2728,89 @@ async fn test_create_notebook_default_manager_with_deps() {
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
+
+/// Heartbeat presence frames must keep a quiet but live peer connected past
+/// the daemon's `idle_peer_timeout`. Without this the desktop client - which
+/// only sends Presence on cursor/focus events - gets kicked after 5 minutes
+/// of no typing and the WASM frontend trips a stale-handle render during the
+/// daemon-disconnect re-bootstrap.
+#[tokio::test]
+async fn test_heartbeat_keeps_idle_peer_connected() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    // Compress the timeout so the test runs in seconds, not 30s.
+    config.idle_peer_timeout_ms = Some(1500);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "heartbeat-peer",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .expect("client should connect");
+    let client = result.handle;
+    assert_session_ready(&client, "heartbeat client").await;
+
+    // Drive heartbeats every 500ms (3× under the 1500ms timeout) for ~3.5s.
+    // That's well past the timeout — if the daemon were resetting the deadline
+    // only on Request frames the connection would have died by ~1.5s.
+    let heartbeat_handle = client.clone();
+    let heartbeats = tokio::spawn(async move {
+        for _ in 0..7 {
+            let payload = notebook_doc::presence::encode_heartbeat("heartbeat-peer")
+                .expect("encode heartbeat");
+            heartbeat_handle
+                .send_presence(payload)
+                .await
+                .expect("send heartbeat");
+            sleep(Duration::from_millis(500)).await;
+        }
+    });
+
+    sleep(Duration::from_millis(3500)).await;
+    assert_eq!(
+        client.status().connection,
+        notebook_sync::status::ConnectionState::Connected,
+        "heartbeats should keep the peer Connected past idle_peer_timeout"
+    );
+
+    heartbeats.await.expect("heartbeat task should finish");
+
+    // Stop heartbeats. Now the deadline runs to completion and the daemon
+    // disconnects. The DocHandle observes the close and flips to Disconnected.
+    let mut status_rx = client.subscribe_status();
+    let disconnect_deadline = Duration::from_millis(3500);
+    let disconnect_observed = tokio::time::timeout(disconnect_deadline, async {
+        loop {
+            if status_rx.borrow().connection == notebook_sync::status::ConnectionState::Disconnected
+            {
+                return;
+            }
+            if status_rx.changed().await.is_err() {
+                return;
+            }
+        }
+    })
+    .await;
+    assert!(
+        disconnect_observed.is_ok(),
+        "peer should disconnect once heartbeats stop (status={:?})",
+        client.status()
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}


### PR DESCRIPTION
Three cooperating fixes for a regression observed in stable
`2.4.4-stable.202605050246+012dd55`: an idle notebook window throws
"null pointer passed to rust" and the React ErrorBoundary covers the
notebook with a crash dialog. Same failure mode reaches every other
`notebook-sync::connect` client: a quiet `runt-mcp` or `runtimed-py`
session also gets kicked after 5 minutes.

## Root cause

#2549 added a daemon-side idle-peer timeout that disconnects any peer
that hasn't sent a Request or Presence frame for 5 minutes. The intent
was to clean up orphaned `runt-nightly mcp` proxies that survive
runtime teardown. The desktop client and the headless clients are also
peers, and none of them send Presence on a clock - the desktop hook
fires only on cursor/selection/focus, and the shared
`notebook-sync::presence` helpers only announce once on connect. So a
quiet but live notebook window or MCP session has no inbound traffic
and the daemon kicks it.

That disconnect surfaces a latent frontend bug.
`useAutomergeNotebook.bootstrap()` `free()`s the prior WASM
`NotebookHandle` and then `await`s a blob-port refresh before
installing the new handle in `notebook-metadata.ts`'s module-level
`_handle`. Any render that runs during that await - notably the
daemon-disconnect re-bootstrap - calls `useDetectRuntime`, which
dereferences `_handle` and trips
`wasm_bindgen::__rt::assert_not_null` on the freed `JsCell` ptr.

```
__wbg___wbindgen_throw
wasm_bindgen::__rt::assert_not_null
<runtimed_wasm::JsCell as RefFromWasmAbi>::ref_from_abi
notebookhandle_detect_runtime
```

All three fixes need to land. Heartbeats keep live peers alive so they
never see a disconnect; the bootstrap-order fix makes the disconnect
path safe for any other reason (sleep/wake, daemon restart, crash).

## What changed

### `fix(presence)` - send periodic heartbeats from the webview

`notebook_doc::presence::encode_heartbeat` already exists and the
daemon already accepts `PresenceMessage::Heartbeat` (it `mark_seen`s
the peer and the Presence frame type resets the idle deadline in
`peer_loop`). The pieces just weren't wired up.

- Expose `encode_heartbeat_presence` to wasm-bindgen.
- `usePresence` fires a heartbeat on mount and every 15s thereafter.
  15s matches `DEFAULT_HEARTBEAT_MS` (so room presence TTL pruning
  stays satisfied at 3× heartbeat) and sits 20× under the 300s
  production timeout.
- Promote `idle_peer_timeout_ms` to a configurable
  `DaemonConfig` field. Production and the existing 30s test default
  are unchanged when the field is `None`; the new integration test
  uses 20s.

### `fix(notebook)` - clear handle ref before freeing during re-bootstrap

Move `setNotebookHandle(null)` ahead of `handleRef.current?.free()` in
`bootstrap()`. The cleanup-at-unmount path already follows this
ordering; bootstrap was the lone reverse-order caller.

### `fix(notebook-sync)` - auto-heartbeat full-peer clients

The desktop fix above only covers the webview. `runt-mcp` and
`runtimed-py` connect via `notebook-sync::connect::connect /
connect_open / connect_create` into `build_and_spawn`, and the shared
presence helpers (`announce`, `emit_cursor`, `emit_focus`) only fire
on explicit user actions. A live but quiet MCP session still ate the
5-minute disconnect. (Thanks Codex for catching this in review.)

`build_and_spawn` now spawns a background heartbeat task that reuses
the `sync_task` command channel: every 15s it sends a
`SendPresence` command carrying
`encode_heartbeat("local")`. The task holds only a clone of the
`SyncCommand` sender, so when the user drops their `DocHandle` the
sync task tears down and the heartbeat sender's `.send()` returns
`SendError` - the loop exits cleanly without keeping `cmd_tx` alive
past its purpose.

## Behavioral coverage

| Scenario | Before | After |
|----------|--------|-------|
| Open desktop window, idle 5 minutes | Daemon disconnects, re-bootstrap renders, "null pointer passed to rust" crash dialog | Webview heartbeat keeps connection alive; no disconnect |
| Idle MCP/Python session, 5 minutes silent | Daemon disconnects | `build_and_spawn` heartbeat keeps connection alive |
| Daemon disconnect for any reason (sleep/wake, restart, crash) | Re-bootstrap renders during the freed-handle await window, same crash | Re-bootstrap clears the metadata handle ref before freeing; `useDetectRuntime` returns `null` until the new handle installs |
| Orphan proxy with stale TCP socket | Original #2549 case - frame-type guard catches it within 5 minutes | Same: the frame-type guard on idle deadline reset is unchanged, so reflexive sync ACKs from a dead-but-attached proxy don't keep the deadline fresh |

## Test plan

- [x] `cargo xtask wasm runtimed`
- [x] `cargo xtask lint --fix`
- [x] `cargo test -p runtimed-wasm`
- [x] `cargo test -p notebook-doc presence`
- [x] `cargo test -p runtimed --test tokio_mutex_lint`
- [x] `pnpm test:run` - 1187 tests pass
- [ ] CI: `cargo test -p runtimed --test integration test_auto_heartbeat_keeps_idle_peer_connected` (runs in ~25s; not run locally)
- [ ] Manual: open a notebook in the dev build, leave idle past 5
  minutes, verify no disconnect and no crash dialog
- [ ] Manual: kill the daemon while a notebook is open, verify
  re-bootstrap completes without the crash dialog
- [ ] Manual: open an MCP session, leave it idle 5+ minutes, verify
  the room stays attached

## Predecessor

#2549 - the orphan-kernel fix whose 5-minute idle timeout these three
changes finish wiring around.
