### PR TITLE
refactor(sift): share parquet feature hints via predicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,6 +4663,7 @@ dependencies = [
  "chrono",
  "parquet",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 bytes = { workspace = true }
 chrono = { version = "0.4", default-features = false }
 

--- a/crates/nteract-predicate/src/lib.rs
+++ b/crates/nteract-predicate/src/lib.rs
@@ -12,10 +12,15 @@
 
 pub mod arrow_utils;
 pub mod filter;
+pub mod parquet_features;
 pub mod parquet_summary;
 pub mod summary;
 pub mod utils;
 
 pub use filter::{filter_rows, string_contains};
+pub use parquet_features::{
+    parquet_column_hints, parquet_file_key_value_metadata, parse_parquet_column_hints,
+    ParquetColumnHint, ParquetSemanticType,
+};
 pub use parquet_summary::{summarize_parquet, ColumnStats, ColumnSummary, ParquetSummary};
 pub use summary::{histogram, value_counts, CategoryCount, HistogramBin};

--- a/crates/nteract-predicate/src/parquet_features.rs
+++ b/crates/nteract-predicate/src/parquet_features.rs
@@ -1,0 +1,311 @@
+//! Canonical interpretation of Parquet file-level metadata.
+//!
+//! Sift uses these hints for UI column behavior, while `repr-llm` can use the
+//! same signal when describing rich Parquet outputs for agents. Keep the JSON
+//! footer parsing here so native and WASM consumers agree on pandas/HF meaning.
+
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::file::metadata::ParquetMetaData;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ParquetColumnHint {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub numeric: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sortable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub pandas_index: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_type: Option<ParquetSemanticType>,
+}
+
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ParquetSemanticType {
+    PandasIndex,
+    HuggingfaceClassLabel,
+    HuggingfaceImage,
+    HuggingfaceImageList,
+}
+
+impl ParquetColumnHint {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            column_type: None,
+            numeric: None,
+            sortable: None,
+            width: None,
+            label: None,
+            pandas_index: false,
+            semantic_type: None,
+        }
+    }
+
+    fn has_effect(&self) -> bool {
+        self.column_type.is_some()
+            || self.numeric.is_some()
+            || self.sortable.is_some()
+            || self.width.is_some()
+            || self.label.is_some()
+            || self.pandas_index
+            || self.semantic_type.is_some()
+    }
+
+    fn set_min_width(&mut self, width: u32) {
+        self.width = Some(self.width.unwrap_or(0).max(width));
+    }
+}
+
+pub fn parquet_file_key_value_metadata(
+    parquet_bytes: &[u8],
+) -> Result<HashMap<String, String>, Box<dyn std::error::Error + Send + Sync>> {
+    let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)?;
+    Ok(file_key_value_metadata(builder.metadata()))
+}
+
+pub fn parquet_column_hints(
+    parquet_bytes: &[u8],
+) -> Result<Vec<ParquetColumnHint>, Box<dyn std::error::Error + Send + Sync>> {
+    let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)?;
+    let metadata = builder.metadata();
+    let kv_metadata = file_key_value_metadata(metadata);
+    let total_rows = metadata.file_metadata().num_rows().max(0) as u64;
+    let column_names: Vec<String> = builder
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    Ok(parse_parquet_column_hints(
+        &column_names,
+        total_rows,
+        &kv_metadata,
+    ))
+}
+
+pub fn parse_parquet_column_hints(
+    column_names: &[String],
+    total_rows: u64,
+    metadata: &HashMap<String, String>,
+) -> Vec<ParquetColumnHint> {
+    let pandas_index_cols = parse_pandas_index_columns(metadata);
+    let hf_features = parse_huggingface_features(metadata);
+
+    column_names
+        .iter()
+        .filter_map(|name| {
+            let mut hint = ParquetColumnHint::new(name);
+            apply_pandas_hint(&mut hint, total_rows, pandas_index_cols.contains(name));
+            apply_huggingface_hint(&mut hint, hf_features.as_ref());
+            hint.has_effect().then_some(hint)
+        })
+        .collect()
+}
+
+pub fn file_key_value_metadata(metadata: &ParquetMetaData) -> HashMap<String, String> {
+    metadata
+        .file_metadata()
+        .key_value_metadata()
+        .into_iter()
+        .flatten()
+        .filter_map(|kv| {
+            kv.value
+                .as_ref()
+                .map(|value| (kv.key.clone(), value.clone()))
+        })
+        .collect()
+}
+
+fn parse_pandas_index_columns(metadata: &HashMap<String, String>) -> Vec<String> {
+    let Some(raw) = metadata.get("pandas") else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(raw) else {
+        return Vec::new();
+    };
+    value
+        .get("index_columns")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn parse_huggingface_features(metadata: &HashMap<String, String>) -> Option<Value> {
+    let raw = metadata.get("huggingface")?;
+    serde_json::from_str::<Value>(raw)
+        .ok()?
+        .get("info")?
+        .get("features")
+        .cloned()
+}
+
+fn apply_pandas_hint(hint: &mut ParquetColumnHint, total_rows: u64, in_pandas_metadata: bool) {
+    if !in_pandas_metadata && !is_index_like_name(&hint.name) {
+        return;
+    }
+    hint.pandas_index = true;
+    hint.semantic_type = Some(ParquetSemanticType::PandasIndex);
+    hint.sortable = Some(false);
+    hint.set_min_width((formatted_digit_count(total_rows) * 9 + 24).max(60));
+    if is_pandas_artifact_label(&hint.name) {
+        hint.label = Some(String::new());
+    }
+}
+
+fn apply_huggingface_hint(hint: &mut ParquetColumnHint, features: Option<&Value>) {
+    let Some(feature) = features.and_then(|features| features.get(&hint.name)) else {
+        return;
+    };
+    match feature.get("_type").and_then(Value::as_str) {
+        Some("ClassLabel") => {
+            hint.column_type = Some("categorical".to_string());
+            hint.numeric = Some(false);
+            hint.semantic_type = Some(ParquetSemanticType::HuggingfaceClassLabel);
+        }
+        Some("Image") => {
+            apply_image_hint(hint, false);
+        }
+        Some("List") | Some("Sequence")
+            if feature
+                .get("feature")
+                .and_then(|inner| inner.get("_type"))
+                .and_then(Value::as_str)
+                == Some("Image") =>
+        {
+            apply_image_hint(hint, true);
+        }
+        _ => {}
+    }
+}
+
+fn apply_image_hint(hint: &mut ParquetColumnHint, is_list: bool) {
+    hint.column_type = Some("image".to_string());
+    hint.numeric = Some(false);
+    hint.sortable = Some(false);
+    hint.set_min_width(if is_list { 320 } else { 140 });
+    hint.semantic_type = Some(if is_list {
+        ParquetSemanticType::HuggingfaceImageList
+    } else {
+        ParquetSemanticType::HuggingfaceImage
+    });
+}
+
+fn formatted_digit_count(value: u64) -> u32 {
+    let digits = value.to_string().len() as u32;
+    digits + digits.saturating_sub(1) / 3
+}
+
+fn is_index_like_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    is_pandas_artifact_label(&lower)
+        || matches!(
+            lower.as_str(),
+            "index" | "id" | "_id" | "rowid" | "row_id" | "rownum" | "row_num"
+        )
+}
+
+fn is_pandas_artifact_label(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if let Some(rest) = lower.strip_prefix("unnamed") {
+        return rest
+            .chars()
+            .all(|ch| ch == ':' || ch == '_' || ch == ' ' || ch.is_ascii_digit());
+    }
+    if let Some(rest) = lower
+        .strip_prefix("__index_level_")
+        .and_then(|rest| rest.strip_suffix("__"))
+    {
+        return !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit());
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_pandas_and_huggingface_column_hints() {
+        let columns = vec![
+            "__index_level_0__".to_string(),
+            "image".to_string(),
+            "frames".to_string(),
+            "label".to_string(),
+        ];
+        let metadata = metadata(&[
+            ("pandas", r#"{"index_columns":["__index_level_0__"]}"#),
+            (
+                "huggingface",
+                r#"{"info":{"features":{"image":{"_type":"Image"},"frames":{"_type":"Sequence","feature":{"_type":"Image"}},"label":{"_type":"ClassLabel","names":["cat","dog"]}}}}"#,
+            ),
+        ]);
+
+        let hints = parse_parquet_column_hints(&columns, 12_345, &metadata);
+
+        assert_eq!(hints.len(), 4);
+        assert_eq!(
+            hints[0],
+            ParquetColumnHint {
+                name: "__index_level_0__".to_string(),
+                column_type: None,
+                numeric: None,
+                sortable: Some(false),
+                width: Some(78),
+                label: Some(String::new()),
+                pandas_index: true,
+                semantic_type: Some(ParquetSemanticType::PandasIndex),
+            }
+        );
+        assert_eq!(hints[1].column_type.as_deref(), Some("image"));
+        assert_eq!(hints[1].width, Some(140));
+        assert_eq!(
+            hints[1].semantic_type,
+            Some(ParquetSemanticType::HuggingfaceImage)
+        );
+        assert_eq!(hints[2].width, Some(320));
+        assert_eq!(
+            hints[2].semantic_type,
+            Some(ParquetSemanticType::HuggingfaceImageList)
+        );
+        assert_eq!(hints[3].column_type.as_deref(), Some("categorical"));
+        assert_eq!(
+            hints[3].semantic_type,
+            Some(ParquetSemanticType::HuggingfaceClassLabel)
+        );
+    }
+
+    #[test]
+    fn tolerates_malformed_footer_json() {
+        let columns = vec!["index".to_string(), "value".to_string()];
+        let metadata = metadata(&[("pandas", "{"), ("huggingface", "{")]);
+
+        let hints = parse_parquet_column_hints(&columns, 10, &metadata);
+
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].name, "index");
+        assert!(hints[0].pandas_index);
+    }
+}

