### PR TITLE
ci: update GitHub Actions versions

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -36,7 +36,7 @@ runs:
       with:
         run-install: false
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             source:
@@ -73,7 +73,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           run-install: false
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -175,7 +175,7 @@ jobs:
         run: cargo xtask verify-plugins
 
       - name: Install Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@v2.0.4
         with:
           deno-version: "2.4"
 
@@ -209,7 +209,7 @@ jobs:
           pnpm --dir apps/notebook build
 
       - name: Upload UI build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-build-dist
           path: |
@@ -217,7 +217,7 @@ jobs:
           retention-days: 1
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-artifacts
           retention-days: 1
@@ -268,13 +268,13 @@ jobs:
           lfs: true
 
       - name: Download UI build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-build-dist
           path: apps/notebook/dist
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -284,7 +284,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -329,7 +329,7 @@ jobs:
         run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Upload Linux Rust binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-rust-binaries
           path: |
@@ -352,7 +352,7 @@ jobs:
           cp crates/notebook/binaries/nteract-mcp-* target/release/binaries/
 
       - name: Upload E2E app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-app-linux
           path: |
@@ -379,7 +379,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -459,7 +459,7 @@ jobs:
 
       - name: Download UI build artifacts
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-build-dist
           path: apps/notebook/dist
@@ -470,7 +470,7 @@ jobs:
 
       - name: Install uv
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install rust
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
@@ -483,7 +483,7 @@ jobs:
 
       - name: Download WASM artifacts
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -617,7 +617,7 @@ jobs:
         run: pnpm install
 
       - name: Download E2E artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: e2e-app-linux
           path: ./target/release
