### PR TITLE
feat(notebook): add cream markdown typography

### DIFF
--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -99,6 +99,20 @@ describe("generateFrameHtml", () => {
       expect(creamLightHtml).toContain("--border-color: #d8cec3");
     });
 
+    it("scopes cream document typography to markdown outputs", () => {
+      const creamHtml = generateFrameHtml({ darkMode: false, colorTheme: "cream" });
+      expect(creamHtml).toContain(
+        "--markdown-document-font: KaTeX_Main, Georgia, 'Times New Roman', serif",
+      );
+      expect(creamHtml).toContain('[data-color-theme="cream"] [data-slot="markdown-output"]');
+      expect(creamHtml).toContain('[data-color-theme="cream"] [data-slot="markdown-output"] code');
+
+      const classicHtml = generateFrameHtml({ darkMode: false });
+      expect(classicHtml).toContain(
+        "--markdown-document-font: system-ui, -apple-system, BlinkMacSystemFont",
+      );
+    });
+
     it("uses dark text colors when darkMode is true", () => {
       const darkHtml = generateFrameHtml({ darkMode: true });
       expect(darkHtml).toContain("--text-primary: #e0e0e0");

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -52,6 +52,11 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       --accent-color: ${colorTheme === "cream" ? "#d4896a" : "#3b82f6"};
       --error-color: #ef4444;
       --success-color: #22c55e;
+      --markdown-document-font: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+
+    [data-color-theme="cream"] {
+      --markdown-document-font: KaTeX_Main, Georgia, 'Times New Roman', serif;
     }
 
     * {
@@ -85,6 +90,19 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
     pre, code {
       font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.875rem;
+    }
+
+    [data-color-theme="cream"] [data-slot="markdown-output"] {
+      font-family: var(--markdown-document-font);
+      font-size: 1rem;
+      line-height: 1.65;
+      font-kerning: normal;
+      text-rendering: optimizeLegibility;
+    }
+
+    [data-color-theme="cream"] [data-slot="markdown-output"] pre,
+    [data-color-theme="cream"] [data-slot="markdown-output"] code {
+      font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
     }
 
     pre {


### PR DESCRIPTION
## Summary

- Give cream-themed isolated markdown outputs a KaTeX-backed document font stack.
- Keep the isolated iframe body, app chrome, code, and preformatted markdown content on their existing system/mono fonts.
- Add a frame-template regression test for the cream-only markdown typography scope.

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts`
- `cargo xtask lint --fix`
