### PR TITLE
refactor(sift): dedupe Arrow IPC index-name fallback

### DIFF
--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -1,6 +1,10 @@
 import { catchError, defer, EMPTY, Observable, Subject, switchMap } from "rxjs";
 import { DATASETS, type DatasetEntry } from "./datasets";
-import { applyParquetColumnHints, pandasIndexColumnsFromHints } from "./parquet-features";
+import {
+  applyParquetColumnHints,
+  looksLikeIndexColumnName,
+  pandasIndexColumnsFromHints,
+} from "./parquet-features";
 import { resolveHuggingFaceParquetUrl } from "./parquet-loader";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
 import { type Column, createTable, type TableData, type TableEngine } from "./table";
@@ -487,7 +491,9 @@ function updateWasmSummaries(
         if (nonZeroBins <= 10) {
           summary.uniqueCount = nonZeroBins;
         }
-        if (pandasIndexCols?.has(col.key)) {
+        // Parquet loads carry `pandasIndexCols` from the Rust hints; Arrow IPC
+        // and other sources without footer metadata fall back to a name match.
+        if (pandasIndexCols?.has(col.key) ?? looksLikeIndexColumnName(col.key)) {
           (summary as any).isIndex = true;
         }
         return summary;

--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -487,10 +487,7 @@ function updateWasmSummaries(
         if (nonZeroBins <= 10) {
           summary.uniqueCount = nonZeroBins;
         }
-        // Detect index/ID columns: pandas metadata or name pattern.
-        const isPandasIndex = pandasIndexCols?.has(col.key) ?? false;
-        const isIndexName = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i.test(col.key);
-        if (isPandasIndex || isIndexName) {
+        if (pandasIndexCols?.has(col.key)) {
           (summary as any).isIndex = true;
         }
         return summary;

--- a/packages/sift/src/parquet-features.ts
+++ b/packages/sift/src/parquet-features.ts
@@ -29,6 +29,18 @@ export function pandasIndexColumnsFromHints(hints: ParquetColumnHint[]): Set<str
   return new Set(hints.filter((hint) => hint.pandasIndex).map((hint) => hint.name));
 }
 
+/**
+ * Name-based fallback for index/ID columns when the source has no parquet
+ * footer to read (Arrow IPC, generated data, …). Mirrors Rust's
+ * `nteract_predicate::is_index_like_name`; for parquet loads the Rust path is
+ * authoritative and these names already round-trip through `pandasIndexCols`.
+ */
+const INDEX_NAME_PATTERN = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i;
+
+export function looksLikeIndexColumnName(name: string): boolean {
+  return INDEX_NAME_PATTERN.test(name);
+}
+
 export function applyColumnOverrides(
   columns: Column[],
   columnOverrides?: Record<string, Partial<Column>>,

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   applyColumnOverrides,
   applyParquetColumnHints,
+  looksLikeIndexColumnName,
   pandasIndexColumnsFromHints,
 } from "./parquet-features";
 import { ensureModule, getModuleSync, loadIpc } from "./predicate";
@@ -215,12 +216,15 @@ function updateWasmSummaries(
           count: number;
         }[];
         if (bins.length === 0) return null;
+        // Parquet loads carry `pandasIndexCols` from the Rust hints; Arrow IPC
+        // and other sources without footer metadata fall back to a name match.
+        const isIndex = pandasIndexCols?.has(col.key) ?? looksLikeIndexColumnName(col.key);
         return {
           kind: "numeric" as const,
           min: bins[0].x0,
           max: bins[bins.length - 1].x1,
           bins,
-          isIndex: pandasIndexCols?.has(col.key) ? true : undefined,
+          isIndex: isIndex ? true : undefined,
         };
       }
     }

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -215,14 +215,12 @@ function updateWasmSummaries(
           count: number;
         }[];
         if (bins.length === 0) return null;
-        const isPandasIndex = pandasIndexCols?.has(col.key) ?? false;
-        const isIndexName = /^(unnamed[: _]*\d*|index|_?id|rowid|row_?id|row_?num)$/i.test(col.key);
         return {
           kind: "numeric" as const,
           min: bins[0].x0,
           max: bins[bins.length - 1].x1,
           bins,
-          isIndex: isPandasIndex || isIndexName ? true : undefined,
+          isIndex: pandasIndexCols?.has(col.key) ? true : undefined,
         };
       }
     }


### PR DESCRIPTION
After #2628, footer interpretation is centralized in `nteract-predicate`. The TS-side `updateWasmSummaries` had an inline regex duplicated across `main.ts` and `react.tsx` for detecting `index`, `id`, `_id`, `rowid`, `row_id`, `rownum`, `row_num`, and pandas artifact names.

For parquet loads, Rust's `is_index_like_name` already covers those names and lands them in `pandasIndexCols` via `pandasIndexColumnsFromHints`. For Arrow IPC and other sources without footer metadata, the regex is the only signal — `updateWasmSummaries` is called without hints from the IPC paths.

Dedup the regex into `looksLikeIndexColumnName` in `parquet-features.ts` and use it as the fallback when `pandasIndexCols` is undefined. Parquet keeps using the Rust hints; Arrow IPC keeps the name-pattern fallback. One regex, one comment, both call sites read the same way.

## Verification

- `npm test` in `packages/sift` (148 passed)
- `cargo xtask lint --fix`
