### PR TITLE
feat(notebook-host): add browser dev relay transport

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -24,6 +24,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@nteract/notebook-host": "workspace:*",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-log": "^2.8.0",
@@ -45,7 +46,6 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "@nteract/notebook-host": "workspace:*",
     "runtimed": "workspace:*",
     "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0"
@@ -54,11 +54,13 @@
     "@tailwindcss/vite": "^4.1.8",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.1.8",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "ws": "^8.20.0"
   }
 }

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -6,17 +6,7 @@ import {
   SquareDashedMousePointer,
   SquareMousePointer,
 } from "lucide-react";
-import {
-  lazy,
-  memo,
-  type ReactNode,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { anyOutputNeedsIsolation, OutputArea } from "@/components/cell/OutputArea";
@@ -49,13 +39,7 @@ import { presenceSenderExtension } from "../lib/presence-sender";
 import { tabCompletionKeymap } from "../lib/tab-completion";
 import type { CodeCell as CodeCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
-
-// Lazy load HistorySearchDialog — only loaded when user opens history search (Ctrl+R)
-const HistorySearchDialog = lazy(() =>
-  import("./HistorySearchDialog").then((m) => ({
-    default: m.HistorySearchDialog,
-  })),
-);
+import { HistorySearchDialog } from "./HistorySearchDialog";
 
 interface CodeCellProps {
   cell: CodeCellType;
@@ -456,15 +440,13 @@ export const CodeCell = memo(function CodeCell({
         hideOutput={outputs.length === 0 || bothHidden}
       />
 
-      {/* History Search Dialog (Ctrl+R) - lazy loaded */}
+      {/* History Search Dialog (Ctrl+R) */}
       {historyDialogOpen && (
-        <Suspense fallback={null}>
-          <HistorySearchDialog
-            open={historyDialogOpen}
-            onOpenChange={setHistoryDialogOpen}
-            onSelect={handleHistorySelect}
-          />
-        </Suspense>
+        <HistorySearchDialog
+          open={historyDialogOpen}
+          onOpenChange={setHistoryDialogOpen}
+          onSelect={handleHistorySelect}
+        />
       )}
     </>
   );

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -1,7 +1,4 @@
-import { NotebookHostProvider } from "@nteract/notebook-host";
-import { createTauriHost } from "@nteract/notebook-host/tauri";
-import { isTauri } from "@tauri-apps/api/core";
-import { attachLogger, LogLevel } from "@tauri-apps/plugin-log";
+import { NotebookHostProvider, type NotebookHost } from "@nteract/notebook-host";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
@@ -32,26 +29,10 @@ const loadRendererBundle = async () => {
   return { rendererCode, rendererCss };
 };
 
-// Tauri host is constructed once at boot. Every host-platform side
-// effect flows through it (see @nteract/notebook-host types). The
-// transport is part of the host and shared by the SyncEngine,
-// NotebookClient, and anything else that needs to talk to the daemon.
-const host = createTauriHost();
-// Module-scope helpers that can't reach for useNotebookHost() — hand them
-// the references they need right after the host is constructed.
-setMetadataTransport(host.transport);
-setBlobPortHost(host);
-setLoggerHost(host);
-setOpenUrlHost(host);
-setKernelCompletionHost(host);
-setErrorBoundarySink((error, componentStack) => {
-  logger.error(
-    "[ErrorBoundary] render error:",
-    error,
-    "component stack:",
-    componentStack ?? "(unavailable)",
-  );
-});
+function isTauriRuntime(): boolean {
+  const w = window as Window & { __TAURI__?: unknown; __TAURI_INTERNALS__?: unknown };
+  return "__TAURI_INTERNALS__" in w || "__TAURI__" in w;
+}
 
 // Capture original console methods BEFORE wrapping. The Rust-log mirror
 // below uses these originals to avoid re-entering the `console.error`
@@ -63,26 +44,25 @@ const originalConsoleInfo = console.info.bind(console);
 const originalConsoleDebug = console.debug.bind(console);
 const originalConsoleLog = console.log.bind(console);
 
-// Forward `console.error` into the host logger so it lands in notebook.log in
-// packaged / CI builds, not just dev devtools. Specifically: WASM panics
-// routed via `console_error_panic_hook` become visible in `e2e-logs/app.log`
-// with file:line:message — without this, they disappear in production.
-// Preserves the original console behavior so devtools stays unchanged.
-console.error = (...args: unknown[]) => {
-  originalConsoleError(...args);
-  try {
-    logger.error(...args);
-  } catch {
-    // Never let the forwarding path break the original error.
+async function createNotebookHost(): Promise<NotebookHost> {
+  if (isTauriRuntime()) {
+    const { createTauriHost } = await import("@nteract/notebook-host/tauri");
+    return createTauriHost();
   }
-};
 
-// Mirror Rust log entries into devtools during dev so plugin-log output is
-// visible alongside frontend logs. Uses `attachLogger` (not `attachConsole`,
-// which would route through the wrapped `console.error` above and loop) and
-// dispatches to the ORIGINAL console methods. The wrapped forwarder never
-// sees these writes, so no feedback cycle.
-if (isTauri() && import.meta.env.DEV) {
+  const { createBrowserHost } = await import("@nteract/notebook-host/browser");
+  return createBrowserHost();
+}
+
+async function attachTauriDevLogMirror(): Promise<void> {
+  if (!isTauriRuntime() || !import.meta.env.DEV) return;
+
+  const { attachLogger, LogLevel } = await import("@tauri-apps/plugin-log");
+  // Mirror Rust log entries into devtools during dev so plugin-log output is
+  // visible alongside frontend logs. Uses `attachLogger` (not `attachConsole`,
+  // which would route through the wrapped `console.error` below and loop) and
+  // dispatches to the ORIGINAL console methods. The wrapped forwarder never
+  // sees these writes, so no feedback cycle.
   attachLogger(({ level, message }) => {
     switch (level) {
       case LogLevel.Trace:
@@ -106,12 +86,59 @@ if (isTauri() && import.meta.env.DEV) {
   });
 }
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <NotebookHostProvider host={host}>
-      <IsolatedRendererProvider loader={loadRendererBundle}>
-        <App />
-      </IsolatedRendererProvider>
-    </NotebookHostProvider>
-  </StrictMode>,
-);
+async function boot() {
+  // Host is constructed once at boot. Every host-platform side effect flows
+  // through it (see @nteract/notebook-host types). Tauri and browser/dev hosts
+  // provide the same transport surface to SyncEngine and NotebookClient.
+  const host = await createNotebookHost();
+
+  // Module-scope helpers that can't reach for useNotebookHost() — hand them
+  // the references they need right after the host is constructed.
+  setMetadataTransport(host.transport);
+  setBlobPortHost(host);
+  setLoggerHost(host);
+  setOpenUrlHost(host);
+  setKernelCompletionHost(host);
+  setErrorBoundarySink((error, componentStack) => {
+    logger.error(
+      "[ErrorBoundary] render error:",
+      error,
+      "component stack:",
+      componentStack ?? "(unavailable)",
+    );
+  });
+
+  // Forward `console.error` into the host logger so it lands in notebook.log in
+  // packaged / CI builds, not just dev devtools. Specifically: WASM panics
+  // routed via `console_error_panic_hook` become visible in `e2e-logs/app.log`
+  // with file:line:message — without this, they disappear in production.
+  // Preserves the original console behavior so devtools stays unchanged.
+  console.error = (...args: unknown[]) => {
+    originalConsoleError(...args);
+    try {
+      logger.error(...args);
+    } catch {
+      // Never let the forwarding path break the original error.
+    }
+  };
+
+  void attachTauriDevLogMirror();
+
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <NotebookHostProvider host={host}>
+        <IsolatedRendererProvider loader={loadRendererBundle}>
+          <App />
+        </IsolatedRendererProvider>
+      </NotebookHostProvider>
+    </StrictMode>,
+  );
+}
+
+void boot().catch((err) => {
+  originalConsoleError("[main] failed to boot notebook app", err);
+  const root = document.getElementById("root");
+  if (root) {
+    root.textContent = err instanceof Error ? err.message : String(err);
+  }
+});

--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -1,0 +1,355 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Socket } from "node:net";
+import { WebSocketServer, type RawData, type WebSocket } from "ws";
+import type { Plugin, ViteDevServer } from "vite-plus";
+
+const CONFIG_PATH = "/__nteract_dev_relay/config";
+const WS_PATH = "/__nteract_dev_relay/ws";
+const MAGIC = [0xc0, 0xde, 0x01, 0xac] as const;
+const PROTOCOL_VERSION = 4;
+const MAX_FRAME_SIZE = 100 * 1024 * 1024;
+
+interface DaemonInfoJson {
+  version?: string;
+  socket_path?: string;
+  is_dev_mode?: boolean;
+  blob_port?: number;
+}
+
+interface RelayOptions {
+  repoRoot: string;
+}
+
+class LengthPrefixedFrames {
+  private buffer = Buffer.alloc(0);
+  private waiters: Array<{
+    resolve: (frame: Buffer) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private liveHandler: ((frame: Buffer) => void) | null = null;
+
+  push(chunk: Buffer): void {
+    this.buffer = this.buffer.length ? Buffer.concat([this.buffer, chunk]) : chunk;
+    this.drain();
+  }
+
+  readFrame(): Promise<Buffer> {
+    const frame = this.shiftFrame();
+    if (frame) return Promise.resolve(frame);
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  pipeTo(handler: (frame: Buffer) => void): void {
+    this.liveHandler = handler;
+    this.drain();
+  }
+
+  fail(err: Error): void {
+    for (const waiter of this.waiters) waiter.reject(err);
+    this.waiters = [];
+  }
+
+  private drain(): void {
+    let frame: Buffer | null;
+    while ((frame = this.shiftFrame())) {
+      const waiter = this.waiters.shift();
+      if (waiter) waiter.resolve(frame);
+      else this.liveHandler?.(frame);
+    }
+  }
+
+  private shiftFrame(): Buffer | null {
+    if (this.buffer.length < 4) return null;
+    const length = this.buffer.readUInt32BE(0);
+    if (length > MAX_FRAME_SIZE) {
+      throw new Error(`daemon frame too large: ${length} bytes`);
+    }
+    if (this.buffer.length < 4 + length) return null;
+    const frame = this.buffer.subarray(4, 4 + length);
+    this.buffer = this.buffer.subarray(4 + length);
+    return frame;
+  }
+}
+
+function cacheDir(): string {
+  if (process.env.XDG_CACHE_HOME) return process.env.XDG_CACHE_HOME;
+  if (process.platform === "darwin") return path.join(os.homedir(), "Library", "Caches");
+  if (process.platform === "win32") {
+    return process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+  }
+  return path.join(os.homedir(), ".cache");
+}
+
+function worktreeHash(repoRoot: string): string {
+  return crypto.createHash("sha256").update(repoRoot).digest("hex").slice(0, 12);
+}
+
+function resolveSocketPath(repoRoot: string): string {
+  if (process.env.RUNTIMED_SOCKET_PATH) return process.env.RUNTIMED_SOCKET_PATH;
+  const namespace = process.env.RUNTIMED_CACHE_NAMESPACE ?? "runt-nightly";
+  return path.join(cacheDir(), namespace, "worktrees", worktreeHash(repoRoot), "runtimed.sock");
+}
+
+function readDaemonInfo(socketPath: string): DaemonInfoJson | null {
+  try {
+    const daemonJson = path.join(path.dirname(socketPath), "daemon.json");
+    return JSON.parse(fs.readFileSync(daemonJson, "utf8")) as DaemonInfoJson;
+  } catch {
+    return null;
+  }
+}
+
+function writeFrame(socket: net.Socket, frame: Buffer | string): void {
+  const payload = Buffer.isBuffer(frame) ? frame : Buffer.from(frame);
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(payload.length, 0);
+  socket.write(header);
+  socket.write(payload);
+}
+
+function writePreamble(socket: net.Socket): void {
+  socket.write(Buffer.from([...MAGIC, PROTOCOL_VERSION]));
+}
+
+function connectSocket(socketPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.once("connect", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, value: unknown): void {
+  const body = JSON.stringify(value);
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Content-Length", Buffer.byteLength(body));
+  res.end(body);
+}
+
+function requestUrl(req: IncomingMessage): URL {
+  return new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+}
+
+function sameOrigin(req: IncomingMessage): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === req.headers.host;
+  } catch {
+    return false;
+  }
+}
+
+function relayHandshake(url: URL, repoRoot: string): Record<string, unknown> {
+  const notebookPath = url.searchParams.get("path");
+  if (notebookPath) {
+    return { channel: "open_notebook", path: notebookPath };
+  }
+
+  const notebookId = url.searchParams.get("notebook_id");
+  const runtime = url.searchParams.get("runtime") ?? "python";
+  const workingDir = url.searchParams.get("working_dir") ?? repoRoot;
+  return {
+    channel: "create_notebook",
+    runtime,
+    working_dir: workingDir,
+    ...(notebookId ? { notebook_id: notebookId } : {}),
+    ephemeral: true,
+  };
+}
+
+function control(ws: WebSocket, value: unknown): void {
+  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(value));
+}
+
+function binaryFromRaw(data: RawData): Buffer | null {
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return null;
+}
+
+async function handleRelayConnection(
+  ws: WebSocket,
+  req: IncomingMessage,
+  repoRoot: string,
+  logger: ViteDevServer["config"]["logger"],
+): Promise<void> {
+  const socketPath = resolveSocketPath(repoRoot);
+  const url = requestUrl(req);
+  let daemon: net.Socket | null = null;
+
+  try {
+    daemon = await connectSocket(socketPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    control(ws, {
+      type: "unavailable",
+      payload: {
+        reason: "daemon_socket_unavailable",
+        message,
+        guidance: "Start the dev daemon with `cargo xtask dev-daemon`.",
+      },
+    });
+    ws.close(1011, "daemon unavailable");
+    return;
+  }
+
+  const frames = new LengthPrefixedFrames();
+  daemon.on("data", (chunk) => {
+    try {
+      frames.push(chunk);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`[browser-relay] ${message}`);
+      ws.close(1011, "daemon frame error");
+      daemon?.destroy();
+    }
+  });
+  daemon.on("error", (err) => {
+    frames.fail(err);
+    control(ws, {
+      type: "unavailable",
+      payload: {
+        reason: "daemon_socket_error",
+        message: err.message,
+        guidance: "Restart the dev daemon with `cargo xtask dev-daemon`.",
+      },
+    });
+    ws.close(1011, "daemon socket error");
+  });
+  daemon.on("close", () => {
+    frames.fail(new Error("daemon socket closed"));
+    control(ws, { type: "disconnected" });
+    ws.close(1011, "daemon socket closed");
+  });
+
+  try {
+    writePreamble(daemon);
+    writeFrame(daemon, JSON.stringify(relayHandshake(url, repoRoot)));
+    const infoFrame = await frames.readFrame();
+    const info = JSON.parse(infoFrame.toString("utf8")) as {
+      notebook_id?: string;
+      cell_count?: number;
+      needs_trust_approval?: boolean;
+      error?: string;
+      ephemeral?: boolean;
+      notebook_path?: string | null;
+      runtime?: string;
+    };
+
+    if (info.error) throw new Error(info.error);
+
+    const daemonInfoJson = readDaemonInfo(socketPath);
+    control(ws, {
+      type: "ready",
+      payload: {
+        notebook_id: info.notebook_id,
+        cell_count: info.cell_count,
+        needs_trust_approval: info.needs_trust_approval,
+        ephemeral: info.ephemeral ?? true,
+        notebook_path: info.notebook_path ?? null,
+        runtime: info.runtime,
+      },
+      blob_port: daemonInfoJson?.blob_port ?? null,
+      daemon: daemonInfoJson
+        ? {
+            version: daemonInfoJson.version ?? "unknown",
+            socket_path: daemonInfoJson.socket_path ?? socketPath,
+            is_dev_mode: daemonInfoJson.is_dev_mode ?? true,
+          }
+        : null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    control(ws, {
+      type: "unavailable",
+      payload: {
+        reason: "notebook_handshake_failed",
+        message,
+        guidance: "Check the dev daemon logs with `./target/debug/runt daemon logs -f`.",
+      },
+    });
+    ws.close(1011, "notebook handshake failed");
+    daemon.destroy();
+    return;
+  }
+
+  frames.pipeTo((frame) => {
+    if (ws.readyState === ws.OPEN) ws.send(frame);
+  });
+
+  ws.on("message", (data, isBinary) => {
+    if (!isBinary || !daemon || daemon.destroyed) return;
+    const frame = binaryFromRaw(data);
+    if (!frame) return;
+    writeFrame(daemon, frame);
+  });
+  ws.on("close", () => daemon?.destroy());
+}
+
+export function browserDevRelayPlugin(options: RelayOptions): Plugin {
+  return {
+    name: "browser-dev-relay",
+    apply: "serve",
+    configureServer(server) {
+      const token = crypto.randomBytes(32).toString("base64url");
+      const wss = new WebSocketServer({ noServer: true });
+
+      server.middlewares.use((req, res, next) => {
+        const url = requestUrl(req);
+        if (url.pathname !== CONFIG_PATH) {
+          next();
+          return;
+        }
+
+        const socketPath = resolveSocketPath(options.repoRoot);
+        const daemonInfo = readDaemonInfo(socketPath);
+        const host = req.headers.host ?? "127.0.0.1";
+        sendJson(res, 200, {
+          websocket_url: `ws://${host}${WS_PATH}`,
+          token,
+          blob_port: daemonInfo?.blob_port ?? null,
+          daemon: daemonInfo
+            ? {
+                version: daemonInfo.version ?? "unknown",
+                socket_path: daemonInfo.socket_path ?? socketPath,
+                is_dev_mode: daemonInfo.is_dev_mode ?? true,
+              }
+            : null,
+        });
+      });
+
+      server.httpServer?.on("upgrade", (req, socket: Socket, head) => {
+        const url = requestUrl(req);
+        if (url.pathname !== WS_PATH) return;
+
+        if (!sameOrigin(req) || url.searchParams.get("token") !== token) {
+          socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+          socket.destroy();
+          return;
+        }
+
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit("connection", ws, req);
+        });
+      });
+
+      wss.on("connection", (ws, req) => {
+        void handleRelayConnection(ws, req, options.repoRoot, server.config.logger);
+      });
+
+      server.httpServer?.once("close", () => wss.close());
+      server.config.logger.info("[browser-relay] dev WebSocket relay enabled");
+    },
+  };
+}

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import { visualizer } from "rollup-plugin-visualizer";
 import { type Plugin, defineConfig } from "vite-plus";
+import { browserDevRelayPlugin } from "./vite-plugin-browser-relay";
 import { isolatedRendererPlugin } from "./vite-plugin-isolated-renderer";
 import { rawLibPlugin } from "./vite-plugin-raw-lib";
 
@@ -47,6 +48,7 @@ export default defineConfig(() => {
       tailwindcss(),
       rawLibPlugin(path.resolve(__dirname, "../../node_modules")),
       isolatedRendererPlugin(),
+      browserDevRelayPlugin({ repoRoot: path.resolve(__dirname, "../..") }),
       subAppTrailingSlashRedirect(["onboarding", "settings", "feedback", "upgrade", "gallery"]),
       visualizer({
         filename: "dist/stats.html",

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./browser": "./src/browser/index.ts",
     "./tauri": "./src/tauri/index.ts"
   },
   "dependencies": {

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -1,0 +1,527 @@
+/**
+ * Browser/dev implementation of `NotebookHost`.
+ *
+ * This host talks to a local Vite-only relay over WebSocket. The relay owns the
+ * daemon Unix-socket connection and exposes the same typed notebook frames that
+ * the Tauri host receives through `notebook:frame`.
+ */
+
+import {
+  FrameType,
+  type FrameListener,
+  type NotebookRequest,
+  type NotebookRequestOptions,
+  type NotebookResponse,
+  type NotebookTransport,
+} from "runtimed";
+import { createCommandRegistry } from "../commands";
+import type {
+  DaemonInfo,
+  DaemonProgressPayload,
+  DaemonReadyPayload,
+  DaemonUnavailablePayload,
+  GitInfo,
+  HostUpdaterState,
+  NotebookHost,
+  TyposquatWarning,
+  Unlisten,
+} from "../types";
+
+const DEFAULT_CONFIG_URL = "/__nteract_dev_relay/config";
+const FRAME_TYPE_REQUEST = 0x01;
+const FRAME_TYPE_RESPONSE = 0x02;
+
+interface BrowserRelayConfig {
+  websocket_url: string;
+  token: string;
+  blob_port: number | null;
+  daemon: DaemonInfo | null;
+}
+
+type BrowserRelayControl =
+  | {
+      type: "ready";
+      payload: DaemonReadyPayload;
+      blob_port?: number | null;
+      daemon?: DaemonInfo | null;
+    }
+  | { type: "progress"; payload: DaemonProgressPayload }
+  | { type: "disconnected" }
+  | { type: "unavailable"; payload: DaemonUnavailablePayload };
+
+export interface CreateBrowserHostOptions {
+  /** Relay config endpoint. Defaults to the Vite dev relay path. */
+  configUrl?: string;
+  /** Test seam. */
+  fetchImpl?: typeof fetch;
+  /** Test seam. */
+  WebSocketImpl?: typeof WebSocket;
+}
+
+interface PendingEntry {
+  resolve: (response: NotebookResponse) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+function requestTimeoutMs(request: NotebookRequest): number {
+  switch (request.type) {
+    case "launch_kernel":
+    case "sync_environment":
+      return 300_000;
+    case "complete":
+      return 7_000;
+    default:
+      return 30_000;
+  }
+}
+
+function addToken(url: string, token: string): string {
+  const resolved = new URL(url, window.location.href);
+  resolved.searchParams.set("token", token);
+
+  // Convenience for manual local debugging:
+  //   /?path=/tmp/foo.ipynb
+  //   /?notebook_id=<uuid>
+  //   /?runtime=deno
+  const pageParams = new URLSearchParams(window.location.search);
+  for (const key of ["path", "notebook_id", "runtime", "working_dir"]) {
+    const value = pageParams.get(key);
+    if (value) resolved.searchParams.set(key, value);
+  }
+
+  return resolved.toString();
+}
+
+async function loadConfig(configUrl: string, fetchImpl: typeof fetch): Promise<BrowserRelayConfig> {
+  const response = await fetchImpl(configUrl, {
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`browser relay config failed: ${response.status}`);
+  }
+  return (await response.json()) as BrowserRelayConfig;
+}
+
+function makeUnavailable(message: string): DaemonUnavailablePayload {
+  return {
+    reason: "browser_relay_unavailable",
+    message,
+    guidance: "Start the dev daemon with `cargo xtask dev-daemon`, then run `cargo xtask vite`.",
+  };
+}
+
+class BrowserDevTransport implements NotebookTransport {
+  private readonly url: string;
+  private readonly WebSocketImpl: typeof WebSocket;
+  private readonly onControl: (control: BrowserRelayControl) => void;
+  private ws: WebSocket | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private subscribers = new Set<FrameListener>();
+  private pending = new Map<string, PendingEntry>();
+  private queuedFrames: number[][] = [];
+  private framesReleased = false;
+  private _connected = false;
+
+  constructor(
+    config: BrowserRelayConfig,
+    WebSocketImpl: typeof WebSocket,
+    onControl: (control: BrowserRelayControl) => void,
+  ) {
+    this.url = addToken(config.websocket_url, config.token);
+    this.WebSocketImpl = WebSocketImpl;
+    this.onControl = onControl;
+  }
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  connect(): Promise<void> {
+    if (
+      this.connectPromise &&
+      this.ws &&
+      (this.ws.readyState === this.WebSocketImpl.CONNECTING ||
+        this.ws.readyState === this.WebSocketImpl.OPEN)
+    ) {
+      return this.connectPromise;
+    }
+
+    this.framesReleased = false;
+    this.queuedFrames = [];
+    this.connectPromise = new Promise((resolve, reject) => {
+      const ws = new this.WebSocketImpl(this.url);
+      ws.binaryType = "arraybuffer";
+      this.ws = ws;
+
+      ws.onopen = () => {
+        this._connected = true;
+        resolve();
+      };
+      ws.onerror = () => {
+        const err = new Error("browser relay WebSocket failed");
+        this.rejectPending(err);
+        reject(err);
+      };
+      ws.onclose = () => {
+        const wasConnected = this._connected;
+        this._connected = false;
+        this.connectPromise = null;
+        this.rejectPending(new Error("browser relay disconnected"));
+        if (wasConnected) this.onControl({ type: "disconnected" });
+      };
+      ws.onmessage = (event) => {
+        void this.handleMessage(event.data).catch((err) => {
+          console.error("[browser-transport] message handling failed:", err);
+        });
+      };
+    });
+
+    return this.connectPromise;
+  }
+
+  releaseFrames(): void {
+    this.framesReleased = true;
+    const queued = this.queuedFrames;
+    this.queuedFrames = [];
+    for (const frame of queued) this.deliver(frame);
+  }
+
+  async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    if (frameType === FrameType.SESSION_CONTROL) {
+      throw new Error("SESSION_CONTROL is server-originated only");
+    }
+    await this.connect();
+    if (!this.ws || this.ws.readyState !== this.WebSocketImpl.OPEN) {
+      throw new Error("browser relay is not connected");
+    }
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = frameType;
+    frame.set(payload, 1);
+    this.ws.send(frame);
+  }
+
+  onFrame(callback: FrameListener): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
+    const req = request as NotebookRequest;
+    const id = crypto.randomUUID();
+    const { type, ...rest } = req as { type: string } & Record<string, unknown>;
+    const envelope = {
+      id,
+      ...(options?.required_heads?.length ? { required_heads: options.required_heads } : {}),
+      action: type,
+      ...rest,
+    };
+    const payload = new TextEncoder().encode(JSON.stringify(envelope));
+    const timeoutMs = requestTimeoutMs(req);
+
+    return new Promise<NotebookResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          reject(new Error(`Request timeout after ${timeoutMs}ms: ${type}`));
+        }
+      }, timeoutMs);
+
+      this.pending.set(id, { resolve, reject, timer });
+      void this.sendFrame(FRAME_TYPE_REQUEST, payload).catch((err) => {
+        if (this.pending.delete(id)) {
+          clearTimeout(timer);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    });
+  }
+
+  disconnect(): void {
+    this._connected = false;
+    this.ws?.close();
+    this.ws = null;
+    this.subscribers.clear();
+    this.queuedFrames = [];
+    this.rejectPending(new Error("browser relay disconnected"));
+  }
+
+  private async handleMessage(data: unknown): Promise<void> {
+    if (typeof data === "string") {
+      this.onControl(JSON.parse(data) as BrowserRelayControl);
+      return;
+    }
+
+    let bytes: Uint8Array;
+    if (data instanceof ArrayBuffer) {
+      bytes = new Uint8Array(data);
+    } else if (ArrayBuffer.isView(data)) {
+      bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    } else if (data instanceof Blob) {
+      bytes = new Uint8Array(await data.arrayBuffer());
+    } else {
+      return;
+    }
+
+    const frame = Array.from(bytes);
+    this.dispatchResponseFrame(frame);
+    if (this.framesReleased) this.deliver(frame);
+    else this.queuedFrames.push(frame);
+  }
+
+  private deliver(frame: number[]): void {
+    for (const cb of this.subscribers) {
+      try {
+        cb(frame);
+      } catch (err) {
+        console.error("[browser-transport] frame subscriber failed:", err);
+      }
+    }
+  }
+
+  private dispatchResponseFrame(bytes: number[]): void {
+    if (bytes[0] !== FRAME_TYPE_RESPONSE) return;
+    const json = new TextDecoder().decode(new Uint8Array(bytes.slice(1)));
+    let envelope: { id?: string } & Record<string, unknown>;
+    try {
+      envelope = JSON.parse(json);
+    } catch {
+      return;
+    }
+    const id = envelope.id;
+    if (typeof id !== "string") return;
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    clearTimeout(entry.timer);
+    const { id: _id, ...response } = envelope;
+    entry.resolve(response as NotebookResponse);
+  }
+
+  private rejectPending(err: Error): void {
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+}
+
+export async function createBrowserHost(
+  opts: CreateBrowserHostOptions = {},
+): Promise<NotebookHost> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const WebSocketImpl = opts.WebSocketImpl ?? WebSocket;
+  let config = await loadConfig(opts.configUrl ?? DEFAULT_CONFIG_URL, fetchImpl);
+  let lastReady: DaemonReadyPayload | null = null;
+  let blobPort = config.blob_port;
+  let daemonInfo = config.daemon;
+
+  const readySubscribers = new Set<(payload: DaemonReadyPayload) => void>();
+  const progressSubscribers = new Set<(payload: DaemonProgressPayload) => void>();
+  const disconnectedSubscribers = new Set<() => void>();
+  const unavailableSubscribers = new Set<(payload: DaemonUnavailablePayload) => void>();
+
+  const emit = <T>(subscribers: Set<(payload: T) => void>, payload: T) => {
+    for (const cb of subscribers) cb(payload);
+  };
+
+  const transport = new BrowserDevTransport(config, WebSocketImpl, (control) => {
+    switch (control.type) {
+      case "ready":
+        lastReady = control.payload;
+        blobPort = control.blob_port ?? blobPort;
+        daemonInfo = control.daemon ?? daemonInfo;
+        emit(readySubscribers, control.payload);
+        break;
+      case "progress":
+        emit(progressSubscribers, control.payload);
+        break;
+      case "disconnected":
+        for (const cb of disconnectedSubscribers) cb();
+        break;
+      case "unavailable":
+        emit(unavailableSubscribers, control.payload);
+        break;
+    }
+  });
+
+  const reconnect = async () => {
+    try {
+      await transport.connect();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      emit(unavailableSubscribers, makeUnavailable(message));
+      throw err;
+    }
+  };
+
+  void reconnect();
+
+  const idleUpdaterState: HostUpdaterState = { status: "idle", version: null, error: null };
+  const commands = createCommandRegistry();
+
+  return {
+    name: "browser",
+    transport,
+    daemon: {
+      async isConnected() {
+        return transport.connected;
+      },
+      reconnect,
+      async getInfo() {
+        return daemonInfo;
+      },
+      async getReadyInfo() {
+        return lastReady;
+      },
+    },
+    daemonEvents: {
+      onReadyLive(cb) {
+        readySubscribers.add(cb);
+        return () => readySubscribers.delete(cb);
+      },
+      onReady(cb) {
+        readySubscribers.add(cb);
+        if (lastReady) queueMicrotask(() => cb(lastReady as DaemonReadyPayload));
+        return () => readySubscribers.delete(cb);
+      },
+      onProgress(cb) {
+        progressSubscribers.add(cb);
+        return () => progressSubscribers.delete(cb);
+      },
+      onDisconnected(cb) {
+        disconnectedSubscribers.add(cb);
+        return () => disconnectedSubscribers.delete(cb);
+      },
+      onUnavailable(cb) {
+        unavailableSubscribers.add(cb);
+        return () => unavailableSubscribers.delete(cb);
+      },
+    },
+    relay: {
+      async notifySyncReady() {
+        transport.releaseFrames();
+      },
+    },
+    blobs: {
+      async port() {
+        if (blobPort !== null) return blobPort;
+        config = await loadConfig(opts.configUrl ?? DEFAULT_CONFIG_URL, fetchImpl);
+        blobPort = config.blob_port;
+        daemonInfo = config.daemon;
+        if (blobPort === null) throw new Error("Blob server not available");
+        return blobPort;
+      },
+    },
+    trust: {
+      async approve(options) {
+        const response = (await transport.sendRequest({
+          type: "approve_trust",
+          ...(options?.observedHeads !== undefined
+            ? { observed_heads: options.observedHeads }
+            : {}),
+        })) as NotebookResponse;
+        if (response.result === "ok") return;
+        if (response.result === "guard_rejected") throw new Error(response.reason);
+        if (response.result === "error") throw new Error(response.error);
+        throw new Error(`Unexpected approve_trust response: ${JSON.stringify(response)}`);
+      },
+    },
+    deps: {
+      async checkTyposquats(_packages: string[]): Promise<TyposquatWarning[]> {
+        return [];
+      },
+    },
+    notebook: {
+      async applyPathChanged() {},
+      async getDefaultSaveDirectory() {
+        return "";
+      },
+      async saveAs() {
+        throw new Error("Save As is not available in the browser dev host");
+      },
+      async openInNewWindow() {
+        throw new Error("Open in new window is not available in the browser dev host");
+      },
+      async cloneToEphemeral() {
+        throw new Error("Clone is not available in the browser dev host");
+      },
+    },
+    window: {
+      async getTitle() {
+        return document.title;
+      },
+      async setTitle(title) {
+        document.title = title;
+      },
+      onFocusChange(cb) {
+        const onFocus = () => cb(true);
+        const onBlur = () => cb(false);
+        window.addEventListener("focus", onFocus);
+        window.addEventListener("blur", onBlur);
+        return () => {
+          window.removeEventListener("focus", onFocus);
+          window.removeEventListener("blur", onBlur);
+        };
+      },
+    },
+    system: {
+      async getGitInfo(): Promise<GitInfo | null> {
+        return null;
+      },
+      async getUsername() {
+        return "browser";
+      },
+    },
+    dialog: {
+      async openFile() {
+        return null;
+      },
+      async saveFile() {
+        return null;
+      },
+    },
+    externalLinks: {
+      async open(url) {
+        window.open(url, "_blank", "noopener,noreferrer");
+      },
+    },
+    updater: {
+      getSnapshot() {
+        return idleUpdaterState;
+      },
+      subscribe(_cb) {
+        return (() => {}) satisfies Unlisten;
+      },
+      async check() {
+        return idleUpdaterState;
+      },
+      async beginUpgrade() {
+        window.location.reload();
+      },
+    },
+    settings: {
+      async openWindow() {
+        window.open("/settings/", "_blank", "noopener,noreferrer");
+      },
+    },
+    commands,
+    log: {
+      debug(message) {
+        console.debug(message);
+      },
+      info(message) {
+        console.info(message);
+      },
+      warn(message) {
+        console.warn(message);
+      },
+      error(message) {
+        console.error(message);
+      },
+    },
+  };
+}

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createBrowserHost } from "../src/browser";
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  sent: Array<Uint8Array> = [];
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  send(data: Uint8Array) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  message(data: unknown) {
+    this.onmessage?.({ data });
+  }
+}
+
+const config = {
+  websocket_url: "ws://127.0.0.1:5174/__nteract_dev_relay/ws",
+  token: "dev-token",
+  blob_port: 48123,
+  daemon: {
+    version: "dev",
+    socket_path: "/tmp/runtimed.sock",
+    is_dev_mode: true,
+  },
+};
+
+function fetchConfig() {
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => config,
+  })) as unknown as typeof fetch;
+}
+
+function textFrame(value: unknown): Uint8Array {
+  const payload = new TextEncoder().encode(JSON.stringify(value));
+  const frame = new Uint8Array(1 + payload.length);
+  frame[0] = 0x02;
+  frame.set(payload, 1);
+  return frame;
+}
+
+describe("createBrowserHost()", () => {
+  it("connects to the dev relay with a token and emits ready", async () => {
+    FakeWebSocket.instances = [];
+    const host = await createBrowserHost({
+      fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toContain("token=dev-token");
+
+    const ready = vi.fn();
+    host.daemonEvents.onReady(ready);
+    ws.open();
+    ws.message(
+      JSON.stringify({
+        type: "ready",
+        payload: { notebook_id: "nb-1", cell_count: 0, ephemeral: true },
+        blob_port: 48124,
+        daemon: config.daemon,
+      }),
+    );
+
+    expect(ready).toHaveBeenCalledWith({ notebook_id: "nb-1", cell_count: 0, ephemeral: true });
+    await expect(host.blobs.port()).resolves.toBe(48124);
+    await expect(host.daemon.getReadyInfo()).resolves.toMatchObject({ notebook_id: "nb-1" });
+  });
+
+  it("buffers daemon frames until the relay is marked ready", async () => {
+    FakeWebSocket.instances = [];
+    const host = await createBrowserHost({
+      fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+
+    const frameListener = vi.fn();
+    host.transport.onFrame(frameListener);
+    ws.message(new Uint8Array([0x00, 1, 2, 3]).buffer);
+    expect(frameListener).not.toHaveBeenCalled();
+
+    await host.relay.notifySyncReady();
+    expect(frameListener).toHaveBeenCalledWith([0x00, 1, 2, 3]);
+  });
+
+  it("sends notebook requests as request frames and resolves response frames", async () => {
+    FakeWebSocket.instances = [];
+    const host = await createBrowserHost({
+      fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+
+    const result = host.transport.sendRequest({ type: "get_history", query: "import" });
+    await Promise.resolve();
+    const sent = ws.sent[0];
+    expect(sent[0]).toBe(0x01);
+    const request = JSON.parse(new TextDecoder().decode(sent.slice(1))) as {
+      id: string;
+      action: string;
+      query: string;
+    };
+    expect(request).toMatchObject({ action: "get_history", query: "import" });
+
+    ws.message(
+      textFrame({
+        id: request.id,
+        result: "ok",
+        entries: [],
+      }).buffer,
+    );
+    await expect(result).resolves.toEqual({ result: "ok", entries: [] });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.5
         version: 19.2.3(@types/react@19.2.14)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
@@ -462,6 +465,9 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.6.1)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   apps/renderer-test:
     dependencies:
@@ -643,7 +649,7 @@ importers:
     devDependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.73.0
-        version: 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        version: 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.73.0
         version: 0.73.0
@@ -9332,6 +9338,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -10848,9 +10866,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       typebox: 1.1.34
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -10861,14 +10879,14 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1038.0
       '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.34
@@ -10883,11 +10901,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.73.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -17417,9 +17435,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.26.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.26.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.20.0
       zod: 4.3.6
 
   ora@5.4.1:
@@ -19721,6 +19739,8 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.19.0: {}
+
+  ws@8.20.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -1,6 +1,6 @@
 # Isolated output frame — security model and renderers
 
-Untrusted cell outputs render inside a sandboxed iframe loaded from a `blob:` URL. The iframe's opaque origin prevents Tauri IPC injection, and the sandbox attribute list is the primary defense against malicious JavaScript in outputs.
+Untrusted cell outputs render inside a sandboxed iframe. Tauri loads the iframe from a `blob:` URL so the opaque origin prevents Tauri IPC injection. The plain browser dev host uses `srcDoc` because Chrome rejects this sandboxed `blob:` navigation from localhost; the sandbox attribute list remains the primary defense against malicious JavaScript in outputs.
 
 Scope: `src/components/isolated/**`, `src/isolated-renderer/**`.
 
@@ -18,7 +18,7 @@ Fullscreen (sift maximize, maps, 3D) comes from the separate `allowFullScreen` i
 
 ### Blob URL origin
 
-Generate HTML with `generateFrameHtml({ darkMode })`, wrap it in a `Blob`, and mount with `URL.createObjectURL`. Blob URLs produce a unique opaque origin (shown as `"null"`), so Tauri's IPC bridge doesn't inject into the iframe.
+In Tauri, generate HTML with `generateFrameHtml({ darkMode })`, wrap it in a `Blob`, and mount with `URL.createObjectURL`. Blob URLs produce a unique opaque origin (shown as `"null"`), so Tauri's IPC bridge doesn't inject into the iframe. In the browser dev host, mount the same generated HTML with `srcDoc`; do not add `allow-same-origin`.
 
 ### Content Security Policy
 
@@ -66,7 +66,7 @@ The iframe's message handler rejects anything whose `event.source !== window.par
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | Manages blob URL lifecycle, exposes `installRenderer()` |
+| `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | Manages iframe document lifecycle, exposes `installRenderer()` |
 | `CommBridgeManager` | `src/components/isolated/comm-bridge-manager.ts` | Parent-side widget state sync |
 | `jsonrpc-transport.ts` | `src/components/isolated/jsonrpc-transport.ts` | JSON-RPC 2.0 transport over `postMessage` |
 | `rpc-methods.ts` | `src/components/isolated/rpc-methods.ts` | Shared widget-bridge method constants |

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../jsonrpc-transport", () => ({
 
 vi.mock("../frame-html", () => ({
   createFrameBlobUrl: vi.fn(() => "blob:isolated-frame-test"),
+  generateFrameHtml: vi.fn(() => "<!DOCTYPE html><html><body></body></html>"),
 }));
 
 vi.mock("../isolated-renderer-context", () => ({
@@ -122,5 +123,13 @@ describe("IsolatedFrame theme updates", () => {
     const iframe = container.querySelector("iframe") as HTMLIFrameElement;
 
     expect(iframe.style.pointerEvents).toBe("none");
+  });
+
+  it("uses srcdoc in a non-Tauri browser runtime", () => {
+    const { container } = render(<IsolatedFrame darkMode={false} />);
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    expect(iframe.getAttribute("srcdoc")).toContain("<!DOCTYPE html>");
+    expect(iframe.getAttribute("src")).toBeNull();
   });
 });

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
 import { isIframeMessage } from "./frame-bridge";
-import { createFrameBlobUrl } from "./frame-html";
+import { createFrameBlobUrl, generateFrameHtml } from "./frame-html";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
 import { JsonRpcTransport } from "./jsonrpc-transport";
 import {
@@ -248,6 +248,16 @@ const SANDBOX_ATTRS = [
   // separate `allowFullScreen` iframe attribute (not a sandbox flag).
 ].join(" ");
 
+type FrameDocument = { kind: "blob"; url: string } | { kind: "srcdoc"; html: string };
+
+function isTauriRuntime(): boolean {
+  const globalWindow = window as Window & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
+}
+
 /**
  * IsolatedFrame component - Renders untrusted content in a secure iframe.
  *
@@ -314,7 +324,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     } = useIsolatedRenderer();
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const rpcRef = useRef<JsonRpcTransport | null>(null);
-    const [blobUrl, setBlobUrl] = useState<string | null>(null);
+    const [frameDocument, setFrameDocument] = useState<FrameDocument | null>(null);
     // Track iframe ready (bootstrap HTML loaded)
     const [isIframeReady, setIsIframeReady] = useState(false);
     // Track renderer ready (React bundle initialized)
@@ -380,13 +390,23 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       applyMeasuredHeight(measuredHeightRef.current);
     }, [applyMeasuredHeight]);
 
-    // Create blob URL on mount (only once, with initial darkMode)
+    // Create frame document on mount (only once, with initial darkMode).
+    // Tauri keeps the blob URL path so the iframe has an opaque origin and
+    // the Tauri IPC bridge does not inject. The plain browser host uses
+    // srcDoc because Chrome rejects sandboxed blob: navigations from localhost.
     useEffect(() => {
-      const url = createFrameBlobUrl({
+      const frameOptions = {
         darkMode: initialDarkModeRef.current,
         colorTheme: initialColorThemeRef.current,
-      });
-      setBlobUrl(url);
+      };
+
+      if (!isTauriRuntime()) {
+        setFrameDocument({ kind: "srcdoc", html: generateFrameHtml(frameOptions) });
+        return;
+      }
+
+      const url = createFrameBlobUrl(frameOptions);
+      setFrameDocument({ kind: "blob", url });
 
       return () => {
         URL.revokeObjectURL(url);
@@ -784,7 +804,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       [send, isReady, isIframeReady],
     );
 
-    if (!blobUrl) {
+    if (!frameDocument) {
       return null;
     }
 
@@ -796,7 +816,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       <iframe
         ref={iframeRef}
         id={id}
-        src={blobUrl}
+        src={frameDocument.kind === "blob" ? frameDocument.url : undefined}
+        srcDoc={frameDocument.kind === "srcdoc" ? frameDocument.html : undefined}
         sandbox={SANDBOX_ATTRS}
         allowFullScreen
         allow="fullscreen *"

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -1,12 +1,38 @@
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import type { Theme } from "@tauri-apps/api/window";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useState } from "react";
 import type { ColorTheme, PythonEnvType, Runtime, SyncedSettings, ThemeMode } from "@/bindings";
 
 // Re-export generated types so consumers can import from this module.
 export type { ColorTheme, ThemeMode, Runtime, PythonEnvType };
+
+type NativeTheme = "light" | "dark" | null;
+type Unlisten = () => void;
+
+function isTauriRuntime(): boolean {
+  const globalWindow = window as Window & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
+}
+
+async function invokeTauri<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (!isTauriRuntime()) {
+    throw new Error("Tauri runtime unavailable");
+  }
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(command, args);
+}
+
+async function listenTauri<T>(
+  eventName: string,
+  handler: (event: { payload: T }) => void,
+): Promise<Unlisten> {
+  if (!isTauriRuntime()) {
+    return () => {};
+  }
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen<T>(eventName, handler);
+}
 
 function isValidColorTheme(value: string): value is ColorTheme {
   return value === "classic" || value === "cream";
@@ -50,11 +76,21 @@ function applyThemeToDOM(resolved: "light" | "dark") {
 
 async function syncNativeWindowTheme(theme: ThemeMode): Promise<void> {
   try {
-    const tauriTheme: Theme | null = theme === "system" ? null : theme;
+    if (!isTauriRuntime()) return;
+    const tauriTheme: NativeTheme = theme === "system" ? null : theme;
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
     await getCurrentWindow().setTheme(tauriTheme);
   } catch {
     // Silently fail if not in Tauri context
   }
+}
+
+function persistSyncedSetting(key: string, value: unknown, warning: string): void {
+  invokeTauri("set_synced_setting", { key, value }).catch((e) => {
+    if (isTauriRuntime()) {
+      console.warn(warning, e);
+    }
+  });
 }
 
 function isValidTheme(value: string): value is ThemeMode {
@@ -169,7 +205,7 @@ export function useSyncedSettings() {
 
   // Load initial settings from daemon
   useEffect(() => {
-    invoke<SyncedSettings>("get_synced_settings")
+    invokeTauri<SyncedSettings>("get_synced_settings")
       .then((settings) => {
         if (isValidTheme(settings.theme)) {
           setThemeState(settings.theme);
@@ -230,7 +266,7 @@ export function useSyncedSettings() {
 
   // Listen for cross-window settings changes via Tauri events
   useEffect(() => {
-    const unlisten = listen<SyncedSettings>("settings:changed", (event) => {
+    const unlisten = listenTauri<SyncedSettings>("settings:changed", (event) => {
       const {
         theme: newTheme,
         color_theme: newColorTheme,
@@ -290,102 +326,92 @@ export function useSyncedSettings() {
   const setTheme = useCallback((newTheme: ThemeMode) => {
     setThemeState(newTheme);
     setStoredTheme(newTheme);
-    invoke("set_synced_setting", { key: "theme", value: newTheme }).catch((e) =>
-      console.warn("[settings] Failed to persist theme:", e),
-    );
+    persistSyncedSetting("theme", newTheme, "[settings] Failed to persist theme:");
   }, []);
 
   const setColorTheme = useCallback((newColorTheme: ColorTheme) => {
     setColorThemeState(newColorTheme);
     setStoredColorTheme(newColorTheme);
-    invoke("set_synced_setting", { key: "color_theme", value: newColorTheme }).catch((e) =>
-      console.warn("[settings] Failed to persist color theme:", e),
-    );
+    persistSyncedSetting("color_theme", newColorTheme, "[settings] Failed to persist color theme:");
   }, []);
 
   const setDefaultRuntime = useCallback((newRuntime: string) => {
     setDefaultRuntimeState(newRuntime);
-    invoke("set_synced_setting", {
-      key: "default_runtime",
-      value: newRuntime,
-    }).catch((e) => console.warn("[settings] Failed to persist runtime:", e));
+    persistSyncedSetting("default_runtime", newRuntime, "[settings] Failed to persist runtime:");
   }, []);
 
   const setDefaultPythonEnv = useCallback((newEnv: string) => {
     setDefaultPythonEnvState(newEnv);
-    invoke("set_synced_setting", {
-      key: "default_python_env",
-      value: newEnv,
-    }).catch((e) => console.warn("[settings] Failed to persist python env:", e));
+    persistSyncedSetting("default_python_env", newEnv, "[settings] Failed to persist python env:");
   }, []);
 
   const setDefaultUvPackages = useCallback((packages: string[]) => {
     setDefaultUvPackagesState(packages);
-    invoke("set_synced_setting", {
-      key: "uv.default_packages",
-      value: packages,
-    }).catch((e) => console.warn("[settings] Failed to persist uv packages:", e));
+    persistSyncedSetting(
+      "uv.default_packages",
+      packages,
+      "[settings] Failed to persist uv packages:",
+    );
   }, []);
 
   const setDefaultCondaPackages = useCallback((packages: string[]) => {
     setDefaultCondaPackagesState(packages);
-    invoke("set_synced_setting", {
-      key: "conda.default_packages",
-      value: packages,
-    }).catch((e) => console.warn("[settings] Failed to persist conda packages:", e));
+    persistSyncedSetting(
+      "conda.default_packages",
+      packages,
+      "[settings] Failed to persist conda packages:",
+    );
   }, []);
 
   const setDefaultPixiPackages = useCallback((packages: string[]) => {
     setDefaultPixiPackagesState(packages);
-    invoke("set_synced_setting", {
-      key: "pixi.default_packages",
-      value: packages,
-    }).catch((e) => console.warn("[settings] Failed to persist pixi packages:", e));
+    persistSyncedSetting(
+      "pixi.default_packages",
+      packages,
+      "[settings] Failed to persist pixi packages:",
+    );
   }, []);
 
   const setInstallDefaultDataPackages = useCallback((enabled: boolean) => {
     setInstallDefaultDataPackagesState(enabled);
-    invoke("set_synced_setting", {
-      key: "install_default_data_packages",
-      value: enabled,
-    }).catch((e) => console.warn("[settings] Failed to persist install_default_data_packages:", e));
+    persistSyncedSetting(
+      "install_default_data_packages",
+      enabled,
+      "[settings] Failed to persist install_default_data_packages:",
+    );
   }, []);
 
   const setKeepAliveSecs = useCallback((secs: number) => {
     setKeepAliveSecsState(secs);
-    invoke("set_synced_setting", {
-      key: "keep_alive_secs",
-      value: secs,
-    }).catch((e) => console.warn("[settings] Failed to persist keep_alive_secs:", e));
+    persistSyncedSetting("keep_alive_secs", secs, "[settings] Failed to persist keep_alive_secs:");
   }, []);
 
   const setFeatureFlag = useCallback((id: FeatureFlagId, enabled: boolean) => {
     setFeatureFlagsState((prev) => ({ ...prev, [id]: enabled }));
-    invoke("set_synced_setting", {
-      key: id,
-      value: enabled,
-    }).catch((e) => console.warn(`[settings] Failed to persist ${id}:`, e));
+    persistSyncedSetting(id, enabled, `[settings] Failed to persist ${id}:`);
   }, []);
 
   const setTelemetryEnabled = useCallback((value: boolean) => {
     setTelemetryEnabledState(value);
-    invoke("set_synced_setting", {
-      key: "telemetry_enabled",
+    persistSyncedSetting(
+      "telemetry_enabled",
       value,
-    }).catch((e) => console.warn("[settings] Failed to persist telemetry_enabled:", e));
+      "[settings] Failed to persist telemetry_enabled:",
+    );
   }, []);
 
   const setTelemetryConsentRecorded = useCallback((value: boolean) => {
     setTelemetryConsentRecordedState(value);
-    invoke("set_synced_setting", {
-      key: "telemetry_consent_recorded",
+    persistSyncedSetting(
+      "telemetry_consent_recorded",
       value,
-    }).catch((e) => console.warn("[settings] Failed to persist telemetry_consent_recorded:", e));
+      "[settings] Failed to persist telemetry_consent_recorded:",
+    );
   }, []);
 
   const rotateInstallId = useCallback(async (): Promise<string | null> => {
     try {
-      const newId = await invoke<string>("rotate_install_id");
+      const newId = await invokeTauri<string>("rotate_install_id");
       setInstallIdState(newId);
       setLastDaemonPingAtState(null);
       setLastAppPingAtState(null);

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,8 +1,15 @@
-import type { Theme } from "@tauri-apps/api/window";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useState } from "react";
 
 export type ThemeMode = "light" | "dark" | "system";
+type NativeTheme = "light" | "dark" | null;
+
+function isTauriRuntime(): boolean {
+  const globalWindow = window as Window & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
+}
 
 function getStoredTheme(storageKey: string): ThemeMode {
   try {
@@ -41,7 +48,9 @@ function applyThemeToDOM(resolved: "light" | "dark") {
  */
 async function syncNativeWindowTheme(theme: ThemeMode): Promise<void> {
   try {
-    const tauriTheme: Theme | null = theme === "system" ? null : theme;
+    if (!isTauriRuntime()) return;
+    const tauriTheme: NativeTheme = theme === "system" ? null : theme;
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
     await getCurrentWindow().setTheme(tauriTheme);
   } catch {
     // Silently fail if not in Tauri context (e.g., dev server in browser)


### PR DESCRIPTION
## Summary

- add a browser `NotebookHost` implementation backed by a dev-only WebSocket transport
- add a Vite dev relay that token-gates WebSocket upgrades, performs the daemon `CreateNotebook` / `OpenNotebook` handshake, and pipes typed notebook frames as binary WebSocket messages
- switch notebook boot to choose Tauri vs. browser host dynamically so normal browser loads do not import Tauri modules up front
- make shared settings/theme hooks browser-tolerant by lazily importing Tauri APIs only when Tauri globals exist
- render isolated output frames with `srcDoc` in the plain browser host while preserving the existing blob URL path in Tauri
- load the history search dialog with `CodeCell` instead of a `React.lazy` dynamic import so Ctrl-R cannot fail by fetching a dev-only module URL

## Notes

The dev relay is intentionally local/Vite-only. It generates a per-server token, exposes that token only through the same-origin config endpoint, rejects WebSocket upgrades without the token, and also checks the WebSocket `Origin` host.

Default browser behavior creates an ephemeral Python notebook in the current repo worktree. For manual debugging, the page query can pass `path`, `notebook_id`, `runtime`, or `working_dir`.

Tauri still uses blob-backed isolated output frames to avoid IPC injection. The browser dev host uses the same generated iframe HTML through `srcDoc` because Chrome rejects the sandboxed `blob:http://localhost` navigation in a normal browser page. The iframe sandbox remains unchanged and still excludes `allow-same-origin`.

## Verification

- `pnpm test:run packages/notebook-host/tests/browser-host.test.ts packages/notebook-host/tests/tauri-host.test.ts`
- `pnpm test:run src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/frame-html.test.ts packages/notebook-host/tests/browser-host.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `git diff --check`
- Vite relay smoke without daemon: config endpoint returns a nontrivial token, unauthenticated WebSocket upgrades return `401`, authenticated WebSocket clients receive structured `daemon_socket_unavailable`
- Vite relay smoke with `cargo xtask dev-daemon`: config endpoint reports a real blob port and tokenized WebSocket receives a `ready` control message with a generated notebook id
- Browser smoke at `http://[::1]:5174/?runtime=python`: app loaded with no Tauri `transformCallback` errors, executing `print("hey")` created sandboxed output iframes with `srcdoc` and no `blob:http` / local-resource load errors
- Dev transform check: `CodeCell.tsx` now statically imports `HistorySearchDialog`; there is no `import("./HistorySearchDialog")` lazy fetch path

