### PR TITLE
fix(sync): retry runtime state frames after panic recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
+source = "git+https://github.com/nteract/automerge?rev=24bf6c8b15be31767770e8fd37a607a31ad1d02b#24bf6c8b15be31767770e8fd37a607a31ad1d02b"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
+source = "git+https://github.com/nteract/automerge?rev=24bf6c8b15be31767770e8fd37a607a31ad1d02b#24bf6c8b15be31767770e8fd37a607a31ad1d02b"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "4a605a43586e08de090bb1321b661b15c1e71962" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "24bf6c8b15be31767770e8fd37a607a31ad1d02b" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -108,6 +108,7 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(message)) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
@@ -115,7 +116,11 @@ impl SharedDocState {
                 if let Err(source) = self.rebuild_doc() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || self.receive_sync_message(retry_message)) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -161,6 +166,7 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_state_sync_message(message)) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
@@ -168,7 +174,13 @@ impl SharedDocState {
                 if let Err(source) = self.rebuild_state_doc() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_state_sync_message(retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -82,6 +82,8 @@ use automerge::{
 use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{
     KernelActivity, KernelErrorReason, ProjectContext, ProjectFile, ProjectFileExtras,
@@ -338,6 +340,9 @@ pub struct RuntimeStateDoc {
     doc: AutoCommit,
 }
 
+#[cfg(test)]
+static PANIC_ON_NEXT_RECEIVE_SYNC_CALLS: AtomicUsize = AtomicUsize::new(0);
+
 impl RuntimeStateDoc {
     /// Create a new `RuntimeStateDoc` for the **daemon** with schema scaffolded.
     ///
@@ -384,6 +389,27 @@ impl RuntimeStateDoc {
 
     pub fn new_empty() -> Self {
         Self::try_new_empty().unwrap_or_else(|err| panic!("seed runtime state schema: {err}"))
+    }
+
+    #[cfg(test)]
+    fn __panic_on_next_receive_sync_calls_for_test(count: usize) {
+        PANIC_ON_NEXT_RECEIVE_SYNC_CALLS.store(count, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn panic_if_receive_sync_requested_for_test(label: &str) {
+        if PANIC_ON_NEXT_RECEIVE_SYNC_CALLS
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                if count > 0 {
+                    Some(count - 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+        {
+            panic!("injected RuntimeStateDoc {label} panic");
+        }
     }
 
     fn schema_seed_doc() -> Result<AutoCommit, RuntimeStateError> {
@@ -2684,6 +2710,9 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
+        #[cfg(test)]
+        Self::panic_if_receive_sync_requested_for_test("receive sync");
+
         if !message.changes.is_empty() {
             tracing::debug!(
                 "[runtime-state] Stripped {} change(s) from client RuntimeStateDoc sync message",
@@ -2711,6 +2740,7 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
             Ok(Ok(())) => Ok(()),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
@@ -2719,7 +2749,13 @@ impl RuntimeStateDoc {
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -2737,6 +2773,9 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<bool, AutomergeError> {
+        #[cfg(test)]
+        Self::panic_if_receive_sync_requested_for_test("receive sync with changes");
+
         let heads_before = self.doc.get_heads();
         self.doc.sync().receive_sync_message(peer_state, message)?;
         let heads_after = self.doc.get_heads();
@@ -2751,6 +2790,7 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<bool, AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || {
             self.receive_sync_message_with_changes(peer_state, message)
         }) {
@@ -2761,7 +2801,13 @@ impl RuntimeStateDoc {
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message_with_changes(peer_state, retry_message)
+                }) {
+                    Ok(Ok(changed)) => Ok(changed),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -2795,6 +2841,9 @@ impl RuntimeStateDoc {
     where
         F: Fn(&ActorId) -> bool,
     {
+        #[cfg(test)]
+        Self::panic_if_receive_sync_requested_for_test("receive sync and foreign comms");
+
         let heads_before = self.doc.get_heads();
         self.doc.sync().receive_sync_message(peer_state, message)?;
 
@@ -2889,8 +2938,9 @@ impl RuntimeStateDoc {
     where
         F: Fn(&ActorId) -> bool,
     {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || {
-            self.receive_sync_and_foreign_comms(peer_state, message, is_foreign)
+            self.receive_sync_and_foreign_comms(peer_state, message, &is_foreign)
         }) {
             Ok(Ok(view)) => Ok(view),
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
@@ -2899,7 +2949,13 @@ impl RuntimeStateDoc {
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_and_foreign_comms(peer_state, retry_message, is_foreign)
+                }) {
+                    Ok(Ok(view)) => Ok(view),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -5136,6 +5192,97 @@ mod tests {
         // Object values are always written (no deep comparison)
         let delta = serde_json::json!({"nested": {"a": 1}});
         doc.merge_comm_state_delta("w1", &delta).unwrap();
+    }
+
+    #[test]
+    fn receive_sync_with_changes_retries_original_message_after_panic_rebuild() {
+        let mut receiver = RuntimeStateDoc::new_empty();
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = RuntimeStateDoc::new();
+        donor
+            .create_execution_with_source("exec-retry", "cell-retry", "x = 1", 1)
+            .unwrap();
+        let mut donor_sync = sync::State::new();
+        if let Some(handshake) = receiver.generate_sync_message(&mut receiver_sync) {
+            donor
+                .doc
+                .sync()
+                .receive_sync_message(&mut donor_sync, handshake)
+                .expect("donor receives receiver handshake");
+        }
+        let message = donor
+            .generate_sync_message(&mut donor_sync)
+            .expect("donor should advertise execution");
+
+        RuntimeStateDoc::__panic_on_next_receive_sync_calls_for_test(1);
+        let changed = receiver
+            .receive_sync_message_with_changes_recovering(
+                &mut receiver_sync,
+                message,
+                "receive-sync-retry-test",
+            )
+            .expect("recovery should retry the original message");
+
+        assert!(changed, "retried message should apply donor changes");
+        assert!(
+            receiver.read_state().executions.contains_key("exec-retry"),
+            "execution from the panic-triggering frame should not be dropped"
+        );
+    }
+
+    #[test]
+    fn receive_sync_and_foreign_comms_retries_original_message_after_panic_rebuild() {
+        let mut receiver = RuntimeStateDoc::new();
+        receiver.set_actor("rt:kernel:deadbeef");
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = receiver.fork();
+        donor.fork_and_merge(|f| {
+            f.set_actor("human:peer");
+            f.put_comm(
+                "human-widget",
+                "j.w",
+                "",
+                "",
+                &serde_json::json!({"value": 2}),
+                0,
+            )
+            .unwrap();
+        });
+        let mut donor_sync = sync::State::new();
+        if let Some(handshake) = receiver.generate_sync_message(&mut receiver_sync) {
+            donor
+                .doc
+                .sync()
+                .receive_sync_message(&mut donor_sync, handshake)
+                .expect("donor receives receiver handshake");
+        }
+        let message = donor
+            .generate_sync_message(&mut donor_sync)
+            .expect("donor should advertise comm change");
+
+        RuntimeStateDoc::__panic_on_next_receive_sync_calls_for_test(1);
+        let view = receiver
+            .receive_sync_and_foreign_comms_recovering(
+                &mut receiver_sync,
+                message,
+                |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                "receive-sync-foreign-retry-test",
+            )
+            .expect("recovery should retry the original message");
+
+        assert!(
+            view.applied_actors
+                .iter()
+                .any(|actor| actor.to_bytes().starts_with(b"human:")),
+            "retried message should report the applied frontend actor"
+        );
+        let foreign_comms = view.foreign_comms.expect("foreign comm view");
+        assert!(
+            foreign_comms.contains_key("human-widget"),
+            "foreign comm from the panic-triggering frame should not be dropped"
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -148,7 +148,7 @@ pub struct JupyterKernel {
     pub env_path: Option<PathBuf>,
     /// Session ID for Jupyter protocol.
     session_id: String,
-    /// Automerge actor ID for kernel writes (e.g. "rt:kernel:a1b2c3d4").
+    /// Automerge actor ID for kernel writes (e.g. "rt:kernel:<uuid>").
     kernel_actor_id: String,
     /// Connection info for the kernel.
     connection_info: Option<ConnectionInfo>,
@@ -946,9 +946,11 @@ impl KernelConnection for JupyterKernel {
         #[cfg(unix)]
         let kernel_pid = process.id().map(|pid| pid as i32);
 
-        // Fresh session_id for ZMQ connections
-        let session_id = Uuid::new_v4().to_string();
-        let kernel_actor_id = format!("rt:kernel:{}", &session_id[..8]);
+        // Fresh session_id for ZMQ connections. Reuse the same full-entropy UUID
+        // for the kernel actor label so runtime-state actor streams cannot collide.
+        let session_uuid = Uuid::new_v4();
+        let session_id = session_uuid.to_string();
+        let kernel_actor_id = format!("rt:kernel:{}", session_uuid.simple());
 
         // ── ZMQ connections and background tasks ─────────────────────────
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3714,7 +3714,7 @@ pub(crate) async fn auto_launch_kernel(
         // Always pass the room UUID so the agent's RuntimeAgent handshake
         // finds the room in the UUID-keyed rooms map.
         let nb_id = room.id.to_string();
-        let runtime_agent_id = format!("runtime-agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let runtime_agent_id = format!("runtime-agent:{}", uuid::Uuid::new_v4().simple());
         let socket_path = daemon.socket_path().clone();
 
         // Set provenance BEFORE spawn so stale agents are rejected by the

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1498,7 +1498,7 @@ pub(crate) async fn handle(
         // Always pass the room UUID so the agent's RuntimeAgent
         // handshake finds the room in the UUID-keyed rooms map.
         let notebook_id = room.id.to_string();
-        let runtime_agent_id = format!("runtime-agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let runtime_agent_id = format!("runtime-agent:{}", uuid::Uuid::new_v4().simple());
         let socket_path = daemon.socket_path().clone();
 
         // Set provenance + bump generation + create oneshot BEFORE spawn


### PR DESCRIPTION
## Summary

- retry the original Automerge sync message after RuntimeStateDoc panic recovery rebuilds and resets peer state
- apply the same retry behavior to notebook-sync shared doc recovery wrappers
- add runtime-doc tests that prove the panic-triggering frame still applies queued executions and foreign comm updates
- pin nteract/automerge to the fork fix from nteract/automerge#2
- use full-entropy UUID labels for runtime-agent and kernel Automerge actors instead of truncating to 8 hex chars

## Why

The failing PR #2558 `runtimed-py Integration Tests` job timed out in the daemon health check after gw4 logged an Automerge `PatchLogMismatch` panic while the runtime agent was receiving `RuntimeStateSync`.

The existing recovery path rebuilt the document and reset local sync state, but then returned `Err(Panic)` without applying the frame that carried the queued execution. In the runtime-agent path, that can leave the health-check execution unseen by the kernel even though the process stayed alive.

The underlying Automerge panic is also fixed in nteract/automerge#2: inactive/empty patch logs can retarget to the current actor table, and real `PatchLogMismatch` cases return an error instead of unwrapping.

I also audited the runtime-state actor usage. The production kernel write paths use live-document `transact_at_*` helpers, not concurrent forks with the same actor, so I did not find evidence of the duplicate-sequence actor bug there. The 8-character actor labels were still unnecessary collision risk, so this PR removes that truncation.

## Verification

- `cargo test -p runtime-doc`
- `cargo test -p notebook-sync`
- `cargo check -p runtime-doc`
- `cargo check -p runtimed`
- `cargo test -p runtime-doc receive_sync -- --nocapture --test-threads=1`
- `cargo test -p notebook-sync runtime_state_sync_panic_is_caught_and_later_updates_still_apply -- --nocapture --test-threads=1`
- `cargo test -p runtimed runtime_agent_manifest -- --nocapture`
- `cargo xtask lint --fix`

Note: the lint pass still reports the pre-existing `plugins/nteract/pi/extensions/repl.ts:217` `eslint-plugin-unicorn(no-new-array)` warning, but exits successfully.
