### PR TITLE
chore(xtask): bump split-out runtimed-client siblings to 2.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-telemetry"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "log",
  "reqwest 0.12.28",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-outputs"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "base64 0.22.1",
  "notebook-doc",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-service"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "dirs",
  "log",
@@ -7237,7 +7237,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-settings-sync"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "automerge",
  "log",

--- a/crates/nteract-telemetry/Cargo.toml
+++ b/crates/nteract-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-telemetry"
-version = "2.4.5"
+version = "2.4.6"
 edition.workspace = true
 description = "Anonymous phone-home telemetry for nteract Rust binaries"
 repository.workspace = true

--- a/crates/runtimed-outputs/Cargo.toml
+++ b/crates/runtimed-outputs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-outputs"
-version = "2.4.5"
+version = "2.4.6"
 edition.workspace = true
 description = "Output resolution and LLM-friendly output formatting for runtimed"
 repository.workspace = true

--- a/crates/runtimed-service/Cargo.toml
+++ b/crates/runtimed-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-service"
-version = "2.4.5"
+version = "2.4.6"
 edition.workspace = true
 description = "Cross-platform service management for the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-settings-sync/Cargo.toml
+++ b/crates/runtimed-settings-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-settings-sync"
-version = "2.4.5"
+version = "2.4.6"
 edition.workspace = true
 description = "Live settings sync client over the runtimed UDS protocol"
 repository.workspace = true

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -67,6 +67,27 @@ const TARGETS: &[Target] = &[
         format: Format::Toml,
         matches: 1,
     },
+    // Sibling crates split out of runtimed-client in #2567 / #2570.
+    Target {
+        path: "crates/runtimed-outputs/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-service/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runtimed-settings-sync/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/nteract-telemetry/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
     Target {
         path: "crates/notebook-doc/Cargo.toml",
         format: Format::Toml,


### PR DESCRIPTION
Follow-up to #2609. Brings four workspace crates split out in #2567 / #2570 into the 2.4.6 release that just shipped.

## What was wrong

`cargo xtask bump` reads a hand-maintained `TARGETS` list in `crates/xtask/src/bump.rs`. When the runtimed-client refactor split out `runtimed-outputs`, `runtimed-service`, `runtimed-settings-sync`, and `nteract-telemetry`, the list wasn't updated. Those four crates have been pinned at 2.4.5 across every release since, while the rest of the workspace marched forward.

Builds didn't break: every consumer references the four via `path = "..."` rather than `version = "..."`. But anything that surfaces the workspace's runtime version mosaic (telemetry payloads, diagnostics output, the `notebook` Tauri bundle bringing them in transitively) saw a mix of 2.4.5 and 2.4.6.

## What this changes

- Adds the four to `TARGETS` so future `xtask bump` runs keep them in lockstep.
- Bumps the four crates' `Cargo.toml` from 2.4.5 to 2.4.6.
- Refreshes `Cargo.lock`.

## Out of scope

`build-metadata` and `automerge-recovery` (both at 0.1.0) and `notebook-wire` (at 0.2.7) are also workspace members not in `TARGETS`. They've been intentionally on independent cadences and aren't part of this round.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo xtask lint --fix` — clean.
- [ ] CI matches.