--- a/crates/nteract-predicate/src/parquet_summary.rs
+++ b/crates/nteract-predicate/src/parquet_summary.rs
@@ -18,6 +18,10 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::Serialize;
 use std::collections::HashMap;
 
+use crate::parquet_features::{
+    file_key_value_metadata, parse_parquet_column_hints, ParquetColumnHint,
+};
+
 /// Maximum number of distinct values to enumerate for categorical columns.
 const TOP_N_CATEGORIES: usize = 5;
 
@@ -40,6 +44,8 @@ pub struct ParquetSummary {
     pub num_bytes: u64,
     /// One entry per column, in schema order.
     pub columns: Vec<ColumnSummary>,
+    /// Rich semantic hints parsed from file-level Parquet metadata.
+    pub column_hints: Vec<ParquetColumnHint>,
 }
 
 /// Summary of a single column.
@@ -90,6 +96,15 @@ pub fn summarize_parquet(
     let bytes_vec = bytes.to_vec();
     let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes_vec))?;
     let schema = builder.schema().clone();
+    let metadata = builder.metadata();
+    let kv_metadata = file_key_value_metadata(metadata);
+    let footer_rows = metadata.file_metadata().num_rows().max(0) as u64;
+    let column_names: Vec<String> = schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    let column_hints = parse_parquet_column_hints(&column_names, footer_rows, &kv_metadata);
     let reader = builder.build()?;
 
     let num_cols = schema.fields().len();
