### PR TITLE
feat: surface HF rich types end-to-end via launcher + Sift

### DIFF
--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -1436,18 +1436,24 @@ pub fn parquet_metadata(parquet_bytes: &[u8]) -> Result<Vec<u32>, JsValue> {
     Ok(vec![num_row_groups, total_rows])
 }
 
-/// Extract key-value metadata from a Parquet file's schema.
-/// Returns a JSON object with metadata keys like "pandas", "huggingface", etc.
+/// Extract file-level key-value metadata from a Parquet footer.
+/// Returns metadata keys like "pandas", "huggingface", etc.
 #[wasm_bindgen]
 pub fn parquet_schema_metadata(parquet_bytes: &[u8]) -> Result<JsValue, JsValue> {
     let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
     let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let schema = builder.schema();
-    let metadata = schema.metadata();
+    let metadata = builder.metadata();
     let map: HashMap<String, String> = metadata
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
+        .file_metadata()
+        .key_value_metadata()
+        .into_iter()
+        .flatten()
+        .filter_map(|kv| {
+            kv.value
+                .as_ref()
+                .map(|value| (kv.key.clone(), value.clone()))
+        })
         .collect();
     serde_wasm_bindgen::to_value(&map).map_err(|e| JsValue::from_str(&e.to_string()))
 }

--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -1,5 +1,12 @@
 import { catchError, defer, EMPTY, Observable, Subject, switchMap } from "rxjs";
 import { DATASETS, type DatasetEntry } from "./datasets";
+import {
+  applyHfFeatureOverrides,
+  applyPandasIndexOverrides,
+  parseHfFeatures,
+  parsePandasIndexColumns,
+  parseSchemaMetadata,
+} from "./parquet-features";
 import { resolveHuggingFaceParquetUrl } from "./parquet-loader";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
 import { type Column, createTable, type TableData, type TableEngine } from "./table";
@@ -337,49 +344,17 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
           const numRowGroups = meta[0];
           const totalRows = meta[1];
 
-          // Read schema metadata for pandas index_columns and HuggingFace feature types
-          // `parquet_schema_metadata` is a Rust `HashMap` returned via
-          // `serde_wasm_bindgen`, which lands in JS as a `Map<string,string>` —
-          // NOT a plain object. Reading it via property access (the previous
-          // code) silently returned undefined for every key, leaving HF
-          // ClassLabel/Image detection dead. Coerce through `Object.fromEntries`
-          // so the rest of this function can keep doing record-style access.
-          let schemaMetadata: Record<string, string> = {};
-          try {
-            const raw = mod.parquet_schema_metadata(parquetBytes) as unknown;
-            if (raw instanceof Map) {
-              schemaMetadata = Object.fromEntries(raw as Map<string, string>);
-            } else if (raw && typeof raw === "object") {
-              schemaMetadata = raw as Record<string, string>;
-            }
-          } catch {
-            /* metadata extraction is best-effort */
-          }
-
-          // Parse pandas index columns
-          const pandasIndexCols = new Set<string>();
-          if (schemaMetadata.pandas) {
-            try {
-              const pandas = JSON.parse(schemaMetadata.pandas);
-              for (const ic of pandas.index_columns ?? []) {
-                if (typeof ic === "string") pandasIndexCols.add(ic);
-                // Range index descriptors don't map to a named column
+          const schemaMetadata = parseSchemaMetadata(
+            (() => {
+              try {
+                return mod.parquet_schema_metadata(parquetBytes);
+              } catch {
+                return undefined;
               }
-            } catch {
-              /* ignore parse errors */
-            }
-          }
-
-          // Parse HuggingFace feature metadata
-          const hfFeatures: Record<string, { _type: string; names?: string[] }> = {};
-          if (schemaMetadata.huggingface) {
-            try {
-              const hf = JSON.parse(schemaMetadata.huggingface);
-              Object.assign(hfFeatures, hf?.info?.features ?? {});
-            } catch {
-              /* ignore parse errors */
-            }
-          }
+            })(),
+          );
+          const pandasIndexCols = parsePandasIndexColumns(schemaMetadata);
+          const hfFeatures = parseHfFeatures(schemaMetadata);
 
           // Load first row group → mount table immediately
           const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
@@ -389,42 +364,8 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
           tableData.recomputeSummaries = () =>
             updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
 
-          // Apply metadata: mark pandas index columns, narrow index columns
-          const isIndexName = (name: string) =>
-            /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i.test(name);
-          for (const col of columns) {
-            if (pandasIndexCols.has(col.key) || isIndexName(col.key)) {
-              // Size to fit the max row number — estimate from digit count
-              const digits = totalRows.toLocaleString().length;
-              col.width = Math.max(60, digits * 9 + 24); // ~9px per char + cell padding
-              col.sortable = false;
-              // Hide labels for pandas artifacts — not real column names users would query
-              if (/^(unnamed[: _]*\d*|__index_level_\d+__)$/i.test(col.key)) col.label = "";
-            }
-            const hfFeature = hfFeatures[col.key];
-            if (hfFeature?._type === "ClassLabel" && col.columnType !== "categorical") {
-              // HF says this is a classification label — treat as categorical
-              col.columnType = "categorical";
-              col.numeric = false;
-            }
-            // HF Image -> thumbnail. List<Image> / Sequence<Image> -> a strip
-            // of thumbs, sized wider so multiple fit. Both share the same
-            // wasm-side getter (`get_cell_image_count` + `_at`).
-            const inner =
-              hfFeature?._type === "Image"
-                ? hfFeature
-                : hfFeature?._type === "List" || hfFeature?._type === "Sequence"
-                  ? (hfFeature as { feature?: { _type?: string } }).feature
-                  : undefined;
-            if (inner?._type === "Image") {
-              col.columnType = "image";
-              col.numeric = false;
-              col.sortable = false;
-              const isList = hfFeature?._type !== "Image";
-              const minWidth = isList ? 320 : 140;
-              if (col.width < minWidth) col.width = minWidth;
-            }
-          }
+          applyPandasIndexOverrides(columns, pandasIndexCols, totalRows);
+          applyHfFeatureOverrides(columns, hfFeatures);
 
           // Compute initial summaries from first row group
           updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);

