### PR TITLE
refactor(runtimed-client): drop foreign re-exports

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1649,7 +1649,7 @@ async fn get_daemon_info() -> Option<DaemonInfoForBanner> {
             }
         };
         let version = info.version;
-        let socket_path = runtimed_client::default_socket_path();
+        let socket_path = runt_workspace::default_socket_path();
         let socket_path_full = if info.endpoint.is_empty() {
             socket_path.to_string_lossy().to_string()
         } else {
@@ -2466,7 +2466,7 @@ fn get_daemon_status(
 /// Get pool statistics from the daemon.
 /// Returns pool state from the daemon's PoolDoc.
 #[tauri::command]
-async fn get_pool_status() -> Result<runtimed::PoolState, String> {
+async fn get_pool_status() -> Result<notebook_doc::pool_state::PoolState, String> {
     let client = runtimed::client::PoolClient::default();
     client
         .status()

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -12,9 +12,12 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use serde::Serialize;
 
-use crate::connection::{self, Handshake};
+use notebook_doc::pool_state::PoolState;
+use notebook_protocol::connection::{self, Handshake};
+use runt_workspace::default_socket_path;
+
 use crate::protocol::{Request, Response};
-use crate::{default_socket_path, EnvType, PoolState, PooledEnv};
+use crate::{EnvType, PooledEnv};
 
 /// Progress updates during daemon startup.
 ///
@@ -53,7 +56,7 @@ use tokio::net::windows::named_pipe::ClientOptions;
 #[derive(Debug, Clone)]
 pub struct InspectResult {
     pub notebook_id: String,
-    pub cells: Vec<crate::notebook_doc::CellSnapshot>,
+    pub cells: Vec<notebook_doc::CellSnapshot>,
     /// Outputs keyed by cell_id. Outputs live in `RuntimeStateDoc` keyed
     /// by `execution_id` and travel alongside the cell snapshot rather
     /// than on it. Cells without outputs are absent from the map.

--- a/crates/runtimed-client/src/daemon_connection.rs
+++ b/crates/runtimed-client/src/daemon_connection.rs
@@ -264,7 +264,7 @@ impl DaemonConnection {
 /// supervisor task when the process exits.
 pub fn shared() -> &'static DaemonConnection {
     static SHARED: std::sync::OnceLock<DaemonConnection> = std::sync::OnceLock::new();
-    SHARED.get_or_init(|| DaemonConnection::spawn(crate::default_socket_path()))
+    SHARED.get_or_init(|| DaemonConnection::spawn(runt_workspace::default_socket_path()))
 }
 
 impl Drop for DaemonConnection {

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -24,31 +24,13 @@ pub mod client;
 pub mod daemon_connection;
 pub mod daemon_paths;
 pub mod execution_store;
-pub use notebook_doc;
-pub use notebook_doc::metadata as notebook_metadata;
-pub use notebook_doc::pool_state::{PoolState, RuntimePoolState};
-/// Re-export connection types from notebook-protocol.
-///
-/// The canonical definitions live in `notebook_protocol::connection`.
-/// This re-export preserves backward compatibility for existing callers.
-pub use notebook_protocol::connection;
 pub mod protocol;
 pub mod runtime;
 pub mod settings_doc;
 pub mod singleton;
 
-// ============================================================================
-// Development Mode and Worktree Isolation
-// ============================================================================
-
-// Re-export from runt-workspace for backwards compatibility
-pub use runt_workspace::{
-    build_channel, cache_namespace, cache_namespace_for, config_namespace, daemon_base_dir,
-    daemon_base_dir_for, daemon_binary_basename, daemon_binary_basename_for, daemon_launchd_label,
-    daemon_service_basename, default_notebook_log_path, default_socket_path, desktop_display_name,
-    desktop_display_name_for, desktop_product_name, get_workspace_name, get_workspace_path,
-    is_dev_mode, mcp_logs_dir, open_notebook_app_for_channel, session_state_path,
-    settings_json_path, socket_path_for_channel, worktree_hash, BuildChannel,
+use runt_workspace::{
+    cache_namespace, daemon_base_dir, get_workspace_path, is_dev_mode, worktree_hash,
 };
 
 /// Get the default log path for the daemon.
@@ -221,7 +203,7 @@ pub fn connections_dir() -> PathBuf {
 pub fn settings_schema_path() -> PathBuf {
     dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join(config_namespace())
+        .join(runt_workspace::config_namespace())
         .join("settings.schema.json")
 }
 

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -29,9 +29,9 @@ pub mod runtime;
 pub mod settings_doc;
 pub mod singleton;
 
-use runt_workspace::{
-    cache_namespace, daemon_base_dir, get_workspace_path, is_dev_mode, worktree_hash,
-};
+use runt_workspace::daemon_base_dir;
+#[cfg(unix)]
+use runt_workspace::{cache_namespace, get_workspace_path, is_dev_mode, worktree_hash};
 
 /// Get the default log path for the daemon.
 pub fn default_log_path() -> PathBuf {

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -11,7 +11,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::{EnvType, PoolState, PooledEnv};
+use notebook_doc::pool_state::PoolState;
+
+use crate::{EnvType, PooledEnv};
 
 // Re-export all notebook protocol types from the shared crate.
 pub use notebook_protocol::connection::{EnvSource, LaunchSpec};
@@ -159,7 +161,7 @@ pub enum Response {
         /// The notebook ID.
         notebook_id: String,
         /// Cell snapshots from the Automerge doc.
-        cells: Vec<crate::notebook_doc::CellSnapshot>,
+        cells: Vec<notebook_doc::CellSnapshot>,
         /// Outputs keyed by cell_id. Outputs live in `RuntimeStateDoc`
         /// keyed by `execution_id`, so they travel here as a parallel map
         /// rather than on `CellSnapshot`. Only cells with non-empty outputs
@@ -421,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_response_stats() {
-        use crate::RuntimePoolState;
+        use notebook_doc::pool_state::RuntimePoolState;
 
         let state = PoolState {
             uv: RuntimePoolState {

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -15,7 +15,7 @@ use automerge::{AutoCommit, ObjType, ReadDoc};
 use log::info;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use runtimed_client::connection::{self, Handshake};
+use notebook_protocol::connection::{self, Handshake};
 use runtimed_client::settings_doc::{
     default_pool_sizes_for_python_env, read_nested_list, split_comma_list, ColorTheme,
     CondaDefaults, PixiDefaults, SyncedSettings, ThemeMode, UvDefaults,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -26,7 +26,6 @@ use tokio::sync::RwLock;
 
 use crate::blob_server;
 use crate::blob_store::BlobStore;
-use crate::connection::{self, Handshake};
 use crate::notebook_sync_server::{NotebookRooms, PathIndex};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
@@ -35,6 +34,7 @@ use crate::singleton::DaemonLock;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::trusted_packages::{log_store_unavailable, TrustedPackageStore};
 use crate::{default_blob_store_dir, is_pool_env_dir, is_within_cache_dir, EnvType, PooledEnv};
+use notebook_protocol::connection::{self, Handshake};
 use runtimed_client::singleton::DaemonInfo;
 
 /// Configuration for the pool daemon.
@@ -130,7 +130,7 @@ impl DaemonConfig {
 fn legacy_settings_doc_path(config: &DaemonConfig) -> PathBuf {
     match &config.settings_json_path {
         Some(json_path) => json_path.with_file_name("settings.automerge"),
-        None => runtimed_client::daemon_base_dir().join("settings.automerge"),
+        None => runt_workspace::daemon_base_dir().join("settings.automerge"),
     }
 }
 
@@ -1407,10 +1407,10 @@ impl Daemon {
     /// payload.
     async fn build_daemon_info(&self) -> Response {
         let blob_port = *self.blob_port.lock().await;
-        let (worktree_path, workspace_description) = if crate::is_dev_mode() {
+        let (worktree_path, workspace_description) = if runt_workspace::is_dev_mode() {
             (
-                crate::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
-                crate::get_workspace_name(),
+                runt_workspace::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
+                runt_workspace::get_workspace_name(),
             )
         } else {
             (None, None)
@@ -2486,7 +2486,7 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        use crate::connection::{
+        use notebook_protocol::connection::{
             send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
         };
 
@@ -2828,7 +2828,7 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        use crate::connection::{
+        use notebook_protocol::connection::{
             send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
         };
 
@@ -3442,7 +3442,7 @@ impl Daemon {
                     let persist_path = self.config.notebook_docs_dir.join(filename);
                     if persist_path.exists() {
                         match std::fs::read(&persist_path) {
-                            Ok(data) => match crate::notebook_doc::NotebookDoc::load(&data) {
+                            Ok(data) => match notebook_doc::NotebookDoc::load(&data) {
                                 Ok(doc) => {
                                     let cells = doc.get_cells();
                                     let outputs_by_cell: std::collections::HashMap<
@@ -3657,7 +3657,7 @@ impl Daemon {
             // Clean up stale worktree state directories
             let worktrees_dir = dirs::cache_dir()
                 .unwrap_or_else(|| PathBuf::from("/tmp"))
-                .join(crate::cache_namespace())
+                .join(runt_workspace::cache_namespace())
                 .join("worktrees");
 
             if let Ok(total_cleaned) = Self::cleanup_stale_worktrees(&worktrees_dir).await {

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -60,7 +60,7 @@ pub(crate) mod uv_project;
 pub mod warm_env;
 
 pub fn trusted_packages_db_path() -> std::path::PathBuf {
-    runtimed_client::daemon_base_dir().join("trusted-packages.sqlite")
+    runt_workspace::daemon_base_dir().join("trusted-packages.sqlite")
 }
 
 /// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -295,14 +295,14 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     // Log dev mode status
-    if runtimed::is_dev_mode() {
-        if let Some(worktree) = runtimed::get_workspace_path() {
+    if runt_workspace::is_dev_mode() {
+        if let Some(worktree) = runt_workspace::get_workspace_path() {
             info!(
                 "Development mode enabled for worktree: {}",
                 worktree.display()
             );
             info!("Logs: {}", log_path.display());
-            if let Some(name) = runtimed::get_workspace_name() {
+            if let Some(name) = runt_workspace::get_workspace_name() {
                 info!("Workspace description: {}", name);
             }
         } else {
@@ -351,7 +351,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             let config = DaemonConfig {
-                socket_path: socket.unwrap_or_else(runtimed::default_socket_path),
+                socket_path: socket.unwrap_or_else(runt_workspace::default_socket_path),
                 cache_dir: cache_dir.unwrap_or_else(runtimed::default_cache_dir),
                 blob_store_dir: blob_store_dir.unwrap_or_else(runtimed::default_blob_store_dir),
                 execution_store_dir: runtimed::default_execution_store_dir(),

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -930,7 +930,7 @@ pub(crate) fn build_new_notebook_metadata(
     package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: &[String],
 ) -> NotebookMetadataSnapshot {
-    use crate::notebook_metadata::{
+    use notebook_doc::metadata::{
         CondaInlineMetadata, KernelspecSnapshot, LanguageInfoSnapshot, RuntMetadata,
         UvInlineMetadata,
     };

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -36,15 +36,15 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch, Mutex, RwLock};
 use tracing::{debug, error, info, warn};
 
 use crate::blob_store::BlobStore;
-use crate::connection::{self, NotebookFrameType};
 use crate::markdown_assets::{extract_markdown_asset_refs, resolve_markdown_assets};
-use crate::notebook_doc::{AttachmentEncoding, AttachmentRef, CellSnapshot, NotebookDoc};
-use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::output_prep::{DenoLaunchedConfig, LaunchedEnvConfig};
 use crate::paths::notebook_doc_filename;
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookResponse};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
+use notebook_doc::metadata::NotebookMetadataSnapshot;
 use notebook_doc::presence::{self, PresenceState};
+use notebook_doc::{AttachmentEncoding, AttachmentRef, CellSnapshot, NotebookDoc};
+use notebook_protocol::connection::{self, NotebookFrameType};
 use runtime_doc::RuntimeStateDoc;
 
 mod attachments;

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -1,7 +1,7 @@
 use automerge::sync;
 use tracing::warn;
 
-use crate::connection::NotebookFrameType;
+use notebook_protocol::connection::NotebookFrameType;
 
 use super::peer_writer::PeerWriter;
 use super::{

--- a/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncWrite;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use crate::connection::{self, NotebookFrameType};
+use notebook_protocol::connection::{self, NotebookFrameType};
 
 use super::peer_writer::PeerWriter;
 

--- a/crates/runtimed/src/notebook_sync_server/peer_presence.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_presence.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncWrite;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use crate::connection::{self, NotebookFrameType};
+use notebook_protocol::connection::{self, NotebookFrameType};
 
 use super::peer_writer::PeerWriter;
 use super::NotebookRoom;

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -4,7 +4,7 @@ use automerge::sync;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
-use crate::connection::NotebookFrameType;
+use notebook_protocol::connection::NotebookFrameType;
 
 use super::peer_writer::PeerWriter;
 use super::NotebookRoom;

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -5,7 +5,7 @@ use automerge::sync;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{info, warn};
 
-use crate::connection::{self, NotebookFrameType};
+use notebook_protocol::connection::{self, NotebookFrameType};
 
 use super::{streaming_load_cells, NotebookRoom, STATE_SYNC_COMPACT_THRESHOLD};
 

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncWrite;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
-use crate::connection::{self, NotebookFrameType};
+use notebook_protocol::connection::{self, NotebookFrameType};
 
 use super::NotebookRoom;
 use crate::requests::{handle_notebook_request, request_label};

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -164,13 +164,12 @@ fn test_trusted_packages() -> crate::trusted_packages::TrustedPackageStore {
 }
 
 fn legacy_pre_seed_v4_doc_bytes(notebook_id: &str, actor: &str, cell_id: &str) -> Vec<u8> {
-    let mut doc =
-        AutoCommit::new_with_encoding(crate::notebook_doc::TextEncoding::UnicodeCodePoint);
+    let mut doc = AutoCommit::new_with_encoding(notebook_doc::TextEncoding::UnicodeCodePoint);
     doc.set_actor(ActorId::from(actor.as_bytes()));
     doc.put(
         automerge::ROOT,
         "schema_version",
-        crate::notebook_doc::SCHEMA_VERSION,
+        notebook_doc::SCHEMA_VERSION,
     )
     .unwrap();
     doc.put(automerge::ROOT, "notebook_id", notebook_id)
@@ -680,10 +679,10 @@ fn snapshot_with_uv(deps: Vec<String>) -> NotebookMetadataSnapshot {
     NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
-            uv: Some(crate::notebook_metadata::UvInlineMetadata {
+            uv: Some(notebook_doc::metadata::UvInlineMetadata {
                 dependencies: deps,
                 requires_python: None,
                 prerelease: None,
@@ -704,11 +703,11 @@ fn snapshot_with_conda(deps: Vec<String>) -> NotebookMetadataSnapshot {
     NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
             uv: None,
-            conda: Some(crate::notebook_metadata::CondaInlineMetadata {
+            conda: Some(notebook_doc::metadata::CondaInlineMetadata {
                 dependencies: deps,
                 channels: vec!["conda-forge".to_string()],
                 python: None,
@@ -728,12 +727,12 @@ fn snapshot_with_pixi(deps: Vec<String>, pypi_deps: Vec<String>) -> NotebookMeta
     NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
             uv: None,
             conda: None,
-            pixi: Some(crate::notebook_metadata::PixiInlineMetadata {
+            pixi: Some(notebook_doc::metadata::PixiInlineMetadata {
                 dependencies: deps,
                 pypi_dependencies: pypi_deps,
                 channels: vec!["conda-forge".to_string()],
@@ -753,7 +752,7 @@ fn snapshot_empty() -> NotebookMetadataSnapshot {
     NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
             uv: None,
@@ -807,15 +806,15 @@ fn test_check_inline_deps_uv_priority() {
     let snapshot = NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
-            uv: Some(crate::notebook_metadata::UvInlineMetadata {
+            uv: Some(notebook_doc::metadata::UvInlineMetadata {
                 dependencies: vec!["numpy".to_string()],
                 requires_python: None,
                 prerelease: None,
             }),
-            conda: Some(crate::notebook_metadata::CondaInlineMetadata {
+            conda: Some(notebook_doc::metadata::CondaInlineMetadata {
                 dependencies: vec!["pandas".to_string()],
                 channels: vec!["conda-forge".to_string()],
                 python: None,
@@ -841,17 +840,17 @@ fn test_check_inline_deps_deno() {
     let snapshot = NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: crate::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
-            uv: Some(crate::notebook_metadata::UvInlineMetadata {
+            uv: Some(notebook_doc::metadata::UvInlineMetadata {
                 dependencies: vec!["numpy".to_string()],
                 requires_python: None,
                 prerelease: None,
             }),
             conda: None,
             pixi: None,
-            deno: Some(crate::notebook_metadata::DenoMetadata {
+            deno: Some(notebook_doc::metadata::DenoMetadata {
                 permissions: vec![],
                 import_map: None,
                 config: None,
@@ -889,7 +888,7 @@ fn test_room_with_path_and_store(
     let blob_store = test_blob_store(tmp);
     let notebook_id = notebook_path.to_string_lossy().to_string();
 
-    let doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let doc = notebook_doc::NotebookDoc::new(&notebook_id);
     let persist_path = tmp.path().join("doc.automerge");
     let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
     let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
@@ -2060,7 +2059,7 @@ async fn test_load_notebook_from_disk_routes_outputs_through_blob_store() {
     .unwrap();
 
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
     let mut state_doc = RuntimeStateDoc::new();
 
     let count = load_notebook_from_disk_with_state_doc(
@@ -2188,7 +2187,7 @@ async fn test_load_notebook_reuses_matching_durable_execution_id() {
     .unwrap();
 
     let context_id = ipynb_path.to_string_lossy().to_string();
-    let mut first_doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut first_doc = notebook_doc::NotebookDoc::new(&context_id);
     let mut first_state = RuntimeStateDoc::new();
     load_notebook_from_disk_with_state_doc(
         &mut first_doc,
@@ -2223,7 +2222,7 @@ async fn test_load_notebook_reuses_matching_durable_execution_id() {
         .await
         .unwrap();
 
-    let mut reload_doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut reload_doc = notebook_doc::NotebookDoc::new(&context_id);
     let mut reload_state = RuntimeStateDoc::new();
     load_notebook_from_disk_with_state_doc_and_execution_store(
         &mut reload_doc,
@@ -2305,7 +2304,7 @@ async fn test_load_notebook_mints_execution_id_when_durable_record_no_longer_mat
         .await
         .unwrap();
 
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&context_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&context_id);
     let mut state_doc = RuntimeStateDoc::new();
     load_notebook_from_disk_with_state_doc_and_execution_store(
         &mut doc,
@@ -2354,7 +2353,7 @@ async fn test_load_notebook_from_disk_resolves_nbformat_attachments() {
     .unwrap();
 
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
 
     let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
         .await
@@ -2417,7 +2416,7 @@ async fn test_load_notebook_from_disk_preserves_json_attachment_payloads() {
     .unwrap();
 
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
     load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
         .await
         .unwrap();
@@ -2462,7 +2461,7 @@ async fn test_load_notebook_from_disk_rejects_invalid_attachment_payloads() {
     .unwrap();
 
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
     let error = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
         .await
         .expect_err("invalid attachment payload should fail load");
@@ -2502,7 +2501,7 @@ async fn test_load_notebook_from_disk_skips_code_cell_asset_resolution() {
     .unwrap();
 
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
 
     let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
         .await
@@ -3026,7 +3025,7 @@ async fn bench_streaming_load_steps() {
     eprintln!("  jiter parse: {:?}", parse_elapsed);
 
     // Create doc + peer state
-    let mut doc = crate::notebook_doc::NotebookDoc::new("bench");
+    let mut doc = notebook_doc::NotebookDoc::new("bench");
     let mut peer_state = automerge::sync::State::new();
 
     let batch_size = STREAMING_BATCH_SIZE;
@@ -4220,7 +4219,7 @@ async fn test_check_and_update_trust_state_no_deps() {
     // returns Some (post-refactor: empty runt alone produces a None
     // snapshot because no keys get written to the doc).
     let mut snapshot = snapshot_empty();
-    snapshot.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+    snapshot.kernelspec = Some(notebook_doc::metadata::KernelspecSnapshot {
         name: "python3".to_string(),
         display_name: "Python 3".to_string(),
         language: Some("python".to_string()),
@@ -4481,7 +4480,7 @@ async fn test_check_and_update_trust_state_idempotent() {
     // returns Some (post-refactor: empty runt alone produces a None
     // snapshot because no keys get written to the doc).
     let mut snapshot = snapshot_empty();
-    snapshot.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+    snapshot.kernelspec = Some(notebook_doc::metadata::KernelspecSnapshot {
         name: "python3".to_string(),
         display_name: "Python 3".to_string(),
         language: Some("python".to_string()),
@@ -5204,7 +5203,7 @@ async fn test_pre_v4_ipynb_output_id_round_trip() {
 
     // --- Load 1: pre-v4 notebook, no output_id fields ---
     let notebook_id = ipynb_path.to_string_lossy().to_string();
-    let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
+    let mut doc = notebook_doc::NotebookDoc::new(&notebook_id);
     let mut state_doc = RuntimeStateDoc::new();
     load_notebook_from_disk_with_state_doc(
         &mut doc,
@@ -5320,7 +5319,7 @@ async fn test_pre_v4_ipynb_output_id_round_trip() {
     .unwrap();
 
     // Load the saved notebook
-    let mut doc2 = crate::notebook_doc::NotebookDoc::new("reload-test");
+    let mut doc2 = notebook_doc::NotebookDoc::new("reload-test");
     let mut state_doc2 = RuntimeStateDoc::new();
     load_notebook_from_disk_with_state_doc(
         &mut doc2,
@@ -7211,7 +7210,7 @@ async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
     {
         let mut doc = source_room.doc.write().await;
         let mut snap = snapshot_empty();
-        snap.kernelspec = Some(crate::notebook_metadata::KernelspecSnapshot {
+        snap.kernelspec = Some(notebook_doc::metadata::KernelspecSnapshot {
             name: "python3".to_string(),
             display_name: "Python 3".to_string(),
             language: Some("python".to_string()),

--- a/crates/runtimed/src/runtime_agent_manifest.rs
+++ b/crates/runtimed/src/runtime_agent_manifest.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
 
-use crate::daemon_base_dir;
+use runt_workspace::daemon_base_dir;
 
 pub const SCHEMA_VERSION: u32 = 1;
 

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -154,10 +154,10 @@ impl DaemonLock {
     /// Write daemon info after successful startup.
     pub fn write_info(&self, endpoint: &str, blob_port: Option<u16>) -> std::io::Result<()> {
         // Populate worktree info when in dev mode
-        let (worktree_path, workspace_description) = if crate::is_dev_mode() {
+        let (worktree_path, workspace_description) = if runt_workspace::is_dev_mode() {
             (
-                crate::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
-                crate::get_workspace_name(),
+                runt_workspace::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
+                runt_workspace::get_workspace_name(),
             )
         } else {
             (None, None)

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -15,8 +15,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
 
-use crate::connection;
 use crate::settings_doc::{SettingsDoc, SyncedSettings};
+use notebook_protocol::connection;
 
 /// Check if an error is just a normal connection close.
 pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1207,7 +1207,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
     let persist_path = temp_dir
         .path()
         .join("notebook-docs")
-        .join(runtimed::notebook_doc::notebook_doc_filename(&notebook_id));
+        .join(notebook_doc::notebook_doc_filename(&notebook_id));
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(meta) = tokio::fs::metadata(&persist_path).await {


### PR DESCRIPTION
Final piece of the `runtimed-client` thinning plan in `.context/plans/2026-05-06-runtimed-client-thinning.md`. Subprojects A through D landed in #2566 and #2567.

`runtimed-client` used to re-export `notebook_doc`, `notebook_protocol::connection`, and the full `runt_workspace::*` path/namespace block. Consumers that needed those types reached for them under `runtimed_client::PoolState` / `runtimed_client::daemon_base_dir` / `runtimed_client::is_dev_mode`, even though the canonical homes are elsewhere. The re-exports widened `runtimed-client`'s public surface and obscured the dep graph.

After this PR, `runtimed-client` publishes only what it owns: `PoolClient`, settings types, protocol types, output plumbing helpers, and a small set of path/version utilities like `default_log_path`, `default_cache_dir`, `is_pool_env_dir`. Everything else gets imported from `notebook-doc`, `notebook-protocol`, or `runt-workspace` directly.

## Changes

- `runtimed-client/src/lib.rs`: drops `pub use notebook_doc;`, `pub use notebook_doc::metadata as notebook_metadata;`, `pub use notebook_doc::pool_state::{PoolState, RuntimePoolState};`, `pub use notebook_protocol::connection;`, and the `pub use runt_workspace::{...}` block. The internal calls to `daemon_base_dir`, `cache_namespace`, `is_dev_mode`, `worktree_hash`, `get_workspace_path` now go through a private `use runt_workspace::{...}`.
- `runtimed-client/src/{client,protocol,daemon_connection}.rs`: switch their `crate::connection`, `crate::PoolState`, `crate::default_socket_path`, `crate::notebook_doc::CellSnapshot`, `crate::RuntimePoolState` references to canonical paths.
- `runtimed-settings-sync/src/lib.rs`: imports `connection` from `notebook_protocol` instead of `runtimed_client`.
- `crates/notebook/src/lib.rs`: `runtimed_client::default_socket_path` → `runt_workspace::default_socket_path`; `runtimed::PoolState` → `notebook_doc::pool_state::PoolState`.
- `crates/runtimed/src/main.rs`: `runtimed::is_dev_mode/get_workspace_path/get_workspace_name/default_socket_path` → `runt_workspace::*`.
- `crates/runtimed/src/{daemon,lib}.rs`: `runtimed_client::daemon_base_dir` → `runt_workspace::daemon_base_dir`.
- 13 daemon source files (`daemon.rs`, `notebook_sync_server/*`, `singleton.rs`, `sync_server.rs`, `runtime_agent_manifest.rs`): mechanical sed of `crate::connection` → `notebook_protocol::connection`, `crate::notebook_doc` → `notebook_doc`, `crate::notebook_metadata` → `notebook_doc::metadata`, plus the `runt_workspace::*` path renames. These all came in scope through the daemon's `pub use runtimed_client::*;` glob.
- `crates/runtimed/tests/integration.rs`: `runtimed::notebook_doc` → `notebook_doc`.

## Verification

- `cargo check --workspace` clean.
- `cargo xtask lint --fix` reformats and passes.
- `cargo xtask clippy` passes.
- Tests run in CI.

Description gets rewritten before merge.
