### PR TITLE
chore(macos): align deployment target to 11.0

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -12,6 +12,15 @@ PATH_add bin
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_DEV=1
 
+# Match cc-rs's C compilation target to Rust's link target on macOS.
+# The aarch64-apple-darwin Rust target floors at 11.0 (Apple Silicon
+# never ran below Big Sur). Without this, cc-rs builds C objects in
+# zstd-sys / friends against the host SDK (e.g. 26.4) and ld64.lld
+# warns once per object that the build version is newer than the link
+# target. cc-rs reads MACOSX_DEPLOYMENT_TARGET and forwards it to
+# clang as -mmacosx-version-min, so the C side and Rust side agree.
+export MACOSX_DEPLOYMENT_TARGET=11.0
+
 # Link through LLVM lld on macOS arm64 when it's installed. Local dev
 # gets the faster linker; CI and contributors without lld fall back to
 # Apple's default ld. Scoped via CARGO_TARGET_<triple>_RUSTFLAGS so it

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -37,7 +37,7 @@
     "macOS": {
       "entitlements": "entitlements.plist",
       "hardenedRuntime": true,
-      "minimumSystemVersion": "10.13"
+      "minimumSystemVersion": "11.0"
     },
     "windows": {
       "signCommand": "trusted-signing-cli -e https://eus.codesigning.azure.net -a NumFOCUS -c TrustedCertificateProfileForALLNumFOCUS -d nteract %1",


### PR DESCRIPTION
Two related changes to silence the `ld64.lld` warning chain on local builds and stop understating Tauri's actual minimum macOS version.

## Background

`cargo build --workspace` on a current Mac emitted ~20 warnings of the form:

```
ld64.lld: warning: ...zstd-sys.../zstd_common.o has version 26.4.0,
which is newer than target minimum of 11.0.0
```

The chain:

1. `cc-rs` invokes `clang` to compile `zstd-sys`'s C objects (pulled via `compression-codecs → astral_async_zip → rattler_package_streaming → rattler`). With no `-mmacosx-version-min`, `clang` stamps each `.o` with the host SDK version (`26.4.0` on a current macOS install).
2. The `aarch64-apple-darwin` Rust target floors at `11.0` (Apple Silicon never existed before Big Sur).
3. The linker sees C objects stamped 26.4 going into a binary linked for 11.0, and warns once per object.

Setting `MACOSX_DEPLOYMENT_TARGET` is the canonical fix; `cc-rs` reads it and forwards `-mmacosx-version-min=11.0` to `clang`. The C side then matches the link target.

## Changes

**`.envrc`**: export `MACOSX_DEPLOYMENT_TARGET=11.0`. Sourced via direnv so local builds pick it up automatically.

**`tauri.conf.json`**: bump `minimumSystemVersion` from `10.13` (High Sierra) to `11.0` (Big Sur). The 10.13 value predated the Apple Silicon transition and was inconsistent with Tauri 2.x's actual requirement (10.15). 11.0 matches:

- The arm64 Rust toolchain floor.
- The `MACOSX_DEPLOYMENT_TARGET` we just set.
- Conservative practice for a Tauri 2.x app shipping an arm64 build.

macOS versions dropped: 10.13 / 10.14 / 10.15 — all unsupported by Apple since 2020-2022. macOS 11 (Big Sur) supports Macs back to 2013-2014, so the practical user impact is minimal.

## Verification

- `cargo build --workspace`: zero `newer than target minimum` warnings (was ~20).
- `cargo xtask lint`: passes.
- `cargo xtask clippy`: passes.

## Tradeoffs noted

- More aggressive choices (12.0 Monterey, 13.0 Ventura) would match Apple's current support window. 11.0 is the conservative round number that aligns with the Rust toolchain.
- CI typically uses a different macOS SDK and may not see the warning at all. This change is mostly local-dev hygiene plus a manifest correctness fix.
