### PR TITLE
fix(runtimed): move presence heartbeat into sync engine

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -46,7 +46,17 @@ import {
   useRuntimeState,
 } from "../lib/runtime-state";
 import type { JupyterOutput, NotebookCell } from "../types";
-import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import init, {
+  encode_heartbeat_presence,
+  NotebookHandle,
+} from "../wasm/runtimed-wasm/runtimed_wasm.js";
+
+/**
+ * Matches `notebook_doc::presence::DEFAULT_HEARTBEAT_MS`.
+ * The heartbeat is owned by SyncEngine after WASM init so React presence stays
+ * user-driven and Tauri remains a byte transport.
+ */
+const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
 
 const wasmReady: Promise<void> = init().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
@@ -248,6 +258,10 @@ export function useAutomergeNotebook() {
     const engine = new SyncEngine({
       getHandle: () => handleHost.current as SyncableHandle | null,
       transport,
+      presenceHeartbeat: {
+        intervalMs: PRESENCE_HEARTBEAT_INTERVAL_MS,
+        encode: () => encode_heartbeat_presence("local"),
+      },
       logger,
     });
 

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -1,21 +1,12 @@
 import { useNotebookHost } from "@nteract/notebook-host";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { sendPresenceFrame } from "runtimed";
 import { logger } from "../lib/logger";
 import {
   encode_cursor_presence,
   encode_focus_presence,
-  encode_heartbeat_presence,
   encode_selection_presence,
 } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-
-/**
- * Heartbeat interval in milliseconds. Matches the Rust-side
- * `notebook_doc::presence::DEFAULT_HEARTBEAT_MS` so room presence TTL
- * pruning (3× heartbeat) and the daemon's 300s idle-peer timeout both
- * stay comfortably ahead of an idle but live notebook window.
- */
-const HEARTBEAT_INTERVAL_MS = 15_000;
 
 // ── Hook ─────────────────────────────────────────────────────────────
 
@@ -98,28 +89,6 @@ export function usePresence(
     },
     [peerId, peerLabel, actorLabel, transport],
   );
