### PR TITLE
docs(codex): trim nested agent guidance

### DIFF
--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -20,38 +20,13 @@ Two independent integers, separate from the artifact version:
 
 Artifact versions follow standard semver. Protocol or schema bumps don't automatically force a major version bump.
 
-### Release channels
-
-- **Stable.** `v*` tag publishes Python wheels to PyPI at the `pyproject.toml` version (no separate `python-v*` tag — the desktop release ships Python too).
-- **Nightly.** Daily builds publish PEP 440 alpha pre-releases (e.g. `2.0.1a202603100900`). Install with `pip install runtimed --pre`.
-- **Python-only.** The `python-v*` path (`python-package.yml`) is for Python-specific patches that don't need a full desktop release.
-
 ### Desktop-app compatibility
 
 The desktop app bundles its own daemon binary. Version-mismatch detection between the app and its bundled daemon compares git commit hashes (appended as `+{sha}` at build time), not semver — both always build from the same CI commit.
 
 ## Connection topology
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  Notebook Window (Tauri webview)                        │
-│                                                         │
-│  ┌──────────┐   Tauri invoke()   ┌──────────────────┐  │
-│  │ Frontend  │ ←───────────────→ │   Tauri Relay     │  │
-│  │ (WASM +   │   Tauri events    │ (NotebookSync-    │  │
-│  │  React)   │ ←──────────────── │  Client)          │  │
-│  └──────────┘                    └────────┬─────────┘  │
-│                                           │             │
-└───────────────────────────────────────────┼─────────────┘
-                                            │ Unix socket
-                                            ▼
-                                   ┌─────────────────┐
-                                   │    runtimed     │
-                                   │   (daemon)      │
-                                   └─────────────────┘
-```
-
-The **Tauri relay** is a transparent byte pipe for Automerge sync, request, runtime-state, pool-state, and presence frames — it holds no document replica of its own. Broadcasts, responses, presence, and session-control frames arrive through the unified `notebook:frame` event.
+The frontend talks to the Tauri relay through `invoke()` calls and Tauri events. The relay is a transparent byte pipe to the runtimed socket for Automerge sync, request, runtime-state, pool-state, and presence frames; it holds no document replica of its own. Broadcasts, responses, presence, and session-control frames arrive through the unified `notebook:frame` event.
 
 ## Connection lifecycle
 
@@ -292,7 +267,7 @@ Cell outputs use inline manifests with blob offload for large payloads. When the
 
 1. Output becomes nbformat JSON, then an inline **manifest** as an Automerge Map in `RuntimeStateDoc` (`output_store.rs`).
 2. Each MIME's content is a `ContentRef`: `Inline` for ≤ 1 KB, `Blob { hash, size }` for > 1 KB.
-3. Large binary content (images, plots) lives in a content-addressed **blob store** (`blob_store.rs`, SHA-256, `~/.cache/runt/blobs/`).
+3. Blob content lives in a content-addressed **blob store** (`blob_store.rs`, SHA-256, under `runt_workspace::daemon_base_dir()/blobs`).
 4. MIME types and small payloads are readable straight from the CRDT without a blob fetch.
 5. Clients resolve large blobs from the daemon's HTTP blob server (`GET /blob/{hash}` on a dynamic port).
 

--- a/src/components/widgets/AGENTS.md
+++ b/src/components/widgets/AGENTS.md
@@ -42,7 +42,7 @@ Scope: `src/components/widgets/**`. The JSON-RPC transport and iframe lifecycle 
 
 ## Reserved comm namespace: `nteract.dx.*`
 
-`nteract.dx.*` target-names are reserved for nteract kernel-side protocols (dx uses `nteract.dx.blob`; future subsystems may use `nteract.dx.query`, `nteract.dx.stream`). The runtime agent filters this namespace out of `RuntimeStateDoc::comms` — it's not widget state, doesn't sync to the frontend, and never reaches `WidgetStore`. Pick a different prefix for widget targets.
+`nteract.dx.*` target-names are reserved for nteract kernel-side protocols. The runtime agent filters this namespace out of `RuntimeStateDoc::comms` and `NotebookBroadcast::Comm`, so it is not widget state and never reaches `WidgetStore`. v1 has no live `nteract.dx.blob` handler; reserved messages are dropped with a warning while current blob refs ride IOPub `display_data` buffers. Pick a different prefix for widget targets.
 
 ## Key files
 


### PR DESCRIPTION
## Summary

- Follow up on the docs cleanup after #2575 with a narrow Codex-guidance pass.
- Trim `crates/notebook-wire/AGENTS.md` so the root + nested instruction chain stays under Codex's default 32 KiB `project_doc_max_bytes` limit.
- Correct stale blob-store path wording in the wire guide.
- Align the widget guide's `nteract.dx.*` description with the current reserved-and-dropped runtime behavior.

## Verification

- Checked current OpenAI Codex docs for AGENTS discovery/size behavior and skill locations.
- Measured loaded instruction-chain size for `crates/notebook-wire`: `32172` bytes after this patch.
- Cross-checked `nteract.dx.*` wording against `crates/runtimed/src/dx_blob_comm.rs`, `crates/runtimed/src/jupyter_kernel.rs`, and `crates/runtimed/src/output_store.rs`.
- `rg` stale-pattern checks for old blob path / live dx-blob wording.
- `git diff --check`
- `cargo xtask lint --fix` (passes; reports existing unicorn warning in `plugins/nteract/pi/extensions/repl.ts`)
