### PR TITLE
fix(runtimed): send presence heartbeat immediately

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -53,8 +53,8 @@ import init, {
 
 /**
  * Matches `notebook_doc::presence::DEFAULT_HEARTBEAT_MS`.
- * The heartbeat is owned by SyncEngine after WASM init so React presence stays
- * user-driven and Tauri remains a byte transport.
+ * The heartbeat is owned by SyncEngine; the encoder is called lazily so React
+ * presence stays user-driven and Tauri remains a byte transport.
  */
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -408,19 +408,24 @@ export class SyncEngine {
     });
     sub.add(() => unlisten());
 
+    const sendHeartbeat = () => {
+      let payload: Uint8Array;
+      try {
+        payload = this.opts.presenceHeartbeat.encode();
+      } catch (e) {
+        log.warn("[sync-engine] encode presence heartbeat failed:", e);
+        return;
+      }
+      this.opts.transport
+        .sendFrame(FrameType.PRESENCE, payload)
+        .catch((e: unknown) => log.warn("[sync-engine] send presence heartbeat failed:", e));
+    };
+
+    sendHeartbeat();
     sub.add(
-      interval(this.opts.presenceHeartbeat.intervalMs, this.opts.scheduler).subscribe(() => {
-        let payload: Uint8Array;
-        try {
-          payload = this.opts.presenceHeartbeat.encode();
-        } catch (e) {
-          log.warn("[sync-engine] encode presence heartbeat failed:", e);
-          return;
-        }
-        this.opts.transport
-          .sendFrame(FrameType.PRESENCE, payload)
-          .catch((e: unknown) => log.warn("[sync-engine] send presence heartbeat failed:", e));
-      }),
+      interval(this.opts.presenceHeartbeat.intervalMs, this.opts.scheduler).subscribe(
+        sendHeartbeat,
+      ),
     );
 
     // Subject bridging sync_applied events into the coalescing buffer

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -199,18 +199,21 @@ describe("SyncEngine", () => {
       expect(engine.running).toBe(false);
     });
 
-    it("sends required presence heartbeat from the engine interval", () => {
+    it("sends required presence heartbeat immediately and on the engine interval", () => {
       const engine = createEngine();
       engine.start();
+      expect(transport.sentFrames.filter((f) => f.frameType === FrameType.PRESENCE)).toHaveLength(
+        1,
+      );
 
       advanceBy(scheduler, 14_999);
       expect(transport.sentFrames.filter((f) => f.frameType === FrameType.PRESENCE)).toHaveLength(
-        0,
+        1,
       );
 
       advanceBy(scheduler, 1);
       expect(transport.sentFrames.filter((f) => f.frameType === FrameType.PRESENCE)).toHaveLength(
-        1,
+        2,
       );
       engine.stop();
     });
@@ -1014,6 +1017,7 @@ describe("SyncEngine", () => {
 
       const engine = createEngine();
       engine.start();
+      transport.sentFrames.length = 0;
       engine.scheduleFlush();
       engine.scheduleFlush();
       engine.scheduleFlush();
@@ -1038,6 +1042,7 @@ describe("SyncEngine", () => {
 
       const engine = createEngine();
       engine.start();
+      transport.sentFrames.length = 0;
 
       // First call at t=0
       engine.scheduleFlush();
@@ -1527,6 +1532,7 @@ describe("SyncEngine", () => {
       const sendSpy = vi.spyOn(transport, "sendFrame");
       const engine = createEngine();
       engine.start();
+      sendSpy.mockClear();
 
       transport.deliver([0x00, 0x99]);
       advanceBy(scheduler, 1);
@@ -1627,9 +1633,9 @@ describe("SyncEngine", () => {
           { type: "sync_error", changed: false, reply: replyBytes } as FrameEvent,
         ]),
       });
-      vi.spyOn(transport, "sendFrame").mockRejectedValueOnce(new Error("send failed"));
       const engine = createEngine();
       engine.start();
+      vi.spyOn(transport, "sendFrame").mockRejectedValueOnce(new Error("send failed"));
 
       transport.deliver([0x00, 0x99]);
       advanceBy(scheduler, 1);
@@ -1647,9 +1653,9 @@ describe("SyncEngine", () => {
           { type: "runtime_state_sync_error", changed: false, reply: replyBytes } as FrameEvent,
         ]),
       });
-      vi.spyOn(transport, "sendFrame").mockRejectedValueOnce(new Error("send failed"));
       const engine = createEngine();
       engine.start();
+      vi.spyOn(transport, "sendFrame").mockRejectedValueOnce(new Error("send failed"));
 
       transport.deliver([0x05, 0x99]);
       advanceBy(scheduler, 1);
@@ -1664,9 +1670,9 @@ describe("SyncEngine", () => {
       handle = createMockHandle({
         receive_frame: vi.fn(() => [{ type: "sync_error", changed: false } as FrameEvent]),
       });
-      const sendSpy = vi.spyOn(transport, "sendFrame");
       const engine = createEngine();
       engine.start();
+      const sendSpy = vi.spyOn(transport, "sendFrame");
 
       transport.deliver([0x00, 0x99]);
       advanceBy(scheduler, 1);


### PR DESCRIPTION
## Summary

- Send the required `SyncEngine` presence heartbeat immediately on engine start, then continue on the configured interval.
- Preserve the old `send(); setInterval(send, ...)` timing behavior from the React hook after moving heartbeat ownership into `SyncEngine`.
- Update the focused SyncEngine tests around the immediate presence frame.

## Verification

- `pnpm test:run packages/runtimed/tests/sync-engine.test.ts`
- `pnpm --dir apps/notebook build`
- `git diff --check`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` reported one existing warning in `plugins/nteract/pi/extensions/repl.ts` about `new Array(singleArgument)`, outside this change, and completed successfully.
