### PR TITLE
fix(runtimed): guard project detection and settings sync compatibility

### DIFF
--- a/crates/runt-mcp/src/project_file.rs
+++ b/crates/runt-mcp/src/project_file.rs
@@ -46,16 +46,32 @@ impl DetectedProjectFile {
 /// A `pyproject.toml` with `[tool.pixi]` is treated as a pixi project.
 /// Stops at `.git` boundaries or the user's home directory.
 pub fn detect_project_file(start_path: &Path) -> Option<DetectedProjectFile> {
+    detect_project_file_with_home(start_path, dirs::home_dir())
+}
+
+fn detect_project_file_with_home(
+    start_path: &Path,
+    home_dir: Option<PathBuf>,
+) -> Option<DetectedProjectFile> {
     let start_dir = if start_path.is_file() {
         start_path.parent()?
     } else {
         start_path
     };
 
-    let home_dir = dirs::home_dir();
     let mut current = start_dir.to_path_buf();
 
     loop {
+        // Treat the user's home directory as a boundary before checking files
+        // there. A top-level ~/pyproject.toml or ~/pixi.toml is valid for
+        // other tooling, but MCP notebooks under ~/ should not inherit it
+        // implicitly.
+        if let Some(ref home) = home_dir {
+            if current == *home {
+                return None;
+            }
+        }
+
         // Check pyproject.toml first (higher priority in tiebreaker)
         let pyproject = current.join("pyproject.toml");
         if pyproject.exists() {
@@ -81,12 +97,7 @@ pub fn detect_project_file(start_path: &Path) -> Option<DetectedProjectFile> {
             });
         }
 
-        // Stop at home directory or git repo root
-        if let Some(ref home) = home_dir {
-            if current == *home {
-                return None;
-            }
-        }
+        // Stop at git repo root
         if current.join(".git").exists() {
             return None;
         }
@@ -105,4 +116,51 @@ fn has_pixi_section(path: &Path) -> bool {
     std::fs::read_to_string(path)
         .ok()
         .is_some_and(|content| content.contains("[tool.pixi]") || content.contains("[tool.pixi."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(dir: &Path, name: &str, content: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn home_directory_project_file_is_boundary_not_match() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let notebooks = home.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+        write_file(&home, "pyproject.toml", "[project]\nname = \"home\"\n");
+
+        let found =
+            detect_project_file_with_home(&notebooks.join("analysis.ipynb"), Some(home.clone()));
+
+        assert!(
+            found.is_none(),
+            "project detection must not bind notebooks to ~/pyproject.toml"
+        );
+    }
+
+    #[test]
+    fn subdirectory_project_file_still_matches_before_home_boundary() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = home.join("project");
+        let notebooks = project.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+        write_file(
+            &project,
+            "pyproject.toml",
+            "[project]\nname = \"project\"\n",
+        );
+
+        let found =
+            detect_project_file_with_home(&notebooks.join("analysis.ipynb"), Some(home)).unwrap();
+
+        assert_eq!(found.kind, ProjectFileKind::PyprojectToml);
+        assert_eq!(found.path, project.join("pyproject.toml"));
+    }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2248,10 +2248,13 @@ impl Daemon {
         // connections don't hold resources. All clients must send the 5-byte
         // magic preamble (0xC0DE01AC + version byte) before the JSON handshake.
         //
-        // The preamble version is validated in two tiers:
+        // The preamble version is validated in tiers:
         //   - Pool channel: any version with valid magic is accepted. Older
         //     stable apps ping the daemon during upgrade; rejecting them would
         //     break the version-check → upgrade_daemon_via_sidecar flow.
+        //   - SettingsSync: any historical nonzero version through the current
+        //     version is accepted. The channel is raw Automerge document sync,
+        //     so keep older app windows from spinning during daemon upgrades.
         //   - All other channels: MIN_PROTOCOL_VERSION..=PROTOCOL_VERSION.
         let (handshake_bytes, client_protocol_version) =
             tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -2285,16 +2288,29 @@ impl Daemon {
             .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
-        // Pool connections accept any preamble version (upgrade compat).
-        // Everything else must be within the supported range.
-        if !matches!(handshake, Handshake::Pool)
-            && (client_protocol_version < connection::MIN_PROTOCOL_VERSION as u8
-                || client_protocol_version > connection::PROTOCOL_VERSION as u8)
-        {
+        const SETTINGS_SYNC_MIN_PROTOCOL_VERSION: u8 = 1;
+        let protocol_supported = match handshake {
+            Handshake::Pool => true,
+            Handshake::SettingsSync => {
+                client_protocol_version >= SETTINGS_SYNC_MIN_PROTOCOL_VERSION
+                    && client_protocol_version <= connection::PROTOCOL_VERSION as u8
+            }
+            _ => {
+                client_protocol_version >= connection::MIN_PROTOCOL_VERSION as u8
+                    && client_protocol_version <= connection::PROTOCOL_VERSION as u8
+            }
+        };
+
+        if !protocol_supported {
             anyhow::bail!(
-                "unsupported protocol version: got {}, supported range [{}, {}]",
+                "unsupported protocol version for {:?}: got {}, supported range [{}, {}]",
+                handshake,
                 client_protocol_version,
-                connection::MIN_PROTOCOL_VERSION,
+                if matches!(handshake, Handshake::SettingsSync) {
+                    SETTINGS_SYNC_MIN_PROTOCOL_VERSION as u32
+                } else {
+                    connection::MIN_PROTOCOL_VERSION
+                },
                 connection::PROTOCOL_VERSION
             );
         }

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -58,16 +58,32 @@ pub fn find_nearest_project_file(
     start_path: &Path,
     kinds: &[ProjectFileKind],
 ) -> Option<DetectedProjectFile> {
+    find_nearest_project_file_with_home(start_path, kinds, dirs::home_dir())
+}
+
+fn find_nearest_project_file_with_home(
+    start_path: &Path,
+    kinds: &[ProjectFileKind],
+    home_dir: Option<PathBuf>,
+) -> Option<DetectedProjectFile> {
     let start_dir = if start_path.is_file() {
         start_path.parent()?
     } else {
         start_path
     };
 
-    let home_dir = dirs::home_dir();
-
     let mut current = start_dir.to_path_buf();
     loop {
+        // Treat the home directory as a boundary, not a project root. A
+        // top-level ~/environment.yml is usually a shell/conda default, and
+        // letting notebooks under ~/notebooks inherit it makes unrelated
+        // notebooks project-backed.
+        if let Some(ref home) = home_dir {
+            if current == *home {
+                return None;
+            }
+        }
+
         // Check all requested project file types at this level, in tiebreaker order
         for (filename, kind) in ALL_CANDIDATES {
             if !kinds.contains(kind) {
@@ -92,12 +108,7 @@ pub fn find_nearest_project_file(
             }
         }
 
-        // Stop at home directory or git repo root
-        if let Some(ref home) = home_dir {
-            if current == *home {
-                return None;
-            }
-        }
+        // Stop at git repo root
         if current.join(".git").exists() {
             return None;
         }
@@ -393,6 +404,30 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let found = detect_project_file(temp.path());
         assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_home_directory_project_file_is_boundary_not_match() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let notebooks = home.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+        write_file(&home, "environment.yml", "dependencies:\n  - pandas\n");
+
+        let found = find_nearest_project_file_with_home(
+            &notebooks.join("analysis.ipynb"),
+            &[
+                ProjectFileKind::PyprojectToml,
+                ProjectFileKind::PixiToml,
+                ProjectFileKind::EnvironmentYml,
+            ],
+            Some(home),
+        );
+
+        assert!(
+            found.is_none(),
+            "project detection must not bind notebooks to ~/environment.yml"
+        );
     }
 
     #[test]

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -423,6 +423,48 @@ async fn test_settings_sync_via_unified_socket() {
 }
 
 #[tokio::test]
+async fn test_settings_sync_accepts_legacy_v3_preamble() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    for version in [1, 3] {
+        let mut stream = connect_raw_stream(&socket_path)
+            .await
+            .expect("should connect");
+
+        let mut preamble = [0u8; 5];
+        preamble[..4].copy_from_slice(&[0xC0, 0xDE, 0x01, 0xAC]);
+        preamble[4] = version;
+        stream.write_all(&preamble).await.unwrap();
+
+        let handshake = br#"{"channel":"settings_sync"}"#;
+        let len = (handshake.len() as u32).to_be_bytes();
+        stream.write_all(&len).await.unwrap();
+        stream.write_all(handshake).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut frame_len = [0u8; 4];
+        tokio::time::timeout(Duration::from_secs(2), stream.read_exact(&mut frame_len))
+            .await
+            .expect("settings sync server should send initial sync frame")
+            .unwrap_or_else(|_| panic!("legacy v{version} settings sync should stay connected"));
+        assert!(u32::from_be_bytes(frame_len) > 0);
+    }
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_external_settings_json_edit_survives_settings_sync_ack() {
     use runtimed::settings_doc::{PythonEnvType, SyncedSettings};
     use runtimed::sync_client::SyncClient;


### PR DESCRIPTION
## Summary

- Prevent top-level home project files from being implicitly inherited by daemon project detection.
- Let old settings-sync clients reconnect across daemon upgrades without protocol-skew log spam.
- Align MCP project detection with daemon project detection around the home-directory boundary.

## Tests

- `cargo test -p runtimed project_file::tests::test_home_directory_project_file_is_boundary_not_match`
- `cargo test -p runtimed --test integration test_settings_sync_accepts_legacy_v3_preamble`
- `cargo test -p runt-mcp project_file`
- `cargo xtask lint --fix`

## Follow-up

- PR 2 should handle the project-default environment model and an explicit notebook-owned override for agents creating clean notebooks inside projects.
