### PR TITLE
test(e2e): cover dx bootstrap llm repr

### DIFF
--- a/.github/workflows/dx-bootstrap-e2e.yml
+++ b/.github/workflows/dx-bootstrap-e2e.yml
@@ -1,0 +1,207 @@
+name: DX Bootstrap E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/dx-bootstrap-e2e.yml"
+      - ".github/actions/build-runtime-artifacts/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/kernel-env/**"
+      - "crates/notebook/**"
+      - "crates/runt-workspace/**"
+      - "crates/runtimed/**"
+      - "crates/runtimed-client/**"
+      - "crates/xtask/**"
+      - "e2e/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "python/nteract-kernel-launcher/**"
+      - "rust-toolchain.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/dx-bootstrap-e2e.yml"
+      - ".github/actions/build-runtime-artifacts/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/kernel-env/**"
+      - "crates/notebook/**"
+      - "crates/runt-workspace/**"
+      - "crates/runtimed/**"
+      - "crates/runtimed-client/**"
+      - "crates/xtask/**"
+      - "e2e/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "python/nteract-kernel-launcher/**"
+      - "rust-toolchain.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  repr-llm:
+    name: _repr_llm_ launcher formatter
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            xvfb \
+            webkit2gtk-driver
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: dx-bootstrap-e2e
+
+      - uses: ./.github/actions/build-runtime-artifacts
+
+      - name: Install cargo-binstall
+        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install tauri-cli
+        run: cargo binstall tauri-cli --no-confirm --locked --force
+
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+
+      - name: Build E2E app
+        run: cargo xtask e2e build
+
+      - name: Run DX bootstrap E2E
+        timeout-minutes: 15
+        run: |
+          set -o pipefail
+          mkdir -p e2e-logs
+
+          # Seed both namespaces before runtimed starts; debug/Linux CI normally
+          # uses nteract-nightly, while nteract keeps this robust locally.
+          for app_id in nteract nteract-nightly; do
+            mkdir -p "$HOME/.config/$app_id"
+            echo '{"onboarding_completed": true, "bootstrap_dx": true}' \
+              > "$HOME/.config/$app_id/settings.json"
+          done
+
+          Xvfb :99 -screen 0 1920x1080x24 2>/dev/null &
+          export DISPLAY=:99
+          sleep 2
+
+          env -u UV_CACHE_DIR -u UV_PYTHON_INSTALL_DIR \
+            RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+            ./target/debug/runtimed --dev run \
+            --uv-pool-size 3 --conda-pool-size 0 \
+            > e2e-logs/daemon.log 2>&1 &
+          DAEMON_PID=$!
+
+          wait_for_daemon() {
+            local timeout="$1"
+            local status=""
+
+            for i in $(seq 1 "$timeout"); do
+              kill -0 "$DAEMON_PID" 2>/dev/null || {
+                echo "Daemon died while waiting for readiness"
+                cat e2e-logs/daemon.log
+                exit 1
+              }
+
+              status=$(env -u UV_CACHE_DIR -u UV_PYTHON_INSTALL_DIR \
+                RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+                ./target/debug/runt daemon status --json 2>/dev/null || true)
+
+              if [ -n "$status" ] && STATUS_JSON="$status" python3 -c 'import json, os, sys; status = json.loads(os.environ["STATUS_JSON"]); pool = status.get("pool_stats") or {}; uv = pool.get("uv") or {}; ready = status.get("running") and int(uv.get("available") or 0) > 0; sys.exit(0 if ready else 1)'
+              then
+                echo "Daemon ready after ${i}s"
+                echo "$status"
+                return 0
+              fi
+
+              sleep 1
+            done
+
+            echo "Daemon was not ready within ${timeout}s"
+            echo "Last daemon status:"
+            echo "${status:-<none>}"
+            echo "Daemon log:"
+            cat e2e-logs/daemon.log
+            exit 1
+          }
+
+          wait_for_daemon 120
+
+          env -u UV_CACHE_DIR -u UV_PYTHON_INSTALL_DIR \
+            RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+            RUST_LOG=info,notebook=debug \
+            ./target/debug/notebook \
+            > e2e-logs/app.log 2>&1 &
+          APP_PID=$!
+
+          for _ in $(seq 1 60); do
+            curl -s http://localhost:4445/status >/dev/null 2>&1 && break
+            kill -0 "$APP_PID" 2>/dev/null || {
+              echo "App died"
+              cat e2e-logs/app.log
+              exit 1
+            }
+            sleep 1
+          done
+          echo "WebDriver ready"
+
+          WEBDRIVER_PORT=4445 \
+            E2E_SPEC=e2e/specs/dx-bootstrap-repr-llm.spec.js \
+            pnpm test:e2e 2>&1 | tee e2e-logs/test-output.log
+          EXIT=$?
+
+          kill "$APP_PID" "$DAEMON_PID" 2>/dev/null || true
+          exit "$EXIT"
+        env:
+          NO_AT_BRIDGE: 1
+          LIBGL_ALWAYS_SOFTWARE: 1
+          WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS: 1
+          WEBKIT_DISABLE_COMPOSITING_MODE: 1
+
+      - name: Collect daemon logs
+        if: always()
+        run: |
+          mkdir -p e2e-logs
+          find ~/.cache/runt/worktrees -name "runtimed.log" -exec cp {} e2e-logs/ \; 2>/dev/null || true
+          find ~/.cache/runt/worktrees -name "daemon.json" -exec cp {} e2e-logs/ \; 2>/dev/null || true
+          echo "=== Daemon log ===" && cat e2e-logs/runtimed.log 2>/dev/null || echo "No daemon log found"
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dx-bootstrap-e2e-screenshots
+          path: e2e-screenshots/failures/
+          retention-days: 7
+
+      - name: Upload E2E logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dx-bootstrap-e2e-logs
+          path: e2e-logs/
+          retention-days: 7

--- a/e2e/specs/dx-bootstrap-repr-llm.spec.js
+++ b/e2e/specs/dx-bootstrap-repr-llm.spec.js
@@ -1,0 +1,72 @@
+/**
+ * DX bootstrap LLM formatter E2E test.
+ *
+ * This spec must run with the `bootstrap_dx` setting enabled before the daemon
+ * starts. That makes the Python kernel launch through nteract_kernel_launcher,
+ * which installs the `text/llm+plain` display formatter.
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  getKernelStatus,
+  setCellSource,
+  waitForCellOutputMatching,
+  waitForKernelReady,
+  waitForNotebookSynced,
+} from "../helpers.js";
+
+const LLM_REPR_SENTINEL = "llm-e2e: dx bootstrap repr";
+
+describe("DX bootstrap LLM formatter", () => {
+  it("registers _repr_llm_ in the launched kernel", async () => {
+    await waitForKernelReady(300000);
+    expect(await getKernelStatus()).toBe("idle");
+
+    await waitForNotebookSynced();
+
+    const codeCell = await $('[data-cell-type="code"]');
+    await codeCell.waitForExist({ timeout: 5000 });
+
+    await setCellSource(
+      codeCell,
+      `
+class LLMExample:
+    def _repr_llm_(self):
+        return "${LLM_REPR_SENTINEL}"
+
+example = LLMExample()
+ip = get_ipython()
+formatter = ip.display_formatter.formatters.get("text/llm+plain")
+data, _metadata = ip.display_formatter.format(example)
+
+print("LLM_FORMATTER", type(formatter).__name__ if formatter else "missing")
+print("HAS_LLM_MIME", "text/llm+plain" in data)
+print("LLM_VALUE", data.get("text/llm+plain"))
+`.trim(),
+    );
+
+    const executeButton = await codeCell.$('[data-testid="execute-button"]');
+    if (await executeButton.isExisting()) {
+      await executeButton.waitForClickable({ timeout: 5000 });
+      await executeButton.click();
+    } else {
+      const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+      await editor.click();
+      await browser.pause(200);
+      await browser.keys(["Shift", "Enter"]);
+    }
+
+    const outputText = await waitForCellOutputMatching(
+      codeCell,
+      (text) =>
+        text.includes("LLM_FORMATTER LLMFormatter") &&
+        text.includes("HAS_LLM_MIME True") &&
+        text.includes(`LLM_VALUE ${LLM_REPR_SENTINEL}`),
+      120000,
+    );
+
+    expect(outputText).toContain("LLM_FORMATTER LLMFormatter");
+    expect(outputText).toContain("HAS_LLM_MIME True");
+    expect(outputText).toContain(`LLM_VALUE ${LLM_REPR_SENTINEL}`);
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -31,6 +31,7 @@ const FIXTURE_SPECS = [
   "cell-visibility.spec.js", // Requires fixture notebook with pre-existing outputs
   "conda-inline.spec.js",
   "deno.spec.js",
+  "dx-bootstrap-repr-llm.spec.js", // Requires bootstrap_dx before daemon startup
   "prewarmed-uv.spec.js",
   "trust-dialog-dismiss.spec.js",
   "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory


### PR DESCRIPTION
## Summary

- Add a focused WebDriverIO spec that proves a DX-bootstrapped Python kernel registers the `text/llm+plain` formatter and calls `_repr_llm_`
- Exclude the settings-dependent spec from the default E2E sweep
- Add an isolated `DX Bootstrap E2E` workflow that seeds `bootstrap_dx` before starting `runtimed`

## Verification

- `node --check e2e/specs/dx-bootstrap-repr-llm.spec.js`
- `node --check e2e/wdio.conf.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dx-bootstrap-e2e.yml"); puts "yaml ok"'`
- `./actionlint -color .github/workflows/dx-bootstrap-e2e.yml`
- `cargo xtask lint --fix`
- `cargo xtask e2e build` (stopped after `runtimed` completed; full E2E path is left to isolated CI)
