### PR TITLE
feat(outputs): preserve table blob metadata

### DIFF
--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -578,7 +578,8 @@ pub async fn create_manifest(
     let manifest = match output_type {
         "display_data" => {
             let data = convert_data_bundle(output.get("data"), blob_store, threshold).await?;
-            let metadata = extract_metadata(output.get("metadata"));
+            let metadata =
+                extract_metadata_with_blob_ref_hints(output.get("metadata"), output.get("data"));
             let transient = extract_transient(output.get("transient"));
             OutputManifest::DisplayData {
                 output_id: existing_output_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
@@ -589,7 +590,8 @@ pub async fn create_manifest(
         }
         "execute_result" => {
             let data = convert_data_bundle(output.get("data"), blob_store, threshold).await?;
-            let metadata = extract_metadata(output.get("metadata"));
+            let metadata =
+                extract_metadata_with_blob_ref_hints(output.get("metadata"), output.get("data"));
             let transient = extract_transient(output.get("transient"));
             let execution_count = output
                 .get("execution_count")
@@ -861,7 +863,9 @@ pub async fn update_manifest_display_data(
             ..
         } => {
             let data = convert_data_bundle(Some(new_data), blob_store, threshold).await?;
-            let metadata = new_metadata.clone().into_iter().collect();
+            let metadata_value = Value::Object(new_metadata.clone());
+            let metadata =
+                extract_metadata_with_blob_ref_hints(Some(&metadata_value), Some(new_data));
             let updated = OutputManifest::DisplayData {
                 output_id: output_id.clone(),
                 data,
@@ -877,7 +881,9 @@ pub async fn update_manifest_display_data(
             ..
         } => {
             let data = convert_data_bundle(Some(new_data), blob_store, threshold).await?;
-            let metadata = new_metadata.clone().into_iter().collect();
+            let metadata_value = Value::Object(new_metadata.clone());
+            let metadata =
+                extract_metadata_with_blob_ref_hints(Some(&metadata_value), Some(new_data));
             let updated = OutputManifest::ExecuteResult {
                 output_id: output_id.clone(),
                 data,
@@ -1167,6 +1173,63 @@ fn extract_metadata(metadata: Option<&Value>) -> HashMap<String, Value> {
     }
 }
 
+/// Extract metadata and lift transport-level blob-ref hints into the wrapped
+/// MIME's metadata namespace.
+///
+/// Python emits `BLOB_REF_MIME` as the buffer transport envelope, with
+/// `summary` and `query` describing the wrapped binary table payload. The
+/// manifest stores the payload under the wrapped `content_type`, so these hints
+/// need to move with it instead of being dropped with the transport MIME.
+fn extract_metadata_with_blob_ref_hints(
+    metadata: Option<&Value>,
+    data: Option<&Value>,
+) -> HashMap<String, Value> {
+    let mut metadata = extract_metadata(metadata);
+    merge_blob_ref_hints_into_metadata(&mut metadata, data);
+    metadata
+}
+
+fn merge_blob_ref_hints_into_metadata(metadata: &mut HashMap<String, Value>, data: Option<&Value>) {
+    let Some(Value::Object(data_map)) = data else {
+        return;
+    };
+    let Some(Value::Object(ref_map)) = data_map.get(BLOB_REF_MIME) else {
+        return;
+    };
+    let Some(content_type) = ref_map.get("content_type").and_then(Value::as_str) else {
+        return;
+    };
+
+    let mut hints = serde_json::Map::new();
+    if let Some(summary) = ref_map.get("summary") {
+        hints.insert("summary".to_string(), summary.clone());
+    }
+    if let Some(query) = ref_map.get("query").filter(|value| !value.is_null()) {
+        hints.insert("query".to_string(), query.clone());
+    }
+    if hints.is_empty() {
+        return;
+    }
+
+    let per_mime = metadata
+        .entry(content_type.to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Value::Object(per_mime_map) = per_mime else {
+        return;
+    };
+
+    let nteract = per_mime_map
+        .entry("nteract".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Value::Object(nteract_map) = nteract else {
+        return;
+    };
+
+    for (key, value) in hints {
+        nteract_map.entry(key).or_insert(value);
+    }
+}
+
 /// Extract transient data (display_id) from a Jupyter output.
 fn extract_transient(transient: Option<&Value>) -> TransientData {
     match transient {
@@ -1381,6 +1444,12 @@ mod tests {
                     "hash": hash,
                     "content_type": "application/vnd.apache.parquet",
                     "size": raw.len(),
+                    "summary": {
+                        "total_rows": 3,
+                        "included_rows": 3,
+                        "sampled": false,
+                        "sample_strategy": "none"
+                    },
                     "query": null,
                 },
                 "text/llm+plain": "DataFrame (pandas): 3 rows × 2 columns"
@@ -1388,8 +1457,8 @@ mod tests {
         });
 
         let manifest = create_manifest(&output, &blob_store, 1024).await.unwrap();
-        let data = match manifest {
-            OutputManifest::DisplayData { data, .. } => data,
+        let (data, metadata) = match manifest {
+            OutputManifest::DisplayData { data, metadata, .. } => (data, metadata),
             other => panic!("expected DisplayData, got {other:?}"),
         };
 
@@ -1404,6 +1473,17 @@ mod tests {
             }
             other => panic!("expected blob ref, got {other:?}"),
         }
+
+        assert_eq!(
+            metadata["application/vnd.apache.parquet"]["nteract"]["summary"]["total_rows"],
+            3
+        );
+        assert!(
+            metadata["application/vnd.apache.parquet"]["nteract"]
+                .get("query")
+                .is_none(),
+            "null query hints should not be promoted"
+        );
     }
 
     /// When a bundle carries BOTH a BLOB_REF_MIME and a fallback entry under
@@ -2391,6 +2471,13 @@ mod tests {
                 "hash": hash,
                 "content_type": "application/vnd.apache.parquet",
                 "size": payload_bytes.len(),
+                "summary": {
+                    "total_rows": 5,
+                    "included_rows": 5,
+                    "sampled": false,
+                    "sample_strategy": "none"
+                },
+                "query": { "projection": ["a", "b"] },
             }
         });
 
@@ -2409,7 +2496,7 @@ mod tests {
         // After update, the manifest's data map MUST contain the wrapped
         // content-type, not the raw blob-ref MIME. This is the fix: before
         // this change, the update path stored the ref MIME as-is.
-        let OutputManifest::DisplayData { data, .. } = updated else {
+        let OutputManifest::DisplayData { data, metadata, .. } = updated else {
             panic!("expected DisplayData variant");
         };
         assert!(
@@ -2420,6 +2507,14 @@ mod tests {
         assert!(
             !data.contains_key("application/vnd.nteract.blob-ref+json"),
             "raw blob-ref MIME must not appear in promoted manifest"
+        );
+        assert_eq!(
+            metadata["application/vnd.apache.parquet"]["nteract"]["summary"]["total_rows"],
+            5
+        );
+        assert_eq!(
+            metadata["application/vnd.apache.parquet"]["nteract"]["query"]["projection"][0],
+            "a"
         );
     }
 

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1527,7 +1527,7 @@ mod tests {
         };
 
         assert!(
-            metadata.get("application/vnd.apache.parquet").is_none(),
+            !metadata.contains_key("application/vnd.apache.parquet"),
             "null summary/query hints should not create per-MIME metadata"
         );
     }

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1201,7 +1201,7 @@ fn merge_blob_ref_hints_into_metadata(metadata: &mut HashMap<String, Value>, dat
     };
 
     let mut hints = serde_json::Map::new();
-    if let Some(summary) = ref_map.get("summary") {
+    if let Some(summary) = ref_map.get("summary").filter(|value| !value.is_null()) {
         hints.insert("summary".to_string(), summary.clone());
     }
     if let Some(query) = ref_map.get("query").filter(|value| !value.is_null()) {
@@ -1215,6 +1215,10 @@ fn merge_blob_ref_hints_into_metadata(metadata: &mut HashMap<String, Value>, dat
         .entry(content_type.to_string())
         .or_insert_with(|| Value::Object(serde_json::Map::new()));
     let Value::Object(per_mime_map) = per_mime else {
+        tracing::warn!(
+            "[dx] blob-ref hints ignored because metadata for content_type={} is not an object",
+            content_type
+        );
         return;
     };
 
@@ -1222,10 +1226,16 @@ fn merge_blob_ref_hints_into_metadata(metadata: &mut HashMap<String, Value>, dat
         .entry("nteract".to_string())
         .or_insert_with(|| Value::Object(serde_json::Map::new()));
     let Value::Object(nteract_map) = nteract else {
+        tracing::warn!(
+            "[dx] blob-ref hints ignored because metadata for content_type={}.nteract is not an \
+             object",
+            content_type
+        );
         return;
     };
 
     for (key, value) in hints {
+        // Explicit caller-supplied metadata wins over transport-derived hints.
         nteract_map.entry(key).or_insert(value);
     }
 }
@@ -1484,6 +1494,85 @@ mod tests {
                 .is_none(),
             "null query hints should not be promoted"
         );
+    }
+
+    #[tokio::test]
+    async fn dx_ref_mime_drops_null_metadata_hints() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let raw = b"PAR1-fake-parquet-body";
+        let hash = blob_store
+            .put(raw, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                notebook_doc::mime::BLOB_REF_MIME: {
+                    "hash": hash,
+                    "content_type": "application/vnd.apache.parquet",
+                    "size": raw.len(),
+                    "summary": null,
+                    "query": null,
+                }
+            },
+        });
+
+        let manifest = create_manifest(&output, &blob_store, 1024).await.unwrap();
+        let metadata = match manifest {
+            OutputManifest::DisplayData { metadata, .. } => metadata,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+
+        assert!(
+            metadata.get("application/vnd.apache.parquet").is_none(),
+            "null summary/query hints should not create per-MIME metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn dx_ref_mime_does_not_overwrite_explicit_metadata_hints() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let raw = b"PAR1-fake-parquet-body";
+        let hash = blob_store
+            .put(raw, "application/vnd.apache.parquet")
+            .await
+            .unwrap();
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "metadata": {
+                "application/vnd.apache.parquet": {
+                    "nteract": {
+                        "summary": { "total_rows": 999, "sampled": true }
+                    }
+                }
+            },
+            "data": {
+                notebook_doc::mime::BLOB_REF_MIME: {
+                    "hash": hash,
+                    "content_type": "application/vnd.apache.parquet",
+                    "size": raw.len(),
+                    "summary": { "total_rows": 3, "sampled": false },
+                    "query": { "projection": ["x"] },
+                }
+            },
+        });
+
+        let manifest = create_manifest(&output, &blob_store, 1024).await.unwrap();
+        let metadata = match manifest {
+            OutputManifest::DisplayData { metadata, .. } => metadata,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+        let nteract = &metadata["application/vnd.apache.parquet"]["nteract"];
+
+        assert_eq!(nteract["summary"]["total_rows"], 999);
+        assert_eq!(nteract["summary"]["sampled"], true);
+        assert_eq!(nteract["query"]["projection"][0], "x");
     }
 
     /// When a bundle carries BOTH a BLOB_REF_MIME and a fallback entry under

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -1,0 +1,158 @@
+# Arrow-Native Notebook Outputs
+
+Issue: https://github.com/nteract/desktop/issues/1816
+
+This note captures the current Python/Rust output path and the next steps for
+making table outputs Arrow-native while preserving ordinary notebook fallback
+behavior.
+
+## Current Path
+
+The launcher registers lazy IPython `mimebundle_formatter` handlers in
+`nteract_kernel_launcher/_bootstrap.py` for pandas, polars, narwhals,
+`pyarrow.Table`, `pyarrow.RecordBatch`, and Hugging Face datasets.
+
+Today those rich table paths serialize bytes as parquet, stash the bytes in the
+kernel-side pending buffer map, and return a bundle shaped like:
+
+```json
+{
+  "application/vnd.nteract.blob-ref+json": {
+    "hash": "sha256...",
+    "content_type": "application/vnd.apache.parquet",
+    "size": 12345,
+    "summary": {
+      "total_rows": 1000,
+      "included_rows": 1000,
+      "sampled": false,
+      "sample_strategy": "none"
+    },
+    "buffer_index": 0
+  },
+  "text/llm+plain": "..."
+}
+```
+
+The default IPython formatter chain can still add `text/plain` or `text/html`
+fallbacks. That is the compatibility contract: a vanilla notebook should render
+the fallback MIME, while nteract consumes the content-addressed binary payload.
+
+The `pyarrow.Table` and dataset paths are already the most metadata-correct
+paths because `serialize_arrow_table` writes the Arrow table directly to
+parquet, preserving schema key/value metadata such as Hugging Face `features`.
+The dataframe paths are less faithful because conversion through pandas/polars
+does not preserve arbitrary Arrow schema metadata.
+
+## Near-Term Rust Contract
+
+The blob-ref MIME is a transport envelope, not the durable output MIME. When
+`runtimed` promotes the ref to its wrapped `content_type`, it should also lift
+the Python-provided `summary` and `query` into `OutputManifest.metadata` under
+the wrapped MIME:
+
+```json
+{
+  "metadata": {
+    "application/vnd.apache.parquet": {
+      "nteract": {
+        "summary": {
+          "total_rows": 1000,
+          "included_rows": 1000,
+          "sampled": false,
+          "sample_strategy": "none"
+        }
+      }
+    }
+  }
+}
+```
+
+This keeps the manifest canonical: renderers, MCP, `repr_llm`, and saved
+notebooks can inspect output-level metadata without knowing about the
+transport-only blob-ref MIME. The data bundle still points at the
+content-addressed binary bytes. Non-null `query` hints should live next to
+`summary` in the same `nteract` object.
+
+## Arrow IPC As A First-Class MIME
+
+The next incremental step is to add `application/vnd.apache.arrow.stream` as a
+first-class table output MIME alongside parquet.
+
+Python should prefer Arrow IPC stream bytes when the object is already Arrow:
+
+- `pyarrow.Table`
+- `pyarrow.RecordBatch`
+- Hugging Face datasets with an underlying Arrow table
+- narwhals backends that expose Arrow natively without forcing pandas
+
+Parquet should remain available for persistence-oriented paths and as a
+fallback when Arrow IPC support is missing.
+
+Runtime and frontend work needed for the first-class MIME:
+
+- Add `application/vnd.apache.arrow.stream` to the ref-MIME save whitelist so
+  saved `.ipynb` files keep the binary payload externalized as a blob ref
+  instead of base64-inlining it.
+- Add the MIME to runtime/MCP MIME priority so Sift is selected before generic
+  text fallbacks.
+- Teach plugin loading and binary renderer gates that Arrow IPC is a Sift table
+  MIME, just like parquet.
+- Add Rust-side Arrow IPC summary support in the predicate layer, then expose it
+  to `repr_llm` and Sift/WASM. This should live beside the parquet predicate
+  logic so both `repr_llm` and Sift share the same schema/type interpretation.
+
+This gives us an Arrow-native notebook at rest, but it is still not the full
+streaming design from issue #1816 because the blob is complete before renderers
+can consume it.
+
+## True Streaming With Content-Addressed Storage
+
+True streaming needs a manifest rather than one monolithic blob. The durable
+shape should describe an Arrow stream in content-addressed chunks:
+
+```json
+{
+  "mime": "application/vnd.nteract.arrow-stream-manifest+json",
+  "schema_hash": "sha256...",
+  "chunks": [
+    {
+      "hash": "sha256...",
+      "content_type": "application/vnd.apache.arrow.stream",
+      "record_batch_count": 4,
+      "row_count": 4096,
+      "byte_length": 98304
+    }
+  ],
+  "complete": true,
+  "summary": {
+    "total_rows": 1000000,
+    "included_rows": 4096,
+    "sampled": true,
+    "sample_strategy": "head"
+  }
+}
+```
+
+Each chunk should align to Arrow IPC message or record-batch boundaries so Rust,
+WASM, and browser readers can validate and append data without reparsing an
+arbitrary byte splice. The CAS key remains the hash of the raw chunk bytes. A
+separate schema hash lets renderers reject incompatible chunk sequences early.
+
+The Python layer should be able to publish the schema and first chunk before the
+full dataframe is materialized when the source supports streaming. That matters
+for long `to_pandas()` calls, remote fetches, and large datasets where the user
+only inspects the first page.
+
+## Compatibility Rules
+
+- Always emit `text/plain` and/or `text/html` fallback data for notebook
+  interoperability.
+- Keep binary table payloads behind nteract-specific ref metadata on save.
+- Do not rely on TypeScript to parse parquet or Arrow metadata when Rust can do
+  it once in `nteract-predicate` and share the result with WASM and `repr_llm`.
+- Treat parquet and Arrow IPC as complementary. Parquet is still better for
+  compressed persistence and footer-driven random access; Arrow IPC is better
+  for in-memory schema fidelity and progressive rendering.
+- Avoid a TypeScript-only metadata model. Python should emit known source facts,
+  Rust should normalize and validate them, and WASM/renderers should consume the
+  canonical predicate summaries.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -71,7 +71,7 @@ This keeps the manifest canonical: renderers, MCP, `repr_llm`, and saved
 notebooks can inspect output-level metadata without knowing about the
 transport-only blob-ref MIME. The data bundle still points at the
 content-addressed binary bytes. Non-null `query` hints should live next to
-`summary` in the same `nteract` object.
+`summary` in the same `nteract` object. Null hint values are not promoted.
 
 ## Arrow IPC As A First-Class MIME
 


### PR DESCRIPTION
## Summary

- Preserve Python-emitted blob-ref `summary` and `query` hints by lifting them into per-MIME `OutputManifest.metadata` under `metadata[content_type].nteract`
- Keep the binary table payload content-addressed under the wrapped MIME instead of exposing the transport-only blob-ref MIME
- Add an Arrow-native output design note for issue #1816, including the Python producer path, Rust predicate/WASM split, first-class Arrow IPC MIME work, and the chunked CAS streaming model needed for true progressive rendering

## Verification

- `cargo test -p runtimed output_store`
- `cargo xtask lint --fix`
- `git diff --check`

