### PR TITLE
ci: resolve MCP widget vp through pnpm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+      - run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Clippy (Windows cross-check)
         # runtimed-node stays excluded here: napi's build script needs libnode.dll
@@ -298,7 +298,7 @@ jobs:
           skip-wasm: true
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+      - run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         shell: bash
@@ -392,7 +392,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+      - run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       # Excludes: notebook (needs bundled binaries, checked in build-linux),
       # runtimed-wasm (needs wasm-pack, tested in wasm-deno),
@@ -493,7 +493,7 @@ jobs:
           skip-wasm: true
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+      - run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
 
       - name: Build external binaries

--- a/.github/workflows/dx-bootstrap-e2e.yml
+++ b/.github/workflows/dx-bootstrap-e2e.yml
@@ -86,7 +86,7 @@ jobs:
         run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build E2E app
         run: cargo xtask e2e build

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -182,7 +182,7 @@ jobs:
       # build-runtime-artifacts already ran the cargo xtask wasm chain
       # earlier in this job; this only adds the small _output.html file.
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -158,7 +158,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build for Linux x64
         run: cargo build --release --target x86_64-unknown-linux-gnu -p runt -p runtimed -p nteract-mcp
@@ -229,7 +229,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build for macOS ARM64
         run: cargo build --release --target aarch64-apple-darwin -p runt
@@ -355,7 +355,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |
@@ -536,7 +536,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |
@@ -702,7 +702,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         shell: bash
@@ -864,7 +864,7 @@ jobs:
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -59,7 +59,7 @@ jobs:
       # Build the MCP output widget HTML. runt-mcp's include_str! needs it
       # before we compile the Rust binaries.
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         shell: bash
@@ -420,7 +420,7 @@ jobs:
       # runt-mcp's include_str! pulls in the MCP output widget HTML. Build
       # before compiling Rust so the assets/_output.html target exists.
       - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install && vp run nteract-mcp-app#build
+        run: pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build runtimed and runt
         run: cargo build --release -p runtimed -p runt -p nteract-mcp


### PR DESCRIPTION
## Summary

- resolve MCP output widget builds through `pnpm exec vp` instead of a bare `vp`
- update release, build, smoke, PR binary, and DX bootstrap workflow call sites

## Verification

- `pnpm --filter nteract-mcp-app install && pnpm exec vp run nteract-mcp-app#build`
- `actionlint .github/workflows/release-common.yml .github/workflows/build.yml .github/workflows/smoke.yml .github/workflows/pr-binary-generation.yml .github/workflows/dx-bootstrap-e2e.yml`
- `cargo xtask lint --fix`

## Notes

The nightly release failure in `release / Build macOS x64 Notebook` happened when the widget step ran `vp run nteract-mcp-app#build` and the runner could not find a bare `vp` binary. The dependency install step had already completed, so using `pnpm exec` keeps the command tied to the workspace-installed Vite+ CLI.
