### PR TITLE
fix(release): resume runtimed binding publishing

### DIFF
--- a/.agents/skills/releasing/SKILL.md
+++ b/.agents/skills/releasing/SKILL.md
@@ -8,14 +8,17 @@ disable-model-invocation: true
 
 ## Version Scheme
 
-All published artifacts share the same version (semver). Five sources must stay in sync:
+Published desktop, CLI, daemon, and `runtimed` Python artifacts share the same
+base version. Python release jobs stamp the wheel version from the Rust release
+source during the workflow, after `cargo xtask bump` has updated the checked-in
+version files.
 
 | Artifact | Version source |
 |---|---|
 | nteract desktop app | `crates/notebook/tauri.conf.json` |
 | `runt` CLI | `crates/runt/Cargo.toml` |
 | `runtimed` daemon | `crates/runtimed/Cargo.toml` |
-| `runtimed` Python package | `python/runtimed/pyproject.toml` |
+| `runtimed` Python package | `python/runtimed/pyproject.toml`, then stamped from `crates/runt/Cargo.toml` during release |
 | `nteract` Python package | `python/nteract/pyproject.toml` |
 
 ### Internal Compatibility Markers
@@ -30,7 +33,7 @@ These evolve independently from each other and from the artifact version.
 ## Bumping Versions
 
 ```bash
-# Update ALL of these to the same version:
+# Update the checked-in release sources to the same version:
 #   crates/runtimed/Cargo.toml
 #   crates/runt/Cargo.toml
 #   crates/notebook/Cargo.toml
@@ -56,8 +59,8 @@ git push origin v2.1.0
 Triggers `release-stable.yml` which:
 1. Builds desktop app (macOS, Windows, Linux)
 2. Builds `runt` CLI binaries
-3. Builds Python wheels at version from `pyproject.toml`
-4. Publishes wheels to PyPI (stable)
+3. Builds Python wheels stamped to the base version from `crates/runt/Cargo.toml`
+4. Publishes `runtimed` wheels to PyPI (stable)
 5. Creates GitHub Release with all artifacts
 6. Updates `stable-latest` Tauri updater channel
 7. Posts to Discord
@@ -74,25 +77,20 @@ Runs automatically at 9am UTC daily via `release-nightly.yml`, or manually via w
 
 Install nightly Python: `pip install runtimed --pre`
 
-### Python-Only Release
+### Python Release Policy
 
-For Python fixes without a full desktop release:
-
-```bash
-# Bump python/runtimed/pyproject.toml (and Cargo.tomls if Rust changed)
-git tag python-v2.1.1
-git push origin python-v2.1.1
-```
-
-Builds macOS + Linux wheels and publishes to PyPI.
+`runtimed` Python wheels ship from the stable and nightly release workflows.
+Nightly builds stamp the next patch alpha version (PEP 440), and stable builds
+stamp the base version from `crates/runt/Cargo.toml`. `cargo xtask bump` still
+updates `python/runtimed/pyproject.toml`; workflow stamping is a guardrail so a
+stale pyproject cannot publish the wrong wheel version.
 
 ## Tag Reference
 
 | Tag pattern | Workflow | What it publishes |
 |---|---|---|
-| `v*` | `release-stable.yml` | Desktop app + CLI + Python (stable) |
-| `python-v*` | `python-package.yml` | Python wheels only |
-| _(cron)_ | `release-nightly.yml` | Desktop app + CLI + Python (pre-release) |
+| `v*` | `release-stable.yml` | Desktop app + CLI + `runtimed` Python (stable) |
+| _(cron)_ | `release-nightly.yml` | Desktop app + CLI + `runtimed` Python (pre-release) |
 
 ## Protocol Version Change Procedure
 
@@ -115,9 +113,9 @@ Schema changes don't require a protocol bump — wire format for sync frames sta
 
 `release-common.yml` accepts inputs:
 - `github_release_prerelease: true` — applies PEP 440 alpha stamp to Python version
-- `github_release_prerelease: false` — uses `pyproject.toml` version as-is
+- `github_release_prerelease: false` — stamps Python version from `crates/runt/Cargo.toml`
 
-Python wheels always built (macOS arm64, Linux x64, Windows x64) and published. `continue-on-error: true` on PyPI step handles duplicate version conflicts.
+Python wheels are always built (macOS arm64, macOS x64, Linux x64, Windows x64) and published.
 
 Desktop version: `{runt version}-{suffix}.{timestamp}` stamped into `tauri.conf.json` and `Cargo.toml` at build time (not committed).
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,11 +1,12 @@
 name: Publish npm packages
 
-# Manual-only npm publishing for the Pi package and runtimed Node bindings.
+# npm publishing for the runtimed Node bindings and Pi package.
 #
 # Publishes stable releases to the `latest` dist-tag via GitHub OIDC trusted
-# publishing (no npm token required). Nightly releases are published manually
-# with `npm publish --tag next` from a local checkout, since trusted publishing
-# doesn't support operations that require an npm token (like dist-tag management).
+# publishing (no npm token required). Stable releases on the default branch
+# invoke this workflow after the Stable Release workflow succeeds;
+# workflow_dispatch remains available for republishing or filling in a missing
+# package.
 #
 # Before using this workflow, configure npm trusted publishing for:
 # - @runtimed/node
@@ -16,6 +17,9 @@ name: Publish npm packages
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Stable Release"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -36,6 +40,7 @@ env:
 jobs:
   native:
     name: Native package (${{ matrix.target }})
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -51,6 +56,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: dsherret/rust-toolchain-file@v1
 
@@ -78,16 +84,26 @@ jobs:
         run: pnpm --dir packages/runtimed-node/npm/${{ matrix.target }} pack:dry-run
 
       - name: Publish platform package
-        run: npm publish packages/runtimed-node/npm/${{ matrix.target }} --tag latest --access public --provenance
+        shell: bash
+        run: |
+          PACKAGE="@runtimed/node-${{ matrix.target }}"
+          VERSION=$(node -p "require('./packages/runtimed-node/npm/${{ matrix.target }}/package.json').version")
+          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE}@${VERSION} is already published; skipping."
+            exit 0
+          fi
+          npm publish packages/runtimed-node/npm/${{ matrix.target }} --tag latest --access public --provenance
 
   wrapper:
     name: Wrapper package
     needs: [native]
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: dsherret/rust-toolchain-file@v1
 
@@ -137,16 +153,26 @@ jobs:
           NODE
 
       - name: Publish wrapper package
-        run: npm publish "$RUNNER_TEMP"/runtimed-node-*.tgz --tag latest --access public --provenance
+        shell: bash
+        run: |
+          PACKAGE="@runtimed/node"
+          VERSION=$(node -p "require('./packages/runtimed-node/package.json').version")
+          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE}@${VERSION} is already published; skipping."
+            exit 0
+          fi
+          npm publish "$RUNNER_TEMP"/runtimed-node-*.tgz --tag latest --access public --provenance
 
   pi:
     name: Pi package
     needs: [wrapper]
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -189,4 +215,12 @@ jobs:
           NODE
 
       - name: Publish Pi package
-        run: npm publish "$RUNNER_TEMP"/nteract-pi-*.tgz --tag latest --access public --provenance
+        shell: bash
+        run: |
+          PACKAGE="@nteract/pi"
+          VERSION=$(node -p "require('./plugins/nteract/pi/package.json').version")
+          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE}@${VERSION} is already published; skipping."
+            exit 0
+          fi
+          npm publish "$RUNNER_TEMP"/nteract-pi-*.tgz --tag latest --access public --provenance

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -61,6 +61,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
       timestamp: ${{ steps.version.outputs.TIMESTAMP }}
+      base_version: ${{ steps.version.outputs.BASE_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -74,8 +75,11 @@ jobs:
           TIMESTAMP=$(date -u +%Y%m%d%H%M)
           VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${TIMESTAMP}"
           echo "Setting version to: ${VERSION}"
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "TIMESTAMP=${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+          {
+            echo "VERSION=${VERSION}"
+            echo "TIMESTAMP=${TIMESTAMP}"
+            echo "BASE_VERSION=${CURRENT_VERSION}"
+          } >> "$GITHUB_OUTPUT"
 
   build-wasm:
     name: Build WASM artifacts
@@ -937,88 +941,6 @@ jobs:
               bash scripts/ci/fedora-appimage-smoke.sh "$1"
             ' bash "$APPIMAGE"
 
-  build-nteract-package:
-    name: Build nteract Package
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: compute-version
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          lfs: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Set dev version
-        if: inputs.github_release_prerelease
-        run: |
-          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          MAJOR_MINOR="${CURRENT_VERSION%.*}"
-          PATCH="${CURRENT_VERSION##*.}"
-          NEXT_PATCH=$((PATCH + 1))
-          TIMESTAMP="${{ needs.compute-version.outputs.timestamp }}"
-          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
-          echo "Setting nteract version to: ${DEV_VERSION}"
-          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
-          # Pin runtimed dep to the same prerelease timestamp
-          sed -i "s/runtimed>=[^,]*/runtimed>=${DEV_VERSION}/" pyproject.toml
-        working-directory: python/nteract
-
-      - name: Build sdist + wheel
-        run: uv build --no-sources
-        working-directory: python/nteract
-
-      - name: Upload dist
-        uses: actions/upload-artifact@v7
-        with:
-          name: nteract-dist
-          path: dist
-          if-no-files-found: error
-
-  build-dx-package:
-    name: Build dx Package
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: compute-version
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          lfs: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Set dev version
-        if: inputs.github_release_prerelease
-        run: |
-          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          MAJOR_MINOR="${CURRENT_VERSION%.*}"
-          PATCH="${CURRENT_VERSION##*.}"
-          NEXT_PATCH=$((PATCH + 1))
-          TIMESTAMP="${{ needs.compute-version.outputs.timestamp }}"
-          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
-          echo "Setting dx version to: ${DEV_VERSION}"
-          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
-        working-directory: python/dx
-
-      - name: Build sdist + wheel
-        run: uv build --no-sources
-        working-directory: python/dx
-
-      - name: Upload dist
-        uses: actions/upload-artifact@v7
-        with:
-          name: dx-dist
-          # uv build in a workspace writes to repo-root dist/, not
-          # python/dx/dist — same as the nteract job above.
-          path: dist/dx-*
-          if-no-files-found: error
-
   build-python-wheels:
     name: Build Python Wheels (${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
@@ -1081,35 +1003,41 @@ jobs:
           cargo build --release --target ${{ matrix.platform.target }} -p runtimed
           cp target/${{ matrix.platform.target }}/release/runtimed.exe python/runtimed/src/runtimed/_bin/
 
-      - name: Set dev version (Unix)
-        if: runner.os != 'Windows' && inputs.github_release_prerelease
+      - name: Set package version (Unix)
+        if: runner.os != 'Windows'
         run: |
-          CURRENT_VERSION=$(grep '^version' python/runtimed/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          # Bump patch and use alpha tag so it sorts after current stable (PEP 440)
-          MAJOR_MINOR="${CURRENT_VERSION%.*}"
-          PATCH="${CURRENT_VERSION##*.}"
-          NEXT_PATCH=$((PATCH + 1))
-          TIMESTAMP="${{ needs.compute-version.outputs.timestamp }}"
-          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
-          echo "Setting Python version to: ${DEV_VERSION}"
-          sed -i.bak "s/^version = .*/version = \"${DEV_VERSION}\"/" python/runtimed/pyproject.toml
+          BASE_VERSION="${{ needs.compute-version.outputs.base_version }}"
+          if [ "${{ inputs.github_release_prerelease }}" = "true" ]; then
+            # Bump patch and use alpha tag so it sorts after current stable (PEP 440).
+            MAJOR_MINOR="${BASE_VERSION%.*}"
+            PATCH="${BASE_VERSION##*.}"
+            NEXT_PATCH=$((PATCH + 1))
+            TIMESTAMP="${{ needs.compute-version.outputs.timestamp }}"
+            PACKAGE_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
+          else
+            PACKAGE_VERSION="${BASE_VERSION}"
+          fi
+          echo "Setting Python version to: ${PACKAGE_VERSION}"
+          sed -i.bak "s/^version = .*/version = \"${PACKAGE_VERSION}\"/" python/runtimed/pyproject.toml
 
-      - name: Set dev version (Windows)
-        if: runner.os == 'Windows' && inputs.github_release_prerelease
+      - name: Set package version (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $content = Get-Content python/runtimed/pyproject.toml -Raw
-          if ($content -match 'version = "([^"]+)"') {
-            $currentVersion = $matches[1]
+          $baseVersion = "${{ needs.compute-version.outputs.base_version }}"
+          if ("${{ inputs.github_release_prerelease }}" -eq "true") {
+            # Bump patch and use alpha tag so it sorts after current stable (PEP 440).
+            $parts = $baseVersion.Split('.')
+            $parts[2] = [string]([int]$parts[2] + 1)
+            $nextVersion = $parts -join '.'
+            $timestamp = "${{ needs.compute-version.outputs.timestamp }}"
+            $packageVersion = "${nextVersion}a${timestamp}"
+          } else {
+            $packageVersion = $baseVersion
           }
-          # Bump patch and use alpha tag so it sorts after current stable (PEP 440)
-          $parts = $currentVersion.Split('.')
-          $parts[2] = [string]([int]$parts[2] + 1)
-          $nextVersion = $parts -join '.'
-          $timestamp = "${{ needs.compute-version.outputs.timestamp }}"
-          $devVersion = "${nextVersion}a${timestamp}"
-          Write-Host "Setting Python version to: $devVersion"
-          $content = $content -replace 'version = "[^"]+"', "version = `"$devVersion`""
+          Write-Host "Setting Python version to: $packageVersion"
+          $content = $content -replace 'version = "[^"]+"', "version = `"$packageVersion`""
           Set-Content python/runtimed/pyproject.toml $content -NoNewline
 
       - name: Build wheels
@@ -1268,8 +1196,6 @@ jobs:
         build-notebook-linux-x64,
         smoke-fedora-appimage,
         build-python-wheels,
-        build-nteract-package,
-        build-dx-package,
       ]
     steps:
       - name: Checkout
@@ -1474,51 +1400,29 @@ jobs:
           path: ./wheels
           merge-multiple: true
 
-      - name: Download nteract dist
-        uses: actions/download-artifact@v8
-        with:
-          name: nteract-dist
-          path: ./nteract-dist
-
-      - name: Download dx dist
-        uses: actions/download-artifact@v8
-        with:
-          name: dx-dist
-          path: ./dx-dist
-
       - name: Report final release asset sizes
         run: |
           echo "Release asset directories:"
-          du -sh release-assets wheels nteract-dist dx-dist
+          du -sh release-assets wheels
           echo ""
           echo "Release asset files:"
-          find release-assets wheels nteract-dist dx-dist -type f -printf "%12s  %p\n" | sort -nr
+          find release-assets wheels -type f -printf "%12s  %p\n" | sort -nr
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
-      # PyPI publishes are gated to pre-releases (nightly) only. Stable
-      # publishes are paused while the `runtimed` / `nteract` / `dx`
-      # library surface is still in flux — see #2217. Pre-releases carry
-      # unique per-minute versions (e.g. 2.2.1a202604150406) so there's
-      # no collision risk.
+      # Nightly publishes carry unique per-minute alpha versions
+      # (e.g. 2.2.1a202604150406). Stable publishes use the base version
+      # from crates/runt/Cargo.toml so the stable release promotes the same
+      # API users install without --pre, even if pyproject.toml was stale.
       #
       # Trusted-publisher config on PyPI must include an entry for this
-      # workflow (`release-common.yml`) per published project. Missing
+      # workflow (`release-common.yml`) for runtimed. Missing
       # entries surface here as "403 Invalid API Token … not valid for
       # project 'X'". Fix at https://pypi.org/manage/project/{name}/settings/publishing/.
 
       - name: Publish runtimed to PyPI
-        if: inputs.github_release_prerelease
-        run: uv publish --trusted-publishing always ./wheels/*.whl
-
-      - name: Publish nteract to PyPI
-        if: inputs.github_release_prerelease
-        run: uv publish --trusted-publishing always ./nteract-dist/*
-
-      - name: Publish dx to PyPI
-        if: inputs.github_release_prerelease
-        run: uv publish --trusted-publishing always ./dx-dist/*
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/runtimed/ ./wheels/*.whl
 
       - name: Generate release body
         env:
@@ -1579,13 +1483,11 @@ jobs:
             echo '## runtimed (Python — macOS, Linux, Windows)'
             echo ''
             echo '```bash'
