### PR TITLE
fix(sync): pin automerge patch log recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
+source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=4a605a43586e08de090bb1321b661b15c1e71962#4a605a43586e08de090bb1321b661b15c1e71962"
+source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "4a605a43586e08de090bb1321b661b15c1e71962" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "c24f070ca171ece9b67021483ffc518f5340e841" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- Pin `automerge` to [nteract/automerge#1](https://github.com/nteract/automerge/pull/1) (`c24f070c`) so RuntimeStateSync no longer panics on stale inactive patch logs.
- Update `Cargo.lock` for the matching `automerge` and `hexane` git sources only.

## Root Cause

The failing CI job hit Automerge's `PatchLogMismatch` panic while applying inbound RuntimeStateSync frames. Desktop was pinned to `4a605a4`, where `BatchApply::apply` unwraps `PatchLog::migrate_actors(...)`. During sync receive, AutoCommit can carry an inactive, empty internal patch log whose actor table is stale relative to the document actor table after the incoming change is loaded. Since the patch log has no events or exposed IDs to migrate, retargeting that log to the document actor table is safe; [nteract/automerge#1](https://github.com/nteract/automerge/pull/1) now includes that fix and leaves real mismatches as errors instead of panics.

The closed desktop recovery PR handled the symptom by catching/rebuilding/retrying after the panic. This pin moves the fix to the Automerge fork so the sync path does not panic in the first place.

## Verification

- `cargo test --manifest-path /tmp/automerge-pr2/rust/automerge/Cargo.toml sync_receive_with_stale_inactive_patch_log_does_not_fail -- --nocapture`
- `cargo check -p runtimed`
- `cargo test -p runtime-doc`
- `cargo test -p notebook-sync`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kylekelley/.codex/worktrees/5867/desktop/target/debug/runtimed uv run pytest tests/test_daemon_integration.py::TestExecuteCell::test_execution_watch_streams_terminal_progress_and_matches_result -v --tb=short`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- `cargo xtask lint --fix` passed and reported the existing `eslint-plugin-unicorn(no-new-array)` warning in `plugins/nteract/pi/extensions/repl.ts`.
