### PR TITLE
fix(runt-mcp-proxy): strip RUNTIMED_* from inherited env on child spawn

### DIFF
--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -354,6 +354,11 @@ mod tests {
         );
     }
 
+    /// `child_env_for_channel` returns the additive env map only. It does not
+    /// (and cannot) prevent the spawned child from inheriting a parent shell's
+    /// `RUNTIMED_DEV` / workspace path. The actual strip lives in
+    /// `runt-mcp-proxy`'s `apply_child_env`; this test guards the additive
+    /// contract that strip relies on.
     #[test]
     fn child_env_is_limited_to_the_channel_contract() {
         let env = child_env_for_channel("stable");

--- a/crates/runt-mcp-proxy/src/child.rs
+++ b/crates/runt-mcp-proxy/src/child.rs
@@ -109,6 +109,31 @@ struct SpawnedTransport {
     lifecycle_handle: tokio::task::JoinHandle<()>,
 }
 
+/// Daemon-resolution env vars `runt`/`runtimed` consult to pick a socket.
+/// The proxy strips these from the inherited environment so the parent
+/// shell can't silently redirect a child to the wrong daemon. Callers that
+/// genuinely need them (the dev supervisor) pass them in `env`; the
+/// `Command` API applies modifications in call order, so a later `envs()`
+/// re-asserts the caller's values.
+const DAEMON_RESOLUTION_VARS: [&str; 3] = [
+    "RUNTIMED_DEV",
+    "RUNTIMED_WORKSPACE_PATH",
+    "RUNTIMED_SOCKET_PATH",
+];
+
+/// Configure a child process command's environment.
+///
+/// `envs(...)` alone leaves the parent's environment intact, so direnv-set
+/// vars like `RUNTIMED_DEV` flow through to the child and silently redirect
+/// daemon resolution. The proxy is a gateway — the caller decides which
+/// daemon the child binds to, not the parent shell.
+fn apply_child_env(cmd: &mut Command, env: &HashMap<String, String>) {
+    for var in DAEMON_RESOLUTION_VARS {
+        cmd.env_remove(var);
+    }
+    cmd.envs(env);
+}
+
 fn spawn_managed_transport_inner(
     command: &Path,
     args: &[String],
@@ -116,10 +141,10 @@ fn spawn_managed_transport_inner(
 ) -> std::io::Result<SpawnedTransport> {
     let mut cmd = Command::new(command);
     cmd.args(args)
-        .envs(env)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
+    apply_child_env(&mut cmd, env);
 
     let mut child = cmd.spawn()?;
     let stdin = child
@@ -425,6 +450,94 @@ mod tests {
         assert!(
             closed,
             "is_transport_closed() must flip to true when the child's stdio closes"
+        );
+    }
+
+    /// Helper: snapshot the explicit env modifications attached to a Command
+    /// (added via `.envs()` / `.env_remove()`), keyed by name. `None` means
+    /// the var is explicitly removed; `Some(value)` means explicitly set.
+    /// Inherited parent-process vars do not appear here.
+    fn explicit_envs(cmd: &Command) -> HashMap<String, Option<String>> {
+        cmd.as_std()
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    /// The proxy is a thin gateway: when the caller's explicit env map does
+    /// not name a daemon-resolution var, the child must not inherit one from
+    /// the parent process. Otherwise the system nightly plugin gets pulled to
+    /// a per-worktree dev daemon whenever Claude Code is launched from a
+    /// direnv-active repo.
+    #[test]
+    fn apply_child_env_strips_dev_redirect_vars_when_caller_does_not_set_them() {
+        let mut cmd = Command::new("/usr/bin/true");
+        let env = HashMap::from([("NTERACT_CHANNEL".to_string(), "nightly".to_string())]);
+        apply_child_env(&mut cmd, &env);
+
+        let envs = explicit_envs(&cmd);
+
+        assert_eq!(
+            envs.get("NTERACT_CHANNEL"),
+            Some(&Some("nightly".to_string())),
+            "NTERACT_CHANNEL must be added to the child env"
+        );
+        assert_eq!(
+            envs.get("RUNTIMED_DEV"),
+            Some(&None),
+            "RUNTIMED_DEV must be stripped from the inherited env"
+        );
+        assert_eq!(
+            envs.get("RUNTIMED_WORKSPACE_PATH"),
+            Some(&None),
+            "RUNTIMED_WORKSPACE_PATH must be stripped from the inherited env"
+        );
+        assert_eq!(
+            envs.get("RUNTIMED_SOCKET_PATH"),
+            Some(&None),
+            "RUNTIMED_SOCKET_PATH must be stripped from the inherited env"
+        );
+    }
+
+    /// The dev supervisor (nteract-dev) intentionally injects daemon-resolution
+    /// vars into `child_env` so its `runt mcp` child binds to the worktree's
+    /// dev daemon. The strip must not clobber values the caller explicitly
+    /// supplies — explicit env wins.
+    #[test]
+    fn apply_child_env_preserves_caller_supplied_dev_redirect_vars() {
+        let mut cmd = Command::new("/usr/bin/true");
+        let env = HashMap::from([
+            ("RUNTIMED_DEV".to_string(), "1".to_string()),
+            (
+                "RUNTIMED_SOCKET_PATH".to_string(),
+                "/tmp/dev-runtimed.sock".to_string(),
+            ),
+            (
+                "RUNTIMED_WORKSPACE_PATH".to_string(),
+                "/tmp/worktree".to_string(),
+            ),
+        ]);
+        apply_child_env(&mut cmd, &env);
+
+        let envs = explicit_envs(&cmd);
+
+        assert_eq!(
+            envs.get("RUNTIMED_DEV"),
+            Some(&Some("1".to_string())),
+            "explicit RUNTIMED_DEV must reach the child (supervisor case)"
+        );
+        assert_eq!(
+            envs.get("RUNTIMED_SOCKET_PATH"),
+            Some(&Some("/tmp/dev-runtimed.sock".to_string()))
+        );
+        assert_eq!(
+            envs.get("RUNTIMED_WORKSPACE_PATH"),
+            Some(&Some("/tmp/worktree".to_string()))
         );
     }
 


### PR DESCRIPTION
## Diagnosis

`runt-mcp-proxy` spawned children with `cmd.envs(env)`, which only adds to the inherited environment. When Claude Code launches from a direnv-active worktree, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` flow through every nested layer (Claude Code → `nteract-mcp` system plugin → `runt-nightly mcp` child), so the system nightly plugin silently redirects to the per-worktree dev daemon. The plugin enqueues cells on a phantom session that has no kernel attached, so executions never produce output.

The existing test at `crates/nteract-mcp/src/main.rs:358` checks that `child_env_for_channel` does not put `RUNTIMED_DEV` in the additive env map. That contract holds, but it says nothing about the inherited environment, so the leak passed CI cleanly.

## Fix

`apply_child_env` now `env_remove`s the three daemon-resolution vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`, `RUNTIMED_SOCKET_PATH`) before applying the caller's env map. `Command` modifications are last-write-wins, so the supervisor (`nteract-dev`) keeps working: it injects all three explicitly into `env`, and those values override the prior remove.

## Behavioral coverage

| Caller | Parent shell has `RUNTIMED_DEV=1` | Child sees `RUNTIMED_DEV` |
| --- | --- | --- |
| `nteract-mcp` (system plugin) | yes | no (stripped) |
| `nteract-mcp` (system plugin) | no | no |
| `mcp-supervisor` (`nteract-dev`) | yes | yes (caller value wins) |
| `mcp-supervisor` (`nteract-dev`) | no | yes (caller-injected) |

## How to repro before this PR

1. `cd` into a direnv-active worktree of `nteract/desktop` so `RUNTIMED_DEV=1` is set.
2. Launch Claude Code from that shell.
3. Open a notebook on the system nightly daemon.
4. `mcp__plugin_nightly_notebook__list_active_notebooks` returns `[]` even with a real session running, and any `execute_cell` against a newly created cell never produces output.
5. `ps -E -p $(pgrep -f "runt-nightly mcp")` shows `RUNTIMED_DEV=1` in the child env.

## Verification

- `cargo test -p runt-mcp-proxy -p mcp-supervisor -p nteract-mcp` — 96 + 21 + 6 tests pass.
- `cargo xtask lint` — clean.

## Test plan

- [ ] CI green
- [ ] After this lands, ship a nightly and confirm system nightly plugin executes cells from a Claude Code launched in a direnv-active worktree