@@ -144,6 +159,7 @@ pub fn summarize_parquet(
         num_rows: total_rows,
         num_bytes: bytes.len() as u64,
         columns,
+        column_hints,
     })
 }
 
@@ -549,6 +565,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use parquet::arrow::ArrowWriter;
     use parquet::file::properties::WriterProperties;
+    use parquet::format::KeyValue;
     use std::sync::Arc;
 
     fn make_test_batch() -> RecordBatch {
@@ -581,8 +598,17 @@ mod tests {
     }
 
     fn batch_to_parquet_bytes(batch: &RecordBatch) -> Vec<u8> {
+        batch_to_parquet_bytes_with_metadata(batch, None)
+    }
+
+    fn batch_to_parquet_bytes_with_metadata(
+        batch: &RecordBatch,
+        metadata: Option<Vec<KeyValue>>,
+    ) -> Vec<u8> {
         let mut buf = Vec::new();
-        let props = WriterProperties::builder().build();
+        let props = WriterProperties::builder()
+            .set_key_value_metadata(metadata)
+            .build();
         let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), Some(props)).unwrap();
         writer.write(batch).unwrap();
         writer.close().unwrap();
@@ -634,6 +660,38 @@ mod tests {
             }
             _ => panic!("expected boolean stats"),
         }
+    }
+
+    #[test]
+    fn summarize_parquet_includes_footer_column_hints() {
+        let batch = make_test_batch();
+        let metadata = vec![KeyValue::new(
+            "huggingface".to_string(),
+            Some(
+                r#"{"info":{"features":{"name":{"_type":"ClassLabel","names":["alice","bob"]}}}}"#
+                    .to_string(),
+            ),
+        )];
+        let bytes = batch_to_parquet_bytes_with_metadata(&batch, Some(metadata));
+        let summary = summarize_parquet(&bytes).unwrap();
+
+        assert_eq!(summary.column_hints.len(), 2);
+        let id_hint = summary
+            .column_hints
+            .iter()
+            .find(|hint| hint.name == "id")
+            .unwrap();
+        assert!(id_hint.pandas_index);
+        let name_hint = summary
+            .column_hints
+            .iter()
+            .find(|hint| hint.name == "name")
+            .unwrap();
+        assert_eq!(name_hint.column_type.as_deref(), Some("categorical"));
+        assert_eq!(
+            name_hint.semantic_type,
+            Some(crate::parquet_features::ParquetSemanticType::HuggingfaceClassLabel)
+        );
     }
 
     #[test]

