### PR TITLE
fix(notebook): shield static iframes from scroll

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -288,6 +288,10 @@ export const CodeCell = memo(function CodeCell({
   );
 
   const handleLinkClick = useCallback((url: string) => openUrl(url), []);
+  const handleOutputMouseDown = useCallback(() => {
+    editorRef.current?.getEditor()?.contentDOM.blur();
+    onFocus();
+  }, [onFocus]);
 
   const gutterContent = bothHidden ? null : (
     <CompactExecutionButton
@@ -403,7 +407,7 @@ export const CodeCell = memo(function CodeCell({
               searchQuery={searchQuery}
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
-              onIframeMouseDown={onFocus}
+              onIframeMouseDown={handleOutputMouseDown}
               expandIframeOutputs={isIframeOutputExpanded}
             />
           )

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,6 +1,15 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
 import { Pencil } from "lucide-react";
-import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -209,9 +218,20 @@ export const MarkdownCell = memo(function MarkdownCell({
     onFocus();
   }, [onFocus]);
 
-  const deactivatePreviewFrameInteraction = useCallback(() => {
-    setPreviewFrameInteractionActive(false);
-  }, []);
+  const deactivatePreviewFrameInteractionWhenIdle = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (
+        event.relatedTarget instanceof Node &&
+        event.currentTarget.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+      if (!(event.buttons > 0)) {
+        setPreviewFrameInteractionActive(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!isFocused || editing) {
@@ -496,9 +516,9 @@ export const MarkdownCell = memo(function MarkdownCell({
           >
             {/* Always render IsolatedFrame to preload it (hidden when no content) */}
             <div
-              className={cn(cell.source ? "outline-none" : "hidden")}
-              onMouseDown={activatePreviewFrameInteraction}
-              onMouseLeave={deactivatePreviewFrameInteraction}
+              className={cell.source ? undefined : "hidden"}
+              onPointerDown={activatePreviewFrameInteraction}
+              onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
             >
               <IsolatedFrame
                 ref={frameRef}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -138,6 +138,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const injectedLibsRef = useRef(new Set<string>());
   const viewRef = useRef<HTMLDivElement>(null);
+  const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
 
   // Register EditorView with the cursor registry when in edit mode.
   const registeredViewRef = useRef<EditorView | null>(null);
@@ -202,6 +203,21 @@ export const MarkdownCell = memo(function MarkdownCell({
   const handleDoubleClick = useCallback(() => {
     setEditing(true);
   }, []);
+
+  const activatePreviewFrameInteraction = useCallback(() => {
+    setPreviewFrameInteractionActive(true);
+    onFocus();
+  }, [onFocus]);
+
+  const deactivatePreviewFrameInteraction = useCallback(() => {
+    setPreviewFrameInteractionActive(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isFocused || editing) {
+      setPreviewFrameInteractionActive(false);
+    }
+  }, [isFocused, editing]);
 
   const handleBlur = useCallback(() => {
     if (cell.source.trim()) {
@@ -479,17 +495,23 @@ export const MarkdownCell = memo(function MarkdownCell({
             onKeyDown={handleViewKeyDown}
           >
             {/* Always render IsolatedFrame to preload it (hidden when no content) */}
-            <div className={cell.source ? undefined : "hidden"}>
+            <div
+              className={cn(cell.source ? "outline-none" : "hidden")}
+              onMouseDown={activatePreviewFrameInteraction}
+              onMouseLeave={deactivatePreviewFrameInteraction}
+            >
               <IsolatedFrame
                 ref={frameRef}
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 minHeight={24}
                 autoHeight
+                scrollPassthrough={!previewFrameInteractionActive}
+                allowWheelBoundaryScroll={previewFrameInteractionActive}
                 revealOnRender
                 onReady={handleFrameReady}
                 onLinkClick={handleLinkClick}
-                onMouseDown={onFocus}
+                onMouseDown={activatePreviewFrameInteraction}
                 onDoubleClick={handleDoubleClick}
                 onError={handleIframeError}
                 className="w-full"

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -1,0 +1,177 @@
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { CodeCell as CodeCellType } from "../../types";
+
+let mockOutputs: unknown[] = [];
+const mockEditorBlur = vi.fn();
+
+vi.mock("@/components/cell/CellContainer", () => ({
+  CellContainer: ({
+    codeContent,
+    outputContent,
+  }: {
+    codeContent?: React.ReactNode;
+    outputContent?: React.ReactNode;
+  }) => (
+    <div>
+      {codeContent}
+      {outputContent}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/cell/CompactExecutionButton", () => ({
+  CompactExecutionButton: () => null,
+}));
+
+vi.mock("@/components/cell/OutputArea", () => ({
+  anyOutputNeedsIsolation: () => false,
+  OutputArea: ({ onIframeMouseDown }: { onIframeMouseDown?: () => void }) => (
+    <button data-testid="output" type="button" onMouseDown={onIframeMouseDown}>
+      output
+    </button>
+  ),
+}));
+
+vi.mock("@/components/editor/codemirror-editor", async () => {
+  const React = await import("react");
+
+  const CodeMirrorEditor = React.forwardRef(function CodeMirrorEditor(_props, ref) {
+    React.useImperativeHandle(ref, () => ({
+      focus: vi.fn(),
+      setCursorPosition: vi.fn(),
+      getEditor: () => ({
+        contentDOM: {
+          blur: mockEditorBlur,
+        },
+      }),
+    }));
+
+    return <div data-testid="editor" />;
+  });
+
+  return { CodeMirrorEditor };
+});
+
+vi.mock("@/components/editor/remote-cursors", () => ({
+  remoteCursorsExtension: () => [],
+}));
+
+vi.mock("@/components/editor/search-highlight", () => ({
+  searchHighlight: () => [],
+}));
+
+vi.mock("@/components/editor/text-attribution", () => ({
+  textAttributionExtension: () => [],
+}));
+
+vi.mock("../../contexts/PresenceContext", () => ({
+  usePresenceContext: () => null,
+}));
+
+vi.mock("../../hooks/useCellKeyboardNavigation", () => ({
+  useCellKeyboardNavigation: () => [],
+}));
+
+vi.mock("../../hooks/useCrdtBridge", () => ({
+  useCrdtBridge: () => ({ extension: [], bridge: { replaceSource: vi.fn() } }),
+}));
+
+vi.mock("../../lib/cell-ui-state", () => ({
+  useIsCellExecuting: () => false,
+  useIsCellFocused: () => false,
+  useIsCellQueued: () => false,
+  useIsGroupExecuting: () => false,
+  useIsNextCellFromFocused: () => false,
+  useIsPreviousCellFromFocused: () => false,
+  useSearchActiveOffset: () => null,
+  useSearchQuery: () => "",
+}));
+
+vi.mock("../../lib/cursor-registry", () => ({
+  onEditorRegistered: vi.fn(),
+  onEditorUnregistered: vi.fn(),
+}));
+
+vi.mock("../../lib/editor-registry", () => ({
+  registerCellEditor: vi.fn(),
+  unregisterCellEditor: vi.fn(),
+}));
+
+vi.mock("../../lib/kernel-completion", () => ({
+  kernelCompletionExtension: [],
+}));
+
+vi.mock("../../lib/notebook-executions", () => ({
+  useCellExecutionId: () => null,
+  useExecution: () => null,
+}));
+
+vi.mock("../../lib/notebook-outputs", () => ({
+  useCellOutputs: () => mockOutputs,
+}));
+
+vi.mock("../../lib/open-url", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../../lib/presence-sender", () => ({
+  presenceSenderExtension: () => [],
+}));
+
+vi.mock("../../lib/tab-completion", () => ({
+  tabCompletionKeymap: [],
+}));
+
+vi.mock("../cell/CellPresenceIndicators", () => ({
+  CellPresenceIndicators: () => null,
+}));
+
+import { CodeCell } from "../CodeCell";
+
+function makeCell(): CodeCellType {
+  return {
+    cell_type: "code",
+    execution_count: null,
+    id: "code-1",
+    source: "import polars as pl\n\npl.DataFrame({'x': [1]})",
+    metadata: {},
+    outputs: [],
+  };
+}
+
+describe("CodeCell output focus", () => {
+  beforeEach(() => {
+    mockOutputs = [
+      {
+        output_type: "display_data",
+        data: { "application/vnd.apache.parquet": "blob://df" },
+        metadata: {},
+      },
+    ];
+    mockEditorBlur.mockClear();
+  });
+
+  it("blurs the editor before marking the cell focused from iframe output interaction", () => {
+    const onFocus = vi.fn();
+
+    const { getByTestId } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={onFocus}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    fireEvent.mouseDown(getByTestId("output"));
+
+    expect(mockEditorBlur).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(mockEditorBlur.mock.invocationCallOrder[0]).toBeLessThan(
+      onFocus.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MarkdownCell as MarkdownCellType } from "../../types";
@@ -154,6 +154,12 @@ function makeCell(): MarkdownCellType {
   };
 }
 
+function pointerOutWithButtons(element: HTMLElement, buttons: number) {
+  const event = createEvent.pointerOut(element);
+  Object.defineProperty(event, "buttons", { value: buttons });
+  fireEvent(element, event);
+}
+
 describe("MarkdownCell theme sync", () => {
   beforeEach(() => {
     mockDarkMode = false;
@@ -223,13 +229,20 @@ describe("MarkdownCell theme sync", () => {
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
 
-    fireEvent.mouseDown(getByTestId("markdown-frame").parentElement as HTMLElement);
+    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
+
+    fireEvent.pointerDown(previewWrapper);
 
     expect(onFocus).toHaveBeenCalled();
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
 
-    fireEvent.mouseLeave(getByTestId("markdown-frame").parentElement as HTMLElement);
+    pointerOutWithButtons(previewWrapper, 1);
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+
+    pointerOutWithButtons(previewWrapper, 0);
 
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/components/isolated", async () => {
 
   const MockIsolatedFrame = React.forwardRef<
     typeof mockFrameHandle,
-    Record<string, unknown> & { onReady?: () => void }
+    Record<string, unknown> & { onMouseDown?: () => void; onReady?: () => void }
   >(function MockIsolatedFrame(props, ref) {
     isolatedFrameProps.push(props);
     React.useImperativeHandle(ref, () => mockFrameHandle);
@@ -45,7 +45,7 @@ vi.mock("@/components/isolated", async () => {
       props.onReady?.();
     }, [props.onReady]);
 
-    return <div data-testid="markdown-frame" />;
+    return <div data-testid="markdown-frame" onMouseDown={props.onMouseDown} />;
   });
 
   return {
@@ -211,6 +211,28 @@ describe("MarkdownCell theme sync", () => {
     await waitFor(() => {
       expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
+  });
+
+  it("activates markdown iframe pointer interaction after clicking the preview", () => {
+    const onFocus = vi.fn();
+
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={onFocus} onDelete={() => {}} />,
+    );
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+
+    fireEvent.mouseDown(getByTestId("markdown-frame").parentElement as HTMLElement);
+
+    expect(onFocus).toHaveBeenCalled();
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+
+    fireEvent.mouseLeave(getByTestId("markdown-frame").parentElement as HTMLElement);
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
   });
 
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -160,6 +160,22 @@ function selectMimeType(
   return firstAvailable || null;
 }
 
+function isScrollPassthroughMimeType(mimeType: string): boolean {
+  return mimeType === "text/markdown" || mimeType === "text/html" || mimeType === "image/svg+xml";
+}
+
+function outputAllowsScrollPassthrough(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  if (output.output_type === "execute_result" || output.output_type === "display_data") {
+    const mimeType = selectMimeType(output.data, priority);
+    return mimeType != null && isScrollPassthroughMimeType(mimeType);
+  }
+
+  return true;
+}
+
 /**
  * Check if a single output needs iframe isolation.
  * Uses the safe-list: anything not explicitly safe defaults to isolation.
@@ -293,10 +309,12 @@ export function OutputArea({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
+  const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
+  const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
 
   const darkMode = useDarkMode();
   const colorTheme = useColorTheme();
@@ -331,8 +349,32 @@ export function OutputArea({
   // Check if we have widgets and should set up comm bridge
   const hasWidgets = hasWidgetOutputs(outputs, priority);
   const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
+  const shouldUseScrollPassthroughFrame =
+    shouldIsolate &&
+    !hasWidgets &&
+    outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
+  const shouldScrollPassthroughFrame =
+    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
+
+  useEffect(() => {
+    if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
+      setStaticFrameInteractionActive(false);
+    }
+  }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
+
+  const activateStaticFrameInteraction = useCallback(() => {
+    if (shouldUseScrollPassthroughFrame) {
+      setStaticFrameInteractionActive(true);
+      staticFrameInteractionRef.current?.focus({ preventScroll: true });
+    }
+    onIframeMouseDown?.();
+  }, [shouldUseScrollPassthroughFrame, onIframeMouseDown]);
+
+  const deactivateStaticFrameInteraction = useCallback(() => {
+    setStaticFrameInteractionActive(false);
+  }, []);
 
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
@@ -593,7 +635,17 @@ export function OutputArea({
         >
           {/* Preloaded or active isolated frame */}
           {(shouldIsolate || showPreloadedIframe) && (
-            <div className={shouldIsolate ? undefined : "hidden"}>
+            <div
+              ref={staticFrameInteractionRef}
+              className={cn(shouldIsolate ? "outline-none" : "hidden")}
+              tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
+              onMouseDown={
+                shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
+              }
+              onMouseLeave={
+                shouldUseScrollPassthroughFrame ? deactivateStaticFrameInteraction : undefined
+              }
+            >
               <IsolatedFrame
                 ref={frameRef}
                 darkMode={darkMode}
@@ -601,10 +653,11 @@ export function OutputArea({
                 minHeight={24}
                 maxHeight={isolatedOutputWellMaxHeight}
                 autoHeight={shouldIsolate}
-                allowWheelBoundaryScroll
+                allowWheelBoundaryScroll={!shouldScrollPassthroughFrame}
+                scrollPassthrough={shouldScrollPassthroughFrame}
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}
-                onMouseDown={onIframeMouseDown}
+                onMouseDown={activateStaticFrameInteraction}
                 onWidgetUpdate={onWidgetUpdate}
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,5 +1,14 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   CommBridgeManager,
   type IframeToParentMessage,
@@ -367,14 +376,27 @@ export function OutputArea({
   const activateStaticFrameInteraction = useCallback(() => {
     if (shouldUseScrollPassthroughFrame) {
       setStaticFrameInteractionActive(true);
+      // Move DOM focus off CodeMirror without scrolling; this wrapper owns
+      // focus until iframe pointer interaction is active.
       staticFrameInteractionRef.current?.focus({ preventScroll: true });
     }
     onIframeMouseDown?.();
   }, [shouldUseScrollPassthroughFrame, onIframeMouseDown]);
 
-  const deactivateStaticFrameInteraction = useCallback(() => {
-    setStaticFrameInteractionActive(false);
-  }, []);
+  const deactivateStaticFrameInteractionWhenIdle = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (
+        event.relatedTarget instanceof Node &&
+        event.currentTarget.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+      if (!(event.buttons > 0)) {
+        setStaticFrameInteractionActive(false);
+      }
+    },
+    [],
+  );
 
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
@@ -639,11 +661,13 @@ export function OutputArea({
               ref={staticFrameInteractionRef}
               className={cn(shouldIsolate ? "outline-none" : "hidden")}
               tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
-              onMouseDown={
+              onPointerDown={
                 shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
               }
-              onMouseLeave={
-                shouldUseScrollPassthroughFrame ? deactivateStaticFrameInteraction : undefined
+              onPointerOut={
+                shouldUseScrollPassthroughFrame
+                  ? deactivateStaticFrameInteractionWhenIdle
+                  : undefined
               }
             >
               <IsolatedFrame

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -76,6 +76,12 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
   ];
 }
 
+function pointerOutWithButtons(element: HTMLElement, buttons: number) {
+  const event = createEvent.pointerOut(element);
+  Object.defineProperty(event, "buttons", { value: buttons });
+  fireEvent(element, event);
+}
+
 describe("OutputArea iframe theme sync", () => {
   beforeEach(() => {
     Object.defineProperty(window, "innerHeight", {
@@ -146,7 +152,7 @@ describe("OutputArea iframe theme sync", () => {
     const frame = getByTestId("isolated-frame");
     const activationWell = frame.parentElement as HTMLElement;
 
-    fireEvent.mouseDown(activationWell);
+    fireEvent.pointerDown(activationWell);
 
     expect(onIframeMouseDown).toHaveBeenCalled();
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
@@ -154,7 +160,14 @@ describe("OutputArea iframe theme sync", () => {
       "true",
     );
 
-    fireEvent.mouseLeave(activationWell);
+    pointerOutWithButtons(activationWell, 1);
+
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "true",
+    );
+
+    pointerOutWithButtons(activationWell, 0);
 
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("true");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -34,8 +34,16 @@ vi.mock("@/components/isolated", async () => {
 
   const MockIsolatedFrame = React.forwardRef<
     typeof mockFrameHandle,
-    { allowWheelBoundaryScroll?: boolean; autoHeight?: boolean; onReady?: () => void }
-  >(function MockIsolatedFrame({ allowWheelBoundaryScroll, autoHeight, onReady }, ref) {
+    {
+      allowWheelBoundaryScroll?: boolean;
+      autoHeight?: boolean;
+      scrollPassthrough?: boolean;
+      onReady?: () => void;
+    }
+  >(function MockIsolatedFrame(
+    { allowWheelBoundaryScroll, autoHeight, scrollPassthrough, onReady },
+    ref,
+  ) {
     React.useImperativeHandle(ref, () => mockFrameHandle);
 
     React.useEffect(() => {
@@ -46,6 +54,7 @@ vi.mock("@/components/isolated", async () => {
       <div
         data-allow-wheel-boundary-scroll={String(allowWheelBoundaryScroll)}
         data-auto-height={String(autoHeight)}
+        data-scroll-passthrough={String(scrollPassthrough)}
         data-testid="isolated-frame"
       />
     );
@@ -119,9 +128,52 @@ describe("OutputArea iframe theme sync", () => {
     });
   });
 
-  it("forwards iframe wheel boundary scroll from notebook outputs", () => {
+  it("makes static markdown iframe outputs scroll-transparent", () => {
     const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
 
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "false",
+    );
+  });
+
+  it("activates static iframe outputs for pointer interaction until the pointer leaves", () => {
+    const onIframeMouseDown = vi.fn();
+    const { getByTestId } = render(
+      <OutputArea outputs={makeMarkdownOutput()} isolated onIframeMouseDown={onIframeMouseDown} />,
+    );
+
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.mouseDown(activationWell);
+
+    expect(onIframeMouseDown).toHaveBeenCalled();
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "true",
+    );
+
+    fireEvent.mouseLeave(activationWell);
+
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "false",
+    );
+  });
+
+  it("keeps interactive plugin iframe outputs on the wheel-boundary path", () => {
+    const plotlyOutput: JupyterOutput[] = [
+      {
+        output_type: "display_data",
+        data: { "application/vnd.plotly.v1+json": { data: [] } },
+        metadata: {},
+      },
+    ];
+
+    const { getByTestId } = render(<OutputArea outputs={plotlyOutput} isolated />);
+
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
     );

--- a/src/components/editor/__tests__/codemirror-editor.test.tsx
+++ b/src/components/editor/__tests__/codemirror-editor.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { CodeMirrorEditor } from "../codemirror-editor";
+
+vi.mock("@/lib/dark-mode", () => ({
+  isDarkMode: () => false,
+  useColorTheme: () => undefined,
+}));
+
+describe("CodeMirrorEditor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it("focuses without scrolling before handling a mouse click into an unfocused editor", async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
+
+    render(<CodeMirrorEditor initialValue={"first\nsecond\nthird"} theme="light" />);
+
+    const content = await waitFor(() => {
+      const el = document.querySelector(".cm-content");
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    fireEvent.pointerDown(content);
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+});

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -256,7 +256,6 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         }
       };
       view.dom.addEventListener("pointerdown", focusWithoutScroll, { capture: true });
-      view.dom.addEventListener("mousedown", focusWithoutScroll, { capture: true });
 
       // Toggling the placeholder forces a decoration change that triggers
       // updateInner(), rebuilding the line tiles. Without this, the initial
@@ -278,7 +277,6 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
 
       return () => {
         view.dom.removeEventListener("pointerdown", focusWithoutScroll, { capture: true });
-        view.dom.removeEventListener("mousedown", focusWithoutScroll, { capture: true });
         viewRef.current = null;
         view.destroy();
       };

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -250,6 +250,14 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
 
       viewRef.current = view;
 
+      const focusWithoutScroll = () => {
+        if (!view.hasFocus) {
+          view.contentDOM.focus({ preventScroll: true });
+        }
+      };
+      view.dom.addEventListener("pointerdown", focusWithoutScroll, { capture: true });
+      view.dom.addEventListener("mousedown", focusWithoutScroll, { capture: true });
+
       // Toggling the placeholder forces a decoration change that triggers
       // updateInner(), rebuilding the line tiles. Without this, the initial
       // tile DOM renders a few pixels too tall — CM's measure cycle alone
@@ -269,6 +277,8 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       });
 
       return () => {
+        view.dom.removeEventListener("pointerdown", focusWithoutScroll, { capture: true });
+        view.dom.removeEventListener("mousedown", focusWithoutScroll, { capture: true });
         viewRef.current = null;
         view.destroy();
       };

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -116,4 +116,11 @@ describe("IsolatedFrame theme updates", () => {
       expect(iframe.style.height).toBe("2600px");
     });
   });
+
+  it("can make static frames transparent to parent scroll hit-testing", () => {
+    const { container } = render(<IsolatedFrame darkMode={false} scrollPassthrough />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    expect(iframe.style.pointerEvents).toBe("none");
+  });
 });

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -93,6 +93,14 @@ export interface IsolatedFrameProps {
   allowWheelBoundaryScroll?: boolean;
 
   /**
+   * When true, the iframe is transparent to pointer hit-testing so wheel
+   * gestures stay on the parent document's native scroll path. Use for
+   * full-height static/document-like frames that should not trap scrolling.
+   * @default false
+   */
+  scrollPassthrough?: boolean;
+
+  /**
    * Callback when the iframe is ready to receive messages.
    */
   onReady?: () => void;
@@ -284,6 +292,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       autoHeight = false,
       className = "",
       allowWheelBoundaryScroll = true,
+      scrollPassthrough = false,
       onReady,
       onResize,
       onLinkClick,
@@ -799,6 +808,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           opacity: displayOpacity,
           border: "none",
           display: "block",
+          pointerEvents: scrollPassthrough ? "none" : undefined,
           background: "transparent",
           colorScheme: darkMode ? "dark" : "light",
           // Hide iframe during reload to prevent white flash from blank document.


### PR DESCRIPTION
## Summary

- Add a `scrollPassthrough` mode for isolated iframes that makes static iframe content transparent to pointer hit-testing.
- Start rendered markdown and static document-like outputs on the native parent scroll path instead of the iframe wheel-boundary forwarding path.
- Let users click the markdown preview or output well to temporarily activate iframe pointer interaction for selection and links, then return to scroll passthrough when the pointer leaves.
- Focus CodeMirror with `preventScroll` before an unfocused editor handles a click, avoiding a WKWebView jump back to a stale cursor after iframe/output interaction.
- Blur the owning CodeMirror editor when the user enters a code-cell output iframe, so later editor clicks return through the unfocused-editor path.
- Keep iframe interaction active while the pointer leaves with a button held, so text-selection drags are not interrupted by passthrough reactivation.

## Why

Safari/WKWebView scrolling over many full-height isolated frames can hit compositor-heavy stalls when wheel input is captured inside the iframe and bridged back to the parent with `nteract/wheelBoundary` messages. Static markdown and document-like outputs do not need to own wheel gestures during normal notebook scrolling.

This keeps the fast path native for scrolling while preserving an explicit activation path for text selection and link interaction.

The editor focus guard handles a related old failure mode where clicking back into a large code cell after interacting with an output can make WebKit scroll the stale contenteditable caret into view before CodeMirror places the clicked selection. Output interactions now explicitly blur the editor first, because some iframe interactions can leave CodeMirror as the active DOM focus owner.

The activation wrapper only deactivates on idle pointer exit, so dragging a selection out of markdown/static HTML output does not flip `pointer-events` mid-gesture.

## Validation

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx src/components/editor/__tests__/codemirror-editor.test.tsx apps/notebook/src/lib/__tests__/window-focus.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/cell/__tests__/OutputArea.test.tsx apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
