### PR TITLE
fix(sift): cache-bust wasm plugin loads

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -826,8 +826,8 @@ async fn setup_sync_receivers(
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_commit_hash, next_available_sample_path, reopen_action, ReopenAction,
-        SyncReadyState,
+        daemon_version_matches_bundled, extract_commit_hash, next_available_sample_path,
+        reopen_action, ReopenAction, SyncReadyState,
     };
     use tempfile::TempDir;
 
@@ -840,6 +840,28 @@ mod tests {
             "dirty suffix is informational; SHA equality is what drives upgrade decisions"
         );
         assert_eq!(extract_commit_hash("1.4.1"), None);
+    }
+
+    #[test]
+    fn daemon_version_match_uses_commit_when_present() {
+        assert!(daemon_version_matches_bundled(
+            "2.4.7-nightly.202605091416+abc1234",
+            "2.4.7-nightly.202605091523+abc1234",
+        ));
+        assert!(daemon_version_matches_bundled(
+            "2.4.7+abc1234+dirty",
+            "2.4.7+abc1234",
+        ));
+        assert!(!daemon_version_matches_bundled(
+            "2.4.7+abc1234",
+            "2.4.7+def5678",
+        ));
+    }
+
+    #[test]
+    fn daemon_version_match_falls_back_when_commit_missing() {
+        assert!(daemon_version_matches_bundled("2.4.7", "2.4.7"));
+        assert!(!daemon_version_matches_bundled("2.4.7", "2.4.8"));
     }
 
     #[test]
@@ -954,6 +976,13 @@ fn extract_commit_hash(version: &str) -> Option<&str> {
     version.split('+').nth(1)
 }
 
+fn daemon_version_matches_bundled(running: &str, bundled: &str) -> bool {
+    match (extract_commit_hash(running), extract_commit_hash(bundled)) {
+        (Some(running_commit), Some(bundled_commit)) => running_commit == bundled_commit,
+        _ => runtimed_client::versions_match_ignoring_dirty(running, bundled),
+    }
+}
+
 /// Upgrade the daemon via sidecar when version mismatch detected.
 ///
 /// Runs `runtimed install` which handles: stop old → copy binary → start new.
@@ -969,7 +998,7 @@ where
 
     let bundled = bundled_daemon_version();
     log::info!("[startup] Upgrading daemon to bundled version: {}", bundled);
-    on_progress(DaemonProgress::Installing); // Reuse "installing" state for upgrade
+    on_progress(DaemonProgress::Upgrading);
 
     // "runtimed install" handles: stop old → copy binary → start new
     // The sidecar resolves to the runtimed binary bundled in the app.
@@ -1022,8 +1051,12 @@ where
         return Err(error);
     }
 
-    // Wait for upgraded daemon to be ready
-    log::info!("[startup] Sidecar install exited successfully, waiting for daemon to be ready...");
+    // Wait for upgraded daemon to be ready. A plain ping is not enough here:
+    // launchd can briefly leave the old daemon alive while the new service is
+    // being bootstrapped, and the old daemon serves stale embedded plugin WASM.
+    log::info!(
+        "[startup] Sidecar install exited successfully, waiting for bundled daemon version..."
+    );
     on_progress(DaemonProgress::Starting);
 
     let client = runtimed::client::PoolClient::default();
@@ -1034,47 +1067,48 @@ where
             max_attempts,
         });
 
-        if client.ping().await.is_ok() {
-            let endpoint = runt_workspace::default_socket_path()
-                .to_string_lossy()
-                .to_string();
+        let running_info =
+            runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path())
+                .await;
 