-            echo 'pip install runtimed --pre'
-            echo '```'
-            echo ''
-            echo '## dx (Python kernel-side helpers)'
-            echo ''
-            echo '```bash'
-            echo 'pip install dx --pre'
+            if [ "$VERSION_SUFFIX" = "nightly" ]; then
+              echo 'pip install --pre runtimed'
+            else
+              echo 'pip install runtimed'
+            fi
             echo '```'
           } > release-body.md
 
@@ -1617,8 +1519,6 @@ jobs:
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe.sig
             ./release-assets/latest.json
             ./wheels/*.whl
-            ./nteract-dist/*
-            ./dx-dist/*
 
       - name: Update ${{ inputs.updater_channel_tag }} updater channel
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,8 @@
 |--------|-----|---------|-------------|
 | **Stable** | `v{version}-stable.{timestamp}` | Tag push (`v*`) or manual | GitHub Releases |
 | **Nightly** | `v{version}-nightly.{timestamp}` | Cron (daily, 24h cadence) or manual | GitHub Pre-releases |
-| **Python package** | `python-v{semver}` | Manual tag push | PyPI + GitHub Releases |
+| **runtimed Python package** | same as stable/nightly | Stable/nightly release workflow | PyPI + GitHub Releases |
+| **npm packages** | same commit as stable | Successful stable release or manual | npm |
 
 Timestamps are UTC in `YYYYMMDDHHMM` format, e.g. `v2.0.0-stable.202507010900`.
 
@@ -16,7 +17,7 @@ The desktop app, `runt` CLI, and `runtimed` daemon are all built and released to
 
 Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-releases run every 24 hours. Both can also be triggered manually.
 
-> **Note:** Desktop releases also build Python wheels and attempt to publish the `runtimed` and `nteract` packages to PyPI via trusted publishing (`continue-on-error: true`, so publishing is best-effort and will silently skip if the version already exists). This means every stable and nightly release builds and attempts to push new Python wheels — the separate `python-v*` tag workflow is only needed for Python-specific patches that don't warrant a full desktop release.
+> **Note:** Desktop releases also build `runtimed` Python wheels and publish them to PyPI via trusted publishing. Nightly releases publish a unique pre-release version; stable releases publish the base version from `crates/runt/Cargo.toml`. `cargo xtask bump` still bumps `python/runtimed/pyproject.toml`; the release workflow stamps it again inside the ephemeral Actions checkout so PyPI publishing follows the Rust release version even if that file drifts.
 
 ### Artifacts
 
@@ -43,29 +44,13 @@ curl -fsSL https://sh.nteract.io | bash
 
 `runt`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, and `xtask` are **not published to crates.io** (`publish = false`).
 
-## Python Packages (runtimed, nteract)
+## Published Bindings
 
-The `runtimed` and `nteract` Python packages are released separately.
+The `runtimed` Python package is released by the stable and nightly release workflows.
 
-### 1. Bump the version
+Nightly builds publish the next patch alpha version, for example `2.4.7a202605082121`, and stable builds publish the checked-in Rust release version, for example `2.4.6`.
 
-Edit `python/runtimed/pyproject.toml` and `python/nteract/pyproject.toml` and update the `version` field in each.
-
-### 2. Create a PR
-
-Open a PR with the version bump, get it reviewed and merged.
-
-### 3. Tag and push
-
-```
-git tag python-v<version>
-git push origin python-v<version>
-```
-
-The `python-package.yml` workflow triggers on `python-v*` tags and will:
-- Build wheels for macOS arm64, macOS x86_64, and Linux x64
-- Publish to PyPI via trusted publishing (OIDC)
-- Create a GitHub release with wheels and nteract-dist packages
+The `publish-npm.yml` workflow publishes `@runtimed/node`, its native platform packages, and `@nteract/pi` to npm after a successful stable release. It can also be run manually to fill in missing packages.
 
 ## Development
 

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -240,6 +240,10 @@ impl AsyncClient {
     ///     package_manager: Package manager ("uv", "conda", "pixi"). When None, daemon uses default_python_env.
     ///     dependencies: Dependencies to seed before kernel auto-launch.
     ///     environment_mode: Environment source mode ("auto", "project", "notebook"). Defaults to "auto".
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "PyO3 exposes these as Python keyword arguments; grouping them would break the public API"
+    )]
     #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None, package_manager=None, dependencies=None, environment_mode=None))]
     fn create_notebook<'py>(
         &self,


### PR DESCRIPTION
## Summary

- resume `runtimed` PyPI publishing from stable and nightly release workflows
- stamp Python wheel versions from `crates/runt/Cargo.toml` during release so stale `python/runtimed/pyproject.toml` versions do not block shipping
- stop building/publishing `nteract` and `dx` Python package artifacts from desktop releases
- publish `@runtimed/node`, its native npm packages, and `@nteract/pi` after stable releases
- keep the PyO3 `create_notebook` keyword-argument API intact while satisfying Clippy

## Verification

- `cargo clippy -p runtimed-py --all-targets -- -D warnings`
- `actionlint .github/workflows/release-common.yml .github/workflows/publish-npm.yml`
- YAML parse check for changed workflows
- `git diff --check`
- `cargo xtask lint --fix`