--- a/crates/repr-llm/src/lib.rs
+++ b/crates/repr-llm/src/lib.rs
@@ -37,7 +37,10 @@ pub use json::summarize_json;
 pub use parquet::summarize as summarize_parquet_summary;
 
 // Re-export the core types so callers don't need a separate dep on nteract-predicate.
-pub use nteract_predicate::{summarize_parquet, ColumnStats, ColumnSummary, ParquetSummary};
+pub use nteract_predicate::{
+    summarize_parquet, ColumnStats, ColumnSummary, ParquetColumnHint, ParquetSemanticType,
+    ParquetSummary,
+};
 
 /// Attempt to produce an LLM-friendly text summary from a visualization spec.
 ///

--- a/crates/repr-llm/src/parquet.rs
+++ b/crates/repr-llm/src/parquet.rs
@@ -1,6 +1,8 @@
 //! Format a `nteract_predicate::ParquetSummary` as compact text for LLM consumption.
 
-use nteract_predicate::{ColumnStats, ColumnSummary, ParquetSummary};
+use nteract_predicate::{
+    ColumnStats, ColumnSummary, ParquetColumnHint, ParquetSemanticType, ParquetSummary,
+};
 
 /// Summarize a parquet dataset for LLM consumption.
 /// Returns a compact multi-line string describing row count, size, and per-column stats.
@@ -30,13 +32,17 @@ pub fn summarize(summary: &ParquetSummary) -> String {
 
     out.push_str("\nColumns:\n");
     for col in &summary.columns {
-        out.push_str(&format_column(col, summary.num_rows));
+        let hint = summary
+            .column_hints
+            .iter()
+            .find(|hint| hint.name == col.name);
+        out.push_str(&format_column(col, summary.num_rows, hint));
     }
 
     out
 }
 
-fn format_column(col: &ColumnSummary, total_rows: u64) -> String {
+fn format_column(col: &ColumnSummary, total_rows: u64, hint: Option<&ParquetColumnHint>) -> String {
     let null_info = if col.null_count == 0 {
         String::new()
     } else if total_rows > 0 {
@@ -111,7 +117,22 @@ fn format_column(col: &ColumnSummary, total_rows: u64) -> String {
         ColumnStats::Other => String::new(),
     };
 
-    format!("  {} ({}){}{}\n", col.name, col.data_type, null_info, stats)
+    let hint_info = format_column_hint(hint);
+
+    format!(
+        "  {} ({}){}{}{}\n",
+        col.name, col.data_type, hint_info, null_info, stats
+    )
+}
+
+fn format_column_hint(hint: Option<&ParquetColumnHint>) -> String {
+    match hint.and_then(|hint| hint.semantic_type) {
+        Some(ParquetSemanticType::HuggingfaceImage) => " · HF Image".to_string(),
+        Some(ParquetSemanticType::HuggingfaceImageList) => " · HF Image list".to_string(),
+        Some(ParquetSemanticType::HuggingfaceClassLabel) => " · HF ClassLabel".to_string(),
+        Some(ParquetSemanticType::PandasIndex) => " · pandas index".to_string(),
+        _ => String::new(),
+    }
 }
 
 fn format_bytes(n: u64) -> String {
@@ -174,6 +195,7 @@ mod tests {
             num_rows: 0,
             num_bytes: 0,
             columns: vec![],
+            column_hints: vec![],
         });
         assert!(s.contains("0 rows × 0 columns"));
     }
@@ -213,6 +235,7 @@ mod tests {
                     },
                 },
             ],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("1,200 rows × 3 columns"));
