### PR TITLE
fix(notebook): refine history search shortcut

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -276,10 +276,10 @@ export const CodeCell = memo(function CodeCell({
     cellId: cell.id,
   });
 
-  // Cmd/Ctrl+R to open history search seeded from the active editor line.
+  // Ctrl+R opens history search seeded from the active editor line.
   const historyKeyBinding: KeyBinding = useMemo(
     () => ({
-      key: "Mod-r",
+      key: "Ctrl-r",
       run: () => {
         setHistoryInitialQuery(
           historyQueryFromEditor(editorRef.current?.getEditor() ?? null, cell.source),

--- a/apps/notebook/src/components/HistorySearchDialog.tsx
+++ b/apps/notebook/src/components/HistorySearchDialog.tsx
@@ -1,4 +1,13 @@
-import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { StaticCodeBlock } from "@/components/editor/static-highlight";
 import {
   Command,
@@ -64,19 +73,39 @@ export function HistorySearchDialog({
   const deferredSearchValue = useDeferredValue(searchValue);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const skipNextDebouncedSearchRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const shouldPlaceCaretAtEndRef = useRef(false);
 
   // Fetch initial history (Tail) when dialog opens
   useEffect(() => {
     if (open) {
       const query = initialQuery.trim();
       skipNextDebouncedSearchRef.current = true;
+      shouldPlaceCaretAtEndRef.current = true;
       setSearchValue(query);
       searchHistory(query || undefined);
     } else {
       clearEntries();
+      setSearchValue("");
       skipNextDebouncedSearchRef.current = false;
+      shouldPlaceCaretAtEndRef.current = false;
     }
   }, [open, initialQuery, searchHistory, clearEntries]);
+
+  useLayoutEffect(() => {
+    if (!open || !shouldPlaceCaretAtEndRef.current) return;
+    const input = inputRef.current;
+    if (!input || input.value !== searchValue) return;
+
+    shouldPlaceCaretAtEndRef.current = false;
+    const frame = window.requestAnimationFrame(() => {
+      input.focus();
+      const caret = input.value.length;
+      input.setSelectionRange(caret, caret);
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, searchValue]);
 
   // Debounced kernel search when user types
   useEffect(() => {
@@ -159,6 +188,7 @@ export function HistorySearchDialog({
           className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-1 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
         >
           <CommandInput
+            ref={inputRef}
             placeholder="Search history..."
             value={searchValue}
             onValueChange={setSearchValue}

--- a/apps/notebook/src/hooks/__tests__/useHistorySearch.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useHistorySearch.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import { orderHistoryMostRecentFirst, type HistoryEntry } from "../useHistorySearch";
+
+function historyEntry(session: number, line: number, source = ""): HistoryEntry {
+  return { session, line, source };
+}
+
+describe("orderHistoryMostRecentFirst", () => {
+  it("orders history entries by newest session and line first", () => {
+    const oldest = historyEntry(1, 10, "old");
+    const newestLine = historyEntry(1, 12, "newer line");
+    const newestSession = historyEntry(2, 1, "newer session");
+
+    expect(orderHistoryMostRecentFirst([oldest, newestSession, newestLine])).toEqual([
+      newestSession,
+      newestLine,
+      oldest,
+    ]);
+  });
+
+  it("does not mutate the original result array", () => {
+    const entries = [historyEntry(1, 1), historyEntry(1, 2)];
+
+    expect(orderHistoryMostRecentFirst(entries)).toEqual([historyEntry(1, 2), historyEntry(1, 1)]);
+    expect(entries).toEqual([historyEntry(1, 1), historyEntry(1, 2)]);
+  });
+});

--- a/apps/notebook/src/hooks/useHistorySearch.ts
+++ b/apps/notebook/src/hooks/useHistorySearch.ts
@@ -14,6 +14,10 @@ function getCacheKey(pattern: string | undefined): string {
   return pattern ?? "__tail__";
 }
 
+export function orderHistoryMostRecentFirst(entries: HistoryEntry[]): HistoryEntry[] {
+  return [...entries].sort((a, b) => b.session - a.session || b.line - a.line);
+}
+
 function getCachedResult(pattern: string | undefined): HistoryEntry[] | null {
   const key = getCacheKey(pattern);
   const result = searchCache.get(key);
@@ -67,7 +71,9 @@ export function useHistorySearch() {
       setError(null);
 
       try {
-        const results = await client.getHistory(pattern || null, 100, true);
+        const results = orderHistoryMostRecentFirst(
+          await client.getHistory(pattern || null, 100, true),
+        );
 
         if (currentSearchRef.current === pattern) {
           // Don't replace good entries with empty kernel results — the kernel


### PR DESCRIPTION
## Summary

- Move notebook history search from Cmd/Ctrl-R to Ctrl-R so Cmd-R remains available for reload.
- Keep the seeded history query editable by placing the caret at the end of the prefill.
- Normalize kernel history results to show most recent entries first.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/hooks/__tests__/useHistorySearch.test.ts`
- `pnpm --dir apps/notebook build`
