### PR TITLE
fix(notebook): keep output visibility toggle

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -524,21 +524,23 @@ export const CodeCell = memo(function CodeCell({
           )
         }
         outputRightGutterContent={
-          outputs.length > 0 && !isOutputsHidden && showOutputChrome ? (
+          outputs.length > 0 && !isOutputsHidden && (showOutputChrome || onToggleOutputsHidden) ? (
             <>
-              <OutputModeStrip
-                mode={outputFocused ? "focused" : isIframeOutputExpanded ? "expanded" : "compact"}
-                onChange={(next) => {
-                  if (next === "focused") {
-                    setIsIframeOutputExpanded(false);
-                    onOutputFocusChange?.(true);
-                  } else {
-                    setIsIframeOutputExpanded(next === "expanded");
-                    if (outputFocused) onOutputFocusChange?.(false);
-                  }
-                  onFocus();
-                }}
-              />
+              {showOutputChrome && (
+                <OutputModeStrip
+                  mode={outputFocused ? "focused" : isIframeOutputExpanded ? "expanded" : "compact"}
+                  onChange={(next) => {
+                    if (next === "focused") {
+                      setIsIframeOutputExpanded(false);
+                      onOutputFocusChange?.(true);
+                    } else {
+                      setIsIframeOutputExpanded(next === "expanded");
+                      if (outputFocused) onOutputFocusChange?.(false);
+                    }
+                    onFocus();
+                  }}
+                />
+              )}
               {onToggleOutputsHidden && (
                 <button
                   type="button"

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -255,7 +255,7 @@ describe("CodeCell output focus", () => {
 
     expect(getByTestId("output").getAttribute("data-use-output-well")).toBe("false");
     expect(queryByLabelText("Output mode")).toBeNull();
-    expect(queryByTitle("Hide outputs")).toBeNull();
+    expect(queryByTitle("Hide outputs")).toBeTruthy();
   });
 
   it("keeps output chrome for rich output", () => {


### PR DESCRIPTION
## Summary

- follow up on #2648 after the original PR merged before the CI correction
- hide the output mode controls for short stream or plain-text output
- let those simple outputs render at intrinsic height without the compact output well
- keep hide/show outputs available for notebook visibility controls
- keep compact/expand/focus handling for rich, long, or otherwise complex outputs

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb e2e/specs/cell-visibility.spec.js`