--- a/packages/sift/src/parquet-features.test.ts
+++ b/packages/sift/src/parquet-features.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  applyColumnOverrides,
+  applyHfFeatureOverrides,
+  applyPandasIndexOverrides,
+} from "./parquet-features";
+import type { Column } from "./table";
+
+function column(overrides: Partial<Column> = {}): Column {
+  return {
+    key: "image",
+    label: "image",
+    width: 80,
+    sortable: true,
+    numeric: false,
+    columnType: "categorical",
+    ...overrides,
+  };
+}
+
+describe("parquet feature overrides", () => {
+  it("lets explicit column overrides win over parquet metadata defaults", () => {
+    const columns = [
+      column({
+        key: "__index_level_0__",
+        label: "__index_level_0__",
+        width: 40,
+        sortable: true,
+        numeric: true,
+        columnType: "numeric",
+      }),
+      column(),
+    ];
+
+    applyPandasIndexOverrides(columns, new Set(["__index_level_0__"]), 10_000);
+    applyHfFeatureOverrides(columns, { image: { _type: "Image" } });
+    applyColumnOverrides(columns, {
+      __index_level_0__: { label: "Row", width: 120, sortable: true },
+      image: { columnType: "categorical", sortable: true, width: 180 },
+    });
+
+    expect(columns[0]).toMatchObject({ label: "Row", width: 120, sortable: true });
+    expect(columns[1]).toMatchObject({
+      columnType: "categorical",
+      sortable: true,
+      width: 180,
+    });
+  });
+});

--- a/packages/sift/src/parquet-features.ts
+++ b/packages/sift/src/parquet-features.ts
@@ -119,3 +119,14 @@ export function applyHfFeatureOverrides(
     }
   }
 }
+
+export function applyColumnOverrides(
+  columns: Column[],
+  columnOverrides?: Record<string, Partial<Column>>,
+): void {
+  if (!columnOverrides) return;
+  for (const col of columns) {
+    const override = columnOverrides[col.key];
+    if (override) Object.assign(col, override);
+  }
+}

