### PR TITLE
feat(sift): collapse text rows by default, expand on click

### DIFF
--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -35,7 +35,7 @@
     "cache-datasets": "npx tsx scripts/cache-datasets.ts"
   },
   "peerDependencies": {
-    "@chenglou/pretext": ">=0.0.4",
+    "@chenglou/pretext": ">=0.0.6",
     "react": ">=18",
     "react-dom": ">=18"
   },
@@ -64,7 +64,7 @@
     "vite-plus": "catalog:"
   },
   "dependencies": {
-    "@chenglou/pretext": ">=0.0.4",
+    "@chenglou/pretext": ">=0.0.6",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -754,8 +754,12 @@ h1 {
   display: flex;
   /* Top-anchor so images stay discoverable in tall rows driven by long
      adjacent text columns (e.g. MathNet's PROBLEM_MARKDOWN) instead of
-     drifting to the vertical centre of a 1000+ px row. */
+     drifting to the vertical centre of a 1000+ px row.
+     `align-content: flex-start` packs wrapped lines at the top too — the
+     default `stretch` would split a 2-line image strip across the full
+     height of an expanded row, leaving an empty gap between the lines. */
   align-items: flex-start;
+  align-content: flex-start;
   justify-content: flex-start;
   gap: 4px;
   padding: 2px;

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -702,6 +702,18 @@ h1 {
   text-overflow: ellipsis;
 }
 
+/* Soft fade on text cells whose natural height exceeded the collapsed cap.
+   The row's `height` style already clips the overflow; this just signals
+   "more text below, click the row to expand". */
+.sift-cell-truncated {
+  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent);
+  mask-image: linear-gradient(to bottom, black calc(100% - 16px), transparent);
+}
+
+.sift-row-focused {
+  background: color-mix(in srgb, var(--sift-accent) 6%, transparent);
+}
+
 .sift-badge {
   display: inline-block;
   padding: 2px 8px;

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -176,7 +176,9 @@ describe("createTable", () => {
       vi.mocked(layout).mockImplementation((prepared: unknown) => {
         const { text } = prepared as { text?: string };
         return {
-          lineCount: text?.includes("tall wrapped categorical text") ? 6 : 1,
+          // lineCount stays at MAX_COLLAPSED_LINES so the engine keeps the
+          // measured height instead of clamping for the row-collapse path.
+          lineCount: text?.includes("tall wrapped categorical text") ? 3 : 1,
           height: text?.includes("tall wrapped categorical text") ? 120 : 20,
         } as ReturnType<typeof layout>;
       });
@@ -189,6 +191,53 @@ describe("createTable", () => {
 
       const thirdRenderedRow = container.querySelector<HTMLElement>('[aria-rowindex="4"]');
       expect(thirdRenderedRow?.style.transform).toBe("translateY(172px)");
+    });
+
+    it("clamps a multi-line text cell to MAX_COLLAPSED_LINES until its row is focused", async () => {
+      engine.destroy();
+      container.innerHTML = "";
+
+      vi.mocked(prepare).mockImplementation(
+        (text: string) =>
+          ({ __brand: "PreparedText", text }) as unknown as ReturnType<typeof prepare>,
+      );
+      // Every categorical cell reports 6 lines — well over the cap of 3.
+      vi.mocked(layout).mockImplementation(
+        () =>
+          ({
+            lineCount: 6,
+            height: 120,
+          }) as ReturnType<typeof layout>,
+      );
+
+      engine = createTable(container, makeTableData(makeRows(4)));
+      const viewport = container.querySelector<HTMLElement>(".sift-viewport")!;
+      // Force enough viewport height that the render loop reaches all 4 rows
+      // and measures their categorical column.
+      Object.defineProperty(viewport, "clientHeight", { value: 800, configurable: true });
+      viewport.dispatchEvent(new Event("scroll"));
+      await vi.advanceTimersByTimeAsync(20);
+
+      // Collapsed: every row's tall categorical column caps at 3 × 20 + 16 = 76.
+      // View row 2 (aria-rowindex=4 — header is 1) sits at heights[0]+heights[1] = 152.
+      const beforeRow2 = container.querySelector<HTMLElement>('[aria-rowindex="4"]');
+      expect(beforeRow2?.style.transform).toBe("translateY(152px)");
+
+      // The truncated cell carries the soft-fade class.
+      expect(container.querySelector(".sift-cell-truncated")).not.toBeNull();
+
+      // Focus row 1 → its height grows to the full 120 + 16 = 136.
+      engine.setFocusedDataRow(1);
+      await vi.advanceTimersByTimeAsync(20);
+
+      const afterRow2 = container.querySelector<HTMLElement>('[aria-rowindex="4"]');
+      // Row 0 still capped (76), row 1 expanded (136). View row 2 sits at 76 + 136 = 212.
+      expect(afterRow2?.style.transform).toBe("translateY(212px)");
+
+      // Truncation class is gone for the focused row's text cells.
+      const focusedRow = container.querySelector(".sift-row-focused");
+      expect(focusedRow).not.toBeNull();
+      expect(focusedRow?.querySelector(".sift-cell-truncated")).toBeNull();
     });
   });
 
@@ -534,7 +583,9 @@ describe("createTable", () => {
         const { text } = prepared as { text?: string };
         const tall = text?.includes("wrap-sensitive above viewport") && width < 500;
         return {
-          lineCount: tall ? 6 : 1,
+          // lineCount stays at MAX_COLLAPSED_LINES so the row-collapse path
+          // doesn't clamp this fixture's height back to the cap.
+          lineCount: tall ? 3 : 1,
           height: tall ? 120 : 20,
         } as ReturnType<typeof layout>;
       });
@@ -583,7 +634,9 @@ describe("createTable", () => {
         const { text } = prepared as { text?: string };
         const tall = text?.includes("wrap-sensitive above viewport") && width < 500;
         return {
-          lineCount: tall ? 6 : 1,
+          // lineCount stays at MAX_COLLAPSED_LINES so the row-collapse path
+          // doesn't clamp this fixture's height back to the cap.
+          lineCount: tall ? 3 : 1,
           height: tall ? 120 : 20,
         } as ReturnType<typeof layout>;
       });

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -136,6 +136,17 @@ export type TableEngine = {
   getFilters(): { column: string; filter: ColumnFilter }[];
   /** Get the full explorer state (sort + filters + counts) in a serializable format. */
   getState(): TableEngineState;
+  /**
+   * Currently focused (expanded) data row, or `null` when every row uses the
+   * collapsed text-line cap. Tracked by data row, so focus survives sort
+   * changes; reset on filter changes since the focused row may filter out.
+   */
+  getFocusedDataRow(): number | null;
+  /**
+   * Programmatically focus a data row (expanding its text cells past the
+   * collapsed cap). Pass `null` to collapse everything.
+   */
+  setFocusedDataRow(dataRow: number | null): void;
 };
 
 type SortState = { col: number; dir: "asc" | "desc" } | null;
@@ -148,6 +159,14 @@ const CELL_PAD_H = 24; // 12px each side
 const CELL_PAD_V = 16; // 8px top + 8px bottom
 const IMAGE_THUMB_MAX_HEIGHT = 64; // matches .sift-cell-image-thumb max-height in style.css
 const IMAGE_THUMB_CAP = 6; // max thumbnails rendered per List<Image> cell; rest collapse to "+N"
+// Text cells render at most this many lines unless their row is focused.
+// Modeled after HuggingFace's dataset viewer: long markdown columns clamp by
+// default and the user clicks a row to expand it inline.
+const MAX_COLLAPSED_LINES = 3;
+// Pixel slop for distinguishing "click on a row" (toggle focus) from
+// "drag to select text" (no focus change). Matches the existing tap-vs-scroll
+// thresholds for the mobile detail sheet.
+const FOCUS_TOGGLE_MAX_DRAG_PX = 4;
 const MIN_COL_WIDTH = 60;
 const OVERSCAN = 40; // buffer rows above and below viewport
 
@@ -211,13 +230,21 @@ export function createTable(
     viewIndices = newSorted;
   }
 
-  // Per-cell cache: prepared text + last laid-out width/height
+  // Per-cell cache: prepared text + last laid-out width/height. `lastTruncated`
+  // tracks whether the cell's natural height exceeded the collapsed cap so
+  // renderCell can apply the soft fade affordance without re-running layout.
   type CellCache = {
     prepared: PreparedText;
     lastWidth: number;
     lastHeight: number;
+    lastTruncated: boolean;
   };
   const cellCaches: (CellCache[] | null)[] = [];
+
+  // Data row that the user clicked to expand. Tracked by data row (not view
+  // row) so focus survives sort changes; reset explicitly on filter changes.
+  // `null` means every row uses the collapsed cap.
+  let focusedDataRow: number | null = null;
 
   function prepareCellRow(r: number): CellCache[] {
     const row = Array.from<CellCache>({ length: columns.length });
@@ -226,6 +253,7 @@ export function createTable(
         prepared: prepare(data.getCell(r, c), FONT),
         lastWidth: -1,
         lastHeight: 0,
+        lastTruncated: false,
       };
     }
     return row;
@@ -244,6 +272,8 @@ export function createTable(
     const dataRow = viewIndices[sortedRow];
     const cache = cellCaches[dataRow];
     if (!cache) return LINE_HEIGHT + CELL_PAD_V; // estimate for unprepared rows
+    const isFocused = focusedDataRow === dataRow;
+    const cap = MAX_COLLAPSED_LINES * LINE_HEIGHT;
 
     let maxH = LINE_HEIGHT;
     for (let c = 0; c < columns.length; c++) {
@@ -253,13 +283,26 @@ export function createTable(
         const colType = columns[c].columnType;
         if (colType === "numeric" || colType === "timestamp" || colType === "boolean") {
           cell.lastHeight = LINE_HEIGHT;
+          cell.lastTruncated = false;
         } else if (colType === "image") {
           // Mirrors the thumbnail max-height in style.css (.sift-cell-image-thumb).
-          // Keep this in sync with that CSS value.
+          // Keep this in sync with that CSS value. Image rows don't expand
+          // when focused — they're already terse and the row's text columns
+          // are what the user wants to read.
           cell.lastHeight = IMAGE_THUMB_MAX_HEIGHT;
+          cell.lastTruncated = false;
         } else {
-          const { height } = layout(cell.prepared, cellW, LINE_HEIGHT);
-          cell.lastHeight = height;
+          // Pretext returns lineCount alongside height in 0.0.6, so the
+          // collapsed/expanded decision is free.
+          const { height, lineCount } = layout(cell.prepared, cellW, LINE_HEIGHT);
+          const overflows = lineCount > MAX_COLLAPSED_LINES;
+          if (overflows && !isFocused) {
+            cell.lastHeight = cap;
+            cell.lastTruncated = true;
+          } else {
+            cell.lastHeight = height;
+            cell.lastTruncated = false;
+          }
         }
         cell.lastWidth = cellW;
       }
@@ -268,12 +311,73 @@ export function createTable(
     return maxH + CELL_PAD_V;
   }
 
+  /// Force `computeRowHeight` to re-layout the given data row's text cells —
+  /// width didn't change but the focus-state input did, so the cached height
+  /// would otherwise lie. Numeric/boolean/image cells aren't affected, so
+  /// invalidating only when text exists keeps the recompute cheap.
+  function invalidateRowLayout(dataRow: number) {
+    const cache = cellCaches[dataRow];
+    if (!cache) return;
+    for (let c = 0; c < columns.length; c++) {
+      const colType = columns[c].columnType;
+      if (
+        colType !== "numeric" &&
+        colType !== "timestamp" &&
+        colType !== "boolean" &&
+        colType !== "image"
+      ) {
+        cache[c].lastWidth = -1;
+      }
+    }
+  }
+
   function recomputeAllHeights() {
     for (let i = 0; i < filteredCount; i++) {
       rowHeights[i] = computeRowHeight(i);
     }
     rebuildPositions();
     heightsDirty = false;
+  }
+
+  /// Toggle focus on a data row. Recomputes only the two affected rows'
+  /// heights (the previously focused one collapsing, the new one expanding)
+  /// then `rebuildPositions()` shifts everything below by the delta.
+  /// Pass `null` to clear focus.
+  function setFocusedDataRow(next: number | null) {
+    if (next === focusedDataRow) return;
+    const prev = focusedDataRow;
+    focusedDataRow = next;
+    if (prev !== null) invalidateRowLayout(prev);
+    if (next !== null) invalidateRowLayout(next);
+    // Recompute only the visible-or-affected rows. `rowHeights` is indexed by
+    // sortedRow (view index), so we have to translate from dataRow → viewRow
+    // via viewIndices. Cheap linear scan since viewIndices is filtered/sorted.
+    for (let i = 0; i < filteredCount; i++) {
+      const dr = viewIndices[i];
+      if (dr === prev || dr === next) {
+        rowHeights[i] = computeRowHeight(i);
+      }
+    }
+    rebuildPositions();
+    // Update DOM directly for any pooled row tied to the changed dataRows:
+    // toggle the focused class and re-render cells so the truncation class
+    // tracks the new state. The standard render loop's `if (existing)
+    // continue` short-circuits class updates for rows that didn't get
+    // reassigned, so we have to do it here.
+    for (const pr of pool) {
+      if (pr.assignedRow === -1) continue;
+      const dataRow = viewIndices[pr.assignedRow];
+      if (dataRow !== prev && dataRow !== next) continue;
+      if (focusedDataRow !== null && dataRow === focusedDataRow) {
+        pr.el.classList.add("sift-row-focused");
+      } else {
+        pr.el.classList.remove("sift-row-focused");
+      }
+      for (let c = 0; c < columns.length; c++) {
+        renderCell(pr.cells[c], dataRow, c);
+      }
+    }
+    scheduleRender();
   }
 
   function rebuildPositions() {
@@ -1253,6 +1357,13 @@ export function createTable(
     // Clear previous content
     cellEl.textContent = "";
     cellEl.className = "sift-cell";
+    // Apply the soft-fade affordance when this text cell's natural height
+    // exceeded the collapsed cap. `computeRowHeight` writes `lastTruncated`
+    // alongside `lastHeight` so we don't have to re-run pretext here.
+    const cellCache = cellCaches[dataRow]?.[colIndex];
+    if (cellCache?.lastTruncated) {
+      cellEl.classList.add("sift-cell-truncated");
+    }
 
     // Null values get a distinct badge regardless of column type
     if (raw == null) {
@@ -1463,6 +1574,11 @@ export function createTable(
 
       if (r % 2 === 1) pr.el.classList.add("sift-row-alt");
       else pr.el.classList.remove("sift-row-alt");
+      if (focusedDataRow !== null && dataRow === focusedDataRow) {
+        pr.el.classList.add("sift-row-focused");
+      } else {
+        pr.el.classList.remove("sift-row-focused");
+      }
 
       for (let c = 0; c < columns.length; c++) {
         renderCell(pr.cells[c], dataRow, c);
@@ -1633,6 +1749,48 @@ export function createTable(
       sheet.classList.add("sift-detail-sheet-open");
     });
   }
+
+  // Click detection on rows: toggle inline focus (HF-style row expand) on
+  // desktop / mouse, fall through to the mobile detail-sheet path below for
+  // touch under 768 px. Track pointerdown/up coordinates so dragging to
+  // select text doesn't trip the toggle.
+  let focusDownX = 0;
+  let focusDownY = 0;
+  let focusDownActive = false;
+
+  viewport.addEventListener("pointerdown", (e) => {
+    // Skip the cases owned by the mobile detail-sheet handler below.
+    if (window.innerWidth < 768 && e.pointerType === "touch") return;
+    focusDownX = e.clientX;
+    focusDownY = e.clientY;
+    focusDownActive = true;
+  });
+
+  viewport.addEventListener("pointerup", (e) => {
+    if (!focusDownActive) return;
+    focusDownActive = false;
+    if (window.innerWidth < 768 && e.pointerType === "touch") return;
+    if (e.button !== 0 && e.pointerType === "mouse") return; // left-click only
+    const dx = Math.abs(e.clientX - focusDownX);
+    const dy = Math.abs(e.clientY - focusDownY);
+    if (dx > FOCUS_TOGGLE_MAX_DRAG_PX || dy > FOCUS_TOGGLE_MAX_DRAG_PX) return; // dragged → text selection
+
+    const target = e.target as HTMLElement;
+    // Skip if the click landed on something interactive — the column resize
+    // handle, an image thumb, an inline button, the detail sheet, etc.
+    if (target.closest("button, a, .sift-resize-handle, .sift-cell-image-thumb")) {
+      return;
+    }
+    const rowEl = target.closest(".sift-row") as HTMLDivElement | null;
+    if (!rowEl) return;
+    for (const pr of pool) {
+      if (pr.el === rowEl && pr.assignedRow !== -1) {
+        const dataRow = viewIndices[pr.assignedRow];
+        setFocusedDataRow(focusedDataRow === dataRow ? null : dataRow);
+        break;
+      }
+    }
+  });
 
   // Tap detection on rows: click on narrow viewports opens detail sheet.
   // We use pointerdown/pointerup to distinguish taps from scrolls/long-presses.
@@ -2097,6 +2255,9 @@ export function createTable(
   }
 
   function onFilterChanged() {
+    // Filtering can hide the focused row entirely, leaving the user with no
+    // visual cue for what's still expanded. Reset and let them re-pick.
+    focusedDataRow = null;
     applyFilterAndSort();
     // Fast path: update rows immediately, defer expensive summary recomputation
     updateRowCountDisplay();
@@ -2396,5 +2557,7 @@ export function createTable(
     setSort: setSortByName,
     getFilters,
     getState,
+    getFocusedDataRow: () => focusedDataRow,
+    setFocusedDataRow,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,8 +562,8 @@ importers:
   packages/sift:
     dependencies:
       '@chenglou/pretext':
-        specifier: '>=0.0.4'
-        version: 0.0.5
+        specifier: '>=0.0.6'
+        version: 0.0.6
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1060,8 +1060,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@chenglou/pretext@0.0.5':
-    resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
+  '@chenglou/pretext@0.0.6':
+    resolution: {integrity: sha512-U10s4tFeyu3oVHfXuNWwZSKqHXefhaigpcBkGj60qQFRJ+yUoQ+ez3cGJelP7BWDAB58HCgjcTSmOcg+77afBQ==}
 
   '@chevrotain/cst-dts-gen@11.1.2':
     resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
@@ -10180,7 +10180,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@chenglou/pretext@0.0.5': {}
+  '@chenglou/pretext@0.0.6': {}
 
   '@chevrotain/cst-dts-gen@11.1.2':
     dependencies:


### PR DESCRIPTION
Modeled after HuggingFace's dataset viewer: long text columns clamp to 3 lines and the row a user clicks expands to its full height. Solves the MathNet failure mode where one `PROBLEM_MARKDOWN` cell stretched a row to 1000+ px and pushed everything else off-screen.

## Visual

| Before (`#2621`) | After |
| --- | --- |
| 1 MathNet row fills the viewport | 7 MathNet rows fit + click any row to expand inline |

## How it works

`@chenglou/pretext` 0.0.6 returns `lineCount` alongside `height` from `layout()`, so the collapsed/expanded decision is free — we don't pay for an extra layout pass. `computeRowHeight` checks `lineCount > MAX_COLLAPSED_LINES` and either clamps to the cap (`3 × LINE_HEIGHT + CELL_PAD_V = 76 px`) or returns the full natural height when the row is focused.

`focusedDataRow` is tracked by data row — focus survives sort changes because the dataRow→viewRow translation happens in `viewIndices`. Filter changes reset focus since the focused row may filter out.

`setFocusedDataRow(next)` invalidates only the two affected rows' caches (`prev` collapsing, `next` expanding), recomputes their heights, and re-renders just those rows' cells so the truncation class tracks state. Pool rows that didn't change don't get touched.

## Trigger

Click on `.sift-row` in `viewport` toggles focus on `pointerup`. Selection-friendly: `pointerdown`/`pointerup` distance > `FOCUS_TOGGLE_MAX_DRAG_PX = 4` is treated as a drag and skipped, so dragging to select text leaves focus alone. Skips buttons, links, image thumbs, and the column-resize handle. The existing mobile detail-sheet path (touch + < 768 px) stays the primary affordance — inline expand on a phone feels cramped.

## Behavioral coverage

| Scenario | Result |
| --- | --- |
| Click a collapsed row | That row expands; previously focused row collapses |
| Click the focused row | Collapses, no row focused |
| Drag inside a cell to select text (> 4 px) | Selection works; focus state unchanged |
| Click on column-resize handle / image thumb / button | Focus state unchanged |
| Filter change | Focus reset (focused row may filter out) |
| Sort change | Focus preserved (keyed on data row) |
| Numeric / boolean / image cells | Heights unchanged regardless of focus |

## Engine API

```ts
engine.getFocusedDataRow(): number | null
engine.setFocusedDataRow(dataRow: number | null): void
```

## CSS

- `.sift-cell-truncated` — `mask-image` fade so the user sees "more below". The existing `.sift-cell { overflow: hidden }` does the actual clipping.
- `.sift-row-focused` — subtle accent-tinted background.

## Test plan

- [ ] CI green
- [ ] Vercel preview renders MathNet with collapsed rows by default
- [ ] Click a row → expands; click again → collapses; click another → swaps
- [ ] Drag-select inside a cell preserves focus
- [ ] Existing demo datasets (Spotify, Titanic) still render unchanged

## Follow-ups (not this PR)

- HF-style image lightbox on thumbnail click (deferred per discussion)
- The `#2622` issue still applies — `replaceData` for in-place dataset switches; this PR shipped focus tracking that survives sort but resets on filter, which is the cheapest "in-place" semantic in scope here.