@@ -223,6 +246,34 @@ mod tests {
         assert!(s.contains("12 nulls (1%)"));
         assert!(s.contains("500 distinct"));
         assert!(s.contains("\"alice\""));
+    }
+
+    #[test]
+    fn summarize_surfaces_rich_parquet_hints() {
+        let summary = ParquetSummary {
+            num_rows: 3,
+            num_bytes: 0,
+            columns: vec![ColumnSummary {
+                name: "image".to_string(),
+                data_type: "struct<2 fields>".to_string(),
+                null_count: 0,
+                stats: ColumnStats::Other,
+            }],
+            column_hints: vec![ParquetColumnHint {
+                name: "image".to_string(),
+                column_type: Some("image".to_string()),
+                numeric: Some(false),
+                sortable: Some(false),
+                width: Some(140),
+                label: None,
+                pandas_index: false,
+                semantic_type: Some(ParquetSemanticType::HuggingfaceImage),
+            }],
+        };
+
+        let s = summarize(&summary);
+
+        assert!(s.contains("image (struct<2 fields>) · HF Image"));
     }
 
     #[test]
@@ -293,6 +344,7 @@ mod tests {
                     max: f64::NAN,
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("score (float64)"));
@@ -319,6 +371,7 @@ mod tests {
                     top: vec![],
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("≥100,000 distinct"));
@@ -339,6 +392,7 @@ mod tests {
                     max: "2024-12-31T23:59:59".to_string(),
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("2024-01-01T00:00:00 to 2024-12-31T23:59:59"));
@@ -361,6 +415,7 @@ mod tests {
                     max: String::new(),
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("ts (timestamp[us])"));
@@ -381,6 +436,7 @@ mod tests {
                 null_count: 0,
                 stats: ColumnStats::Other,
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("payload (binary)"));
@@ -400,6 +456,7 @@ mod tests {
                 null_count: 5,
                 stats: ColumnStats::Other,
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("5 nulls"));
@@ -422,6 +479,7 @@ mod tests {
                     false_count: 100,
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains("true 0% / false 100%"));
@@ -446,6 +504,7 @@ mod tests {
                     top: vec![(long_label, 30)],
                 },
             }],
+            column_hints: vec![],
         };
         let s = summarize(&summary);
         assert!(s.contains('…'));

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -11,6 +11,7 @@ use arrow_cast::display::ArrayFormatter;
 use arrow_ord::sort::{sort_to_indices, SortOptions};
 use arrow_select::concat::concat;
 use chrono::DateTime;
+use nteract_predicate::parquet_column_hints as predicate_parquet_column_hints;
 use nteract_predicate::summary::{CategoryCount, HistogramBin};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
@@ -1436,26 +1437,12 @@ pub fn parquet_metadata(parquet_bytes: &[u8]) -> Result<Vec<u32>, JsValue> {
     Ok(vec![num_row_groups, total_rows])
 }
 
-/// Extract file-level key-value metadata from a Parquet footer.
-/// Returns metadata keys like "pandas", "huggingface", etc.
+/// Extract canonical column hints from Parquet file-level metadata.
 #[wasm_bindgen]
-pub fn parquet_schema_metadata(parquet_bytes: &[u8]) -> Result<JsValue, JsValue> {
-    let bytes = bytes::Bytes::copy_from_slice(parquet_bytes);
-    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
+pub fn parquet_column_hints(parquet_bytes: &[u8]) -> Result<JsValue, JsValue> {
+    let hints = predicate_parquet_column_hints(parquet_bytes)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let metadata = builder.metadata();
-    let map: HashMap<String, String> = metadata
-        .file_metadata()
-        .key_value_metadata()
-        .into_iter()
-        .flatten()
-        .filter_map(|kv| {
-            kv.value
-                .as_ref()
-                .map(|value| (kv.key.clone(), value.clone()))
-        })
-        .collect();
-    serde_wasm_bindgen::to_value(&map).map_err(|e| JsValue::from_str(&e.to_string()))
+    serde_wasm_bindgen::to_value(&hints).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Load a single Parquet row group into a new or existing store.

--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -1,12 +1,6 @@
 import { catchError, defer, EMPTY, Observable, Subject, switchMap } from "rxjs";
 import { DATASETS, type DatasetEntry } from "./datasets";
-import {
-  applyHfFeatureOverrides,
-  applyPandasIndexOverrides,
-  parseHfFeatures,
-  parsePandasIndexColumns,
-  parseSchemaMetadata,
-} from "./parquet-features";
+import { applyParquetColumnHints, pandasIndexColumnsFromHints } from "./parquet-features";
 import { resolveHuggingFaceParquetUrl } from "./parquet-loader";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
 import { type Column, createTable, type TableData, type TableEngine } from "./table";
@@ -342,19 +336,8 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
           // Get metadata to know how many row groups
           const meta = mod.parquet_metadata(parquetBytes);
           const numRowGroups = meta[0];
-          const totalRows = meta[1];
-
-          const schemaMetadata = parseSchemaMetadata(
-            (() => {
-              try {
-                return mod.parquet_schema_metadata(parquetBytes);
-              } catch {
-                return undefined;
-              }
-            })(),
-          );
-          const pandasIndexCols = parsePandasIndexColumns(schemaMetadata);
-          const hfFeatures = parseHfFeatures(schemaMetadata);
+          const columnHints = mod.parquet_column_hints(parquetBytes);
+          const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
 
           // Load first row group → mount table immediately
           const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
@@ -364,8 +347,7 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
           tableData.recomputeSummaries = () =>
             updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
 
-          applyPandasIndexOverrides(columns, pandasIndexCols, totalRows);
-          applyHfFeatureOverrides(columns, hfFeatures);
+          applyParquetColumnHints(columns, columnHints);
 
           // Compute initial summaries from first row group
           updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);

--- a/packages/sift/src/parquet-features.test.ts
+++ b/packages/sift/src/parquet-features.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   applyColumnOverrides,
-  applyHfFeatureOverrides,
-  applyPandasIndexOverrides,
+  applyParquetColumnHints,
+  pandasIndexColumnsFromHints,
 } from "./parquet-features";
 import type { Column } from "./table";
 
