### PR TITLE
docs: add design system guide

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,645 @@
+---
+version: alpha
+name: nteract Desktop
+description: A dense, calm notebook workspace for local data, code, runtime, and collaboration workflows.
+colors:
+  primary: "#262626"
+  on-primary: "#FAFAFA"
+  secondary: "#F5F5F5"
+  on-secondary: "#262626"
+  tertiary: "#955F3B"
+  on-tertiary: "#FFFDF9"
+  background: "#FFFFFF"
+  on-background: "#171717"
+  surface: "#FFFFFF"
+  surface-container-low: "#FAFAFA"
+  surface-container: "#F5F5F5"
+  surface-container-high: "#E5E5E5"
+  on-surface: "#171717"
+  on-surface-variant: "#737373"
+  outline: "#E5E5E5"
+  outline-strong: "#A1A1A1"
+  input: "#E5E5E5"
+  ring: "#A1A1A1"
+  destructive: "#E7000B"
+  on-destructive: "#FAFAFA"
+  dark-background: "#171717"
+  dark-on-background: "#FAFAFA"
+  dark-surface: "#262626"
+  dark-surface-container: "#404040"
+  dark-surface-container-high: "#525252"
+  dark-on-surface: "#FAFAFA"
+  dark-on-surface-variant: "#A1A1A1"
+  dark-outline: "#2E2E2E"
+  dark-input: "#393939"
+  dark-ring: "#737373"
+  dark-destructive: "#FF6467"
+  cream-background: "#F5F2EC"
+  cream-on-background: "#1E1A18"
+  cream-surface: "#FFFDF9"
+  cream-surface-container: "#EBE6DF"
+  cream-on-surface-variant: "#6E655F"
+  cream-outline: "#D8CEC3"
+  cream-primary: "#955F3B"
+  cream-on-primary: "#FFFDF9"
+  cream-destructive: "#C4513A"
+  cream-dark-background: "#1A1816"
+  cream-dark-on-background: "#E8E2DC"
+  cream-dark-surface: "#242120"
+  cream-dark-surface-container: "#3A3533"
+  cream-dark-on-surface-variant: "#9A918A"
+  cream-dark-primary: "#D4896A"
+  cream-dark-on-primary: "#1A1816"
+  accent-code: "#38BDF8"
+  accent-code-dark: "#0284C7"
+  accent-markdown: "#34D399"
+  accent-markdown-dark: "#059669"
+  accent-raw: "#FB7185"
+  accent-raw-dark: "#E11D48"
+  accent-sql: "#FBBF24"
+  accent-sql-dark: "#D97706"
+  accent-ai: "#C084FC"
+  accent-ai-dark: "#9333EA"
+  accent-uv: "#D946EF"
+  accent-conda: "#22C55E"
+  accent-pixi: "#F59E0B"
+  accent-deno: "#10B981"
+  status-idle: "#22C55E"
+  status-busy: "#F59E0B"
+  status-connecting: "#3B82F6"
+  status-disconnected: "#EF4444"
+  editor-light-background: "#FFFFFF"
+  editor-light-foreground: "#24292E"
+  editor-light-selection: "#BBDFFF"
+  editor-dark-background: "#0D1117"
+  editor-dark-foreground: "#C9D1D9"
+  editor-dark-selection: "#003D73"
+  editor-cream-background: "#F5F2EC"
+  editor-cream-foreground: "#3C3836"
+  editor-cream-selection: "#D8CEC3"
+themes:
+  classic-light:
+    colorMode: light
+    background: "#FFFFFF"
+    onBackground: "#171717"
+    surface: "#FFFFFF"
+    surfaceContainer: "#F5F5F5"
+    surfaceContainerHigh: "#E5E5E5"
+    onSurface: "#171717"
+    onSurfaceVariant: "#737373"
+    primary: "#262626"
+    onPrimary: "#FAFAFA"
+    secondary: "#F5F5F5"
+    onSecondary: "#262626"
+    accent: "#F5F5F5"
+    onAccent: "#262626"
+    destructive: "#E7000B"
+    onDestructive: "#FAFAFA"
+    border: "#E5E5E5"
+    input: "#E5E5E5"
+    ring: "#A1A1A1"
+    editorBackground: "#FFFFFF"
+    editorForeground: "#24292E"
+    editorSelection: "#BBDFFF"
+    editorGutter: "#6E7781"
+    outputUiFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    outputMonoFont: "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace"
+    outputDocumentFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+  classic-dark:
+    colorMode: dark
+    background: "#171717"
+    onBackground: "#FAFAFA"
+    surface: "#262626"
+    surfaceContainer: "#404040"
+    surfaceContainerHigh: "#525252"
+    onSurface: "#FAFAFA"
+    onSurfaceVariant: "#A1A1A1"
+    primary: "#E5E5E5"
+    onPrimary: "#262626"
+    secondary: "#404040"
+    onSecondary: "#FAFAFA"
+    accent: "#404040"
+    onAccent: "#FAFAFA"
+    destructive: "#FF6467"
+    onDestructive: "#A1A1A1"
+    border: "#2E2E2E"
+    input: "#393939"
+    ring: "#737373"
+    editorBackground: "#0D1117"
+    editorForeground: "#C9D1D9"
+    editorSelection: "#003D73"
+    editorGutter: "#6E7781"
+    outputUiFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    outputMonoFont: "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace"
+    outputDocumentFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+  cream-light:
+    colorMode: light
+    background: "#F5F2EC"
+    onBackground: "#1E1A18"
+    surface: "#FFFDF9"
+    surfaceContainer: "#EBE6DF"
+    surfaceContainerHigh: "#D8CEC3"
+    onSurface: "#1E1A18"
+    onSurfaceVariant: "#6E655F"
+    primary: "#955F3B"
+    onPrimary: "#FFFDF9"
+    secondary: "#EBE6DF"
+    onSecondary: "#1E1A18"
+    accent: "#EBE6DF"
+    onAccent: "#1E1A18"
+    destructive: "#C4513A"
+    onDestructive: "#FFFDF9"
+    border: "#D8CEC3"
+    input: "#D8CEC3"
+    ring: "#955F3B"
+    editorBackground: "#F5F2EC"
+    editorForeground: "#3C3836"
+    editorSelection: "#D8CEC3"
+    editorGutter: "#6E655F"
+    outputUiFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    outputMonoFont: "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace"
+    outputDocumentFont: "KaTeX_Main, Georgia, Times New Roman, serif"
+  cream-dark:
+    colorMode: dark
+    background: "#1A1816"
+    onBackground: "#E8E2DC"
+    surface: "#242120"
+    surfaceContainer: "#3A3533"
+    surfaceContainerHigh: "#4A4441"
+    onSurface: "#E8E2DC"
+    onSurfaceVariant: "#9A918A"
+    primary: "#D4896A"
+    onPrimary: "#1A1816"
+    secondary: "#3A3533"
+    onSecondary: "#E8E2DC"
+    accent: "#3A3533"
+    onAccent: "#E8E2DC"
+    destructive: "#E07A64"
+    onDestructive: "#1A1816"
+    border: "#34302E"
+    input: "#413B38"
+    ring: "#D4896A"
+    editorBackground: "#1A1816"
+    editorForeground: "#EBDBB2"
+    editorSelection: "#3A3533"
+    editorGutter: "#9A918A"
+    outputUiFont: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    outputMonoFont: "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace"
+    outputDocumentFont: "KaTeX_Main, Georgia, Times New Roman, serif"
+typography:
+  display:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 30px
+    fontWeight: 600
+    lineHeight: 36px
+    letterSpacing: -0.01em
+  title-lg:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 18px
+    fontWeight: 600
+    lineHeight: 28px
+    letterSpacing: 0em
+  title-md:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 24px
+    letterSpacing: 0em
+  body-md:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 22px
+    letterSpacing: 0em
+  body-sm:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 16px
+    letterSpacing: 0em
+  label-md:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 20px
+    letterSpacing: 0em
+  label-sm:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 16px
+    letterSpacing: 0em
+  label-caps:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 12px
+    fontWeight: 600
+    lineHeight: 16px
+    letterSpacing: 0.06em
+  micro-label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif"
+    fontSize: 10px
+    fontWeight: 500
+    lineHeight: 14px
+    letterSpacing: 0.08em
+  code-md:
+    fontFamily: "SF Mono, Consolas, Monaco, Andale Mono, monospace"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 20px
+    letterSpacing: 0em
+  code-sm:
+    fontFamily: "SF Mono, Consolas, Monaco, Andale Mono, monospace"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 16px
+    letterSpacing: 0em
+  output-ui:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 21px
+    letterSpacing: 0em
+  output-mono:
+    fontFamily: "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 21px
+    letterSpacing: 0em
+  output-document-body:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 26.4px
+    letterSpacing: 0em
+  output-document-body-cream:
+    fontFamily: "KaTeX_Main, Georgia, Times New Roman, serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 26.4px
+    letterSpacing: 0em
+  output-document-h1:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 30px
+    fontWeight: 700
+    lineHeight: 36px
+    letterSpacing: 0em
+  output-document-h2:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 28.8px
+    letterSpacing: 0em
+  output-document-h3:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 20px
+    fontWeight: 700
+    lineHeight: 24px
+    letterSpacing: 0em
+  output-document-h4:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 18px
+    fontWeight: 700
+    lineHeight: 21.6px
+    letterSpacing: 0em
+  output-document-h5:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 19.2px
+    letterSpacing: 0em
+  output-document-h6:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif"
+    fontSize: 14px
+    fontWeight: 600
+    lineHeight: 16.8px
+    letterSpacing: 0em
+rounded:
+  none: 0px
+  xs: 2px
+  sm: 4px
+  md: 8px
+  lg: 10px
+  xl: 14px
+  2xl: 18px
+  3xl: 22px
+  4xl: 26px
+  full: 9999px
+spacing:
+  hairline: 1px
+  micro: 2px
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+  xl: 24px
+  2xl: 32px
+  3xl: 40px
+  4xl: 64px
+  toolbar-height: 40px
+  control-height-sm: 32px
+  control-height-md: 36px
+  control-height-lg: 40px
+  gutter-width: 40px
+  ribbon-width: 4px
+  panel-width: 512px
+  wizard-card-width: 208px
+  wizard-card-height: 256px
+shadows:
+  none: "none"
+  xs: "0 1px 2px 0 #0000000D"
+  sm: "0 1px 3px 0 #0000001A, 0 1px 2px -1px #0000001A"
+  md: "0 4px 6px -1px #0000001A, 0 2px 4px -2px #0000001A"
+  lg: "0 10px 15px -3px #0000001A, 0 4px 6px -4px #0000001A"
+  xl: "0 20px 25px -5px #0000001A, 0 8px 10px -6px #0000001A"
+  dialog: "0 10px 30px -12px #00000040"
+  drag-preview: "0 25px 50px -12px #00000040"
+elevation:
+  base:
+    backgroundColor: "{colors.background}"
+    borderColor: "{colors.outline}"
+    shadow: "{shadows.none}"
+  raised:
+    backgroundColor: "{colors.surface}"
+    borderColor: "{colors.outline}"
+    shadow: "{shadows.sm}"
+  floating:
+    backgroundColor: "{colors.surface}"
+    borderColor: "{colors.outline}"
+    shadow: "{shadows.md}"
+  modal:
+    backgroundColor: "{colors.surface}"
+    borderColor: "{colors.outline}"
+    shadow: "{shadows.dialog}"
+motion:
+  duration-instant: 100ms
+  duration-fast: 150ms
+  duration-default: 200ms
+  duration-slow: 300ms
+  duration-queued: 3000ms
+  duration-executing: 3000ms
+  easing-standard: ease-out
+  easing-emphasis: "cubic-bezier(0.34, 1.56, 0.64, 1)"
+  fade-scale-enter: "fade in with 95% to 100% scale over 200ms"
+  toolbar-hover: "color and background shift over 150ms"
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.md}"
+    height: "{spacing.control-height-md}"
+    padding: "8px 16px"
+  button-secondary:
+    backgroundColor: "{colors.secondary}"
+    textColor: "{colors.on-secondary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.md}"
+    height: "{spacing.control-height-md}"
+    padding: "8px 16px"
+  button-ghost:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface-variant}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.sm}"
+    height: "{spacing.control-height-sm}"
+    padding: "4px 8px"
+  toolbar-button:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface-variant}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.sm}"
+    height: 28px
+    padding: "4px 8px"
+  icon-button:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface-variant}"
+    rounded: "{rounded.sm}"
+    height: 28px
+    width: 28px
+    padding: 4px
+  input-field:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    height: "{spacing.control-height-md}"
+    padding: "4px 12px"
+  textarea-field:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+  popover:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.md}"
+    padding: 4px
+  dialog:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.on-background}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+  segmented-control:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "#525252"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.md}"
+    padding: 2px
+  segmented-control-active:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.sm}"
+    padding: "4px 10px"
+  notebook-toolbar:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.on-surface}"
+    height: "{spacing.toolbar-height}"
+    padding: "0 12px"
+  notebook-cell:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.code-md}"
+    padding: "6px 12px 12px 24px"
+  notebook-cell-focused-code:
+    backgroundColor: "#F0F9FF"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.none}"
+  notebook-cell-focused-markdown:
+    backgroundColor: "#ECFDF5"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.none}"
+  notebook-cell-focused-raw:
+    backgroundColor: "#FFF1F2"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.none}"
+  cell-ribbon-code:
+    backgroundColor: "{colors.accent-code}"
+    width: "{spacing.ribbon-width}"
+  cell-ribbon-markdown:
+    backgroundColor: "{colors.accent-markdown}"
+    width: "{spacing.ribbon-width}"
+  cell-ribbon-raw:
+    backgroundColor: "{colors.accent-raw}"
+    width: "{spacing.ribbon-width}"
+  cell-ribbon-sql:
+    backgroundColor: "{colors.accent-sql}"
+    width: "{spacing.ribbon-width}"
+  cell-ribbon-ai:
+    backgroundColor: "{colors.accent-ai}"
+    width: "{spacing.ribbon-width}"
+  execution-button:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface-variant}"
+    typography: "{typography.code-sm}"
+    rounded: "{rounded.none}"
+    height: 24px
+    padding: "0px"
+  status-badge:
+    backgroundColor: "{colors.secondary}"
+    textColor: "{colors.on-secondary}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.md}"
+    height: 20px
+    padding: "0 10px"
+  selection-card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.2xl}"
+    width: "{spacing.wizard-card-width}"
+    height: "{spacing.wizard-card-height}"
+    padding: 32px
+  selection-card-active:
+    backgroundColor: "#DBEAFE"
+    textColor: "#1D4ED8"
+    rounded: "{rounded.2xl}"
+    padding: 32px
+  disclosure-card:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.lg}"
+    padding: 16px
+  slider-track:
+    backgroundColor: "#DBEAFE"
+    rounded: "{rounded.full}"
+    height: 6px
+  slider-thumb:
+    backgroundColor: "{colors.background}"
+    rounded: "{rounded.full}"
+    height: 16px
+    width: 16px
+  rendered-document:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.output-document-body}"
+    rounded: "{rounded.none}"
+    padding: "8px 0"
+  rendered-document-heading:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.output-document-h2}"
+    rounded: "{rounded.none}"
+    padding: "0"
+  rendered-code-block:
+    backgroundColor: "{colors.secondary}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.output-mono}"
+    rounded: "{rounded.sm}"
+    padding: 8px
+---
+
+# Design System: nteract Desktop
+
+## Overview
+
+nteract Desktop is a quiet, work-focused notebook environment. The interface should feel like a precise desktop tool rather than a marketing surface: compact, readable, keyboard-friendly, and intentionally restrained. Its visual identity comes from thin borders, neutral surfaces, small icon-led controls, monospaced execution affordances, and narrow colored ribbons that mark cell meaning without overwhelming the page.
+
+The product has two themes and each theme has light and dark color modes. Classic is crisp and almost monochrome, optimized for focus and legibility. Cream warms the same structure with parchment-like backgrounds, brown primary actions, and Gruvbox-inspired accents. Classic light, classic dark, cream light, and cream dark are all first-class targets; none should feel like an afterthought.
+
+## Colors
+
+The base palette is neutral black, white, and gray. Primary actions use deep charcoal on light surfaces and near-white on dark surfaces, producing a utilitarian desktop feel. Muted gray is the main color for labels, disabled states, toolbar commands, gutters, scrollbars, and secondary copy.
+
+Cream mode is a first-class alternate palette, not a decorative skin. It shifts the workspace toward warm paper, soft clay, and desaturated earth tones while preserving the same hierarchy. Use cream primary brown for important actions and focus rings; use cream borders and muted backgrounds to keep density comfortable.
+
+Cell color is semantic and narrow. Code uses sky blue, markdown uses emerald, raw cells use rose, SQL uses amber, and AI-adjacent cells use purple. These accents should usually appear as slim ribbons, small badges, dots, or subtle translucent focus fields. Avoid flooding entire panels with these hues.
+
+Runtime and environment colors are treated as product signals: Python blue, Deno emerald, uv fuchsia, Conda green, and Pixi amber. They should read as small identifying accents around badges, icons, or selected setup cards.
+
+## Theme Matrix
+
+Classic light uses white surfaces, near-black text, pale gray muted fills, and charcoal primary actions. It should feel like a native desktop editor: bright, spare, and precise.
+
+Classic dark inverts the neutral system into near-black backgrounds, dark gray panels, white text, and pale primary controls. It should feel practical rather than theatrical; avoid saturated dark-blue or purple washes.
+
+Cream light uses warm paper backgrounds, off-white cards, clay-brown primary actions, and muted tan borders. It should feel warmer than classic while preserving the same working density and control geometry.
+
+Cream dark uses a warm charcoal-brown foundation, soft bone foreground text, brown-orange primary actions, and low-contrast warm borders. It should preserve the comfort of cream mode without becoming sepia-heavy or low-contrast.
+
+When adding new UI, define the semantic role first, then resolve it through all four combinations. Do not hard-code a color that only works in one theme or one color mode.
+
+## Typography
+
+The system uses the native platform sans stack for application UI. This keeps the app feeling like a desktop tool and avoids a branded web-app voice. Type should be modest in scale: 30px is reserved for first-run onboarding titles, 18px for window-level headings, 14px for working UI, and 12px or 10px for toolbar labels, metadata, badges, and helper text.
+
+Code, execution counts, inline package names, and collapsed source previews use a compact monospaced stack. Monospaced text is part of the product identity: it makes notebook state feel inspectable and exact. Use tabular numbers for execution counters and duration values.
+
+Rendered notebook documents have their own typography. Markdown and HTML outputs use 16px body text with a 1.65 line-height, normal kerning, and optimized legibility. Classic rendered documents use the same system UI family as the application. Cream rendered documents switch to a serif document face, led by KaTeX_Main with Georgia and Times New Roman fallbacks, so prose and equations feel warmer and more book-like while tables, controls, SVG, canvas, and form elements stay in the UI font.
+
+Rendered document headings are larger and heavier than app headings: h1 is 30px, h2 is 24px, h3 is 20px, h4 is 18px, h5 is 16px, and h6 is 14px semibold. Keep heading line-height tight at 1.2. Use the document font for headings in prose outputs, but preserve the monospace font inside code blocks and inline code.
+
+Use weight instead of size for hierarchy inside dense panels. Labels may be semibold and uppercase with generous letter spacing, but body copy should remain regular weight with calm line height.
+
+## Layout
+
+The layout is a fixed desktop workspace with a sticky top toolbar and a scrollable notebook body. The toolbar is only 40px tall, with 12px horizontal padding and small controls. It should recede into the background and let cells own the main reading area.
+
+Notebook cells use a three-part rhythm: a 40px left gutter for execution and presence, a 4px semantic ribbon, and a flexible content area with generous left padding. Focused cells may extend horizontally to make room for emphasis, but they should still look like rows in a continuous document, not isolated cards.
+
+Settings, feedback, and onboarding views use centered narrow columns. Settings and feedback should stay compact, around a 512px measure. Onboarding can use larger selection cards, but still within a restrained, symmetrical layout.
+
+Spacing is based on small 4px and 8px increments. Prefer tight groups with clear internal rhythm over large page sections. Use 24px and 32px only for modal, wizard, or top-level panel padding.
+
+## Elevation & Depth
+
+Depth is functional and sparse. Most hierarchy comes from borders, tonal surfaces, opacity, and color rather than heavy shadows. Buttons and inputs may use very light shadows; menus and dialogs may float with medium shadows; drag previews may use the strongest shadow because they need to detach clearly from the notebook.
+
+Overlays should use a dark scrim and a short scale/fade entrance. Popovers and menus are compact, border-defined, and lightly elevated. Avoid glassmorphism, large blurred backdrops, dramatic gradients, or decorative depth.
+
+## Shapes
+
+The shape language is slightly softened but still engineered. Standard controls use 8px corners; dialogs and larger panels use 10px to 18px corners; wizard selection cards use 18px corners. Tiny toolbar controls and row actions use 4px corners. Pills are reserved for toggles, switches, slider tracks, avatars, status dots, and compact badges.
+
+Cells themselves are mostly squared and continuous. Their identity comes from ribbons and subtle focus fields, not card outlines. Avoid turning every cell into a separate rounded card.
+
+## Components
+
+Buttons are compact, icon-led, and text-light. Primary buttons are solid and high-contrast. Secondary and outline buttons use borders and subtle shadows. Ghost buttons are the default for toolbar and row actions, changing only background and foreground on hover.
+
+Toolbar controls should remain small: 12px labels, 12px to 14px icons, and 28px-ish control height. Hide secondary text responsively when space is tight, keeping icons and tooltips as the durable interaction layer.
+
+Notebook cells use slim semantic ribbons. Focused code, markdown, raw, SQL, and AI cells receive a faint color wash that should remain below the level of a highlighted card. Output rows can use a softer segmented ribbon and reduced opacity when not adjacent to focus.
+
+The execution button is intentionally textual and monospaced. It should look like a compact notebook prompt: bracket, count or play marker, and colon. Queued state breathes slowly; executing state uses a delayed squish pulse so short executions do not create unnecessary motion.
+
+Inputs, textareas, and package-entry fields are border-based with muted fills. Placeholder text is quiet. Focus is shown by a ring in the current primary color, not by a large color fill.
+
+Dialogs and popovers are simple surfaces with borders, modest padding, and short motion. Keep content dense and practical; use descriptive headings and concise supporting text.
+
+Selection cards appear mainly in onboarding and setup flows. They can scale slightly and gain shadow when selected, but the color remains translucent and tied to the runtime or environment identity.
+
+## Do's and Don'ts
+
+- Do keep notebook content, outputs, and code editing as the visual center.
+- Do use semantic ribbons and tiny status marks for color rather than broad saturated panels.
+- Do preserve compact toolbar and settings density.
+- Do use warm cream tones only when the cream theme is active; do not mix cream and classic neutrals casually.
+- Do keep motion short and functional, with longer loops reserved only for execution and queue state.
+- Don't create large marketing-style hero layouts for working surfaces.
+- Don't turn notebook cells into floating cards.
+- Don't use decorative gradients, glass effects, or oversized shadows.
+- Don't use color as the only state indicator when a badge, icon, label, or shape can clarify the state.
+- Don't enlarge typography inside dense panels when weight, spacing, or muted color can establish hierarchy.


### PR DESCRIPTION
## Summary

- Add a self-contained `DESIGN.md` for the nteract Desktop visual system.
- Capture structured design tokens for colors, themes, typography, spacing, radii, shadows, elevation, motion, and components.
- Document the four supported theme combinations: classic light, classic dark, cream light, and cream dark.
- Include rendered output typography from the latest markdown/html frame CSS.

## Verification

- `npx --yes @google/design.md lint DESIGN.md`
- `cargo xtask lint --fix`

Note: the design-md linter reports expected unused-token warnings because the file intentionally includes broad palette tokens for a self-contained design system.
