### PR TITLE
fix(npm): remove private runtimed dependency from node wrapper

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -114,6 +114,28 @@ jobs:
       - name: Pack wrapper package
         run: pnpm --dir packages/runtimed-node pack --pack-destination "$RUNNER_TEMP"
 
+      - name: Verify wrapper package manifest
+        run: |
+          tar -xOf "$RUNNER_TEMP"/runtimed-node-*.tgz package/package.json > "$RUNNER_TEMP/wrapper-package.json"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const manifest = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/wrapper-package.json`, "utf8"));
+          const deps = manifest.dependencies ?? {};
+          const optionalDeps = manifest.optionalDependencies ?? {};
+
+          if (deps.runtimed) {
+            throw new Error(`@runtimed/node tarball must not depend on private package runtimed; found ${deps.runtimed}`);
+          }
+
+          for (const [section, entries] of Object.entries({ dependencies: deps, optionalDependencies: optionalDeps })) {
+            for (const [name, version] of Object.entries(entries)) {
+              if (String(version).startsWith("workspace:")) {
+                throw new Error(`${section}.${name} still uses workspace protocol in packed manifest`);
+              }
+            }
+          }
+          NODE
+
       - name: Publish wrapper package
         run: npm publish "$RUNNER_TEMP"/runtimed-node-*.tgz --tag latest --access public --provenance
 
@@ -145,6 +167,26 @@ jobs:
 
       - name: Pack Pi package
         run: pnpm --dir plugins/nteract/pi pack --pack-destination "$RUNNER_TEMP"
+
+      - name: Verify Pi package manifest
+        run: |
+          tar -xOf "$RUNNER_TEMP"/nteract-pi-*.tgz package/package.json > "$RUNNER_TEMP/pi-package.json"
+          node <<'NODE'
+          const fs = require("node:fs");
+          const pi = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/pi-package.json`, "utf8"));
+          const wrapper = JSON.parse(fs.readFileSync("packages/runtimed-node/package.json", "utf8"));
+          const deps = pi.dependencies ?? {};
+
+          if (deps["@runtimed/node"] !== wrapper.version) {
+            throw new Error(`@nteract/pi must depend on @runtimed/node ${wrapper.version}; found ${deps["@runtimed/node"]}`);
+          }
+
+          for (const [name, version] of Object.entries(deps)) {
+            if (String(version).startsWith("workspace:")) {
+              throw new Error(`dependencies.${name} still uses workspace protocol in packed manifest`);
+            }
+          }
+          NODE
 
       - name: Publish Pi package
         run: npm publish "$RUNNER_TEMP"/nteract-pi-*.tgz --tag latest --access public --provenance

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",
@@ -59,7 +59,6 @@
     "smoke:api": "node scripts/smoke-api.cjs"
   },
   "dependencies": {
-    "runtimed": "workspace:*",
     "rxjs": "^7.8.2"
   },
   "optionalDependencies": {

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -1,5 +1,28 @@
 import type { Observable } from "rxjs";
-import type { ExecutionTransition, RuntimeState, SessionStatus } from "runtimed";
+
+export type NotebookDocPhase = "pending" | "syncing" | "interactive";
+export type RuntimeStatePhase = "pending" | "syncing" | "ready";
+
+export type InitialLoadPhase =
+  | { phase: "not_needed" }
+  | { phase: "streaming" }
+  | { phase: "ready" }
+  | { phase: "failed"; reason: string };
+
+export interface SessionStatus {
+  notebook_doc: NotebookDocPhase;
+  runtime_state: RuntimeStatePhase;
+  initial_load: InitialLoadPhase;
+}
+
+export interface ExecutionTransition {
+  execution_id: string;
+  cell_id: string;
+  kind: "started" | "done" | "error";
+  execution_count: number | null;
+}
+
+export type RuntimeState = Record<string, unknown>;
 
 export type RuntimeKind = "python" | "deno" | (string & {});
 export type PackageManager = "uv" | "conda" | "pixi";

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Persistent notebook-backed Python REPL for Pi coding agents. Stateful execution, hot dependency sync, zero cold starts.",
   "author": "nteract contributors",
   "icon": "icon.png",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,9 +529,6 @@ importers:
 
   packages/runtimed-node:
     dependencies:
-      runtimed:
-        specifier: workspace:*
-        version: link:../runtimed
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2


### PR DESCRIPTION
## Summary

- removes the private workspace-only `runtimed` dependency from the published `@runtimed/node` wrapper
- makes the wrapper declaration file self-contained so npm installs do not need the private package
- bumps `@runtimed/node` and native package manifests to `0.2.4`, and bumps `@nteract/pi` to `0.1.6`
- adds publish-time tarball manifest checks to catch private `runtimed` or `workspace:` dependency leaks before npm publish

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --config.ignore-scripts=true --dir packages/runtimed-node pack --pack-destination /tmp/runtimed-node-verify --json`
- `pnpm --config.ignore-scripts=true --dir plugins/nteract/pi pack --pack-destination /tmp/runtimed-node-verify --json`
- inspected packed manifests for `@runtimed/node@0.2.4` and `@nteract/pi@0.1.6`
- `actionlint .github/workflows/publish-npm.yml`