@@ -32,8 +32,27 @@ describe("parquet feature overrides", () => {
       column(),
     ];
 
-    applyPandasIndexOverrides(columns, new Set(["__index_level_0__"]), 10_000);
-    applyHfFeatureOverrides(columns, { image: { _type: "Image" } });
+    const hints = [
+      {
+        name: "__index_level_0__",
+        sortable: false,
+        width: 78,
+        label: "",
+        pandasIndex: true,
+        semanticType: "pandas_index",
+      },
+      {
+        name: "image",
+        columnType: "image" as const,
+        numeric: false,
+        sortable: false,
+        width: 140,
+        pandasIndex: false,
+        semanticType: "huggingface_image",
+      },
+    ];
+
+    applyParquetColumnHints(columns, hints);
     applyColumnOverrides(columns, {
       __index_level_0__: { label: "Row", width: 120, sortable: true },
       image: { columnType: "categorical", sortable: true, width: 180 },
@@ -45,5 +64,6 @@ describe("parquet feature overrides", () => {
       sortable: true,
       width: 180,
     });
+    expect([...pandasIndexColumnsFromHints(hints)]).toEqual(["__index_level_0__"]);
   });
 });

--- a/packages/sift/src/parquet-features.ts
+++ b/packages/sift/src/parquet-features.ts
@@ -1,123 +1,32 @@
-/**
- * Shared parsers for parquet schema KV metadata.
- *
- * Two emitters write rich-type hints into the parquet footer that Sift
- * consumes:
- *
- * - HuggingFace datasets stash a JSON ``huggingface`` key naming each
- *   feature (Image, ClassLabel, Translation, …). Sift uses this to
- *   render thumbnails, narrow types, and skip pointless sort handles.
- * - pandas writes an ``index_columns`` list under the ``pandas`` key so
- *   we can label and size the row-index column reasonably.
- *
- * Both consumers (the standalone demo's ``main.ts`` loader and the
- * embedded ``SiftTable`` URL path) need the same parsing + apply logic.
- * Keep them lockstep here.
- */
-
 import type { Column } from "./table";
 
