### PR TITLE
feat(runtimed): add create notebook environment mode

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -7,7 +7,7 @@ mod env;
 mod framing;
 mod handshake;
 
-pub use env::{EnvSource, LaunchSpec, PackageManager};
+pub use env::{CreateNotebookEnvironmentMode, EnvSource, LaunchSpec, PackageManager};
 
 pub use framing::{
     recv_control_frame, recv_frame, recv_json_frame, recv_preamble, recv_typed_frame, send_frame,
@@ -210,6 +210,7 @@ mod tests {
             notebook_id: None,
             ephemeral: None,
             package_manager: None,
+            environment_mode: None,
             dependencies: vec![],
         })
         .unwrap();
@@ -222,6 +223,7 @@ mod tests {
             notebook_id: None,
             ephemeral: None,
             package_manager: None,
+            environment_mode: None,
             dependencies: vec![],
         })
         .unwrap();
@@ -237,12 +239,28 @@ mod tests {
             notebook_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
             ephemeral: None,
             package_manager: None,
+            environment_mode: None,
             dependencies: vec![],
         })
         .unwrap();
         assert_eq!(
             json,
             r#"{"channel":"create_notebook","runtime":"python","notebook_id":"550e8400-e29b-41d4-a716-446655440000"}"#
+        );
+
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "python".into(),
+            working_dir: Some("/home/user/project".into()),
+            notebook_id: None,
+            ephemeral: None,
+            package_manager: None,
+            environment_mode: Some(CreateNotebookEnvironmentMode::Notebook),
+            dependencies: vec![],
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"create_notebook","runtime":"python","working_dir":"/home/user/project","environment_mode":"notebook"}"#
         );
     }
 

--- a/crates/notebook-protocol/src/connection/env.rs
+++ b/crates/notebook-protocol/src/connection/env.rs
@@ -10,12 +10,13 @@ use serde::{Deserialize, Serialize};
 /// project file inheritance vs notebook-owned inline/prewarmed environments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum CreateNotebookEnvironmentMode {
-    /// Default behavior: use notebook-owned metadata when present, otherwise
-    /// inherit the nearest project file from `working_dir` when one exists.
+    /// Default behavior: preserve the existing project-first launch policy.
+    /// Inherit the nearest project file from `working_dir` when one exists,
+    /// otherwise use notebook-owned metadata/prewarmed environments.
     #[default]
     Auto,
-    /// Prefer the nearest project file from `working_dir`; fall back to
-    /// notebook-owned metadata/prewarmed envs when no project file exists.
+    /// Explicit project-file inheritance. Equivalent to `auto` today, but
+    /// lets callers state that inheriting the surrounding project is intended.
     Project,
     /// Ignore project files for environment selection. `working_dir` still
     /// controls kernel cwd and project context reporting.