-
-  // Periodic heartbeats keep the daemon's idle-peer timeout from disconnecting
-  // a quiet but live window. Cursor/selection/focus frames already reset the
-  // timer on user activity; this covers the no-activity case.
-  useEffect(() => {
-    if (!peerId) return;
-    const send = () => {
-      let payload: Uint8Array;
-      try {
-        payload = encode_heartbeat_presence(peerId);
-      } catch (e) {
-        logger.warn("[presence] encode heartbeat failed:", e);
-        return;
-      }
-      sendPresenceFrame(transport, payload).catch((e: unknown) =>
-        logger.warn("[presence] send heartbeat failed:", e),
-      );
-    };
-    send();
-    const id = setInterval(send, HEARTBEAT_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [peerId, transport]);
 
   return {
     /** Set the local cursor position (fire-and-forget). */

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -7,7 +7,7 @@
 
 // Core
 export { SyncEngine } from "./sync-engine";
-export type { SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
+export type { PresenceHeartbeatOptions, SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
 
 // Transport
 export type { FrameListener, NotebookRequestOptions, NotebookTransport } from "./transport";

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -23,6 +23,7 @@ import {
   EMPTY,
   filter,
   from,
+  interval,
   mergeMap,
   Observable,
   ReplaySubject,
@@ -78,6 +79,14 @@ const nullLogger: SyncEngineLogger = {
   warn() {},
   error() {},
 };
+
+export interface PresenceHeartbeatOptions {
+  /** Interval in milliseconds between idle presence heartbeats. */
+  intervalMs: number;
+
+  /** Encode a Presence heartbeat payload using the caller's WASM module. */
+  encode: () => Uint8Array;
+}
 
 function initialLoadPhaseName(phase: InitialLoadPhase): InitialLoadPhase["phase"] {
   return phase.phase;
@@ -213,6 +222,9 @@ export interface SyncEngineOptions {
   /** Pluggable transport to the daemon. */
   transport: NotebookTransport;
 
+  /** Required client-side idle heartbeat for keeping the daemon peer alive. */
+  presenceHeartbeat: PresenceHeartbeatOptions;
+
   /** Optional logger (defaults to silent). */
   logger?: SyncEngineLogger;
 
@@ -232,7 +244,9 @@ export interface SyncEngineOptions {
 // ── SyncEngine ───────────────────────────────────────────────────────
 
 export class SyncEngine {
-  private readonly opts: Required<Pick<SyncEngineOptions, "getHandle" | "transport" | "logger">> &
+  private readonly opts: Required<
+    Pick<SyncEngineOptions, "getHandle" | "transport" | "logger" | "presenceHeartbeat">
+  > &
     Pick<SyncEngineOptions, "scheduler">;
   private readonly flushDeliveryTimeoutMs: number;
   private subscription: Subscription | null = null;
@@ -393,6 +407,21 @@ export class SyncEngine {
       this.frameIn$.next(payload);
     });
     sub.add(() => unlisten());
+
+    sub.add(
+      interval(this.opts.presenceHeartbeat.intervalMs, this.opts.scheduler).subscribe(() => {
+        let payload: Uint8Array;
+        try {
+          payload = this.opts.presenceHeartbeat.encode();
+        } catch (e) {
+          log.warn("[sync-engine] encode presence heartbeat failed:", e);
+          return;
+        }
+        this.opts.transport
+          .sendFrame(FrameType.PRESENCE, payload)
+          .catch((e: unknown) => log.warn("[sync-engine] send presence heartbeat failed:", e));
+      }),
+    );
 
     // Subject bridging sync_applied events into the coalescing buffer
     const materialize$ = new Subject<CellChangeset | null>();

--- a/packages/runtimed/tests/fixture-integration.test.ts
+++ b/packages/runtimed/tests/fixture-integration.test.ts
@@ -130,6 +130,10 @@ async function setupFixtureSync(scenario: string) {
   const engine = new SyncEngine({
     getHandle: () => client as unknown as SyncableHandle,
     transport,
+    presenceHeartbeat: {
+      intervalMs: 15_000,
+      encode: () => new Uint8Array([0]),
+    },
     scheduler,
   });
 
@@ -361,6 +365,10 @@ describe("fixture-based integration: daemon-authored docs through WASM sync", ()
       const engine = new SyncEngine({
         getHandle: () => client as unknown as SyncableHandle,
         transport,
+        presenceHeartbeat: {
+          intervalMs: 15_000,
+          encode: () => new Uint8Array([0]),
+        },
         scheduler,
       });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -178,6 +178,10 @@ describe("SyncEngine", () => {
     return new SyncEngine({
       getHandle: opts?.getHandle ?? (() => handle),
       transport,
+      presenceHeartbeat: {
+        intervalMs: 15_000,
+        encode: () => new Uint8Array([0]),
+      },
       scheduler,
       flushDeliveryTimeoutMs: opts?.flushDeliveryTimeoutMs,
     });
@@ -193,6 +197,22 @@ describe("SyncEngine", () => {
       expect(engine.running).toBe(true);
       engine.stop();
       expect(engine.running).toBe(false);
+    });
+
+    it("sends required presence heartbeat from the engine interval", () => {
+      const engine = createEngine();
+      engine.start();
+
+      advanceBy(scheduler, 14_999);
+      expect(transport.sentFrames.filter((f) => f.frameType === FrameType.PRESENCE)).toHaveLength(
+        0,
+      );
+
+      advanceBy(scheduler, 1);
+      expect(transport.sentFrames.filter((f) => f.frameType === FrameType.PRESENCE)).toHaveLength(
+        1,
+      );
+      engine.stop();
     });
 
     it("start is idempotent", () => {
@@ -1138,6 +1158,10 @@ describe("SyncEngine", () => {
       const nullEngine = new SyncEngine({
         getHandle: () => null,
         transport,
+        presenceHeartbeat: {
+          intervalMs: 15_000,
+          encode: () => new Uint8Array([0]),
+        },
         scheduler,
       });
 
@@ -1159,6 +1183,10 @@ describe("SyncEngine", () => {
       const engine = new SyncEngine({
         getHandle: () => returnHandle,
         transport,
+        presenceHeartbeat: {
+          intervalMs: 15_000,
+          encode: () => new Uint8Array([0]),
+        },
         scheduler,
       });
       engine.start();

--- a/packages/runtimed/tests/wasm-harness.ts
+++ b/packages/runtimed/tests/wasm-harness.ts
@@ -159,6 +159,10 @@ export async function createWasmHarness(notebookId = "test-notebook"): Promise<W
   const engine = new SyncEngine({
     getHandle: () => clientHandle as unknown as SyncableHandle,
     transport,
+    presenceHeartbeat: {
+      intervalMs: 15_000,
+      encode: () => new Uint8Array([0]),
+    },
     scheduler,
   });
 


### PR DESCRIPTION
## Summary

- Move idle presence heartbeat ownership into `SyncEngine` with a required WASM-backed encoder.
- Remove the React `usePresence` heartbeat effect so cursor/selection/focus presence stays user-driven.
- Keep Tauri relay behavior as a byte transport; the heartbeat is sent through the existing transport API.

## Verification

- `pnpm test:run packages/runtimed/tests/sync-engine.test.ts`
- `pnpm test:run packages/runtimed/tests/fixture-integration.test.ts packages/runtimed/tests/wasm-integration.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo fmt --check`
- `git diff --check`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` reported one existing warning in `plugins/nteract/pi/extensions/repl.ts` about `new Array(singleArgument)`, outside this change, and completed successfully.
