### PR TITLE
test(runtimed-py): isolate environment yml fixture

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2671,9 +2671,13 @@ class TestCreateNotebook:
 
         Regression test for nteract/desktop#1643.
         """
+        import uuid
+
+        env_name = f"nteract-missing-env-{uuid.uuid4().hex}"
+
         # Create environment.yml in tmp_path
         (tmp_path / "environment.yml").write_text(
-            "name: test-conda\nchannels:\n  - conda-forge\ndependencies:\n  - python\n"
+            f"name: {env_name}\nchannels:\n  - conda-forge\ndependencies:\n  - python\n"
         )
 
         session = await client.create_notebook(runtime="python", working_dir=str(tmp_path))
@@ -2681,7 +2685,7 @@ class TestCreateNotebook:
 
         await async_wait_for_conda_env_yml_missing(
             session,
-            "test-conda",
+            env_name,
             expected_path_fragment="environment.yml",
         )
 


### PR DESCRIPTION
## Summary

- make the `environment.yml` missing-env integration fixture use a UUID-backed conda env name
- avoid colliding with a real `test-conda` environment that may already exist on CI workers
- keep the regression assertion on the `AwaitingEnvBuild` path

## Verification

- `cargo xtask lint --fix`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kylekelley/.codex/worktrees/2420/desktop/target/debug/runtimed RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 uv run pytest tests/test_daemon_integration.py::TestCreateNotebook::test_create_notebook_conda_with_environment_yml -v --tb=short -s`
