### PR TITLE
docs: correct consolidated agent guidance

### DIFF
--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -154,7 +154,7 @@ Both sides use the workspace `automerge` dependency from the pinned `nteract/aut
 
 ```
 user types in cell
-  → React calls handle.update_source(cell_id, text)
+  → CodeMirror bridge calls handle.splice_source(cell_id, index, delete_count, text)
   → WASM applies mutation locally (instant)
   → engine.scheduleFlush() (20 ms debounce) → flush_local_changes() → sync bytes
   → sendFrame(AUTOMERGE_SYNC, msg) → raw binary via tauri::ipc::Request

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -78,7 +78,7 @@ The core renderer bundle is built inline by `apps/notebook/vite-plugin-isolated-
 
 ## Renderer plugins
 
-Heavy renderers (markdown, plotly, vega, leaflet) are **not** in the core IIFE. They're on-demand CJS modules loaded via `frame.installRenderer()` only when their MIME types appear.
+Heavy renderers (markdown, plotly, vega, leaflet, sift) are **not** in the core IIFE. They're on-demand CJS modules loaded via `frame.installRenderer()` only when their MIME types appear.
 
 ```
 ┌──────────────────────────────┐     ┌──────────────────────────┐
@@ -94,7 +94,7 @@ Heavy renderers (markdown, plotly, vega, leaflet) are **not** in the core IIFE. 
 └──────────────────────────────┘     └──────────────────────────┘
 ```
 
-- `OutputArea` scans each output's MIME types via `getRequiredLibraries()`.
+- `OutputArea` and the raw-frame prewarm path scan output MIME types with `needsPlugin()` from `src/components/isolated/iframe-libraries.ts`.
 - Matching plugins lazy-load from their own Vite virtual module (`virtual:renderer-plugin/{name}`).
 - Parent sends `nteract/installRenderer` with plugin code + CSS.
 - Iframe runs `new Function("module", "exports", "require", code)` with a `require` shim that injects the shared React instance.
@@ -113,6 +113,7 @@ Heavy renderers (markdown, plotly, vega, leaflet) are **not** in the core IIFE. 
 | Vega | `application/vnd.vega*.v*` | `virtual:renderer-plugin/vega` | ~865 KB |
 | Plotly | `application/vnd.plotly.v1+json` | `virtual:renderer-plugin/plotly` | ~4.8 MB |
 | Leaflet | `application/geo+json` | `virtual:renderer-plugin/leaflet` | ~194 KB |
+| Sift | `application/vnd.apache.parquet` | `virtual:renderer-plugin/sift` | ~380 KB JS + 138 KB CSS |
 
 ### Adding a plugin
 
@@ -138,7 +139,7 @@ export function install(ctx: {
 
 2. Extend `apps/notebook/vite-plugin-isolated-renderer.ts`: add the entry path, code/css variables, `invalidateCache()` entry, the `buildRendererPlugin()` call, and a `load()` case for the virtual module.
 3. Declare the virtual module in `apps/notebook/src/vite-env.d.ts`.
-4. In `src/components/isolated/iframe-libraries.ts`, add the MIME → plugin entry to `PLUGIN_MIME_TYPES` and the import case in `loadPluginForMime()`.
+4. In `src/components/isolated/iframe-libraries.ts`, add the MIME → plugin entry to `PLUGIN_MIME_TYPES`. Vega-style pattern matchers can use a shared loader; exact MIME types should live in the map.
 5. Remove the component from `src/isolated-renderer/index.tsx` so it no longer ships in the core bundle.
 
 ### Key files


### PR DESCRIPTION
## Summary

- Update isolated renderer guidance to reflect the live Sift/parquet plugin and `needsPlugin()` discovery path.
- Correct the protocol sync-flow diagram so UI source edits use the CodeMirror `splice_source` path.

## Verification

- `rg` stale-pattern checks for `getRequiredLibraries()` and stale `update_source` sync-flow wording in the remaining touched docs.
- `rg` checks against live Sift plugin code, virtual module declarations, `needsPlugin()` call sites, and `splice_source` editor bridge code.
- `git diff --check origin/main...HEAD`

Note: this branch was rebased after #2568 merged, and the obsolete `.claude/rules/frontend-architecture.md` hunk was dropped.
