### PR TITLE
fix(notebook): allow isolated iframe scripts in CSP

### DIFF
--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -14,8 +14,8 @@
     "security": {
       "csp": {
         "default-src": "'self'",
-        "script-src": "'self' 'wasm-unsafe-eval'",
-        "style-src": "'self' 'unsafe-inline'",
+        "script-src": "'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https: http://127.0.0.1:* 'sha256-O/N72GCuG1dWVaY+Iz9rjgP7JT4TZuPk7omd2ijEPn4='",
+        "style-src": "'self' 'unsafe-inline' https: http://127.0.0.1:*",
         "img-src": "'self' data: blob: http://127.0.0.1:* https:",
         "font-src": "'self' data:",
         "media-src": "'self' data: blob: http://127.0.0.1:* https:",

--- a/crates/notebook/tests/tauri_csp.rs
+++ b/crates/notebook/tests/tauri_csp.rs
@@ -48,9 +48,17 @@ fn production_csp_is_enabled_and_restrictive() {
     let csp = object_field(security(&config), "csp");
 
     let script_src = directive(csp, "script-src");
-    assert_eq!(script_src, "'self' 'wasm-unsafe-eval'");
+    assert_eq!(
+        script_src,
+        "'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https: http://127.0.0.1:* 'sha256-O/N72GCuG1dWVaY+Iz9rjgP7JT4TZuPk7omd2ijEPn4='"
+    );
+    assert!(!script_src.contains("'unsafe-inline'"));
 
     assert_eq!(directive(csp, "default-src"), "'self'");
+    assert_eq!(
+        directive(csp, "style-src"),
+        "'self' 'unsafe-inline' https: http://127.0.0.1:*"
+    );
     assert_eq!(directive(csp, "base-uri"), "'none'");
     assert_eq!(directive(csp, "form-action"), "'none'");
     assert_eq!(directive(csp, "frame-src"), "blob:");

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -7,8 +7,17 @@
  * 3. Message handler validates source
  */
 
+import { createHash } from "node:crypto";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { createFrameBlobUrl, generateFrameHtml } from "../frame-html";
+
+const TAURI_IFRAME_BOOTSTRAP_SCRIPT_HASH = "sha256-O/N72GCuG1dWVaY+Iz9rjgP7JT4TZuPk7omd2ijEPn4=";
+
+function inlineScriptHash(html: string): string {
+  const match = html.match(/  <script>\n([\s\S]*?)\n  <\/script>/);
+  expect(match).not.toBeNull();
+  return `sha256-${createHash("sha256").update(match![1]).digest("base64")}`;
+}
 
 describe("generateFrameHtml", () => {
   let html: string;
@@ -29,6 +38,10 @@ describe("generateFrameHtml", () => {
 
   it("includes Content-Security-Policy meta tag", () => {
     expect(html).toContain('http-equiv="Content-Security-Policy"');
+  });
+
+  it("matches the bootstrap script hash allowlisted by Tauri", () => {
+    expect(inlineScriptHash(html)).toBe(TAURI_IFRAME_BOOTSTRAP_SCRIPT_HASH);
   });
 
   it("includes viewport meta tag", () => {


### PR DESCRIPTION
## Summary

- relax the packaged Tauri CSP enough for sandboxed output iframes to run their bootstrap and renderer/plugin code
- keep inline script execution narrow by allowlisting the generated iframe bootstrap script hash instead of adding `unsafe-inline`
- add tests that pin the Tauri CSP and verify the generated iframe script hash stays synchronized

## Verification

- `cargo xtask lint --fix`
- `cargo test -p notebook --test tauri_csp`
- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts`