-export interface HfFeature {
-  _type: string;
-  names?: string[];
-  feature?: HfFeature;
+export interface ParquetColumnHint {
+  name: string;
+  columnType?: Column["columnType"];
+  numeric?: boolean;
+  sortable?: boolean;
+  width?: number;
+  label?: string;
+  pandasIndex: boolean;
+  semanticType?: string;
 }
 
-export type SchemaMetadata = Record<string, string>;
-
-/**
- * The wasm-bindgen ``parquet_schema_metadata`` result lands in JS as a
- * ``Map<string,string>`` (because the Rust side returns a ``HashMap``).
- * Property access on a Map returns ``undefined`` for every key, which
- * has silently broken HF detection in the past. Coerce to a record so
- * the rest of the pipeline can read keys with ordinary syntax.
- */
-export function parseSchemaMetadata(raw: unknown): SchemaMetadata {
-  if (raw instanceof Map) return Object.fromEntries(raw as Map<string, string>);
-  if (raw && typeof raw === "object") return raw as SchemaMetadata;
-  return {};
-}
-
-export function parseHfFeatures(metadata: SchemaMetadata): Record<string, HfFeature> {
-  if (!metadata.huggingface) return {};
-  try {
-    const hf = JSON.parse(metadata.huggingface);
-    return (hf?.info?.features ?? {}) as Record<string, HfFeature>;
-  } catch {
-    return {};
-  }
-}
-
-export function parsePandasIndexColumns(metadata: SchemaMetadata): Set<string> {
-  const out = new Set<string>();
-  if (!metadata.pandas) return out;
-  try {
-    const pandas = JSON.parse(metadata.pandas);
-    for (const ic of pandas.index_columns ?? []) {
-      if (typeof ic === "string") out.add(ic);
-      // Range-index descriptors (objects) don't map to a named column.
-    }
-  } catch {
-    /* ignore parse errors */
-  }
-  return out;
-}
-
-const PANDAS_INDEX_LABEL_PATTERN = /^(unnamed[: _]*\d*|__index_level_\d+__)$/i;
-const INDEX_NAME_PATTERN = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i;
-
-/**
- * Narrow + de-sort columns that look like a row index. ``totalRows``
- * sizes the column to fit the largest displayed row number.
- */
-export function applyPandasIndexOverrides(
-  columns: Column[],
-  pandasIndexCols: Set<string>,
-  totalRows: number,
-): void {
+export function applyParquetColumnHints(columns: Column[], hints: ParquetColumnHint[]): void {
+  const hintsByName = new Map(hints.map((hint) => [hint.name, hint]));
   for (const col of columns) {
-    if (!pandasIndexCols.has(col.key) && !INDEX_NAME_PATTERN.test(col.key)) continue;
-    const digits = totalRows.toLocaleString().length;
-    col.width = Math.max(60, digits * 9 + 24);
-    col.sortable = false;
-    if (PANDAS_INDEX_LABEL_PATTERN.test(col.key)) col.label = "";
+    const hint = hintsByName.get(col.key);
+    if (!hint) continue;
+
+    if (hint.columnType) col.columnType = hint.columnType;
+    if (hint.numeric !== undefined) col.numeric = hint.numeric;
+    if (hint.sortable !== undefined) col.sortable = hint.sortable;
+    if (hint.width !== undefined && col.width < hint.width) col.width = hint.width;
+    if (hint.label !== undefined) col.label = hint.label;
   }
 }
 
-/**
- * Narrow column types based on HuggingFace feature declarations.
- *
- * ``ClassLabel`` → categorical. ``Image`` and ``List<Image>`` /
- * ``Sequence<Image>`` → image with a wider min-width when it's a strip.
- */
-export function applyHfFeatureOverrides(
-  columns: Column[],
-  hfFeatures: Record<string, HfFeature>,
-): void {
-  for (const col of columns) {
-    const feature = hfFeatures[col.key];
-    if (!feature) continue;
-
-    if (feature._type === "ClassLabel" && col.columnType !== "categorical") {
-      col.columnType = "categorical";
-      col.numeric = false;
-    }
-
-    const inner =
-      feature._type === "Image"
-        ? feature
-        : feature._type === "List" || feature._type === "Sequence"
-          ? feature.feature
-          : undefined;
-    if (inner?._type === "Image") {
-      col.columnType = "image";
-      col.numeric = false;
-      col.sortable = false;
-      const isList = feature._type !== "Image";
-      const minWidth = isList ? 320 : 140;
-      if (col.width < minWidth) col.width = minWidth;
-    }
-  }
+export function pandasIndexColumnsFromHints(hints: ParquetColumnHint[]): Set<string> {
+  return new Set(hints.filter((hint) => hint.pandasIndex).map((hint) => hint.name));
 }
 
 export function applyColumnOverrides(

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -5,6 +5,8 @@
  * initial page load for users who don't need compute operations.
  */
 
+import type { ParquetColumnHint } from "./parquet-features";
+
 /** Filter spec passed to WASM store_filter_rows. */
 export type FilterSpecJson =
   | { kind: "range"; col: number; min: number; max: number }
@@ -24,13 +26,7 @@ type PredicateModule = {
   load_ipc(ipc_bytes: Uint8Array): number;
   load_parquet(parquet_bytes: Uint8Array): number;
   parquet_metadata(parquet_bytes: Uint8Array): Uint32Array;
-  /**
-   * Returns parquet file-level KV metadata as a `Map`, not a plain object —
-   * `serde_wasm_bindgen` defaults to `Map` for Rust `HashMap`. Callers must
-   * use `.get(key)` or coerce via `Object.fromEntries(...)` before any
-   * record-style access.
-   */
-  parquet_schema_metadata(parquet_bytes: Uint8Array): Map<string, string>;
+  parquet_column_hints(parquet_bytes: Uint8Array): ParquetColumnHint[];
   load_parquet_row_group(parquet_bytes: Uint8Array, row_group: number, handle: number): number;
   cast_column(handle: number, col: number, target_type: string): void;
   has_original_column(handle: number, col: number): boolean;

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -16,11 +16,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   applyColumnOverrides,
-  applyHfFeatureOverrides,
-  applyPandasIndexOverrides,
-  parseHfFeatures,
-  parsePandasIndexColumns,
-  parseSchemaMetadata,
+  applyParquetColumnHints,
+  pandasIndexColumnsFromHints,
 } from "./parquet-features";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
 import {
@@ -151,6 +148,7 @@ function updateWasmSummaries(
   handle: number,
   tableData: TableData,
   columns: Column[],
+  pandasIndexCols?: Set<string>,
 ) {
   const numRows = mod.num_rows(handle);
   const BIN_COUNT = 25;
@@ -217,11 +215,14 @@ function updateWasmSummaries(
           count: number;
         }[];
         if (bins.length === 0) return null;
+        const isPandasIndex = pandasIndexCols?.has(col.key) ?? false;
+        const isIndexName = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i.test(col.key);
         return {
           kind: "numeric" as const,
           min: bins[0].x0,
           max: bins[bins.length - 1].x1,
           bins,
+          isIndex: isPandasIndex || isIndexName ? true : undefined,
         };
       }
     }
@@ -312,7 +313,6 @@ export function SiftTable({
 
       const meta = mod.parquet_metadata(parquetBytes);
       const numRowGroups = meta[0];
-      const totalRows = meta[1];
 
       if (numRowGroups === 0) {
         setError("Parquet file has no row groups.");
@@ -320,21 +320,8 @@ export function SiftTable({
         return;
       }
 
-      // Pull rich-type hints from the parquet footer. HF features
-      // (Image, ClassLabel, …) and pandas index columns get applied
-      // to the column list before the engine mounts so headers and
-      // cell renderers light up on first paint.
-      const schemaMetadata = parseSchemaMetadata(
-        (() => {
-          try {
-            return mod.parquet_schema_metadata(parquetBytes);
-          } catch {
-            return undefined;
-          }
-        })(),
-      );
-      const pandasIndexCols = parsePandasIndexColumns(schemaMetadata);
-      const hfFeatures = parseHfFeatures(schemaMetadata);
+      const columnHints = mod.parquet_column_hints(parquetBytes);
+      const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
 
       // Load first row group → mount table immediately
       const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
@@ -342,13 +329,13 @@ export function SiftTable({
 
       const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
       tableData.prefetchViewport = prefetchViewport;
-      tableData.recomputeSummaries = () => updateWasmSummaries(mod, handle, tableData, columns);
+      tableData.recomputeSummaries = () =>
+        updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
 
-      applyPandasIndexOverrides(columns, pandasIndexCols, totalRows);
-      applyHfFeatureOverrides(columns, hfFeatures);
+      applyParquetColumnHints(columns, columnHints);
       applyColumnOverrides(columns, columnOverrides);
 
-      updateWasmSummaries(mod, handle, tableData, columns);
+      updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
 
       if (cancelled) return;
       mountEngine(tableData);
@@ -361,7 +348,7 @@ export function SiftTable({
         if (cancelled) return;
         mod.load_parquet_row_group(parquetBytes, g, handle);
         tableData.rowCount = mod.num_rows(handle);
-        updateWasmSummaries(mod, handle, tableData, columns);
+        updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
         engineRef.current?.onBatchAppended();
       }
 


### PR DESCRIPTION
## Summary

- move pandas/HuggingFace parquet footer interpretation into `nteract-predicate`
- expose typed parquet column hints through `sift-wasm` and remove Sift's TS JSON footer parsers
- attach the same hints to `ParquetSummary` so `repr-llm` can surface rich parquet semantics

## Verification

- `cargo test -p nteract-predicate -p repr-llm -p sift-wasm`
- `npm test -- parquet-features.test.ts react.test.tsx` in `packages/sift`
- `npm run build` in `packages/sift`
- `cargo xtask wasm sift`
- `cargo xtask lint --fix`
