### PR TITLE
fix(runtimed): surface environment preparation failures

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -790,8 +790,9 @@ function AppContent() {
 
         if (response.result === "sync_environment_failed" && !response.needs_restart) {
           // Error but doesn't need restart (e.g., package cannot resolve).
-          // Leave RuntimeStateDoc env progress visible so the toolbar can
-          // show the solver/install error instead of silently dismissing it.
+          // The runtime agent already wrote EnvProgressPhase::Error into
+          // RuntimeStateDoc before replying, so keep the local progress
+          // banner visible instead of dismissing it.
           logger.error("[App] Hot-sync failed:", {
             error: response.error,
             envSource,

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -789,13 +789,14 @@ function AppContent() {
         }
 
         if (response.result === "sync_environment_failed" && !response.needs_restart) {
-          // Error but doesn't need restart (e.g., install failed)
+          // Error but doesn't need restart (e.g., package cannot resolve).
+          // Leave RuntimeStateDoc env progress visible so the toolbar can
+          // show the solver/install error instead of silently dismissing it.
           logger.error("[App] Hot-sync failed:", {
             error: response.error,
             envSource,
             packages: envSyncState?.diff?.added,
           });
-          envProgress.reset();
           return false;
         }
 

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -18,8 +18,8 @@ import { Button } from "@/components/ui/button";
  * - Skip `runtime === "deno"`: toolbar renders the Deno
  *   "auto-install failed" prompt that already consumes it.
  *
- * Everything else — stderr tails from generic subprocess crashes,
- * env-build rate limits — falls through to this banner.
+ * Everything else — solver/install errors, stderr tails from generic
+ * subprocess crashes, env-build rate limits — falls through to this banner.
  */
 export function shouldShowKernelLaunchErrorBanner(params: {
   lifecycle: RuntimeLifecycle;
@@ -50,14 +50,14 @@ interface KernelLaunchErrorBannerProps {
 
 /**
  * Banner surfaced when the daemon reports `RuntimeLifecycle::Error`
- * without a typed `KernelErrorReason`. Those typed cases
- * (`MissingIpykernel`, `CondaEnvYmlMissing`) have their own targeted
- * prompts; this one covers everything else — subprocess crashes,
- * import errors, rate-limited env builds, etc.
+ * with launch details that are not owned by a more targeted remediation
+ * prompt. Those targeted cases (`MissingIpykernel`, `CondaEnvYmlMissing`)
+ * have their own prompts; this one covers everything else — env solve
+ * failures, subprocess crashes, import errors, rate-limited env builds, etc.
  *
- * App.tsx gates visibility on lifecycle + a non-typed reason and
- * resets the dismiss state when `errorDetails` changes, so a new
- * failure after a retry re-shows the banner.
+ * App.tsx gates visibility on lifecycle + non-targeted remediation
+ * cases and resets the dismiss state when `errorDetails` changes, so
+ * a new failure after a retry re-shows the banner.
  */
 export function KernelLaunchErrorBanner({
   errorDetails,

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -13,8 +13,9 @@ import { Button } from "@/components/ui/button";
  * Rules:
  *
  * - Only show in `Error` state with non-empty `errorDetails`.
- * - Skip `MissingIpykernel`: toolbar renders a targeted "install
- *   ipykernel" prompt that already consumes the error message.
+ * - Skip typed remediation cases such as missing ipykernel,
+ *   dependency-cache mismatches, and missing environment.yml builds:
+ *   toolbar renders targeted prompts that already consume the error message.
  * - Skip `runtime === "deno"`: toolbar renders the Deno
  *   "auto-install failed" prompt that already consumes it.
  *
@@ -51,9 +52,10 @@ interface KernelLaunchErrorBannerProps {
 /**
  * Banner surfaced when the daemon reports `RuntimeLifecycle::Error`
  * with launch details that are not owned by a more targeted remediation
- * prompt. Those targeted cases (`MissingIpykernel`, `CondaEnvYmlMissing`)
- * have their own prompts; this one covers everything else — env solve
- * failures, subprocess crashes, import errors, rate-limited env builds, etc.
+ * prompt. Those targeted cases are skipped by
+ * `shouldShowKernelLaunchErrorBanner`; this one covers everything else —
+ * env solve failures, subprocess crashes, import errors, rate-limited env
+ * builds, etc.
  *
  * App.tsx gates visibility on lifecycle + non-targeted remediation
  * cases and resets the dismiss state when `errorDetails` changes, so

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -154,6 +154,17 @@ describe("shouldShowKernelLaunchErrorBanner", () => {
     ).toBe(false);
   });
 
+  it("shows for environment prepare failures", () => {
+    expect(
+      shouldShowKernelLaunchErrorBanner({
+        lifecycle: ERROR,
+        errorDetails: "Failed to prepare conda inline environment: No candidates found",
+        errorReason: KERNEL_ERROR_REASON.ENVIRONMENT_PREPARE_FAILED,
+        runtime: "python",
+      }),
+    ).toBe(true);
+  });
+
   it("hides for Deno runtime (toolbar renders its own install prompt)", () => {
     // Deno failures show `Deno not available. Auto-install failed…`
     // in NotebookToolbar. Rendering the red banner on top would be

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -27,6 +27,7 @@ import {
 } from "runtimed";
 
 const ERROR_REASON_LABELS: Record<string, string> = {
+  [KERNEL_ERROR_REASON.ENVIRONMENT_PREPARE_FAILED]: "environment setup failed",
   [KERNEL_ERROR_REASON.MISSING_IPYKERNEL]: "ipykernel missing",
   [KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL]: "ipykernel missing",
   [KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH]: "Python environment mismatch",

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -58,6 +58,7 @@ pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
     "anywidget",
+    "pip",
     "nbformat",
     "pyarrow>=14",
 ];
@@ -482,6 +483,7 @@ async fn install_conda_env(
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
     specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
     specs.push(MatchSpec::from_str("anywidget", match_spec_options)?);
+    specs.push(MatchSpec::from_str("pip", match_spec_options)?);
     specs.push(MatchSpec::from_str("nbformat", match_spec_options)?);
     specs.push(MatchSpec::from_str("pyarrow>=14", match_spec_options)?);
 
@@ -489,6 +491,7 @@ async fn install_conda_env(
         if dep != "ipykernel"
             && dep != "ipywidgets"
             && dep != "anywidget"
+            && dep != "pip"
             && dep != "nbformat"
             && dep != "pyarrow>=14"
         {
@@ -663,7 +666,11 @@ pub async fn create_prewarmed_environment_in(
 
     tokio::fs::create_dir_all(cache_dir).await?;
 
-    let mut deps_list = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
+    let mut deps_list = vec![
+        "ipykernel".to_string(),
+        "ipywidgets".to_string(),
+        "pip".to_string(),
+    ];
     if !extra_packages.is_empty() {
         info!("[prewarm] Including extra packages: {:?}", extra_packages);
         deps_list.extend(extra_packages.iter().cloned());
@@ -920,6 +927,7 @@ pub async fn sync_dependencies(
         MatchSpec::from_str("ipykernel", match_spec_options)?,
         MatchSpec::from_str("ipywidgets", match_spec_options)?,
         MatchSpec::from_str("anywidget", match_spec_options)?,
+        MatchSpec::from_str("pip", match_spec_options)?,
         MatchSpec::from_str("nbformat", match_spec_options)?,
         MatchSpec::from_str("pyarrow>=14", match_spec_options)?,
     ];
@@ -954,6 +962,7 @@ pub async fn sync_dependencies(
         if dep != "ipykernel"
             && dep != "ipywidgets"
             && dep != "anywidget"
+            && dep != "pip"
             && dep != "nbformat"
             && dep != "pyarrow>=14"
         {
@@ -1137,6 +1146,7 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
     specs.push("ipykernel".to_string());
     specs.push("ipywidgets".to_string());
     specs.push("anywidget".to_string());
+    specs.push("pip".to_string());
     specs.push("nbformat".to_string());
     specs.push("pyarrow>=14".to_string());
 
@@ -1144,6 +1154,7 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
         if dep != "ipykernel"
             && dep != "ipywidgets"
             && dep != "anywidget"
+            && dep != "pip"
             && dep != "nbformat"
             && dep != "pyarrow>=14"
         {

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -290,6 +290,7 @@ mod strip_base_tests {
             "ipykernel",
             "ipywidgets",
             "anywidget",
+            "pip",
             "nbformat",
             "pyarrow>=14",
             "scipy",

--- a/crates/runtime-doc/src/types.rs
+++ b/crates/runtime-doc/src/types.rs
@@ -207,6 +207,10 @@ impl KernelActivity {
 /// value via `KERNEL_ERROR_REASON` in `@runtimed`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KernelErrorReason {
+    /// A package-manager environment prepare/sync step failed before the
+    /// kernel process could launch. `error_details` carries the manager's
+    /// solve/install error.
+    EnvironmentPrepareFailed,
     /// Pixi-managed environment is missing the `ipykernel` package.
     /// `NotebookToolbar` gates its "install ipykernel" prompt on this.
     MissingIpykernel,
@@ -231,6 +235,7 @@ pub enum KernelErrorReason {
 impl KernelErrorReason {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::EnvironmentPrepareFailed => "environment_prepare_failed",
             Self::MissingIpykernel => "missing_ipykernel",
             Self::DependencyCacheMissingIpykernel => "dependency_cache_missing_ipykernel",
             Self::IpykernelSitePackagesMismatch => "ipykernel_site_packages_mismatch",
@@ -241,6 +246,7 @@ impl KernelErrorReason {
 
     pub fn parse(s: &str) -> Option<Self> {
         match s {
+            "environment_prepare_failed" => Some(Self::EnvironmentPrepareFailed),
             "missing_ipykernel" => Some(Self::MissingIpykernel),
             "dependency_cache_missing_ipykernel" => Some(Self::DependencyCacheMissingIpykernel),
             "ipykernel_site_packages_mismatch" => Some(Self::IpykernelSitePackagesMismatch),
@@ -456,6 +462,10 @@ mod tests {
     #[test]
     fn error_reason_as_str() {
         assert_eq!(
+            KernelErrorReason::EnvironmentPrepareFailed.as_str(),
+            "environment_prepare_failed"
+        );
+        assert_eq!(
             KernelErrorReason::MissingIpykernel.as_str(),
             "missing_ipykernel"
         );
@@ -475,6 +485,10 @@ mod tests {
 
     #[test]
     fn error_reason_parse() {
+        assert_eq!(
+            KernelErrorReason::parse("environment_prepare_failed"),
+            Some(KernelErrorReason::EnvironmentPrepareFailed)
+        );
         assert_eq!(
             KernelErrorReason::parse("missing_ipykernel"),
             Some(KernelErrorReason::MissingIpykernel)
@@ -501,6 +515,7 @@ mod tests {
     #[test]
     fn error_reason_as_str_round_trips_through_parse() {
         let reasons = [
+            KernelErrorReason::EnvironmentPrepareFailed,
             KernelErrorReason::MissingIpykernel,
             KernelErrorReason::DependencyCacheMissingIpykernel,
             KernelErrorReason::IpykernelSitePackagesMismatch,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -387,6 +387,7 @@ const BASE_RUNTIME_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
     "anywidget",
+    "pip",
     "nbformat",
     "pyarrow",
 ];
@@ -443,6 +444,7 @@ fn conda_prewarmed_packages(extra: &[String], install_default_data_packages: boo
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
+        "pip".to_string(),
     ];
     extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
@@ -453,6 +455,7 @@ fn pixi_prewarmed_packages(extra: &[String], install_default_data_packages: bool
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
+        "pip".to_string(),
     ];
     extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
@@ -5068,6 +5071,14 @@ mod tests {
         }
         assert!(packages.iter().any(|pkg| pkg == "nbformat"));
         assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+    }
+
+    #[test]
+    fn test_conda_and_pixi_prewarmed_packages_include_pip() {
+        let conda = conda_prewarmed_packages(&[], false);
+        let pixi = pixi_prewarmed_packages(&[], false);
+        assert!(conda.iter().any(|pkg| pkg == "pip"));
+        assert!(pixi.iter().any(|pkg| pkg == "pip"));
     }
 
     #[test]

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -161,6 +161,17 @@ pub(crate) fn inline_deps_with_required_packages(deps: &[String]) -> Vec<String>
     effective
 }
 
+/// Return inline deps plus the managed packages expected in Conda/Pixi
+/// environments. `pip` is explicit so `%pip` uses the running environment's
+/// interpreter rather than depending on a package-manager default.
+pub(crate) fn inline_deps_with_conda_required_packages(deps: &[String]) -> Vec<String> {
+    let mut effective = inline_deps_with_required_packages(deps);
+    if !has_dep_named(&effective, "pip") {
+        effective.push("pip".to_string());
+    }
+    effective
+}
+
 /// Prepare a cached UV environment with the given inline dependencies.
 ///
 /// If a cached environment with the same deps already exists, returns it
@@ -197,7 +208,7 @@ pub async fn prepare_conda_inline_env(
     handler: Arc<dyn ProgressHandler>,
 ) -> Result<PreparedEnv> {
     let conda_deps = kernel_env::CondaDependencies {
-        dependencies: inline_deps_with_required_packages(deps),
+        dependencies: inline_deps_with_conda_required_packages(deps),
         channels: if channels.is_empty() {
             vec!["conda-forge".to_string()]
         } else {
@@ -252,7 +263,7 @@ pub async fn claim_pool_env_for_conda_inline_cache(
     channels: &[String],
     python: Option<&str>,
 ) {
-    let dependencies = inline_deps_with_required_packages(deps);
+    let dependencies = inline_deps_with_conda_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
         dependencies,
         channels: if channels.is_empty() {
@@ -609,7 +620,7 @@ pub fn check_conda_inline_cache(
     channels: &[String],
     python: Option<&str>,
 ) -> Option<PreparedEnv> {
-    let dependencies = inline_deps_with_required_packages(deps);
+    let dependencies = inline_deps_with_conda_required_packages(deps);
     let conda_deps = kernel_env::CondaDependencies {
         dependencies: dependencies.clone(),
         channels: if channels.is_empty() {
@@ -979,6 +990,32 @@ mod tests {
                 "pyarrow>=14".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn test_inline_deps_with_conda_required_packages_adds_pip() {
+        let deps = vec!["pandas".to_string(), "numpy".to_string()];
+        assert_eq!(
+            inline_deps_with_conda_required_packages(&deps),
+            vec![
+                "pandas".to_string(),
+                "numpy".to_string(),
+                "nbformat".to_string(),
+                "pyarrow>=14".to_string(),
+                "pip".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_inline_deps_with_conda_required_packages_does_not_duplicate_pip() {
+        let deps = vec![
+            "pandas".to_string(),
+            "pip>=24".to_string(),
+            "nbformat".to_string(),
+            "pyarrow>=14".to_string(),
+        ];
+        assert_eq!(inline_deps_with_conda_required_packages(&deps), deps);
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2296,6 +2296,43 @@ pub(crate) async fn reset_starting_state(
         .await;
 }
 
+fn env_progress_type_for_source(env_source: &str) -> &'static str {
+    if env_source.starts_with("conda:") {
+        "conda"
+    } else if env_source.starts_with("pixi:") {
+        "pixi"
+    } else {
+        "uv"
+    }
+}
+
+/// Publish a pre-spawn environment preparation failure into RuntimeStateDoc.
+///
+/// Request callers already receive an error response, but the UI's persistent
+/// state comes from RuntimeStateDoc. Without this write, clients stay in a
+/// starting lifecycle after a solver/install failure and render only
+/// "Initializing".
+pub(crate) fn publish_environment_launch_error(
+    room: &NotebookRoom,
+    env_source: &str,
+    reason: Option<KernelErrorReason>,
+    details: &str,
+) {
+    let error_phase = kernel_env::EnvProgressPhase::Error {
+        message: details.to_string(),
+    };
+    if let Err(e) = room.state.with_doc(|sd| {
+        sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
+        sd.set_kernel_info("python", "python", env_source)?;
+        if let Ok(value) = serde_json::to_value(&error_phase) {
+            sd.set_env_progress(env_progress_type_for_source(env_source), &value)?;
+        }
+        Ok(())
+    }) {
+        warn!("[runtime-state] {}", e);
+    }
+}
+
 /// Try to satisfy UV inline deps from the prewarmed pool.
 ///
 /// Takes the pool env first, then compares against its *actual* `prewarmed_packages`
@@ -2427,7 +2464,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
-    let effective_deps = crate::inline_env::inline_deps_with_required_packages(deps);
+    let effective_deps = crate::inline_env::inline_deps_with_conda_required_packages(deps);
 
     // Only use pool for default conda-forge channel
     let is_default_channels =
@@ -3008,8 +3045,15 @@ pub(crate) async fn auto_launch_kernel(
                     (env, Some(deps.clone()))
                 }
                 Err(e) => {
-                    error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
+                    let details = format!("Failed to prepare PEP 723 environment: {}", e);
+                    error!("[notebook-sync] {}", details);
                     reset_starting_state(room, None).await;
+                    publish_environment_launch_error(
+                        room,
+                        env_source.as_str(),
+                        Some(KernelErrorReason::EnvironmentPrepareFailed),
+                        &details,
+                    );
                     return;
                 }
             }
@@ -3078,8 +3122,16 @@ pub(crate) async fn auto_launch_kernel(
                                 (env, Some(deps))
                             }
                             Err(e) => {
-                                error!("[notebook-sync] Failed to prepare inline env: {}", e);
+                                let details =
+                                    format!("Failed to prepare inline environment: {}", e);
+                                error!("[notebook-sync] {}", details);
                                 reset_starting_state(room, None).await;
+                                publish_environment_launch_error(
+                                    room,
+                                    env_source.as_str(),
+                                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                                    &details,
+                                );
                                 return;
                             }
                         }
@@ -3112,8 +3164,15 @@ pub(crate) async fn auto_launch_kernel(
                         (env, Some(deps))
                     }
                     Err(e) => {
-                        error!("[notebook-sync] Failed to prepare inline env: {}", e);
+                        let details = format!("Failed to prepare inline environment: {}", e);
+                        error!("[notebook-sync] {}", details);
                         reset_starting_state(room, None).await;
+                        publish_environment_launch_error(
+                            room,
+                            env_source.as_str(),
+                            Some(KernelErrorReason::EnvironmentPrepareFailed),
+                            &details,
+                        );
                         return;
                     }
                 }
@@ -3190,8 +3249,16 @@ pub(crate) async fn auto_launch_kernel(
                                 (env, Some(deps))
                             }
                             Err(e) => {
-                                error!("[notebook-sync] Failed to prepare conda inline env: {}", e);
+                                let details =
+                                    format!("Failed to prepare conda inline environment: {}", e);
+                                error!("[notebook-sync] {}", details);
                                 reset_starting_state(room, None).await;
+                                publish_environment_launch_error(
+                                    room,
+                                    env_source.as_str(),
+                                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                                    &details,
+                                );
                                 return;
                             }
                         }
@@ -3303,6 +3370,9 @@ pub(crate) async fn auto_launch_kernel(
             .collect();
         if !base_names.contains("ipykernel") {
             all_deps.push("ipykernel".to_string());
+        }
+        if !base_names.contains("pip") {
+            all_deps.push("pip".to_string());
         }
 
         let channels = if env_config.channels.is_empty() {
@@ -3525,7 +3595,7 @@ pub(crate) async fn auto_launch_kernel(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
-        let deps = crate::inline_env::inline_deps_with_required_packages(&deps);
+        let deps = crate::inline_env::inline_deps_with_conda_required_packages(&deps);
         if !deps.is_empty() {
             info!("[notebook-sync] pixi:inline deps for pixi exec: {:?}", deps);
             (None, Some(deps))
@@ -3535,7 +3605,7 @@ pub(crate) async fn auto_launch_kernel(
     } else if matches!(env_source, EnvSource::Pep723(PackageManager::Pixi)) {
         // PEP 723 deps via pixi exec -w (same mechanism as pixi:inline)
         if let Some(ref deps) = pep723_deps {
-            let deps = crate::inline_env::inline_deps_with_required_packages(deps);
+            let deps = crate::inline_env::inline_deps_with_conda_required_packages(deps);
             info!("[notebook-sync] pixi:pep723 deps for pixi exec: {:?}", deps);
             (None, Some(deps))
         } else {
@@ -3568,7 +3638,7 @@ pub(crate) async fn auto_launch_kernel(
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error_details(
                         &RuntimeLifecycle::Error,
-                        None,
+                        Some(KernelErrorReason::EnvironmentPrepareFailed),
                         Some(&details),
                     )?;
                     sd.set_kernel_info("python", "python", env_source.as_str())?;
@@ -4544,7 +4614,7 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
             error!("[notebook-sync] SyncEnvironment failed: {}", error);
             NotebookResponse::SyncEnvironmentFailed {
                 error,
-                needs_restart: true,
+                needs_restart: false,
             }
         }
         Ok(_) => {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -50,6 +50,24 @@ pub(crate) fn write_trust_to_runtime_state(room: &NotebookRoom, trust: &TrustSta
     }
 }
 
+async fn clear_environment_prepare_error_when_trust_blocks_launch(room: &NotebookRoom) {
+    let should_clear = room
+        .state
+        .read(|sd| {
+            let state = sd.read_state();
+            matches!(state.kernel.lifecycle, RuntimeLifecycle::Error)
+                && state.kernel.error_reason.as_deref()
+                    == Some(KernelErrorReason::EnvironmentPrepareFailed.as_str())
+        })
+        .unwrap_or(false);
+    if should_clear {
+        info!(
+            "[notebook-sync] Clearing stale environment prepare error because notebook trust now blocks launch"
+        );
+        reset_starting_state(room, None).await;
+    }
+}
+
 /// Check if a notebook's metadata snapshot has inline dependencies or Deno config.
 /// Returns the appropriate env_source if found ("uv:inline", "conda:inline", or "deno").
 ///
@@ -884,7 +902,12 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
 
         // Update RuntimeStateDoc so the frontend banner reacts immediately
         let ts = room.trust_state.read().await;
+        let trust_blocks_launch = trust_needs_approval(&ts.status);
         write_trust_to_runtime_state(room, &ts);
+        drop(ts);
+        if trust_blocks_launch {
+            clear_environment_prepare_error_when_trust_blocks_launch(room).await;
+        }
     } else {
         let current_info = {
             let ts = room.trust_state.read().await;
@@ -902,7 +925,12 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
                 *ts = new_trust;
             }
             let ts = room.trust_state.read().await;
+            let trust_blocks_launch = trust_needs_approval(&ts.status);
             write_trust_to_runtime_state(room, &ts);
+            drop(ts);
+            if trust_blocks_launch {
+                clear_environment_prepare_error_when_trust_blocks_launch(room).await;
+            }
         }
     }
 }
@@ -2342,6 +2370,15 @@ pub(crate) fn publish_environment_launch_error(
     }
 }
 
+async fn trust_allows_auto_launch_error_publish(room: &NotebookRoom) -> bool {
+    check_and_update_trust_state(room).await;
+    let trust = room.trust_state.read().await;
+    matches!(
+        trust.status,
+        runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
+    )
+}
+
 async fn reset_and_publish_environment_launch_error(
     room: &NotebookRoom,
     env_source: &str,
@@ -2349,7 +2386,34 @@ async fn reset_and_publish_environment_launch_error(
     details: &str,
 ) {
     reset_starting_state(room, None).await;
+    if !trust_allows_auto_launch_error_publish(room).await {
+        info!(
+            "[notebook-sync] Suppressing auto-launch environment error because notebook trust now blocks launch"
+        );
+        return;
+    }
     publish_environment_launch_error(room, env_source, reason, details);
+}
+
+async fn reset_auto_launch_error_with_trust_check(
+    room: &NotebookRoom,
+    expected_runtime_agent_id: Option<&str>,
+    reason: Option<KernelErrorReason>,
+    details: &str,
+) {
+    if trust_allows_auto_launch_error_publish(room).await {
+        reset_starting_state_with_outcome(
+            room,
+            expected_runtime_agent_id,
+            ResetOutcome::Error { reason, details },
+        )
+        .await;
+    } else {
+        info!(
+            "[notebook-sync] Suppressing auto-launch failure because notebook trust now blocks launch"
+        );
+        reset_starting_state(room, expected_runtime_agent_id).await;
+    }
 }
 
 async fn reset_and_publish_prewarmed_acquire_error(room: &NotebookRoom, env_source: &str) {
@@ -3971,13 +4035,11 @@ pub(crate) async fn auto_launch_kernel(
                         // string usually carries the stderr tail from
                         // `jupyter_kernel.rs` — exactly what the user
                         // needs to see.
-                        reset_starting_state_with_outcome(
+                        reset_auto_launch_error_with_trust_check(
                             room,
                             Some(&runtime_agent_id),
-                            ResetOutcome::Error {
-                                reason: None,
-                                details: &error,
-                            },
+                            None,
+                            &error,
                         )
                         .await;
                     }
@@ -3985,26 +4047,22 @@ pub(crate) async fn auto_launch_kernel(
                         warn!(
                             "[notebook-sync] Unexpected runtime agent response during auto-launch"
                         );
-                        reset_starting_state_with_outcome(
+                        reset_auto_launch_error_with_trust_check(
                             room,
                             Some(&runtime_agent_id),
-                            ResetOutcome::Error {
-                                reason: None,
-                                details: "Unexpected runtime agent response during kernel launch",
-                            },
+                            None,
+                            "Unexpected runtime agent response during kernel launch",
                         )
                         .await;
                     }
                     Err(e) => {
                         warn!("[notebook-sync] Agent communication error: {}", e);
                         let details = format!("Agent communication error: {e}");
-                        reset_starting_state_with_outcome(
+                        reset_auto_launch_error_with_trust_check(
                             room,
                             Some(&runtime_agent_id),
-                            ResetOutcome::Error {
-                                reason: None,
-                                details: &details,
-                            },
+                            None,
+                            &details,
                         )
                         .await;
                     }
@@ -4013,15 +4071,7 @@ pub(crate) async fn auto_launch_kernel(
             Err(e) => {
                 warn!("[notebook-sync] Failed to spawn runtime agent: {}", e);
                 let details = format!("Failed to spawn runtime agent: {e}");
-                reset_starting_state_with_outcome(
-                    room,
-                    None,
-                    ResetOutcome::Error {
-                        reason: None,
-                        details: &details,
-                    },
-                )
-                .await;
+                reset_auto_launch_error_with_trust_check(room, None, None, &details).await;
             }
         }
     }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2297,6 +2297,9 @@ pub(crate) async fn reset_starting_state(
 }
 
 fn env_progress_type_for_source(env_source: &str) -> &'static str {
+    // Current environment-prepare failures are Python package-manager paths.
+    // Keep unknown/legacy Python sources on the UV rail, which is also the
+    // historical fallback package manager.
     if env_source.starts_with("conda:") {
         "conda"
     } else if env_source.starts_with("pixi:") {
@@ -2312,24 +2315,70 @@ fn env_progress_type_for_source(env_source: &str) -> &'static str {
 /// state comes from RuntimeStateDoc. Without this write, clients stay in a
 /// starting lifecycle after a solver/install failure and render only
 /// "Initializing".
+///
+/// Current call sites are Python environment preparation paths, so this writes
+/// Python kernel info. Other runtime families should add a runtime-aware
+/// variant before reusing this helper.
 pub(crate) fn publish_environment_launch_error(
     room: &NotebookRoom,
     env_source: &str,
     reason: Option<KernelErrorReason>,
     details: &str,
 ) {
-    let error_phase = kernel_env::EnvProgressPhase::Error {
-        message: details.to_string(),
-    };
+    let progress_value = serde_json::json!({
+        "phase": "error",
+        "message": details,
+    });
     if let Err(e) = room.state.with_doc(|sd| {
         sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
         sd.set_kernel_info("python", "python", env_source)?;
-        if let Ok(value) = serde_json::to_value(&error_phase) {
-            sd.set_env_progress(env_progress_type_for_source(env_source), &value)?;
-        }
+        sd.set_env_progress(env_progress_type_for_source(env_source), &progress_value)?;
         Ok(())
     }) {
-        warn!("[runtime-state] {}", e);
+        error!(
+            "[runtime-state] failed to publish environment launch error: {}",
+            e
+        );
+    }
+}
+
+async fn reset_and_publish_environment_launch_error(
+    room: &NotebookRoom,
+    env_source: &str,
+    reason: Option<KernelErrorReason>,
+    details: &str,
+) {
+    reset_starting_state(room, None).await;
+    publish_environment_launch_error(room, env_source, reason, details);
+}
+
+async fn reset_and_publish_prewarmed_acquire_error(room: &NotebookRoom, env_source: &str) {
+    let details = format!(
+        "Failed to acquire prewarmed environment for {env_source}. Retry once the environment pool finishes warming."
+    );
+    error!("[notebook-sync] {}", details);
+    reset_and_publish_environment_launch_error(
+        room,
+        env_source,
+        Some(KernelErrorReason::EnvironmentPrepareFailed),
+        &details,
+    )
+    .await;
+}
+
+pub(crate) fn sync_environment_agent_error_response(error: String) -> NotebookResponse {
+    NotebookResponse::SyncEnvironmentFailed {
+        error,
+        needs_restart: false,
+    }
+}
+
+pub(crate) fn sync_environment_agent_communication_error_response(
+    error: String,
+) -> NotebookResponse {
+    NotebookResponse::SyncEnvironmentFailed {
+        error,
+        needs_restart: true,
     }
 }
 
@@ -2707,10 +2756,11 @@ pub(crate) async fn auto_launch_kernel(
     let (inline_source, pep723_deps) = if inline_source.is_some() {
         (inline_source, None)
     } else {
+        use notebook_protocol::connection::{EnvSource, PackageManager};
+
         let cells = room.doc.read().await.get_cells();
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
             Ok(Some(meta)) if !meta.dependencies.is_empty() => {
-                use notebook_protocol::connection::{EnvSource, PackageManager};
                 // Route PEP 723 deps based on user's default Python env
                 let pep723_source = match default_python_env {
                     crate::settings_doc::PythonEnvType::Pixi => {
@@ -2727,8 +2777,22 @@ pub(crate) async fn auto_launch_kernel(
             }
             Ok(_) => (None, None),
             Err(e) => {
-                warn!("[notebook-sync] PEP 723 parse error: {}", e);
-                (None, None)
+                let pep723_source = match default_python_env {
+                    crate::settings_doc::PythonEnvType::Pixi => {
+                        EnvSource::Pep723(PackageManager::Pixi)
+                    }
+                    _ => EnvSource::Pep723(PackageManager::Uv),
+                };
+                let details = format!("Invalid PEP 723 metadata in notebook: {}", e);
+                warn!("[notebook-sync] {}", details);
+                reset_and_publish_environment_launch_error(
+                    room,
+                    pep723_source.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                )
+                .await;
+                return;
             }
         }
     };
@@ -2860,7 +2924,8 @@ pub(crate) async fn auto_launch_kernel(
                         }
                         Ok(None) => None,
                         Err(()) => {
-                            reset_starting_state(room, None).await;
+                            reset_and_publish_prewarmed_acquire_error(room, env_source.as_str())
+                                .await;
                             return;
                         }
                     }
@@ -2925,7 +2990,11 @@ pub(crate) async fn auto_launch_kernel(
                             }
                             Ok(None) => None,
                             Err(()) => {
-                                reset_starting_state(room, None).await;
+                                reset_and_publish_prewarmed_acquire_error(
+                                    room,
+                                    env_source.as_str(),
+                                )
+                                .await;
                                 return;
                             }
                         }
@@ -2957,7 +3026,7 @@ pub(crate) async fn auto_launch_kernel(
                     }
                     Ok(None) => None,
                     Err(()) => {
-                        reset_starting_state(room, None).await;
+                        reset_and_publish_prewarmed_acquire_error(room, prewarmed.as_str()).await;
                         return;
                     }
                 };
@@ -3284,8 +3353,15 @@ pub(crate) async fn auto_launch_kernel(
             });
 
         let Some(yml_path) = yml_path else {
-            warn!("[notebook-sync] conda:env_yml but no environment.yml found");
-            reset_starting_state(room, None).await;
+            let details = "conda:env_yml requested but no environment.yml was found";
+            warn!("[notebook-sync] {}", details);
+            reset_and_publish_environment_launch_error(
+                room,
+                env_source.as_str(),
+                Some(KernelErrorReason::EnvironmentPrepareFailed),
+                details,
+            )
+            .await;
             return;
         };
 
@@ -3318,8 +3394,15 @@ pub(crate) async fn auto_launch_kernel(
         let env_config = match crate::project_file::parse_environment_yml(&yml_path) {
             Ok(config) => config,
             Err(e) => {
-                error!("[notebook-sync] Failed to parse environment.yml: {}", e);
-                reset_starting_state(room, None).await;
+                let details = format!("Failed to parse environment.yml: {}", e);
+                error!("[notebook-sync] {}", details);
+                reset_and_publish_environment_launch_error(
+                    room,
+                    env_source.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                )
+                .await;
                 return;
             }
         };
@@ -3439,17 +3522,13 @@ pub(crate) async fn auto_launch_kernel(
                             env_config.name.as_deref().unwrap_or("<env>"),
                         );
                         warn!("[notebook-sync] {}", details);
-                        if let Err(e) = room.state.with_doc(|sd| {
-                            sd.set_lifecycle_with_error_details(
-                                &RuntimeLifecycle::Error,
-                                None,
-                                Some(&details),
-                            )?;
-                            sd.clear_env_progress()?;
-                            Ok(())
-                        }) {
-                            warn!("[runtime-state] {}", e);
-                        }
+                        reset_and_publish_environment_launch_error(
+                            room,
+                            env_source.as_str(),
+                            None,
+                            &details,
+                        )
+                        .await;
                         return;
                     }
                 } else {
@@ -3480,17 +3559,13 @@ pub(crate) async fn auto_launch_kernel(
             {
                 let details = format!("conda:env_yml sync into existing env failed: {}", e);
                 error!("[notebook-sync] {}", details);
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::CondaEnvBuildFailed),
-                        Some(&details),
-                    )?;
-                    sd.clear_env_progress()?;
-                    Ok(())
-                }) {
-                    warn!("[runtime-state] {}", e);
-                }
+                reset_and_publish_environment_launch_error(
+                    room,
+                    env_source.as_str(),
+                    Some(KernelErrorReason::CondaEnvBuildFailed),
+                    &details,
+                )
+                .await;
                 return;
             }
             // The banner stays lit until a terminal phase is written. Emit Ready so
@@ -3519,17 +3594,13 @@ pub(crate) async fn auto_launch_kernel(
             if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 let details = format!("Failed to create conda envs directory {:?}: {}", parent, e);
                 error!("[notebook-sync] {}", details);
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::CondaEnvBuildFailed),
-                        Some(&details),
-                    )?;
-                    sd.clear_env_progress()?;
-                    Ok(())
-                }) {
-                    warn!("[runtime-state] {}", e);
-                }
+                reset_and_publish_environment_launch_error(
+                    room,
+                    env_source.as_str(),
+                    Some(KernelErrorReason::CondaEnvBuildFailed),
+                    &details,
+                )
+                .await;
                 return;
             }
 
@@ -3573,17 +3644,13 @@ pub(crate) async fn auto_launch_kernel(
                         env_name_display, e
                     );
                     error!("[notebook-sync] {}", details);
-                    if let Err(e) = room.state.with_doc(|sd| {
-                        sd.set_lifecycle_with_error_details(
-                            &RuntimeLifecycle::Error,
-                            Some(KernelErrorReason::CondaEnvBuildFailed),
-                            Some(&details),
-                        )?;
-                        sd.clear_env_progress()?;
-                        Ok(())
-                    }) {
-                        warn!("[runtime-state] {}", e);
-                    }
+                    reset_and_publish_environment_launch_error(
+                        room,
+                        env_source.as_str(),
+                        Some(KernelErrorReason::CondaEnvBuildFailed),
+                        &details,
+                    )
+                    .await;
                     return;
                 }
             }
@@ -3631,24 +3698,13 @@ pub(crate) async fn auto_launch_kernel(
             Err(e) => {
                 let details = format!("Failed to prepare UV project environment: {e}");
                 error!("[notebook-sync] {}", details);
-                reset_starting_state(room, None).await;
-                let error_phase = kernel_env::EnvProgressPhase::Error {
-                    message: details.clone(),
-                };
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::EnvironmentPrepareFailed),
-                        Some(&details),
-                    )?;
-                    sd.set_kernel_info("python", "python", env_source.as_str())?;
-                    if let Ok(value) = serde_json::to_value(&error_phase) {
-                        sd.set_env_progress("uv", &value)?;
-                    }
-                    Ok(())
-                }) {
-                    warn!("[runtime-state] {}", e);
-                }
+                reset_and_publish_environment_launch_error(
+                    room,
+                    env_source.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                )
+                .await;
                 return;
             }
         }
@@ -4612,10 +4668,7 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
         }
         Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
             error!("[notebook-sync] SyncEnvironment failed: {}", error);
-            NotebookResponse::SyncEnvironmentFailed {
-                error,
-                needs_restart: false,
-            }
+            sync_environment_agent_error_response(error)
         }
         Ok(_) => {
             error!("[notebook-sync] SyncEnvironment received unexpected response type");
@@ -4629,10 +4682,10 @@ pub(crate) async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResp
                 "[notebook-sync] SyncEnvironment agent communication error: {}",
                 e
             );
-            NotebookResponse::SyncEnvironmentFailed {
-                error: format!("Agent communication error: {}", e),
-                needs_restart: false,
-            }
+            sync_environment_agent_communication_error_response(format!(
+                "Agent communication error: {}",
+                e
+            ))
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use automerge::{transaction::Transactable, ActorId, AutoCommit, ObjType};
-use runtime_doc::{KernelActivity, RuntimeLifecycle};
+use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle};
 use serial_test::serial;
 use uuid::Uuid;
 
@@ -7461,6 +7461,72 @@ async fn reset_starting_state_error_variant_writes_details() {
     // No typed reason (generic launch error); `error_reason` is empty
     // but present so readers can skip typed-reason branches cleanly.
     assert_eq!(state.kernel.error_reason.as_deref(), Some(""));
+}
+
+#[tokio::test]
+async fn publish_environment_launch_error_writes_kernel_and_env_progress() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "env-prepare-failure.ipynb");
+    let details = "Failed to prepare conda inline environment: no candidates for pywidget";
+
+    publish_environment_launch_error(
+        &room,
+        "conda:inline",
+        Some(KernelErrorReason::EnvironmentPrepareFailed),
+        details,
+    );
+
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
+    assert!(
+        matches!(state.kernel.lifecycle, RuntimeLifecycle::Error),
+        "expected Error lifecycle, got {:?}",
+        state.kernel.lifecycle
+    );
+    assert_eq!(
+        state.kernel.error_reason.as_deref(),
+        Some("environment_prepare_failed")
+    );
+    assert_eq!(state.kernel.error_details.as_deref(), Some(details));
+    assert_eq!(state.kernel.language, "python");
+    assert_eq!(state.kernel.env_source, "conda:inline");
+    assert_eq!(
+        state.env.progress,
+        Some(serde_json::json!({
+            "env_type": "conda",
+            "phase": "error",
+            "message": details,
+        }))
+    );
+}
+
+#[test]
+fn sync_environment_failure_contract_distinguishes_agent_error_from_transport_error() {
+    match sync_environment_agent_error_response("No candidates found".to_string()) {
+        NotebookResponse::SyncEnvironmentFailed {
+            error,
+            needs_restart,
+        } => {
+            assert_eq!(error, "No candidates found");
+            assert!(
+                !needs_restart,
+                "runtime agent already published env progress"
+            );
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+
+    match sync_environment_agent_communication_error_response(
+        "Agent communication error: channel closed".to_string(),
+    ) {
+        NotebookResponse::SyncEnvironmentFailed {
+            error,
+            needs_restart,
+        } => {
+            assert_eq!(error, "Agent communication error: channel closed");
+            assert!(needs_restart, "transport failure requires a kernel restart");
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
 }
 
 // ── Regression tests for #2351: outputs not serialized to notebook ───

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -563,22 +563,26 @@ pub(crate) async fn handle(
                     }
                     Ok(None) => None,
                     Err(()) => {
-                        // `acquire_prewarmed_env_with_capture`
-                        // already broadcast the error; bail out.
+                        let error = format!(
+                            "{} pool empty - no environment available",
+                            if matches!(parsed_resolved, EnvSource::Prewarmed(PackageManager::Uv)) {
+                                "UV"
+                            } else {
+                                "Conda"
+                            }
+                        );
+                        let details = format!(
+                            "Failed to acquire prewarmed environment for {}. {error}",
+                            parsed_resolved.as_str(),
+                        );
                         reset_starting_state(room, None).await;
-                        return NotebookResponse::Error {
-                            error: format!(
-                                "{} pool empty - no environment available",
-                                if matches!(
-                                    parsed_resolved,
-                                    EnvSource::Prewarmed(PackageManager::Uv)
-                                ) {
-                                    "UV"
-                                } else {
-                                    "Conda"
-                                }
-                            ),
-                        };
+                        publish_environment_launch_error(
+                            room,
+                            parsed_resolved.as_str(),
+                            Some(KernelErrorReason::EnvironmentPrepareFailed),
+                            &details,
+                        );
+                        return NotebookResponse::Error { error };
                     }
                 }
             }
@@ -1083,15 +1087,13 @@ pub(crate) async fn handle(
                                         requested,
                                         env_config.name.as_deref().unwrap_or("<env>"),
                                     );
-                                    reset_starting_state_with_outcome(
+                                    reset_starting_state(room, None).await;
+                                    publish_environment_launch_error(
                                         room,
+                                        parsed_resolved.as_str(),
                                         None,
-                                        ResetOutcome::Error {
-                                            reason: None,
-                                            details: &details,
-                                        },
-                                    )
-                                    .await;
+                                        &details,
+                                    );
                                     return NotebookResponse::Error { error: details };
                                 }
                             } else {
@@ -1122,17 +1124,13 @@ pub(crate) async fn handle(
                             let details =
                                 format!("conda:env_yml sync into existing env failed: {}", e);
                             error!("[notebook-sync] {}", details);
-                            reset_starting_state_with_outcome(
+                            reset_starting_state(room, None).await;
+                            publish_environment_launch_error(
                                 room,
-                                None,
-                                ResetOutcome::Error {
-                                    reason: Some(
-                                        runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
-                                    ),
-                                    details: &details,
-                                },
-                            )
-                            .await;
+                                parsed_resolved.as_str(),
+                                Some(KernelErrorReason::CondaEnvBuildFailed),
+                                &details,
+                            );
                             return NotebookResponse::Error { error: details };
                         }
                         // Terminal phase so the banner clears. Matches the env_yml path in
@@ -1166,17 +1164,13 @@ pub(crate) async fn handle(
                                 "Failed to create conda envs directory {:?}: {}",
                                 parent, e
                             );
-                            reset_starting_state_with_outcome(
+                            reset_starting_state(room, None).await;
+                            publish_environment_launch_error(
                                 room,
-                                None,
-                                ResetOutcome::Error {
-                                    reason: Some(
-                                        runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
-                                    ),
-                                    details: &details,
-                                },
-                            )
-                            .await;
+                                parsed_resolved.as_str(),
+                                Some(KernelErrorReason::CondaEnvBuildFailed),
+                                &details,
+                            );
                             return NotebookResponse::Error { error: details };
                         }
                         match kernel_env::conda::prepare_environment_in(
@@ -1220,32 +1214,43 @@ pub(crate) async fn handle(
                                     "Failed to create conda env '{}' from environment.yml: {}",
                                     env_name_display, e
                                 );
-                                reset_starting_state_with_outcome(
+                                reset_starting_state(room, None).await;
+                                publish_environment_launch_error(
                                     room,
-                                    None,
-                                    ResetOutcome::Error {
-                                        reason: Some(
-                                            runtime_doc::KernelErrorReason::CondaEnvBuildFailed,
-                                        ),
-                                        details: &details,
-                                    },
-                                )
-                                .await;
+                                    parsed_resolved.as_str(),
+                                    Some(KernelErrorReason::CondaEnvBuildFailed),
+                                    &details,
+                                );
                                 return NotebookResponse::Error { error: details };
                             }
                         }
                     }
                 }
                 Err(e) => {
+                    let details = format!("Failed to parse environment.yml: {}", e);
                     reset_starting_state(room, None).await;
-                    return NotebookResponse::Error {
-                        error: format!("Failed to parse environment.yml: {}", e),
-                    };
+                    publish_environment_launch_error(
+                        room,
+                        parsed_resolved.as_str(),
+                        Some(KernelErrorReason::EnvironmentPrepareFailed),
+                        &details,
+                    );
+                    return NotebookResponse::Error { error: details };
                 }
             }
         } else {
-            warn!("[notebook-sync] conda:env_yml but no environment.yml found");
-            (pooled_env, None)
+            let details = "conda:env_yml requested but no environment.yml was found";
+            warn!("[notebook-sync] {}", details);
+            reset_starting_state(room, None).await;
+            publish_environment_launch_error(
+                room,
+                parsed_resolved.as_str(),
+                Some(KernelErrorReason::EnvironmentPrepareFailed),
+                details,
+            );
+            return NotebookResponse::Error {
+                error: details.to_string(),
+            };
         }
     } else if matches!(parsed_resolved, EnvSource::Inline(PackageManager::Pixi)) {
         // pixi exec handles its own caching — just extract deps for -w flags
@@ -1297,23 +1302,12 @@ pub(crate) async fn handle(
                 let details = format!("Failed to prepare UV project environment: {e}");
                 error!("[notebook-sync] {}", details);
                 reset_starting_state(room, None).await;
-                let error_phase = kernel_env::EnvProgressPhase::Error {
-                    message: details.clone(),
-                };
-                if let Err(e) = room.state.with_doc(|sd| {
-                    sd.set_lifecycle_with_error_details(
-                        &RuntimeLifecycle::Error,
-                        Some(KernelErrorReason::EnvironmentPrepareFailed),
-                        Some(&details),
-                    )?;
-                    sd.set_kernel_info("python", "python", parsed_resolved.as_str())?;
-                    if let Ok(value) = serde_json::to_value(&error_phase) {
-                        sd.set_env_progress("uv", &value)?;
-                    }
-                    Ok(())
-                }) {
-                    warn!("[runtime-state] {}", e);
-                }
+                publish_environment_launch_error(
+                    room,
+                    parsed_resolved.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                );
                 return NotebookResponse::Error { error: details };
             }
         }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -21,11 +21,11 @@ use crate::notebook_sync_server::{
     extract_pixi_toml_deps, format_conda_env_yml_build_details, get_inline_conda_channels,
     get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps, get_inline_uv_prerelease,
     missing_conda_env_yml_decision, project_environment_build_approved,
-    promote_inline_deps_to_project, publish_kernel_state_presence, reset_starting_state,
-    reset_starting_state_with_outcome, resolve_metadata_snapshot,
-    send_runtime_agent_request_with_kernel_ports, try_conda_pool_for_inline_deps,
-    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
-    ResetOutcome,
+    promote_inline_deps_to_project, publish_environment_launch_error,
+    publish_kernel_state_presence, reset_starting_state, reset_starting_state_with_outcome,
+    resolve_metadata_snapshot, send_runtime_agent_request_with_kernel_ports,
+    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, unified_env_on_disk,
+    CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -652,10 +652,15 @@ pub(crate) async fn handle(
                     "[notebook-sync] Invalid PEP 723 metadata in notebook: {}",
                     e
                 );
+                let details = format!("Invalid PEP 723 metadata in notebook: {}", e);
                 reset_starting_state(room, None).await;
-                return NotebookResponse::Error {
-                    error: format!("Invalid PEP 723 metadata in notebook: {}", e),
-                };
+                publish_environment_launch_error(
+                    room,
+                    parsed_resolved.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                );
+                return NotebookResponse::Error { error: details };
             }
         };
 
@@ -686,17 +691,29 @@ pub(crate) async fn handle(
                 }
                 Err(e) => {
                     error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
+                    let details = format!("Failed to prepare PEP 723 environment: {}", e);
                     reset_starting_state(room, None).await;
-                    return NotebookResponse::Error {
-                        error: format!("Failed to prepare PEP 723 environment: {}", e),
-                    };
+                    publish_environment_launch_error(
+                        room,
+                        parsed_resolved.as_str(),
+                        Some(KernelErrorReason::EnvironmentPrepareFailed),
+                        &details,
+                    );
+                    return NotebookResponse::Error { error: details };
                 }
             }
         } else {
+            let details =
+                "No PEP 723 dependencies found in notebook cells for requested env_source \"uv:pep723\"";
             reset_starting_state(room, None).await;
+            publish_environment_launch_error(
+                room,
+                parsed_resolved.as_str(),
+                Some(KernelErrorReason::EnvironmentPrepareFailed),
+                details,
+            );
             return NotebookResponse::Error {
-                error: "No PEP 723 dependencies found in notebook cells for requested env_source \"uv:pep723\""
-                    .to_string(),
+                error: details.to_string(),
             };
         }
     } else if matches!(parsed_resolved, EnvSource::Inline(PackageManager::Uv)) {
@@ -762,10 +779,16 @@ pub(crate) async fn handle(
                                 (env, Some(deps))
                             }
                             Err(e) => {
+                                let details =
+                                    format!("Failed to prepare inline environment: {}", e);
                                 reset_starting_state(room, None).await;
-                                return NotebookResponse::Error {
-                                    error: format!("Failed to prepare inline environment: {}", e),
-                                };
+                                publish_environment_launch_error(
+                                    room,
+                                    parsed_resolved.as_str(),
+                                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                                    &details,
+                                );
+                                return NotebookResponse::Error { error: details };
                             }
                         }
                     }
@@ -793,10 +816,15 @@ pub(crate) async fn handle(
                         (env, Some(deps))
                     }
                     Err(e) => {
+                        let details = format!("Failed to prepare inline environment: {}", e);
                         reset_starting_state(room, None).await;
-                        return NotebookResponse::Error {
-                            error: format!("Failed to prepare inline environment: {}", e),
-                        };
+                        publish_environment_launch_error(
+                            room,
+                            parsed_resolved.as_str(),
+                            Some(KernelErrorReason::EnvironmentPrepareFailed),
+                            &details,
+                        );
+                        return NotebookResponse::Error { error: details };
                     }
                 }
             }
@@ -868,13 +896,16 @@ pub(crate) async fn handle(
                                 (env, Some(deps))
                             }
                             Err(e) => {
+                                let details =
+                                    format!("Failed to prepare conda inline environment: {}", e);
                                 reset_starting_state(room, None).await;
-                                return NotebookResponse::Error {
-                                    error: format!(
-                                        "Failed to prepare conda inline environment: {}",
-                                        e
-                                    ),
-                                };
+                                publish_environment_launch_error(
+                                    room,
+                                    parsed_resolved.as_str(),
+                                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                                    &details,
+                                );
+                                return NotebookResponse::Error { error: details };
                             }
                         }
                     }
@@ -975,13 +1006,17 @@ pub(crate) async fn handle(
                         }
                     }
 
-                    // Always include ipykernel
+                    // Always include ipykernel and pip. pip is explicit so
+                    // `%pip` installs into this prepared Conda environment.
                     let base_names: std::collections::HashSet<String> = all_deps
                         .iter()
                         .map(|d| notebook_doc::metadata::extract_package_name(d).to_lowercase())
                         .collect();
                     if !base_names.contains("ipykernel") {
                         all_deps.push("ipykernel".to_string());
+                    }
+                    if !base_names.contains("pip") {
+                        all_deps.push("pip".to_string());
                     }
 
                     let channels = if env_config.channels.is_empty() {
@@ -1219,7 +1254,7 @@ pub(crate) async fn handle(
             .and_then(|s| s.runt.pixi.as_ref())
             .map(|p| p.dependencies.clone())
             .unwrap_or_default();
-        let deps = crate::inline_env::inline_deps_with_required_packages(&deps);
+        let deps = crate::inline_env::inline_deps_with_conda_required_packages(&deps);
         if !deps.is_empty() {
             info!(
                 "[notebook-sync] LaunchKernel: pixi:inline deps for pixi exec: {:?}",
@@ -1235,7 +1270,7 @@ pub(crate) async fn handle(
         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
             Ok(Some(meta)) if !meta.dependencies.is_empty() => {
                 let deps =
-                    crate::inline_env::inline_deps_with_required_packages(&meta.dependencies);
+                    crate::inline_env::inline_deps_with_conda_required_packages(&meta.dependencies);
                 info!("[notebook-sync] LaunchKernel: pixi:pep723 deps: {:?}", deps);
                 (None, Some(deps))
             }
@@ -1268,7 +1303,7 @@ pub(crate) async fn handle(
                 if let Err(e) = room.state.with_doc(|sd| {
                     sd.set_lifecycle_with_error_details(
                         &RuntimeLifecycle::Error,
-                        None,
+                        Some(KernelErrorReason::EnvironmentPrepareFailed),
                         Some(&details),
                     )?;
                     sd.set_kernel_info("python", "python", parsed_resolved.as_str())?;

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -24,6 +24,7 @@ export type KernelActivity = "Unknown" | "Idle" | "Busy";
  * gating UI on a specific cause.
  */
 export type KernelErrorReasonKey =
+  | "environment_prepare_failed"
   | "missing_ipykernel"
   | "dependency_cache_missing_ipykernel"
   | "ipykernel_site_packages_mismatch"
@@ -36,6 +37,7 @@ export type KernelErrorReasonKey =
  * unambiguous.
  */
 export const KERNEL_ERROR_REASON = {
+  ENVIRONMENT_PREPARE_FAILED: "environment_prepare_failed",
   MISSING_IPYKERNEL: "missing_ipykernel",
   DEPENDENCY_CACHE_MISSING_IPYKERNEL: "dependency_cache_missing_ipykernel",
   IPYKERNEL_SITE_PACKAGES_MISMATCH: "ipykernel_site_packages_mismatch",


### PR DESCRIPTION
## Summary

- publish package-manager prepare failures into RuntimeStateDoc so notebooks leave the starting lifecycle and show the solver/install error
- keep hot-sync install failures visible instead of immediately dismissing env progress
- include `pip` in managed Conda/Pixi environments so `%pip` targets the active environment
- cover auto-launch prewarmed, PEP 723 parse, and `conda:env_yml` prepare failures with the same surfaced error path
- keep runtime-agent install failures restart-free while preserving restart behavior for agent communication failures

## Verification

- `vp check`
- `cargo xtask lint`
- `cargo xtask clippy`
- `cargo test -p runtimed --test integration test_untrusted_launch_and_sync_environment_are_daemon_rejected`
- `cargo test -p runtimed publish_environment_launch_error_writes_kernel_and_env_progress`
- `cargo test -p runtimed sync_environment_failure_contract_distinguishes_agent_error_from_transport_error`
- `cargo test -p runtime-doc error_reason`
- `cargo test -p kernel-env strip_base_tests --features runtime`
- `cargo test -p kernel-env managed_specs_enforce_gil_python_by_default --features runtime`
- `cargo test -p runtimed inline_deps_with_conda_required_packages`
- `cargo test -p runtimed test_conda_and_pixi_prewarmed_packages_include_pip`
- `pnpm test:run apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx`

## Notes

- Installed `wasm-bindgen-cli 0.2.118` with `cargo install` on this dev machine so `cargo xtask clippy` could rebuild the wasm packages.
- `vp check` still reports the existing `eslint-plugin-unicorn(no-new-array)` warning in `plugins/nteract/pi/extensions/repl.ts:217`; it exits successfully.
- `SyncEnvironmentFailed.needs_restart` now distinguishes runtime-agent package-manager errors (`false`, env progress already contains the error) from agent communication errors (`true`, restart required).
