### PR TITLE
refactor(runtime): drop dead bootstrap_dx arg, document pyarrow base dep

### DIFF
--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -73,6 +73,7 @@ pub const UV_BASE_PACKAGES: &[&str] = &[
     "ipywidgets",
     "anywidget",
     "nbformat",
+    // Required by `nteract_kernel_launcher`'s Arrow/DataFrame formatters.
     "pyarrow>=14",
     "uv",
 ];

--- a/crates/runtimed/src/uv_project.rs
+++ b/crates/runtimed/src/uv_project.rs
@@ -41,7 +41,7 @@ fn uv_run_base_args() -> Vec<OsString> {
     ]
 }
 
-pub(crate) fn uv_pyproject_prepare_args(_bootstrap_dx: bool) -> Vec<OsString> {
+pub(crate) fn uv_pyproject_prepare_args() -> Vec<OsString> {
     let mut args = uv_run_base_args();
     args.extend([
         OsString::from("python"),
@@ -133,7 +133,7 @@ pub(crate) async fn prepare_uv_pyproject_environment(
         .await
         .context("failed to locate uv executable")?;
     let mut cmd = Command::new(&uv_path);
-    cmd.args(uv_pyproject_prepare_args(bootstrap_dx));
+    cmd.args(uv_pyproject_prepare_args());
     cmd.current_dir(&cwd);
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
@@ -185,25 +185,7 @@ mod tests {
     #[test]
     fn prepare_args_include_base_uv_packages() {
         assert_eq!(
-            args_to_strings(uv_pyproject_prepare_args(false)),
-            vec![
-                "run",
-                "--with",
-                "ipykernel",
-                "--with",
-                "uv",
-                "python",
-                "-Xfrozen_modules=off",
-                "-c",
-                "import ipykernel",
-            ]
-        );
-    }
-
-    #[test]
-    fn prepare_args_do_not_install_dx_when_bootstrap_is_enabled() {
-        assert_eq!(
-            args_to_strings(uv_pyproject_prepare_args(true)),
+            args_to_strings(uv_pyproject_prepare_args()),
             vec![
                 "run",
                 "--with",


### PR DESCRIPTION
Two cleanups on top of #2634.

## `_bootstrap_dx` arg on `uv_pyproject_prepare_args`

After #2634 the prepare probe is a constant `python -c 'import ipykernel'` regardless of bootstrap state. The arg only ever existed so we could push `--with dx` into the install set, and that path is gone. With `nteract_kernel_launcher` reaching the env via `PYTHONPATH` instead of a PyPI install, nothing the probe runs cares about the flag. Drop the parameter and merge the two now-identical tests.

`bootstrap_dx` is still meaningful at the layer above:

- `prepare_uv_pyproject_environment` uses it to set `PYTHONPATH` to the launcher cache dir.
- `uv_pyproject_kernel_args` uses it to pick `nteract_kernel_launcher` vs `ipykernel_launcher`.

## `pyarrow>=14` in `UV_BASE_PACKAGES`

#2634 swapped `dx` out of the base set and `pyarrow>=14` in. The `dx` removal is documented in the doc comment; the pyarrow addition is not. Add a one-line code comment so a future reader doesn't have to chase why every UV env carries pyarrow. It's required by `nteract_kernel_launcher`'s Arrow/DataFrame formatters.
