### PR TITLE
fix(runt-trust): thread-local test key override to isolate parallel tests

### DIFF
--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -19,31 +19,48 @@
 use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Mutex;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Thread-safe override for the trust key path.
-///
-/// Tests use [`set_test_key_path`] instead of `std::env::set_var("RUNT_TRUST_KEY_PATH", ...)`
-/// to avoid process-wide env mutation, which is undefined behavior under concurrent
-/// threads (glibc `setenv`/`getenv` are not thread-safe).
-static TEST_KEY_PATH_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
+thread_local! {
+    /// Per-thread override for the trust key path.
+    ///
+    /// Tests use [`set_test_key_path`] instead of `std::env::set_var("RUNT_TRUST_KEY_PATH", ...)`
+    /// to avoid process-wide env mutation, which is undefined behavior under concurrent
+    /// threads (glibc `setenv`/`getenv` are not thread-safe).
+    ///
+    /// The override is thread-local so concurrent `cargo test` runs are naturally
+    /// isolated: setting the path on test A's thread cannot flip the path that
+    /// test B reads on a different thread mid-sign-then-verify. A previous
+    /// implementation used a process-wide `Mutex<Option<PathBuf>>`, which made
+    /// individual reads/writes atomic but did not isolate test logic - non-serial
+    /// trust tests would intermittently see another test's override flip between
+    /// their sign and verify calls and fail with a signature mismatch.
+    static TEST_KEY_PATH_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
 
 /// Set (or clear) the trust key path override for tests.
 ///
-/// Pass `Some(path)` to redirect all trust operations to a test-specific key file.
-/// Pass `None` to clear the override and fall back to the default path.
+/// Pass `Some(path)` to redirect all trust operations on this thread to a
+/// test-specific key file. Pass `None` to clear the override and fall back
+/// to the default path.
 ///
-/// This is safe to call from concurrent tests because it uses a `Mutex` instead
-/// of mutating the process environment.
+/// The override is thread-local: concurrent tests do not interfere. Production
+/// code never calls this, so production path resolution always falls through
+/// to the system key.
+///
+/// Caveat: a tokio multi-threaded runtime can move a task between OS threads
+/// across `.await` points; if a future polls on a thread that didn't set the
+/// override, it reads `None`. No multi-threaded tokio path in this workspace
+/// currently calls `set_test_key_path`, so this isn't a problem in practice -
+/// but if you reach for this from a multi-thread tokio context, set the
+/// override on every worker (e.g. via `Builder::on_thread_start`) or pass the
+/// path explicitly through your call chain.
 pub fn set_test_key_path(path: Option<PathBuf>) {
-    let mut guard = TEST_KEY_PATH_OVERRIDE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    *guard = path;
+    TEST_KEY_PATH_OVERRIDE.with(|cell| *cell.borrow_mut() = path);
 }
 
 /// Result of verifying a notebook's trust status.
@@ -100,20 +117,12 @@ pub struct TrustInfo {
 /// Path to the trust key file.
 ///
 /// Checks (in order):
-/// 1. Thread-safe override via [`set_test_key_path`] — preferred for tests.
+/// 1. Thread-local override via [`set_test_key_path`] - preferred for tests.
 /// 2. Platform config dir (`~/.config/runt/trust-key` on Linux).
 fn trust_key_path() -> Option<PathBuf> {
-    // 1. Thread-safe test override (no env mutation needed)
-    //    Recover from poison so a panicked test doesn't silently fall
-    //    through to the system key path.
-    let guard = TEST_KEY_PATH_OVERRIDE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    if let Some(ref path) = *guard {
-        return Some(path.clone());
+    if let Some(path) = TEST_KEY_PATH_OVERRIDE.with(|cell| cell.borrow().clone()) {
+        return Some(path);
     }
-    drop(guard);
-    // 2. Platform default
     dirs::config_dir().map(|d| d.join("runt").join("trust-key"))
 }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use automerge::{transaction::Transactable, ActorId, AutoCommit, ObjType};
 use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle};
-use serial_test::serial;
 use uuid::Uuid;
 
 const SCHEMA_SEED_ACTOR_LABEL: &str = "nteract:notebook-schema:v4";
@@ -591,7 +590,6 @@ async fn test_untitled_room_preserves_legacy_persisted_automerge_history() {
 /// Regression test for #1646: untitled notebooks must read trust from
 /// the persisted Automerge doc, not from a non-existent .ipynb file.
 #[tokio::test]
-#[serial]
 async fn test_new_fresh_untitled_trust_from_doc() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4092,7 +4090,6 @@ fn test_verify_trust_from_snapshot_no_deps() {
 }
 
 #[test]
-#[serial]
 fn test_verify_trust_from_snapshot_unsigned_deps() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4107,7 +4104,6 @@ fn test_verify_trust_from_snapshot_unsigned_deps() {
 }
 
 #[test]
-#[serial]
 fn test_verify_trust_from_snapshot_unsigned_pixi_deps() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4124,7 +4120,6 @@ fn test_verify_trust_from_snapshot_unsigned_pixi_deps() {
 }
 
 #[test]
-#[serial]
 fn test_verify_trust_from_snapshot_signed_trusted() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4148,7 +4143,6 @@ fn test_verify_trust_from_snapshot_signed_trusted() {
 }
 
 #[test]
-#[serial]
 fn test_verify_trust_from_snapshot_invalid_signature() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4166,7 +4160,6 @@ fn test_verify_trust_from_snapshot_invalid_signature() {
 }
 
 #[test]
-#[serial]
 fn test_verify_trust_from_snapshot_conda_trusted() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4244,7 +4237,6 @@ async fn test_check_and_update_trust_state_no_deps() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_approve_trust_adds_dependencies_to_allowlist() {
     let tmp = tempfile::TempDir::new().unwrap();
     let key_path = tmp.path().join("trust-key");
@@ -4282,7 +4274,6 @@ async fn test_approve_trust_adds_dependencies_to_allowlist() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_allowlisted_unsigned_dependencies_auto_sign_and_trust() {
     let tmp = tempfile::TempDir::new().unwrap();
     let key_path = tmp.path().join("trust-key");
@@ -4331,7 +4322,6 @@ async fn test_allowlisted_unsigned_dependencies_auto_sign_and_trust() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_allowlist_partial_coverage_stays_untrusted_with_markers() {
     let tmp = tempfile::TempDir::new().unwrap();
     let key_path = tmp.path().join("trust-key");
@@ -4377,7 +4367,6 @@ async fn test_allowlist_partial_coverage_stays_untrusted_with_markers() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_allowlist_does_not_override_invalid_signature() {
     let tmp = tempfile::TempDir::new().unwrap();
     let key_path = tmp.path().join("trust-key");
@@ -4417,7 +4406,6 @@ async fn test_allowlist_does_not_override_invalid_signature() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_check_and_update_trust_state_approval_updates_room() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4522,7 +4510,6 @@ async fn test_check_and_update_trust_state_idempotent() {
 /// SignatureInvalid verification, re-sign in place with the daemon's trust
 /// key and keep the notebook Trusted.
 #[tokio::test]
-#[serial]
 async fn test_check_and_update_trust_state_auto_resigns_trusted_notebook() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4613,7 +4600,6 @@ async fn test_check_and_update_trust_state_auto_resigns_trusted_notebook() {
 /// A brand-new notebook with unsigned deps must still land in Untrusted —
 /// the user has not approved anything yet.
 #[tokio::test]
-#[serial]
 async fn test_check_and_update_trust_state_no_autoresign_when_not_previously_trusted() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4646,7 +4632,6 @@ async fn test_check_and_update_trust_state_no_autoresign_when_not_previously_tru
 // the user explicitly copies them into metadata.
 
 #[tokio::test]
-#[serial]
 async fn test_auto_sign_in_place_uv_yields_trusted() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4668,7 +4653,6 @@ async fn test_auto_sign_in_place_uv_yields_trusted() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_auto_sign_in_place_conda_yields_trusted() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -4686,7 +4670,6 @@ async fn test_auto_sign_in_place_conda_yields_trusted() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_auto_sign_in_place_pixi_writes_signature() {
     let temp_dir = tempfile::tempdir().unwrap();
     let key_path = temp_dir.path().join("trust-key");
@@ -6556,7 +6539,6 @@ fn test_project_file_deps_match_trust_info_no_project_file() {
 /// build) must land on Trusted at room creation, so the auto-launch
 /// gate in peer_connection.rs doesn't block.
 #[tokio::test]
-#[serial]
 async fn test_new_fresh_promotes_untrusted_when_project_file_deps_match() {
     let key_tmp = tempfile::tempdir().unwrap();
     let key_path = key_tmp.path().join("trust-key");
@@ -6595,7 +6577,6 @@ async fn test_new_fresh_promotes_untrusted_when_project_file_deps_match() {
 
 /// Counterpart: if deps differ, room init must leave trust Untrusted.
 #[tokio::test]
-#[serial]
 async fn test_new_fresh_leaves_untrusted_when_deps_differ() {
     let key_tmp = tempfile::tempdir().unwrap();
     let key_path = key_tmp.path().join("trust-key");
@@ -7354,7 +7335,6 @@ async fn test_file_watcher_replacement_drops_stale_top_level_metadata() {
 /// another editor) should flow into `RuntimeStateDoc.project_context`
 /// without any client round-trip.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[serial]
 async fn project_file_watcher_refreshes_context_on_external_edit() {
     use runtime_doc::ProjectContext;
     use tokio::time::{sleep, Duration};


### PR DESCRIPTION
Fixes the test isolation flake in `cargo test -p runtimed --lib`. Drops 19 `#[serial]` annotations along the way.

## Symptom

Running `cargo test -p runtimed --lib` (default parallel test runner) intermittently surfaced one of:

```
test requests::approve_trust::tests::approval_writes_trust_fields_to_the_doc ... FAILED
test notebook_sync_server::tests::test_verify_trust_from_snapshot_signed_trusted ... FAILED
```

`--test-threads=1` always passed. Different runs surfaced different failures; sometimes none.

## Root cause

`runt_trust::TEST_KEY_PATH_OVERRIDE` was a process-wide `Mutex<Option<PathBuf>>`. The `Mutex` made individual reads/writes atomic but **did not isolate test logic**. The race:

1. Test A sets the override to `tempdir_A/trust-key`.
2. Test B (running in parallel) calls `auto_sign_in_place` → `get_or_create_trust_key()` reads override → reads `K_A`. Signs.
3. Test A clears the override.
4. Test B calls `verify_trust_from_snapshot` → `get_or_create_trust_key()` reads override = `None` → falls through to system path → reads `K_system`.
5. `K_A ≠ K_system` → signature mismatch → Test B fails with `SignatureInvalid`.

The 19 `#[serial]` annotations on `notebook_sync_server/tests.rs` were workarounds, not architecture. They serialized trust tests against each other but did nothing to protect non-serial tests like `requests::approve_trust::tests::approval_writes_trust_fields_to_the_doc`. Adding `#[serial]` to one more test would just shift the landmine.

## Fix

Switch `TEST_KEY_PATH_OVERRIDE` from `Mutex<Option<PathBuf>>` to `thread_local! { RefCell<Option<PathBuf>> }`. Each test thread gets its own slot. `set_test_key_path` on test A's thread is invisible to test B. Tests can run fully in parallel.

Verified safe:
- All trust-touching tests are plain `#[test]` (sync, one OS thread per test) or `#[tokio::test]` defaults to `current_thread`. No `#[tokio::test(flavor = "multi_thread")]` in the trust path.
- Production code never calls `set_test_key_path`, so production path resolution falls through to the system key as before.
- A new doc comment on `set_test_key_path` notes the multi-threaded tokio caveat for future readers.

Drops the 19 `#[serial]` annotations from `notebook_sync_server/tests.rs` plus the now-unused `use serial_test::serial;` import there. The other `serial_test` usage in the workspace (`sync_server.rs::serial(settings_sync_panic_hooks)`) is a different group around panic-hook globals and stays.

## Verification

- `cargo test -p runtimed --lib` 5x in a row: 663 passed, 0 failed each run.
- `cargo test -p runt-trust`: 8 passed.
- `cargo xtask lint`, `cargo xtask clippy`: clean.

## Not in scope

Saw a one-off flake on `kernel_ports::tests::successful_reservation_releases_on_drop` once during reproduction. That's a separate issue (TCP port 19030 contention or static `RESERVED_KERNEL_PORTS` set drift), not related to trust. Did not recur during the verification runs above; tracking separately if it shows up again.
