### PR TITLE
fix(kernel-launcher): register LLM repr formatter

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -1,20 +1,24 @@
 """IPython extension — the launcher-hosted bootstrap.
 
 Loaded automatically via ``NteractKernelApp.default_extensions`` before any
-user code runs. Three things happen on ``load_ipython_extension``:
+user code runs. Four things happen on ``load_ipython_extension``:
 
-1. ``mimebundle_formatter`` entries for pandas / polars / narwhals /
+1. A ``text/llm+plain`` formatter is registered for objects that expose
+   ``_repr_llm_``. This mirrors the original ``repr_llm`` convention while
+   keeping the launcher self-contained.
+
+2. ``mimebundle_formatter`` entries for pandas / polars / narwhals /
    datasets are registered by **dotted type name** (no eager imports).
    IPython binds them lazily on first encounter — dx's historical
    ``import pandas as pd`` at install time becomes unnecessary.
 
-2. :func:`_buffer_hook.install` registers the single buffer-attachment
+3. :func:`_buffer_hook.install` registers the single buffer-attachment
    hook on *both* ``ip.display_pub`` and ``ip.displayhook``. With the
    hook chain in place on both seats, ``execute_result`` (bare ``df``
    on last line) and ``display_data`` / ``update_display_data`` all
    pick up parquet buffers from the same pending-bytes stash.
 
-3. Third-party visualization libraries (altair, plotly) are flipped to
+4. Third-party visualization libraries (altair, plotly) are flipped to
    their ``"nteract"`` renderer if they happen to be importable. Each
    is guarded so the bootstrap stays a no-op in minimal envs.
 
@@ -34,6 +38,9 @@ import logging
 import os
 from typing import Any
 
+from IPython.core.formatters import BaseFormatter
+from traitlets import ObjectName, Unicode
+
 from nteract_kernel_launcher import _buffer_hook, _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import serialize_dataframe
@@ -44,6 +51,17 @@ log = logging.getLogger("nteract_kernel_launcher")
 
 # Server-side blob ceiling is ~100 MiB; leave ~10 MiB for overhead.
 _MAX_PAYLOAD_BYTES = int(os.environ.get("DX_MAX_PAYLOAD_BYTES", str(90 * 1024 * 1024)))
+
+
+class LLMFormatter(BaseFormatter):
+    """Formatter for plaintext LLM representations.
+
+    Objects can opt in by defining ``_repr_llm_``. Callers may also use the
+    inherited ``for_type`` / ``for_type_by_name`` registration APIs.
+    """
+
+    format_type = Unicode("text/llm+plain")  # type: ignore[assignment]
+    print_method = ObjectName("_repr_llm_")  # type: ignore[assignment]
 
 
 # ─── mimebundle formatters (lazy-bound via for_type_by_name) ──────────────
@@ -163,6 +181,22 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
 # ─── Install functions — called from load_ipython_extension ───────────────
 
 
+def _install_llm_formatter(ip: Any) -> BaseFormatter | None:
+    """Register ``text/llm+plain`` support for ``_repr_llm_`` objects."""
+    display_formatter = getattr(ip, "display_formatter", None)
+    formatters = getattr(display_formatter, "formatters", None)
+    if not isinstance(formatters, dict):
+        return None
+
+    existing = formatters.get("text/llm+plain")
+    if existing is not None:
+        return existing
+
+    llm_formatter = LLMFormatter(parent=display_formatter)
+    formatters["text/llm+plain"] = llm_formatter
+    return llm_formatter
+
+
 def _install_dataframe_formatters(ip: Any) -> None:
     """Register mimebundle formatters lazily via ``for_type_by_name``.
 
