### PR TITLE
refactor(notebook-host): own daemon reconnect on disconnect

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -225,15 +225,10 @@ export function useDaemonKernel({
       logger.warn("[daemon-kernel] Daemon disconnected, resetting state");
       resetRuntimeState();
       resetBlobPort();
-      try {
-        await host.daemon.reconnect();
-        logger.debug("[daemon-kernel] Reconnected to daemon");
-        refreshBlobPort();
-      } catch (e) {
-        logger.error("[daemon-kernel] Failed to reconnect:", e);
-      }
     });
 
+    // Reconnect is owned by the host layer. When it succeeds, the host emits
+    // daemon:ready and this hook refreshes the blob port for the new daemon.
     const unlistenReady = host.daemonEvents.onReadyLive(() => {
       if (cancelled) return;
       logger.debug("[daemon-kernel] Daemon ready");

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -89,6 +89,15 @@ function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten
 
 export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost {
   const transport = opts.transport ?? new TauriTransport();
+  let reconnectPromise: Promise<void> | null = null;
+  const reconnectDaemon = (): Promise<void> => {
+    if (reconnectPromise) return reconnectPromise;
+    reconnectPromise = invoke<void>("reconnect_to_daemon").finally(() => {
+      reconnectPromise = null;
+    });
+    return reconnectPromise;
+  };
+
   const daemon: HostDaemon = {
     async isConnected() {
       try {
@@ -98,7 +107,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       }
     },
     async reconnect() {
-      await invoke("reconnect_to_daemon");
+      await reconnectDaemon();
     },
     async getInfo() {
       return invoke<DaemonInfo | null>("get_daemon_info");
@@ -174,7 +183,11 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
       };
     },
     onProgress: (cb) => listenWebview<DaemonProgressPayload>("daemon:progress", cb),
-    onDisconnected: (cb) => listenWebview<void>("daemon:disconnected", () => cb()),
+    onDisconnected: (cb) =>
+      listenWebview<void>("daemon:disconnected", () => {
+        cb();
+        reconnectDaemon().catch(() => {});
+      }),
     onUnavailable: (cb) => listenWebview<DaemonUnavailablePayload>("daemon:unavailable", cb),
   };
 

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 const capturedInvokes: Array<{ cmd: string; args: unknown }> = [];
 const capturedListens: Array<{ event: string; cb: (ev: { payload: unknown }) => void }> = [];
 const mockUnlisten = vi.fn();
+let reconnectPromiseOverride: Promise<unknown> | null = null;
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn((cmd: string, args?: unknown) => {
@@ -12,6 +13,8 @@ vi.mock("@tauri-apps/api/core", () => ({
     switch (cmd) {
       case "is_daemon_connected":
         return Promise.resolve(true);
+      case "reconnect_to_daemon":
+        return reconnectPromiseOverride ?? Promise.resolve(undefined);
       case "get_git_info":
         return Promise.resolve({ branch: "main", commit: "abc", description: null });
       case "get_daemon_info":
@@ -147,6 +150,7 @@ beforeEach(() => {
   saveDialogResult = null;
   updateCheckResult = null;
   updateCheckCount = 0;
+  reconnectPromiseOverride = null;
   mockUnlisten.mockReset();
   mockWindowUnlisten.mockReset();
   vi.mocked(stubTransport.sendRequest).mockReset();
@@ -363,6 +367,32 @@ describe("createTauriHost()", () => {
     const host = createTauriHost({ transport: stubTransport });
     await expect(host.daemon.isConnected()).resolves.toBe(false);
     rejectOnce.mockRestore();
+  });
+
+  it("daemonEvents.onDisconnected starts one host-owned reconnect", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    let resolveReconnect: (() => void) | null = null;
+    reconnectPromiseOverride = new Promise((resolve) => {
+      resolveReconnect = () => resolve(undefined);
+    });
+    const first = vi.fn();
+    const second = vi.fn();
+
+    host.daemonEvents.onDisconnected(first);
+    host.daemonEvents.onDisconnected(second);
+    await Promise.resolve();
+
+    const entries = capturedListens.filter((x) => x.event === "daemon:disconnected");
+    expect(entries).toHaveLength(2);
+    entries[0]?.cb({ payload: undefined });
+    entries[1]?.cb({ payload: undefined });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toHaveLength(1);
+
+    resolveReconnect?.();
+    await reconnectPromiseOverride;
   });
 
   it("exposes a command registry", () => {


### PR DESCRIPTION
## Summary

- Move automatic daemon reconnect on `daemon:disconnected` into the Tauri `NotebookHost`.
- Keep React consumers responsible for UI state reset and banners, not recovery policy.
- Deduplicate reconnect attempts with a host-level single-flight helper.

## Verification

- `pnpm test:run packages/notebook-host/tests/tauri-host.test.ts`
- `pnpm --dir apps/notebook build`
- `git diff --check`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` reported one existing warning in `plugins/nteract/pi/extensions/repl.ts` about `new Array(singleArgument)`, outside this change, and completed successfully.