--- a/crates/notebook-protocol/src/connection/env.rs
+++ b/crates/notebook-protocol/src/connection/env.rs
@@ -4,6 +4,69 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
+/// Environment inheritance mode for `CreateNotebook`.
+///
+/// `package_manager` chooses uv/conda/pixi. This chooses the source family:
+/// project file inheritance vs notebook-owned inline/prewarmed environments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CreateNotebookEnvironmentMode {
+    /// Default behavior: use notebook-owned metadata when present, otherwise
+    /// inherit the nearest project file from `working_dir` when one exists.
+    #[default]
+    Auto,
+    /// Prefer the nearest project file from `working_dir`; fall back to
+    /// notebook-owned metadata/prewarmed envs when no project file exists.
+    Project,
+    /// Ignore project files for environment selection. `working_dir` still
+    /// controls kernel cwd and project context reporting.
+    Notebook,
+}
+
+impl CreateNotebookEnvironmentMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Project => "project",
+            Self::Notebook => "notebook",
+        }
+    }
+
+    pub fn parse(input: &str) -> Result<Self, String> {
+        match input {
+            "auto" => Ok(Self::Auto),
+            "project" => Ok(Self::Project),
+            "notebook" => Ok(Self::Notebook),
+            _ => Err(format!(
+                "Unsupported environment_mode '{}'. Supported: auto, project, notebook.",
+                input
+            )),
+        }
+    }
+
+    pub fn allows_project_files(self) -> bool {
+        !matches!(self, Self::Notebook)
+    }
+}
+
+impl fmt::Display for CreateNotebookEnvironmentMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for CreateNotebookEnvironmentMode {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CreateNotebookEnvironmentMode {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Supported package managers for Python notebooks.
 ///
 /// The canonical wire format is the lowercase variant name (`"uv"`, `"conda"`,

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::env::PackageManager;
+use super::env::{CreateNotebookEnvironmentMode, PackageManager};
 
 /// Channel handshake — the first frame on every connection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,6 +83,10 @@ pub enum Handshake {
         /// When None, the daemon uses its default_python_env setting.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         package_manager: Option<PackageManager>,
+        /// Environment inheritance mode: auto, project, or notebook.
+        /// Defaults to auto.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment_mode: Option<CreateNotebookEnvironmentMode>,
         /// Dependencies to seed into notebook metadata before auto-launch.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         dependencies: Vec<String>,

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -278,6 +278,30 @@ pub async fn connect_create(
     package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
 ) -> Result<CreateResult, SyncError> {
+    connect_create_with_environment_mode(
+        socket_path,
+        runtime,
+        working_dir,
+        actor_label,
+        ephemeral,
+        package_manager,
+        dependencies,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn connect_create_with_environment_mode(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    actor_label: &str,
+    ephemeral: bool,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
+) -> Result<CreateResult, SyncError> {
     connect_create_inner(
         socket_path,
         runtime,
@@ -287,6 +311,7 @@ pub async fn connect_create(
         ephemeral,
         package_manager,
         dependencies,
+        environment_mode,
     )
     .await
 }
@@ -301,6 +326,7 @@ async fn connect_create_inner(
     ephemeral: bool,
     package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
+    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
 ) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -319,6 +345,7 @@ async fn connect_create_inner(
         notebook_id,
         ephemeral: if ephemeral { Some(true) } else { None },
         package_manager,
+        environment_mode,
         dependencies,
     };
     connection::send_json_frame(&mut writer, &handshake)
@@ -501,6 +528,7 @@ pub async fn connect_create_relay(
     ephemeral: bool,
     package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
+    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
 ) -> Result<RelayCreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -519,6 +547,7 @@ pub async fn connect_create_relay(
         notebook_id,
         ephemeral: if ephemeral { Some(true) } else { None },
         package_manager,
+        environment_mode,
         dependencies,
     };
     connection::send_json_frame(&mut writer, &handshake)

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -568,6 +568,7 @@ async fn initialize_notebook_sync_create(
         false,
         None,
         vec![],
+        None,
     )
     .await
     .map_err(|e| format!("sync connect (create): {}", e))?;

--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -72,7 +72,7 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         "tools": [
             { "name": "list_active_notebooks", "description": "List running notebook sessions." },
             { "name": "connect_notebook", "description": "Attach to a notebook. Pass path (.ipynb) or notebook_id (UUID) — not both." },
-            { "name": "create_notebook", "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist." },
+            { "name": "create_notebook", "description": "Create a new notebook. Ephemeral by default; use environment_mode=\"notebook\" to ignore project files for env selection, and save_notebook(path) to persist." },
             { "name": "save_notebook", "description": "Save notebook to disk. For notebooks created with create_notebook(), you must provide a path." },
             { "name": "show_notebook", "description": "Open the notebook in the nteract app for the user. Headless: returns a structured no-display reason." },
             { "name": "disconnect_notebook", "description": "Release a notebook session's peer connection. Omit notebook_id to disconnect the active session." },

--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -56,7 +56,7 @@
       "destructiveHint": false,
       "openWorldHint": false
     },
-    "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
+    "description": "Create a new notebook. Ephemeral by default; use environment_mode=\"notebook\" to ignore project files for env selection, and save_notebook(path) to persist.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -68,6 +68,14 @@
           },
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "environment_mode": {
+          "default": null,
+          "description": "Environment source mode: \"auto\", \"project\", or \"notebook\".\nDefaults to \"auto\".",
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -124,7 +124,7 @@ pub async fn restart_kernel(
             // Derive the scoped auto-detect from the previous env_source,
             // preserving the package manager family. The daemon's auto:*
             // variants re-resolve through the normal launch priority
-            // (project files → inline deps → captured envs → prewarmed).
+            // (project files unless opted out, then notebook metadata and prewarmed).
             match EnvSource::parse(prev) {
                 EnvSource::Prewarmed(PackageManager::Conda) => "auto:conda".to_string(),
                 EnvSource::Prewarmed(PackageManager::Pixi) => "auto:pixi".to_string(),

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -105,7 +105,7 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(always_load_meta()),
         Tool::new(
             "create_notebook",
-            "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
+            "Create a new notebook. Ephemeral by default; use environment_mode=\"notebook\" to ignore project files for env selection, and save_notebook(path) to persist.",
             schema_for::<session::CreateNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
@@ -624,6 +624,23 @@ mod tests {
         assert_eq!(annotations.destructive_hint, Some(false));
         assert_eq!(annotations.idempotent_hint, Some(true));
         assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn create_notebook_tool_exposes_environment_mode() {
+        let tool = registered_tool("create_notebook");
+        let properties = tool
+            .input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .expect("create_notebook schema should expose properties");
+
+        assert!(properties.contains_key("environment_mode"));
+        assert!(tool
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .contains("environment_mode=\"notebook\""));
     }
 
     #[test]

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -367,6 +367,10 @@ pub struct CreateNotebookParams {
     /// Defaults to the user's default_python_env setting.
     #[serde(default)]
     pub package_manager: Option<String>,
+    /// Environment source mode: "auto", "project", or "notebook".
+    /// Defaults to "auto".
+    #[serde(default)]
+    pub environment_mode: Option<String>,
     /// When true (default for MCP), notebook exists only in memory.
     /// Use save_notebook(path=...) to persist to disk.
     #[serde(default)]
@@ -769,6 +773,14 @@ pub async fn create_notebook(
         }
         None => None,
     };
+    let environment_mode = match arg_str(request, "environment_mode") {
+        Some(mode) => {
+            let parsed = notebook_protocol::connection::CreateNotebookEnvironmentMode::parse(mode)
+                .map_err(|msg| McpError::invalid_params(msg, None))?;
+            Some(parsed)
+        }
+        None => None,
+    };
 
     let prev = previous_notebook_id(server).await;
 
@@ -776,7 +788,7 @@ pub async fn create_notebook(
     // (keeps peer connection alive, preventing eviction).
     park_previous_session(server, None).await;
 
-    match notebook_sync::connect::connect_create(
+    match notebook_sync::connect::connect_create_with_environment_mode(
         server.socket_path.clone(),
         runtime,
         working_dir,
@@ -784,6 +796,7 @@ pub async fn create_notebook(
         ephemeral,
         explicit_pkg_manager.clone(),
         deps.clone(),
+        environment_mode,
     )
     .await
     {
@@ -861,6 +874,7 @@ pub async fn create_notebook(
                     None => "deno",
                 },
                 "ephemeral": ephemeral,
+                "environment_mode": environment_mode.unwrap_or_default().as_str(),
                 "project_context": project_context,
             });
 

--- a/crates/runtimed-node/src/lib.rs
+++ b/crates/runtimed-node/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Phase 1 surface (intentionally small):
 //!   - `defaultSocketPath()` / `socketPathForChannel(channel)`
-//!   - `createNotebook({ runtime, workingDir?, socketPath?, dependencies?, packageManager? }) -> Session`
+//!   - `createNotebook({ runtime, workingDir?, socketPath?, dependencies?, packageManager?, environmentMode? }) -> Session`
 //!   - `openNotebook(notebookId, { socketPath? }) -> Session`
 //!   - `getExecutionResult(executionId, { socketPath? }) -> CellResult`
 //!   - `Session.notebookId`
@@ -31,12 +31,13 @@ pub use parquet::{read_parquet_file, summarize_parquet_file};
 pub use session::{
     create_notebook, get_execution_result, list_active_notebooks, open_notebook,
     open_notebook_path, show_notebook, shutdown_notebook, ActiveNotebook, CellResult,
-    CondaDependencyStatus, CreateCellOptions, CreateNotebookOptions, DependencyEditOptions,
-    DependencyStatus, DependencyTrustStatus, EventSubscription, ExecuteCellOptions,
-    GetExecutionResultOptions, JsCellSnapshot, JsOutput, ListActiveNotebooksOptions,
-    MoveCellOptions, OpenNotebookOptions, PackageManager, PixiDependencyStatus, QueueCellOptions,
-    QueuedExecution, RunCellOptions, RuntimeStatus, Session, SetCellOptions, ShowNotebookOptions,
-    ShowNotebookResult, ShutdownNotebookOptions, UvDependencyStatus, WaitExecutionOptions,
+    CondaDependencyStatus, CreateCellOptions, CreateNotebookEnvironmentMode, CreateNotebookOptions,
+    DependencyEditOptions, DependencyStatus, DependencyTrustStatus, EventSubscription,
+    ExecuteCellOptions, GetExecutionResultOptions, JsCellSnapshot, JsOutput,
+    ListActiveNotebooksOptions, MoveCellOptions, OpenNotebookOptions, PackageManager,
+    PixiDependencyStatus, QueueCellOptions, QueuedExecution, RunCellOptions, RuntimeStatus,
+    Session, SetCellOptions, ShowNotebookOptions, ShowNotebookResult, ShutdownNotebookOptions,
+    UvDependencyStatus, WaitExecutionOptions,
 };
 
 /// Return the default daemon socket path.

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -55,6 +55,27 @@ impl From<PackageManager> for notebook_protocol::connection::PackageManager {
     }
 }
 
+/// Environment source mode for `createNotebook()`.
+#[napi(string_enum = "lowercase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CreateNotebookEnvironmentMode {
+    Auto,
+    Project,
+    Notebook,
+}
+
+impl From<CreateNotebookEnvironmentMode>
+    for notebook_protocol::connection::CreateNotebookEnvironmentMode
+{
+    fn from(value: CreateNotebookEnvironmentMode) -> Self {
+        match value {
+            CreateNotebookEnvironmentMode::Auto => Self::Auto,
+            CreateNotebookEnvironmentMode::Project => Self::Project,
+            CreateNotebookEnvironmentMode::Notebook => Self::Notebook,
+        }
+    }
+}
+
 /// Options for `createNotebook()`.
 #[napi(object)]
 #[derive(Default)]
@@ -75,6 +96,8 @@ pub struct CreateNotebookOptions {
     pub dependencies: Option<Vec<String>>,
     /// Package manager for Python dependencies. Defaults to the daemon/user setting.
     pub package_manager: Option<PackageManager>,
+    /// Environment source mode. Defaults to auto.
+    pub environment_mode: Option<CreateNotebookEnvironmentMode>,
 }
 
 /// Options for `openNotebook()` and `openNotebookPath()`.
@@ -1156,8 +1179,9 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
     let actor_label = peer_label_or_description(opts.peer_label, opts.description);
     let dependencies = opts.dependencies.unwrap_or_default();
     let package_manager = opts.package_manager.map(Into::into);
+    let environment_mode = opts.environment_mode.map(Into::into);
 
-    let result = notebook_sync::connect::connect_create(
+    let result = notebook_sync::connect::connect_create_with_environment_mode(
         socket_path.clone(),
         &runtime,
         working_dir.clone(),
@@ -1165,6 +1189,7 @@ pub async fn create_notebook(options: Option<CreateNotebookOptions>) -> Result<S
         /* ephemeral */ false,
         package_manager,
         dependencies,
+        environment_mode,
     )
     .await
     .map_err(to_napi_err)?;

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -239,7 +239,8 @@ impl AsyncClient {
     ///     peer_label: Optional label override (defaults to client's peer_label).
     ///     package_manager: Package manager ("uv", "conda", "pixi"). When None, daemon uses default_python_env.
     ///     dependencies: Dependencies to seed before kernel auto-launch.
-    #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None, package_manager=None, dependencies=None))]
+    ///     environment_mode: Environment source mode ("auto", "project", "notebook"). Defaults to "auto".
+    #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None, package_manager=None, dependencies=None, environment_mode=None))]
     fn create_notebook<'py>(
         &self,
         py: Python<'py>,
@@ -248,6 +249,7 @@ impl AsyncClient {
         peer_label: Option<String>,
         package_manager: Option<String>,
         dependencies: Option<Vec<String>>,
+        environment_mode: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if let Some(wd) = working_dir {
             let path = std::path::Path::new(wd);
@@ -275,6 +277,15 @@ impl AsyncClient {
                 ),
                 None => None,
             };
+        let parsed_environment_mode: Option<
+            notebook_protocol::connection::CreateNotebookEnvironmentMode,
+        > = match &environment_mode {
+            Some(mode) => Some(
+                notebook_protocol::connection::CreateNotebookEnvironmentMode::parse(mode)
+                    .map_err(pyo3::exceptions::PyValueError::new_err)?,
+            ),
+            None => None,
+        };
 
         let label = peer_label.or_else(|| self.peer_label.clone());
         let socket_path = self.socket_path.clone();
@@ -289,6 +300,7 @@ impl AsyncClient {
                 label,
                 parsed_pm,
                 deps,
+                parsed_environment_mode,
             )
             .await
         })

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -157,6 +157,7 @@ impl AsyncSession {
         peer_label: Option<String>,
         package_manager: Option<notebook_protocol::connection::PackageManager>,
         dependencies: Vec<String>,
+        environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
     ) -> PyResult<Self> {
         let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
@@ -167,6 +168,7 @@ impl AsyncSession {
             actor_label.as_deref(),
             package_manager,
             dependencies,
+            environment_mode,
         )
         .await?;
         state.peer_label = peer_label.clone();

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -448,6 +448,7 @@ pub(crate) async fn connect_create(
     actor_label: Option<&str>,
     package_manager: Option<notebook_protocol::connection::PackageManager>,
     dependencies: Vec<String>,
+    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
 ) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
     let default_label;
     let label = match actor_label {
@@ -457,7 +458,7 @@ pub(crate) async fn connect_create(
             &default_label
         }
     };
-    let result = notebook_sync::connect::connect_create(
+    let result = notebook_sync::connect::connect_create_with_environment_mode(
         socket_path.clone(),
         runtime,
         working_dir.clone(),
@@ -465,6 +466,7 @@ pub(crate) async fn connect_create(
         false,
         package_manager,
         dependencies,
+        environment_mode,
     )
     .await
     .map_err(to_py_err)?;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2432,6 +2432,7 @@ impl Daemon {
                 notebook_id,
                 ephemeral,
                 package_manager,
+                environment_mode,
                 dependencies,
             } => {
                 self.handle_create_notebook(
@@ -2441,6 +2442,7 @@ impl Daemon {
                     notebook_id,
                     ephemeral,
                     package_manager,
+                    environment_mode,
                     dependencies,
                     client_protocol_version,
                 )
@@ -2599,6 +2601,7 @@ impl Daemon {
                         stream,
                         settings.default_runtime.to_string(),
                         Some(dir_path),
+                        None,
                         None,
                         None,
                         None,
@@ -2838,6 +2841,7 @@ impl Daemon {
         notebook_id_hint: Option<String>,
         ephemeral: Option<bool>,
         package_manager: Option<notebook_protocol::connection::PackageManager>,
+        environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
         dependencies: Vec<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
@@ -2849,8 +2853,11 @@ impl Daemon {
         };
 
         info!(
-            "[runtimed] CreateNotebook requested (runtime={}, working_dir={:?}, notebook_id_hint={:?})",
-            runtime, working_dir, notebook_id_hint
+            "[runtimed] CreateNotebook requested (runtime={}, working_dir={:?}, notebook_id_hint={:?}, environment_mode={})",
+            runtime,
+            working_dir,
+            notebook_id_hint,
+            environment_mode.unwrap_or_default().as_str()
         );
 
         // Get settings for default Python env preference
@@ -2861,6 +2868,7 @@ impl Daemon {
         // Use provided notebook_id (session restore) or generate a new UUID
         let notebook_id = notebook_id_hint.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let ephemeral = ephemeral.unwrap_or(false);
+        let environment_mode = environment_mode.unwrap_or_default();
 
         // Create room for this notebook. For CreateNotebook, the notebook_id is
         // always a UUID (new room) or an existing UUID (session restore).
@@ -2939,6 +2947,11 @@ impl Daemon {
             send_json_frame(&mut writer, &response).await?;
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
             return Ok(());
+        }
+
+        {
+            let mut mode = room.identity.environment_mode.write().await;
+            *mode = environment_mode;
         }
 
         // Send NotebookConnectionInfo response.

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -101,7 +101,7 @@ pub(crate) fn select_auto_python_env_source(
             project_source.or(notebook_source).unwrap_or(fallback)
         }
         notebook_protocol::connection::CreateNotebookEnvironmentMode::Auto => {
-            notebook_source.or(project_source).unwrap_or(fallback)
+            project_source.or(notebook_source).unwrap_or(fallback)
         }
         notebook_protocol::connection::CreateNotebookEnvironmentMode::Notebook => {
             notebook_source.unwrap_or(fallback)
@@ -2944,10 +2944,9 @@ pub(crate) async fn auto_launch_kernel(
                 ("deno", EnvSource::Deno, None)
             }
             Some("python") => {
-                // Notebook is a Python notebook - resolve environment
-                // Auto/default priority: notebook-owned env signals > project file > prewarmed.
-                // Explicit project mode keeps project files first; explicit notebook mode
-                // suppresses project_source above.
+                // Notebook is a Python notebook - resolve environment.
+                // Auto keeps the legacy project-first policy. `notebook` is
+                // the explicit opt-out and suppresses project_source above.
                 let inline_source = inline_source.as_ref().filter(|source| {
                     // Skip Deno inline source for Python notebooks (kernelspec takes priority).
                     !matches!(source, EnvSource::Deno)
@@ -3021,9 +3020,8 @@ pub(crate) async fn auto_launch_kernel(
                     info!("[notebook-sync] Auto-launch: Deno kernel (default runtime)");
                     ("deno", EnvSource::Deno, None)
                 } else {
-                    // Default to Python
-                    // Auto/default priority: notebook-owned env signals > project file > prewarmed.
-                    // Explicit project mode keeps project files first; explicit notebook mode
+                    // Default to Python. Auto keeps the legacy project-first
+                    // policy. `notebook` is the explicit opt-out and
                     // suppresses project_source above.
                     let fallback =
                         EnvSource::Prewarmed(default_prewarmed_manager(default_python_env.clone()));

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -90,6 +90,25 @@ pub(crate) fn default_prewarmed_manager(
     }
 }
 
+pub(crate) fn select_auto_python_env_source(
+    environment_mode: notebook_protocol::connection::CreateNotebookEnvironmentMode,
+    notebook_source: Option<notebook_protocol::connection::EnvSource>,
+    project_source: Option<notebook_protocol::connection::EnvSource>,
+    fallback: notebook_protocol::connection::EnvSource,
+) -> notebook_protocol::connection::EnvSource {
+    match environment_mode {
+        notebook_protocol::connection::CreateNotebookEnvironmentMode::Project => {
+            project_source.or(notebook_source).unwrap_or(fallback)
+        }
+        notebook_protocol::connection::CreateNotebookEnvironmentMode::Auto => {
+            notebook_source.or(project_source).unwrap_or(fallback)
+        }
+        notebook_protocol::connection::CreateNotebookEnvironmentMode::Notebook => {
+            notebook_source.unwrap_or(fallback)
+        }
+    }
+}
+
 pub(crate) fn check_inline_deps(
     snapshot: &NotebookMetadataSnapshot,
 ) -> Option<notebook_protocol::connection::EnvSource> {
@@ -2791,7 +2810,7 @@ pub(crate) async fn auto_launch_kernel(
 
     // Detection priority:
     // 1. Notebook's kernelspec (for existing notebooks) - determines python vs deno
-    // 2. For Python: resolve environment (inline deps → project files → prewarmed)
+    // 2. For Python: resolve environment (notebook-owned deps → project files → prewarmed)
     // 3. For Deno: just launch Deno (no env resolution needed)
     // 4. For new notebooks (no kernelspec): use default_runtime setting
 
@@ -2861,13 +2880,18 @@ pub(crate) async fn auto_launch_kernel(
         }
     };
 
+    let environment_mode = *room.identity.environment_mode.read().await;
+
     // Step 3: Check project files (for Python environment resolution)
     // Use notebook path for saved notebooks, or working_dir for untitled notebooks
     let detection_path = notebook_path_opt
         .as_ref()
         .or(working_dir_for_detection.as_ref());
-    let detected_project_file =
-        detection_path.and_then(|path| crate::project_file::detect_project_file(path));
+    let detected_project_file = if environment_mode.allows_project_files() {
+        detection_path.and_then(|path| crate::project_file::detect_project_file(path))
+    } else {
+        None
+    };
     if let Some(ref detected) = detected_project_file {
         info!(
             "[notebook-sync] Auto-launch: detected project file {:?} -> {}",
@@ -2921,45 +2945,35 @@ pub(crate) async fn auto_launch_kernel(
             }
             Some("python") => {
                 // Notebook is a Python notebook - resolve environment
-                // Priority: project file > inline deps > prewarmed
-                // Project file wins because inline deps get promoted to the
-                // project file at sync/launch time (project is source of truth).
-                let env_source: EnvSource = if let Some(ref proj) = project_source {
-                    info!(
-                        "[notebook-sync] Auto-launch: using project file -> {}",
-                        proj.as_str()
-                    );
-                    proj.clone()
-                } else if let Some(ref source) = inline_source {
-                    // Skip Deno inline source for Python notebooks (kernelspec takes priority)
-                    if !matches!(source, EnvSource::Deno) {
-                        info!(
-                            "[notebook-sync] Auto-launch: found inline deps -> {}",
-                            source.as_str()
-                        );
-                        source.clone()
-                    } else {
-                        EnvSource::Prewarmed(default_prewarmed_manager(default_python_env.clone()))
-                    }
-                } else {
-                    // Check if the metadata has an explicit manager section
-                    // (e.g. create_notebook(package_manager="conda") with empty deps).
-                    // Use that to pick the pool type instead of default_python_env.
-                    let manager = metadata_snapshot
-                        .as_ref()
-                        .and_then(detect_manager_from_metadata)
-                        .and_then(|pm| match pm {
-                            PackageManager::Unknown(_) => None,
-                            canonical => Some(canonical),
-                        })
-                        .unwrap_or_else(|| default_prewarmed_manager(default_python_env.clone()));
-                    let prewarmed = EnvSource::Prewarmed(manager);
-                    info!(
-                        "[notebook-sync] Auto-launch: using prewarmed ({})",
-                        prewarmed.as_str()
-                    );
-                    prewarmed
-                };
+                // Auto/default priority: notebook-owned env signals > project file > prewarmed.
+                // Explicit project mode keeps project files first; explicit notebook mode
+                // suppresses project_source above.
+                let inline_source = inline_source.as_ref().filter(|source| {
+                    // Skip Deno inline source for Python notebooks (kernelspec takes priority).
+                    !matches!(source, EnvSource::Deno)
+                });
+                // Check if the metadata has an explicit manager section
+                // (e.g. create_notebook(package_manager="conda") with empty deps).
+                // Use that to pick the pool type instead of default_python_env.
+                let manager = metadata_snapshot
+                    .as_ref()
+                    .and_then(detect_manager_from_metadata)
+                    .and_then(|pm| match pm {
+                        PackageManager::Unknown(_) => None,
+                        canonical => Some(canonical),
+                    })
+                    .unwrap_or_else(|| default_prewarmed_manager(default_python_env.clone()));
+                let fallback = EnvSource::Prewarmed(manager);
+                let env_source = select_auto_python_env_source(
+                    environment_mode,
+                    inline_source.cloned(),
+                    project_source.clone(),
+                    fallback,
+                );
+                info!(
+                    "[notebook-sync] Auto-launch: resolved env_source -> {}",
+                    env_source.as_str()
+                );
                 let pooled_env = if env_source.prepares_own_env() {
                     info!(
                         "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
@@ -3008,29 +3022,21 @@ pub(crate) async fn auto_launch_kernel(
                     ("deno", EnvSource::Deno, None)
                 } else {
                     // Default to Python
-                    // Priority: project file > inline deps > prewarmed
-                    let env_source: EnvSource = if let Some(ref source) = project_source {
-                        info!(
-                            "[notebook-sync] Auto-launch: using project file -> {}",
-                            source.as_str()
-                        );
-                        source.clone()
-                    } else if let Some(ref source) = inline_source {
-                        info!(
-                            "[notebook-sync] Auto-launch: found inline deps -> {}",
-                            source.as_str()
-                        );
-                        source.clone()
-                    } else {
-                        let prewarmed = EnvSource::Prewarmed(default_prewarmed_manager(
-                            default_python_env.clone(),
-                        ));
-                        info!(
-                            "[notebook-sync] Auto-launch: using prewarmed ({})",
-                            prewarmed.as_str()
-                        );
-                        prewarmed
-                    };
+                    // Auto/default priority: notebook-owned env signals > project file > prewarmed.
+                    // Explicit project mode keeps project files first; explicit notebook mode
+                    // suppresses project_source above.
+                    let fallback =
+                        EnvSource::Prewarmed(default_prewarmed_manager(default_python_env.clone()));
+                    let env_source = select_auto_python_env_source(
+                        environment_mode,
+                        inline_source.clone(),
+                        project_source.clone(),
+                        fallback,
+                    );
+                    info!(
+                        "[notebook-sync] Auto-launch: resolved env_source -> {}",
+                        env_source.as_str()
+                    );
                     let pooled_env = if env_source.prepares_own_env() {
                         info!(
                             "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -11,6 +11,8 @@ pub struct RoomIdentity {
     /// When the notebook_id is a UUID (untitled), this provides the directory
     /// context for finding pyproject.toml, pixi.toml, or environment.yaml.
     pub working_dir: RwLock<Option<PathBuf>>,
+    /// Environment inheritance mode for daemon-created untitled notebooks.
+    pub environment_mode: RwLock<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
 }
 
 impl RoomIdentity {
@@ -18,6 +20,7 @@ impl RoomIdentity {
         Self {
             persist_path,
             working_dir: RwLock::new(None),
+            environment_mode: RwLock::new(Default::default()),
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6205,7 +6205,7 @@ fn select_auto_python_env_source_respects_environment_mode() {
             project.clone(),
             fallback.clone(),
         ),
-        EnvSource::Inline(PackageManager::Uv)
+        EnvSource::Pyproject
     );
     assert_eq!(
         select_auto_python_env_source(

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6190,6 +6190,69 @@ fn launch_kernel_captured_override_respects_auto_scope() {
     assert_eq!(apply_scope(captured_conda, Some("pixi")), None);
 }
 
+#[test]
+fn select_auto_python_env_source_respects_environment_mode() {
+    use notebook_protocol::connection::{CreateNotebookEnvironmentMode, EnvSource, PackageManager};
+
+    let notebook = Some(EnvSource::Inline(PackageManager::Uv));
+    let project = Some(EnvSource::Pyproject);
+    let fallback = EnvSource::Prewarmed(PackageManager::Conda);
+
+    assert_eq!(
+        select_auto_python_env_source(
+            CreateNotebookEnvironmentMode::Auto,
+            notebook.clone(),
+            project.clone(),
+            fallback.clone(),
+        ),
+        EnvSource::Inline(PackageManager::Uv)
+    );
+    assert_eq!(
+        select_auto_python_env_source(
+            CreateNotebookEnvironmentMode::Project,
+            notebook.clone(),
+            project.clone(),
+            fallback.clone(),
+        ),
+        EnvSource::Pyproject
+    );
+    assert_eq!(
+        select_auto_python_env_source(
+            CreateNotebookEnvironmentMode::Notebook,
+            notebook,
+            project,
+            fallback,
+        ),
+        EnvSource::Inline(PackageManager::Uv)
+    );
+}
+
+#[test]
+fn select_auto_python_env_source_falls_back_without_project_or_notebook_env() {
+    use notebook_protocol::connection::{CreateNotebookEnvironmentMode, EnvSource, PackageManager};
+
+    let fallback = EnvSource::Prewarmed(PackageManager::Uv);
+
+    assert_eq!(
+        select_auto_python_env_source(
+            CreateNotebookEnvironmentMode::Auto,
+            None,
+            None,
+            fallback.clone(),
+        ),
+        fallback
+    );
+    assert_eq!(
+        select_auto_python_env_source(
+            CreateNotebookEnvironmentMode::Notebook,
+            None,
+            Some(EnvSource::Pyproject),
+            EnvSource::Prewarmed(PackageManager::Conda),
+        ),
+        EnvSource::Prewarmed(PackageManager::Conda)
+    );
+}
+
 /// Pre-upgrade notebooks: env_id is set but deps are empty. The capture
 /// step must still record the env_id (no-op) and populate user_defaults
 /// if they were derived from the pool. This is the migration path from

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -236,15 +236,22 @@ pub(crate) async fn handle(
             detected.to_env_source()
         });
 
-        // `environment_mode=project` is the one project-first mode. Otherwise
-        // project files are the default only when the notebook has not declared
-        // its own env via captured, inline, or PEP 723 metadata.
-        if matches!(
+        // Auto keeps the legacy project-first policy. `notebook` is the
+        // explicit opt-out and suppresses project_source above.
+        if let Some(source) = if matches!(
             environment_mode,
-            notebook_protocol::connection::CreateNotebookEnvironmentMode::Project
-        ) && project_source.is_some()
-        {
-            project_source.unwrap()
+            notebook_protocol::connection::CreateNotebookEnvironmentMode::Auto
+                | notebook_protocol::connection::CreateNotebookEnvironmentMode::Project
+        ) {
+            project_source.clone()
+        } else {
+            None
+        } {
+            info!(
+                "[notebook-sync] LaunchKernel: using project file -> {}",
+                source.as_str()
+            );
+            source
         }
         // Captured prewarmed env wins over inline deps. Captured deps look
         // structurally identical to user-authored inline deps, so without this
@@ -336,15 +343,6 @@ pub(crate) async fn handle(
                     pep723_source.as_str()
                 );
                 pep723_source
-            }
-            // Project files are the default only when the notebook has not
-            // declared its own env via captured, inline, or PEP 723 metadata.
-            else if let Some(source) = project_source {
-                info!(
-                    "[notebook-sync] LaunchKernel: using project file -> {}",
-                    source.as_str()
-                );
-                source
             }
             // Fall back to prewarmed (scoped to family)
             else {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -207,44 +207,49 @@ pub(crate) async fn handle(
             Some(PackageManager::Unknown(_)) | None => None,
         };
 
-        // Priority 1: Detect project files near notebook path.
-        // Project file wins because inline deps get promoted to the
-        // project file at sync/launch time (project is source of truth).
-        // A project file added after capture means the user wants the
-        // project env, not the stale captured one.
-        if let Some(detected) = notebook_path.as_ref().and_then(|path| match auto_scope {
-            Some("uv") => crate::project_file::find_nearest_project_file(
-                path,
-                &[crate::project_file::ProjectFileKind::PyprojectToml],
-            ),
-            Some("conda") => crate::project_file::find_nearest_project_file(
-                path,
-                &[crate::project_file::ProjectFileKind::EnvironmentYml],
-            ),
-            Some("pixi") => crate::project_file::find_nearest_project_file(
-                path,
-                &[crate::project_file::ProjectFileKind::PixiToml],
-            ),
-            _ => crate::project_file::detect_project_file(path),
-        }) {
+        let environment_mode = *room.identity.environment_mode.read().await;
+        let detected_project = if environment_mode.allows_project_files() {
+            notebook_path.as_ref().and_then(|path| match auto_scope {
+                Some("uv") => crate::project_file::find_nearest_project_file(
+                    path,
+                    &[crate::project_file::ProjectFileKind::PyprojectToml],
+                ),
+                Some("conda") => crate::project_file::find_nearest_project_file(
+                    path,
+                    &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                ),
+                Some("pixi") => crate::project_file::find_nearest_project_file(
+                    path,
+                    &[crate::project_file::ProjectFileKind::PixiToml],
+                ),
+                _ => crate::project_file::detect_project_file(path),
+            })
+        } else {
+            None
+        };
+        let project_source = detected_project.as_ref().map(|detected| {
             info!(
                 "[notebook-sync] Auto-detected project file: {:?} -> {}",
                 detected.path,
                 detected.to_env_source().as_str()
             );
             detected.to_env_source()
+        });
+
+        // `environment_mode=project` is the one project-first mode. Otherwise
+        // project files are the default only when the notebook has not declared
+        // its own env via captured, inline, or PEP 723 metadata.
+        if matches!(
+            environment_mode,
+            notebook_protocol::connection::CreateNotebookEnvironmentMode::Project
+        ) && project_source.is_some()
+        {
+            project_source.unwrap()
         }
-        // Priority 2: Captured prewarmed env wins over inline deps.
-        // Captured deps look structurally identical to user-authored
-        // inline deps, so without this override, reopening a captured
-        // notebook would route through the inline-deps path and miss
-        // the already-claimed env. Ordering is project file > captured
-        // > inline > default so a pyproject.toml added post-capture
-        // still wins.
-        //
-        // Respects `auto_scope`: `auto:uv` with a conda-captured
-        // notebook (or vice versa) falls through. `auto:pixi` always
-        // falls through — no pixi capture path yet.
+        // Captured prewarmed env wins over inline deps. Captured deps look
+        // structurally identical to user-authored inline deps, so without this
+        // override, reopening a captured notebook would route through the
+        // inline-deps path and miss the already-claimed env.
         else if let Some(captured_src) = captured_env_source_override(metadata_snapshot.as_ref())
             .filter(|src| match auto_scope {
                 Some("uv") => matches!(src, EnvSource::Prewarmed(PackageManager::Uv)),
@@ -293,7 +298,7 @@ pub(crate) async fn handle(
             );
             inline_source
         } else {
-            // Priority 3: Check PEP 723 script blocks in cell source
+            // Check PEP 723 script blocks in cell source.
             let has_pep723_deps = if auto_scope == Some("conda") {
                 false
             } else {
@@ -332,7 +337,16 @@ pub(crate) async fn handle(
                 );
                 pep723_source
             }
-            // Priority 4: Fall back to prewarmed (scoped to family)
+            // Project files are the default only when the notebook has not
+            // declared its own env via captured, inline, or PEP 723 metadata.
+            else if let Some(source) = project_source {
+                info!(
+                    "[notebook-sync] LaunchKernel: using project file -> {}",
+                    source.as_str()
+                );
+                source
+            }
+            // Fall back to prewarmed (scoped to family)
             else {
                 let fallback = match auto_scope {
                     Some("conda") => EnvSource::Prewarmed(PackageManager::Conda),

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -945,6 +945,100 @@ async fn test_untrusted_launch_and_sync_environment_are_daemon_rejected() {
 }
 
 #[tokio::test]
+async fn test_launch_kernel_environment_mode_controls_project_priority() {
+    use notebook_protocol::connection::CreateNotebookEnvironmentMode;
+
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(
+        project_dir.join("environment.yml"),
+        "name: runtimed-env-mode-missing\nchannels:\n  - defaults\ndependencies:\n  - python=3.11\n",
+    )
+    .unwrap();
+    let notebook_path = project_dir.join("notebook.ipynb");
+    write_test_ipynb(&notebook_path, &[]);
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let launch_with_mode = |mode: CreateNotebookEnvironmentMode, label: &'static str| {
+        let socket_path = socket_path.clone();
+        let project_dir = project_dir.clone();
+        let notebook_path = notebook_path.clone();
+        async move {
+            let result = connect::connect_create_with_environment_mode(
+                socket_path,
+                "python",
+                Some(project_dir),
+                label,
+                false,
+                None,
+                vec![],
+                Some(mode),
+            )
+            .await
+            .unwrap();
+            let handle = result.handle;
+            assert!(
+                wait_for_session_ready(&handle, SESSION_READY_TIMEOUT).await,
+                "{label} client should reach session-ready state"
+            );
+
+            handle
+                .send_request(NotebookRequest::LaunchKernel {
+                    kernel_type: "python".to_string(),
+                    env_source: LaunchSpec::Auto,
+                    notebook_path: Some(notebook_path.display().to_string()),
+                })
+                .await
+                .unwrap()
+        }
+    };
+
+    let auto = launch_with_mode(CreateNotebookEnvironmentMode::Auto, "auto").await;
+    assert!(
+        matches!(
+            auto,
+            NotebookResponse::Error { ref error }
+                if error.contains("environment.yml declares conda env")
+        ),
+        "auto should preserve project-first priority and stop at the project environment.yml, got {auto:?}"
+    );
+
+    let project = launch_with_mode(CreateNotebookEnvironmentMode::Project, "project").await;
+    assert!(
+        matches!(
+            project,
+            NotebookResponse::Error { ref error }
+                if error.contains("environment.yml declares conda env")
+        ),
+        "project should explicitly use project-first priority and stop at the project environment.yml, got {project:?}"
+    );
+
+    let notebook = launch_with_mode(CreateNotebookEnvironmentMode::Notebook, "notebook").await;
+    assert!(
+        matches!(
+            notebook,
+            NotebookResponse::Error { ref error }
+                if error.contains("UV pool empty") && !error.contains("environment.yml")
+        ),
+        "notebook mode should ignore project files and fall through to notebook/prewarmed selection, got {notebook:?}"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_sync_environment_guard_rejects_stale_observed_dependencies() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -69,7 +69,7 @@
       "name": "connect_notebook"
     },
     {
-      "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
+      "description": "Create a new notebook. Ephemeral by default; use environment_mode=\"notebook\" to ignore project files for env selection, and save_notebook(path) to persist.",
       "name": "create_notebook"
     },
     {

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -69,7 +69,7 @@
       "name": "connect_notebook"
     },
     {
-      "description": "Create a new notebook. Ephemeral by default; use save_notebook(path) to persist.",
+      "description": "Create a new notebook. Ephemeral by default; use environment_mode=\"notebook\" to ignore project files for env selection, and save_notebook(path) to persist.",
       "name": "create_notebook"
     },
     {

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -25,13 +25,21 @@ export interface ExecutionTransition {
 export type RuntimeState = Record<string, unknown>;
 
 export type RuntimeKind = "python" | "deno" | (string & {});
-export type PackageManager = "uv" | "conda" | "pixi";
 
 export const PackageManager: {
   readonly Uv: "uv";
   readonly Conda: "conda";
   readonly Pixi: "pixi";
 };
+export type PackageManager = (typeof PackageManager)[keyof typeof PackageManager];
+
+export const CreateNotebookEnvironmentMode: {
+  readonly Auto: "auto";
+  readonly Project: "project";
+  readonly Notebook: "notebook";
+};
+export type CreateNotebookEnvironmentMode =
+  (typeof CreateNotebookEnvironmentMode)[keyof typeof CreateNotebookEnvironmentMode];
 
 export interface CreateNotebookOptions {
   runtime?: RuntimeKind;
@@ -41,6 +49,7 @@ export interface CreateNotebookOptions {
   description?: string;
   dependencies?: string[];
   packageManager?: PackageManager;
+  environmentMode?: CreateNotebookEnvironmentMode;
 }
 
 export interface OpenNotebookOptions {


### PR DESCRIPTION
## Summary

- Add `environment_mode` / `environmentMode` for `create_notebook` / `createNotebook`.
- Keep `package_manager` focused on uv/conda/pixi while `environment_mode` controls project inheritance.
- Preserve the existing project-first `auto` behavior while adding an explicit notebook-owned opt-out.
- Support explicit modes:
  - `auto`: inherit project files when available, matching the existing default.
  - `project`: explicitly prefer project files when available.
  - `notebook`: ignore project files for env selection while keeping `working_dir` for cwd/context.

## Tests

- `cargo test -p notebook-protocol connection::tests::test_handshake_serialization`
- `cargo test -p runtimed select_auto_python_env_source`
- `cargo test -p runtimed --test integration test_launch_kernel_environment_mode_controls_project_priority`
- `cargo clippy -p runtimed --all-targets -- -D warnings`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `cargo xtask sync-tool-cache --check`
- `cargo check -p runt-mcp -p runtimed-py -p runtimed-node -p notebook-sync -p notebook`
- `cargo test -p runt-mcp create_notebook_tool_exposes_environment_mode`
- `cargo test -p notebook-sync test_convenience_uv_dependencies`
- `cargo xtask lint --fix`

## Notes

- `cargo test -p runtimed-node package_manager_converts_to_protocol_enum` was attempted but the Rust test binary failed to link on local N-API symbols (`napi_delete_reference`, `napi_reference_unref`). `cargo check -p runtimed-node` passed.
