### PR TITLE
refactor(notebook): route blobs through host resolver

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -51,7 +51,7 @@ import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
-import { getBlobPort, useBlobPort } from "./lib/blob-port";
+import { getBlobResolver, useBlobPort } from "./lib/blob-port";
 import { useRuntimeState } from "./lib/runtime-state";
 import {
   flushCellUIState,
@@ -129,14 +129,14 @@ function resolveCommOutputs(
   outputs: unknown[],
   store: import("@/components/widgets/widget-store").WidgetStore,
 ): void {
-  const port = getBlobPort();
-  if (port === null) return;
+  const blobResolver = getBlobResolver();
+  if (blobResolver === null) return;
 
   const gen = (_outputResolveGen.get(commId) ?? 0) + 1;
   _outputResolveGen.set(commId, gen);
 
   void (async () => {
-    const resolved = await Promise.all(outputs.map((o) => resolveOutputValue(o, port)));
+    const resolved = await Promise.all(outputs.map((o) => resolveOutputValue(o, blobResolver)));
     if (_outputResolveGen.get(commId) !== gen) return;
 
     const resolvedOutputs = resolved.filter((o): o is JupyterOutput => o !== null);

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -22,7 +22,7 @@ import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
-import { useBlobPort } from "../lib/blob-port";
+import { useBlobResolver } from "../lib/blob-port";
 import {
   useIsCellFocused,
   useIsNextCellFromFocused,
@@ -207,7 +207,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const colorThemeRef = useRef(colorTheme);
   colorThemeRef.current = colorTheme;
 
-  const blobPort = useBlobPort();
+  const blobResolver = useBlobResolver();
 
   const handleDoubleClick = useCallback(() => {
     setEditing(true);
@@ -254,14 +254,18 @@ export const MarkdownCell = memo(function MarkdownCell({
     injectedLibsRef.current.clear();
     // Inject markdown renderer plugin before rendering (idempotent, cached after first load)
     await injectPluginsForMimes(frameRef.current, ["text/markdown"], injectedLibsRef.current);
-    const processedSource = rewriteMarkdownAssetRefs(cell.source, cell.resolvedAssets, blobPort);
+    const processedSource = rewriteMarkdownAssetRefs(
+      cell.source,
+      cell.resolvedAssets,
+      blobResolver,
+    );
     frameRef.current.render({
       mimeType: "text/markdown",
       data: processedSource,
       cellId: cell.id,
       replace: true,
     });
-  }, [cell.source, cell.id, cell.resolvedAssets, blobPort]);
+  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver]);
 
   // Sync markdown to iframe whenever source or resolved assets change (supports RTC updates)
   useEffect(() => {
@@ -272,7 +276,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         const processedSource = rewriteMarkdownAssetRefs(
           cell.source,
           cell.resolvedAssets,
-          blobPort,
+          blobResolver,
         );
         frame.render({
           mimeType: "text/markdown",
@@ -282,7 +286,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         });
       });
     }
-  }, [cell.source, cell.id, cell.resolvedAssets, blobPort]);
+  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver]);
 
   // Handle link clicks from iframe - open in system browser
   const handleLinkClick = useCallback((url: string) => {

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -107,6 +107,7 @@ vi.mock("../../hooks/useCrdtBridge", () => ({
 }));
 
 vi.mock("../../lib/blob-port", () => ({
+  useBlobResolver: () => null,
   useBlobPort: () => null,
 }));
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -11,7 +11,12 @@ import {
 } from "runtimed";
 import { concatMap, from, Observable, switchMap } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
-import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
+import {
+  getBlobPort,
+  getBlobResolver,
+  refreshBlobPort,
+  refreshBlobResolver,
+} from "../lib/blob-port";
 import { materializeChangeset } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
 import {
@@ -131,10 +136,11 @@ export function useAutomergeNotebook() {
     const start = performance.now();
     // Resolve blob port BEFORE reading cells — WASM needs it to
     // convert binary ContentRefs to Url variants in get_cells_json().
-    let blobPort = getBlobPort();
-    if (blobPort === null) {
-      blobPort = await refreshBlobPort();
+    let blobResolver = getBlobResolver();
+    if (blobResolver === null) {
+      blobResolver = await refreshBlobResolver();
     }
+    const blobPort = blobResolver?.port ?? null;
     if (blobPort !== null) {
       handle.set_blob_port(blobPort);
     }
@@ -142,7 +148,7 @@ export function useAutomergeNotebook() {
     const snapshots: CellSnapshot[] = JSON.parse(json);
     const newCells = await cellSnapshotsToNotebookCells(
       snapshots,
-      blobPort,
+      blobResolver,
       outputCacheRef.current,
     );
     // Pre-warm plugin cache from output MIME types so iframe rendering
@@ -173,7 +179,7 @@ export function useAutomergeNotebook() {
     const newCells = cellSnapshotsToNotebookCellsSync(
       snapshots,
       outputCacheRef.current,
-      getBlobPort(),
+      getBlobResolver(),
     );
     replaceNotebookCells(newCells);
   }, []);

--- a/apps/notebook/src/hooks/useManifestResolver.ts
+++ b/apps/notebook/src/hooks/useManifestResolver.ts
@@ -1,3 +1,4 @@
+import type { HostBlobResolver } from "@nteract/notebook-host";
 import { logger } from "../lib/logger";
 import { isOutputManifest, type OutputManifest, resolveManifest } from "../lib/manifest-resolution";
 import type { JupyterOutput } from "../types";
@@ -17,12 +18,12 @@ import type { JupyterOutput } from "../types";
  */
 export async function resolveOutputValue(
   output: unknown,
-  blobPort: number,
+  blobResolver: HostBlobResolver,
 ): Promise<JupyterOutput | null> {
   // Structured manifest from WASM — resolve ContentRefs (inline + blob)
   if (isOutputManifest(output)) {
     try {
-      return await resolveManifest(output as OutputManifest, blobPort);
+      return await resolveManifest(output as OutputManifest, blobResolver);
     } catch (e) {
       logger.warn("[manifest-resolver] Failed to resolve manifest:", e);
       return null;
@@ -40,7 +41,7 @@ export async function resolveOutputValue(
       const parsed = JSON.parse(output);
       if (isOutputManifest(parsed)) {
         try {
-          return await resolveManifest(parsed as OutputManifest, blobPort);
+          return await resolveManifest(parsed as OutputManifest, blobResolver);
         } catch (e) {
           logger.warn("[manifest-resolver] Failed to resolve parsed manifest:", e);
           return null;

--- a/apps/notebook/src/lib/__tests__/blob-port.test.ts
+++ b/apps/notebook/src/lib/__tests__/blob-port.test.ts
@@ -4,19 +4,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   _testGetGeneration,
   _testReset,
+  getBlobResolver,
   getBlobPort,
   refreshBlobPort,
   resetBlobPort,
   setBlobPortHost,
 } from "../blob-port";
 
-const mockPort = vi.fn();
+const mockResolver = vi.fn();
 
-/** Minimal host stub: only `blobs.port()` is exercised. */
+function resolverFor(port: number) {
+  return {
+    port,
+    url: ({ blob }: { blob: string }) => `http://127.0.0.1:${port}/blob/${blob}`,
+    fetch: vi.fn(),
+  };
+}
+
+/** Minimal host stub: only `blobs.resolver()` is exercised. */
 function makeHost(): NotebookHost {
   return {
     name: "test",
-    blobs: { port: mockPort },
+    blobs: {
+      port: async () => (await mockResolver()).port,
+      resolver: mockResolver,
+    },
   } as unknown as NotebookHost;
 }
 
@@ -26,24 +38,26 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  mockPort.mockReset();
+  mockResolver.mockReset();
   setBlobPortHost(null);
 });
 
 describe("blob-port store", () => {
   it("starts with null", () => {
     expect(getBlobPort()).toBeNull();
+    expect(getBlobResolver()).toBeNull();
   });
 
   it("refreshBlobPort fetches and caches the port", async () => {
-    mockPort.mockResolvedValueOnce(12345);
+    mockResolver.mockResolvedValueOnce(resolverFor(12345));
     const port = await refreshBlobPort();
     expect(port).toBe(12345);
     expect(getBlobPort()).toBe(12345);
+    expect(getBlobResolver()?.url({ blob: "abc" })).toBe("http://127.0.0.1:12345/blob/abc");
   });
 
   it("deduplicates concurrent refresh calls", async () => {
-    mockPort.mockResolvedValueOnce(9999);
+    mockResolver.mockResolvedValueOnce(resolverFor(9999));
     const [a, b, c] = await Promise.all([
       refreshBlobPort(),
       refreshBlobPort(),
@@ -52,16 +66,17 @@ describe("blob-port store", () => {
     expect(a).toBe(9999);
     expect(b).toBe(9999);
     expect(c).toBe(9999);
-    expect(mockPort).toHaveBeenCalledTimes(1);
+    expect(mockResolver).toHaveBeenCalledTimes(1);
   });
 
   it("resetBlobPort clears the port", async () => {
-    mockPort.mockResolvedValueOnce(12345);
+    mockResolver.mockResolvedValueOnce(resolverFor(12345));
     await refreshBlobPort();
     expect(getBlobPort()).toBe(12345);
 
     resetBlobPort();
     expect(getBlobPort()).toBeNull();
+    expect(getBlobResolver()).toBeNull();
   });
 
   it("resetBlobPort increments generation", () => {
@@ -71,9 +86,9 @@ describe("blob-port store", () => {
   });
 
   it("discards stale refresh after reset", async () => {
-    let resolveFetch: (v: number) => void;
-    mockPort.mockReturnValueOnce(
-      new Promise<number>((r) => {
+    let resolveFetch: (v: ReturnType<typeof resolverFor>) => void;
+    mockResolver.mockReturnValueOnce(
+      new Promise<ReturnType<typeof resolverFor>>((r) => {
         resolveFetch = r;
       }),
     );
@@ -83,32 +98,32 @@ describe("blob-port store", () => {
     resetBlobPort();
     expect(getBlobPort()).toBeNull();
 
-    resolveFetch!(54321);
+    resolveFetch!(resolverFor(54321));
     await refreshPromise;
 
     expect(getBlobPort()).toBeNull();
   });
 
   it("retries on failure", async () => {
-    mockPort
+    mockResolver
       .mockRejectedValueOnce(new Error("not ready"))
       .mockRejectedValueOnce(new Error("not ready"))
-      .mockResolvedValueOnce(7777);
+      .mockResolvedValueOnce(resolverFor(7777));
 
     const port = await refreshBlobPort();
     expect(port).toBe(7777);
-    expect(mockPort).toHaveBeenCalledTimes(3);
+    expect(mockResolver).toHaveBeenCalledTimes(3);
   });
 
   it("allows fresh refresh after reset", async () => {
-    mockPort.mockResolvedValueOnce(1111);
+    mockResolver.mockResolvedValueOnce(resolverFor(1111));
     await refreshBlobPort();
     expect(getBlobPort()).toBe(1111);
 
     resetBlobPort();
     expect(getBlobPort()).toBeNull();
 
-    mockPort.mockResolvedValueOnce(2222);
+    mockResolver.mockResolvedValueOnce(resolverFor(2222));
     await refreshBlobPort();
     expect(getBlobPort()).toBe(2222);
   });

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -33,6 +33,7 @@ vi.mock("../notebook-metadata", () => ({
 }));
 
 vi.mock("../blob-port", () => ({
+  getBlobResolver: () => null,
   getBlobPort: () => 12345,
   refreshBlobPort: () => Promise.resolve(12345),
 }));

--- a/apps/notebook/src/lib/blob-port.ts
+++ b/apps/notebook/src/lib/blob-port.ts
@@ -1,13 +1,13 @@
-import type { NotebookHost } from "@nteract/notebook-host";
+import type { HostBlobResolver, NotebookHost } from "@nteract/notebook-host";
 import { useSyncExternalStore } from "react";
 import { logger } from "./logger";
 
 // ---------------------------------------------------------------------------
-// Blob port store — single source of truth for the daemon's blob server port.
+// Blob resolver store — single source of truth for host-owned blob access.
 //
-// The blob port is set once on daemon connect and only changes on reconnect.
-// All consumers read synchronously from this store instead of re-awaiting
-// a promise on every access.
+// The resolver is set once on daemon connect and only changes on reconnect.
+// All consumers read synchronously from this store instead of reconstructing
+// daemon-local URLs at each call site.
 //
 // Usage:
 //   - React components: `const port = useBlobPort()`
@@ -16,7 +16,8 @@ import { logger } from "./logger";
 // ---------------------------------------------------------------------------
 
 let _blobPort: number | null = null;
-let _refreshPromise: Promise<number | null> | null = null;
+let _blobResolver: HostBlobResolver | null = null;
+let _refreshPromise: Promise<HostBlobResolver | null> | null = null;
 
 // Generation counter — incremented on every reset. Refresh results from
 // a previous generation are discarded to prevent a stale port from a
@@ -25,10 +26,10 @@ let _generation = 0;
 
 const _subscribers = new Set<() => void>();
 
-// Module-level host reference for fetching the blob port. Wired at boot
+// Module-level host reference for fetching the blob resolver. Wired at boot
 // by main.tsx via `setBlobPortHost(host)`. Kept as a reference so the
-// module doesn't reach for Tauri directly; any host implementation
-// (Tauri, Electron, future browser) provides `host.blobs.port()`.
+// module doesn't reach for Tauri directly; any host implementation provides
+// `host.blobs.resolver()`.
 let _host: NotebookHost | null = null;
 
 /** Install the `NotebookHost` this module fetches the blob port from. */
@@ -61,15 +62,23 @@ export function getBlobPort(): number | null {
 }
 
 /**
- * Fetch the blob port from the daemon and update the store.
+ * Get the current host-owned blob resolver synchronously. Returns `null` if
+ * not yet resolved.
+ */
+export function getBlobResolver(): HostBlobResolver | null {
+  return _blobResolver;
+}
+
+/**
+ * Fetch the blob resolver from the host and update the store.
  *
  * Call on initial connect and on `daemon:ready` / reconnect events.
  * Deduplicates concurrent calls — only one IPC request in flight at a time.
  * If `resetBlobPort()` is called while a refresh is in flight, the stale
  * result is discarded (generation counter check).
- * Returns the resolved port (or null on failure).
+ * Returns the resolved host blob accessor (or null on failure).
  */
-export async function refreshBlobPort(): Promise<number | null> {
+export async function refreshBlobResolver(): Promise<HostBlobResolver | null> {
   if (_refreshPromise) return _refreshPromise;
 
   const gen = _generation;
@@ -79,20 +88,21 @@ export async function refreshBlobPort(): Promise<number | null> {
     // after daemon startup.
     for (let attempt = 1; attempt <= 5; attempt++) {
       // Bail early if a reset occurred while we were retrying.
-      if (_generation !== gen) return _blobPort;
+      if (_generation !== gen) return _blobResolver;
 
       try {
         if (!_host) {
           throw new Error("blob-port: no NotebookHost configured — call setBlobPortHost at boot");
         }
-        const port = await _host.blobs.port();
+        const resolver = await _host.blobs.resolver();
 
         // Discard result if a reset happened since we started.
-        if (_generation !== gen) return _blobPort;
+        if (_generation !== gen) return _blobResolver;
 
-        _blobPort = port;
+        _blobResolver = resolver;
+        _blobPort = resolver.port ?? null;
         emit();
-        return port;
+        return resolver;
       } catch (e) {
         if (attempt < 5) {
           await new Promise((r) => setTimeout(r, 500));
@@ -119,6 +129,14 @@ export async function refreshBlobPort(): Promise<number | null> {
 }
 
 /**
+ * Fetch the blob resolver and return its compatibility port for the WASM
+ * bridge. New frontend call sites should prefer `refreshBlobResolver()`.
+ */
+export async function refreshBlobPort(): Promise<number | null> {
+  return (await refreshBlobResolver())?.port ?? null;
+}
+
+/**
  * Reset the blob port (e.g., on daemon disconnect). Forces the next
  * `refreshBlobPort()` call to fetch fresh. Any in-flight refresh from
  * a prior generation will be discarded when it resolves.
@@ -126,6 +144,7 @@ export async function refreshBlobPort(): Promise<number | null> {
 export function resetBlobPort(): void {
   _generation++;
   _blobPort = null;
+  _blobResolver = null;
   _refreshPromise = null;
   emit();
 }
@@ -138,6 +157,10 @@ export function useBlobPort(): number | null {
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
+export function useBlobResolver(): HostBlobResolver | null {
+  return useSyncExternalStore(subscribe, getBlobResolver);
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers — only exported for unit tests
 // ---------------------------------------------------------------------------
@@ -145,6 +168,7 @@ export function useBlobPort(): number | null {
 /** @internal Reset all state for test isolation. */
 export function _testReset(): void {
   _blobPort = null;
+  _blobResolver = null;
   _refreshPromise = null;
   _generation = 0;
   _subscribers.clear();

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -13,7 +13,7 @@ import {
 import { isDisplayCapableJupyterOutputType, planCellChangesetProjection } from "runtimed";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-import { getBlobPort } from "./blob-port";
+import { getBlobResolver } from "./blob-port";
 import type { CellChangeset } from "./cell-changeset";
 import { logger } from "./logger";
 import { materializeCellFromWasm } from "./materialize-cells";
@@ -119,7 +119,7 @@ export async function materializeChangeset(
   // ── Per-cell incremental materialization ───────────────────────────
 
   const cache = deps.outputCache;
-  const blobPort = getBlobPort();
+  const blobResolver = getBlobResolver();
   let cellStoreTouched = 0;
   let outputOnlySkipped = 0;
 
@@ -155,7 +155,7 @@ export async function materializeChangeset(
       cellId,
       cache,
       getCellById(cellId),
-      blobPort,
+      blobResolver,
     );
     if (!cell) continue;
 

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -1,4 +1,20 @@
+import type { HostBlobResolver } from "@nteract/notebook-host";
 import type { JupyterOutput } from "../types";
+
+export type BlobResolverInput = HostBlobResolver | number;
+
+function normalizeBlobResolver(input: BlobResolverInput): HostBlobResolver {
+  if (typeof input !== "number") return input;
+  const port = input;
+  const url = (ref: { blob: string }) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
+  return {
+    port,
+    url,
+    fetch(ref) {
+      return fetch(url(ref));
+    },
+  };
+}
 
 /**
  * Quick check for binary MIME types — safety net for blob refs that WASM
@@ -128,9 +144,10 @@ function isContentRef(value: unknown): value is ContentRef {
  */
 export async function resolveContentRef(
   ref: ContentRef,
-  blobPort: number,
+  blobResolverInput: BlobResolverInput,
   mimeType?: string,
 ): Promise<string> {
+  const blobResolver = normalizeBlobResolver(blobResolverInput);
   if ("inline" in ref) {
     return ref.inline;
   }
@@ -140,10 +157,10 @@ export async function resolveContentRef(
   // Safety net: binary blob refs that WASM couldn't resolve to Url
   // (blob port wasn't set yet). Construct the URL directly.
   if (mimeType && looksLikeBinaryMime(mimeType)) {
-    return `http://127.0.0.1:${blobPort}/blob/${ref.blob}`;
+    return blobResolver.url(ref);
   }
   // Text blob ref — fetch content from blob server
-  const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
+  const response = await blobResolver.fetch(ref);
   if (!response.ok) {
     throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
   }
@@ -163,9 +180,10 @@ export async function resolveContentRef(
  */
 function resolveContentRefSync(
   ref: ContentRef,
-  blobPort: number,
+  blobResolverInput: BlobResolverInput,
   mimeType?: string,
 ): string | null {
+  const blobResolver = normalizeBlobResolver(blobResolverInput);
   if ("inline" in ref) {
     return ref.inline;
   }
@@ -174,7 +192,7 @@ function resolveContentRefSync(
   }
   // Safety net: binary blob refs that WASM couldn't resolve to Url
   if (mimeType && looksLikeBinaryMime(mimeType)) {
-    return `http://127.0.0.1:${blobPort}/blob/${ref.blob}`;
+    return blobResolver.url(ref);
   }
   // Text blob ref — needs async fetch
   return null;
@@ -189,12 +207,12 @@ function resolveContentRefSync(
  */
 export async function resolveDataBundle(
   data: Record<string, ContentRef>,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): Promise<Record<string, unknown>> {
   const entries = Object.entries(data);
   const contents = await Promise.all(
     entries.map(([mimeType, ref]) =>
-      resolveContentRef(ref, blobPort, mimeType),
+      resolveContentRef(ref, blobResolver, mimeType),
     ),
   );
   const resolved: Record<string, unknown> = {};
@@ -220,11 +238,11 @@ export async function resolveDataBundle(
  */
 function resolveDataBundleSync(
   data: Record<string, ContentRef>,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): Record<string, unknown> | null {
   const resolved: Record<string, unknown> = {};
   for (const [mimeType, ref] of Object.entries(data)) {
-    const content = resolveContentRefSync(ref, blobPort, mimeType);
+    const content = resolveContentRefSync(ref, blobResolver, mimeType);
     if (content === null) return null;
     if (mimeType.includes("json")) {
       try {
@@ -244,12 +262,12 @@ function resolveDataBundleSync(
  */
 export async function resolveManifest(
   manifest: OutputManifest,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): Promise<JupyterOutput> {
   const output_id = manifest.output_id;
   switch (manifest.output_type) {
     case "display_data": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
+      const data = await resolveDataBundle(manifest.data, blobResolver);
       return {
         output_id,
         output_type: "display_data",
@@ -259,7 +277,7 @@ export async function resolveManifest(
       };
     }
     case "execute_result": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
+      const data = await resolveDataBundle(manifest.data, blobResolver);
       return {
         output_id,
         output_type: "execute_result",
@@ -270,7 +288,7 @@ export async function resolveManifest(
       };
     }
     case "stream": {
-      const text = await resolveContentRef(manifest.text, blobPort);
+      const text = await resolveContentRef(manifest.text, blobResolver);
       return {
         output_id,
         output_type: "stream",
@@ -279,9 +297,9 @@ export async function resolveManifest(
       };
     }
     case "error": {
-      const tracebackJson = await resolveContentRef(manifest.traceback, blobPort);
+      const tracebackJson = await resolveContentRef(manifest.traceback, blobResolver);
       const traceback = JSON.parse(tracebackJson) as string[];
-      const rich = await resolveRich(manifest.rich, blobPort);
+      const rich = await resolveRich(manifest.rich, blobResolver);
       return {
         output_id,
         output_type: "error",
@@ -304,11 +322,11 @@ export async function resolveManifest(
  */
 async function resolveRich(
   ref: ContentRef | undefined,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): Promise<Record<string, unknown> | undefined> {
   if (!ref) return undefined;
   try {
-    const json = await resolveContentRef(ref, blobPort);
+    const json = await resolveContentRef(ref, blobResolver);
     return JSON.parse(json) as Record<string, unknown>;
   } catch {
     return undefined;
@@ -329,10 +347,10 @@ type RichSyncResult = "absent" | "async" | Record<string, unknown>;
 
 function resolveRichSync(
   ref: ContentRef | undefined,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): RichSyncResult {
   if (!ref) return "absent";
-  const json = resolveContentRefSync(ref, blobPort);
+  const json = resolveContentRefSync(ref, blobResolver);
   if (json === null) return "async";
   try {
     return JSON.parse(json) as Record<string, unknown>;
@@ -355,12 +373,12 @@ function resolveRichSync(
  */
 export function resolveManifestSync(
   manifest: OutputManifest,
-  blobPort: number,
+  blobResolver: BlobResolverInput,
 ): JupyterOutput | null {
   const output_id = manifest.output_id;
   switch (manifest.output_type) {
     case "display_data": {
-      const data = resolveDataBundleSync(manifest.data, blobPort);
+      const data = resolveDataBundleSync(manifest.data, blobResolver);
       if (data === null) return null;
       return {
         output_id,
@@ -371,7 +389,7 @@ export function resolveManifestSync(
       };
     }
     case "execute_result": {
-      const data = resolveDataBundleSync(manifest.data, blobPort);
+      const data = resolveDataBundleSync(manifest.data, blobResolver);
       if (data === null) return null;
       return {
         output_id,
@@ -383,7 +401,7 @@ export function resolveManifestSync(
       };
     }
     case "stream": {
-      const text = resolveContentRefSync(manifest.text, blobPort);
+      const text = resolveContentRefSync(manifest.text, blobResolver);
       if (text === null) return null;
       return {
         output_id,
@@ -393,10 +411,10 @@ export function resolveManifestSync(
       };
     }
     case "error": {
-      const tracebackJson = resolveContentRefSync(manifest.traceback, blobPort);
+      const tracebackJson = resolveContentRefSync(manifest.traceback, blobResolver);
       if (tracebackJson === null) return null;
       const traceback = JSON.parse(tracebackJson) as string[];
-      const richResult = resolveRichSync(manifest.rich, blobPort);
+      const richResult = resolveRichSync(manifest.rich, blobResolver);
       // If the rich sibling exists but needs a blob fetch, defer the
       // whole output to the async path. Otherwise callers treat this
       // as fully resolved and never upgrade to rich rendering.

--- a/apps/notebook/src/lib/markdown-assets.ts
+++ b/apps/notebook/src/lib/markdown-assets.ts
@@ -1,3 +1,10 @@
+import type { BlobResolverInput } from "./manifest-resolution";
+
+function blobUrl(blobResolver: BlobResolverInput, hash: string): string {
+  if (typeof blobResolver === "number") return `http://127.0.0.1:${blobResolver}/blob/${hash}`;
+  return blobResolver.url({ blob: hash });
+}
+
 /**
  * Rewrite markdown and inline HTML asset refs to blob URLs.
  *
@@ -9,11 +16,11 @@
 export function rewriteMarkdownAssetRefs(
   source: string,
   resolvedAssets: Record<string, string> | undefined,
-  blobPort: number | null,
+  blobResolver: BlobResolverInput | null,
 ): string {
   if (
     !resolvedAssets ||
-    blobPort === null ||
+    blobResolver === null ||
     Object.keys(resolvedAssets).length === 0
   ) {
     return source;
@@ -22,7 +29,7 @@ export function rewriteMarkdownAssetRefs(
   let result = source;
 
   for (const [assetRef, hash] of Object.entries(resolvedAssets)) {
-    const blobUrl = `http://127.0.0.1:${blobPort}/blob/${hash}`;
+    const url = blobUrl(blobResolver, hash);
     const escapedRef = assetRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const markdownImageSuffix = `((?:[ \\t]+(?:"[^"]*"|'[^']*'|\\([^\\n)]*\\)))?[ \\t]*\\))`;
 
@@ -32,26 +39,26 @@ export function rewriteMarkdownAssetRefs(
           `(!\\[[^\\]]*\\]\\([ \\t]*)<?${escapedRef}>?${markdownImageSuffix}`,
           "g",
         ),
-        `$1${blobUrl}$2`,
+        `$1${url}$2`,
       )
       .replace(
         new RegExp(
           `(^[ \\t]{0,3}\\[[^\\]]+\\]:[ \\t]*<?)${escapedRef}(>?((?:[ \\t]+(?:"[^"]*"|'[^']*'|\\([^\\n)]*\\)))?)[ \\t]*$)`,
           "gm",
         ),
-        `$1${blobUrl}$2`,
+        `$1${url}$2`,
       )
       .replace(
         new RegExp(`(\\bsrc\\s*=\\s*")${escapedRef}(")`, "gi"),
-        `$1${blobUrl}$2`,
+        `$1${url}$2`,
       )
       .replace(
         new RegExp(`(\\bsrc\\s*=\\s*')${escapedRef}(')`, "gi"),
-        `$1${blobUrl}$2`,
+        `$1${url}$2`,
       )
       .replace(
         new RegExp(`(\\bsrc\\s*=\\s*)${escapedRef}(?=[\\s>])`, "gi"),
-        `$1${blobUrl}`,
+        `$1${url}`,
       );
   }
 

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -2,6 +2,7 @@ import type { JupyterOutput, NotebookCell } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { logger } from "./logger";
 import {
+  type BlobResolverInput,
   isOutputManifest,
   resolveManifest,
   resolveManifestSync,
@@ -82,14 +83,14 @@ export interface CellSnapshot {
  *
  * - If cached, returns the cached value.
  * - If a structured OutputManifest (has ContentRef data), resolves via
- *   resolveManifest (may fetch blobs).
+ *   resolveManifest (may fetch blob content).
  * - If an object with output_type but no ContentRefs, treats as raw
  *   JupyterOutput.
  * - If a string, parses as JSON (legacy fallback).
  */
 export async function resolveOutput(
   output: unknown,
-  blobPort: number | null,
+  blobResolver: BlobResolverInput | null,
   cache: Map<string, JupyterOutput>,
 ): Promise<JupyterOutput | null> {
   const key = outputCacheKey(output);
@@ -98,12 +99,12 @@ export async function resolveOutput(
 
   // Structured manifest from WASM — resolve ContentRefs
   if (isOutputManifest(output)) {
-    if (blobPort === null) {
-      logger.warn("[materialize-cells] Manifest object but no blob port");
+    if (blobResolver === null) {
+      logger.warn("[materialize-cells] Manifest object but no blob resolver");
       return null;
     }
     try {
-      const resolved = await resolveManifest(output, blobPort);
+      const resolved = await resolveManifest(output, blobResolver);
       cache.set(key, resolved);
       return resolved;
     } catch (e) {
@@ -119,7 +120,7 @@ export async function resolveOutput(
             ...output,
             data: { "text/plain": output.data["text/plain"] },
           } as typeof output;
-          const resolved = await resolveManifest(fallback, blobPort);
+          const resolved = await resolveManifest(fallback, blobResolver);
           // Don't cache the fallback — leave the original key as a cache miss
           // so the next materialization retries the rich MIME type.
           return resolved;
@@ -166,7 +167,7 @@ export async function resolveOutput(
  */
 function resolveOutputSync(
   output: unknown,
-  blobPort: number | null,
+  blobResolver: BlobResolverInput | null,
   cache: Map<string, JupyterOutput>,
 ): JupyterOutput | null {
   const key = outputCacheKey(output);
@@ -175,8 +176,8 @@ function resolveOutputSync(
 
   // Structured manifest — try sync resolution (inline + binary URL only)
   if (isOutputManifest(output)) {
-    if (blobPort === null) return null;
-    const resolved = resolveManifestSync(output, blobPort);
+    if (blobResolver === null) return null;
+    const resolved = resolveManifestSync(output, blobResolver);
     if (resolved) {
       cache.set(key, resolved);
       return resolved;
@@ -247,7 +248,7 @@ export function reuseOutputsIfUnchanged(
 export function cellSnapshotsToNotebookCellsSync(
   snapshots: CellSnapshot[],
   cache: Map<string, JupyterOutput>,
-  blobPort?: number | null,
+  blobResolver?: BlobResolverInput | null,
 ): NotebookCell[] {
   return snapshots.map((snap) => {
     const metadata = snap.metadata ?? {};
@@ -255,7 +256,7 @@ export function cellSnapshotsToNotebookCellsSync(
     if (snap.cell_type === "code") {
       // Resolve outputs from cache or sync-resolvable manifests
       const resolvedOutputs = snap.outputs
-        .map((output) => resolveOutputSync(output, blobPort ?? null, cache))
+        .map((output) => resolveOutputSync(output, blobResolver ?? null, cache))
         .filter((o): o is JupyterOutput => o !== null);
 
       const ec = resolveExecutionCount(
@@ -302,7 +303,7 @@ export function cellSnapshotsToNotebookCellsSync(
  */
 export async function cellSnapshotsToNotebookCells(
   snapshots: CellSnapshot[],
-  blobPort: number | null,
+  blobResolver: BlobResolverInput | null,
   cache: Map<string, JupyterOutput>,
 ): Promise<NotebookCell[]> {
   return Promise.all(
@@ -314,7 +315,7 @@ export async function cellSnapshotsToNotebookCells(
         // Resolve all outputs (structured manifests or legacy JSON strings)
         const resolvedOutputs = (
           await Promise.all(
-            snap.outputs.map((o) => resolveOutput(o, blobPort, cache)),
+            snap.outputs.map((o) => resolveOutput(o, blobResolver, cache)),
           )
         ).filter((o): o is JupyterOutput => o !== null);
 
@@ -367,7 +368,7 @@ export function materializeCellFromWasm(
   cellId: string,
   cache: Map<string, JupyterOutput>,
   previousCell?: NotebookCell,
-  blobPort?: number | null,
+  blobResolver?: BlobResolverInput | null,
 ): NotebookCell | null {
   const cellType = handle.get_cell_type(cellId);
   if (!cellType) return null;
@@ -378,7 +379,7 @@ export function materializeCellFromWasm(
   if (cellType === "code") {
     const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
     const resolvedOutputs = rawOutputs
-      .map((output) => resolveOutputSync(output, blobPort ?? null, cache))
+      .map((output) => resolveOutputSync(output, blobResolver ?? null, cache))
       .filter((o): o is JupyterOutput => o !== null);
 
     const prevOutputs =

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -17,8 +17,10 @@ import {
   RuntimeExecutionProjector,
   type RuntimeState,
 } from "runtimed";
+import type { HostBlobResolver } from "@nteract/notebook-host";
+import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-import { getBlobPort, refreshBlobPort } from "./blob-port";
+import { getBlobResolver, refreshBlobResolver } from "./blob-port";
 import { logger } from "./logger";
 import {
   type OutputManifest,
@@ -38,7 +40,6 @@ import {
   resetNotebookOutputs,
   setOutput,
 } from "./notebook-outputs";
-import type { JupyterOutput } from "../types";
 
 // ── Executions store projection ──────────────────────────────────────
 
@@ -116,7 +117,7 @@ export function seedOutputStoresFromHandle(
       if (!oid) continue;
       const existing = getOutputById(oid);
       if (existing === output) continue;
-      const sync = tryResolveSync(output, getBlobPort());
+      const sync = tryResolveSync(output, getBlobResolver());
       if (sync) setOutput(oid, sync);
     }
   }
@@ -161,29 +162,29 @@ export async function applyOutputChangeset(
   }
   if (changed.length === 0) return;
 
-  // Stream/display-update manifests with text blob refs need the blob
-  // port to resolve. Fetch it on demand so a race between the first
-  // manifest and blob-port discovery doesn't drop outputs on the floor.
-  let port = getBlobPort();
-  if (port === null && changed.some(([, raw]) => isOutputManifest(raw))) {
-    port = await refreshBlobPort();
+  // Stream/display-update manifests with text blob refs need host blob access.
+  // Fetch it on demand so a race between the first manifest and resolver
+  // discovery doesn't drop outputs on the floor.
+  let blobResolver = getBlobResolver();
+  if (blobResolver === null && changed.some(([, raw]) => isOutputManifest(raw))) {
+    blobResolver = await refreshBlobResolver();
   }
 
   for (const [output_id, raw] of changed) {
-    const sync = tryResolveSync(raw, port);
+    const sync = tryResolveSync(raw, blobResolver);
     if (sync) {
       setOutput(output_id, sync);
       continue;
     }
-    if (port === null) {
+    if (blobResolver === null) {
       logger.warn(
-        `[outputs-store] blob port unavailable; deferring output ${output_id}`,
+        `[outputs-store] blob resolver unavailable; deferring output ${output_id}`,
       );
       continue;
     }
     if (!isOutputManifest(raw)) continue;
     try {
-      const resolved = await resolveManifest(raw, port);
+      const resolved = await resolveManifest(raw, blobResolver);
       setOutput(output_id, resolved);
     } catch (err) {
       logger.warn(
@@ -196,11 +197,11 @@ export async function applyOutputChangeset(
 
 function tryResolveSync(
   raw: unknown,
-  blobPort: number | null,
+  blobResolver: HostBlobResolver | null,
 ): JupyterOutput | null {
   if (isOutputManifest(raw)) {
-    if (blobPort === null) return null;
-    return resolveManifestSync(raw as OutputManifest, blobPort);
+    if (blobResolver === null) return null;
+    return resolveManifestSync(raw as OutputManifest, blobResolver);
   }
   // Plain JupyterOutput object — no refs, no resolution needed.
   if (typeof raw === "object" && raw !== null && "output_type" in raw) {

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -21,6 +21,9 @@ import type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
+  HostBlobRef,
+  HostBlobResolver,
+  HostBlobs,
   HostUpdaterState,
   NotebookHost,
   TyposquatWarning,
@@ -74,6 +77,17 @@ function requestTimeoutMs(request: NotebookRequest): number {
     default:
       return 30_000;
   }
+}
+
+function createHttpBlobResolver(port: number, fetchImpl: typeof fetch): HostBlobResolver {
+  const url = (ref: HostBlobRef) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
+  return {
+    port,
+    url,
+    fetch(ref) {
+      return fetchImpl(url(ref));
+    },
+  };
 }
 
 function addToken(url: string, token: string): string {
@@ -317,6 +331,8 @@ export async function createBrowserHost(
   let config = await loadConfig(opts.configUrl ?? DEFAULT_CONFIG_URL, fetchImpl);
   let lastReady: DaemonReadyPayload | null = null;
   let blobPort = config.blob_port;
+  let blobResolver: HostBlobResolver | null =
+    blobPort === null ? null : createHttpBlobResolver(blobPort, fetchImpl);
   let daemonInfo = config.daemon;
 
   const readySubscribers = new Set<(payload: DaemonReadyPayload) => void>();
@@ -333,6 +349,7 @@ export async function createBrowserHost(
       case "ready":
         lastReady = control.payload;
         blobPort = control.blob_port ?? blobPort;
+        blobResolver = blobPort === null ? null : createHttpBlobResolver(blobPort, fetchImpl);
         daemonInfo = control.daemon ?? daemonInfo;
         emit(readySubscribers, control.payload);
         break;
@@ -362,6 +379,23 @@ export async function createBrowserHost(
 
   const idleUpdaterState: HostUpdaterState = { status: "idle", version: null, error: null };
   const commands = createCommandRegistry();
+
+  const browserBlobHost: HostBlobs = {
+    async port() {
+      const resolver = await browserBlobHost.resolver();
+      if (resolver.port === undefined) throw new Error("Blob server not available");
+      return resolver.port;
+    },
+    async resolver() {
+      if (blobResolver) return blobResolver;
+      config = await loadConfig(opts.configUrl ?? DEFAULT_CONFIG_URL, fetchImpl);
+      blobPort = config.blob_port;
+      daemonInfo = config.daemon;
+      if (blobPort === null) throw new Error("Blob server not available");
+      blobResolver = createHttpBlobResolver(blobPort, fetchImpl);
+      return blobResolver;
+    },
+  };
 
   return {
     name: "browser",
@@ -406,16 +440,7 @@ export async function createBrowserHost(
         transport.releaseFrames();
       },
     },
-    blobs: {
-      async port() {
-        if (blobPort !== null) return blobPort;
-        config = await loadConfig(opts.configUrl ?? DEFAULT_CONFIG_URL, fetchImpl);
-        blobPort = config.blob_port;
-        daemonInfo = config.daemon;
-        if (blobPort === null) throw new Error("Blob server not available");
-        return blobPort;
-      },
-    },
+    blobs: browserBlobHost,
     trust: {
       async approve(options) {
         const response = (await transport.sendRequest({

--- a/packages/notebook-host/src/index.ts
+++ b/packages/notebook-host/src/index.ts
@@ -4,6 +4,8 @@ export type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
+  HostBlobRef,
+  HostBlobResolver,
   HostBlobs,
   HostDaemon,
   HostDaemonEvents,

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -35,6 +35,8 @@ import type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
+  HostBlobRef,
+  HostBlobResolver,
   HostBlobs,
   HostDaemon,
   HostDaemonEvents,
@@ -87,6 +89,17 @@ function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten
   };
 }
 
+function createHttpBlobResolver(port: number, fetchImpl: typeof fetch = fetch): HostBlobResolver {
+  const url = (ref: HostBlobRef) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
+  return {
+    port,
+    url,
+    fetch(ref) {
+      return fetchImpl(url(ref));
+    },
+  };
+}
+
 export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost {
   const transport = opts.transport ?? new TauriTransport();
   let reconnectPromise: Promise<void> | null = null;
@@ -117,9 +130,17 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     },
   };
 
-  const blobs: HostBlobs = {
+  let blobResolver: HostBlobResolver | null = null;
+
+  const blobHost: HostBlobs = {
     async port() {
-      return invoke<number>("get_blob_port");
+      return (await blobHost.resolver()).port ?? invoke<number>("get_blob_port");
+    },
+    async resolver() {
+      const port = await invoke<number>("get_blob_port");
+      if (blobResolver?.port === port) return blobResolver;
+      blobResolver = createHttpBlobResolver(port);
+      return blobResolver;
     },
   };
 
@@ -404,7 +425,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     daemon,
     daemonEvents,
     relay,
-    blobs,
+    blobs: blobHost,
     trust,
     deps,
     notebook,

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -115,10 +115,35 @@ export interface HostDaemon {
   getReadyInfo(): Promise<DaemonReadyPayload | null>;
 }
 
-/** Blob store — the daemon's HTTP blob server port. */
+export interface HostBlobRef {
+  blob: string;
+  size?: number;
+  media_type?: string;
+}
+
+export interface HostBlobResolver {
+  /**
+   * Local blob port when this resolver is backed by the daemon HTTP server.
+   *
+   * Kept for WASM compatibility while frontend render paths move to `url()`
+   * and `fetch()`.
+   */
+  readonly port?: number;
+
+  /** Return a browser-consumable URL for renderers that stream/fetch directly. */
+  url(ref: HostBlobRef): string;
+
+  /** Fetch blob bytes/text through the host, including any auth/proxy policy. */
+  fetch(ref: HostBlobRef): Promise<Response>;
+}
+
+/** Blob store — host-owned access to daemon blob content. */
 export interface HostBlobs {
   /** Current blob server port. Implementations handle their own retry/caching. */
   port(): Promise<number>;
+
+  /** Current blob resolver. Implementations handle their own retry/caching. */
+  resolver(): Promise<HostBlobResolver>;
 }
 
 /**

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -93,6 +93,10 @@ describe("createBrowserHost()", () => {
 
     expect(ready).toHaveBeenCalledWith({ notebook_id: "nb-1", cell_count: 0, ephemeral: true });
     await expect(host.blobs.port()).resolves.toBe(48124);
+    await expect(host.blobs.resolver()).resolves.toMatchObject({ port: 48124 });
+    expect((await host.blobs.resolver()).url({ blob: "abc123" })).toBe(
+      "http://127.0.0.1:48124/blob/abc123",
+    );
     await expect(host.daemon.getReadyInfo()).resolves.toMatchObject({ notebook_id: "nb-1" });
   });
 

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -201,6 +201,10 @@ describe("createTauriHost()", () => {
     const host = createTauriHost({ transport: stubTransport });
     await expect(host.blobs.port()).resolves.toBe(12345);
     expect(capturedInvokes.at(-1)?.cmd).toBe("get_blob_port");
+
+    const resolver = await host.blobs.resolver();
+    expect(resolver.port).toBe(12345);
+    expect(resolver.url({ blob: "abc123" })).toBe("http://127.0.0.1:12345/blob/abc123");
   });
 
   it("routes trust.approve through the notebook transport", async () => {


### PR DESCRIPTION
## Summary

- add a host-owned blob resolver surface with `url()` and `fetch()` while keeping `port()` for the current WASM bridge
- route output manifest resolution, markdown asset rewriting, and widget output manifest resolution through the resolver instead of reconstructing localhost blob URLs at call sites
- implement the resolver in both Tauri and browser hosts, with compatibility adapters for existing low-level tests

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/blob-port.test.ts apps/notebook/src/lib/__tests__/markdown-assets.test.ts apps/notebook/src/lib/__tests__/manifest-resolution.test.ts apps/notebook/src/lib/__tests__/materialize-cells.test.ts packages/notebook-host/tests/tauri-host.test.ts packages/notebook-host/tests/browser-host.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `git diff --check`
