### PR TITLE
fix(mcp-supervisor): rebuild runtimed-wasm on rebuild=true

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2129,7 +2129,18 @@ impl ServerHandler for Supervisor {
                     info!("Skipping maturin develop (SKIP_MATURIN=1)");
                 }
 
-                // 3. Stop whatever daemon is running (managed or not) and start fresh
+                // 3. Rebuild runtimed-wasm so the frontend bundle stays in
+                // lockstep with the daemon's runtime-state schema. See
+                // `run_xtask_wasm_runtimed` for why a stale wasm here ends
+                // in stuck "Initializing" via duplicate-seq-1.
+                if !run_xtask_wasm_runtimed(&project_root) {
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        "cargo xtask wasm runtimed failed — check the supervisor logs for details\n\
+                         (daemon binary was rebuilt successfully; the frontend wasm bundle may be stale)",
+                    )]));
+                }
+
+                // 4. Stop whatever daemon is running (managed or not) and start fresh
                 {
                     let mut state = self.state.write().await;
                     if let Some(ref mut child) = state.daemon_child {

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -507,6 +507,48 @@ fn run_cargo_build_daemon(project_root: &Path) -> bool {
     }
 }
 
+/// Rebuild `runtimed-wasm` so the frontend bundle matches the daemon's
+/// runtime-state schema. Skipping this on rebuild produces a fresh daemon
+/// against a stale `.wasm`; the two then disagree on the schema seed and
+/// every notebook's runtime-state doc gets stuck behind a duplicate-seq-1
+/// rejection from automerge. Always run on rebuild=true.
+///
+/// We invoke `cargo xtask wasm runtimed --skip-renderer-plugins` so the
+/// build path matches what `cargo xtask build` and `cargo xtask dev-daemon`
+/// already do, and so the renderer-plugin glue (sift) isn't pulled in.
+fn run_xtask_wasm_runtimed(project_root: &Path) -> bool {
+    info!("Rebuilding runtimed-wasm (cargo xtask wasm runtimed --skip-renderer-plugins)...");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--package",
+            "xtask",
+            "--",
+            "wasm",
+            "runtimed",
+            "--skip-renderer-plugins",
+        ])
+        .current_dir(project_root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            info!("cargo xtask wasm runtimed succeeded");
+            true
+        }
+        Ok(s) => {
+            error!("cargo xtask wasm runtimed failed with {s}");
+            false
+        }
+        Err(e) => {
+            error!("Failed to run cargo xtask wasm runtimed: {e}");
+            false
+        }
+    }
+}
+
 /// Build the runt CLI binary (which includes runt-mcp).
 /// Respects release mode so the built binary matches what cargo_binary() resolves.
 fn build_runt_cli(project_root: &Path) -> bool {
@@ -1364,6 +1406,20 @@ impl Supervisor {
             } else {
                 report.push("rebuild: maturin skipped (SKIP_MATURIN=1)".into());
             }
+
+            // runtimed-wasm has to track the daemon's runtime-state schema
+            // exactly: both sides bootstrap their RuntimeStateDoc with the
+            // same well-known schema actor, and any divergence in the
+            // scaffolded ops produces a `(actor, seq)` collision that
+            // automerge rejects on receive. Stale wasm leaves the frontend
+            // stuck on "Initializing" with no surfaced error. Always rebuild.
+            if !run_xtask_wasm_runtimed(&project_root) {
+                return Ok(CallToolResult::success(vec![Content::text(
+                    "up: cargo xtask wasm runtimed failed. Daemon was rebuilt; \
+                     the frontend wasm bundle may be stale. See the supervisor logs.",
+                )]));
+            }
+            report.push("rebuild: runtimed-wasm rebuilt".into());
         }
 
         // Step 3: sweep zombie vites


### PR DESCRIPTION
`up rebuild=true` rebuilt the daemon binary but left the gitignored `apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm` alone. After a `git pull` that touched the runtime-state schema (e.g. #2599, adding `approved_conda_channels` / `approved_pixi_channels`), the next rebuild paired a fresh daemon with stale wasm. Both peers run `scaffold_runtime_state_schema()` to seed their `RuntimeStateDoc` under the well-known `nteract:runtime-state-schema:v1` actor at seq=1; the scaffolds disagreed by a couple of `put_object` ops, so the seed changes had identical `(actor, seq)` and different hashes. Automerge rejected the second one:

```
[notebook-sync] state receive_sync_message error: [state-receive-sync]
  automerge operation failed: duplicate seq 1 found for actor
  6e7465726163743a72756e74696d652d73746174652d736368656d613a7631
```

The runtime-state doc never converged. Daemon-side kernel ran fine -- `runt ps` showed `idle`, cells executed, outputs were in the doc -- but the frontend's runtime-state didn't move past initial defaults. Env pill stuck on "Initializing", no execution count, no outputs.

## Fix

Run `cargo xtask wasm runtimed --skip-renderer-plugins` in both supervisor rebuild paths -- the `up rebuild=true` flow and the `supervisor_rebuild` manual tool -- right after maturin. Mirrors what `cargo xtask dev-daemon` already does via `ensure_volatile_wasm_built()`; the supervisor was the only entry point that bypassed it.

wasm-pack delegates to cargo, so a no-source-change rebuild is ~0.5s of post-processing. Cheap next to the failure mode it prevents.

## Verification

- `cargo build -p mcp-supervisor` clean
- `cargo clippy -p mcp-supervisor --no-deps -- -D warnings` clean
- `cargo test -p mcp-supervisor` 21 passed
- `cargo xtask lint --fix` clean
- Manual repro: pre-fix, every newly-created notebook on the dev daemon hit duplicate-seq-1; pill stuck on "Initializing"; outputs invisible. After rebuilding wasm by hand and reloading, kernel pill went green/Idle, exec count rendered, outputs synced. With this patch, the same recovery happens automatically on `up rebuild=true`.

## Follow-up

The seed-as-bootstrap-validation approach (deterministic well-known-actor scaffold on every peer) means *any* future scaffold drift between daemon and frontend produces the same silent-stuck symptom. A separate change worth considering: surface the scaffold mismatch directly (compile-time fingerprint in the handshake) so a stale wasm shows up as a clear error instead of a stuck "Initializing". Out of scope here.
