### PR TITLE
refactor(notebook): host wasm handle lifecycle

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -2,7 +2,7 @@ import { useNotebookHost, type DaemonReadyPayload } from "@nteract/notebook-host
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
 import {
-  DEFAULT_MIME_PRIORITY,
+  NotebookHandleHost,
   SyncEngine,
   isDisplayCapableJupyterOutput,
   isInitialLoadFailed,
@@ -48,7 +48,6 @@ import {
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
-// Module-level WASM init — runs before React renders.
 const wasmReady: Promise<void> = init().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
 });
@@ -78,6 +77,19 @@ export function useAutomergeNotebook() {
   const interactiveReadyRef = useRef(false);
   const latestSessionStatusRef = useRef<SessionStatus | null>(null);
   const prevPathRef = useRef<string | null>(null);
+
+  const [handleHost] = useState(
+    () =>
+      new NotebookHandleHost<NotebookHandle>({
+        actorLabel: () => `human:${sessionIdRef.current}`,
+        createHandle: (actorLabel) => NotebookHandle.create_empty_with_actor(actorLabel),
+        getBlobPort,
+        publishHandle: setNotebookHandle,
+        ready: wasmReady,
+        refreshBlobPort,
+        slot: handleRef,
+      }),
+  );
 
   // SyncEngine and transport refs — stable across re-renders.
   const engineRef = useRef<SyncEngine | null>(null);
@@ -156,11 +168,14 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  const refreshCanAcceptCellMutations = useCallback((handle = handleRef.current) => {
-    const canAccept = handle?.has_cells_map() ?? false;
-    setCanAcceptCellMutations(canAccept);
-    return canAccept;
-  }, []);
+  const refreshCanAcceptCellMutations = useCallback(
+    (handle = handleHost.current) => {
+      const canAccept = handle?.has_cells_map() ?? false;
+      setCanAcceptCellMutations(canAccept);
+      return canAccept;
+    },
+    [handleHost],
+  );
 
   /**
    * Guard + commit helper for WASM mutations.
@@ -168,7 +183,7 @@ export function useAutomergeNotebook() {
    */
   const commitMutation = useCallback(
     (mutate: (handle: NotebookHandle) => boolean) => {
-      const handle = handleRef.current;
+      const handle = handleHost.current;
       const engine = engineRef.current;
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] commitMutation skipped: no handle/engine");
@@ -179,53 +194,34 @@ export function useAutomergeNotebook() {
       engine.flush();
       return true;
     },
-    [rematerializeCellsSync],
+    [handleHost, rematerializeCellsSync],
   );
 
   // ── Bootstrap ──────────────────────────────────────────────────────
 
-  const bootstrap = useCallback(async (isCancelled: () => boolean = () => false) => {
-    await wasmReady;
-    if (isCancelled()) return false;
+  const bootstrap = useCallback(
+    async (isCancelled: () => boolean = () => false) => {
+      const bootstrapped = await handleHost.bootstrap(isCancelled);
+      if (!bootstrapped) return false;
 
-    const handle = NotebookHandle.create_empty_with_actor(`human:${sessionIdRef.current}`);
+      interactiveReadyRef.current = false;
+      latestSessionStatusRef.current = null;
+      setCanAcceptCellMutations(false);
+      setLoadError(null);
+      setIsLoading(true);
 
-    // Drop the metadata module's reference BEFORE freeing the prior handle.
-    // Renders that fire during the await below (e.g. the daemon-disconnect
-    // re-bootstrap) must not call into a freed wasm-bindgen pointer.
-    setNotebookHandle(null);
-    handleRef.current?.free();
-    handleRef.current = handle;
-    handle.set_mime_priority(DEFAULT_MIME_PRIORITY);
-    let initialBlobPort = getBlobPort();
-    if (initialBlobPort === null) {
-      initialBlobPort = await refreshBlobPort();
-    }
-    // React StrictMode can run the effect cleanup while the blob-port
-    // refresh is pending. Cleanup frees the WASM handle, so make sure this
-    // async continuation still owns the current handle before calling into it.
-    if (isCancelled() || handleRef.current !== handle) return false;
-    if (initialBlobPort !== null) {
-      handle.set_blob_port(initialBlobPort);
-    }
-    setNotebookHandle(handle);
+      // Flush initial sync message through the engine.
+      const engine = engineRef.current;
+      if (engine) {
+        engine.resetForBootstrap();
+        engine.flush();
+      }
 
-    interactiveReadyRef.current = false;
-    latestSessionStatusRef.current = null;
-    setCanAcceptCellMutations(false);
-    setLoadError(null);
-    setIsLoading(true);
-
-    // Flush initial sync message through the engine.
-    const engine = engineRef.current;
-    if (engine) {
-      engine.resetForBootstrap();
-      engine.flush();
-    }
-
-    logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
-    return true;
-  }, []);
+      logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
+      return true;
+    },
+    [handleHost],
+  );
 
   const notifyRelayReady = useCallback(
     (relayGeneration?: number) => {
@@ -250,7 +246,7 @@ export function useAutomergeNotebook() {
     // and any other consumer. One socket, one listener path.
     const transport = host.transport;
     const engine = new SyncEngine({
-      getHandle: () => handleRef.current as SyncableHandle | null,
+      getHandle: () => handleHost.current as SyncableHandle | null,
       transport,
       logger,
     });
@@ -283,7 +279,7 @@ export function useAutomergeNotebook() {
     // Initial sync completion → full materialization.
     const initialSyncSub = engine.initialSyncComplete$.subscribe(() => {
       logger.info("[automerge-notebook] Notebook interactive, materializing");
-      const handle = handleRef.current;
+      const handle = handleHost.current;
       if (handle) {
         materializeCells(handle)
           .then(() => {
@@ -329,7 +325,7 @@ export function useAutomergeNotebook() {
         concatMap((changeset) =>
           from(
             materializeChangeset(changeset, {
-              getHandle: () => handleRef.current,
+              getHandle: () => handleHost.current,
               materializeCells,
               outputCache: outputCacheRef.current,
             })
@@ -338,7 +334,7 @@ export function useAutomergeNotebook() {
                 // from the canonical notebook doc so <CellLabel> / future
                 // Out[N] readers see the current execution, not whatever
                 // RuntimeStateDoc entry happened to land last.
-                const handle = handleRef.current;
+                const handle = handleHost.current;
                 if (!handle) return;
                 refreshCanAcceptCellMutations(handle);
                 const pointerRefresh = planCellPointerRefresh(changeset);
@@ -475,16 +471,21 @@ export function useAutomergeNotebook() {
       resetRuntimeStoresProjection();
       resetPoolState();
       setCanAcceptCellMutations(false);
-      setNotebookHandle(null);
-      handleRef.current?.free();
-      handleRef.current = null;
+      handleHost.clear();
     };
-  }, [bootstrap, host, materializeCells, notifyRelayReady, refreshCanAcceptCellMutations]);
+  }, [
+    bootstrap,
+    handleHost,
+    host,
+    materializeCells,
+    notifyRelayReady,
+    refreshCanAcceptCellMutations,
+  ]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 
   const updateCellSource = useCallback((cellId: string, source: string) => {
-    const handle = handleRef.current;
+    const handle = handleHost.current;
     const engine = engineRef.current;
     if (!handle || !engine) return;
 
@@ -497,7 +498,7 @@ export function useAutomergeNotebook() {
 
   const addCell = useCallback(
     (cellType: "code" | "markdown" | "raw", afterCellId?: string | null): NotebookCell | null => {
-      const handle = handleRef.current;
+      const handle = handleHost.current;
       const engine = engineRef.current;
 
       if (!handle || !engine) {
@@ -569,7 +570,7 @@ export function useAutomergeNotebook() {
     (cellIds: string | string[]) => {
       const ids = Array.isArray(cellIds) ? cellIds : [cellIds];
       if (ids.length === 0) return false;
-      const handle = handleRef.current;
+      const handle = handleHost.current;
       const engine = engineRef.current;
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] clearOutputs skipped: no handle/engine");
@@ -679,7 +680,7 @@ export function useAutomergeNotebook() {
 
   // ── Public interface ───────────────────────────────────────────────
 
-  const getHandle = useCallback(() => handleRef.current, []);
+  const getHandle = useCallback(() => handleHost.current, [handleHost]);
   const triggerSync = useCallback(() => engineRef.current?.scheduleFlush(), []);
   const localActor = `human:${sessionIdRef.current}`;
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -47,6 +47,14 @@ export type {
   TextAttribution,
 } from "./handle";
 
+// Notebook handle host
+export {
+  NotebookHandleHost,
+  type HostedNotebookHandle,
+  type NotebookHandleHostOptions,
+  type NotebookHandleSlot,
+} from "./notebook-handle-host";
+
 // Text attribution events
 export {
   createTextAttributionEvent,

--- a/packages/runtimed/src/notebook-handle-host.ts
+++ b/packages/runtimed/src/notebook-handle-host.ts
@@ -1,0 +1,126 @@
+import { DEFAULT_MIME_PRIORITY } from "./mime-priority";
+
+export interface HostedNotebookHandle {
+  /** Release the underlying handle. Must not be called while published. */
+  free(): void;
+
+  /** Configure MIME selection used by output/runtime-state projection. */
+  set_mime_priority(priority: readonly string[]): void;
+
+  /** Configure the daemon blob server port used for ContentRef resolution. */
+  set_blob_port(port: number): void;
+}
+
+export interface NotebookHandleSlot<THandle extends HostedNotebookHandle = HostedNotebookHandle> {
+  current: THandle | null;
+}
+
+export interface NotebookHandleHostOptions<THandle extends HostedNotebookHandle> {
+  /** Mutable owner slot used by sync engines and callers that need current handle access. */
+  slot: NotebookHandleSlot<THandle>;
+
+  /** Actor label for new local handles. */
+  actorLabel: () => string;
+
+  /** Create a new local handle once `ready` resolves. */
+  createHandle: (actorLabel: string) => THandle;
+
+  /**
+   * Publish the current handle to any external readers, or clear it.
+   *
+   * This is called with `null` before any previous handle is freed so
+   * external readers cannot call into a stale wasm-bindgen pointer.
+   */
+  publishHandle: (handle: THandle | null) => void;
+
+  /** Optional readiness gate, commonly WASM initialization. */
+  ready?: Promise<void>;
+
+  /** Optional current blob port provider. */
+  getBlobPort?: () => number | null;
+
+  /** Optional async blob port refresh. */
+  refreshBlobPort?: () => Promise<number | null>;
+
+  /** MIME priority to install on each handle. */
+  mimePriority?: readonly string[];
+}
+
+/**
+ * Transport-agnostic owner for the active notebook handle.
+ *
+ * UI frameworks can build lifecycle around this class without duplicating the
+ * ordering that protects external readers from freed wasm-bindgen handles.
+ */
+export class NotebookHandleHost<THandle extends HostedNotebookHandle = HostedNotebookHandle> {
+  readonly #slot: NotebookHandleSlot<THandle>;
+  readonly #actorLabel: () => string;
+  readonly #createHandle: (actorLabel: string) => THandle;
+  readonly #publishHandle: (handle: THandle | null) => void;
+  readonly #getBlobPort?: () => number | null;
+  readonly #refreshBlobPort?: () => Promise<number | null>;
+  readonly #mimePriority: readonly string[];
+  #ready: Promise<void>;
+
+  constructor(options: NotebookHandleHostOptions<THandle>) {
+    this.#slot = options.slot;
+    this.#actorLabel = options.actorLabel;
+    this.#createHandle = options.createHandle;
+    this.#publishHandle = options.publishHandle;
+    this.#getBlobPort = options.getBlobPort;
+    this.#refreshBlobPort = options.refreshBlobPort;
+    this.#mimePriority = options.mimePriority ?? DEFAULT_MIME_PRIORITY;
+    this.#ready = options.ready ?? Promise.resolve();
+  }
+
+  get current(): THandle | null {
+    return this.#slot.current;
+  }
+
+  async bootstrap(isCancelled: () => boolean = () => false): Promise<boolean> {
+    const ready = this.#ready;
+    await ready;
+    if (isCancelled()) return false;
+
+    const handle = this.#createHandle(this.#actorLabel());
+    this.#replaceHandle(handle);
+    handle.set_mime_priority(this.#mimePriority);
+
+    const initialBlobPort = await this.#resolveBlobPort();
+
+    // A caller may run cleanup while the blob-port refresh is pending. Cleanup
+    // frees the handle, so only the current owner may publish or configure it.
+    if (isCancelled() || this.#slot.current !== handle) {
+      if (this.#slot.current === handle) {
+        this.clear();
+      }
+      return false;
+    }
+
+    if (initialBlobPort !== null) {
+      handle.set_blob_port(initialBlobPort);
+    }
+    this.#publishHandle(handle);
+    return true;
+  }
+
+  clear(): void {
+    this.#replaceHandle(null);
+  }
+
+  async #resolveBlobPort(): Promise<number | null> {
+    const existingPort = this.#getBlobPort?.() ?? null;
+    if (existingPort !== null) return existingPort;
+    return (await this.#refreshBlobPort?.()) ?? null;
+  }
+
+  #replaceHandle(nextHandle: THandle | null): void {
+    const previousHandle = this.#slot.current;
+    if (previousHandle === nextHandle) return;
+
+    this.#publishHandle(null);
+    this.#slot.current = null;
+    previousHandle?.free();
+    this.#slot.current = nextHandle;
+  }
+}

--- a/packages/runtimed/tests/notebook-handle-host.test.ts
+++ b/packages/runtimed/tests/notebook-handle-host.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { NotebookHandleHost, type HostedNotebookHandle, type NotebookHandleSlot } from "../src";
+
+function createHandle(name: string, calls: string[]): HostedNotebookHandle {
+  return {
+    free: vi.fn(() => calls.push(`free:${name}`)),
+    set_blob_port: vi.fn((port: number) => calls.push(`blob:${name}:${port}`)),
+    set_mime_priority: vi.fn(() => calls.push(`mime:${name}`)),
+  };
+}
+
+describe("NotebookHandleHost", () => {
+  it("clears published handle before freeing a replaced handle", async () => {
+    const calls: string[] = [];
+    const previousHandle = createHandle("previous", calls);
+    const nextHandle = createHandle("next", calls);
+    const slot: NotebookHandleSlot = { current: previousHandle };
+
+    const host = new NotebookHandleHost({
+      actorLabel: () => "human:test",
+      createHandle: vi.fn(() => nextHandle),
+      getBlobPort: vi.fn(() => 42),
+      publishHandle: vi.fn((handle) => calls.push(handle ? "publish:next" : "publish:null")),
+      refreshBlobPort: vi.fn(),
+      slot,
+    });
+
+    await expect(host.bootstrap()).resolves.toBe(true);
+
+    expect(calls).toEqual([
+      "publish:null",
+      "free:previous",
+      "mime:next",
+      "blob:next:42",
+      "publish:next",
+    ]);
+    expect(slot.current).toBe(nextHandle);
+  });
+
+  it("frees an unpublished handle when bootstrap is cancelled during blob-port refresh", async () => {
+    const calls: string[] = [];
+    let cancelled = false;
+    let resolveBlobPort: (port: number | null) => void = () => {};
+    const handle = createHandle("next", calls);
+    const slot: NotebookHandleSlot = { current: null };
+    const publishHandle = vi.fn((publishedHandle) =>
+      calls.push(publishedHandle ? "publish:next" : "publish:null"),
+    );
+
+    const host = new NotebookHandleHost({
+      actorLabel: () => "human:test",
+      createHandle: vi.fn(() => handle),
+      getBlobPort: vi.fn(() => null),
+      publishHandle,
+      refreshBlobPort: vi.fn(
+        () =>
+          new Promise<number | null>((resolve) => {
+            resolveBlobPort = resolve;
+          }),
+      ),
+      slot,
+    });
+
+    const bootstrap = host.bootstrap(() => cancelled);
+    await Promise.resolve();
+    cancelled = true;
+    resolveBlobPort(42);
+
+    await expect(bootstrap).resolves.toBe(false);
+    expect(calls).toEqual(["publish:null", "mime:next", "publish:null", "free:next"]);
+    expect(slot.current).toBeNull();
+    expect(publishHandle).not.toHaveBeenCalledWith(handle);
+  });
+
+  it("clear publishes null before freeing the current handle", () => {
+    const calls: string[] = [];
+    const handle = createHandle("current", calls);
+    const slot: NotebookHandleSlot = { current: handle };
+
+    const host = new NotebookHandleHost({
+      actorLabel: () => "human:test",
+      createHandle: vi.fn(() => createHandle("next", calls)),
+      publishHandle: vi.fn((publishedHandle) =>
+        calls.push(publishedHandle ? "publish:next" : "publish:null"),
+      ),
+      slot,
+    });
+
+    host.clear();
+
+    expect(calls).toEqual(["publish:null", "free:current"]);
+    expect(slot.current).toBeNull();
+  });
+
+  it("does not clear a newer bootstrap that replaces it during blob-port refresh", async () => {
+    const calls: string[] = [];
+    const blobPortResolvers: Array<(port: number | null) => void> = [];
+    const pendingHandle = createHandle("pending", calls);
+    const replacementHandle = createHandle("replacement", calls);
+    const slot: NotebookHandleSlot = { current: null };
+    const publishHandle = vi.fn((publishedHandle) => {
+      if (publishedHandle === pendingHandle) calls.push("publish:pending");
+      else if (publishedHandle === replacementHandle) calls.push("publish:replacement");
+      else calls.push("publish:null");
+    });
+    const handles = [pendingHandle, replacementHandle];
+
+    const host = new NotebookHandleHost({
+      actorLabel: () => "human:test",
+      createHandle: vi.fn(() => handles.shift() ?? createHandle("unexpected", calls)),
+      getBlobPort: vi.fn(() => null),
+      publishHandle,
+      refreshBlobPort: vi.fn(
+        () =>
+          new Promise<number | null>((resolve) => {
+            blobPortResolvers.push(resolve);
+          }),
+      ),
+      slot,
+    });
+
+    const firstBootstrap = host.bootstrap();
+    await Promise.resolve();
+    const secondBootstrap = host.bootstrap();
+    await Promise.resolve();
+    blobPortResolvers[0](42);
+
+    await expect(firstBootstrap).resolves.toBe(false);
+    expect(slot.current).toBe(replacementHandle);
+    expect(publishHandle).not.toHaveBeenCalledWith(pendingHandle);
+    expect(pendingHandle.free).toHaveBeenCalledTimes(1);
+    expect(replacementHandle.free).not.toHaveBeenCalled();
+
+    blobPortResolvers[1](43);
+    await expect(secondBootstrap).resolves.toBe(true);
+
+    expect(calls).toEqual([
+      "publish:null",
+      "mime:pending",
+      "publish:null",
+      "free:pending",
+      "mime:replacement",
+      "blob:replacement:43",
+      "publish:replacement",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Follow-up to #2556: extracts the freed-handle ordering fix into a tested package API.
- Add `NotebookHandleHost` to the `runtimed` JS package as a transport/framework-agnostic handle lifecycle API.
- Keep the notebook app responsible for WASM init/create, blob-port lookup, and metadata publication by passing those as host callbacks.
- Delegate `useAutomergeNotebook` bootstrap/cleanup handle ownership to that package API.
- Cover the crash-sensitive ordering with package-level unit tests: publication clears before freeing the previous handle, `clear()` clears before free, cancelled bootstrap does not publish a stale handle, and an older bootstrap does not clear a newer one.

## Verification

- `pnpm -C packages/runtimed exec tsc -b`
- `pnpm -C apps/notebook exec tsc -b`
- `pnpm test:run packages/runtimed/tests/notebook-handle-host.test.ts`
- `cargo xtask lint --fix` (passes; reports the existing `plugins/nteract/pi/extensions/repl.ts` `unicorn/no-new-array` warning)

Not run: GUI smoke for daemon kill/re-bootstrap. Repo instructions ask agents not to launch the desktop app from an agent terminal.
