### PR TITLE
fix(notebook): render markdown on ctrl-enter

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -262,11 +262,14 @@ export const MarkdownCell = memo(function MarkdownCell({
       } else if (e.key === "ArrowUp") {
         onFocusPrevious?.("end");
         e.preventDefault();
-      } else if (e.key === "Enter" && e.shiftKey) {
+      } else if (e.key === "Enter" && e.ctrlKey && !e.metaKey && !e.altKey) {
+        setEditing(false);
+        e.preventDefault();
+      } else if (e.key === "Enter" && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Shift+Enter: move to next cell (like execute for code cells)
         onFocusNext?.("start");
         e.preventDefault();
-      } else if (e.key === "Enter" && !e.shiftKey) {
+      } else if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Enter: enter edit mode
         setEditing(true);
         e.preventDefault();
@@ -331,6 +334,13 @@ export const MarkdownCell = memo(function MarkdownCell({
   // Combine navigation with markdown-specific keys
   const keyMap: KeyBinding[] = useMemo(
     () => [
+      {
+        key: "Ctrl-Enter",
+        run: () => {
+          setEditing(false);
+          return true;
+        },
+      },
       ...navigationKeyMap,
       {
         key: "Escape",

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MarkdownCell as MarkdownCellType } from "../../types";
@@ -58,8 +58,23 @@ vi.mock("@/components/cell/CellContainer", () => ({
 }));
 
 vi.mock("@/components/editor/codemirror-editor", () => ({
-  CodeMirrorEditor: React.forwardRef(function CodeMirrorEditor(_props, _ref) {
-    return <div data-testid="markdown-editor" />;
+  CodeMirrorEditor: React.forwardRef(function CodeMirrorEditor(
+    props: { keyMap?: Array<{ key: string; run: () => boolean }> },
+    _ref,
+  ) {
+    return (
+      <div
+        data-testid="markdown-editor"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          const key = event.ctrlKey && event.key === "Enter" ? "Ctrl-Enter" : event.key;
+          const binding = props.keyMap?.find((entry) => entry.key === key);
+          if (binding?.run()) {
+            event.preventDefault();
+          }
+        }}
+      />
+    );
   }),
 }));
 
@@ -196,5 +211,38 @@ describe("MarkdownCell theme sync", () => {
     await waitFor(() => {
       expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
+  });
+
+  it("Ctrl+Enter exits edit mode for markdown cells", async () => {
+    const cell = { ...makeCell(), source: "" };
+
+    const { getByLabelText, getByTestId } = render(
+      <MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(preview.className).toContain("hidden");
+
+    fireEvent.keyDown(getByTestId("markdown-editor"), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+
+    await waitFor(() => {
+      expect(preview.className).not.toContain("hidden");
+    });
+  });
+
+  it("Ctrl+Enter keeps markdown preview in view mode", () => {
+    const { getByLabelText } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(preview.className).not.toContain("hidden");
+
+    fireEvent.keyDown(preview, { key: "Enter", ctrlKey: true });
+
+    expect(preview.className).not.toContain("hidden");
   });
 });


### PR DESCRIPTION
## Summary

- Make `Ctrl-Enter` switch Markdown cells from edit mode to rendered view mode.
- Keep Markdown preview mode stable when `Ctrl-Enter` is pressed while already rendered.
- Add focused Markdown cell tests for both shortcut paths.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`

## Notes

- `pnpm --dir apps/notebook build` is currently blocked by `src/hooks/usePresence.ts` importing `encode_heartbeat_presence`, which is not exported by the generated `runtimed_wasm.js` in this checkout.
