### PR TITLE
fix(notebook): hide chrome for small outputs

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -31,9 +31,13 @@ import { useCellOutputs } from "../lib/notebook-outputs";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
 import { tabCompletionKeymap } from "../lib/tab-completion";
-import type { CodeCell as CodeCellType } from "../types";
+import type { CodeCell as CodeCellType, JupyterOutput } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 import { HistorySearchDialog } from "./HistorySearchDialog";
+
+const SIMPLE_OUTPUT_MAX_CHARS = 2000;
+const SIMPLE_OUTPUT_MAX_LINES = 24;
+const SIMPLE_OUTPUT_MAX_LINE_CHARS = 180;
 
 interface CodeCellProps {
   cell: CodeCellType;
@@ -88,6 +92,52 @@ function historyQueryFromEditor(view: EditorView | null, fallbackSource: string)
   }
 
   return fallbackSource.trim();
+}
+
+function normalizeOutputText(text: string | string[]): string {
+  return Array.isArray(text) ? text.join("") : text;
+}
+
+function simpleOutputText(output: JupyterOutput): string | null {
+  if (output.output_type === "stream") {
+    return normalizeOutputText(output.text);
+  }
+
+  if (output.output_type !== "execute_result" && output.output_type !== "display_data") {
+    return null;
+  }
+
+  const populatedMimeTypes = Object.entries(output.data).filter(([, value]) => value != null);
+  if (populatedMimeTypes.length !== 1) {
+    return null;
+  }
+
+  const [mimeType, value] = populatedMimeTypes[0]!;
+  if (mimeType !== "text/plain" || (typeof value !== "string" && !Array.isArray(value))) {
+    return null;
+  }
+
+  return normalizeOutputText(value as string | string[]);
+}
+
+function needsOutputChrome(outputs: readonly JupyterOutput[]): boolean {
+  let totalChars = 0;
+  let totalLines = 0;
+
+  for (const output of outputs) {
+    const text = simpleOutputText(output);
+    if (text == null) return true;
+
+    totalChars += text.length;
+    const lines = text.split(/\r\n|\r|\n/);
+    totalLines += lines.length;
+
+    if (lines.some((line) => line.length > SIMPLE_OUTPUT_MAX_LINE_CHARS)) {
+      return true;
+    }
+  }
+
+  return totalChars > SIMPLE_OUTPUT_MAX_CHARS || totalLines > SIMPLE_OUTPUT_MAX_LINES;
 }
 
 /**
@@ -180,6 +230,7 @@ export const CodeCell = memo(function CodeCell({
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
+  const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -197,13 +248,13 @@ export const CodeCell = memo(function CodeCell({
   // share the strip, that gate stomped on focus the moment it engaged
   // for any non-iframe output.
   useEffect(() => {
-    if (isOutputsHidden || outputs.length === 0) {
+    if (isOutputsHidden || outputs.length === 0 || !showOutputChrome) {
       setIsIframeOutputExpanded(false);
       if (outputFocused) {
         onOutputFocusChange?.(false);
       }
     }
-  }, [isOutputsHidden, onOutputFocusChange, outputFocused, outputs.length]);
+  }, [isOutputsHidden, onOutputFocusChange, outputFocused, outputs.length, showOutputChrome]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -468,11 +519,12 @@ export const CodeCell = memo(function CodeCell({
               onIframeMouseDown={handleOutputMouseDown}
               expandIframeOutputs={isIframeOutputExpanded}
               focused={outputFocused}
+              useOutputWell={showOutputChrome}
             />
           )
         }
         outputRightGutterContent={
-          outputs.length > 0 && !isOutputsHidden ? (
+          outputs.length > 0 && !isOutputsHidden && showOutputChrome ? (
             <>
               <OutputModeStrip
                 mode={outputFocused ? "focused" : isIframeOutputExpanded ? "expanded" : "compact"}

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -37,13 +37,16 @@ vi.mock("@/components/cell/OutputArea", () => ({
   anyOutputNeedsIsolation: () => true,
   OutputArea: ({
     focused,
+    useOutputWell,
     onIframeMouseDown,
   }: {
     focused?: boolean;
+    useOutputWell?: boolean;
     onIframeMouseDown?: () => void;
   }) => (
     <button
       data-focused={String(focused)}
+      data-use-output-well={String(useOutputWell)}
       data-testid="output"
       type="button"
       onMouseDown={onIframeMouseDown}
@@ -182,6 +185,7 @@ describe("CodeCell output focus", () => {
         onExecute={() => {}}
         onInterrupt={() => {}}
         onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
       />,
     );
 
@@ -203,6 +207,7 @@ describe("CodeCell output focus", () => {
         onExecute={() => {}}
         onInterrupt={() => {}}
         onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
       />,
     );
 
@@ -219,12 +224,55 @@ describe("CodeCell output focus", () => {
         onExecute={() => {}}
         onInterrupt={() => {}}
         onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
       />,
     );
 
     fireEvent.click(getByTitle("Focus output"));
 
     expect(onOutputFocusChange).toHaveBeenCalledWith(true);
+  });
+
+  it("omits output chrome for short stream output", () => {
+    mockOutputs = [
+      {
+        output_type: "stream",
+        name: "stdout",
+        text: "hey\n",
+      },
+    ];
+
+    const { getByTestId, queryByLabelText, queryByTitle } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(getByTestId("output").getAttribute("data-use-output-well")).toBe("false");
+    expect(queryByLabelText("Output mode")).toBeNull();
+    expect(queryByTitle("Hide outputs")).toBeNull();
+  });
+
+  it("keeps output chrome for rich output", () => {
+    const { getByTestId, getByLabelText, getByTitle } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(getByTestId("output").getAttribute("data-use-output-well")).toBe("true");
+    expect(getByLabelText("Output mode")).toBeTruthy();
+    expect(getByTitle("Hide outputs")).toBeTruthy();
   });
 
   it("hides the expand button while output-focused", () => {

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -93,6 +93,11 @@ interface OutputAreaProps {
    */
   focused?: boolean;
   /**
+   * When false, simple in-DOM outputs render at intrinsic height without the
+   * compact/focused output well wrapper behavior.
+   */
+  useOutputWell?: boolean;
+  /**
    * Additional CSS classes for the container.
    */
   className?: string;
