### PR TITLE
ci: use standard GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -434,12 +434,12 @@ jobs:
       matrix:
         platform:
           - name: macOS
-            runner: macos-14-xlarge
+            runner: macos-14
             setup: echo "No extra deps needed on macOS"
             run_on_pr: false
             non_blocking: false
           - name: Windows
-            runner: windows-latest
+            runner: blacksmith-4vcpu-windows-2025
             setup: echo "No extra deps needed on Windows"
             run_on_pr: false
             non_blocking: true

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -68,7 +68,7 @@ jobs:
   build:
     name: Build ${{ inputs.target_os == 'linux' && 'Linux x64' || inputs.target_os == 'macos' && 'macOS' || 'Windows x64' }} binary
     needs: [resolve-pr]
-    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-14-xlarge' || 'windows-latest' }}
+    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-14' || 'blacksmith-4vcpu-windows-2025' }}
     env:
       NTERACT_BUILD_GIT_HASH: ${{ needs.resolve-pr.outputs.head_sha }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,7 +51,7 @@ jobs:
           - target: linux-x64-gnu
             runner: ubuntu-latest
           - target: win32-x64-msvc
-            runner: windows-latest
+            runner: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -187,7 +187,7 @@ jobs:
 
   build-macos:
     name: Build macOS Executables
-    runs-on: macos-14-xlarge
+    runs-on: macos-14
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -258,7 +258,7 @@ jobs:
 
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
-    runs-on: macos-14-xlarge
+    runs-on: macos-14
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -436,7 +436,7 @@ jobs:
 
   build-notebook-macos-x64:
     name: Build macOS x64 Notebook
-    runs-on: macos-14-xlarge
+    runs-on: macos-14
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -951,13 +951,13 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-14-xlarge
+          - runner: macos-14
             target: aarch64-apple-darwin
-          - runner: macos-14-xlarge
+          - runner: macos-14
             target: x86_64-apple-darwin
           - runner: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
-          - runner: nteract-windows-xlarge
+          - runner: blacksmith-4vcpu-windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   windows-smoke:
     name: Windows (build + install + smoke)
-    runs-on: windows-latest
+    runs-on: blacksmith-4vcpu-windows-2025
     timeout-minutes: 75
     # Push-to-main + manual dispatch only. The Windows leg currently runs
     # ~32 minutes (cargo build + NSIS bundling + smoke). Gating PRs on it


### PR DESCRIPTION
## Summary
- replace GitHub macOS larger-runner labels with standard macos-14
- move Windows workflow jobs to blacksmith-4vcpu-windows-2025
- leave existing Linux runner choices unchanged

## Verification
- actionlint -color
- git diff --check
- cargo xtask lint --fix
