### PR TITLE
fix(mcp-app): hash daemon plugin asset urls

### DIFF
--- a/apps/mcp-app/src/lib/__tests__/plugin-loader.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/plugin-loader.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { daemonPluginAssetUrl } from "../plugin-loader";
+
+describe("daemonPluginAssetUrl", () => {
+  it("appends a content hash when one is available", () => {
+    expect(
+      daemonPluginAssetUrl("http://localhost:1234", "markdown.js", {
+        "markdown.js": "abc123",
+      }),
+    ).toBe("http://localhost:1234/plugins/markdown.js?v=abc123");
+  });
+
+  it("leaves the stable URL untouched when no hash is available", () => {
+    expect(daemonPluginAssetUrl("http://localhost:1234", "plotly.js", {})).toBe(
+      "http://localhost:1234/plugins/plotly.js",
+    );
+  });
+});

--- a/apps/mcp-app/src/lib/plugin-loader.ts
+++ b/apps/mcp-app/src/lib/plugin-loader.ts
@@ -13,6 +13,8 @@
 import { isVegaMimeType } from "./mime-priority";
 import { installPluginFromUrl } from "./plugin-executor";
 
+declare const __DAEMON_PLUGIN_ASSET_HASHES__: Record<string, string> | undefined;
+
 interface PluginInfo {
   name: string;
   /** Whether this plugin has a separate CSS file */
@@ -29,6 +31,8 @@ const MIME_TO_PLUGIN: Record<string, PluginInfo> = {
 };
 
 const VEGA_PLUGIN: PluginInfo = { name: "vega", hasCss: false };
+const PLUGIN_ASSET_HASHES =
+  typeof __DAEMON_PLUGIN_ASSET_HASHES__ === "object" ? __DAEMON_PLUGIN_ASSET_HASHES__ : {};
 
 function pluginInfoForMime(mime: string): PluginInfo | undefined {
   if (MIME_TO_PLUGIN[mime]) return MIME_TO_PLUGIN[mime];
@@ -71,8 +75,10 @@ export function loadPluginForMime(
   const existing = loadingPlugins.get(info.name);
   if (existing) return existing;
 
-  const jsUrl = `${blobBaseUrl}/plugins/${info.name}.js`;
-  const cssUrl = info.hasCss ? `${blobBaseUrl}/plugins/${info.name}.css` : undefined;
+  const jsUrl = daemonPluginAssetUrl(blobBaseUrl, `${info.name}.js`);
+  const cssUrl = info.hasCss
+    ? daemonPluginAssetUrl(blobBaseUrl, `${info.name}.css`)
+    : undefined;
 
   const promise = installPluginFromUrl(jsUrl, cssUrl)
     .then(() => {
@@ -86,4 +92,14 @@ export function loadPluginForMime(
 
   loadingPlugins.set(info.name, promise);
   return promise;
+}
+
+export function daemonPluginAssetUrl(
+  blobBaseUrl: string,
+  filename: string,
+  assetHashes: Record<string, string> = PLUGIN_ASSET_HASHES,
+): string {
+  const version = assetHashes[filename];
+  const suffix = version ? `?v=${encodeURIComponent(version)}` : "";
+  return `${blobBaseUrl}/plugins/${filename}${suffix}`;
 }

--- a/apps/mcp-app/vite.config.ts
+++ b/apps/mcp-app/vite.config.ts
@@ -1,11 +1,53 @@
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite-plus";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(appDir, "../..");
+const rendererPluginDir = path.join(repoRoot, "apps/notebook/src/renderer-plugins");
+const siftWasmPath = path.join(repoRoot, "crates/sift-wasm/pkg/sift_wasm_bg.wasm");
+const daemonPluginAssets = [
+  "markdown.js",
+  "markdown.css",
+  "plotly.js",
+  "vega.js",
+  "leaflet.js",
+  "leaflet.css",
+  "sift.js",
+  "sift.css",
+] as const;
+
+function hashFile(filePath: string): string | undefined {
+  if (!fs.existsSync(filePath)) return undefined;
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex").slice(0, 16);
+}
+
+function daemonPluginAssetHashes(): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  for (const asset of daemonPluginAssets) {
+    const hash = hashFile(path.join(rendererPluginDir, asset));
+    if (hash) hashes[asset] = hash;
+  }
+
+  const wasmHash = hashFile(siftWasmPath);
+  if (wasmHash) hashes["sift_wasm.wasm"] = wasmHash;
+  return hashes;
+}
 
 export default defineConfig(({ command }) => {
+  const define = {
+    __DAEMON_PLUGIN_ASSET_HASHES__: JSON.stringify(daemonPluginAssetHashes()),
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  };
+
   if (command === "serve") {
     return {
       root: "src",
       plugins: [tailwindcss()],
+      define,
       server: {
         open: "/dev/index.html",
       },
@@ -58,9 +100,7 @@ export default defineConfig(({ command }) => {
         },
       },
     },
-    define: {
-      "process.env.NODE_ENV": JSON.stringify("production"),
-    },
+    define,
     logLevel: "warn",
   };
 });

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2752,6 +2752,15 @@ fn mcp_widget_needs_rebuild() -> Option<&'static str> {
         Path::new("apps/mcp-app/vite.config.ts"),
         Path::new("apps/mcp-app/build-plugins.ts"),
         Path::new("src/build/renderer-plugin-builder.ts"),
+        Path::new("apps/notebook/src/renderer-plugins/markdown.js"),
+        Path::new("apps/notebook/src/renderer-plugins/markdown.css"),
+        Path::new("apps/notebook/src/renderer-plugins/plotly.js"),
+        Path::new("apps/notebook/src/renderer-plugins/vega.js"),
+        Path::new("apps/notebook/src/renderer-plugins/leaflet.js"),
+        Path::new("apps/notebook/src/renderer-plugins/leaflet.css"),
+        Path::new("apps/notebook/src/renderer-plugins/sift.js"),
+        Path::new("apps/notebook/src/renderer-plugins/sift.css"),
+        Path::new("crates/sift-wasm/pkg/sift_wasm_bg.wasm"),
         Path::new("pnpm-lock.yaml"),
     ];
     for src in &top_level_sources {


### PR DESCRIPTION
## Summary

- append content-hash query params to daemon-served MCP app plugin JS/CSS URLs
- compute the hash manifest from the same renderer plugin assets the daemon embeds
- make the MCP widget rebuild when renderer plugin assets or Sift WASM bytes change

## Verification

- `pnpm test:run apps/mcp-app/src/lib/__tests__/plugin-loader.test.ts apps/mcp-app/src/lib/__tests__/plugin-executor.test.ts`
- `pnpm --dir apps/mcp-app exec vp build`
- `vp run nteract-mcp-app#build`
- `cargo test -p xtask mcp_widget -- --nocapture`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`
- `git diff --check`

Note: `pnpm --dir apps/mcp-app exec tsc --noEmit` is blocked by the pre-existing missing direct dependency declaration for `@modelcontextprotocol/sdk/types.js`; the Vite build path passes.