@@ -310,6 +315,7 @@ export function OutputArea({
   maxHeight,
   expandIframeOutputs = false,
   focused = false,
+  useOutputWell = true,
   className,
   renderers,
   priority = DEFAULT_PRIORITY,
@@ -342,17 +348,21 @@ export function OutputArea({
   //   expanded -> no cap (output grows as tall as its content)
   //   focused  -> focused max with floor, overflow-y-auto, overscroll-contain
   // Explicit `maxHeight` prop still overrides; pass 0 to opt out of compact.
-  const inDomMode: "compact" | "expanded" | "focused" = focused
-    ? "focused"
-    : expandIframeOutputs
-      ? "expanded"
-      : "compact";
-  const inDomMaxHeight =
-    inDomMode === "focused"
-      ? focusedOutputWellMaxHeight
-      : inDomMode === "expanded"
-        ? null
-        : (maxHeight ?? defaultOutputWellMaxHeight);
+  const inDomMode: "plain" | "compact" | "expanded" | "focused" = !useOutputWell
+    ? "plain"
+    : focused
+      ? "focused"
+      : expandIframeOutputs
+        ? "expanded"
+        : "compact";
+  let inDomMaxHeight: number | null;
+  if (inDomMode === "plain" || inDomMode === "expanded") {
+    inDomMaxHeight = null;
+  } else if (inDomMode === "focused") {
+    inDomMaxHeight = focusedOutputWellMaxHeight;
+  } else {
+    inDomMaxHeight = maxHeight ?? defaultOutputWellMaxHeight;
+  }
   const maxHeightStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (!inDomMaxHeight) return undefined;
     if (inDomMode === "focused") {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -77,6 +77,16 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
   ];
 }
 
+function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
+  return [
+    {
+      output_type: "stream",
+      name: "stdout",
+      text,
+    },
+  ];
+}
+
 function makeParquetOutput(): JupyterOutput[] {
   return [
     {
@@ -260,6 +270,14 @@ describe("OutputArea iframe theme sync", () => {
     expect(outputContent.getAttribute("class") ?? "").toContain("overflow-y-auto");
     expect(outputContent.style.maxHeight).toBe("600px");
     expect(outputContent.style.minHeight).toBe("");
+  });
+
+  it("renders plain in-DOM output without output well constraints", () => {
+    const { container } = render(<OutputArea outputs={makeStreamOutput()} useOutputWell={false} />);
+
+    const outputContent = getOutputContent(container);
+    expect(outputContent.getAttribute("class") ?? "").not.toContain("overflow-y-auto");
+    expect(outputContent.style.maxHeight).toBe("");
   });
 
   it("can expand isolated iframe outputs past the default output well cap", () => {


### PR DESCRIPTION
## Summary

- hide the output mode controls for short stream or plain-text output
- let those simple outputs render at intrinsic height without the compact output well
- keep hide/show outputs available for notebook visibility controls
- keep compact/expand/focus handling for rich, long, or otherwise complex outputs

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb e2e/specs/cell-visibility.spec.js`