--- a/packages/sift/src/parquet-features.ts
+++ b/packages/sift/src/parquet-features.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared parsers for parquet schema KV metadata.
+ *
+ * Two emitters write rich-type hints into the parquet footer that Sift
+ * consumes:
+ *
+ * - HuggingFace datasets stash a JSON ``huggingface`` key naming each
+ *   feature (Image, ClassLabel, Translation, …). Sift uses this to
+ *   render thumbnails, narrow types, and skip pointless sort handles.
+ * - pandas writes an ``index_columns`` list under the ``pandas`` key so
+ *   we can label and size the row-index column reasonably.
+ *
+ * Both consumers (the standalone demo's ``main.ts`` loader and the
+ * embedded ``SiftTable`` URL path) need the same parsing + apply logic.
+ * Keep them lockstep here.
+ */
+
+import type { Column } from "./table";
+
+export interface HfFeature {
+  _type: string;
+  names?: string[];
+  feature?: HfFeature;
+}
+
+export type SchemaMetadata = Record<string, string>;
+
+/**
+ * The wasm-bindgen ``parquet_schema_metadata`` result lands in JS as a
+ * ``Map<string,string>`` (because the Rust side returns a ``HashMap``).
+ * Property access on a Map returns ``undefined`` for every key, which
+ * has silently broken HF detection in the past. Coerce to a record so
+ * the rest of the pipeline can read keys with ordinary syntax.
+ */
+export function parseSchemaMetadata(raw: unknown): SchemaMetadata {
+  if (raw instanceof Map) return Object.fromEntries(raw as Map<string, string>);
+  if (raw && typeof raw === "object") return raw as SchemaMetadata;
+  return {};
+}
+
+export function parseHfFeatures(metadata: SchemaMetadata): Record<string, HfFeature> {
+  if (!metadata.huggingface) return {};
+  try {
+    const hf = JSON.parse(metadata.huggingface);
+    return (hf?.info?.features ?? {}) as Record<string, HfFeature>;
+  } catch {
+    return {};
+  }
+}
+
+export function parsePandasIndexColumns(metadata: SchemaMetadata): Set<string> {
+  const out = new Set<string>();
+  if (!metadata.pandas) return out;
+  try {
+    const pandas = JSON.parse(metadata.pandas);
+    for (const ic of pandas.index_columns ?? []) {
+      if (typeof ic === "string") out.add(ic);
+      // Range-index descriptors (objects) don't map to a named column.
+    }
+  } catch {
+    /* ignore parse errors */
+  }
+  return out;
+}
+
+const PANDAS_INDEX_LABEL_PATTERN = /^(unnamed[: _]*\d*|__index_level_\d+__)$/i;
+const INDEX_NAME_PATTERN = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i;
+
+/**
+ * Narrow + de-sort columns that look like a row index. ``totalRows``
+ * sizes the column to fit the largest displayed row number.
+ */
+export function applyPandasIndexOverrides(
+  columns: Column[],
+  pandasIndexCols: Set<string>,
+  totalRows: number,
+): void {
+  for (const col of columns) {
+    if (!pandasIndexCols.has(col.key) && !INDEX_NAME_PATTERN.test(col.key)) continue;
+    const digits = totalRows.toLocaleString().length;
+    col.width = Math.max(60, digits * 9 + 24);
+    col.sortable = false;
+    if (PANDAS_INDEX_LABEL_PATTERN.test(col.key)) col.label = "";
+  }
+}
+
+/**
+ * Narrow column types based on HuggingFace feature declarations.
+ *
+ * ``ClassLabel`` → categorical. ``Image`` and ``List<Image>`` /
+ * ``Sequence<Image>`` → image with a wider min-width when it's a strip.
+ */
+export function applyHfFeatureOverrides(
+  columns: Column[],
+  hfFeatures: Record<string, HfFeature>,
+): void {
+  for (const col of columns) {
+    const feature = hfFeatures[col.key];
+    if (!feature) continue;
+
+    if (feature._type === "ClassLabel" && col.columnType !== "categorical") {
+      col.columnType = "categorical";
+      col.numeric = false;
+    }
+
+    const inner =
+      feature._type === "Image"
+        ? feature
+        : feature._type === "List" || feature._type === "Sequence"
+          ? feature.feature
+          : undefined;
+    if (inner?._type === "Image") {
+      col.columnType = "image";
+      col.numeric = false;
+      col.sortable = false;
+      const isList = feature._type !== "Image";
+      const minWidth = isList ? 320 : 140;
+      if (col.width < minWidth) col.width = minWidth;
+    }
+  }
+}

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -14,6 +14,13 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyHfFeatureOverrides,
+  applyPandasIndexOverrides,
+  parseHfFeatures,
+  parsePandasIndexColumns,
+  parseSchemaMetadata,
+} from "./parquet-features";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
 import {
   type Column,
@@ -304,12 +311,29 @@ export function SiftTable({
 
       const meta = mod.parquet_metadata(parquetBytes);
       const numRowGroups = meta[0];
+      const totalRows = meta[1];
 
       if (numRowGroups === 0) {
         setError("Parquet file has no row groups.");
         setStatus("error");
         return;
       }
+
+      // Pull rich-type hints from the parquet footer. HF features
+      // (Image, ClassLabel, …) and pandas index columns get applied
+      // to the column list before the engine mounts so headers and
+      // cell renderers light up on first paint.
+      const schemaMetadata = parseSchemaMetadata(
+        (() => {
+          try {
+            return mod.parquet_schema_metadata(parquetBytes);
+          } catch {
+            return undefined;
+          }
+        })(),
+      );
+      const pandasIndexCols = parsePandasIndexColumns(schemaMetadata);
+      const hfFeatures = parseHfFeatures(schemaMetadata);
 
       // Load first row group → mount table immediately
       const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
@@ -318,6 +342,10 @@ export function SiftTable({
       const { tableData, columns, prefetchViewport } = createWasmTableData(handle, columnOverrides);
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () => updateWasmSummaries(mod, handle, tableData, columns);
+
+      applyPandasIndexOverrides(columns, pandasIndexCols, totalRows);
+      applyHfFeatureOverrides(columns, hfFeatures);
+
       updateWasmSummaries(mod, handle, tableData, columns);
 
       if (cancelled) return;

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  applyColumnOverrides,
   applyHfFeatureOverrides,
   applyPandasIndexOverrides,
   parseHfFeatures,
@@ -339,12 +340,13 @@ export function SiftTable({
       const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
       wasmHandle = handle;
 
-      const { tableData, columns, prefetchViewport } = createWasmTableData(handle, columnOverrides);
+      const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () => updateWasmSummaries(mod, handle, tableData, columns);
 
       applyPandasIndexOverrides(columns, pandasIndexCols, totalRows);
       applyHfFeatureOverrides(columns, hfFeatures);
+      applyColumnOverrides(columns, columnOverrides);
 
       updateWasmSummaries(mod, handle, tableData, columns);
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -114,7 +114,10 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
             log.debug("dataset mimebundle failed: %s", exc)
             return None
 
-    return _emit_arrow_table(table, total_rows=ds.num_rows, summary_fn=summary)
+    total_rows = getattr(ds, "num_rows", table.num_rows)
+    if not isinstance(total_rows, int):
+        total_rows = table.num_rows
+    return _emit_arrow_table(table, total_rows=total_rows, summary_fn=summary)
 
 
 def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
@@ -319,7 +322,7 @@ def _install_dataframe_formatters(ip: Any) -> None:
     - polars: ``polars.dataframe.frame``
     - narwhals: ``narwhals.dataframe``
     - pyarrow: ``pyarrow.lib`` (Table / RecordBatch are C-extension types)
-    - datasets: ``datasets.arrow_dataset``
+    - datasets: ``datasets.arrow_dataset`` / ``datasets.iterable_dataset``
 
     We register the definitive module each library stamps on the class,
     plus a short-name fallback for pandas/polars/narwhals/pyarrow. Short
@@ -349,8 +352,10 @@ def _install_dataframe_formatters(ip: Any) -> None:
         ("pyarrow", "Table", _pyarrow_table_mimebundle),
         ("pyarrow.lib", "RecordBatch", _pyarrow_record_batch_mimebundle),
         ("pyarrow", "RecordBatch", _pyarrow_record_batch_mimebundle),
-        # datasets — single definitive path.
+        # datasets — materialized datasets can emit parquet; iterable
+        # datasets fall back to summary-only because they have no table.
         ("datasets.arrow_dataset", "Dataset", _dataset_mimebundle),
+        ("datasets.iterable_dataset", "IterableDataset", _dataset_mimebundle),
     ):
         try:
             mimebundle.for_type_by_name(module_path, type_name, fn)

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -36,6 +36,7 @@ import hashlib
 import io
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 from IPython.core.formatters import BaseFormatter
@@ -43,7 +44,7 @@ from traitlets import ObjectName, Unicode
 
 from nteract_kernel_launcher import _buffer_hook, _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
-from nteract_kernel_launcher._format import serialize_dataframe
+from nteract_kernel_launcher._format import serialize_arrow_table, serialize_dataframe
 from nteract_kernel_launcher._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
 from nteract_kernel_launcher._summary import summarize_dataframe, summarize_dataset
 
@@ -82,12 +83,38 @@ def _narwhals_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
     return _emit_dataframe(native, total_rows=total_rows)
 
 
+def _pyarrow_table_mimebundle(table: Any, include=None, exclude=None) -> dict | None:
+    return _emit_arrow_table(table, total_rows=table.num_rows)
+
+
+def _pyarrow_record_batch_mimebundle(batch: Any, include=None, exclude=None) -> dict | None:
+    import pyarrow as pa
+
+    table = pa.Table.from_batches([batch])
+    return _emit_arrow_table(table, total_rows=table.num_rows)
+
+
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
-    try:
-        return {"text/llm+plain": summarize_dataset(ds)}
-    except Exception as exc:  # noqa: BLE001
-        log.debug("dataset mimebundle failed: %s", exc)
-        return None
+    """Emit parquet bytes + HF features summary for a ``datasets.Dataset``.
+
+    The underlying ``ds.data.table`` carries the ``huggingface`` schema KV
+    metadata that Sift uses to detect rich types (Image, ClassLabel,
+    Translation, …). Going through the arrow table preserves that metadata
+    end-to-end. When no underlying table is available (IterableDataset,
+    streaming, …), fall back to the legacy summary-only bundle so the
+    formatter stays best-effort.
+    """
+    table = getattr(getattr(ds, "data", None), "table", None)
+    summary = lambda: summarize_dataset(ds)  # noqa: E731
+
+    if table is None:
+        try:
+            return {"text/llm+plain": summary()}
+        except Exception as exc:  # noqa: BLE001
+            log.debug("dataset mimebundle failed: %s", exc)
+            return None
+
+    return _emit_arrow_table(table, total_rows=ds.num_rows, summary_fn=summary)
 
 
 def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
@@ -148,7 +175,88 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
         except Exception:  # noqa: BLE001
             return None
 
-    # Detect downsampling by reading parquet metadata (footer only, cheap).
+    return _emit_parquet_bytes(
+        data,
+        content_type=content_type,
+        total_rows=total_rows,
+        summary_fn=lambda included, sampled: summarize_dataframe(
+            df, total_rows=total_rows, included_rows=included, sampled=sampled
+        ),
+    )
+
+
+def _emit_arrow_table(
+    table: Any,
+    *,
+    total_rows: int,
+    summary_fn: Callable[[], str] | None = None,
+) -> dict | None:
+    """Serialize a ``pa.Table`` to parquet, preserving schema KV metadata.
+
+    Distinct from :func:`_emit_dataframe` because the dataframe path runs
+    bytes through ``pa.Table.from_pandas`` / ``pl.write_parquet``, which
+    drop schema KV metadata. The table path goes straight through
+    ``pq.write_table`` so the ``huggingface`` key survives — this is what
+    makes Sift's rich-type detection light up for HF parquets the user
+    loaded with ``pq.read_table`` or ``datasets.load_dataset``.
+
+    ``summary_fn`` lets callers (notably ``_dataset_mimebundle``) provide
+    a richer per-domain summary (HF features) instead of the generic
+    pandas-style preview.
+    """
+    try:
+        data, content_type = serialize_arrow_table(table, max_bytes=_MAX_PAYLOAD_BYTES)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("arrow serialize failed: %s — emitting summary-only bundle", exc)
+        if summary_fn is not None:
+            try:
+                return {"text/llm+plain": summary_fn()}
+            except Exception:  # noqa: BLE001
+                return None
+        return None
+
+    def _summary(included: int, sampled: bool) -> str:
+        if summary_fn is not None:
+            return summary_fn()
+        return _summarize_arrow_table(
+            table, total_rows=total_rows, included_rows=included, sampled=sampled
+        )
+
+    return _emit_parquet_bytes(
+        data,
+        content_type=content_type,
+        total_rows=total_rows,
+        summary_fn=_summary,
+    )
+
+
+def _summarize_arrow_table(
+    table: Any, *, total_rows: int, included_rows: int, sampled: bool
+) -> str:
+    """Summary for a ``pa.Table`` — convert head to pandas, reuse summarizer.
+
+    Cheap for the typical display case (modest row counts). Heavy tables
+    pay a one-time conversion of the head sample, which is bounded.
+    """
+    head_n = 50
+    head = table.slice(0, head_n).to_pandas()
+    return summarize_dataframe(
+        head, total_rows=total_rows, included_rows=included_rows, sampled=sampled
+    )
+
+
+def _emit_parquet_bytes(
+    data: bytes,
+    *,
+    content_type: str,
+    total_rows: int,
+    summary_fn: Callable[[int, bool], str],
+) -> dict:
+    """Stash bytes, build the ref bundle, attach a summary.
+
+    ``summary_fn`` receives ``(included_rows, sampled)`` so per-domain
+    summaries can name the sampling state honestly.
+    """
     sampled = False
     included = total_rows
     try:
@@ -172,10 +280,14 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
     ref_bundle = build_ref_bundle(ref, content_type=content_type, summary=summary_hints)
     ref_bundle["buffer_index"] = 0
 
-    llm = summarize_dataframe(df, total_rows=total_rows, included_rows=included, sampled=sampled)
+    bundle: dict[str, Any] = {BLOB_REF_MIME: ref_bundle}
+    try:
+        bundle["text/llm+plain"] = summary_fn(included, sampled)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("summary build failed: %s", exc)
 
     pending_buffers()[h] = data
-    return {BLOB_REF_MIME: ref_bundle, "text/llm+plain": llm}
+    return bundle
 
 
 # ─── Install functions — called from load_ipython_extension ───────────────
@@ -206,11 +318,12 @@ def _install_dataframe_formatters(ip: Any) -> None:
     - pandas: ``pandas`` (pandas sets ``DataFrame.__module__ = "pandas"``)
     - polars: ``polars.dataframe.frame``
     - narwhals: ``narwhals.dataframe``
+    - pyarrow: ``pyarrow.lib`` (Table / RecordBatch are C-extension types)
     - datasets: ``datasets.arrow_dataset``
 
     We register the definitive module each library stamps on the class,
-    plus a short-name fallback for pandas/polars/narwhals. Short names
-    cover both conservative stamping by the library and any future
+    plus a short-name fallback for pandas/polars/narwhals/pyarrow. Short
+    names cover both conservative stamping by the library and any future
     flattening. Registration is cheap and idempotent, so the spray
     costs nothing.
     """
@@ -228,6 +341,14 @@ def _install_dataframe_formatters(ip: Any) -> None:
         # narwhals — class lives in narwhals.dataframe.
         ("narwhals.dataframe", "DataFrame", _narwhals_mimebundle),
         ("narwhals", "DataFrame", _narwhals_mimebundle),
+        # pyarrow — Table / RecordBatch are stamped to pyarrow.lib by
+        # the C extension. Preserves schema KV metadata end-to-end so
+        # Sift's HF rich-type detection lights up for parquets the user
+        # loaded with pq.read_table.
+        ("pyarrow.lib", "Table", _pyarrow_table_mimebundle),
+        ("pyarrow", "Table", _pyarrow_table_mimebundle),
+        ("pyarrow.lib", "RecordBatch", _pyarrow_record_batch_mimebundle),
+        ("pyarrow", "RecordBatch", _pyarrow_record_batch_mimebundle),
         # datasets — single definitive path.
         ("datasets.arrow_dataset", "Dataset", _dataset_mimebundle),
     ):

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -1,15 +1,19 @@
-"""DataFrame → parquet serialization (best-available encoder).
+"""DataFrame / Arrow → parquet serialization (best-available encoder).
 
 Pandas uses pyarrow (or fastparquet as a fallback). Polars uses its native
-parquet writer. If the serialized payload would exceed ``max_bytes``, the
-serializer downsamples via ``head(n)`` with a binary-search-ish loop and
-annotates the result so the caller can advertise partial data in the
-``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
+parquet writer. ``pyarrow.Table`` and ``pyarrow.RecordBatch`` round-trip
+through ``pq.write_table``, which preserves schema KV metadata (the
+``huggingface`` key Sift uses for rich-type detection on HF parquets is
+the load-bearing case). If the serialized payload would exceed
+``max_bytes``, the serializer downsamples via ``head(n)`` / ``slice(0, n)``
+with a halving loop and the caller advertises the partial-data state in
+the ``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
 """
 
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 from typing import Any
 
 PARQUET_MIME = "application/vnd.apache.parquet"
@@ -40,6 +44,38 @@ def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
     return buf.getvalue()
 
 
+def _serialize_arrow_table(table: Any, rows: int | None = None) -> bytes:
+    import pyarrow.parquet as pq
+
+    if rows is not None:
+        table = table.slice(0, rows)
+    buf = io.BytesIO()
+    pq.write_table(table, buf, compression="snappy")
+    return buf.getvalue()
+
+
+def _downsample_loop(encode: Callable[..., bytes], total_rows: int, *, max_bytes: int) -> bytes:
+    """Encode at full size; if too big, halve target rows up to four rounds.
+
+    Parquet compression is non-linear in row count, so the first guess
+    (``rows * max_bytes / full_bytes``) tends to overshoot. Halving from
+    there converges quickly; bottoming out at one row keeps this from
+    raising for sampling.
+    """
+    full = encode()
+    if len(full) <= max_bytes:
+        return full
+    if total_rows <= 1:
+        return full
+    target_rows = max(1, int(total_rows * (max_bytes / len(full))))
+    for _ in range(4):
+        sampled = encode(rows=target_rows)
+        if len(sampled) <= max_bytes:
+            return sampled
+        target_rows = max(1, target_rows // 2)
+    return encode(rows=1)
+
+
 def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str]:
     """Serialize ``df`` to parquet; downsample if it would exceed ``max_bytes``.
 
@@ -49,26 +85,29 @@ def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str]:
     flavor = _detect_flavor(df)
     if flavor == "pandas":
         encoder = _serialize_pandas
+        n = len(df)
     elif flavor == "polars":
         encoder = _serialize_polars
+        n = df.height
     else:
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
 
-    full = encoder(df)
-    if len(full) <= max_bytes:
-        return full, PARQUET_MIME
+    return _downsample_loop(
+        lambda rows=None: encoder(df, rows=rows), n, max_bytes=max_bytes
+    ), PARQUET_MIME
 
-    # Estimate a row count that fits. Parquet compression is non-linear in
-    # row count; try a few downsample rounds before giving up.
-    n = len(df) if flavor == "pandas" else df.height
-    if n <= 1:
-        return full, PARQUET_MIME
-    target_rows = max(1, int(n * (max_bytes / len(full))))
-    for _ in range(4):
-        sampled = encoder(df, rows=target_rows)
-        if len(sampled) <= max_bytes:
-            return sampled, PARQUET_MIME
-        target_rows = max(1, target_rows // 2)
 
-    # Last resort: a single row. Never raise for sampling.
-    return encoder(df, rows=1), PARQUET_MIME
+def serialize_arrow_table(table: Any, *, max_bytes: int) -> tuple[bytes, str]:
+    """Serialize ``pa.Table`` to parquet, preserving schema KV metadata.
+
+    Same downsample semantics as :func:`serialize_dataframe`. Schema KV
+    metadata (``ARROW:schema``, ``huggingface``, ``content_defined_chunking``,
+    etc.) survives the round-trip because ``pq.write_table`` writes whatever
+    the table's schema carries. ``pa.Table.from_pandas`` does *not* survive
+    KV metadata, so the dataframe path can't replace this one.
+    """
+    return _downsample_loop(
+        lambda rows=None: _serialize_arrow_table(table, rows=rows),
+        table.num_rows,
+        max_bytes=max_bytes,
+    ), PARQUET_MIME

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_summary.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_summary.py
@@ -353,12 +353,13 @@ def summarize_dataset(ds: Any) -> str:
     Does NOT call ``.to_pandas()`` or any materializing operation beyond
     reading ``ds[0]`` for a sample row.
     """
-    features = ds.features
-    num_rows = ds.num_rows
+    features = getattr(ds, "features", None)
+    num_rows = getattr(ds, "num_rows", None)
     n_features = len(features) if features else 0
 
     lines: list[str] = []
-    lines.append(f"HuggingFace Dataset: {_format_int(num_rows)} rows × {n_features} features")
+    row_count = _format_int(num_rows) if isinstance(num_rows, int) else "unknown"
+    lines.append(f"HuggingFace Dataset: {row_count} rows × {n_features} features")
 
     if features:
         lines.append("Features:")
@@ -376,7 +377,7 @@ def summarize_dataset(ds: Any) -> str:
             lines.append(f"Description: {excerpt}")
 
     # Sample row
-    if num_rows > 0:
+    if isinstance(num_rows, int) and num_rows > 0:
         try:
             row = ds[0]
             lines.append("")

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -335,3 +335,137 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
     h = bundle[BLOB_REF_MIME]["hash"]
     assert h in _buffer_hook.pending_buffers()
     assert isinstance(_buffer_hook.pending_buffers()[h], bytes)
+
+
+# ─── pyarrow.Table path — preserves schema KV metadata ───────────────────
+
+
+def _pa_table_with_hf_metadata():
+    """Build a small ``pa.Table`` carrying a ``huggingface`` schema KV entry.
+
+    Mirrors the shape of HF parquets: features under ``huggingface``,
+    one column declared ``Image`` with ``Struct{bytes, path}``.
+    """
+    pa = pytest.importorskip("pyarrow")
+
+    image_struct = pa.struct([pa.field("bytes", pa.binary()), pa.field("path", pa.string())])
+    schema = pa.schema(
+        [pa.field("id", pa.string()), pa.field("image", image_struct)],
+        metadata={
+            "huggingface": (
+                '{"info": {"features": {'
+                '"id": {"dtype": "string", "_type": "Value"}, '
+                '"image": {"_type": "Image"}}}}'
+            )
+        },
+    )
+    return pa.Table.from_pylist(
+        [
+            {"id": "row-0", "image": {"bytes": b"\x89PNG\r\n", "path": "0.png"}},
+            {"id": "row-1", "image": {"bytes": b"\x89PNG\r\n", "path": "1.png"}},
+        ],
+        schema=schema,
+    )
+
+
+def test_emit_pyarrow_table_preserves_huggingface_kv_metadata():
+    """The pa.Table path is the load-bearing one for Sift's rich-type
+    detection — the dataframe path drops schema KV metadata, this one
+    keeps it. Verify by reading the parquet footer back out."""
+    import io
+
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    _buffer_hook.pending_buffers().clear()
+    table = _pa_table_with_hf_metadata()
+
+    bundle = _bootstrap._pyarrow_table_mimebundle(table)
+
+    assert bundle is not None
+    assert BLOB_REF_MIME in bundle
+    assert "text/llm+plain" in bundle
+
+    h = bundle[BLOB_REF_MIME]["hash"]
+    data = _buffer_hook.pending_buffers()[h]
+    md = pq.read_metadata(io.BytesIO(data)).metadata or {}
+    assert b"huggingface" in md, f"missing huggingface KV; got keys: {[k.decode() for k in md]}"
+    assert b'"_type": "Image"' in md[b"huggingface"]
+
+
+def test_emit_pyarrow_record_batch_promotes_to_table():
+    """RecordBatch should produce the same kind of bundle as Table."""
+    pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    _buffer_hook.pending_buffers().clear()
+    table = _pa_table_with_hf_metadata()
+    batch = table.to_batches()[0]
+
+    bundle = _bootstrap._pyarrow_record_batch_mimebundle(batch)
+
+    assert bundle is not None
+    assert BLOB_REF_MIME in bundle
+
+
+def test_dataset_mimebundle_emits_parquet_with_hf_features():
+    """``datasets.Dataset`` carries HF features both on ``ds.features`` and
+    on the underlying ``ds.data.table`` schema KV. The bundle must include
+    parquet bytes whose footer carries the ``huggingface`` key, not just
+    the legacy text-summary path."""
+    import io
+
+    pq = pytest.importorskip("pyarrow.parquet")
+    pytest.importorskip("datasets")
+    from datasets import Dataset
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    _buffer_hook.pending_buffers().clear()
+
+    table = _pa_table_with_hf_metadata()
+    ds = Dataset(arrow_table=table)
+
+    bundle = _bootstrap._dataset_mimebundle(ds)
+
+    assert bundle is not None
+    assert BLOB_REF_MIME in bundle
+    assert "text/llm+plain" in bundle
+    # Summary should still go through summarize_dataset (HF-feature aware),
+    # not the generic pandas-style summary.
+    assert "HuggingFace Dataset" in bundle["text/llm+plain"]
+
+    h = bundle[BLOB_REF_MIME]["hash"]
+    data = _buffer_hook.pending_buffers()[h]
+    md = pq.read_metadata(io.BytesIO(data)).metadata or {}
+    assert b"huggingface" in md
+    assert b'"_type": "Image"' in md[b"huggingface"]
+
+
+def test_dataset_mimebundle_falls_back_to_summary_when_no_table():
+    """Streaming / iterable datasets have no ``.data.table``; the formatter
+    must keep the legacy text-only behavior so it stays best-effort."""
+    pytest.importorskip("datasets")
+
+    from nteract_kernel_launcher import _bootstrap
+
+    class FakeFeatures(dict):
+        pass
+
+    class FakeStreamingDataset:
+        features = FakeFeatures(id="string")
+        num_rows = 0
+        info = None
+
+        def __getitem__(self, _idx):
+            raise RuntimeError("streaming")
+
+        # No `data` attribute — mirrors IterableDataset.
+
+    bundle = _bootstrap._dataset_mimebundle(FakeStreamingDataset())
+    assert bundle is not None
+    assert "text/llm+plain" in bundle

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -315,6 +315,20 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     assert called == ["hooks", "r"]
 
 
+def test_install_registers_iterable_dataset_formatter():
+    """Streaming HF datasets must reach the summary-only formatter path."""
+    from IPython.core.formatters import DisplayFormatter
+    from nteract_kernel_launcher import _bootstrap
+
+    display_formatter = DisplayFormatter()
+    ip = SimpleNamespace(display_formatter=display_formatter)
+
+    _bootstrap._install_dataframe_formatters(ip)
+
+    deferred = display_formatter.mimebundle_formatter.deferred_printers
+    assert ("datasets.iterable_dataset", "IterableDataset") in deferred
+
+
 # ─── emit path — only runs if pandas + pyarrow are importable ────────────
 
 
@@ -458,7 +472,6 @@ def test_dataset_mimebundle_falls_back_to_summary_when_no_table():
 
     class FakeStreamingDataset:
         features = FakeFeatures(id="string")
-        num_rows = 0
         info = None
 
         def __getitem__(self, _idx):

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -1,0 +1,61 @@
+"""Tests for the parquet serialization helpers in ``_format``.
+
+Coverage focus: the pa.Table path preserves schema KV metadata (the HF
+``huggingface`` key Sift uses for rich-type detection) and the downsample
+loop converges for both dataframe and arrow inputs.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+
+def _pa_table_with_hf_metadata():
+    pa = pytest.importorskip("pyarrow")
+    schema = pa.schema(
+        [pa.field("a", pa.int64()), pa.field("b", pa.string())],
+        metadata={"huggingface": '{"info":{"features":{}}}', "custom": "value"},
+    )
+    return pa.table({"a": list(range(1000)), "b": [f"row-{i}" for i in range(1000)]}, schema=schema)
+
+
+def test_serialize_arrow_table_preserves_schema_metadata():
+    pq = pytest.importorskip("pyarrow.parquet")
+    from nteract_kernel_launcher._format import PARQUET_MIME, serialize_arrow_table
+
+    table = _pa_table_with_hf_metadata()
+    data, ct = serialize_arrow_table(table, max_bytes=10_000_000)
+    assert ct == PARQUET_MIME
+
+    md = pq.read_metadata(io.BytesIO(data)).metadata or {}
+    assert b"huggingface" in md
+    assert b"custom" in md
+    assert md[b"custom"] == b"value"
+
+
+def test_serialize_arrow_table_downsamples_when_oversized():
+    pq = pytest.importorskip("pyarrow.parquet")
+    from nteract_kernel_launcher._format import serialize_arrow_table
+
+    table = _pa_table_with_hf_metadata()
+    # Force the loop to fire by setting the cap below the full size.
+    full_data, _ = serialize_arrow_table(table, max_bytes=10_000_000)
+    cap = max(1, len(full_data) // 4)
+
+    data, _ = serialize_arrow_table(table, max_bytes=cap)
+    assert len(data) <= cap or pq.read_metadata(io.BytesIO(data)).num_rows < table.num_rows
+
+
+def test_serialize_dataframe_pandas_round_trips_data():
+    pd = pytest.importorskip("pandas")
+    pq = pytest.importorskip("pyarrow.parquet")
+    from nteract_kernel_launcher._format import PARQUET_MIME, serialize_dataframe
+
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    data, ct = serialize_dataframe(df, max_bytes=10_000_000)
+    assert ct == PARQUET_MIME
+    table = pq.read_table(io.BytesIO(data))
+    assert table.column_names == ["a", "b"]
+    assert table.num_rows == 3


### PR DESCRIPTION
Sift's HuggingFace rich-type detection (Image, ClassLabel, Translation, …) only fired in the standalone demo, never in the notebook. Two layered gaps:

1. The launcher emitted parquet bytes via `pa.Table.from_pandas` / `pl.write_parquet`, both of which drop schema KV metadata. Even when a user loaded a HF parquet directly with `pd.read_parquet`, Sift saw a parquet without the `huggingface` key and fell back to plain text rendering.
2. The `huggingface` parser lived inside `packages/sift/src/main.ts` (the standalone demo's loader), so the iframe-embedded `SiftTable` plugin never ran it.

Closing both gaps end-to-end. Loading MathNet via `pq.read_table(...)` or `datasets.load_dataset(...)` and displaying the result in a notebook now produces inline image thumbnails, ClassLabel-as-categorical, and the rest of HF's feature surface — same behavior as the standalone demo.

## Python launcher (commit 1)

`pa.Table` and `pa.RecordBatch` get their own mimebundle formatters. They serialize via `pq.write_table`, which preserves all schema KV metadata (`huggingface`, `pandas`, `ARROW:schema`, …) end-to-end. RecordBatch promotes to Table.

`datasets.Dataset` upgrades from text-summary-only to the full parquet ref bundle. The underlying `ds.data.table` already carries the HF features metadata, so `pq.write_table` against it round-trips the rich types. Streaming / iterable datasets without `.data.table` keep the legacy text-only behavior.

`_format.serialize_arrow_table()` mirrors `serialize_dataframe()` semantics on a `pa.Table`: full encode → halving downsample loop. The shared `_emit_parquet_bytes` helper covers the bookkeeping (sha256, ref bundle, summary hints, blob stash) that all three paths share.

The pandas / polars dataframe paths are unchanged — neither library carries KV metadata on its DataFrame state, so the metadata is structurally lost on load. Workaround: use `pq.read_table()` or `datasets.load_dataset()`.

### Behavioral coverage

| Source | KV metadata path | Sift result |
|---|---|---|
| `pq.read_table(local_or_url)` | preserved through `pq.write_table` | rich types fire |
| `pq.read_table(path, filesystem=HfFileSystem())` | preserved | rich types fire |
| `datasets.load_dataset(...)["train"]` | preserved via `ds.data.table` | rich types fire |
| `pd.read_parquet(local_or_url)` | dropped on read into pandas | plain rendering |
| `pl.read_parquet(local_or_url)` | dropped on read into polars | plain rendering |
| `pl.read_parquet("hf://...")` | dropped — `hf://` is just a polars fetch transport, the DataFrame still doesn't carry KV | plain rendering |
| `pl.scan_parquet(...).collect()` | dropped — LazyFrame doesn't surface KV | plain rendering |
| `IterableDataset` (streaming) | no `.data.table` | text summary fallback |

The polars rows are a structural limitation in polars itself (DataFrames don't have a place to carry parquet KV metadata), not something the launcher can fix downstream. The workaround for users who want polars + rich Sift rendering today is to read via pyarrow's HF filesystem and skip the DataFrame entirely:

```python
from huggingface_hub import HfFileSystem
import pyarrow.parquet as pq
table = pq.read_table("datasets/ShadenA/MathNet/data/.../train-00000-of-00001.parquet",
                       filesystem=HfFileSystem())
table  # rich types fire
```

## Sift (commit 2)

Pulled the `huggingface` parser and `pandas.index_columns` parser out of `main.ts` into `parquet-features.ts`. `SiftTable`'s URL path now runs the same detection as the standalone demo before the engine mounts. The iframe-embedded plugin gets HF rich types for free.

`parseSchemaMetadata` keeps the wasm-bindgen `Map<string,string>` → record coercion that was easy to break and hard to spot — property access on a Map silently returns `undefined` and the previous bug killed HF detection.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] launcher tests pass (40, including 7 new ones covering pa.Table / Dataset / RecordBatch round-trips)
- [x] `pnpm --filter @nteract/sift test` passes (145)
- [x] verified end-to-end on MathNet via Claude in Chrome:
  - `pq.read_table(local_path)` → notebook iframe shows inline image thumbnails for the `images` column, no longer raw `[{bytes: 89504e...}]` text
  - `load_dataset("ShadenA/MathNet", "Asia_Pacific_Mathematics_Olympiad_APMO")["train"]` → 124 rows render with image strips; image-less rows show a `null` badge
