### PR TITLE
fix(sift): theme scrollbar corner

### DIFF
--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1319,6 +1319,10 @@ h1 {
   background: transparent;
 }
 
+.sift-viewport::-webkit-scrollbar-corner {
+  background: var(--sift-bg);
+}
+
 .sift-viewport::-webkit-scrollbar-thumb {
   background: var(--sift-scrollbar-thumb);
   border-radius: 4px;

--- a/packages/sift/src/style.test.ts
+++ b/packages/sift/src/style.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+const styleCss = readFileSync("src/style.css", "utf8");
+
+describe("Sift stylesheet", () => {
+  it("themes the WebKit scrollbar corner with the table surface", () => {
+    expect(styleCss).toMatch(
+      /\.sift-viewport::-webkit-scrollbar-corner\s*\{\s*background:\s*var\(--sift-bg\);\s*\}/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Theme Sift's WebKit scrollbar corner with the table background.
- Add a stylesheet regression test so the corner rule is not dropped later.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir packages/sift test -- style.test.ts`
- Browser check against `http://127.0.0.1:5173/?dataset=titanic`: `::-webkit-scrollbar-corner` computed to `rgb(10, 10, 10)` in dark Classic.
