### PR TITLE
feat(runtime): redact environment values from outputs

### DIFF
--- a/apps/notebook/gallery/App.tsx
+++ b/apps/notebook/gallery/App.tsx
@@ -151,6 +151,7 @@ function OnboardingCTAPreview() {
 
 function PrivacySectionDemo() {
   const [telemetryEnabled, setTelemetryEnabled] = useState(true);
+  const [redactEnvValuesInOutputs, setRedactEnvValuesInOutputs] = useState(true);
   const [installId, setInstallId] = useState("c1d4e7f2-8a3b-4f1c-9e2a-1234567890ab");
   const now = Math.floor(Date.now() / 1000);
   const [lastDaemonPingAt] = useState<number | null>(now - 14 * 3600);
@@ -168,6 +169,8 @@ function PrivacySectionDemo() {
     <PrivacySection
       telemetryEnabled={telemetryEnabled}
       onTelemetryChange={setTelemetryEnabled}
+      redactEnvValuesInOutputs={redactEnvValuesInOutputs}
+      onRedactEnvValuesInOutputsChange={setRedactEnvValuesInOutputs}
       installId={installId}
       onRotate={rotateInstallId}
       lastDaemonPingAt={lastDaemonPingAt}

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -221,6 +221,8 @@ export default function App() {
     setFeatureFlag,
     telemetryEnabled,
     setTelemetryEnabled,
+    redactEnvValuesInOutputs,
+    setRedactEnvValuesInOutputs,
     installId,
     rotateInstallId,
     lastDaemonPingAt,
@@ -467,6 +469,8 @@ export default function App() {
         <PrivacySection
           telemetryEnabled={telemetryEnabled}
           onTelemetryChange={setTelemetryEnabled}
+          redactEnvValuesInOutputs={redactEnvValuesInOutputs}
+          onRedactEnvValuesInOutputsChange={setRedactEnvValuesInOutputs}
           installId={installId}
           onRotate={rotateInstallId}
           lastDaemonPingAt={lastDaemonPingAt}

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -8,6 +8,8 @@ import { Switch } from "@/components/ui/switch";
 interface PrivacySectionProps {
   telemetryEnabled: boolean;
   onTelemetryChange: (value: boolean) => void;
+  redactEnvValuesInOutputs: boolean;
+  onRedactEnvValuesInOutputsChange: (value: boolean) => void;
   installId: string;
   onRotate: () => Promise<string | null>;
   lastDaemonPingAt: number | null;
@@ -35,6 +37,8 @@ function openOrFallThrough(url: string) {
 export function PrivacySection({
   telemetryEnabled,
   onTelemetryChange,
+  redactEnvValuesInOutputs,
+  onRedactEnvValuesInOutputsChange,
   installId,
   onRotate,
   lastDaemonPingAt,
@@ -76,6 +80,21 @@ export function PrivacySection({
             </div>
           }
         />
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-0.5">
+            <span className="text-xs text-muted-foreground">
+              Redact environment values in outputs
+            </span>
+            <p className="text-[10px] text-muted-foreground/70">
+              Masks matching environment variable values before outputs are stored
+            </p>
+          </div>
+          <Switch
+            checked={redactEnvValuesInOutputs}
+            onCheckedChange={onRedactEnvValuesInOutputsChange}
+          />
+        </div>
 
         <div className="space-y-1.5">
           <div className="flex items-center justify-between gap-3">

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -87,7 +87,7 @@ export function PrivacySection({
               Redact environment values in outputs
             </span>
             <p className="text-[10px] text-muted-foreground/70">
-              Masks matching environment variable values before outputs are stored
+              Masks eligible environment variable values for newly launched or restarted kernels
             </p>
           </div>
           <Switch

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -127,6 +127,10 @@ fn default_flexible_npm() -> bool {
     true
 }
 
+fn default_redact_env_values_in_outputs() -> bool {
+    true
+}
+
 /// An entry in the execution queue, pairing a cell with its execution.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct QueueEntry {
@@ -766,6 +770,9 @@ pub enum RuntimeAgentRequest {
         /// Environment variables to set for the kernel process.
         #[serde(default)]
         env_vars: std::collections::HashMap<String, String>,
+        /// Redact eligible environment variable values from textual kernel outputs.
+        #[serde(default = "default_redact_env_values_in_outputs")]
+        redact_env_values_in_outputs: bool,
     },
 
     /// Interrupt the currently executing cell.
@@ -787,6 +794,8 @@ pub enum RuntimeAgentRequest {
         kernel_ports: KernelPorts,
         #[serde(default)]
         env_vars: std::collections::HashMap<String, String>,
+        #[serde(default = "default_redact_env_values_in_outputs")]
+        redact_env_values_in_outputs: bool,
     },
 
     /// Send a comm message to the kernel (widget interactions).
@@ -1579,6 +1588,7 @@ mod tests {
             launched_config: Default::default(),
             kernel_ports: ports,
             env_vars: Default::default(),
+            redact_env_values_in_outputs: true,
         };
         let json = serde_json::to_value(&launch).unwrap();
         assert_eq!(json["kernel_ports"]["stdin"], 9000);
@@ -1595,6 +1605,21 @@ mod tests {
                 ..
             } if kernel_ports == ports
         ));
+        let parsed_legacy: RuntimeAgentRequest = serde_json::from_value(serde_json::json!({
+            "action": "launch_kernel",
+            "kernel_type": "python",
+            "env_source": "uv:prewarmed",
+            "launched_config": {},
+            "kernel_ports": ports,
+        }))
+        .unwrap();
+        assert!(matches!(
+            parsed_legacy,
+            RuntimeAgentRequest::LaunchKernel {
+                redact_env_values_in_outputs: true,
+                ..
+            }
+        ));
 
         let restart = RuntimeAgentRequest::RestartKernel {
             kernel_type: "python".into(),
@@ -1603,6 +1628,7 @@ mod tests {
             launched_config: Default::default(),
             kernel_ports: ports,
             env_vars: Default::default(),
+            redact_env_values_in_outputs: true,
         };
         let json = serde_json::to_value(&restart).unwrap();
         let parsed: RuntimeAgentRequest = serde_json::from_value(json).unwrap();
@@ -1656,6 +1682,7 @@ mod tests {
                 iopub: 9004,
             },
             env_vars: Default::default(),
+            redact_env_values_in_outputs: true,
         }
         .is_command());
         assert!(!RuntimeAgentRequest::RestartKernel {
@@ -1671,6 +1698,7 @@ mod tests {
                 iopub: 9009,
             },
             env_vars: Default::default(),
+            redact_env_values_in_outputs: true,
         }
         .is_command());
         assert!(!RuntimeAgentRequest::SyncEnvironment(EnvKind::Uv {

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -113,6 +113,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("bootstrap_dx")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.bootstrap_dx),
+        redact_env_values_in_outputs: json
+            .get("redact_env_values_in_outputs")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.redact_env_values_in_outputs),
         install_id: json
             .get("install_id")
             .and_then(|v| v.as_str())
@@ -170,6 +174,7 @@ mod tests {
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
+        assert!(settings.redact_env_values_in_outputs);
     }
 
     #[test]

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -299,6 +299,14 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub bootstrap_dx: bool,
 
+    /// Redact eligible environment variable values from newly produced text outputs.
+    ///
+    /// The runtime agent applies this before output manifests or blobs are
+    /// written, so the setting is global-only and intentionally not stored in
+    /// notebook metadata.
+    #[serde(default = "default_redact_env_values_in_outputs")]
+    pub redact_env_values_in_outputs: bool,
+
     // ── Telemetry ───────────────────────────────────────────────────
     /// Opaque per-install UUIDv4. Generated on first heartbeat, persisted in
     /// settings. Not derived from any identifying data.
@@ -357,6 +365,7 @@ impl Default for SyncedSettings {
             pixi_pool_size: pool_sizes.pixi_pool_size,
             install_default_data_packages: true,
             bootstrap_dx: false,
+            redact_env_values_in_outputs: true,
             install_id: String::new(),
             telemetry_enabled: true,
             telemetry_consent_recorded: false,
@@ -368,6 +377,10 @@ impl Default for SyncedSettings {
 }
 
 fn default_telemetry_enabled() -> bool {
+    true
+}
+
+fn default_redact_env_values_in_outputs() -> bool {
     true
 }
 
@@ -548,6 +561,11 @@ impl SettingsDoc {
         let _ = doc.put(automerge::ROOT, "bootstrap_dx", defaults.bootstrap_dx);
         let _ = doc.put(
             automerge::ROOT,
+            "redact_env_values_in_outputs",
+            defaults.redact_env_values_in_outputs,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
             "install_default_data_packages",
             defaults.install_default_data_packages,
         );
@@ -671,6 +689,12 @@ impl SettingsDoc {
         // bootstrap_dx: boolean
         if let Some(enabled) = json.get("bootstrap_dx").and_then(|v| v.as_bool()) {
             settings.put_bool("bootstrap_dx", enabled);
+        }
+        if let Some(enabled) = json
+            .get("redact_env_values_in_outputs")
+            .and_then(|v| v.as_bool())
+        {
+            settings.put_bool("redact_env_values_in_outputs", enabled);
         }
         if let Some(enabled) = json
             .get("install_default_data_packages")
@@ -1121,6 +1145,9 @@ impl SettingsDoc {
             bootstrap_dx: self
                 .get_bool("bootstrap_dx")
                 .unwrap_or(defaults.bootstrap_dx),
+            redact_env_values_in_outputs: self
+                .get_bool("redact_env_values_in_outputs")
+                .unwrap_or(defaults.redact_env_values_in_outputs),
             install_id: self.get("install_id").unwrap_or_default(),
             telemetry_enabled: self.get_bool("telemetry_enabled").unwrap_or(true),
             telemetry_consent_recorded: self
@@ -1323,6 +1350,20 @@ impl SettingsDoc {
             }
         }
         if let Some(enabled) = json
+            .get("redact_env_values_in_outputs")
+            .and_then(|v| v.as_bool())
+        {
+            let current = self.get_bool("redact_env_values_in_outputs");
+            if current != Some(enabled) {
+                info!(
+                    "[settings] apply_json_changes: redact_env_values_in_outputs changed {:?} -> {}",
+                    current, enabled
+                );
+                self.put_bool("redact_env_values_in_outputs", enabled);
+                changed = true;
+            }
+        }
+        if let Some(enabled) = json
             .get("install_default_data_packages")
             .and_then(|v| v.as_bool())
         {
@@ -1500,6 +1541,7 @@ mod tests {
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.pixi.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
+        assert!(settings.redact_env_values_in_outputs);
     }
 
     #[test]
@@ -1560,6 +1602,18 @@ mod tests {
 
         assert_eq!(doc.get_bool("install_default_data_packages"), Some(false));
         assert!(!doc.get_all().install_default_data_packages);
+    }
+
+    #[test]
+    fn test_redact_env_values_in_outputs_can_be_disabled_from_json() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "redact_env_values_in_outputs": false
+        })));
+
+        assert_eq!(doc.get_bool("redact_env_values_in_outputs"), Some(false));
+        assert!(!doc.get_all().redact_env_values_in_outputs);
     }
 
     #[test]
@@ -1929,6 +1983,7 @@ mod tests {
         assert!(schema_str.contains("default_runtime"));
         assert!(schema_str.contains("default_python_env"));
         assert!(schema_str.contains("install_default_data_packages"));
+        assert!(schema_str.contains("redact_env_values_in_outputs"));
         // Should have known values as examples for editor autocomplete
         assert!(schema_str.contains("python"));
         assert!(schema_str.contains("deno"));

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -299,7 +299,8 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub bootstrap_dx: bool,
 
-    /// Redact eligible environment variable values from newly produced text outputs.
+    /// Redact eligible environment variable values from text outputs for newly
+    /// launched or restarted kernels.
     ///
     /// The runtime agent applies this before output manifests or blobs are
     /// written, so the setting is global-only and intentionally not stored in

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -597,6 +597,8 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         install_default_data_packages: get_bool("install_default_data_packages")
             .unwrap_or(defaults.install_default_data_packages),
         bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
+        redact_env_values_in_outputs: get_bool("redact_env_values_in_outputs")
+            .unwrap_or(defaults.redact_env_values_in_outputs),
         install_id: get_str("install_id").unwrap_or_default(),
         telemetry_enabled: get_bool("telemetry_enabled").unwrap_or(true),
         telemetry_consent_recorded: get_bool("telemetry_consent_recorded").unwrap_or(false),

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1165,6 +1165,16 @@ impl Daemon {
         self.settings.read().await.get_all().default_python_env
     }
 
+    /// Whether newly launched kernels should redact eligible environment
+    /// variable values from textual outputs.
+    pub async fn redact_env_values_in_outputs(&self) -> bool {
+        self.settings
+            .read()
+            .await
+            .get_all()
+            .redact_env_values_in_outputs
+    }
+
     /// Mutate canonical `settings.json` first, then refresh the in-memory
     /// Automerge projection used by settings sync.
     ///

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -14,6 +14,7 @@ use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{debug, error, warn};
 
 use crate::blob_store::BlobStore;
+use crate::output_redaction::OutputRedactor;
 use crate::output_prep::QueueCommand;
 use crate::output_prep::{
     apply_display_manifest_updates, build_display_manifest_updates, collect_display_update_targets,
@@ -111,6 +112,7 @@ async fn commit_pending_updates(
     state: &RuntimeStateHandle,
     blob_store: &BlobStore,
     kernel_actor_id: &str,
+    output_redactor: &OutputRedactor,
 ) {
     let updates = take_pending(pending);
     for (display_id, update) in updates {
@@ -132,6 +134,7 @@ async fn commit_pending_updates(
             &preflight_wrapper["data"],
             &update.metadata,
             blob_store,
+            output_redactor,
         )
         .await;
 
@@ -176,6 +179,7 @@ async fn run_display_update_committer(
     state: RuntimeStateHandle,
     blob_store: Arc<BlobStore>,
     kernel_actor_id: String,
+    output_redactor: Arc<OutputRedactor>,
 ) {
     loop {
         tokio::select! {
@@ -187,11 +191,25 @@ async fn run_display_update_committer(
             request = priority_rx.recv() => {
                 match request {
                     Some(request) => {
-                        commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+                        commit_pending_updates(
+                            &pending,
+                            &state,
+                            &blob_store,
+                            &kernel_actor_id,
+                            &output_redactor,
+                        )
+                        .await;
                         let _ = request.ack.send(());
                     }
                     None => {
-                        commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+                        commit_pending_updates(
+                            &pending,
+                            &state,
+                            &blob_store,
+                            &kernel_actor_id,
+                            &output_redactor,
+                        )
+                        .await;
                         break;
                     }
                 }
@@ -200,7 +218,14 @@ async fn run_display_update_committer(
             // Individual notifications are not individual updates; each wake
             // drains all currently pending display_ids.
             _ = pending.notify.notified() => {
-                commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+                commit_pending_updates(
+                    &pending,
+                    &state,
+                    &blob_store,
+                    &kernel_actor_id,
+                    &output_redactor,
+                )
+                .await;
             }
 
             else => break,
@@ -213,6 +238,7 @@ pub(crate) fn start_display_update_committer(
     blob_store: Arc<BlobStore>,
     kernel_actor_id: String,
     lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
+    output_redactor: Arc<OutputRedactor>,
 ) -> DisplayUpdateCommitterHandle {
     let pending = Arc::new(SharedPending {
         updates: StdMutex::new(HashMap::new()),
@@ -228,6 +254,7 @@ pub(crate) fn start_display_update_committer(
             state,
             blob_store,
             kernel_actor_id,
+            output_redactor,
         ),
         move |_| {
             let _ = lifecycle_tx.send(QueueCommand::KernelDied);
@@ -289,6 +316,7 @@ mod tests {
             blob_store,
             "rt:kernel:test".to_string(),
             lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
         );
 
         handle.request_update(

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -14,11 +14,11 @@ use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{debug, error, warn};
 
 use crate::blob_store::BlobStore;
-use crate::output_redaction::OutputRedactor;
 use crate::output_prep::QueueCommand;
 use crate::output_prep::{
     apply_display_manifest_updates, build_display_manifest_updates, collect_display_update_targets,
 };
+use crate::output_redaction::OutputRedactor;
 use crate::task_supervisor::spawn_supervised;
 
 const MAX_PENDING_DISPLAY_IDS: usize = 128;

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -32,12 +32,12 @@ use crate::async_outcome::{
     await_result_with_timeout, recv_oneshot_with_timeout, TimedOneShot, TimedResult,
 };
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
-use crate::output_redaction::OutputRedactor;
 use crate::output_prep::{
     blob_store_large_state_values, escape_glob_pattern, extract_buffer_paths,
     media_to_display_data, message_content_to_nbformat, queue_command_channels,
     store_widget_buffers, QueueCommand, QueueCommandReceivers,
 };
+use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::stream_flush::StreamFlushBuffer;
@@ -1699,25 +1699,26 @@ impl KernelConnection for JupyterKernel {
                                                 &blob_store,
                                             )
                                             .await;
-                                            let manifest_json = match output_store::create_manifest_with_redactor(
-                                                &nbformat_value,
-                                                &blob_store,
-                                                DEFAULT_INLINE_THRESHOLD,
-                                                &iopub_output_redactor,
-                                            )
-                                            .await
-                                            {
-                                                Ok(manifest) => manifest.to_json(),
-                                                Err(e) => {
-                                                    warn!(
+                                            let manifest_json =
+                                                match output_store::create_manifest_with_redactor(
+                                                    &nbformat_value,
+                                                    &blob_store,
+                                                    DEFAULT_INLINE_THRESHOLD,
+                                                    &iopub_output_redactor,
+                                                )
+                                                .await
+                                                {
+                                                    Ok(manifest) => manifest.to_json(),
+                                                    Err(e) => {
+                                                        warn!(
                                                         "[jupyter-kernel] Failed to create manifest: {}",
                                                         e
                                                     );
-                                                    let redacted = iopub_output_redactor
-                                                        .redact_output_value(&nbformat_value);
-                                                    crate::notebook_sync_server::fallback_output_with_id(&redacted)
-                                                }
-                                            };
+                                                        let redacted = iopub_output_redactor
+                                                            .redact_output_value(&nbformat_value);
+                                                        crate::notebook_sync_server::fallback_output_with_id(&redacted)
+                                                    }
+                                                };
 
                                             if let Err(e) = state_for_iopub
                                                 .transact_at_current_heads(
@@ -1903,25 +1904,26 @@ impl KernelConnection for JupyterKernel {
                                         if let Some(nbformat_value) =
                                             message_content_to_nbformat(&message.content)
                                         {
-                                            let manifest_json = match output_store::create_manifest_with_redactor(
-                                                &nbformat_value,
-                                                &blob_store,
-                                                DEFAULT_INLINE_THRESHOLD,
-                                                &iopub_output_redactor,
-                                            )
-                                            .await
-                                            {
-                                                Ok(manifest) => manifest.to_json(),
-                                                Err(e) => {
-                                                    warn!(
+                                            let manifest_json =
+                                                match output_store::create_manifest_with_redactor(
+                                                    &nbformat_value,
+                                                    &blob_store,
+                                                    DEFAULT_INLINE_THRESHOLD,
+                                                    &iopub_output_redactor,
+                                                )
+                                                .await
+                                                {
+                                                    Ok(manifest) => manifest.to_json(),
+                                                    Err(e) => {
+                                                        warn!(
                                                         "[jupyter-kernel] Failed to create error manifest: {}",
                                                         e
                                                     );
-                                                    let redacted = iopub_output_redactor
-                                                        .redact_output_value(&nbformat_value);
-                                                    crate::notebook_sync_server::fallback_output_with_id(&redacted)
-                                                }
-                                            };
+                                                        let redacted = iopub_output_redactor
+                                                            .redact_output_value(&nbformat_value);
+                                                        crate::notebook_sync_server::fallback_output_with_id(&redacted)
+                                                    }
+                                                };
 
                                             if let Err(e) = state_for_iopub
                                                 .transact_at_current_heads(

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -32,6 +32,7 @@ use crate::async_outcome::{
     await_result_with_timeout, recv_oneshot_with_timeout, TimedOneShot, TimedResult,
 };
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
+use crate::output_redaction::OutputRedactor;
 use crate::output_prep::{
     blob_store_large_state_values, escape_glob_pattern, extract_buffer_paths,
     media_to_display_data, message_content_to_nbformat, queue_command_channels,
@@ -45,6 +46,8 @@ use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
 use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig};
+
+const REDACT_ENV_VALUES_IN_OUTPUTS_ENV: &str = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS";
 
 #[cfg(unix)]
 fn ipc_path_prefix(kernel_id: &str) -> PathBuf {
@@ -777,6 +780,19 @@ impl KernelConnection for JupyterKernel {
         for (key, value) in &config.env_vars {
             cmd.env(key, value);
         }
+        cmd.env(
+            REDACT_ENV_VALUES_IN_OUTPUTS_ENV,
+            if config.redact_env_values_in_outputs {
+                "1"
+            } else {
+                "0"
+            },
+        );
+
+        let output_redactor = Arc::new(OutputRedactor::from_current_process_and_command(
+            config.redact_env_values_in_outputs,
+            cmd.as_std(),
+        ));
 
         cmd.kill_on_drop(true);
 
@@ -1225,6 +1241,7 @@ impl KernelConnection for JupyterKernel {
         let iopub_comm_seq = comm_seq.clone();
         let iopub_stream_terminals = stream_terminals.clone();
         let state_for_iopub = shared.state.clone();
+        let iopub_output_redactor = output_redactor.clone();
         // IOPub writes use transactions with the base kernel actor. Async
         // blob/manifest work is completed before the document transaction.
         let iopub_kernel_actor_id = kernel_actor_id.clone();
@@ -1234,6 +1251,7 @@ impl KernelConnection for JupyterKernel {
             iopub_stream_terminals.clone(),
             iopub_kernel_actor_id.clone(),
             iopub_lifecycle_tx.clone(),
+            iopub_output_redactor.clone(),
         );
         let display_update_committer =
             crate::display_update_committer::start_display_update_committer(
@@ -1241,6 +1259,7 @@ impl KernelConnection for JupyterKernel {
                 blob_store.clone(),
                 iopub_kernel_actor_id.clone(),
                 iopub_lifecycle_tx.clone(),
+                iopub_output_redactor.clone(),
             );
 
         // Create coalescing channel early so the IOPub task can capture the sender.
@@ -1430,12 +1449,14 @@ impl KernelConnection for JupyterKernel {
                                             "text": stream.text
                                         });
 
-                                        if let Ok(manifest) = crate::output_store::create_manifest(
-                                            &output,
-                                            &blob_store,
-                                            crate::output_store::DEFAULT_INLINE_THRESHOLD,
-                                        )
-                                        .await
+                                        if let Ok(manifest) =
+                                            crate::output_store::create_manifest_with_redactor(
+                                                &output,
+                                                &blob_store,
+                                                crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                                &iopub_output_redactor,
+                                            )
+                                            .await
                                         {
                                             let manifest_json = manifest.to_json();
                                             let need_clear =
@@ -1564,10 +1585,11 @@ impl KernelConnection for JupyterKernel {
                                             )
                                             .await;
                                             if let Ok(manifest) =
-                                                crate::output_store::create_manifest(
+                                                crate::output_store::create_manifest_with_redactor(
                                                     &nbformat_value,
                                                     &blob_store,
                                                     crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                                    &iopub_output_redactor,
                                                 )
                                                 .await
                                             {
@@ -1677,10 +1699,11 @@ impl KernelConnection for JupyterKernel {
                                                 &blob_store,
                                             )
                                             .await;
-                                            let manifest_json = match output_store::create_manifest(
+                                            let manifest_json = match output_store::create_manifest_with_redactor(
                                                 &nbformat_value,
                                                 &blob_store,
                                                 DEFAULT_INLINE_THRESHOLD,
+                                                &iopub_output_redactor,
                                             )
                                             .await
                                             {
@@ -1690,7 +1713,9 @@ impl KernelConnection for JupyterKernel {
                                                         "[jupyter-kernel] Failed to create manifest: {}",
                                                         e
                                                     );
-                                                    crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
+                                                    let redacted = iopub_output_redactor
+                                                        .redact_output_value(&nbformat_value);
+                                                    crate::notebook_sync_server::fallback_output_with_id(&redacted)
                                                 }
                                             };
 
@@ -1777,10 +1802,11 @@ impl KernelConnection for JupyterKernel {
                                             message_content_to_nbformat(&message.content)
                                         {
                                             if let Ok(manifest) =
-                                                crate::output_store::create_manifest(
+                                                crate::output_store::create_manifest_with_redactor(
                                                     &nbformat_value,
                                                     &blob_store,
                                                     crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                                    &iopub_output_redactor,
                                                 )
                                                 .await
                                             {
@@ -1877,10 +1903,11 @@ impl KernelConnection for JupyterKernel {
                                         if let Some(nbformat_value) =
                                             message_content_to_nbformat(&message.content)
                                         {
-                                            let manifest_json = match output_store::create_manifest(
+                                            let manifest_json = match output_store::create_manifest_with_redactor(
                                                 &nbformat_value,
                                                 &blob_store,
                                                 DEFAULT_INLINE_THRESHOLD,
+                                                &iopub_output_redactor,
                                             )
                                             .await
                                             {
@@ -1890,7 +1917,9 @@ impl KernelConnection for JupyterKernel {
                                                         "[jupyter-kernel] Failed to create error manifest: {}",
                                                         e
                                                     );
-                                                    crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
+                                                    let redacted = iopub_output_redactor
+                                                        .redact_output_value(&nbformat_value);
+                                                    crate::notebook_sync_server::fallback_output_with_id(&redacted)
                                                 }
                                             };
 
@@ -2366,6 +2395,7 @@ impl KernelConnection for JupyterKernel {
         let shell_state = shared.state.clone();
         let shell_blob_store = shared.blob_store.clone();
         let shell_kernel_actor_id = kernel_actor_id.clone();
+        let shell_output_redactor = output_redactor.clone();
 
         let shell_panic_cmd_tx = lifecycle_cmd_tx.clone();
         let shell_reader_task = spawn_supervised(
@@ -2395,10 +2425,11 @@ impl KernelConnection for JupyterKernel {
                                                 let nbformat_value = media_to_display_data(data);
 
                                                 let manifest_json =
-                                                    match output_store::create_manifest(
+                                                    match output_store::create_manifest_with_redactor(
                                                         &nbformat_value,
                                                         &shell_blob_store,
                                                         DEFAULT_INLINE_THRESHOLD,
+                                                        &shell_output_redactor,
                                                     )
                                                     .await
                                                     {
@@ -2408,7 +2439,9 @@ impl KernelConnection for JupyterKernel {
                                                             "[jupyter-kernel] Failed to create page manifest: {}",
                                                             e
                                                         );
-                                                            crate::notebook_sync_server::fallback_output_with_id(&nbformat_value)
+                                                            let redacted = shell_output_redactor
+                                                                .redact_output_value(&nbformat_value);
+                                                            crate::notebook_sync_server::fallback_output_with_id(&redacted)
                                                         }
                                                     };
 

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -42,6 +42,8 @@ pub struct KernelLaunchConfig {
     pub kernel_ports: KernelPorts,
     /// Extra environment variables to set in the kernel process.
     pub env_vars: Vec<(String, String)>,
+    /// Whether textual output should redact matching environment values.
+    pub redact_env_values_in_outputs: bool,
     /// Prewarmed pool environment, if one was claimed.
     pub pooled_env: Option<PooledEnv>,
 }

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -42,6 +42,7 @@ pub mod launcher_cache;
 pub mod markdown_assets;
 pub mod notebook_sync_server;
 pub mod output_prep;
+pub(crate) mod output_redaction;
 pub mod output_store;
 pub mod paths;
 pub(crate) mod pixi_project;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3939,6 +3939,7 @@ pub(crate) async fn auto_launch_kernel(
     {
         warn!("[runtime-state] {}", e);
     }
+    let redact_env_values_in_outputs = daemon.redact_env_values_in_outputs().await;
 
     // (prewarmed_packages no longer needed — runtime agent handles its own launch config)
 
@@ -4036,6 +4037,7 @@ pub(crate) async fn auto_launch_kernel(
                         launched_config: launched_config.clone(),
                         kernel_ports,
                         env_vars: launch_env_vars.clone(),
+                        redact_env_values_in_outputs,
                     }
                 })
                 .await

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1362,6 +1362,83 @@ async fn test_save_notebook_to_disk_with_outputs() {
     );
 }
 
+#[tokio::test]
+async fn test_redacted_output_manifests_do_not_leak_to_state_or_saved_nbformat() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "redacted-outputs.ipynb");
+    let secret = "secret-token-123";
+    let redactor =
+        crate::output_redaction::OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+    let eid = "redacted-exec-1";
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source(
+            "cell1",
+            "import os\nprint(os.environ['TOKEN'])\nraise Exception(os.environ['TOKEN'])",
+        )
+        .unwrap();
+        doc.set_execution_id("cell1", Some(eid)).unwrap();
+    }
+
+    let stream = serde_json::json!({
+        "output_type": "stream",
+        "name": "stdout",
+        "text": format!("{secret}\n")
+    });
+    let error = serde_json::json!({
+        "output_type": "error",
+        "ename": "Exception",
+        "evalue": format!("boom {secret}"),
+        "traceback": [format!("Traceback {secret}")]
+    });
+    let stream_manifest =
+        crate::output_store::create_manifest_with_redactor(&stream, &room.blob_store, 0, &redactor)
+            .await
+            .unwrap();
+    let error_manifest = crate::output_store::create_manifest_with_redactor(
+        &error,
+        &room.blob_store,
+        crate::output_store::DEFAULT_INLINE_THRESHOLD,
+        &redactor,
+    )
+    .await
+    .unwrap();
+    let output_values = vec![stream_manifest.to_json(), error_manifest.to_json()];
+
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution(eid, "cell1")?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_outputs(eid, &output_values)?;
+            sd.set_execution_done(eid, false)?;
+            Ok(())
+        })
+        .unwrap();
+
+    let state_outputs = room.state.read(|sd| sd.get_outputs(eid)).unwrap();
+    let state_json = serde_json::to_string(&state_outputs).unwrap();
+    assert!(state_json.contains(crate::output_redaction::REDACTION_MARKER));
+    assert!(!state_json.contains(secret));
+
+    for output in &state_outputs {
+        let manifest: crate::output_store::OutputManifest =
+            serde_json::from_value(output.clone()).unwrap();
+        let resolved = crate::output_store::resolve_manifest(&manifest, &room.blob_store)
+            .await
+            .unwrap();
+        let resolved_json = serde_json::to_string(&resolved).unwrap();
+        assert!(resolved_json.contains(crate::output_redaction::REDACTION_MARKER));
+        assert!(!resolved_json.contains(secret));
+    }
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+    let saved = std::fs::read_to_string(&notebook_path).unwrap();
+    assert!(saved.contains(crate::output_redaction::REDACTION_MARKER));
+    assert!(!saved.contains(secret));
+}
+
 /// Saves should produce byte-identical output twice in a row for the same
 /// state, and top-level + cell keys should be alphabetically sorted. This is
 /// the git-diff churn fix: a no-op save produces the same bytes, and edits

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -401,36 +401,6 @@ pub(crate) fn apply_display_manifest_updates(
     Ok(found)
 }
 
-/// Update an output by display_id when outputs are inline manifests.
-///
-/// Updates all outputs matching a display_id with new data and metadata.
-///
-/// Uses the `display_index` for O(1) lookup of matching outputs. Falls back
-/// to a full scan if the index has no entries (legacy outputs before indexing).
-///
-/// Returns true if at least one output was updated, false otherwise.
-#[cfg(test)]
-pub(crate) async fn update_output_by_display_id_with_manifests(
-    state_doc: &mut RuntimeStateDoc,
-    display_id: &str,
-    new_data: &serde_json::Value,
-    new_metadata: &serde_json::Map<String, serde_json::Value>,
-    blob_store: &BlobStore,
-) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-    let targets = collect_display_update_targets(state_doc, display_id);
-    let redactor = OutputRedactor::disabled();
-    let updates = build_display_manifest_updates(
-        targets,
-        display_id,
-        new_data,
-        new_metadata,
-        blob_store,
-        &redactor,
-    )
-    .await?;
-    apply_display_manifest_updates(state_doc, &updates).map_err(Into::into)
-}
-
 /// A cell queued for execution.
 #[derive(Debug, Clone)]
 pub struct QueuedCell {
@@ -665,6 +635,27 @@ mod tests {
         BlobStore::new(dir.path().join("blobs"))
     }
 
+    async fn update_output_by_display_id_with_manifests_for_test(
+        state_doc: &mut RuntimeStateDoc,
+        display_id: &str,
+        new_data: &serde_json::Value,
+        new_metadata: &serde_json::Map<String, serde_json::Value>,
+        blob_store: &BlobStore,
+        redactor: &OutputRedactor,
+    ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+        let targets = collect_display_update_targets(state_doc, display_id);
+        let updates = build_display_manifest_updates(
+            targets,
+            display_id,
+            new_data,
+            new_metadata,
+            blob_store,
+            redactor,
+        )
+        .await?;
+        apply_display_manifest_updates(state_doc, &updates).map_err(Into::into)
+    }
+
     /// Helper: create a display_data manifest with a display_id and append
     /// the inline manifest to the given execution in the state doc.
     async fn insert_display_output(
@@ -713,12 +704,14 @@ mod tests {
 
         let new_data = serde_json::json!({ "text/plain": "updated" });
         let new_metadata = serde_json::Map::new();
-        let result = update_output_by_display_id_with_manifests(
+        let redactor = OutputRedactor::disabled();
+        let result = update_output_by_display_id_with_manifests_for_test(
             &mut state_doc,
             "progress",
             &new_data,
             &new_metadata,
             &store,
+            &redactor,
         )
         .await
         .unwrap();
@@ -745,12 +738,14 @@ mod tests {
 
         let new_data = serde_json::json!({ "text/plain": "updated" });
         let new_metadata = serde_json::Map::new();
-        let result = update_output_by_display_id_with_manifests(
+        let redactor = OutputRedactor::disabled();
+        let result = update_output_by_display_id_with_manifests_for_test(
             &mut state_doc,
             "nonexistent-id",
             &new_data,
             &new_metadata,
             &store,
+            &redactor,
         )
         .await
         .unwrap();
@@ -775,12 +770,14 @@ mod tests {
 
         let new_data = serde_json::json!({ "text/plain": "updated" });
         let new_metadata = serde_json::Map::new();
-        let result = update_output_by_display_id_with_manifests(
+        let redactor = OutputRedactor::disabled();
+        let result = update_output_by_display_id_with_manifests_for_test(
             &mut state_doc,
             "progress",
             &new_data,
             &new_metadata,
             &store,
+            &redactor,
         )
         .await
         .unwrap();

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 
 use crate::blob_store::BlobStore;
+use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use runtime_doc::RuntimeStateDoc;
 
@@ -359,16 +360,18 @@ pub(crate) async fn build_display_manifest_updates(
     new_data: &serde_json::Value,
     new_metadata: &serde_json::Map<String, serde_json::Value>,
     blob_store: &BlobStore,
+    redactor: &OutputRedactor,
 ) -> Result<Vec<DisplayManifestUpdate>, Box<dyn std::error::Error + Send + Sync>> {
     let mut updates = Vec::new();
     for target in targets {
-        if let Some(updated) = output_store::update_manifest_display_data(
+        if let Some(updated) = output_store::update_manifest_display_data_with_redactor(
             &target.manifest,
             display_id,
             new_data,
             new_metadata,
             blob_store,
             DEFAULT_INLINE_THRESHOLD,
+            redactor,
         )
         .await?
         {
@@ -415,9 +418,16 @@ pub(crate) async fn update_output_by_display_id_with_manifests(
     blob_store: &BlobStore,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     let targets = collect_display_update_targets(state_doc, display_id);
-    let updates =
-        build_display_manifest_updates(targets, display_id, new_data, new_metadata, blob_store)
-            .await?;
+    let redactor = OutputRedactor::disabled();
+    let updates = build_display_manifest_updates(
+        targets,
+        display_id,
+        new_data,
+        new_metadata,
+        blob_store,
+        &redactor,
+    )
+    .await?;
     apply_display_manifest_updates(state_doc, &updates).map_err(Into::into)
 }
 

--- a/crates/runtimed/src/output_redaction.rs
+++ b/crates/runtimed/src/output_redaction.rs
@@ -1,0 +1,263 @@
+//! Best-effort redaction for text kernel outputs.
+//!
+//! The runtime agent builds one redactor per launched kernel from the effective
+//! process environment. Output storage calls this before writing text into
+//! RuntimeStateDoc or the blob store.
+
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::process::Command;
+
+use notebook_doc::mime::{mime_kind, MimeKind};
+use serde_json::Value;
+
+pub(crate) const REDACTION_MARKER: &str = "[redacted env]";
+const MIN_VALUE_LEN: usize = 8;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct OutputRedactor {
+    values: Vec<String>,
+}
+
+impl OutputRedactor {
+    pub(crate) fn disabled() -> Self {
+        Self { values: Vec::new() }
+    }
+
+    pub(crate) fn from_current_process_and_command(enabled: bool, cmd: &Command) -> Self {
+        if !enabled {
+            return Self::disabled();
+        }
+
+        let mut values = HashSet::new();
+        for (_key, value) in std::env::vars_os() {
+            add_candidate(value.as_os_str(), &mut values);
+        }
+        for (_key, value) in cmd.get_envs() {
+            if let Some(value) = value {
+                add_candidate(value, &mut values);
+            }
+        }
+
+        let mut values: Vec<String> = values.into_iter().collect();
+        values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        Self { values }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_values_for_test(values: impl IntoIterator<Item = String>) -> Self {
+        let mut values: Vec<String> = values
+            .into_iter()
+            .filter(|value| is_eligible(value))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        Self { values }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        !self.values.is_empty()
+    }
+
+    pub(crate) fn redact_text(&self, text: &str) -> String {
+        if self.values.is_empty() {
+            return text.to_string();
+        }
+
+        let mut redacted = text.to_string();
+        for value in &self.values {
+            if redacted.contains(value) {
+                redacted = redacted.replace(value, REDACTION_MARKER);
+            }
+        }
+        redacted
+    }
+
+    pub(crate) fn redact_output_value(&self, output: &Value) -> Value {
+        if self.values.is_empty() {
+            return output.clone();
+        }
+
+        let Some(output_type) = output.get("output_type").and_then(|v| v.as_str()) else {
+            return output.clone();
+        };
+
+        let mut redacted = output.clone();
+        match output_type {
+            "stream" => {
+                redact_object_key(self, &mut redacted, "text");
+            }
+            "display_data" | "execute_result" => {
+                if let Some(data) = redacted.get_mut("data") {
+                    redact_data_bundle(self, data);
+                }
+                if let Some(metadata) = redacted.get_mut("metadata") {
+                    redact_json_strings(self, metadata);
+                }
+            }
+            "error" => {
+                redact_object_key(self, &mut redacted, "ename");
+                redact_object_key(self, &mut redacted, "evalue");
+                if let Some(traceback) = redacted.get_mut("traceback") {
+                    redact_json_strings(self, traceback);
+                }
+            }
+            _ => {}
+        }
+        redacted
+    }
+
+    pub(crate) fn redact_data_bundle_value(&self, data: &Value) -> Value {
+        if self.values.is_empty() {
+            return data.clone();
+        }
+        let mut redacted = data.clone();
+        redact_data_bundle(self, &mut redacted);
+        redacted
+    }
+
+    pub(crate) fn redact_json_value(&self, value: &Value) -> Value {
+        if self.values.is_empty() {
+            return value.clone();
+        }
+        let mut redacted = value.clone();
+        redact_json_strings(self, &mut redacted);
+        redacted
+    }
+}
+
+fn add_candidate(value: &OsStr, values: &mut HashSet<String>) {
+    let Some(value) = value.to_str() else {
+        return;
+    };
+    if is_eligible(value) {
+        values.insert(value.to_string());
+    }
+}
+
+fn is_eligible(value: &str) -> bool {
+    if value.len() < MIN_VALUE_LEN {
+        return false;
+    }
+    let trimmed = value.trim();
+    if trimmed.len() != value.len() || trimmed.is_empty() {
+        return false;
+    }
+    !matches!(
+        trimmed.to_ascii_lowercase().as_str(),
+        "localhost" | "127.0.0.1" | "0.0.0.0" | "disabled" | "enabled"
+    )
+}
+
+fn redact_object_key(redactor: &OutputRedactor, value: &mut Value, key: &str) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    let Some(slot) = obj.get_mut(key) else {
+        return;
+    };
+    redact_json_strings(redactor, slot);
+}
+
+fn redact_data_bundle(redactor: &OutputRedactor, value: &mut Value) {
+    let Some(data) = value.as_object_mut() else {
+        return;
+    };
+    for (mime, body) in data {
+        if mime_kind(mime) != MimeKind::Binary {
+            redact_json_strings(redactor, body);
+        }
+    }
+}
+
+fn redact_json_strings(redactor: &OutputRedactor, value: &mut Value) {
+    match value {
+        Value::String(text) => {
+            *text = redactor.redact_text(text);
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_json_strings(redactor, item);
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values_mut() {
+                redact_json_strings(redactor, value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    #[test]
+    fn redacts_eligible_values() {
+        let redactor = OutputRedactor::from_values_for_test(vec![
+            "secret-token-123".to_string(),
+            "other-secret".to_string(),
+        ]);
+        assert_eq!(
+            redactor.redact_text("a secret-token-123 and other-secret"),
+            "a [redacted env] and [redacted env]"
+        );
+    }
+
+    #[test]
+    fn skips_empty_short_and_common_values() {
+        let redactor = OutputRedactor::from_values_for_test(vec![
+            "".to_string(),
+            "short".to_string(),
+            "localhost".to_string(),
+            "real-secret".to_string(),
+        ]);
+        assert_eq!(
+            redactor.redact_text("localhost short real-secret"),
+            "localhost short [redacted env]"
+        );
+    }
+
+    #[test]
+    fn prefers_longest_overlapping_values() {
+        let redactor = OutputRedactor::from_values_for_test(vec![
+            "secret-value".to_string(),
+            "secret-value-with-suffix".to_string(),
+        ]);
+        assert_eq!(
+            redactor.redact_text("secret-value-with-suffix secret-value"),
+            "[redacted env] [redacted env]"
+        );
+    }
+
+    #[test]
+    fn redacts_textual_output_but_not_binary_mime_payloads() {
+        let secret = "secret-value";
+        let redactor = OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+        let binary = base64::engine::general_purpose::STANDARD.encode(secret);
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": format!("token={secret}"),
+                "application/json": { "token": secret },
+                "image/png": binary,
+            },
+            "metadata": { "text/plain": { "title": secret } }
+        });
+
+        let redacted = redactor.redact_output_value(&output);
+        assert_eq!(redacted["data"]["text/plain"], "token=[redacted env]");
+        assert_eq!(
+            redacted["data"]["application/json"]["token"],
+            "[redacted env]"
+        );
+        assert_eq!(redacted["data"]["image/png"], output["data"]["image/png"]);
+        assert_eq!(
+            redacted["metadata"]["text/plain"]["title"],
+            "[redacted env]"
+        );
+    }
+}

--- a/crates/runtimed/src/output_redaction.rs
+++ b/crates/runtimed/src/output_redaction.rs
@@ -16,12 +16,16 @@ const MIN_VALUE_LEN: usize = 8;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct OutputRedactor {
+    enabled: bool,
     values: Vec<String>,
 }
 
 impl OutputRedactor {
     pub(crate) fn disabled() -> Self {
-        Self { values: Vec::new() }
+        Self {
+            enabled: false,
+            values: Vec::new(),
+        }
     }
 
     pub(crate) fn from_current_process_and_command(enabled: bool, cmd: &Command) -> Self {
@@ -30,18 +34,21 @@ impl OutputRedactor {
         }
 
         let mut values = HashSet::new();
-        for (_key, value) in std::env::vars_os() {
-            add_candidate(value.as_os_str(), &mut values);
+        for (key, value) in std::env::vars_os() {
+            add_env_candidate(key.as_os_str(), value.as_os_str(), &mut values);
         }
-        for (_key, value) in cmd.get_envs() {
+        for (key, value) in cmd.get_envs() {
             if let Some(value) = value {
-                add_candidate(value, &mut values);
+                add_env_candidate(key, value, &mut values);
             }
         }
 
         let mut values: Vec<String> = values.into_iter().collect();
         values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        Self { values }
+        Self {
+            enabled: true,
+            values,
+        }
     }
 
     #[cfg(test)]
@@ -53,11 +60,30 @@ impl OutputRedactor {
             .into_iter()
             .collect();
         values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        Self { values }
+        Self {
+            enabled: true,
+            values,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_env_pairs_for_test(
+        values: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        let mut candidates = HashSet::new();
+        for (key, value) in values {
+            add_env_candidate(OsStr::new(&key), OsStr::new(&value), &mut candidates);
+        }
+        let mut values: Vec<String> = candidates.into_iter().collect();
+        values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        Self {
+            enabled: true,
+            values,
+        }
     }
 
     pub(crate) fn is_enabled(&self) -> bool {
-        !self.values.is_empty()
+        self.enabled
     }
 
     pub(crate) fn redact_text(&self, text: &str) -> String {
@@ -127,13 +153,70 @@ impl OutputRedactor {
     }
 }
 
-fn add_candidate(value: &OsStr, values: &mut HashSet<String>) {
+fn add_env_candidate(key: &OsStr, value: &OsStr, values: &mut HashSet<String>) {
+    let Some(key) = key.to_str() else {
+        // Environment keys are normally UTF-8 on supported platforms. If not,
+        // skip the candidate rather than guessing at a key-based allowlist.
+        return;
+    };
+    if is_known_non_secret_env_key(key) {
+        return;
+    }
+    add_value_candidate(value, values);
+}
+
+fn add_value_candidate(value: &OsStr, values: &mut HashSet<String>) {
     let Some(value) = value.to_str() else {
+        // We only redact textual output, so non-UTF-8 env values cannot match
+        // the strings this redactor sees.
         return;
     };
     if is_eligible(value) {
         values.insert(value.to_string());
     }
+}
+
+fn is_known_non_secret_env_key(key: &str) -> bool {
+    let key = key.to_ascii_uppercase();
+    matches!(
+        key.as_str(),
+        "_" | "__CF_USER_TEXT_ENCODING"
+            | "CARGO_HOME"
+            | "COLORFGBG"
+            | "COLORTERM"
+            | "CONDA_DEFAULT_ENV"
+            | "CONDA_EXE"
+            | "CONDA_PREFIX"
+            | "CONDA_PYTHON_EXE"
+            | "DISPLAY"
+            | "GOPATH"
+            | "GOROOT"
+            | "HOME"
+            | "LANG"
+            | "LANGUAGE"
+            | "LOGNAME"
+            | "OLDPWD"
+            | "PATH"
+            | "PWD"
+            | "PYENV_ROOT"
+            | "PYTHONHOME"
+            | "PYTHONPATH"
+            | "RUSTUP_HOME"
+            | "SHELL"
+            | "SHLVL"
+            | "SSH_AUTH_SOCK"
+            | "TEMP"
+            | "TERM"
+            | "TMP"
+            | "TMPDIR"
+            | "USER"
+            | "USERNAME"
+            | "VIRTUAL_ENV"
+            | "XPC_FLAGS"
+            | "XPC_SERVICE_NAME"
+    ) || key.starts_with("LC_")
+        || key.starts_with("TERM_PROGRAM")
+        || key.starts_with("XDG_")
 }
 
 fn is_eligible(value: &str) -> bool {
@@ -142,6 +225,8 @@ fn is_eligible(value: &str) -> bool {
     }
     let trimmed = value.trim();
     if trimmed.len() != value.len() || trimmed.is_empty() {
+        // Do not redact values with boundary whitespace; those create noisy
+        // incidental matches and are unlikely to be emitted exactly in output.
         return false;
     }
     !matches!(
@@ -219,6 +304,28 @@ mod tests {
             redactor.redact_text("localhost short real-secret"),
             "localhost short [redacted env]"
         );
+    }
+
+    #[test]
+    fn skips_known_non_secret_env_keys() {
+        let redactor = OutputRedactor::from_env_pairs_for_test(vec![
+            ("PATH".to_string(), "secret-looking-path-value".to_string()),
+            ("HOME".to_string(), "/Users/secret-looking-user".to_string()),
+            ("API_TOKEN".to_string(), "secret-token-123".to_string()),
+        ]);
+        assert_eq!(
+            redactor.redact_text(
+                "secret-looking-path-value /Users/secret-looking-user secret-token-123"
+            ),
+            "secret-looking-path-value /Users/secret-looking-user [redacted env]"
+        );
+    }
+
+    #[test]
+    fn tracks_explicit_enabled_state_without_eligible_values() {
+        let redactor = OutputRedactor::from_values_for_test(vec!["short".to_string()]);
+        assert!(redactor.is_enabled());
+        assert_eq!(redactor.redact_text("short"), "short");
     }
 
     #[test]

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -57,6 +57,7 @@ use notebook_doc::mime::{
 };
 
 use crate::blob_store::BlobStore;
+use crate::output_redaction::OutputRedactor;
 
 /// MIME types whose `ContentRef::Blob` outputs are externalized as
 /// [`BLOB_REF_MIME`] entries in saved `.ipynb` files instead of being
@@ -537,6 +538,29 @@ pub async fn create_manifest(
     blob_store: &BlobStore,
     threshold: usize,
 ) -> io::Result<OutputManifest> {
+    create_manifest_inner(output, blob_store, threshold).await
+}
+
+/// Create an output manifest after redacting textual environment values.
+pub(crate) async fn create_manifest_with_redactor(
+    output: &Value,
+    blob_store: &BlobStore,
+    threshold: usize,
+    redactor: &OutputRedactor,
+) -> io::Result<OutputManifest> {
+    if redactor.is_enabled() {
+        let redacted = redactor.redact_output_value(output);
+        create_manifest_inner(&redacted, blob_store, threshold).await
+    } else {
+        create_manifest_inner(output, blob_store, threshold).await
+    }
+}
+
+async fn create_manifest_inner(
+    output: &Value,
+    blob_store: &BlobStore,
+    threshold: usize,
+) -> io::Result<OutputManifest> {
     let output_type = output
         .get("output_type")
         .and_then(|v| v.as_str())
@@ -840,6 +864,65 @@ pub fn get_display_id(manifest: &OutputManifest) -> Option<String> {
 /// Returns the updated OutputManifest if the manifest is a display_data or execute_result
 /// with matching display_id, otherwise returns None.
 pub async fn update_manifest_display_data(
+    manifest: &OutputManifest,
+    display_id: &str,
+    new_data: &serde_json::Value,
+    new_metadata: &serde_json::Map<String, serde_json::Value>,
+    blob_store: &BlobStore,
+    threshold: usize,
+) -> io::Result<Option<OutputManifest>> {
+    update_manifest_display_data_inner(
+        manifest,
+        display_id,
+        new_data,
+        new_metadata,
+        blob_store,
+        threshold,
+    )
+    .await
+}
+
+/// Update display data after redacting textual environment values.
+pub(crate) async fn update_manifest_display_data_with_redactor(
+    manifest: &OutputManifest,
+    display_id: &str,
+    new_data: &serde_json::Value,
+    new_metadata: &serde_json::Map<String, serde_json::Value>,
+    blob_store: &BlobStore,
+    threshold: usize,
+    redactor: &OutputRedactor,
+) -> io::Result<Option<OutputManifest>> {
+    if redactor.is_enabled() {
+        let redacted_data = redactor.redact_data_bundle_value(new_data);
+        let redacted_metadata_value =
+            redactor.redact_json_value(&Value::Object(new_metadata.clone()));
+        let redacted_metadata = redacted_metadata_value
+            .as_object()
+            .cloned()
+            .unwrap_or_default();
+        update_manifest_display_data_inner(
+            manifest,
+            display_id,
+            &redacted_data,
+            &redacted_metadata,
+            blob_store,
+            threshold,
+        )
+        .await
+    } else {
+        update_manifest_display_data_inner(
+            manifest,
+            display_id,
+            new_data,
+            new_metadata,
+            blob_store,
+            threshold,
+        )
+        .await
+    }
+}
+
+async fn update_manifest_display_data_inner(
     manifest: &OutputManifest,
     display_id: &str,
     new_data: &serde_json::Value,
@@ -2678,6 +2761,184 @@ mod tests {
         assert_eq!(resolved["data"]["text/plain"], "test");
     }
 
+    #[tokio::test]
+    async fn create_manifest_with_redactor_redacts_stream_blob_and_preview() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let secret = "secret-token-123";
+        let redactor = OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+        let output = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": format!("before {secret} after")
+        });
+
+        let manifest = create_manifest_with_redactor(&output, &store, 0, &redactor)
+            .await
+            .unwrap();
+
+        let OutputManifest::Stream {
+            text, llm_preview, ..
+        } = &manifest
+        else {
+            panic!("expected stream manifest");
+        };
+        let resolved_text = text.resolve(&store).await.unwrap();
+        assert_eq!(resolved_text, "before [redacted env] after");
+        assert!(!resolved_text.contains(secret));
+        let preview = llm_preview.as_ref().expect("blob stream has preview");
+        assert!(preview
+            .head
+            .contains(crate::output_redaction::REDACTION_MARKER));
+        assert!(!preview.head.contains(secret));
+    }
+
+    #[tokio::test]
+    async fn create_manifest_with_disabled_redactor_preserves_output_text() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let secret = "secret-token-123";
+        let redactor = OutputRedactor::disabled();
+        let output = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": format!("before {secret} after")
+        });
+
+        let manifest =
+            create_manifest_with_redactor(&output, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
+                .await
+                .unwrap();
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["text"], format!("before {secret} after"));
+    }
+
+    #[tokio::test]
+    async fn create_manifest_with_redactor_redacts_textual_outputs_and_metadata() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let secret = "secret-token-123";
+        let redactor = OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+        let binary = base64::engine::general_purpose::STANDARD.encode(secret);
+
+        let display = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": format!("plain {secret}"),
+                "application/json": { "token": secret },
+                "text/html": format!("<b>{secret}</b>"),
+                "image/svg+xml": format!("<svg><text>{secret}</text></svg>"),
+                "image/png": binary,
+            },
+            "metadata": {
+                "text/plain": { "label": secret },
+                "application/json": { "hint": secret }
+            }
+        });
+
+        let manifest =
+            create_manifest_with_redactor(&display, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
+                .await
+                .unwrap();
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["data"]["text/plain"], "plain [redacted env]");
+        assert_eq!(
+            resolved["data"]["application/json"]["token"],
+            "[redacted env]"
+        );
+        assert_eq!(resolved["data"]["text/html"], "<b>[redacted env]</b>");
+        assert_eq!(
+            resolved["data"]["image/svg+xml"],
+            "<svg><text>[redacted env]</text></svg>"
+        );
+        assert_eq!(resolved["data"]["image/png"], display["data"]["image/png"]);
+        assert_eq!(
+            resolved["metadata"]["text/plain"]["label"],
+            "[redacted env]"
+        );
+        assert_eq!(
+            resolved["metadata"]["application/json"]["hint"],
+            "[redacted env]"
+        );
+
+        let execute = serde_json::json!({
+            "output_type": "execute_result",
+            "execution_count": 1,
+            "data": { "text/plain": format!("result {secret}") },
+            "metadata": { "text/plain": { "title": secret } }
+        });
+        let manifest =
+            create_manifest_with_redactor(&execute, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
+                .await
+                .unwrap();
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["data"]["text/plain"], "result [redacted env]");
+        assert_eq!(
+            resolved["metadata"]["text/plain"]["title"],
+            "[redacted env]"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_manifest_with_redactor_redacts_errors_and_rich_tracebacks() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let secret = "secret-token-123";
+        let redactor = OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+
+        let error = serde_json::json!({
+            "output_type": "error",
+            "ename": format!("SecretError {secret}"),
+            "evalue": format!("bad {secret}"),
+            "traceback": [format!("Traceback {secret}")]
+        });
+        let manifest =
+            create_manifest_with_redactor(&error, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
+                .await
+                .unwrap();
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["ename"], "SecretError [redacted env]");
+        assert_eq!(resolved["evalue"], "bad [redacted env]");
+        assert_eq!(resolved["traceback"][0], "Traceback [redacted env]");
+
+        let rich = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                crate::user_error::TRACEBACK_MIME: {
+                    "ename": format!("SecretError {secret}"),
+                    "evalue": format!("bad {secret}"),
+                    "frames": [{
+                        "filename": "cell.py",
+                        "lineno": 1,
+                        "name": "<module>",
+                        "lines": [{ "lineno": 1, "source": format!("raise {secret}"), "highlight": true }]
+                    }],
+                    "language": "python",
+                    "text": format!("Traceback\\n{secret}\\n")
+                }
+            },
+            "metadata": {}
+        });
+        let manifest =
+            create_manifest_with_redactor(&rich, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
+                .await
+                .unwrap();
+        let OutputManifest::Error { rich, .. } = &manifest else {
+            panic!("expected rich traceback to promote to error");
+        };
+        let rich_json = rich
+            .as_ref()
+            .expect("rich payload should be stored")
+            .resolve(&store)
+            .await
+            .unwrap();
+        assert!(rich_json.contains(crate::output_redaction::REDACTION_MARKER));
+        assert!(!rich_json.contains(secret));
+        let resolved = resolve_manifest(&manifest, &store).await.unwrap();
+        assert_eq!(resolved["evalue"], "bad [redacted env]");
+        assert!(!serde_json::to_string(&resolved).unwrap().contains(secret));
+    }
+
     // ── get_display_id / update tests ───────────────────────────────
 
     #[tokio::test]
@@ -2756,6 +3017,59 @@ mod tests {
         .await
         .unwrap();
         assert!(not_updated.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_manifest_display_data_with_redactor_redacts_text_and_metadata() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let secret = "secret-token-123";
+        let redactor = OutputRedactor::from_values_for_test(vec![secret.to_string()]);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {"text/plain": "old"},
+            "metadata": {},
+            "transient": {"display_id": "my-display"}
+        });
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        let new_data = serde_json::json!({
+            "text/plain": format!("new {secret}"),
+            "application/json": { "token": secret },
+            "image/png": base64::engine::general_purpose::STANDARD.encode(secret),
+        });
+        let mut new_metadata = serde_json::Map::new();
+        new_metadata.insert(
+            "text/plain".to_string(),
+            serde_json::json!({ "label": secret }),
+        );
+
+        let updated = update_manifest_display_data_with_redactor(
+            &manifest,
+            "my-display",
+            &new_data,
+            &new_metadata,
+            &store,
+            DEFAULT_INLINE_THRESHOLD,
+            &redactor,
+        )
+        .await
+        .unwrap()
+        .expect("matching display id should update");
+        let resolved = resolve_manifest(&updated, &store).await.unwrap();
+        assert_eq!(resolved["data"]["text/plain"], "new [redacted env]");
+        assert_eq!(
+            resolved["data"]["application/json"]["token"],
+            "[redacted env]"
+        );
+        assert_eq!(resolved["data"]["image/png"], new_data["image/png"]);
+        assert_eq!(
+            resolved["metadata"]["text/plain"]["label"],
+            "[redacted env]"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -531,6 +531,10 @@ impl OutputManifest {
 /// - Text data larger than the threshold is stored in the blob store
 /// - Binary data is always stored in the blob store
 ///
+/// This path does not redact environment values. Live kernel outputs must use
+/// [`create_manifest_with_redactor`] so text is scrubbed before anything is
+/// written into the runtime state document or blob store.
+///
 /// Returns the manifest struct directly. Use `OutputManifest::to_json()` to
 /// serialize it for writing into the CRDT.
 pub async fn create_manifest(
@@ -2800,15 +2804,21 @@ mod tests {
         let secret = "secret-token-123";
         let redactor = OutputRedactor::disabled();
         let output = serde_json::json!({
+            "output_id": "stream-1",
             "output_type": "stream",
             "name": "stdout",
             "text": format!("before {secret} after")
         });
 
+        let direct = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
         let manifest =
             create_manifest_with_redactor(&output, &store, DEFAULT_INLINE_THRESHOLD, &redactor)
                 .await
                 .unwrap();
+        assert_eq!(manifest.to_json(), direct.to_json());
+
         let resolved = resolve_manifest(&manifest, &store).await.unwrap();
         assert_eq!(resolved["text"], format!("before {secret} after"));
     }

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1484,6 +1484,7 @@ pub(crate) async fn handle(
     {
         warn!("[runtime-state] {}", e);
     }
+    let redact_env_values_in_outputs = daemon.redact_env_values_in_outputs().await;
 
     // If runtime agent is already connected, restart kernel in-place
     // (handles the shutdown → launch sequence without subprocess respawn)
@@ -1503,6 +1504,7 @@ pub(crate) async fn handle(
                     launched_config: launched_config.clone(),
                     kernel_ports,
                     env_vars: restart_env_vars.clone(),
+                    redact_env_values_in_outputs,
                 }
             })
             .await
@@ -1653,6 +1655,7 @@ pub(crate) async fn handle(
                         launched_config: launched_config.clone(),
                         kernel_ports,
                         env_vars: launch_env_vars.clone(),
+                        redact_env_values_in_outputs,
                     }
                 })
                 .await

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -817,6 +817,7 @@ async fn handle_runtime_agent_request(
             launched_config,
             kernel_ports,
             env_vars,
+            redact_env_values_in_outputs,
         } => {
             info!(
                 "[runtime-agent] LaunchKernel: type={} source={}",
@@ -855,6 +856,7 @@ async fn handle_runtime_agent_request(
                 launched_config,
                 kernel_ports,
                 env_vars: env_vars.into_iter().collect(),
+                redact_env_values_in_outputs,
                 pooled_env,
             };
 
@@ -903,6 +905,7 @@ async fn handle_runtime_agent_request(
             launched_config,
             kernel_ports,
             env_vars,
+            redact_env_values_in_outputs,
         } => {
             info!(
                 "[runtime-agent] RestartKernel: type={} source={}",
@@ -959,6 +962,7 @@ async fn handle_runtime_agent_request(
                 launched_config,
                 kernel_ports,
                 env_vars: env_vars.into_iter().collect(),
+                redact_env_values_in_outputs,
                 pooled_env,
             };
 

--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -15,6 +15,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, warn};
 
 use crate::blob_store::BlobStore;
+use crate::output_redaction::OutputRedactor;
 use crate::output_prep::QueueCommand;
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::stream_flush::PendingStreamFlush;
@@ -118,9 +119,18 @@ async fn commit_priority_streams(
     stream_terminals: &Arc<Mutex<StreamTerminals>>,
     kernel_actor_id: &str,
     lifecycle_tx: &mpsc::UnboundedSender<QueueCommand>,
+    output_redactor: &OutputRedactor,
 ) {
     for flush in request.flushes {
-        commit_stream_flush(state, blob_store, stream_terminals, kernel_actor_id, flush).await;
+        commit_stream_flush(
+            state,
+            blob_store,
+            stream_terminals,
+            kernel_actor_id,
+            flush,
+            output_redactor,
+        )
+        .await;
     }
     if let Some(signal) = request.signal {
         let _ = lifecycle_tx.send(signal);
@@ -136,8 +146,17 @@ async fn commit_periodic_stream(
     blob_store: &BlobStore,
     stream_terminals: &Arc<Mutex<StreamTerminals>>,
     kernel_actor_id: &str,
+    output_redactor: &OutputRedactor,
 ) {
-    commit_stream_flush(state, blob_store, stream_terminals, kernel_actor_id, flush).await;
+    commit_stream_flush(
+        state,
+        blob_store,
+        stream_terminals,
+        kernel_actor_id,
+        flush,
+        output_redactor,
+    )
+    .await;
 }
 
 async fn run_stream_committer(
@@ -148,6 +167,7 @@ async fn run_stream_committer(
     stream_terminals: Arc<Mutex<StreamTerminals>>,
     kernel_actor_id: String,
     lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
+    output_redactor: Arc<OutputRedactor>,
 ) {
     loop {
         tokio::select! {
@@ -161,6 +181,7 @@ async fn run_stream_committer(
                     &stream_terminals,
                     &kernel_actor_id,
                     &lifecycle_tx,
+                    &output_redactor,
                 ).await;
             }
 
@@ -171,6 +192,7 @@ async fn run_stream_committer(
                     &blob_store,
                     &stream_terminals,
                     &kernel_actor_id,
+                    &output_redactor,
                 ).await;
             }
 
@@ -185,6 +207,7 @@ pub(crate) fn start_stream_committer(
     stream_terminals: Arc<Mutex<StreamTerminals>>,
     kernel_actor_id: String,
     lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
+    output_redactor: Arc<OutputRedactor>,
 ) -> StreamCommitterHandle {
     let (periodic_tx, periodic_rx) = mpsc::channel(STREAM_COMMITTER_QUEUE_CAPACITY);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel();
@@ -199,6 +222,7 @@ pub(crate) fn start_stream_committer(
             stream_terminals,
             kernel_actor_id,
             lifecycle_tx.clone(),
+            output_redactor,
         ),
         move |_| {
             let _ = panic_lifecycle_tx.send(QueueCommand::KernelDied);
@@ -217,6 +241,7 @@ pub(crate) async fn commit_stream_flush(
     stream_terminals: &Arc<Mutex<StreamTerminals>>,
     kernel_actor_id: &str,
     flush: PendingStreamFlush,
+    output_redactor: &OutputRedactor,
 ) {
     let (known_state, rendered_text) = {
         let terminals = stream_terminals.lock().await;
@@ -244,8 +269,13 @@ pub(crate) async fn commit_stream_flush(
     });
 
     let manifest =
-        match output_store::create_manifest(&nbformat_value, blob_store, DEFAULT_INLINE_THRESHOLD)
-            .await
+        match output_store::create_manifest_with_redactor(
+            &nbformat_value,
+            blob_store,
+            DEFAULT_INLINE_THRESHOLD,
+            output_redactor,
+        )
+        .await
         {
             Ok(manifest) => manifest,
             Err(e) => {
@@ -339,6 +369,7 @@ mod tests {
             terminals,
             "rt:kernel:test".to_string(),
             lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
         );
 
         handle.flush_then_signal(
@@ -385,6 +416,7 @@ mod tests {
             terminals,
             "rt:kernel:test".to_string(),
             lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
         );
 
         handle
@@ -418,6 +450,7 @@ mod tests {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
             },
+            &OutputRedactor::disabled(),
         )
         .await;
 

--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -15,8 +15,8 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, warn};
 
 use crate::blob_store::BlobStore;
-use crate::output_redaction::OutputRedactor;
 use crate::output_prep::QueueCommand;
+use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::stream_flush::PendingStreamFlush;
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
@@ -29,6 +29,15 @@ struct PriorityStreamCommit {
     flushes: Vec<PendingStreamFlush>,
     signal: Option<QueueCommand>,
     ack: Option<oneshot::Sender<()>>,
+}
+
+struct StreamCommitterContext {
+    state: RuntimeStateHandle,
+    blob_store: Arc<BlobStore>,
+    stream_terminals: Arc<Mutex<StreamTerminals>>,
+    kernel_actor_id: String,
+    lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
+    output_redactor: Arc<OutputRedactor>,
 }
 
 #[derive(Clone)]
@@ -162,12 +171,7 @@ async fn commit_periodic_stream(
 async fn run_stream_committer(
     mut periodic_rx: mpsc::Receiver<PendingStreamFlush>,
     mut priority_rx: mpsc::UnboundedReceiver<PriorityStreamCommit>,
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    stream_terminals: Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
-    output_redactor: Arc<OutputRedactor>,
+    context: StreamCommitterContext,
 ) {
     loop {
         tokio::select! {
@@ -176,23 +180,23 @@ async fn run_stream_committer(
             Some(request) = priority_rx.recv() => {
                 commit_priority_streams(
                     request,
-                    &state,
-                    &blob_store,
-                    &stream_terminals,
-                    &kernel_actor_id,
-                    &lifecycle_tx,
-                    &output_redactor,
+                    &context.state,
+                    &context.blob_store,
+                    &context.stream_terminals,
+                    &context.kernel_actor_id,
+                    &context.lifecycle_tx,
+                    &context.output_redactor,
                 ).await;
             }
 
             Some(flush) = periodic_rx.recv() => {
                 commit_periodic_stream(
                     flush,
-                    &state,
-                    &blob_store,
-                    &stream_terminals,
-                    &kernel_actor_id,
-                    &output_redactor,
+                    &context.state,
+                    &context.blob_store,
+                    &context.stream_terminals,
+                    &context.kernel_actor_id,
+                    &context.output_redactor,
                 ).await;
             }
 
@@ -212,18 +216,17 @@ pub(crate) fn start_stream_committer(
     let (periodic_tx, periodic_rx) = mpsc::channel(STREAM_COMMITTER_QUEUE_CAPACITY);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel();
     let panic_lifecycle_tx = lifecycle_tx.clone();
+    let context = StreamCommitterContext {
+        state,
+        blob_store,
+        stream_terminals,
+        kernel_actor_id,
+        lifecycle_tx: lifecycle_tx.clone(),
+        output_redactor,
+    };
     spawn_supervised(
         "stream-committer",
-        run_stream_committer(
-            periodic_rx,
-            priority_rx,
-            state,
-            blob_store,
-            stream_terminals,
-            kernel_actor_id,
-            lifecycle_tx.clone(),
-            output_redactor,
-        ),
+        run_stream_committer(periodic_rx, priority_rx, context),
         move |_| {
             let _ = panic_lifecycle_tx.send(QueueCommand::KernelDied);
         },
@@ -268,21 +271,20 @@ pub(crate) async fn commit_stream_flush(
         "text": rendered_text,
     });
 
-    let manifest =
-        match output_store::create_manifest_with_redactor(
-            &nbformat_value,
-            blob_store,
-            DEFAULT_INLINE_THRESHOLD,
-            output_redactor,
-        )
-        .await
-        {
-            Ok(manifest) => manifest,
-            Err(e) => {
-                warn!("[stream-committer] Failed to create stream manifest: {}", e);
-                return;
-            }
-        };
+    let manifest = match output_store::create_manifest_with_redactor(
+        &nbformat_value,
+        blob_store,
+        DEFAULT_INLINE_THRESHOLD,
+        output_redactor,
+    )
+    .await
+    {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            warn!("[stream-committer] Failed to create stream manifest: {}", e);
+            return;
+        }
+    };
     let manifest_json = manifest.to_json();
 
     let blob_hash = if let OutputManifest::Stream { ref text, .. } = manifest {

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -372,6 +372,7 @@ async fn shutdown_then_launch_serialized() {
                 iopub: 9004,
             },
             env_vars: Default::default(),
+            redact_env_values_in_outputs: true,
         },
     )
     .await;

--- a/python/nteract-kernel-launcher/README.md
+++ b/python/nteract-kernel-launcher/README.md
@@ -18,3 +18,9 @@ requiring the legacy `dx` PyPI package.
 If bootstrap raises, the error is logged to stderr but the launcher still
 starts the kernel — a broken bootstrap should not prevent the user from
 running code.
+
+## Output redaction
+
+The launcher performs a first-pass redaction of eligible environment variable
+values from rich traceback payloads before they leave the kernel process.
+Set `NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS=0` to disable this per kernel.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -130,8 +130,10 @@ def _eligible_env_values() -> list[str]:
     for key, raw in os.environ.items():
         if _is_known_non_secret_env_key(key):
             continue
-        value = raw.strip()
+        value = raw
         if len(value) < _MIN_REDACTION_VALUE_LEN:
+            continue
+        if value.strip() != value:
             continue
         if value.lower() in _COMMON_ENV_VALUES:
             continue

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -52,6 +52,66 @@ _CONTEXT_AFTER = 2
 _MAX_HEAD_FRAMES = 5
 _MAX_TAIL_FRAMES = 5
 
+_REDACT_ENV_VALUES_FLAG = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS"
+_REDACTION_MARKER = "[redacted env]"
+_MIN_REDACTION_VALUE_LEN = 8
+_COMMON_ENV_VALUES = {
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "disabled",
+    "enabled",
+}
+
+
+# ─── Environment value redaction ───────────────────────────────────────────
+
+
+def _redaction_enabled() -> bool:
+    raw = os.environ.get(_REDACT_ENV_VALUES_FLAG)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _eligible_env_values() -> list[str]:
+    if not _redaction_enabled():
+        return []
+
+    values = set()
+    for raw in os.environ.values():
+        value = raw.strip()
+        if len(value) < _MIN_REDACTION_VALUE_LEN:
+            continue
+        if value.lower() in _COMMON_ENV_VALUES:
+            continue
+        values.add(value)
+
+    return sorted(values, key=lambda value: (-len(value), value))
+
+
+def _redact_text(text: str, values: list[str]) -> str:
+    for value in values:
+        text = text.replace(value, _REDACTION_MARKER)
+    return text
+
+
+def _redact_payload_value(value: Any, values: list[str]) -> Any:
+    if isinstance(value, str):
+        return _redact_text(value, values)
+    if isinstance(value, list):
+        return [_redact_payload_value(item, values) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_payload_value(item, values) for key, item in value.items()}
+    return value
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    values = _eligible_env_values()
+    if not values:
+        return payload
+    return _redact_payload_value(payload, values)
+
 
 # ─── Payload construction ───────────────────────────────────────────────────
 
@@ -189,7 +249,7 @@ def build_rich_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
     # no user-code frame, but the exception object has the caret info
     # (offset, text) we want to render.
     if isinstance(evalue, SyntaxError):
-        return _build_syntax_error_payload(etype, evalue, tb)
+        return _redact_payload(_build_syntax_error_payload(etype, evalue, tb))
 
     raw_frames = []
     for f in _pytraceback.extract_tb(tb):
@@ -209,13 +269,15 @@ def build_rich_payload(etype: Any, evalue: Any, tb: Any) -> dict[str, Any]:
     frames = _clip_frames(_strip_leading_library_frames(raw_frames))
     text = "".join(_pytraceback.format_exception(etype, evalue, tb))
     ename = etype.__name__ if isinstance(etype, type) else str(etype)
-    return {
-        "ename": ename,
-        "evalue": str(evalue),
-        "frames": frames,
-        "language": "python",
-        "text": text,
-    }
+    return _redact_payload(
+        {
+            "ename": ename,
+            "evalue": str(evalue),
+            "frames": frames,
+            "language": "python",
+            "text": text,
+        }
+    )
 
 
 # ─── Safe showtraceback wrapper ─────────────────────────────────────────────

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -63,6 +63,44 @@ _COMMON_ENV_VALUES = {
     "enabled",
 }
 
+_KNOWN_NON_SECRET_ENV_KEYS = {
+    "_",
+    "__CF_USER_TEXT_ENCODING",
+    "CARGO_HOME",
+    "COLORFGBG",
+    "COLORTERM",
+    "CONDA_DEFAULT_ENV",
+    "CONDA_EXE",
+    "CONDA_PREFIX",
+    "CONDA_PYTHON_EXE",
+    "DISPLAY",
+    "GOPATH",
+    "GOROOT",
+    "HOME",
+    "LANG",
+    "LANGUAGE",
+    "LOGNAME",
+    "OLDPWD",
+    "PATH",
+    "PWD",
+    "PYENV_ROOT",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "RUSTUP_HOME",
+    "SHELL",
+    "SHLVL",
+    "SSH_AUTH_SOCK",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERNAME",
+    "VIRTUAL_ENV",
+    "XPC_FLAGS",
+    "XPC_SERVICE_NAME",
+}
+
 
 # ─── Environment value redaction ───────────────────────────────────────────
 
@@ -74,12 +112,24 @@ def _redaction_enabled() -> bool:
     return raw.strip().lower() not in {"0", "false", "no", "off"}
 
 
+def _is_known_non_secret_env_key(key: str) -> bool:
+    key = key.upper()
+    return (
+        key in _KNOWN_NON_SECRET_ENV_KEYS
+        or key.startswith("LC_")
+        or key.startswith("TERM_PROGRAM")
+        or key.startswith("XDG_")
+    )
+
+
 def _eligible_env_values() -> list[str]:
     if not _redaction_enabled():
         return []
 
     values = set()
-    for raw in os.environ.values():
+    for key, raw in os.environ.items():
+        if _is_known_non_secret_env_key(key):
+            continue
         value = raw.strip()
         if len(value) < _MIN_REDACTION_VALUE_LEN:
             continue

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -7,6 +7,7 @@ code blows up in creative ways.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -19,6 +20,13 @@ from nteract_kernel_launcher._traceback import TRACEBACK_MIME, build_rich_payloa
 def _capture_exc() -> BaseException:
     try:
         raise KeyError("missing_key")
+    except BaseException as exc:
+        return exc
+
+
+def _capture_secret_exc() -> BaseException:
+    try:
+        raise RuntimeError("launcher-secret-token-12345")
     except BaseException as exc:
         return exc
 
@@ -48,6 +56,44 @@ def test_build_payload_marks_highlight_on_fail_line():
     # Each frame that has any lines should have exactly one highlighted entry
     # at its failing lineno.
     assert len(highlights) >= 1
+
+
+def test_build_payload_redacts_environment_values_by_default(monkeypatch):
+    secret = "launcher-secret-token-12345"
+    monkeypatch.setenv("TRACEBACK_TEST_SECRET", secret)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    exc = _capture_secret_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    serialized = json.dumps(payload)
+
+    assert "[redacted env]" in serialized
+    assert secret not in serialized
+
+
+def test_build_payload_preserves_environment_values_when_redaction_disabled(monkeypatch):
+    secret = "launcher-secret-token-12345"
+    monkeypatch.setenv("TRACEBACK_TEST_SECRET", secret)
+    monkeypatch.setenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", "0")
+
+    exc = _capture_secret_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    serialized = json.dumps(payload)
+
+    assert secret in serialized
+
+
+def test_build_payload_does_not_redact_common_environment_values(monkeypatch):
+    monkeypatch.setenv("TRACEBACK_TEST_COMMON", "localhost")
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    try:
+        raise RuntimeError("localhost")
+    except BaseException as exc:
+        payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+
+    serialized = json.dumps(payload)
+    assert "localhost" in serialized
 
 
 # ─── leading-library-frame strip ───────────────────────────────────────────

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -108,6 +108,20 @@ def test_build_payload_does_not_redact_known_non_secret_env_keys(monkeypatch):
     assert value in serialized
 
 
+def test_build_payload_does_not_trim_boundary_whitespace_env_values(monkeypatch):
+    secret = "launcher-secret-token-12345"
+    monkeypatch.setenv("TRACEBACK_TEST_SECRET", f" {secret} ")
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    assert secret not in _traceback._eligible_env_values()
+
+    exc = _capture_secret_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    serialized = json.dumps(payload)
+
+    assert secret in serialized
+
+
 # ─── leading-library-frame strip ───────────────────────────────────────────
 
 

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -96,6 +96,18 @@ def test_build_payload_does_not_redact_common_environment_values(monkeypatch):
     assert "localhost" in serialized
 
 
+def test_build_payload_does_not_redact_known_non_secret_env_keys(monkeypatch):
+    value = "launcher-secret-token-12345"
+    monkeypatch.setenv("PATH", value)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    exc = _capture_secret_exc()
+    payload = build_rich_payload(type(exc), exc, exc.__traceback__)
+    serialized = json.dumps(payload)
+
+    assert value in serialized
+
+
 # ─── leading-library-frame strip ───────────────────────────────────────────
 
 

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -82,6 +82,14 @@ export type SyncedSettings = {
    */
   bootstrap_dx: boolean;
   /**
+   * Redact eligible environment variable values from newly produced text outputs.
+   *
+   * The runtime agent applies this before output manifests or blobs are
+   * written, so the setting is global-only and intentionally not stored in
+   * notebook metadata.
+   */
+  redact_env_values_in_outputs: boolean;
+  /**
    * Opaque per-install UUIDv4. Generated on first heartbeat, persisted in
    * settings. Not derived from any identifying data.
    */

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -198,6 +198,7 @@ export function useSyncedSettings() {
   // Telemetry state — surfaced to Settings → Privacy and the onboarding flow.
   const [telemetryEnabled, setTelemetryEnabledState] = useState<boolean>(true);
   const [telemetryConsentRecorded, setTelemetryConsentRecordedState] = useState<boolean>(false);
+  const [redactEnvValuesInOutputs, setRedactEnvValuesInOutputsState] = useState<boolean>(true);
   const [installId, setInstallIdState] = useState<string>("");
   const [lastDaemonPingAt, setLastDaemonPingAtState] = useState<number | null>(null);
   const [lastAppPingAt, setLastAppPingAtState] = useState<number | null>(null);
@@ -245,6 +246,9 @@ export function useSyncedSettings() {
         }
         if (typeof settings.telemetry_consent_recorded === "boolean") {
           setTelemetryConsentRecordedState(settings.telemetry_consent_recorded);
+        }
+        if (typeof settings.redact_env_values_in_outputs === "boolean") {
+          setRedactEnvValuesInOutputsState(settings.redact_env_values_in_outputs);
         }
         if (typeof settings.install_id === "string") {
           setInstallIdState(settings.install_id);
@@ -312,6 +316,9 @@ export function useSyncedSettings() {
       }
       if (typeof event.payload.telemetry_consent_recorded === "boolean") {
         setTelemetryConsentRecordedState(event.payload.telemetry_consent_recorded);
+      }
+      if (typeof event.payload.redact_env_values_in_outputs === "boolean") {
+        setRedactEnvValuesInOutputsState(event.payload.redact_env_values_in_outputs);
       }
       if (typeof event.payload.install_id === "string") {
         setInstallIdState(event.payload.install_id);
@@ -409,6 +416,15 @@ export function useSyncedSettings() {
     );
   }, []);
 
+  const setRedactEnvValuesInOutputs = useCallback((value: boolean) => {
+    setRedactEnvValuesInOutputsState(value);
+    persistSyncedSetting(
+      "redact_env_values_in_outputs",
+      value,
+      "[settings] Failed to persist redact_env_values_in_outputs:",
+    );
+  }, []);
+
   const rotateInstallId = useCallback(async (): Promise<string | null> => {
     try {
       const newId = await invokeTauri<string>("rotate_install_id");
@@ -448,6 +464,8 @@ export function useSyncedSettings() {
     setTelemetryEnabled,
     telemetryConsentRecorded,
     setTelemetryConsentRecorded,
+    redactEnvValuesInOutputs,
+    setRedactEnvValuesInOutputs,
     installId,
     rotateInstallId,
     lastDaemonPingAt,


### PR DESCRIPTION
## Summary

- Add `redact_env_values_in_outputs`, a global synced setting that defaults to enabled.
- Build a per-kernel output redactor from the effective launch environment and redact eligible env values before output manifest/blob writes.
- Apply redaction across live stream/display/result/error/update/page/widget output paths, plus launcher rich traceback payloads.
- Propagate the setting through runtime-agent launch/restart requests and the Python launcher via `NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS`.
- Skip obvious non-secret environment keys such as `PATH`, `HOME`, `TERM`, `LANG`, and `XDG_*` when building the value set, while still redacting by value for eligible keys.

## Notes

- Redaction is by value, not key name.
- Empty, short, common, and known non-secret environment values are skipped.
- Binary MIME payload bytes are not scanned in this pass.
- Opt-out is global settings only; no notebook metadata override.
- Changes apply to newly launched or restarted kernels.
- Single-pass matcher optimization is tracked separately in #2616.

Closes #1557.

## Verification

- `uv run pytest python/nteract-kernel-launcher/tests/test_traceback.py`
- `cargo test -p runtimed output_redaction`
- `cargo test -p runtimed create_manifest_with_disabled_redactor_preserves_output_text`
- `cargo test -p runtimed test_update_display_id`
- `cargo test -p runtimed test_redacted_output_manifests_do_not_leak_to_state_or_saved_nbformat`
- `cargo xtask lint --fix`
- `git diff --check`
