### PR TITLE
fix(plugins): use Codex-local nteract MCP config

### DIFF
--- a/plugins/nightly/.codex-mcp.json
+++ b/plugins/nightly/.codex-mcp.json
@@ -1,0 +1,10 @@
+{
+  "notebook": {
+    "command": "./bin/nteract-mcp",
+    "args": [],
+    "cwd": ".",
+    "env": {
+      "NTERACT_CHANNEL": "nightly"
+    }
+  }
+}

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
     "visualization"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json",
+  "mcpServers": "./.codex-mcp.json",
   "interface": {
     "displayName": "nteract Nightly",
     "shortDescription": "Open, run, and edit notebooks from Codex (nightly channel)",

--- a/plugins/nteract/.codex-mcp.json
+++ b/plugins/nteract/.codex-mcp.json
@@ -1,0 +1,10 @@
+{
+  "notebook": {
+    "command": "./bin/nteract-mcp",
+    "args": [],
+    "cwd": ".",
+    "env": {
+      "NTERACT_CHANNEL": "stable"
+    }
+  }
+}

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
     "visualization"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json",
+  "mcpServers": "./.codex-mcp.json",
   "interface": {
     "displayName": "nteract",
     "shortDescription": "Open, run, and edit notebooks from Codex",

--- a/scripts/assemble-plugin-dist.sh
+++ b/scripts/assemble-plugin-dist.sh
@@ -11,9 +11,9 @@
 #   .claude-plugin/marketplace.json               — Claude marketplace entries
 #   .agents/plugins/marketplace.json              — Codex marketplace entries
 #   plugins/nteract/                              — stable channel
-#     .mcp.json, .claude-plugin/, .codex-plugin/, skills/, bin/
+#     .mcp.json, .codex-mcp.json, .claude-plugin/, .codex-plugin/, skills/, bin/
 #   plugins/nightly/                              — nightly channel
-#     .mcp.json, .claude-plugin/, .codex-plugin/, skills/, bin/
+#     .mcp.json, .codex-mcp.json, .claude-plugin/, .codex-plugin/, skills/, bin/
 #   README.md
 #
 # Claude user install commands (both valid against the same marketplace):
@@ -106,7 +106,7 @@ rm -rf "$plugin_dir"
 mkdir -p "$plugin_dir/bin"
 
 # Copy plugin manifests + skills verbatim.
-for item in .mcp.json .claude-plugin .codex-plugin skills assets; do
+for item in .mcp.json .codex-mcp.json .claude-plugin .codex-plugin skills assets; do
   if [[ -e "$source_plugin/$item" ]]; then
     cp -R "$source_plugin/$item" "$plugin_dir/"
   fi


### PR DESCRIPTION
## Summary

- add Codex-specific nteract MCP configs that use the documented direct server-map shape and launch the bundled sidecar via `./bin/nteract-mcp`
- point Codex plugin manifests at `.codex-mcp.json` while leaving Claude's `.mcp.json` unchanged
- teach the plugin distribution assembler to copy `.codex-mcp.json` into `agent-plugins`

## Verification

- `jq empty plugins/nteract/.codex-plugin/plugin.json plugins/nightly/.codex-plugin/plugin.json plugins/nteract/.codex-mcp.json plugins/nightly/.codex-mcp.json plugins/nteract/.mcp.json plugins/nightly/.mcp.json`
- `./scripts/assemble-plugin-dist.sh --channel stable --binaries-dir /Users/kylekelley/Documents/Codex/2026-05-08/help-me-figure-out-why-https/agent-plugins/plugins/nteract/bin --out-dir /tmp/nteract-plugin-dist-test`
- `./scripts/assemble-plugin-dist.sh --channel nightly --binaries-dir /Users/kylekelley/Documents/Codex/2026-05-08/help-me-figure-out-why-https/agent-plugins/plugins/nightly/bin --out-dir /tmp/nteract-plugin-dist-test`
- initialized `/tmp/nteract-plugin-dist-test/plugins/nteract/bin/nteract-mcp` through JSON-RPC from the plugin root
- `cargo xtask lint --fix`
