### PR TITLE
fix(history): normalize command search results

### DIFF
--- a/apps/notebook/src/components/HistorySearchDialog.tsx
+++ b/apps/notebook/src/components/HistorySearchDialog.tsx
@@ -152,10 +152,10 @@ export function HistorySearchDialog({ open, onOpenChange, onSelect }: HistorySea
             {emptyMessage ? (
               <CommandEmpty>{emptyMessage}</CommandEmpty>
             ) : (
-              <CommandGroup heading={`History${isLoading ? " (searching...)" : ""}`}>
-                {filteredEntries.map((entry, index) => (
+              <CommandGroup heading={`Recent history${isLoading ? " (updating...)" : ""}`}>
+                {filteredEntries.map((entry) => (
                   <CommandItem
-                    key={`${entry.session}-${entry.line}-${index}`}
+                    key={`${entry.session}-${entry.line}-${entry.source}`}
                     value={`${entry.session}-${entry.line}`}
                     onSelect={() => handleSelect(entry)}
                     className="cursor-pointer"

--- a/packages/runtimed/src/history.ts
+++ b/packages/runtimed/src/history.ts
@@ -1,0 +1,35 @@
+import type { HistoryEntry } from "./request-types";
+
+const CURRENT_SESSION_RANK = Number.MAX_SAFE_INTEGER;
+
+function sessionRecencyRank(session: number): number {
+  // Jupyter uses session 0 as "current session" in history APIs.
+  // Put it ahead of persisted session ids when kernels return it in entries.
+  return session === 0 ? CURRENT_SESSION_RANK : session;
+}
+
+export function historySourceKey(source: string): string {
+  return source.replace(/\r\n?/g, "\n").trim();
+}
+
+export function compareHistoryEntriesByRecency(a: HistoryEntry, b: HistoryEntry): number {
+  const sessionDelta = sessionRecencyRank(b.session) - sessionRecencyRank(a.session);
+  if (sessionDelta !== 0) return sessionDelta;
+  return b.line - a.line;
+}
+
+export function normalizeHistoryEntries(entries: HistoryEntry[]): HistoryEntry[] {
+  const latestBySource = new Map<string, HistoryEntry>();
+
+  for (const entry of entries) {
+    const sourceKey = historySourceKey(entry.source);
+    if (!sourceKey) continue;
+
+    const existing = latestBySource.get(sourceKey);
+    if (!existing || compareHistoryEntriesByRecency(entry, existing) < 0) {
+      latestBySource.set(sourceKey, entry);
+    }
+  }
+
+  return [...latestBySource.values()].sort(compareHistoryEntriesByRecency);
+}

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -184,6 +184,11 @@ export {
 
 // Notebook client
 export { NotebookClient, type NotebookClientOptions, SaveNotebookError } from "./notebook-client";
+export {
+  compareHistoryEntriesByRecency,
+  historySourceKey,
+  normalizeHistoryEntries,
+} from "./history";
 export type {
   CommRequestMessage,
   CompletionItem,

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SyncEngineLogger } from "./sync-engine";
+import { normalizeHistoryEntries } from "./history";
 import type { NotebookRequestOptions, NotebookTransport } from "./transport";
 import type {
   CommRequestMessage,
@@ -254,7 +255,9 @@ export class NotebookClient {
       });
       const result = (response as { result: string }).result;
       if (result === "history_result") {
-        return (response as { result: "history_result"; entries: HistoryEntry[] }).entries;
+        return normalizeHistoryEntries(
+          (response as { result: "history_result"; entries: HistoryEntry[] }).entries,
+        );
       }
       if (result === "no_kernel") {
         throw new Error("No kernel running");

--- a/packages/runtimed/tests/history.test.ts
+++ b/packages/runtimed/tests/history.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeHistoryEntries } from "../src";
+
+describe("normalizeHistoryEntries", () => {
+  it("deduplicates by source and keeps the most recent occurrence", () => {
+    expect(
+      normalizeHistoryEntries([
+        { session: 12, line: 4, source: "x = 1" },
+        { session: 12, line: 9, source: "print(x)" },
+        { session: 13, line: 1, source: "x = 1" },
+        { session: 11, line: 20, source: "print(x)" },
+      ]),
+    ).toEqual([
+      { session: 13, line: 1, source: "x = 1" },
+      { session: 12, line: 9, source: "print(x)" },
+    ]);
+  });
+
+  it("sorts newest history first", () => {
+    expect(
+      normalizeHistoryEntries([
+        { session: 10, line: 20, source: "older same session" },
+        { session: 9, line: 99, source: "older session" },
+        { session: 11, line: 1, source: "newer session" },
+        { session: 10, line: 25, source: "newer same session" },
+      ]).map((entry) => entry.source),
+    ).toEqual(["newer session", "newer same session", "older same session", "older session"]);
+  });
+
+  it("treats session zero as current and ignores empty entries", () => {
+    expect(
+      normalizeHistoryEntries([
+        { session: 999, line: 1, source: "persisted" },
+        { session: 0, line: 2, source: "current" },
+        { session: 0, line: 3, source: "   " },
+      ]),
+    ).toEqual([
+      { session: 0, line: 2, source: "current" },
+      { session: 999, line: 1, source: "persisted" },
+    ]);
+  });
+
+  it("deduplicates sources across line-ending and outer-whitespace differences", () => {
+    expect(
+      normalizeHistoryEntries([
+        { session: 1, line: 1, source: "print('hi')\r\n" },
+        { session: 1, line: 2, source: "print('hi')" },
+      ]),
+    ).toEqual([{ session: 1, line: 2, source: "print('hi')" }]);
+  });
+});

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -89,6 +89,29 @@ describe("NotebookClient", () => {
     });
   });
 
+  it("normalizes kernel history results", async () => {
+    const { client, sendRequest } = stubClient();
+    sendRequest.mockResolvedValueOnce({
+      result: "history_result",
+      entries: [
+        { session: 10, line: 1, source: "print('old')" },
+        { session: 11, line: 1, source: "print('old')" },
+        { session: 10, line: 2, source: "print('middle')" },
+      ],
+    });
+
+    await expect(client.getHistory(null, 100, true)).resolves.toEqual([
+      { session: 11, line: 1, source: "print('old')" },
+      { session: 10, line: 2, source: "print('middle')" },
+    ]);
+    expect(sendRequest).toHaveBeenCalledWith({
+      type: "get_history",
+      pattern: null,
+      n: 100,
+      unique: true,
+    });
+  });
+
   it("attaches required heads to daemon-managed execute requests", async () => {
     const { client, flush, sendRequest } = stubClientWithHeads(["head-a"]);
 


### PR DESCRIPTION
## Summary

- normalize kernel history results in the shared `NotebookClient` layer
- deduplicate equivalent command sources while keeping the newest occurrence
- sort Cmd-R history newest-first and label the dialog as recent history
- add focused coverage for the normalizer and client response contract

## Verification

- `pnpm test:run packages/runtimed/tests/history.test.ts packages/runtimed/tests/notebook-client.test.ts`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
