### PR TITLE
chore: clear loose frontend and Python build warnings

### DIFF
--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -21,7 +21,8 @@ import "@/components/widgets/ipycanvas";
 // Preload output components used in main bundle (via MediaRouter).
 // Note: markdown-output, html-output, svg-output are isolated-only
 // and bundled separately in src/isolated-renderer/ - no need to preload here.
-import("@/components/outputs/ansi-output");
+// ansi-output is now a static import in media-router (also pulled in by
+// OutputArea), so it's already part of the main bundle.
 import("@/components/outputs/image-output");
 import("@/components/outputs/json-output");
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -60,8 +60,8 @@ class LLMFormatter(BaseFormatter):
     inherited ``for_type`` / ``for_type_by_name`` registration APIs.
     """
 
-    format_type = Unicode("text/llm+plain")  # type: ignore[assignment]
-    print_method = ObjectName("_repr_llm_")  # type: ignore[assignment]
+    format_type = Unicode("text/llm+plain")
+    print_method = ObjectName("_repr_llm_")
 
 
 # ─── mimebundle formatters (lazy-bound via for_type_by_name) ──────────────

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -1,10 +1,15 @@
 import { lazy, type ReactNode, Suspense } from "react";
 import { getRenderer } from "@/lib/renderer-registry";
+import { AnsiOutput } from "./ansi-output";
+import { TracebackOutput } from "./traceback-output";
 import { isSafeForMainDom } from "./safe-mime-types";
 import { useMediaContext } from "./media-provider";
 
-// Lazy load built-in output components for better bundle splitting
-const AnsiOutput = lazy(() => import("./ansi-output").then((m) => ({ default: m.AnsiOutput })));
+// AnsiOutput and TracebackOutput stay statically imported: ansi-output is
+// also pulled in by OutputArea (every cell with output) and output-widget,
+// and traceback-output by OutputArea (every error). Both ride along in the
+// main bundle regardless, so a lazy wrapper just adds a Suspense boundary
+// without splitting anything.
 const MarkdownOutput = lazy(() =>
   import("./markdown-output").then((m) => ({ default: m.MarkdownOutput })),
 );
@@ -20,9 +25,6 @@ const JavaScriptOutput = lazy(() =>
   import("./javascript-output").then((m) => ({
     default: m.JavaScriptOutput,
   })),
-);
-const TracebackOutput = lazy(() =>
-  import("./traceback-output").then((m) => ({ default: m.TracebackOutput })),
 );
 
 /**


### PR DESCRIPTION
Quick sweep of loose warnings surfaced by `pnpm exec vp build` (apps/notebook) and `cargo xtask lint` (Python).

## Frontend - ineffective dynamic imports

Vite/rolldown was emitting:

```
ansi-output.tsx is dynamically imported by main.tsx, media-router.tsx but also statically imported by OutputArea.tsx, output-widget.tsx
traceback-output.tsx is dynamically imported by media-router.tsx but also statically imported by OutputArea.tsx
```

Both files were already in the main bundle thanks to the static imports (every cell with output reaches them via OutputArea). The `lazy()` wrappers in media-router and the preload in main.tsx accomplished nothing - they just added a Suspense boundary with no chunk split.

Fix: replace the lazy wrappers in `media-router.tsx` with static imports for `AnsiOutput` and `TracebackOutput`, and drop the now-redundant `import("@/components/outputs/ansi-output")` preload from `main.tsx`. Comment in media-router explains why these two stay static while the others (markdown, html, image, etc.) keep their lazy wrappers.

## Python - unused type: ignore directives

`ruff/ty` flagged two `# type: ignore[assignment]` comments in `python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py` lines 63-64 as no-ops. Removed.

## Verification

- `pnpm exec vp build`: only the informational PLUGIN_TIMINGS warning remains.
- `cargo xtask lint`: all checks pass.
- `cargo xtask clippy`: passes.

## Not addressed here

`cargo build --workspace` emits ~20 `ld64.lld` warnings of the form `zstd-sys ... has version 26.4.0, which is newer than target minimum of 11.0.0`. That's a `MACOSX_DEPLOYMENT_TARGET` mismatch coming from the bundled C library inside `zstd-sys`, not a code-level fix. Left for a separate environment-config PR if it's worth pursuing.
