### PR TITLE
fix(notebook): filter inactive pool retry banners

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -152,7 +152,7 @@ function AppContent() {
   const daemonInfo = useDaemonInfo();
 
   // Apply theme to this window
-  useSyncedTheme();
+  const { defaultPythonEnv } = useSyncedTheme();
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());
@@ -236,16 +236,6 @@ function AppContent() {
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);
   // Track ready timeout so we can cancel it if status changes
   const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Pool state - prewarm pool errors from daemon (typo'd default packages, etc.)
-  const {
-    uvError: poolUvError,
-    condaError: poolCondaError,
-    pixiError: poolPixiError,
-    dismissUvError: dismissPoolUvError,
-    dismissCondaError: dismissPoolCondaError,
-    dismissPixiError: dismissPoolPixiError,
-  } = usePoolState();
 
   // Trust verification for notebook dependencies
   const {
@@ -593,6 +583,17 @@ function AppContent() {
   // daemon hasn't yet reported env_source (kernel still launching).
   // Once envSource is set, toolbar renders the real label off it.
   const envTypeHint = envSource ? null : envType;
+
+  // Pool state - prewarm pool errors from daemon (typo'd default packages, etc.).
+  const activePoolManager = envType ?? defaultPythonEnv;
+  const {
+    uvError: poolUvError,
+    condaError: poolCondaError,
+    pixiError: poolPixiError,
+    dismissUvError: dismissPoolUvError,
+    dismissCondaError: dismissPoolCondaError,
+    dismissPixiError: dismissPoolPixiError,
+  } = usePoolState(activePoolManager);
 
   // Auto-updater
   const {

--- a/apps/notebook/src/hooks/__tests__/usePoolState.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/usePoolState.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  DEFAULT_POOL_STATE,
+  type PoolState,
+  resetPoolState,
+  setPoolState,
+} from "../../lib/pool-state";
+import { usePoolState } from "../usePoolState";
+
+function stateWithErrors(overrides: Partial<PoolState>): PoolState {
+  return {
+    uv: { ...DEFAULT_POOL_STATE.uv },
+    conda: { ...DEFAULT_POOL_STATE.conda },
+    pixi: { ...DEFAULT_POOL_STATE.pixi },
+    ...overrides,
+  };
+}
+
+describe("usePoolState", () => {
+  afterEach(() => {
+    resetPoolState();
+  });
+
+  it("hides transient retry errors from inactive package managers", () => {
+    act(() => {
+      setPoolState(
+        stateWithErrors({
+          pixi: {
+            ...DEFAULT_POOL_STATE.pixi,
+            error: "Pixi environment creation failed: failed to fetch matplotlib",
+            error_kind: "setup_failed",
+            consecutive_failures: 1,
+            retry_in_secs: 30,
+          },
+        }),
+      );
+    });
+
+    const { result } = renderHook(() => usePoolState("uv"));
+
+    expect(result.current.pixiError).toBeNull();
+    expect(result.current.hasErrors).toBe(false);
+  });
+
+  it("shows transient retry errors for the active package manager", () => {
+    act(() => {
+      setPoolState(
+        stateWithErrors({
+          pixi: {
+            ...DEFAULT_POOL_STATE.pixi,
+            error: "Pixi environment creation failed: failed to fetch matplotlib",
+            error_kind: "setup_failed",
+            consecutive_failures: 1,
+            retry_in_secs: 30,
+          },
+        }),
+      );
+    });
+
+    const { result } = renderHook(() => usePoolState("pixi"));
+
+    expect(result.current.pixiError?.message).toContain("Pixi environment creation failed");
+    expect(result.current.hasErrors).toBe(true);
+  });
+
+  it("keeps actionable inactive-manager errors visible", () => {
+    act(() => {
+      setPoolState(
+        stateWithErrors({
+          pixi: {
+            ...DEFAULT_POOL_STATE.pixi,
+            error: "Pixi package not found",
+            error_kind: "invalid_package",
+            failed_package: "not-a-package",
+            consecutive_failures: 1,
+            retry_in_secs: 0,
+          },
+        }),
+      );
+    });
+
+    const { result } = renderHook(() => usePoolState("uv"));
+
+    expect(result.current.pixiError?.failed_package).toBe("not-a-package");
+    expect(result.current.hasErrors).toBe(true);
+  });
+});

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -7,6 +7,8 @@ import {
 
 export type { PoolErrorWithTimestamp } from "../lib/pool-state";
 
+type PoolManager = "uv" | "conda" | "pixi";
+
 /** Compare two pool errors for equality (all fields except receivedAt) */
 function errorsEqual(
   a: PoolErrorWithTimestamp | null | undefined,
@@ -36,13 +38,31 @@ function extractError(pool: PoolState[keyof PoolState]): PoolErrorWithTimestamp 
   };
 }
 
+function isTransientPoolError(error: PoolErrorWithTimestamp): boolean {
+  return error.error_kind === "timeout" || error.error_kind === "setup_failed";
+}
+
+function shouldShowErrorForManager(
+  manager: PoolManager,
+  activeManager: string | null | undefined,
+  error: PoolErrorWithTimestamp | null,
+): boolean {
+  if (!error) return false;
+  if (!activeManager || activeManager === manager) return true;
+
+  // Pool warmups run globally. Avoid alerting users about transient retry
+  // noise from managers they are not currently using, while still surfacing
+  // actionable settings issues like invalid packages.
+  return !isTransientPoolError(error);
+}
+
 /**
  * Hook that reads pool state from the daemon's PoolDoc (Automerge sync).
  *
  * Reports prewarm pool errors (e.g., typo'd package in default_packages)
  * so the UI can display warnings with retry countdowns.
  */
-export function usePoolState() {
+export function usePoolState(activeManager?: string | null) {
   const poolState = usePoolStateStore();
 
   // Track dismissed errors so they don't reappear until state changes
@@ -73,6 +93,17 @@ export function usePoolState() {
     if (dismissedPixi) setDismissedPixi(false);
   }
 
+  const visibleUvError =
+    !dismissedUv && shouldShowErrorForManager("uv", activeManager, uvError) ? uvError : null;
+  const visibleCondaError =
+    !dismissedConda && shouldShowErrorForManager("conda", activeManager, condaError)
+      ? condaError
+      : null;
+  const visiblePixiError =
+    !dismissedPixi && shouldShowErrorForManager("pixi", activeManager, pixiError)
+      ? pixiError
+      : null;
+
   const dismissUvError = useCallback(() => {
     setDismissedUv(true);
   }, []);
@@ -92,13 +123,10 @@ export function usePoolState() {
   }, []);
 
   return {
-    uvError: dismissedUv ? null : uvError,
-    condaError: dismissedConda ? null : condaError,
-    pixiError: dismissedPixi ? null : pixiError,
-    hasErrors:
-      (!dismissedUv && uvError !== null) ||
-      (!dismissedConda && condaError !== null) ||
-      (!dismissedPixi && pixiError !== null),
+    uvError: visibleUvError,
+    condaError: visibleCondaError,
+    pixiError: visiblePixiError,
+    hasErrors: visibleUvError !== null || visibleCondaError !== null || visiblePixiError !== null,
     dismissUvError,
     dismissCondaError,
     dismissPixiError,

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -481,7 +481,7 @@ function readFeatureFlags(
  * Falls back to localStorage if the daemon is unavailable.
  */
 export function useSyncedTheme() {
-  const { theme, setTheme, colorTheme, setColorTheme } = useSyncedSettings();
+  const { theme, setTheme, colorTheme, setColorTheme, defaultPythonEnv } = useSyncedSettings();
 
   const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() => resolveTheme(theme));
 
@@ -514,5 +514,5 @@ export function useSyncedTheme() {
     }
   }, [colorTheme]);
 
-  return { theme, setTheme, colorTheme, setColorTheme, resolvedTheme };
+  return { theme, setTheme, colorTheme, setColorTheme, resolvedTheme, defaultPythonEnv };
 }


### PR DESCRIPTION
## Summary

- Suppress transient pool retry banners for inactive package managers.
- Use the active notebook manager when known, with the user's default Python environment as the fallback.
- Keep actionable inactive-manager errors visible and add hook coverage for both paths.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/hooks/__tests__/usePoolState.test.tsx`
- `cargo xtask wasm runtimed`
- `pnpm exec tsc -b apps/notebook/tsconfig.json --pretty false`