@@ -628,7 +628,7 @@ jobs:
           chmod +x target/release/binaries/*
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Run E2E test
         timeout-minutes: ${{ matrix.timeout }}
@@ -788,7 +788,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots-${{ matrix.name }}
           path: e2e-screenshots/failures/
@@ -796,7 +796,7 @@ jobs:
 
       - name: Upload daemon logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-logs-${{ matrix.name }}
           path: e2e-logs/
@@ -821,10 +821,10 @@ jobs:
           shared-key: ubuntu-py-integration
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@v0.9.5
         with:
           run-install: false
 
@@ -897,7 +897,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runtimed-py-integration-logs
           path: python/runtimed/integration-logs/
@@ -927,7 +927,7 @@ jobs:
           shared-key: python-x86_64-unknown-linux-gnu
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/dx-bootstrap-e2e.yml
+++ b/.github/workflows/dx-bootstrap-e2e.yml
@@ -68,7 +68,7 @@ jobs:
             webkit2gtk-driver
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dx-bootstrap-e2e-screenshots
           path: e2e-screenshots/failures/
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload E2E logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dx-bootstrap-e2e-logs
           path: e2e-logs/

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
           sync-labels: false
 
       # Apply quill label for Quill Agent PRs
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,11 +22,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           lfs: true
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Resolve pull request head commit
         id: resolve
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = Number(context.payload.inputs.pr_number);
@@ -139,7 +139,7 @@ jobs:
 
       - name: Bake PR + commit into version
         id: version
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           COMMIT_SHORT_SHA: ${{ needs.resolve-pr.outputs.head_short_sha }}
@@ -262,14 +262,14 @@ jobs:
 
       - name: Upload runnable binary artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.resolve-pr.outputs.artifact_prefix }}-${{ inputs.target_os == 'linux' && 'linux-x64' || inputs.target_os == 'macos' && 'macos' || 'windows-x64' }}
           path: pr-binary/
           retention-days: 14
 
       - name: Comment on PR with artifact link
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           TARGET_OS: ${{ inputs.target_os }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: dsherret/rust-toolchain-file@v1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -91,7 +91,7 @@ jobs:
 
       - uses: dsherret/rust-toolchain-file@v1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -148,7 +148,7 @@ jobs:
         with:
           lfs: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-artifacts
           retention-days: 1
@@ -141,7 +141,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -173,7 +173,7 @@ jobs:
           chmod +x nteract-mcp-linux-x64
 
       - name: Upload Linux executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runt-linux-executables
           path: |
@@ -212,7 +212,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -245,7 +245,7 @@ jobs:
           chmod +x runt-darwin-x64
 
       - name: Upload macOS executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runt-macos-executables
           path: |
@@ -280,7 +280,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -418,13 +418,13 @@ jobs:
           cp "${TAR_GZ_SIG_BINARIES[0]}" "artifacts/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-macos-arm64
           path: artifacts/
 
       - name: Upload raw nteract-mcp binary for plugin distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-nteract-mcp-aarch64-apple-darwin
           path: crates/notebook/binaries/nteract-mcp-aarch64-apple-darwin
@@ -461,7 +461,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -599,13 +599,13 @@ jobs:
           cp "${TAR_GZ_SIG_BINARIES[0]}" "artifacts/nteract-${CHANNEL}-darwin-x64.app.tar.gz.sig"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-macos-x64
           path: artifacts/
 
       - name: Upload raw nteract-mcp binary for plugin distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-nteract-mcp-x86_64-apple-darwin
           path: crates/notebook/binaries/nteract-mcp-x86_64-apple-darwin
@@ -639,7 +639,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -771,13 +771,13 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-windows-x64
           path: artifacts/
 
       - name: Upload raw nteract-mcp binary for plugin distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-nteract-mcp-x86_64-pc-windows-msvc
           path: crates/notebook/binaries/nteract-mcp-x86_64-pc-windows-msvc.exe
@@ -817,7 +817,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -895,13 +895,13 @@ jobs:
           done
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-linux-x64
           path: artifacts/
 
       - name: Upload raw nteract-mcp binary for plugin distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-nteract-mcp-x86_64-unknown-linux-gnu
           path: crates/notebook/binaries/nteract-mcp-x86_64-unknown-linux-gnu
@@ -918,7 +918,7 @@ jobs:
           lfs: true
 
       - name: Download Linux AppImage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-linux-x64
           path: artifacts
@@ -947,7 +947,7 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -972,7 +972,7 @@ jobs:
         working-directory: python/nteract
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-dist
           path: dist
@@ -988,7 +988,7 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -1011,7 +1011,7 @@ jobs:
         working-directory: python/dx
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dx-dist
           # uv build in a workspace writes to repo-root dist/, not
@@ -1059,7 +1059,7 @@ jobs:
         uses: ./.github/actions/sccache-warmup
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-artifacts
 
@@ -1135,7 +1135,7 @@ jobs:
           fi
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.target }}
           path: python/runtimed/dist
@@ -1169,7 +1169,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download nteract-mcp binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: plugin-nteract-mcp-*
           path: plugin-binaries-staged
@@ -1307,37 +1307,37 @@ jobs:
           echo "$CHANGELOG" > changelog-section.md
 
       - name: Download Linux executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: runt-linux-executables
           path: ./executables
 
       - name: Download macOS executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: runt-macos-executables
           path: ./executables
 
       - name: Download macOS ARM64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-macos-arm64
           path: ./notebook-macos-arm64
 
       - name: Download macOS x64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-macos-x64
           path: ./notebook-macos-x64
 
       - name: Download Windows x64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-windows-x64
           path: ./notebook-windows-x64
 
       - name: Download Linux x64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-linux-x64
           path: ./notebook-linux-x64
@@ -1468,20 +1468,20 @@ jobs:
           cat release-assets/latest.json
 
       - name: Download Python wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: ./wheels
           merge-multiple: true
 
       - name: Download nteract dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-dist
           path: ./nteract-dist
 
       - name: Download dx dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dx-dist
           path: ./dx-dist
@@ -1495,7 +1495,7 @@ jobs:
           find release-assets wheels nteract-dist dx-dist -type f -printf "%12s  %p\n" | sort -nr
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
 
       # PyPI publishes are gated to pre-releases (nightly) only. Stable
       # publishes are paused while the `runtimed` / `nteract` / `dx`
@@ -1590,7 +1590,7 @@ jobs:
           } > release-body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           run-install: false
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -79,7 +79,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: sift-preview
           message: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -217,7 +217,7 @@ jobs:
           # a real MCP client, which is the test we actually want.
 
       - name: Set up Python for MCP smoke
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -349,7 +349,7 @@ jobs:
 
       - name: Upload diagnostics tarballs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-smoke-diagnostics
           path: |
@@ -364,7 +364,7 @@ jobs:
 
       - name: Upload installer
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-smoke-installer
           path: target/release/bundle/nsis/*.exe
@@ -426,7 +426,7 @@ jobs:
         run: cargo build --release -p runtimed -p runt -p nteract-mcp
 
       - name: Set up Python for MCP smoke
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -510,7 +510,7 @@ jobs:
 
       - name: Upload diagnostics tarballs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-smoke-diagnostics
           path: |


### PR DESCRIPTION
## Summary

- update stale GitHub Actions references across CI workflows
- move artifact upload/download actions to the current major versions used by Actions
- pin repositories without floating major tags to their latest resolvable semver tags

## Verification

- `cargo xtask lint --fix`
- `./actionlint .github/workflows/*.yml`
- `git diff --check -- .github`
- verified every external `uses:` reference resolves through the GitHub API