@@ -247,6 +281,11 @@ def load_ipython_extension(ip: Any) -> None:
     further guard each install step so a single failure doesn't abort
     the others.
     """
+    try:
+        _install_llm_formatter(ip)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("LLM formatter install failed: %s", exc)
+
     try:
         _install_dataframe_formatters(ip)
     except Exception as exc:  # noqa: BLE001

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -224,14 +224,66 @@ def test_install_registers_on_both_seats_once():
     assert len(ip.displayhook._hooks) == 1
 
 
+# ─── LLM formatter contract ──────────────────────────────────────────────
+
+
+def test_llm_formatter_uses_repr_llm_method():
+    from IPython.core.formatters import DisplayFormatter
+    from nteract_kernel_launcher import _bootstrap
+
+    display_formatter = DisplayFormatter()
+    ip = SimpleNamespace(display_formatter=display_formatter)
+
+    class Example:
+        def _repr_llm_(self):
+            return "what up"
+
+    formatter = _bootstrap._install_llm_formatter(ip)
+
+    assert formatter is display_formatter.formatters["text/llm+plain"]
+    data, metadata = display_formatter.format(Example())
+    assert data["text/llm+plain"] == "what up"
+    assert metadata == {}
+
+
+def test_llm_formatter_preserves_existing_registration():
+    from IPython.core.formatters import BaseFormatter
+    from nteract_kernel_launcher import _bootstrap
+
+    existing = BaseFormatter()
+    display_formatter = SimpleNamespace(formatters={"text/llm+plain": existing})
+    ip = SimpleNamespace(display_formatter=display_formatter)
+
+    assert _bootstrap._install_llm_formatter(ip) is existing
+    assert display_formatter.formatters["text/llm+plain"] is existing
+
+
+def test_llm_formatter_supports_for_type_registration():
+    from IPython.core.formatters import DisplayFormatter
+    from nteract_kernel_launcher import _bootstrap
+
+    display_formatter = DisplayFormatter()
+    ip = SimpleNamespace(display_formatter=display_formatter)
+    formatter = _bootstrap._install_llm_formatter(ip)
+
+    class Example:
+        pass
+
+    formatter.for_type(Example, lambda obj: "registered")
+
+    data, _metadata = display_formatter.format(Example())
+    assert data["text/llm+plain"] == "registered"
+
+
 # ─── load_ipython_extension contract ─────────────────────────────────────
 
 
-def test_load_extension_invokes_the_three_install_steps(monkeypatch):
+def test_load_extension_invokes_the_install_steps(monkeypatch):
     from nteract_kernel_launcher import _bootstrap
 
     calls = []
 
+    monkeypatch.setattr(_bootstrap, "_install_llm_formatter", lambda ip: calls.append("llm"))
     monkeypatch.setattr(
         _bootstrap, "_install_dataframe_formatters", lambda ip: calls.append("formatters")
     )
@@ -241,7 +293,7 @@ def test_load_extension_invokes_the_three_install_steps(monkeypatch):
     )
 
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert calls == ["formatters", "hooks", "renderers"]
+    assert calls == ["llm", "formatters", "hooks", "renderers"]
 
 
 def test_load_extension_swallows_per_step_failures(monkeypatch):
@@ -253,6 +305,7 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     def boom(*_args, **_kwargs):
         raise RuntimeError("nope")
 
+    monkeypatch.setattr(_bootstrap, "_install_llm_formatter", boom)
     monkeypatch.setattr(_bootstrap, "_install_dataframe_formatters", boom)
     monkeypatch.setattr(_bootstrap, "_install_buffer_hooks", lambda ip: called.append("hooks"))
     monkeypatch.setattr(_bootstrap, "_enable_third_party_renderers", lambda: called.append("r"))


### PR DESCRIPTION
## Summary

- Register a launcher-hosted `text/llm+plain` IPython formatter for objects that expose `_repr_llm_`
- Preserve any existing `text/llm+plain` formatter registration instead of replacing it
- Add launcher bootstrap tests for `_repr_llm_`, existing registration preservation, and `for_type` registration

## Verification

- `uv run --project python/nteract-kernel-launcher pytest python/nteract-kernel-launcher/tests/test_bootstrap.py -q`
- `uv run ruff check python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py python/nteract-kernel-launcher/tests/test_bootstrap.py`
- `cargo xtask lint --fix`
