### PR TITLE
fix(runtime): tolerate heartbeat misses and drop dx injection

### DIFF
--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -92,7 +92,7 @@ Pool warmer and capture step strip a base set so captured metadata records only 
 
 | Constant | Value |
 |----------|-------|
-| `kernel_env::uv::UV_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, nbformat, uv, dx]` |
+| `kernel_env::uv::UV_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, nbformat, pyarrow>=14, uv]` |
 | `kernel_env::conda::CONDA_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, nbformat]` |
 
 ## Prewarming and daemon pool

--- a/crates/kernel-env/src/pixi.rs
+++ b/crates/kernel-env/src/pixi.rs
@@ -170,7 +170,7 @@ pub async fn create_pixi_environment(
 
     // Vendor the `nteract_kernel_launcher` package into site-packages so
     // `python -m nteract_kernel_launcher` resolves from this env. Without
-    // this, bootstrap_dx kernels die with ModuleNotFoundError at launch.
+    // this, launcher-backed kernels die with ModuleNotFoundError at launch.
     // Run before Ready so the env is fully provisioned when the caller sees it.
     crate::launcher::vendor_into_venv(&python_path)
         .await

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -285,10 +285,10 @@ pub struct SyncedSettings {
     #[serde(default = "default_install_default_data_packages")]
     pub install_default_data_packages: bool,
 
-    /// Enable the nteract data-experience kernel bootstrap (nteract/dx).
-    /// When true, the daemon installs `nteract-kernel-launcher` and `dx` into
-    /// UV kernel environments, launches kernels via `nteract_kernel_launcher`,
-    /// and runs `dx.install()` before the first user cell. Default: false.
+    /// Enable the nteract data-experience kernel bootstrap.
+    /// When true, the daemon launches kernels via `nteract_kernel_launcher`
+    /// so the vendored launcher can register rich display formatters before
+    /// the first user cell. Default: false.
     ///
     /// Mirrors `FeatureFlags::bootstrap_dx`. Flattened on the wire so the
     /// settings JSON and Automerge document keep a flat layout even as new
@@ -539,7 +539,7 @@ impl SettingsDoc {
         // Store onboarding_completed as boolean
         let _ = doc.put(automerge::ROOT, "onboarding_completed", false);
 
-        // nteract/dx kernel bootstrap (opt-in)
+        // nteract kernel-launcher bootstrap (opt-in)
         let _ = doc.put(automerge::ROOT, "bootstrap_dx", defaults.bootstrap_dx);
         let _ = doc.put(
             automerge::ROOT,

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -1125,7 +1125,7 @@ mod tests {
     #[test]
     fn test_compare_subset_matches_real_user_seeded_notebook() {
         // Exact shape of a newly-created notebook seeded from the
-        // default rgbkrk user settings (9 UV deps, mix of bare +
+        // default rgbkrk user settings (8 UV deps, mix of bare +
         // version-specifier + marker). Pool built from the same set
         // plus the pool-essentials prefix.
         let pool = vec![
@@ -1134,7 +1134,6 @@ mod tests {
             "anywidget".into(),
             "nbformat".into(),
             "uv".into(),
-            "dx".into(),
             "gremlin ; sys_platform == 'darwin'".into(),
             "narwhals>=1.0".into(),
             "nteract".into(),
@@ -1145,7 +1144,6 @@ mod tests {
             "pyarrow>=14".into(),
         ];
         let inline = vec![
-            "dx".into(),
             "gremlin ; sys_platform == 'darwin'".into(),
             "narwhals>=1.0".into(),
             "nteract".into(),

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -629,13 +629,6 @@ impl KernelConnection for JupyterKernel {
             cmd.env(key, value);
         }
 
-        // Signal dx bootstrap to the launcher module inside the kernel process.
-        // The nteract_kernel_launcher reads RUNT_BOOTSTRAP_DX to decide whether
-        // to append `import dx; dx.install()` to ipykernel's exec_lines.
-        if bootstrap_dx {
-            cmd.env("RUNT_BOOTSTRAP_DX", "1");
-        }
-
         cmd.kill_on_drop(true);
 
         // Capture kernel stderr for diagnostics. Per-line logs go at debug
@@ -2485,13 +2478,29 @@ impl KernelConnection for JupyterKernel {
         let hb_cmd_tx = cmd_tx.clone();
         let hb_panic_cmd_tx = cmd_tx.clone();
         let hb_conn_info = connection_info.clone();
+        let hb_kernel_id = kernel_id.clone();
+        let hb_kernel_type = kernel_type.clone();
+        let hb_env_source = env_source.clone();
+        #[cfg(unix)]
+        let hb_kernel_pid = kernel_pid;
+        #[cfg(not(unix))]
+        let hb_kernel_pid: Option<i32> = None;
+        let hb_launch_elapsed = launch_started;
         let heartbeat_task = spawn_supervised(
             "heartbeat",
             async move {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                const HEARTBEAT_INITIAL_DELAY: std::time::Duration =
+                    std::time::Duration::from_secs(5);
+                const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+                const HEARTBEAT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+                const HEARTBEAT_MAX_FAILURES: u8 = 3;
+
+                let mut consecutive_failures = 0u8;
+
+                tokio::time::sleep(HEARTBEAT_INITIAL_DELAY).await;
 
                 loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    tokio::time::sleep(HEARTBEAT_INTERVAL).await;
 
                     let check = async {
                         let mut hb =
@@ -2500,21 +2509,76 @@ impl KernelConnection for JupyterKernel {
                         hb.single_heartbeat().await
                     };
 
-                    match tokio::time::timeout(std::time::Duration::from_secs(3), check).await {
+                    let failure = match tokio::time::timeout(HEARTBEAT_TIMEOUT, check).await {
                         Ok(Ok(())) => {
-                            // Kernel is alive
+                            if consecutive_failures > 0 {
+                                info!(
+                                    "[jupyter-kernel] Heartbeat recovered: kernel_id={} kernel_type={} env_source={} pid={:?} previous_failures={} launch_elapsed_ms={}",
+                                    hb_kernel_id,
+                                    hb_kernel_type,
+                                    hb_env_source,
+                                    hb_kernel_pid,
+                                    consecutive_failures,
+                                    hb_launch_elapsed.elapsed().as_millis()
+                                );
+                            }
+                            consecutive_failures = 0;
+                            continue;
                         }
                         Ok(Err(e)) => {
-                            warn!("[jupyter-kernel] Heartbeat connection error: {}", e);
-                            let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
-                            break;
+                            format!("connection error: {e}")
                         }
                         Err(_) => {
-                            warn!("[jupyter-kernel] Heartbeat timeout, kernel unresponsive");
+                            format!("timeout after {}ms", HEARTBEAT_TIMEOUT.as_millis())
+                        }
+                    };
+
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+
+                    #[cfg(unix)]
+                    if let Some(pid) = hb_kernel_pid {
+                        if wait_for_pid_exit(pid, std::time::Duration::ZERO).await {
+                            warn!(
+                                "[jupyter-kernel] Heartbeat failed and kernel process is gone: kernel_id={} kernel_type={} env_source={} pid={} failure={} launch_elapsed_ms={}",
+                                hb_kernel_id,
+                                hb_kernel_type,
+                                hb_env_source,
+                                pid,
+                                failure,
+                                hb_launch_elapsed.elapsed().as_millis()
+                            );
                             let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
                             break;
                         }
                     }
+
+                    if consecutive_failures < HEARTBEAT_MAX_FAILURES {
+                        warn!(
+                            "[jupyter-kernel] Heartbeat probe failed; retrying before declaring kernel dead: kernel_id={} kernel_type={} env_source={} pid={:?} failure={} consecutive_failures={}/{} launch_elapsed_ms={}",
+                            hb_kernel_id,
+                            hb_kernel_type,
+                            hb_env_source,
+                            hb_kernel_pid,
+                            failure,
+                            consecutive_failures,
+                            HEARTBEAT_MAX_FAILURES,
+                            hb_launch_elapsed.elapsed().as_millis()
+                        );
+                        continue;
+                    }
+
+                    warn!(
+                        "[jupyter-kernel] Heartbeat failed after retries, kernel unresponsive: kernel_id={} kernel_type={} env_source={} pid={:?} last_failure={} consecutive_failures={} launch_elapsed_ms={}",
+                        hb_kernel_id,
+                        hb_kernel_type,
+                        hb_env_source,
+                        hb_kernel_pid,
+                        failure,
+                        consecutive_failures,
+                        hb_launch_elapsed.elapsed().as_millis()
+                    );
+                    let _ = hb_cmd_tx.try_send(QueueCommand::KernelDied);
+                    break;
                 }
             },
             move |_| {

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5602,7 +5602,6 @@ fn effective_user_deps_from_launched_ignores_prewarmed_packages() {
             "anywidget".to_string(),
             "nbformat".to_string(),
             "uv".to_string(),
-            "dx".to_string(),
             "pandas".to_string(),
         ],
         ..LaunchedEnvConfig::default()

--- a/crates/runtimed/src/uv_project.rs
+++ b/crates/runtimed/src/uv_project.rs
@@ -31,23 +31,18 @@ pub(crate) fn notebook_working_dir(notebook_path: Option<&Path>) -> PathBuf {
     }
 }
 
-fn uv_run_base_args(bootstrap_dx: bool) -> Vec<OsString> {
-    let mut args = vec![
+fn uv_run_base_args() -> Vec<OsString> {
+    vec![
         "run".into(),
         "--with".into(),
         "ipykernel".into(),
         "--with".into(),
         "uv".into(),
-    ];
-    if bootstrap_dx {
-        args.push("--with".into());
-        args.push("dx".into());
-    }
-    args
+    ]
 }
 
-pub(crate) fn uv_pyproject_prepare_args(bootstrap_dx: bool) -> Vec<OsString> {
-    let mut args = uv_run_base_args(bootstrap_dx);
+pub(crate) fn uv_pyproject_prepare_args(_bootstrap_dx: bool) -> Vec<OsString> {
+    let mut args = uv_run_base_args();
     args.extend([
         OsString::from("python"),
         OsString::from("-Xfrozen_modules=off"),
@@ -61,7 +56,7 @@ pub(crate) fn uv_pyproject_kernel_args(
     bootstrap_dx: bool,
     connection_file: &Path,
 ) -> Vec<OsString> {
-    let mut args = uv_run_base_args(bootstrap_dx);
+    let mut args = uv_run_base_args();
     let launcher_module = if bootstrap_dx {
         "nteract_kernel_launcher"
     } else {
@@ -146,7 +141,6 @@ pub(crate) async fn prepare_uv_pyproject_environment(
     cmd.env("LINES", TERMINAL_LINES_STR);
     if bootstrap_dx {
         apply_bootstrap_pythonpath(&mut cmd).await?;
-        cmd.env("RUNT_BOOTSTRAP_DX", "1");
     }
 
     info!(
@@ -207,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_args_include_dx_when_bootstrap_is_enabled() {
+    fn prepare_args_do_not_install_dx_when_bootstrap_is_enabled() {
         assert_eq!(
             args_to_strings(uv_pyproject_prepare_args(true)),
             vec![
@@ -216,8 +210,6 @@ mod tests {
                 "ipykernel",
                 "--with",
                 "uv",
-                "--with",
-                "dx",
                 "python",
                 "-Xfrozen_modules=off",
                 "-c",
@@ -264,8 +256,6 @@ mod tests {
                 "ipykernel",
                 "--with",
                 "uv",
-                "--with",
-                "dx",
                 "python",
                 "-Xfrozen_modules=off",
                 "-m",

--- a/python/nteract-kernel-launcher/README.md
+++ b/python/nteract-kernel-launcher/README.md
@@ -8,14 +8,12 @@ a drop-in replacement for `python -m ipykernel_launcher`:
 python -m nteract_kernel_launcher -f <connection_file>
 ```
 
-## Bootstrap flags
+## Bootstrap behavior
 
-All bootstrap is gated on environment variables so the behavior can be
-controlled per-kernel by the daemon:
-
-| Env var | Effect |
-|---------|--------|
-| `RUNT_BOOTSTRAP_DX=1` | Import `dx` and call `dx.install()` before the kernel starts, wiring up DataFrame formatters and visualization renderers. Silently skipped if `dx` is not installed. |
+When the daemon launches a kernel with `python -m nteract_kernel_launcher`,
+the launcher auto-loads its bundled bootstrap extension before user code runs.
+The bootstrap registers rich DataFrame, Arrow, and dataset formatters without
+requiring the legacy `dx` PyPI package.
 
 If bootstrap raises, the error is logged to stderr but the launcher still
 starts the kernel — a broken bootstrap should not prevent the user from


### PR DESCRIPTION
## Summary

- Stop adding the legacy `dx` package to `uv:pyproject` launch/probe commands and update stale docs/fixtures that treated `dx` as a managed package dependency.
- Keep enhanced-kernel launches on `nteract_kernel_launcher` via vendored `PYTHONPATH`.
- Make heartbeat monitoring require three consecutive failures before declaring the kernel dead, while still declaring death immediately when the kernel process is already gone.
- Add richer heartbeat logs with kernel id, kernel type, env source, pid, retry count, and launch elapsed time.

## Verification

- `cargo xtask wasm`
- `cargo test -p runtimed uv_project`
- `cargo test -p runtimed test_compare_subset_matches_real_user_seeded_notebook`
- `cargo test -p runtimed test_inline_deps_with_required_packages_adds_display_deps`
- `cargo test -p runtimed effective_user_deps_from_launched_ignores_prewarmed_packages`
- `cargo xtask lint --fix`