-            // Verify the running daemon version matches what we intended to install.
-            // `query_daemon_info` is socket-first with a `daemon.json`
-            // fallback for the one-release compat window.
-            let running_version = runtimed_client::singleton::query_daemon_info(
-                runt_workspace::default_socket_path(),
-            )
-            .await
-            .map(|i| i.version);
-            if let Some(version) = running_version {
-                let running_commit = extract_commit_hash(&version);
-                let bundled_commit = extract_commit_hash(&bundled);
-                if running_commit == bundled_commit {
-                    log::info!(
-                        "[startup] Upgraded daemon version confirmed: {} (attempt {})",
-                        version,
-                        attempt
-                    );
-                } else {
-                    log::warn!(
-                        "[startup] Daemon version mismatch after upgrade! running={}, bundled={}",
-                        version,
-                        bundled
-                    );
-                }
+        if let Some(info) = running_info {
+            if daemon_version_matches_bundled(&info.version, &bundled) {
+                let endpoint = runt_workspace::default_socket_path()
+                    .to_string_lossy()
+                    .to_string();
+                log::info!(
+                    "[startup] Upgraded daemon version confirmed: {} (attempt {})",
+                    info.version,
+                    attempt
+                );
+                on_progress(DaemonProgress::Ready {
+                    endpoint: endpoint.clone(),
+                });
+                return Ok(endpoint);
             }
 
-            on_progress(DaemonProgress::Ready {
-                endpoint: endpoint.clone(),
-            });
-            return Ok(endpoint);
+            log::warn!(
+                "[startup] Waiting for upgraded daemon version: running={}, bundled={} (attempt {}/{})",
+                info.version,
+                bundled,
+                attempt,
+                max_attempts
+            );
+        } else if client.ping().await.is_ok() {
+            log::warn!(
+                "[startup] Daemon responded after upgrade but did not report version yet (attempt {}/{})",
+                attempt,
+                max_attempts
+            );
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 
-    let error = "Upgraded daemon did not become ready within timeout".to_string();
+    let error = format!(
+        "Upgraded daemon did not report bundled version {} within timeout",
+        bundled
+    );
     log::error!("[startup] {}", error);
     on_progress(DaemonProgress::Failed {
         error: error.clone(),
@@ -1410,12 +1444,9 @@ where
             .await
             .map(|i| i.version);
             if let Some(version) = running_version {
-                // Compare commit hashes only - CI appends "+{git_sha}" to the version
-                // at build time, so commit hash is the precise compatibility check.
-                let running_commit = extract_commit_hash(&version);
-                let bundled_commit = extract_commit_hash(&bundled_version);
-
-                if running_commit != bundled_commit {
+                // CI appends "+{git_sha}" at build time, so commit equality is
+                // the precise compatibility check when both versions include it.
+                if !daemon_version_matches_bundled(&version, &bundled_version) {
                     log::info!(
                         "[startup] Daemon commit mismatch — will upgrade: running={}, bundled={}",
                         version,
@@ -1432,9 +1463,10 @@ where
             } else {
                 log::warn!(
                     "[startup] Daemon responded to ping but version unavailable via \
-                     socket or daemon.json (bundled={})",
+                     socket or daemon.json; upgrading to bundled version {}",
                     bundled_version
                 );
+                return upgrade_daemon_via_sidecar(app, on_progress).await;
             }
         }
 

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -306,7 +306,10 @@ fn serve_embedded_plugin(name: &str) -> Response<Full<Bytes>> {
         .status(StatusCode::OK)
         .header("Content-Type", content_type)
         .header("Content-Length", body_len.to_string())
-        .header("Cache-Control", "public, max-age=86400")
+        // Plugin URLs are stable across app/daemon upgrades, but their bytes
+        // are version-specific. Do not let WebKit reuse an older sift WASM
+        // binary with a newer renderer bundle.
+        .header("Cache-Control", "no-store")
         .header("Access-Control-Allow-Origin", "*")
         .header("X-Content-Type-Options", "nosniff")
         .body(body)
@@ -557,7 +560,7 @@ mod tests {
         );
         assert_eq!(
             response_header(&response, "cache-control"),
-            Some("public, max-age=86400".into())
+            Some("no-store".into())
         );
         assert_eq!(
             response_header(&response, "access-control-allow-origin"),
@@ -658,7 +661,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response_header(&response, "cache-control"),
-            Some("public, max-age=86400".into())
+            Some("no-store".into())
         );
     }
 

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -9,6 +9,7 @@
  * (plotly alone is 20MB unminified).
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,6 +71,14 @@ function resolveWasmGlue(): string {
   const realPath = path.resolve(srcDir, "../crates/sift-wasm/pkg/sift_wasm.js");
   const mockPath = path.resolve(srcDir, "../packages/sift/src/__mocks__/sift-wasm/sift_wasm.js");
   return fs.existsSync(realPath) ? realPath : mockPath;
+}
+
+function siftWasmCacheKey(): string {
+  const wasmPath = path.resolve(srcDir, "../crates/sift-wasm/pkg/sift_wasm_bg.wasm");
+  if (!fs.existsSync(wasmPath)) {
+    return "missing";
+  }
+  return crypto.createHash("sha256").update(fs.readFileSync(wasmPath)).digest("hex").slice(0, 16);
 }
 
 /**
@@ -195,6 +204,7 @@ export async function buildRendererPlugin(
       sourcemap: false,
     },
     define: {
+      __SIFT_WASM_CACHE_KEY__: JSON.stringify(siftWasmCacheKey()),
       "process.env.NODE_ENV": JSON.stringify("production"),
     },
     logLevel: "warn",

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -12,6 +12,8 @@
 import { setWasmUrl, SiftTable } from "@nteract/sift";
 import "@nteract/sift/style.css";
 
+declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
+
 // --- Types ---
 
 interface RendererProps {
@@ -24,6 +26,9 @@ interface RendererProps {
 
 let wasmConfigured = false;
 
+const SIFT_WASM_CACHE_KEY =
+  typeof __SIFT_WASM_CACHE_KEY__ === "string" ? __SIFT_WASM_CACHE_KEY__ : "dev";
+
 /**
  * Extract the blob server origin from a blob URL and configure WASM
  * to load from the same server's /plugins/ route.
@@ -32,9 +37,11 @@ function configureWasm(blobUrl: string): void {
   if (wasmConfigured) return;
   try {
     const parsed = new URL(blobUrl);
-    const wasmUrl = `${parsed.protocol}//${parsed.host}/plugins/sift_wasm.wasm`;
-    console.debug("[sift-renderer] setWasmUrl:", wasmUrl);
-    setWasmUrl(wasmUrl);
+    const wasmUrl = new URL("/plugins/sift_wasm.wasm", parsed.origin);
+    wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
+    const wasmUrlString = wasmUrl.toString();
+    console.debug("[sift-renderer] setWasmUrl:", wasmUrlString);
+    setWasmUrl(wasmUrlString);
     wasmConfigured = true;
   } catch (err) {
     console.warn("[sift-renderer] configureWasm failed, using defaults:", err);


### PR DESCRIPTION
## Summary

- append a Sift WASM content hash to `/plugins/sift_wasm.wasm` so WebKit cannot reuse an older stable-path cache entry with a newer renderer bundle
- serve embedded plugin assets with `Cache-Control: no-store` as a second guard against stale plugin bytes
- wait for the post-upgrade daemon to report the bundled version before treating the upgrade path as ready

## Verification

- `pnpm i`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook exec tsc --noEmit`
- `cargo xtask verify-plugins`
- `cargo test -p notebook daemon_version_match`
- `cargo test -p notebook extract_commit_hash_returns_sha_without_dirty_suffix`
- `cargo test -p runtimed test_embedded_plugin_served`
- `cargo test -p runtimed test_dev_filesystem_missing_asset_falls_back_to_embedded`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `git diff --check`
