### PR TITLE
ci: probe runtimed-py integration stability

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -333,7 +333,7 @@ async def daemon_health_check(daemon_process):
     except Exception as e:
         print(f"[health] WARNING: could not read status: {e}", file=sys.stderr)
 
-    # 3. Create notebook + start kernel + execute
+    # 3. Create notebook + start kernel + execute. CI probe marker: PR #2647.
     try:
         session = await client.create_notebook(runtime="python")
         print(f"[health] Created notebook: {session.notebook_id}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Empty commit to probe whether `runtimed-py Integration Tests` reproduces the CI timeout seen on PR #2646.
- No source changes; this should represent current `origin/main` after #2646 merged.

## What to watch

- `runtimed-py Integration Tests`, especially daemon health-check setup timeouts on a single xdist worker.
- E2E and release-artifact jobs for control signal.
