### PR TITLE
feat(outputs): add arrow-native table manifests

### DIFF
--- a/apps/mcp-app/src/components/mime-renderer.tsx
+++ b/apps/mcp-app/src/components/mime-renderer.tsx
@@ -9,6 +9,8 @@ import { ImageOutput } from "./image-output";
 import { JsonOutput } from "./json-output";
 import type { CellOutput } from "../types";
 
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
 interface MimeRendererProps {
   data: Record<string, string>;
   /** Base URL for daemon HTTP server (for fetching blob data and plugins) */
@@ -72,7 +74,7 @@ function PluginRenderer({
     const pluginPromise = loadPluginForMime(mime, blobBaseUrl) ?? Promise.resolve();
 
     // Binary plugins (Sift table payloads) expect a URL and fetch data themselves.
-    // Text/JSON plugins (plotly, vega, markdown) need fetched + parsed content.
+    // Manifest/plugin JSON needs fetched + parsed content before rendering.
     const isBinaryPlugin =
       mime === "application/vnd.apache.parquet" || mime === "application/vnd.apache.arrow.stream";
     const parseData = (text: string) => {
@@ -92,7 +94,11 @@ function PluginRenderer({
       .then(([, parsedData]) => {
         if (cancelled) return;
         setPluginReady(true);
-        setData(parsedData);
+        setData(
+          mime === ARROW_STREAM_MANIFEST_MIME
+            ? attachArrowManifestChunkUrls(parsedData, blobBaseUrl)
+            : parsedData,
+        );
       })
       .catch(() => {
         if (!cancelled) setFailed(true);
@@ -117,6 +123,29 @@ function PluginRenderer({
   }
 
   return <RendererComponent data={data} mimeType={mime} />;
+}
+
+function attachArrowManifestChunkUrls(value: unknown, blobBaseUrl: string | undefined): unknown {
+  if (!blobBaseUrl || typeof value !== "object" || value === null) return value;
+  const manifest = value as Record<string, unknown>;
+  if (!Array.isArray(manifest.chunks)) return value;
+
+  const baseUrl = blobBaseUrl.replace(/\/$/, "");
+  let changed = false;
+  const chunks = manifest.chunks.map((chunk) => {
+    if (typeof chunk !== "object" || chunk === null) return chunk;
+    const chunkRecord = chunk as Record<string, unknown>;
+    if (typeof chunkRecord.url === "string") return chunk;
+    if (typeof chunkRecord.hash !== "string") return chunk;
+    changed = true;
+    return {
+      ...chunkRecord,
+      url: `${baseUrl}/blob/${chunkRecord.hash}`,
+    };
+  });
+
+  if (!changed) return value;
+  return { ...manifest, chunks };
 }
 
 function FetchAndRender({

--- a/apps/mcp-app/src/lib/mime-priority.ts
+++ b/apps/mcp-app/src/lib/mime-priority.ts
@@ -7,6 +7,7 @@ export const MIME_PRIORITY: readonly string[] = [
   "application/vnd.plotly.v1+json",
   "application/geo+json",
   // Data tables (Arrow IPC/parquet -> Sift renderer)
+  "application/vnd.nteract.arrow-stream-manifest+json",
   "application/vnd.apache.arrow.stream",
   "application/vnd.apache.parquet",
   // Rich text

--- a/apps/mcp-app/src/lib/plugin-loader.ts
+++ b/apps/mcp-app/src/lib/plugin-loader.ts
@@ -28,6 +28,7 @@ const MIME_TO_PLUGIN: Record<string, PluginInfo> = {
   "application/geo+json": { name: "leaflet", hasCss: true },
   "application/vnd.apache.parquet": { name: "sift", hasCss: true },
   "application/vnd.apache.arrow.stream": { name: "sift", hasCss: true },
+  "application/vnd.nteract.arrow-stream-manifest+json": { name: "sift", hasCss: true },
 };
 
 const VEGA_PLUGIN: PluginInfo = { name: "vega", hasCss: false };

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import {
+  ARROW_STREAM_MANIFEST_MIME,
   type ContentRef,
   isOutputManifest,
   type OutputManifest,
@@ -307,6 +308,37 @@ describe("resolveManifestSync", () => {
       expect(output.data["text/plain"]).toBe("{'key': 'value'}");
     }
   });
+
+  it("adds blob URLs to Arrow stream manifest chunks in sync resolution", () => {
+    const manifest: OutputManifest = {
+      output_type: "display_data",
+      data: {
+        [ARROW_STREAM_MANIFEST_MIME]: {
+          inline: JSON.stringify({
+            version: 1,
+            content_type: "application/vnd.apache.arrow.stream",
+            chunks: [{ index: 0, hash: "arrowhash", size: 128, row_count: 3 }],
+            complete: true,
+          }),
+        },
+        "application/vnd.apache.arrow.stream": {
+          url: `http://127.0.0.1:${blobPort}/blob/arrowhash`,
+        },
+      },
+    };
+    const output = resolveManifestSync(manifest, blobPort);
+    expect(output).not.toBeNull();
+    if (output && output.output_type === "display_data") {
+      expect(output.data[ARROW_STREAM_MANIFEST_MIME]).toMatchObject({
+        chunks: [
+          {
+            hash: "arrowhash",
+            url: `http://127.0.0.1:${blobPort}/blob/arrowhash`,
+          },
+        ],
+      });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -423,6 +455,29 @@ describe("resolveDataBundle", () => {
 
     const result = await resolveDataBundle(data, blobPort);
     expect(result["application/vnd.vegalite.v5+json"]).toEqual(vegaSpec);
+  });
+
+  it("adds blob URLs to Arrow stream manifest chunks", async () => {
+    const data: Record<string, ContentRef> = {
+      [ARROW_STREAM_MANIFEST_MIME]: {
+        inline: JSON.stringify({
+          version: 1,
+          content_type: "application/vnd.apache.arrow.stream",
+          chunks: [{ index: 0, hash: "chunkhash", size: 256, row_count: 4 }],
+          complete: true,
+        }),
+      },
+    };
+
+    const result = await resolveDataBundle(data, blobPort);
+    expect(result[ARROW_STREAM_MANIFEST_MIME]).toMatchObject({
+      chunks: [
+        {
+          hash: "chunkhash",
+          url: `http://127.0.0.1:${blobPort}/blob/chunkhash`,
+        },
+      ],
+    });
   });
 
   it("falls back to raw string for invalid JSON in json MIME type", async () => {

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -1,6 +1,9 @@
 import type { HostBlobResolver } from "@nteract/notebook-host";
 import type { JupyterOutput } from "../types";
 
+export const ARROW_STREAM_MANIFEST_MIME =
+  "application/vnd.nteract.arrow-stream-manifest+json";
+
 export type BlobResolverInput = HostBlobResolver | number;
 
 function normalizeBlobResolver(input: BlobResolverInput): HostBlobResolver {
@@ -221,7 +224,11 @@ export async function resolveDataBundle(
     const content = contents[i];
     if (mimeType.includes("json")) {
       try {
-        resolved[mimeType] = JSON.parse(content);
+        const parsed = JSON.parse(content);
+        resolved[mimeType] =
+          mimeType === ARROW_STREAM_MANIFEST_MIME
+            ? attachArrowManifestChunkUrls(parsed, blobResolver)
+            : parsed;
       } catch {
         resolved[mimeType] = content;
       }
@@ -246,7 +253,11 @@ function resolveDataBundleSync(
     if (content === null) return null;
     if (mimeType.includes("json")) {
       try {
-        resolved[mimeType] = JSON.parse(content);
+        const parsed = JSON.parse(content);
+        resolved[mimeType] =
+          mimeType === ARROW_STREAM_MANIFEST_MIME
+            ? attachArrowManifestChunkUrls(parsed, blobResolver)
+            : parsed;
       } catch {
         resolved[mimeType] = content;
       }
@@ -255,6 +266,32 @@ function resolveDataBundleSync(
     }
   }
   return resolved;
+}
+
+function attachArrowManifestChunkUrls(
+  value: unknown,
+  blobResolverInput: BlobResolverInput,
+): unknown {
+  if (typeof value !== "object" || value === null) return value;
+  const manifest = value as Record<string, unknown>;
+  if (!Array.isArray(manifest.chunks)) return value;
+
+  const blobResolver = normalizeBlobResolver(blobResolverInput);
+  let changed = false;
+  const chunks = manifest.chunks.map((chunk) => {
+    if (typeof chunk !== "object" || chunk === null) return chunk;
+    const chunkRecord = chunk as Record<string, unknown>;
+    if (typeof chunkRecord.url === "string") return chunk;
+    if (typeof chunkRecord.hash !== "string") return chunk;
+    changed = true;
+    return {
+      ...chunkRecord,
+      url: blobResolver.url({ blob: chunkRecord.hash }),
+    };
+  });
+
+  if (!changed) return value;
+  return { ...manifest, chunks };
 }
 
 /**

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eda05e8ff1c1b6f633827867a952e5c51dc104d9be2c79df42d2d98132590d22
-size 1602172
+oid sha256:1df7ddcd09654c0d6cd0388326affb6cb63384b035c442c268870adfd665e2fd
+size 1600723

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d62e026e9e4f3bdddd08dde16b4a50a1e9e4977feb458bd1b342520922e57033
-size 1476789
+oid sha256:130e4107b8798c19d9228fb7748b846a94db1213ec66daec420af232ab1ed3d9
+size 1476840

--- a/crates/kernel-env/src/launcher.rs
+++ b/crates/kernel-env/src/launcher.rs
@@ -60,6 +60,12 @@ pub const LAUNCHER_FILES: &[(&str, &str)] = &[
         include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py"),
     ),
     (
+        "_progressive.py",
+        include_str!(
+            "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py"
+        ),
+    ),
+    (
         "_refs.py",
         include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py"),
     ),

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -774,41 +774,49 @@ pub async fn preflight_ref_buffers(
         if mime != notebook_doc::mime::BLOB_REF_MIME {
             continue;
         }
-        let declared_hash = body.get("hash").and_then(|v| v.as_str()).unwrap_or("");
-        let target_ct = body
-            .get("content_type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let buf_idx = body
-            .get("buffer_index")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as usize;
-        if target_ct.is_empty() || declared_hash.is_empty() {
-            tracing::warn!(
-                "[dx] blob-ref MIME missing hash or content_type (skipping buffer preflight)"
-            );
-            continue;
+        let mut entries = Vec::new();
+        if let Some(refs) = body.get("refs").and_then(|v| v.as_array()) {
+            entries.extend(refs.iter());
+        } else {
+            entries.push(body);
         }
-        let Some(buf) = buffers.get(buf_idx) else {
-            tracing::warn!(
-                "[dx] blob-ref buffer_index {} out of range ({} buffers); skipping",
-                buf_idx,
-                buffers.len()
-            );
-            continue;
-        };
-        match blob_store.put(buf, target_ct).await {
-            Ok(computed) => {
-                if computed != declared_hash {
-                    tracing::warn!(
-                        "[dx] blob-ref hash mismatch: declared={} computed={} — ContentRef will drop",
-                        declared_hash,
-                        computed
-                    );
-                }
+        for entry in entries {
+            let declared_hash = entry.get("hash").and_then(|v| v.as_str()).unwrap_or("");
+            let target_ct = entry
+                .get("content_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let buf_idx = entry
+                .get("buffer_index")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+            if target_ct.is_empty() || declared_hash.is_empty() {
+                tracing::warn!(
+                    "[dx] blob-ref MIME missing hash or content_type (skipping buffer preflight)"
+                );
+                continue;
             }
-            Err(err) => {
-                tracing::warn!("[dx] blob-ref buffer put failed: {}", err);
+            let Some(buf) = buffers.get(buf_idx) else {
+                tracing::warn!(
+                    "[dx] blob-ref buffer_index {} out of range ({} buffers); skipping",
+                    buf_idx,
+                    buffers.len()
+                );
+                continue;
+            };
+            match blob_store.put(buf, target_ct).await {
+                Ok(computed) => {
+                    if computed != declared_hash {
+                        tracing::warn!(
+                            "[dx] blob-ref hash mismatch: declared={} computed={} — ContentRef will drop",
+                            declared_hash,
+                            computed
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!("[dx] blob-ref buffer put failed: {}", err);
+                }
             }
         }
     }
@@ -1052,7 +1060,9 @@ async fn convert_data_bundle(
                 }
             }
             _ => {
-                tracing::warn!("[dx] blob-ref MIME missing hash or content_type (dropping)");
+                if !ref_value.get("refs").is_some_and(|value| value.is_array()) {
+                    tracing::warn!("[dx] blob-ref MIME missing hash or content_type (dropping)");
+                }
             }
         }
     }
@@ -1717,6 +1727,60 @@ mod tests {
             other => panic!("expected blob ref, got {other:?}"),
         }
         assert!(!data.contains_key(notebook_doc::mime::BLOB_REF_MIME));
+    }
+
+    #[tokio::test]
+    async fn preflight_ref_buffers_writes_multiple_refs() {
+        use sha2::Digest;
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+
+        let first = b"ARROW-chunk-one";
+        let second = b"ARROW-chunk-two";
+        let first_hash = hex::encode(sha2::Sha256::digest(first));
+        let second_hash = hex::encode(sha2::Sha256::digest(second));
+
+        let nbformat = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                notebook_doc::mime::BLOB_REF_MIME: {
+                    "refs": [
+                        {
+                            "hash": first_hash.clone(),
+                            "content_type": "application/vnd.apache.arrow.stream",
+                            "size": first.len(),
+                            "buffer_index": 0,
+                        },
+                        {
+                            "hash": second_hash.clone(),
+                            "content_type": "application/vnd.apache.arrow.stream",
+                            "size": second.len(),
+                            "buffer_index": 1,
+                        },
+                    ],
+                },
+                "application/vnd.nteract.arrow-stream-manifest+json": {
+                    "chunks": [
+                        {"hash": first_hash.clone()},
+                        {"hash": second_hash.clone()},
+                    ],
+                    "complete": true,
+                },
+            },
+        });
+
+        preflight_ref_buffers(&nbformat, &[first.to_vec(), second.to_vec()], &blob_store).await;
+
+        assert!(blob_store.exists(&first_hash));
+        assert!(blob_store.exists(&second_hash));
+
+        let manifest = create_manifest(&nbformat, &blob_store, 1024).await.unwrap();
+        let data = match manifest {
+            OutputManifest::DisplayData { data, .. } => data,
+            other => panic!("expected DisplayData, got {other:?}"),
+        };
+        assert!(!data.contains_key(notebook_doc::mime::BLOB_REF_MIME));
+        assert!(data.contains_key("application/vnd.nteract.arrow-stream-manifest+json"));
     }
 
     #[tokio::test]

--- a/crates/sift-wasm/src/store.rs
+++ b/crates/sift-wasm/src/store.rs
@@ -21,11 +21,12 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use wasm_bindgen::prelude::*;
 
 /// A loaded dataset stored in WASM memory.
 struct DataStore {
+    schema: Option<Arc<arrow::datatypes::Schema>>,
     batches: Vec<RecordBatch>,
     /// Prefix sum of batch row counts for O(log n) row→batch lookup
     batch_offsets: Vec<usize>,
@@ -37,6 +38,7 @@ struct DataStore {
     /// Original column arrays saved before casting, keyed by column index.
     /// Used to restore original data when casting back to the original type.
     original_columns: HashMap<usize, (Vec<arrow::array::ArrayRef>, String)>,
+    streaming_complete: bool,
 }
 
 #[derive(Serialize)]
@@ -121,8 +123,9 @@ where
     })
 }
 
-/// Store a vec of RecordBatches, returning a handle.
-fn store_batches(batches: Vec<RecordBatch>, schema: &arrow::datatypes::Schema) -> u32 {
+fn schema_metadata(
+    schema: &arrow::datatypes::Schema,
+) -> (usize, Vec<String>, Vec<String>, Vec<Option<String>>) {
     let num_cols = schema.fields().len();
     let col_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
     let col_types: Vec<String> = schema
@@ -136,12 +139,78 @@ fn store_batches(batches: Vec<RecordBatch>, schema: &arrow::datatypes::Schema) -
         .map(|f| DataStore::extract_timezone(f.data_type()))
         .collect();
 
-    let mut batch_offsets = Vec::new();
-    let mut total_rows = 0;
-    for batch in &batches {
-        batch_offsets.push(total_rows);
-        total_rows += batch.num_rows();
+    (num_cols, col_names, col_types, col_timezones)
+}
+
+fn empty_streaming_store() -> DataStore {
+    DataStore {
+        schema: None,
+        batches: Vec::new(),
+        batch_offsets: Vec::new(),
+        total_rows: 0,
+        num_cols: 0,
+        col_names: Vec::new(),
+        col_types: Vec::new(),
+        col_timezones: Vec::new(),
+        original_columns: HashMap::new(),
+        streaming_complete: false,
     }
+}
+
+fn set_store_schema(store: &mut DataStore, schema: Arc<arrow::datatypes::Schema>) {
+    let (num_cols, col_names, col_types, col_timezones) = schema_metadata(&schema);
+    store.schema = Some(schema);
+    store.num_cols = num_cols;
+    store.col_names = col_names;
+    store.col_types = col_types;
+    store.col_timezones = col_timezones;
+}
+
+fn append_batches_to_store(
+    store: &mut DataStore,
+    schema: Arc<arrow::datatypes::Schema>,
+    batches: Vec<RecordBatch>,
+) -> Result<(), String> {
+    if store.streaming_complete {
+        return Err("Arrow stream store is already finished".to_string());
+    }
+
+    if let Some(existing) = &store.schema {
+        if existing.as_ref() != schema.as_ref() {
+            return Err("Arrow stream chunk schema mismatch".to_string());
+        }
+    } else {
+        set_store_schema(store, schema);
+    }
+
+    for batch in batches {
+        store.batch_offsets.push(store.total_rows);
+        store.total_rows += batch.num_rows();
+        store.batches.push(batch);
+    }
+
+    Ok(())
+}
+
+fn arrow_stream_batches(
+    ipc_bytes: &[u8],
+) -> Result<(Arc<arrow::datatypes::Schema>, Vec<RecordBatch>), String> {
+    let cursor = Cursor::new(ipc_bytes);
+    let reader = StreamReader::try_new(cursor, None).map_err(|e| e.to_string())?;
+    let schema = reader.schema();
+    let mut batches = Vec::new();
+    for batch in reader {
+        batches.push(batch.map_err(|e| e.to_string())?);
+    }
+    Ok((schema, batches))
+}
+
+/// Store a vec of RecordBatches, returning a handle.
+fn store_batches(batches: Vec<RecordBatch>, schema: Arc<arrow::datatypes::Schema>) -> u32 {
+    let mut store = empty_streaming_store();
+    append_batches_to_store(&mut store, schema, batches)
+        .expect("new store should accept its initial batches");
+    store.streaming_complete = true;
 
     let handle = {
         let mut h = NEXT_HANDLE.lock().unwrap_or_else(|e| e.into_inner());
@@ -151,19 +220,7 @@ fn store_batches(batches: Vec<RecordBatch>, schema: &arrow::datatypes::Schema) -
     };
 
     with_stores(|stores| {
-        stores.insert(
-            handle,
-            DataStore {
-                batches,
-                batch_offsets,
-                total_rows,
-                num_cols,
-                col_names,
-                col_types,
-                col_timezones,
-                original_columns: HashMap::new(),
-            },
-        );
+        stores.insert(handle, store);
     });
 
     handle
@@ -182,7 +239,7 @@ pub fn load_ipc(ipc_bytes: &[u8]) -> Result<u32, JsValue> {
         batches.push(batch.map_err(|e| JsValue::from_str(&e.to_string()))?);
     }
 
-    Ok(store_batches(batches, &schema))
+    Ok(store_batches(batches, schema))
 }
 
 /// Load Parquet bytes into WASM memory. Returns a handle for subsequent operations.
@@ -202,7 +259,51 @@ pub fn load_parquet(parquet_bytes: &[u8]) -> Result<u32, JsValue> {
         batches.push(batch.map_err(|e| JsValue::from_str(&e.to_string()))?);
     }
 
-    Ok(store_batches(batches, &schema))
+    Ok(store_batches(batches, schema))
+}
+
+/// Create an empty Arrow stream store. Append self-contained Arrow IPC stream
+/// chunks with `append_arrow_stream_chunk`, then call `finish_arrow_stream_store`
+/// when the manifest is complete.
+#[wasm_bindgen]
+pub fn create_arrow_stream_store() -> u32 {
+    let handle = {
+        let mut h = NEXT_HANDLE.lock().unwrap_or_else(|e| e.into_inner());
+        let id = *h;
+        *h += 1;
+        id
+    };
+
+    with_stores(|stores| {
+        stores.insert(handle, empty_streaming_store());
+    });
+
+    handle
+}
+
+/// Append one self-contained Arrow IPC stream chunk into an existing store.
+/// The first chunk initializes the store schema; later chunks must match it.
+#[wasm_bindgen]
+pub fn append_arrow_stream_chunk(handle: u32, ipc_bytes: &[u8]) -> Result<(), JsValue> {
+    let (schema, batches) = arrow_stream_batches(ipc_bytes).map_err(|e| JsValue::from_str(&e))?;
+    with_stores(|stores| {
+        let store = stores
+            .get_mut(&handle)
+            .ok_or_else(|| JsValue::from_str(&format!("Invalid handle: {}", handle)))?;
+        append_batches_to_store(store, schema, batches).map_err(|e| JsValue::from_str(&e))
+    })
+}
+
+/// Mark an Arrow stream store as complete. Further chunk appends are rejected.
+#[wasm_bindgen]
+pub fn finish_arrow_stream_store(handle: u32) -> Result<(), JsValue> {
+    with_stores(|stores| {
+        let store = stores
+            .get_mut(&handle)
+            .ok_or_else(|| JsValue::from_str(&format!("Invalid handle: {}", handle)))?;
+        store.streaming_complete = true;
+        Ok(())
+    })
 }
 
 /// Free a loaded dataset from WASM memory.
@@ -1495,7 +1596,7 @@ pub fn load_parquet_row_group(
 
     if handle == 0 {
         // Create new store
-        Ok(store_batches(batches, &schema))
+        Ok(store_batches(batches, schema))
     } else {
         // Append to existing store
         with_stores(|stores| {
@@ -2129,6 +2230,99 @@ mod tests {
         );
     }
 
+    fn ipc_stream(schema: Arc<Schema>, columns: Vec<ArrayRef>) -> Vec<u8> {
+        let batch = RecordBatch::try_new(schema.clone(), columns).expect("record batch");
+        let mut buf = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buf, &schema).expect("stream writer");
+            writer.write(&batch).expect("write batch");
+            writer.finish().expect("finish stream");
+        }
+        buf
+    }
+
+    fn append_ipc_chunk(store: &mut DataStore, ipc_bytes: &[u8]) -> Result<(), String> {
+        let (schema, batches) = arrow_stream_batches(ipc_bytes)?;
+        append_batches_to_store(store, schema, batches)
+    }
+
+    #[test]
+    fn arrow_stream_chunks_append_to_empty_store() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let first = ipc_stream(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["alpha", "beta"])) as ArrayRef,
+            ],
+        );
+        let second = ipc_stream(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![3])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["gamma"])) as ArrayRef,
+            ],
+        );
+        let mut store = empty_streaming_store();
+
+        append_ipc_chunk(&mut store, &first).expect("first chunk");
+        append_ipc_chunk(&mut store, &second).expect("second chunk");
+
+        assert_eq!(store.total_rows, 3);
+        assert_eq!(store.batch_offsets, vec![0, 2]);
+        assert_eq!(store.col_names, vec!["id", "name"]);
+        assert_eq!(store.col_types, vec!["numeric", "categorical"]);
+        assert_eq!(
+            cell_string_for(&store, 1, store.batches[0].column(1).as_ref(), 1),
+            "beta"
+        );
+        assert_eq!(
+            cell_string_for(&store, 1, store.batches[1].column(1).as_ref(), 0),
+            "gamma"
+        );
+    }
+
+    #[test]
+    fn arrow_stream_chunks_reject_schema_mismatch() {
+        let first_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let second_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+        let first = ipc_stream(
+            first_schema,
+            vec![Arc::new(Int32Array::from(vec![1])) as ArrayRef],
+        );
+        let second = ipc_stream(
+            second_schema,
+            vec![Arc::new(StringArray::from(vec!["bad"])) as ArrayRef],
+        );
+        let mut store = empty_streaming_store();
+
+        append_ipc_chunk(&mut store, &first).expect("first chunk");
+        let err = append_ipc_chunk(&mut store, &second).expect_err("schema mismatch");
+
+        assert!(err.contains("schema mismatch"));
+        assert_eq!(store.total_rows, 1);
+    }
+
+    #[test]
+    fn arrow_stream_chunks_reject_appends_after_finish() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let chunk = ipc_stream(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1])) as ArrayRef],
+        );
+        let mut store = empty_streaming_store();
+
+        append_ipc_chunk(&mut store, &chunk).expect("first chunk");
+        store.streaming_complete = true;
+        let err = append_ipc_chunk(&mut store, &chunk).expect_err("finished store");
+
+        assert!(err.contains("already finished"));
+        assert_eq!(store.total_rows, 1);
+    }
+
     #[test]
     fn store_filter_rows_matches_struct_value_count_labels() {
         let schema = Arc::new(Schema::new(vec![Field::new(
@@ -2165,10 +2359,13 @@ mod tests {
         let first_batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(first_metrics) as ArrayRef])
                 .expect("record batch");
-        let second_batch =
-            RecordBatch::try_new(schema, vec![Arc::new(second_metrics.clone()) as ArrayRef])
-                .expect("record batch");
+        let second_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(second_metrics.clone()) as ArrayRef],
+        )
+        .expect("record batch");
         let store = DataStore {
+            schema: Some(schema),
             batches: vec![first_batch, second_batch],
             batch_offsets: vec![0, 1],
             total_rows: 2,
@@ -2177,6 +2374,7 @@ mod tests {
             col_types: vec!["categorical".to_string()],
             col_timezones: vec![None],
             original_columns: HashMap::new(),
+            streaming_complete: true,
         };
         let formatter = ArrayFormatter::try_new(&second_metrics, &Default::default()).unwrap();
         let selected = formatter.value(0).to_string();
@@ -2211,6 +2409,7 @@ mod tests {
         )
         .expect("record batch");
         let store = DataStore {
+            schema: Some(schema),
             batches: vec![batch],
             batch_offsets: vec![0],
             total_rows: 2,
@@ -2229,6 +2428,7 @@ mod tests {
             ],
             col_timezones: vec![None, None, None, None],
             original_columns: HashMap::new(),
+            streaming_complete: true,
         };
 
         let out = viewport_cells_for(&store, &[1, 0]);
@@ -2263,6 +2463,7 @@ mod tests {
         let batch = RecordBatch::try_new(schema, vec![Arc::new(NullArray::new(3)) as ArrayRef])
             .expect("record batch");
         let store = DataStore {
+            schema: Some(batch.schema()),
             batches: vec![batch],
             batch_offsets: vec![0],
             total_rows: 3,
@@ -2271,6 +2472,7 @@ mod tests {
             col_types: vec!["categorical".to_string()],
             col_timezones: vec![None],
             original_columns: HashMap::new(),
+            streaming_complete: true,
         };
 
         let out = viewport_cells_for(&store, &[0, 2]);
@@ -2320,6 +2522,7 @@ mod tests {
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(arr) as ArrayRef]).expect("record batch");
         DataStore {
+            schema: Some(batch.schema()),
             batches: vec![batch],
             batch_offsets: vec![0],
             total_rows,
@@ -2328,6 +2531,7 @@ mod tests {
             col_types: vec!["categorical".to_string()],
             col_timezones: vec![None],
             original_columns: HashMap::new(),
+            streaming_complete: true,
         }
     }
 
@@ -2448,6 +2652,7 @@ mod tests {
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(arr) as ArrayRef]).expect("record batch");
         DataStore {
+            schema: Some(batch.schema()),
             batches: vec![batch],
             batch_offsets: vec![0],
             total_rows,
@@ -2456,6 +2661,7 @@ mod tests {
             col_types: vec!["categorical".to_string()],
             col_timezones: vec![None],
             original_columns: HashMap::new(),
+            streaming_complete: true,
         }
     }
 

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -24,6 +24,7 @@ export const DEFAULT_MIME_PRIORITY = [
   // DataFrames — sift renders Arrow IPC/parquet as an interactive table. Must
   // outrank text/html so pandas's HTML fallback doesn't win when both
   // are present (dx emits table bytes + text/html for rich table outputs).
+  "application/vnd.nteract.arrow-stream-manifest+json",
   "application/vnd.apache.arrow.stream",
   "application/vnd.apache.parquet",
   // HTML, PDF, markdown, and LaTeX

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -24,6 +24,9 @@ export type ViewportCells = {
 type PredicateModule = {
   // Data store
   load_ipc(ipc_bytes: Uint8Array): number;
+  create_arrow_stream_store(): number;
+  append_arrow_stream_chunk(handle: number, ipc_bytes: Uint8Array): void;
+  finish_arrow_stream_store(handle: number): void;
   load_parquet(parquet_bytes: Uint8Array): number;
   parquet_metadata(parquet_bytes: Uint8Array): Uint32Array;
   parquet_column_hints(parquet_bytes: Uint8Array): ParquetColumnHint[];

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -1,8 +1,42 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { SiftFocusStatus, SiftScrollHandoffCue } from "./handoff";
 import { SiftTable } from "./react";
 import type { Column, TableData } from "./table";
+
+const predicateModule = vi.hoisted(() => ({
+  create_arrow_stream_store: vi.fn(() => 9),
+  append_arrow_stream_chunk: vi.fn(),
+  finish_arrow_stream_store: vi.fn(),
+  arrow_ipc_column_hints_with_row_count: vi.fn(() => []),
+  num_rows: vi.fn(() => 2),
+  num_cols: vi.fn(() => 2),
+  col_names: vi.fn(() => ["id", "name"]),
+  col_type: vi.fn((_handle: number, col: number) => (col === 0 ? "numeric" : "categorical")),
+  col_timezone: vi.fn(() => null),
+  store_histogram: vi.fn(() => []),
+  store_temporal_histogram: vi.fn(() => []),
+  store_value_counts: vi.fn(() => []),
+  store_bool_counts: vi.fn(() => [0, 0, 0]),
+  store_viewport_cells: vi.fn(() => ({
+    rows: [],
+    strings: [],
+    numeric_values: [],
+    nulls: [],
+  })),
+  is_null: vi.fn(() => false),
+  get_cell_string: vi.fn((_handle: number, row: number, col: number) =>
+    col === 0 ? String(row + 1) : `row ${row + 1}`,
+  ),
+  get_cell_f64: vi.fn((_handle: number, row: number) => row + 1),
+  free: vi.fn(),
+}));
+
+vi.mock("./predicate", () => ({
+  ensureModule: vi.fn(async () => predicateModule),
+  getModuleSync: () => predicateModule,
+  loadIpc: vi.fn(async () => 9),
+}));
 
 function makeColumns(): Column[] {
   return [
@@ -46,6 +80,7 @@ function makeTableData(rows: unknown[][]): TableData {
 
 describe("SiftTable", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
@@ -149,6 +184,44 @@ describe("SiftTable", () => {
 
     const loading = container.querySelector(".sift-loading");
     expect(loading?.textContent).toContain("404");
+
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+  });
+
+  it("loads Arrow stream manifest chunks through the appendable WASM store", async () => {
+    vi.useRealTimers();
+    const chunkBytes = new Uint8Array([1, 2, 3, 4]);
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => chunkBytes.buffer,
+      }),
+    );
+
+    const { container } = render(
+      <SiftTable
+        source={{
+          kind: "arrow-stream-manifest",
+          manifest: {
+            chunks: [{ url: "http://127.0.0.1:9000/blob/chunk" }],
+            complete: true,
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
+      expect(predicateModule.finish_arrow_stream_store).toHaveBeenCalledWith(9);
+      expect(container.querySelector(".sift-table-container")).not.toBeNull();
+    });
+
+    expect(predicateModule.create_arrow_stream_store).toHaveBeenCalledTimes(1);
+    expect(predicateModule.append_arrow_stream_chunk.mock.calls[0][0]).toBe(9);
+    expect(Array.from(predicateModule.append_arrow_stream_chunk.mock.calls[0][1])).toEqual([
+      1, 2, 3, 4,
+    ]);
 
     vi.unstubAllGlobals();
     vi.useFakeTimers();

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { SiftFocusStatus, SiftScrollHandoffCue } from "./handoff";
 import { SiftTable } from "./react";
+import type { SiftSource } from "./react";
 import type { Column, TableData } from "./table";
 
 const predicateModule = vi.hoisted(() => ({
@@ -222,6 +223,40 @@ describe("SiftTable", () => {
     expect(Array.from(predicateModule.append_arrow_stream_chunk.mock.calls[0][1])).toEqual([
       1, 2, 3, 4,
     ]);
+
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+  });
+
+  it("does not reload a manifest source when only object identity changes", async () => {
+    vi.useRealTimers();
+    const chunkBytes = new Uint8Array([1, 2, 3, 4]);
+    vi.stubGlobal("fetch", () =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => chunkBytes.buffer,
+      }),
+    );
+
+    const source = (): SiftSource => ({
+      kind: "arrow-stream-manifest",
+      manifest: {
+        chunks: [{ url: "http://127.0.0.1:9000/blob/chunk" }],
+        complete: true,
+      },
+    });
+
+    const { rerender } = render(<SiftTable source={source()} />);
+
+    await waitFor(() => {
+      expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<SiftTable source={source()} />);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
+    expect(predicateModule.finish_arrow_stream_store).toHaveBeenCalledTimes(1);
 
     vi.unstubAllGlobals();
     vi.useFakeTimers();

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -8,6 +8,9 @@
  *   <SiftTable url="/data.arrow" onChange={handleState} />
  *   <SiftTable url="/data.parquet" onChange={handleState} />
  *
+ * Or with a normalized source:
+ *   <SiftTable source={{ kind: "arrow-stream-manifest", manifest }} onChange={handleState} />
+ *
  * The component manages the imperative TableEngine lifecycle —
  * mounting on first render, updating on data changes, and
  * cleaning up on unmount.
@@ -35,7 +38,24 @@ import { createWasmTableData } from "./wasm-table-data";
 
 // --- Props ---
 
+export type ArrowStreamManifestChunk = {
+  url: string;
+  row_count?: number;
+};
+
+export type ArrowStreamManifest = {
+  chunks: ArrowStreamManifestChunk[];
+  complete?: boolean;
+};
+
+export type SiftSource =
+  | { kind: "table-data"; data: TableData }
+  | { kind: "url"; url: string }
+  | { kind: "arrow-stream-manifest"; manifest: ArrowStreamManifest };
+
 export type SiftTableProps = {
+  /** Normalized table source. Prefer this for new source types. */
+  source?: SiftSource;
   /** Pre-built TableData object. Mutually exclusive with `url`. */
   data?: TableData;
   /** URL to load data from (Arrow IPC or Parquet, auto-detected). Mutually exclusive with `data`. */
@@ -237,6 +257,7 @@ function updateWasmSummaries(
 // --- Component ---
 
 export function SiftTable({
+  source,
   data,
   url,
   typeOverrides,
@@ -286,9 +307,13 @@ export function SiftTable({
     };
   }, []);
 
+  const dataSource = source?.kind === "table-data" ? source.data : data;
+  const urlSource = source?.kind === "url" ? source.url : url;
+  const manifestSource = source?.kind === "arrow-stream-manifest" ? source.manifest : undefined;
+
   // Mount engine when `data` prop is provided directly
   useEffect(() => {
-    if (!data || !containerRef.current) return;
+    if (!dataSource || !containerRef.current) return;
 
     // Clean up previous engine
     if (engineRef.current) {
@@ -301,7 +326,7 @@ export function SiftTable({
     engineDiv.style.height = "100%";
     containerRef.current.appendChild(engineDiv);
 
-    engineRef.current = createTable(engineDiv, data, {
+    engineRef.current = createTable(engineDiv, dataSource, {
       onChange: stableOnChange,
       footerControl: getFooterControlElement(),
     });
@@ -312,14 +337,131 @@ export function SiftTable({
       engineRef.current = null;
       engineDiv.remove();
     };
-  }, [data, stableOnChange, getFooterControlElement]);
+  }, [dataSource, stableOnChange, getFooterControlElement]);
+
+  // Load Arrow stream manifest chunks through the appendable WASM store.
+  useEffect(() => {
+    if (!manifestSource || !containerRef.current) return;
+
+    let cancelled = false;
+    const container = containerRef.current;
+    let wasmHandle: number | null = null;
+    let engineDiv: HTMLDivElement | null = null;
+
+    function mountEngine(tableData: TableData) {
+      if (engineRef.current) {
+        engineRef.current.destroy();
+        engineRef.current = null;
+      }
+      engineDiv?.remove();
+      engineDiv = document.createElement("div");
+      engineDiv.style.height = "100%";
+      container.appendChild(engineDiv);
+      engineRef.current = createTable(engineDiv, tableData, {
+        onChange: stableOnChange,
+        footerControl: getFooterControlElement(),
+      });
+    }
+
+    async function fetchChunkBytes(chunk: ArrowStreamManifestChunk, index: number) {
+      if (!chunk.url) {
+        throw new Error(`Arrow stream manifest chunk ${index} is missing a URL`);
+      }
+      const response = await fetch(chunk.url);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch Arrow stream chunk ${index}: ${response.status} ${response.statusText}`,
+        );
+      }
+      return new Uint8Array(await response.arrayBuffer());
+    }
+
+    async function loadFromManifest() {
+      setStatus("loading");
+      setError(null);
+
+      const chunks = manifestSource.chunks;
+      if (chunks.length === 0) {
+        throw new Error("Arrow stream manifest has no chunks");
+      }
+
+      await ensureModule();
+      if (cancelled) return;
+
+      const mod = getModuleSync();
+      const handle = mod.create_arrow_stream_store();
+      wasmHandle = handle;
+
+      const firstBytes = await fetchChunkBytes(chunks[0], 0);
+      if (cancelled) return;
+      mod.append_arrow_stream_chunk(handle, firstBytes);
+
+      const columnHints = mod.arrow_ipc_column_hints_with_row_count(
+        firstBytes,
+        mod.num_rows(handle),
+      );
+      const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
+      const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+      tableData.prefetchViewport = prefetchViewport;
+      tableData.recomputeSummaries = () =>
+        updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
+
+      applyParquetColumnHints(columns, columnHints);
+      applyColumnOverrides(columns, columnOverrides);
+
+      updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
+
+      if (cancelled) return;
+      mountEngine(tableData);
+      setStatus("ready");
+
+      for (let i = 1; i < chunks.length; i++) {
+        if (cancelled) return;
+        await new Promise((r) => setTimeout(r, 0));
+        if (cancelled) return;
+        const bytes = await fetchChunkBytes(chunks[i], i);
+        if (cancelled) return;
+        mod.append_arrow_stream_chunk(handle, bytes);
+        tableData.rowCount = mod.num_rows(handle);
+        updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
+        engineRef.current?.onBatchAppended();
+      }
+
+      if (manifestSource.complete !== false) {
+        mod.finish_arrow_stream_store(handle);
+        engineRef.current?.setStreamingDone();
+      }
+    }
+
+    loadFromManifest().catch((err) => {
+      if (!cancelled) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        setStatus("error");
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (wasmHandle !== null) {
+        try {
+          getModuleSync().free(wasmHandle);
+        } catch {
+          /* module may not be loaded */
+        }
+      }
+      engineRef.current?.destroy();
+      engineRef.current = null;
+      engineDiv?.remove();
+    };
+  }, [manifestSource, columnOverrides, stableOnChange, getFooterControlElement]);
 
   // Load from URL when `url` prop is provided.
   // Detects format via Content-Type header + magic byte fallback:
   // - Parquet: buffer fully, load via WASM with progressive row groups
   // - Arrow IPC: stream batches (existing behavior)
   useEffect(() => {
-    if (!url || !containerRef.current) return;
+    if (!urlSource || !containerRef.current) return;
 
     let cancelled = false;
     const container = containerRef.current;
@@ -444,7 +586,7 @@ export function SiftTable({
       setStatus("loading");
       setError(null);
 
-      const response = await fetch(url!);
+      const response = await fetch(urlSource);
       if (!response.ok) {
         throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
       }
@@ -480,7 +622,7 @@ export function SiftTable({
       engineRef.current = null;
       engineDiv?.remove();
     };
-  }, [url, typeOverrides, columnOverrides, stableOnChange, getFooterControlElement]);
+  }, [urlSource, typeOverrides, columnOverrides, stableOnChange, getFooterControlElement]);
 
   return (
     <div ref={containerRef} className={className} style={{ height: "100%", ...style }}>

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -74,6 +74,15 @@ export type SiftTableProps = {
   style?: React.CSSProperties;
 };
 
+function arrowStreamManifestKey(manifest: ArrowStreamManifest | undefined): string | null {
+  if (!manifest) return null;
+  const complete = manifest.complete === false ? "open" : "complete";
+  const chunks = manifest.chunks
+    .map((chunk) => `${chunk.url}\u0001${chunk.row_count ?? ""}`)
+    .join("\u0000");
+  return `${complete}\u0002${chunks}`;
+}
+
 // --- Format detection ---
 
 /** Parquet magic bytes: PAR1 */
@@ -310,6 +319,7 @@ export function SiftTable({
   const dataSource = source?.kind === "table-data" ? source.data : data;
   const urlSource = source?.kind === "url" ? source.url : url;
   const manifestSource = source?.kind === "arrow-stream-manifest" ? source.manifest : undefined;
+  const manifestKey = arrowStreamManifestKey(manifestSource);
 
   // Mount engine when `data` prop is provided directly
   useEffect(() => {
@@ -454,7 +464,7 @@ export function SiftTable({
       engineRef.current = null;
       engineDiv?.remove();
     };
-  }, [manifestSource, columnOverrides, stableOnChange, getFooterControlElement]);
+  }, [manifestKey, columnOverrides, stableOnChange, getFooterControlElement]);
 
   // Load from URL when `url` prop is provided.
   // Detects format via Content-Type header + magic byte fallback:

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -29,6 +29,12 @@ The phases below are intended as targeted commits in this PR, not separate PRs.
   notebook output format.
   <https://docs.pola.rs/api/python/stable/reference/api/polars.DataFrame.write_ipc_stream.html>
   <https://docs.pola.rs/api/python/stable/reference/api/polars.read_ipc_stream.html>
+- The Arrow PyCapsule interface standardizes Python export methods such as
+  `__arrow_c_stream__()` and the `arrow_array_stream` capsule name. This gives
+  the launcher a producer-neutral path for pandas, polars, pyarrow, DuckDB,
+  cuDF, narwhals, and other Arrow-compatible DataFrames without depending on
+  producer-specific `_export_to_c` or PyArrow-only object types.
+  <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>
 - Jupyter-compatible incremental replacement is `display_id` plus
   `update_display_data`. It can carry the same MIME-bundle shape as
   `display_data`, so it is the compatibility bridge for progressive updates
@@ -127,7 +133,22 @@ streaming behavior harder to reason about.
 
 ### Python Serialization Policy
 
-pandas should convert through PyArrow and write Arrow IPC stream bytes:
+The primary producer contract should be the Arrow PyCapsule stream protocol:
+
+```python
+reader = pa.RecordBatchReader.from_stream(obj)  # consumes __arrow_c_stream__()
+with pa.ipc.new_stream(sink, reader.schema) as writer:
+    for batch in reader:
+        writer.write_batch(batch)
+```
+
+This matches the DataFrame binding model used by Jupyter Scatter: pandas,
+polars, and any DataFrame implementing the Arrow PyCapsule interface can be
+handled through the same stream import path. Producer-specific logic should be
+fallback or row-limiting glue, not the default serialization model.
+
+For older pandas versions that do not expose `__arrow_c_stream__`, convert
+through PyArrow and write Arrow IPC stream bytes:
 
 ```python
 table = pa.Table.from_pandas(df)  # keep pandas schema metadata
@@ -139,7 +160,8 @@ Do not use `preserve_index=False` for the canonical path. It removes index
 metadata that Arrow can preserve for us. Let the default preserve policy keep
 RangeIndex metadata-only and materialize non-range indexes as tracked columns.
 
-polars should write Arrow IPC stream bytes directly:
+For older polars versions that do not expose `__arrow_c_stream__`, write Arrow
+IPC stream bytes directly:
 
 ```python
 df.write_ipc_stream(buf)
@@ -150,8 +172,9 @@ the fallback should be text/HTML summary first, not silent metadata loss.
 Parquet fallback is acceptable only as an explicit compatibility fallback with a
 different `content_type`.
 
-narwhals should prefer a backend-native Arrow path before converting to pandas.
-Only fall back to pandas conversion if the backend lacks a stable Arrow export.
+narwhals should prefer its native object when the native object implements
+`__arrow_c_stream__`. Only fall back to pandas conversion if the backend lacks
+a stable Arrow export.
 
 ### Metadata Ownership
 
@@ -494,6 +517,9 @@ unless noted):
   `preserve_index=False`) plus `pa.ipc.new_stream` writing into a
   `pa.BufferOutputStream`.
 - `_serialize_polars` switches to `df.write_ipc_stream(buf)`.
+- `serialize_dataframe` first checks for `__arrow_c_stream__()` and imports via
+  `pa.RecordBatchReader.from_stream(obj)` / PyCapsule fallback. The pandas and
+  polars helpers remain compatibility fallbacks for older library versions.
 - `serialize_dataframe` returns `ARROW_STREAM_MIME` instead of `PARQUET_MIME`.
   Drop `PARQUET_MIME` from the dataframe return path; keep the constant for
   parsing old fixtures only.
@@ -503,9 +529,9 @@ unless noted):
 - Rename helpers from parquet-specific names to Arrow/table names where the
   behavior is now generic. A single `serialize_table` codepath shared by
   pandas/polars/pyarrow is fine.
-- For narwhals, dispatch on backend: prefer `nw.to_native().to_arrow()` (or
-  the backend's native Arrow export), fall back to pandas conversion only if
-  no Arrow export is available.
+- For narwhals, dispatch on backend: prefer the native object's
+  `__arrow_c_stream__()` protocol, fall back to pandas conversion only if no
+  Arrow export is available.
 - Hugging Face: keep the Arrow-table-backed path. `IterableDataset` and other
   streaming HF objects materialize a head sample then fall through to
   `text/llm+plain`; do not silently consume the stream.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -645,6 +645,21 @@ for the staged implementation.
   - confirmed-fix: completion-only manifest updates do not resend chunk bytes,
     and progressive manifest construction reuses the first chunk schema instead
     of reparsing it for every revision.
+- Manual QA on `66829fd` found two stacked large-table truncations.
+  Disposition:
+  - confirmed-fix: automatic `pyarrow.Table` outputs that exceed the one-shot
+    payload cap now emit a complete multi-chunk Arrow stream manifest over the
+    original table instead of silently keeping only `head(n)`. The manifest
+    summary carries `total_rows`, `included_rows`, and `sampled: false`.
+  - confirmed-fix: the launcher/daemon attached-buffer path now accepts a
+    multi-ref blob envelope so every manifest chunk can be sent with the same
+    display message and preflighted into CAS before render resolution.
+  - confirmed-fix: `_progressive.py` is included in the vendored launcher file
+    list so `import nteract_kernel_launcher` succeeds after vendoring.
+  - confirmed-defer: Sift's scroll spacer can still hit browser element-height
+    limits for million-row tables. That is independent of the Arrow producer
+    fix and should land as a Sift virtual-scroller follow-up before marketing
+    arrow-native tables as production-ready for very large local data.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -611,6 +611,8 @@ for the staged implementation.
   - Manifest sources fetch complete chunk URLs in order, append them through the
     WASM stream store, and mark the table complete when the manifest is
     complete.
+  - Manifest loading is keyed by completion state and chunk URLs/row counts, so
+    recreating an equivalent `source` object does not reload the table.
   - the isolated renderer now passes manifest objects to Sift instead of
     collapsing them back to a direct URL.
 - Next: run repo-local `pr-reviewer` for the React manifest append commit and

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -591,9 +591,15 @@ for the staged implementation.
     complete stream exceeds `max_bytes`, the formatter rejects rich output for
     now and relies on summary fallback. Progressive chunking is the intended
     rich path for large single-pass sources.
-- Next: rerun the repo-local `pr-reviewer` after the third review-fix commit,
-  then add manifest routing/rendering only after accepted findings are resolved
-  or deferred here.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `68750098`.
+- Done: `feat(outputs): render arrow stream manifests`
+  - notebook and MCP MIME priority now prefer
+    `application/vnd.nteract.arrow-stream-manifest+json` over the direct Arrow
+    stream sidecar.
+  - manifest resolution attaches blob URLs to `chunks[].hash`, and the Sift
+    renderer loads the first complete chunk through its existing Arrow IPC path.
+- Next: run repo-local `pr-reviewer` for the manifest rendering commit and
+  resolve or record all findings before starting progressive chunk append work.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -598,8 +598,14 @@ for the staged implementation.
     stream sidecar.
   - manifest resolution attaches blob URLs to `chunks[].hash`, and the Sift
     renderer loads the first complete chunk through its existing Arrow IPC path.
-- Next: run repo-local `pr-reviewer` for the manifest rendering commit and
-  resolve or record all findings before starting progressive chunk append work.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `a95e61db`.
+- Done: `feat(sift): add arrow stream chunk store`
+  - sift-wasm can create an empty Arrow stream store, append self-contained IPC
+    stream chunks, reject schema mismatches, and mark the store complete.
+  - this is only the WASM/store seam; React still uses the existing one-shot
+    Arrow IPC load path until the next commit wires manifest chunk appends.
+- Next: run repo-local `pr-reviewer` for the chunk-store seam and resolve or
+  record findings before wiring Sift React to append manifest chunks.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -2,18 +2,46 @@
 
 Issue: https://github.com/nteract/desktop/issues/1816
 
-This note captures the current Python/Rust output path and the next steps for
-making table outputs Arrow-native while preserving ordinary notebook fallback
-behavior.
+This plan updates the post-#2629/#2630/#2632 architecture direction. The short
+version: Arrow IPC stream should become the canonical rich table output for
+notebooks. Parquet should remain a supported input/rendering format and a
+backward-compatibility path for already-saved notebooks, but new pandas, polars,
+pyarrow, narwhals, and Hugging Face table outputs should converge on Arrow IPC.
 
-## Current Path
+## Research Constraints
+
+- Arrow IPC has a streaming format for an arbitrary sequence of record batches
+  and a file/random-access format for a fixed set of batches. The stream format
+  is schema-first and must be read in order, which matches progressive notebook
+  rendering better than parquet's footer-oriented layout.
+  <https://arrow.apache.org/docs/python/ipc.html>
+- Arrow IPC stream writers are intended to write batches to any writable sink,
+  including sockets and other streaming IO. That is the right shape for a future
+  kernel-to-daemon chunk protocol.
+  <https://arrow.apache.org/docs/python/ipc.html>
+- PyArrow preserves pandas index information in Arrow schema metadata. With the
+  default `preserve_index=None`, RangeIndex is metadata-only, while other index
+  types become physical columns tracked by the schema metadata.
+  <https://arrow.apache.org/docs/python/pandas.html>
+- Polars exposes Arrow IPC stream IO directly (`write_ipc_stream` /
+  `read_ipc_stream`), so polars does not need parquet as an intermediate
+  notebook output format.
+  <https://docs.pola.rs/api/python/dev/reference/api/polars.DataFrame.write_ipc_stream.html>
+  <https://docs.pola.rs/api/python/stable/reference/api/polars.read_ipc_stream.html>
+- Jupyter-compatible incremental replacement is `display_id` plus
+  `update_display_data`. It can carry the same MIME-bundle shape as
+  `display_data`, so it is the compatibility bridge for progressive updates
+  while plain notebooks keep `text/plain` / `text/html` fallbacks.
+  <https://jupyter-client.readthedocs.io/en/latest/messaging.html>
+
+## Current Merged State
 
 The launcher registers lazy IPython `mimebundle_formatter` handlers in
 `nteract_kernel_launcher/_bootstrap.py` for pandas, polars, narwhals,
 `pyarrow.Table`, `pyarrow.RecordBatch`, and Hugging Face datasets.
 
-Today the rich table paths serialize bytes, stash the bytes in the kernel-side
-pending buffer map, and return a bundle shaped like:
+Today rich table outputs are stored as content-addressed blobs via
+`application/vnd.nteract.blob-ref+json`:
 
 ```json
 {
@@ -33,33 +61,111 @@ pending buffer map, and return a bundle shaped like:
 }
 ```
 
-The default IPython formatter chain can still add `text/plain` or `text/html`
-fallbacks. That is the compatibility contract: a vanilla notebook should render
-the fallback MIME, while nteract consumes the content-addressed binary payload.
+The daemon preflights attached buffers into the blob store, promotes the wrapped
+`content_type` into the manifest data map, and lifts blob-ref `summary` / `query`
+hints into `metadata[content_type].nteract`. Save resolution externalizes
+`application/vnd.apache.arrow.stream` and `application/vnd.apache.parquet` back
+to a single blob-ref MIME so saved `.ipynb` files do not base64-inline large
+table bytes.
 
-The `pyarrow.Table`, `pyarrow.RecordBatch`, and materialized Hugging Face
-dataset paths are Arrow-native: `serialize_arrow_table` writes Arrow IPC stream
-bytes and preserves schema key/value metadata such as Hugging Face `features`.
-The pandas and polars dataframe paths still emit parquet because those objects
-do not necessarily carry arbitrary Arrow schema metadata.
+`application/vnd.apache.arrow.stream` is already first-class across runtime MIME
+priority, notebook rendering, MCP rendering, Sift plugin loading, and Sift/WASM
+schema hints. `nteract-predicate` now owns the canonical pandas/Hugging Face
+schema interpretation for both parquet metadata and Arrow IPC schema metadata.
 
-## Near-Term Rust Contract
+The remaining asymmetry is Python-side production:
 
-The blob-ref MIME is a transport envelope, not the durable output MIME. When
-`runtimed` promotes the ref to its wrapped `content_type`, it should also lift
-the Python-provided `summary` and `query` into `OutputManifest.metadata` under
-the wrapped MIME:
+- `pyarrow.Table`, `pyarrow.RecordBatch`, and materialized Hugging Face datasets
+  emit Arrow IPC stream bytes.
+- pandas and polars still emit parquet.
+- Sift can render Arrow IPC, but buffers complete Arrow IPC bytes before loading
+  them into WASM.
+- The blob-ref MIME points at one complete blob, not a chunk manifest.
+
+## Target Architecture
+
+### Canonical Output Format
+
+New rich table display outputs should prefer:
+
+```text
+application/vnd.apache.arrow.stream
+```
+
+for:
+
+- pandas `DataFrame`
+- polars `DataFrame`
+- narwhals dataframes once normalized to an Arrow-capable backend
+- `pyarrow.Table`
+- `pyarrow.RecordBatch`
+- Hugging Face datasets backed by an Arrow table
+
+Parquet remains supported for:
+
+- old notebooks with parquet blob refs
+- external parquet URLs/datasets opened in Sift
+- explicit user persistence/export workflows
+- fallback only when Arrow IPC serialization is unavailable but parquet succeeds
+
+Do not make parquet a second preferred producer format for notebook display
+outputs. Maintaining two first-class producer formats makes metadata and
+streaming behavior harder to reason about.
+
+### Python Serialization Policy
+
+pandas should convert through PyArrow and write Arrow IPC stream bytes:
+
+```python
+table = pa.Table.from_pandas(df)  # keep pandas schema metadata
+with pa.ipc.new_stream(sink, table.schema) as writer:
+    writer.write_table(table)
+```
+
+Do not use `preserve_index=False` for the canonical path. It removes index
+metadata that Arrow can preserve for us. Let the default preserve policy keep
+RangeIndex metadata-only and materialize non-range indexes as tracked columns.
+
+polars should write Arrow IPC stream bytes directly:
+
+```python
+df.write_ipc_stream(buf)
+```
+
+If polars compatibility or compression flags become unstable across versions,
+the fallback should be text/HTML summary first, not silent metadata loss.
+Parquet fallback is acceptable only as an explicit compatibility fallback with a
+different `content_type`.
+
+narwhals should prefer a backend-native Arrow path before converting to pandas.
+Only fall back to pandas conversion if the backend lacks a stable Arrow export.
+
+### Metadata Ownership
+
+Keep metadata normalization out of TypeScript:
+
+- Python emits source facts it knows cheaply: total rows, included rows, sample
+  strategy, backend flavor, and source display type.
+- Rust validates and canonicalizes schema-derived facts in `nteract-predicate`:
+  pandas index columns, Hugging Face rich types, index display hints, semantic
+  column types.
+- WASM/Sift consumes canonical hints and applies user/display overrides after
+  schema hints.
+- `repr_llm` and MCP should use the same predicate crate rather than inventing a
+  separate table-metadata parser.
+
+The MIME metadata namespace should stay:
 
 ```json
 {
   "metadata": {
-    "application/vnd.apache.parquet": {
+    "application/vnd.apache.arrow.stream": {
       "nteract": {
-        "summary": {
-          "total_rows": 1000,
-          "included_rows": 1000,
-          "sampled": false,
-          "sample_strategy": "none"
+        "summary": { "total_rows": 1000, "included_rows": 1000 },
+        "table": {
+          "format": "arrow-ipc-stream",
+          "producer": "pandas",
+          "schema_hash": "sha256..."
         }
       }
     }
@@ -67,60 +173,45 @@ the wrapped MIME:
 }
 ```
 
-This keeps the manifest canonical: renderers, MCP, `repr_llm`, and saved
-notebooks can inspect output-level metadata without knowing about the
-transport-only blob-ref MIME. The data bundle still points at the
-content-addressed binary bytes. Non-null `query` hints should live next to
-`summary` in the same `nteract` object. Null hint values are not promoted.
+`summary` remains small and stable. `table` can evolve as a nteract-specific
+metadata object without changing the raw Arrow IPC payload.
 
-## Arrow IPC As A First-Class MIME
+## Chunked Arrow Over CAS
 
-`application/vnd.apache.arrow.stream` is now a first-class table output MIME
-alongside parquet.
+The right streaming unit is not "chunked parquet." It is an ordered Arrow stream
+manifest whose parts are content-addressed Arrow IPC chunks.
 
-Python should prefer Arrow IPC stream bytes when the object is already Arrow:
+### Durable Manifest MIME
 
-- `pyarrow.Table`
-- `pyarrow.RecordBatch`
-- Hugging Face datasets with an underlying Arrow table
-- narwhals backends that expose Arrow natively without forcing pandas
+Add a new nteract-specific MIME:
 
-Parquet should remain available for persistence-oriented paths and as a
-fallback when Arrow IPC support is missing.
+```text
+application/vnd.nteract.arrow-stream-manifest+json
+```
 
-Runtime and frontend work included for the first-class MIME:
-
-- `application/vnd.apache.arrow.stream` is in the ref-MIME save whitelist so
-  saved `.ipynb` files keep the binary payload externalized as a blob ref
-  instead of base64-inlining it.
-- The MIME is in runtime/MCP MIME priority so Sift is selected before generic
-  text fallbacks.
-- Plugin loading and binary renderer gates treat Arrow IPC as a Sift table
-  MIME, just like parquet.
-- Rust-side Arrow IPC schema-hint support lives in the predicate layer and is
-  exposed to Sift/WASM, sharing the same pandas/Hugging Face interpretation as
-  parquet footer hints.
-
-This gives us an Arrow-native notebook at rest, but it is still not the full
-streaming design from issue #1816 because the blob is complete before renderers
-can consume it.
-
-## True Streaming With Content-Addressed Storage
-
-True streaming needs a manifest rather than one monolithic blob. The durable
-shape should describe an Arrow stream in content-addressed chunks:
+Shape:
 
 ```json
 {
-  "mime": "application/vnd.nteract.arrow-stream-manifest+json",
-  "schema_hash": "sha256...",
+  "version": 1,
+  "content_type": "application/vnd.apache.arrow.stream",
+  "schema": {
+    "hash": "sha256...",
+    "content_type": "application/vnd.apache.arrow.schema+json",
+    "fields": 12,
+    "metadata": {
+      "pandas": true,
+      "huggingface": true
+    }
+  },
   "chunks": [
     {
+      "index": 0,
       "hash": "sha256...",
-      "content_type": "application/vnd.apache.arrow.stream",
-      "record_batch_count": 4,
+      "size": 98304,
       "row_count": 4096,
-      "byte_length": 98304
+      "record_batch_count": 4,
+      "encoding": "arrow-ipc-stream-fragment"
     }
   ],
   "complete": true,
@@ -133,26 +224,260 @@ shape should describe an Arrow stream in content-addressed chunks:
 }
 ```
 
-Each chunk should align to Arrow IPC message or record-batch boundaries so Rust,
-WASM, and browser readers can validate and append data without reparsing an
-arbitrary byte splice. The CAS key remains the hash of the raw chunk bytes. A
-separate schema hash lets renderers reject incompatible chunk sequences early.
+The manifest is JSON and can live inline in the output manifest. The large bytes
+remain in ordinary CAS blobs. This keeps the notebook document small while still
+giving renderers enough structure to fetch and append parts.
 
-The Python layer should be able to publish the schema and first chunk before the
-full dataframe is materialized when the source supports streaming. That matters
-for long `to_pandas()` calls, remote fetches, and large datasets where the user
-only inspects the first page.
+### Chunk Boundaries
 
-## Compatibility Rules
+Each chunk must be independently valid enough for Rust/WASM to validate:
 
-- Always emit `text/plain` and/or `text/html` fallback data for notebook
-  interoperability.
-- Keep binary table payloads behind nteract-specific ref metadata on save.
-- Do not rely on TypeScript to parse parquet or Arrow metadata when Rust can do
-  it once in `nteract-predicate` and share the result with WASM and `repr_llm`.
-- Treat parquet and Arrow IPC as complementary. Parquet is still better for
-  compressed persistence and footer-driven random access; Arrow IPC is better
-  for in-memory schema fidelity and progressive rendering.
-- Avoid a TypeScript-only metadata model. Python should emit known source facts,
-  Rust should normalize and validate them, and WASM/renderers should consume the
-  canonical predicate summaries.
+- The first chunk should carry the stream schema and the first batch sequence.
+- Later chunks should align to Arrow IPC message / record-batch boundaries.
+- A chunk must never split an Arrow IPC message across blobs.
+- If dictionary encoding is used, dictionary batches must be present before
+  record batches that reference them in any independently decoded segment.
+
+The first implementation can avoid the hard dictionary problem by making each
+chunk a small self-contained Arrow IPC stream with the same schema. That is less
+compact than one long stream, but it is much simpler for CAS, retries, and
+renderer append. Once stable, we can consider a lower-level message-fragment
+format.
+
+### CAS Write Model
+
+The existing `BlobStore::put(bytes, media_type)` is correct for complete chunks.
+It is not enough for progressive writes because the final hash is known only
+after bytes are complete.
+
+Add a small daemon-side staging API:
+
+1. Python emits or uploads one complete chunk at a time.
+2. Daemon stores each chunk with ordinary `BlobStore::put`.
+3. Daemon returns the content hash, size, and media type.
+4. Python sends `display_data` for the first manifest and `update_display_data`
+   for later manifest revisions.
+
+This avoids "mutable blobs" and keeps CAS immutable. We do not need a provisional
+hash if the staging unit is a complete Arrow chunk.
+
+For kernel transport, there are two viable paths:
+
+- **Near-term:** keep using attached Jupyter buffers and blob-ref preflight for
+  each manifest update. This reuses the current kernel path.
+- **Durable:** add a runtime request/typed frame such as `PutBlob` or
+  `PutBlobChunk` so Python can upload chunk bytes directly to the daemon before
+  publishing the display manifest.
+
+The durable path is better because it removes large binary payloads from the
+IOPub message stream and can be reused by other large-output producers.
+
+### Display Update Flow
+
+Use Jupyter-compatible display updates:
+
+1. Formatter creates a display id, writes the first chunk, and emits
+   `display_data` with:
+   - `application/vnd.nteract.arrow-stream-manifest+json`
+   - `text/plain` and/or `text/html` fallback
+   - `transient.display_id`
+2. As later chunks complete, Python emits `update_display_data` with the same
+   display id and a manifest containing the appended chunk list.
+3. Daemon updates all matching output manifests through the existing
+   `display_index` path.
+4. Frontend sees the manifest revision and appends only new chunks.
+5. The final update sets `complete: true`.
+
+Plain Jupyter frontends will render the fallback MIME. nteract frontends will
+prefer the manifest MIME.
+
+## Sift/WASM Runtime Plan
+
+Today `SiftTable` buffers Arrow IPC bytes and calls `load_ipc(bytes)`. The
+streaming path needs a store that can append batches:
+
+```ts
+const handle = mod.create_arrow_stream_store(schemaBytes);
+for (const chunk of chunks) {
+  mod.append_arrow_stream_chunk(handle, chunk.bytes);
+  tableData.rowCount = mod.num_rows(handle);
+  engine.onBatchAppended();
+}
+mod.finish_arrow_stream_store(handle);
+```
+
+Rust/WASM responsibilities:
+
+- validate schema compatibility for each chunk
+- append record batches into the existing store
+- update row counts and summary invalidation incrementally
+- expose chunk-level errors without destroying already-rendered rows
+- keep the parquet row-group append path for old parquet inputs
+
+Frontend responsibilities:
+
+- fetch only chunks not already loaded
+- preserve Sift engine state across manifest revisions
+- avoid reloading the whole table when `chunks.length` grows
+- mark the table complete only when `complete: true`
+- keep `text/plain` fallback available when the plugin fails
+
+## Phased Implementation
+
+### Phase 1: Canonical Arrow For DataFrames
+
+Goal: all new dataframe display outputs use Arrow IPC stream by default.
+
+Changes:
+
+- Change pandas `_serialize_pandas` to `pa.Table.from_pandas(df)` plus
+  `pa.ipc.new_stream`.
+- Change polars `_serialize_polars` to `df.write_ipc_stream`.
+- Rename Python helpers from parquet-specific names to table/Arrow names where
+  the behavior is now generic.
+- Keep parquet deserialization/rendering paths untouched.
+- Extend tests to assert pandas schema metadata survives and pandas index hints
+  are promoted through `nteract-predicate`.
+- Add polars IPC test coverage when polars is installed.
+
+Acceptance:
+
+- pandas, polars, pyarrow table, record batch, and Hugging Face dataset outputs
+  all produce `application/vnd.apache.arrow.stream`.
+- Existing parquet notebook fixtures still render.
+- Saved notebooks still contain simple `text/plain` / `text/html` fallbacks plus
+  nteract blob refs.
+
+### Phase 2: Manifest MIME Without Streaming
+
+Goal: introduce the manifest shape without changing producer timing.
+
+Changes:
+
+- Add `application/vnd.nteract.arrow-stream-manifest+json` to MIME priority and
+  Sift routing.
+- Allow a manifest with exactly one complete Arrow IPC chunk.
+- Teach runtime save/load to externalize manifest chunk blobs.
+- Teach Sift to load a single manifest chunk into the existing `load_ipc` path.
+
+Acceptance:
+
+- Manifest output and direct Arrow IPC output render identically.
+- Saved notebooks round-trip manifest outputs.
+- MCP/repr paths can summarize from the manifest metadata without fetching all
+  bytes.
+
+### Phase 3: Appendable Sift Store
+
+Goal: Sift can append Arrow chunks without reloading prior data.
+
+Changes:
+
+- Add WASM APIs for `create_arrow_stream_store`, `append_arrow_stream_chunk`,
+  and `finish_arrow_stream_store`.
+- Implement schema compatibility checks in Rust.
+- Update Sift table data to invalidate summaries incrementally.
+- Add tests for two chunks, schema mismatch, partial failure, and preserving
+  sort/filter state across appends.
+
+Acceptance:
+
+- A table can show the first chunk and grow as subsequent chunks arrive.
+- Existing row-group parquet loading is unaffected.
+
+### Phase 4: Python Progressive Producer
+
+Goal: Python can publish first page quickly, then append chunks.
+
+Changes:
+
+- Add a chunk writer abstraction in `nteract_kernel_launcher`.
+- Use `display_id` and `update_display_data` for progressive manifest updates.
+- For pandas/polars eager dataframes, chunk rows after conversion.
+- For Arrow-native sources, write record batches directly.
+- For large or lazy sources, publish batches as they are produced.
+
+Acceptance:
+
+- A large Arrow table displays first rows before the whole table is serialized.
+- Final manifest is complete and durable.
+- Vanilla notebook fallback remains simple and stable.
+
+### Phase 5: Direct Daemon Blob Upload
+
+Goal: avoid pushing large binary chunks through Jupyter IOPub buffers.
+
+Changes:
+
+- Add a daemon/client request for content-addressed blob upload.
+- Expose it through the Python runtime package or launcher bootstrap.
+- Keep the attached-buffer path as a compatibility fallback.
+- Consider shared protocol with planned `PutBlob` typed frames.
+
+Acceptance:
+
+- Chunks can be stored before the display message references them.
+- Hash mismatch, missing blob, and upload failure are explicit errors.
+- The manifest never references bytes that the daemon failed to store.
+
+## Backward Compatibility
+
+- Existing `.ipynb` files with parquet blob refs continue to load and render.
+- Existing `.ipynb` files with direct Arrow IPC blob refs continue to load and
+  render.
+- New manifest outputs must save as ordinary JSON plus nteract blob refs, with
+  fallback text/html MIME for non-nteract frontends.
+- The old parquet MIME stays in Sift and MIME priority, but new Python producers
+  stop choosing it by default.
+- `update_display_data` without a matching display id should keep current
+  behavior: no destructive append, no new orphaned manifest.
+
+## Testing Strategy
+
+Python:
+
+- pandas Arrow IPC output includes pandas schema metadata.
+- pandas RangeIndex remains metadata-only; non-range index is represented and
+  hinted correctly.
+- polars output emits Arrow IPC stream.
+- downsampled outputs carry consistent `included_rows` and `sampled` hints.
+- fallback still produces `text/llm+plain` when Arrow serialization fails.
+
+Rust:
+
+- `nteract-predicate` parses Arrow IPC schema metadata for pandas and Hugging
+  Face hints.
+- output store save/load externalizes direct Arrow IPC, parquet, and manifest
+  chunks.
+- update-display-data preserves metadata hints for manifest revisions.
+- blob upload rejects hash mismatches and missing chunks.
+
+WASM/Sift:
+
+- direct Arrow IPC renders.
+- one-chunk manifest renders.
+- multi-chunk manifest appends without full reload.
+- filters/sorts survive append or are explicitly invalidated.
+- schema mismatch produces a visible table error with already-loaded rows left
+  intact.
+
+Notebook/E2E:
+
+- plain pandas display renders in nteract and saves with fallback MIME.
+- old parquet notebook fixture renders.
+- progressive output displays first chunk, then final row count after updates.
+- reopened notebook resolves manifest chunk blobs from CAS.
+
+## Open Decisions
+
+- Compression: use uncompressed Arrow IPC first for simpler chunk validation, or
+  enable lz4/zstd once reader support is confirmed across Rust/WASM.
+- Chunk unit: start with self-contained Arrow IPC streams per chunk, then
+  optimize to lower-level IPC message fragments later if needed.
+- Index display: preserve pandas metadata by default, but decide whether
+  non-range index columns should be hidden, pinned, or visibly labeled in Sift.
+- Upload API: attached Jupyter buffers are enough for Phase 2/3; direct daemon
+  blob upload should be the durable design before large streaming ships.
+- Maximum chunk size: choose a target well below `BlobStore::MAX_BLOB_SIZE`
+  (for example 4-16 MiB) to balance CAS overhead, first paint, and WASM append
+  cost.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -585,7 +585,13 @@ for the staged implementation.
   - confirmed-fix: the private `_import_from_c_capsule` fallback is documented
     as a compatibility bridge only for generic PyCapsule sources on PyArrow
     14/15; known table paths bypass it.
-- Next: rerun the repo-local `pr-reviewer` after the second review-fix commit,
+- Review rerun: `pr-reviewer` found the generic PyCapsule path should not
+  replay a potentially single-pass stream during downsampling. Disposition:
+  - confirmed-fix: generic PyCapsule objects serialize once only; if the
+    complete stream exceeds `max_bytes`, the formatter rejects rich output for
+    now and relies on summary fallback. Progressive chunking is the intended
+    rich path for large single-pass sources.
+- Next: rerun the repo-local `pr-reviewer` after the third review-fix commit,
   then add manifest routing/rendering only after accepted findings are resolved
   or deferred here.
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -578,9 +578,16 @@ for the staged implementation.
   - confirmed-fix: one-chunk manifest construction must not re-read the whole
     IPC blob just to count record batches; omit `record_batch_count` unless the
     writer already knows it.
-- Next: rerun the repo-local `pr-reviewer` after the review-fix commit, then
-  add manifest routing/rendering only after accepted findings are resolved or
-  deferred here.
+- Review rerun: `pr-reviewer` found the known pyarrow table paths should not
+  depend on PyCapsule import support. Disposition:
+  - confirmed-fix: pandas and `pyarrow.Table` paths write Arrow IPC directly
+    through `pa.ipc.new_stream` / `writer.write_table` again.
+  - confirmed-fix: the private `_import_from_c_capsule` fallback is documented
+    as a compatibility bridge only for generic PyCapsule sources on PyArrow
+    14/15; known table paths bypass it.
+- Next: rerun the repo-local `pr-reviewer` after the second review-fix commit,
+  then add manifest routing/rendering only after accepted findings are resolved
+  or deferred here.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -604,8 +604,17 @@ for the staged implementation.
     stream chunks, reject schema mismatches, and mark the store complete.
   - this is only the WASM/store seam; React still uses the existing one-shot
     Arrow IPC load path until the next commit wires manifest chunk appends.
-- Next: run repo-local `pr-reviewer` for the chunk-store seam and resolve or
-  record findings before wiring Sift React to append manifest chunks.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `dac07571`.
+- Done: `feat(sift): append arrow manifest chunks`
+  - Sift React accepts a normalized `source` union, including Arrow stream
+    manifests, while keeping `data` and `url` as compatibility props.
+  - Manifest sources fetch complete chunk URLs in order, append them through the
+    WASM stream store, and mark the table complete when the manifest is
+    complete.
+  - the isolated renderer now passes manifest objects to Sift instead of
+    collapsing them back to a direct URL.
+- Next: run repo-local `pr-reviewer` for the React manifest append commit and
+  resolve or record findings before moving to producer-side progressive chunks.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -571,8 +571,16 @@ for the staged implementation.
     sidecar while keeping direct Arrow IPC selected for rendering.
   - this commit should not change the UI path yet; Sift manifest routing comes
     in a later Phase 2 commit.
-- Next: run the repo-local `pr-reviewer` for this commit, then add manifest
-  routing/rendering only after accepted findings are resolved or deferred here.
+- Review: `pr-reviewer` found two sidecar-stage issues. Disposition:
+  - confirmed-fix: polars must keep its native IPC writer path so polars-only
+    environments do not require pyarrow just because modern polars exposes
+    `__arrow_c_stream__()`.
+  - confirmed-fix: one-chunk manifest construction must not re-read the whole
+    IPC blob just to count record batches; omit `record_batch_count` unless the
+    writer already knows it.
+- Next: rerun the repo-local `pr-reviewer` after the review-fix commit, then
+  add manifest routing/rendering only after accepted findings are resolved or
+  deferred here.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -623,9 +623,17 @@ for the staged implementation.
   - the existing dataframe/table display formatter still emits one complete
     chunk; the chunk writer is the Phase 4 producer seam before display-id
     updates are wired into the formatter path.
-- Next: wire a Jupyter-compatible `display_id` / `update_display_data` path
-  that can publish the first chunk and then manifest revisions without changing
-  the existing one-shot fallback.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `f8a02ed8`.
+- Done: `feat(outputs): add progressive arrow display helper`
+  - `nteract_kernel_launcher.display_arrow_stream(...)` uses the chunk writer
+    to publish an initial raw MIME bundle with a Jupyter `display_id`, then
+    emits full manifest revisions with `DisplayHandle.update(...)`.
+  - the helper is explicit; automatic dataframe reprs remain one-shot until the
+    formatter/displayhook boundary can own display ids without surprising bare
+    expression output.
+- Next: decide whether automatic large dataframe reprs should opt into the
+  helper by publishing their own display output, or stay one-shot while direct
+  daemon blob upload and save/load manifest externalization are completed.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -35,6 +35,24 @@ The phases below are intended as targeted commits in this PR, not separate PRs.
   cuDF, narwhals, and other Arrow-compatible DataFrames without depending on
   producer-specific `_export_to_c` or PyArrow-only object types.
   <https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>
+- The Arrow C stream interface is a pull stream of chunks with a shared schema:
+  consumers call `get_next` serially until end-of-stream. That maps cleanly to a
+  Python `RecordBatchReader`, but it also means a producer stream should be
+  treated as single-pass unless a library documents replay support.
+  <https://arrow.apache.org/docs/format/CStreamInterface.html>
+- Polars, pandas, DataFusion, DuckDB relations, narwhals wrappers, pyarrow
+  tables, and pyarrow record-batch readers all expose or consume this protocol
+  in current releases. The implementation should therefore avoid hardcoding a
+  small producer list and instead treat `__arrow_c_stream__()` as the broad
+  dataframe/table acceptance path.
+  <https://docs.pola.rs/user-guide/misc/arrow/>
+  <https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.from_arrow.html>
+  <https://datafusion.apache.org/python/user-guide/io/arrow.html>
+- Nanoarrow is a useful reference for lightweight Python consumers/producers of
+  Arrow PyCapsule streams. It reinforces that the PyCapsule protocol is the
+  interchange surface, while IPC serialization is a separate transport/storage
+  decision.
+  <https://arrow.apache.org/nanoarrow/latest/getting-started/python.html>
 - Jupyter-compatible incremental replacement is `display_id` plus
   `update_display_data`. It can carry the same MIME-bundle shape as
   `display_data`, so it is the compatibility bridge for progressive updates
@@ -146,6 +164,12 @@ This matches the DataFrame binding model used by Jupyter Scatter: pandas,
 polars, and any DataFrame implementing the Arrow PyCapsule interface can be
 handled through the same stream import path. Producer-specific logic should be
 fallback or row-limiting glue, not the default serialization model.
+
+Treat the imported `RecordBatchReader` as a potentially single-use source. For
+the current one-shot path, it is fine to drain the reader into one complete IPC
+stream. For the progressive path, the chunk writer should drain the same reader
+incrementally and publish chunks as batches arrive; it should not first build a
+complete IPC stream and then split the serialized bytes.
 
 For older pandas versions that do not expose `__arrow_c_stream__`, convert
 through PyArrow and write Arrow IPC stream bytes:
@@ -314,7 +338,20 @@ The architecture has three related storage forms:
 
 ### Chunk Boundaries
 
-Each chunk must be independently valid enough for Rust/WASM to validate:
+The chunking unit is one or more `RecordBatch` values pulled from a
+`RecordBatchReader`, encoded as a self-contained Arrow IPC mini-stream. Do not
+split already-serialized IPC bytes after the fact; that risks cutting through
+message boundaries and dictionary state. The producer should instead:
+
+1. Import the source object as a `RecordBatchReader` via `__arrow_c_stream__()`.
+2. Read batches in order.
+3. Accumulate batches until a byte or row budget is reached.
+4. Write those batches to a new `pa.ipc.new_stream` sink using the shared
+   schema.
+5. Store that complete mini-stream as one immutable CAS chunk before publishing
+   a manifest revision that references it.
+
+Each stored chunk must be independently valid enough for Rust/WASM to validate:
 
 - The first chunk should carry the stream schema and the first batch sequence.
 - Later chunks should align to Arrow IPC message / record-batch boundaries.
@@ -327,6 +364,11 @@ chunk a small self-contained Arrow IPC stream with the same schema. That is less
 compact than one long stream, but it is much simpler for CAS, retries, and
 renderer append. Once stable, we can consider a lower-level message-fragment
 format.
+
+Because PyCapsule streams can be single-pass, failed upload or render
+publication should not require rewinding the source. The safe retry boundary is
+the completed mini-stream bytes for the current chunk, not the upstream
+`RecordBatchReader`.
 
 ### CAS Write Model
 
@@ -601,8 +643,11 @@ Changes:
 - Use `display_id` and `update_display_data` for progressive manifest updates.
 - For pandas/polars eager dataframes, emit `df.head(n)` first, then chunk rows
   after conversion for the remaining data.
-- For Arrow-native sources, write the first record batch/head chunk directly.
-- For large or lazy sources, publish batches as they are produced.
+- For Arrow-native and PyCapsule-compatible sources, import a
+  `RecordBatchReader`, then write the first record batch or bounded mini-stream
+  chunk directly.
+- For large or lazy sources, publish completed mini-stream chunks as batches are
+  produced. Do not require a replayable source.
 
 Acceptance:
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -637,6 +637,7 @@ for the staged implementation.
   sizing/focus renderer. Disposition:
   - confirmed-fix: keep all React hooks in `SiftRenderer` before the invalid
     manifest fallback return.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `a2944dd0`.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -615,8 +615,9 @@ for the staged implementation.
     recreating an equivalent `source` object does not reload the table.
   - the isolated renderer now passes manifest objects to Sift instead of
     collapsing them back to a direct URL.
-- Next: run repo-local `pr-reviewer` for the React manifest append commit and
-  resolve or record findings before moving to producer-side progressive chunks.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `f62da4f6`.
+- Next: start producer-side progressive chunks with a narrow Python manifest
+  update path; preserve one-shot behavior until chunk publication is verified.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -7,6 +7,7 @@ version: Arrow IPC stream should become the canonical rich table output for
 notebooks. Parquet should remain a supported input/rendering format and a
 backward-compatibility path for already-saved notebooks, but new pandas, polars,
 pyarrow, narwhals, and Hugging Face table outputs should converge on Arrow IPC.
+The phases below are intended as targeted commits in this PR, not separate PRs.
 
 ## Research Constraints
 
@@ -26,7 +27,7 @@ pyarrow, narwhals, and Hugging Face table outputs should converge on Arrow IPC.
 - Polars exposes Arrow IPC stream IO directly (`write_ipc_stream` /
   `read_ipc_stream`), so polars does not need parquet as an intermediate
   notebook output format.
-  <https://docs.pola.rs/api/python/dev/reference/api/polars.DataFrame.write_ipc_stream.html>
+  <https://docs.pola.rs/api/python/stable/reference/api/polars.DataFrame.write_ipc_stream.html>
   <https://docs.pola.rs/api/python/stable/reference/api/polars.read_ipc_stream.html>
 - Jupyter-compatible incremental replacement is `display_id` plus
   `update_display_data`. It can carry the same MIME-bundle shape as
@@ -39,6 +40,18 @@ pyarrow, narwhals, and Hugging Face table outputs should converge on Arrow IPC.
 The launcher registers lazy IPython `mimebundle_formatter` handlers in
 `nteract_kernel_launcher/_bootstrap.py` for pandas, polars, narwhals,
 `pyarrow.Table`, `pyarrow.RecordBatch`, and Hugging Face datasets.
+
+Serialization helpers live in `nteract_kernel_launcher/_format.py`:
+
+- `_serialize_pandas` writes parquet via
+  `pa.Table.from_pandas(df, preserve_index=False)` plus
+  `pq.write_table(..., compression="snappy")`.
+- `_serialize_polars` writes parquet via
+  `df.write_parquet(buf, compression="snappy")`.
+- `_serialize_arrow_stream_table` already writes Arrow IPC stream bytes for
+  `pyarrow.Table` and `pyarrow.RecordBatch`.
+- `serialize_dataframe` returns `(bytes, PARQUET_MIME, included_rows)`. Phase 1
+  flips that to `ARROW_STREAM_MIME` and removes `preserve_index=False`.
 
 Today rich table outputs are stored as content-addressed blobs via
 `application/vnd.nteract.blob-ref+json`:
@@ -176,6 +189,18 @@ The MIME metadata namespace should stay:
 `summary` remains small and stable. `table` can evolve as a nteract-specific
 metadata object without changing the raw Arrow IPC payload.
 
+`producer` is one of: `pandas`, `polars`, `pyarrow-table`,
+`pyarrow-record-batch`, `huggingface`, or `narwhals/<backend>`. Renderers must
+treat unknown values as opaque rather than failing.
+
+Every manifest output must provide or preserve `text/plain` and
+`text/llm+plain` summaries. `text/plain` is the user-facing fallback for
+non-nteract Jupyter frontends. `text/llm+plain` stays the canonical short-form
+summary for `repr_llm` and MCP, built from manifest `summary` / `table` facts so
+consumers do not need to fetch chunk blobs. Manifest metadata is the source of
+truth for row counts and shape; `text/llm+plain` is human-readable text derived
+from those facts.
+
 ## Chunked Arrow Over CAS
 
 The right streaming unit is not "chunked parquet." It is an ordered Arrow stream
@@ -197,7 +222,7 @@ Shape:
   "content_type": "application/vnd.apache.arrow.stream",
   "schema": {
     "hash": "sha256...",
-    "content_type": "application/vnd.apache.arrow.schema+json",
+    "content_type": "application/vnd.apache.arrow.schema",
     "fields": 12,
     "metadata": {
       "pandas": true,
@@ -215,6 +240,12 @@ Shape:
     }
   ],
   "complete": true,
+  "coalesced": {
+    "kind": "single_blob",
+    "hash": "sha256...",
+    "content_type": "application/vnd.apache.arrow.stream",
+    "size": 12345678
+  },
   "summary": {
     "total_rows": 1000000,
     "included_rows": 4096,
@@ -227,6 +258,36 @@ Shape:
 The manifest is JSON and can live inline in the output manifest. The large bytes
 remain in ordinary CAS blobs. This keeps the notebook document small while still
 giving renderers enough structure to fetch and append parts.
+
+Hash domains:
+
+- `schema.hash` covers the Arrow IPC schema message bytes (the leading
+  message of an Arrow IPC stream), stored in CAS under the nteract-owned
+  `application/vnd.apache.arrow.schema` content type so renderers can parse it
+  once and key chunk validation off the same hash. Do not store this as JSON
+  unless the hash domain changes to canonical schema JSON at the same time.
+- Each `chunks[].hash` covers the bytes of the chunk blob the daemon stored
+  via `BlobStore::put`. With self-contained per-chunk Arrow IPC streams (see
+  "Chunk Boundaries"), `hash` covers a complete decodable mini-stream
+  including the schema and any dictionary batches.
+
+For v1, "schema compatibility" between chunks means byte-equal `schema.hash`
+against the manifest's top-level schema hash. Promotable type checks are
+deferred until we have a concrete reason for them.
+
+### Stored Forms
+
+The architecture has three related storage forms:
+
+- **Progressive manifest:** the authoritative display state. It owns chunk
+  order, row counts, completion/abort state, table hints, and optional
+  coalesced artifact references.
+- **Progressive chunks:** immutable CAS blobs, targeting 8 MiB before encoding
+  overhead, stored as independently decodable Arrow IPC mini-streams.
+- **Coalesced artifact:** an optional derived artifact written after completion
+  for reopen/export/full-table operations. It is one Arrow IPC stream blob if
+  the stream fits under `BlobStore::MAX_BLOB_SIZE`; otherwise it is a coalesced
+  segment manifest whose segments are larger ordered Arrow IPC blobs.
 
 ### Chunk Boundaries
 
@@ -261,6 +322,66 @@ Add a small daemon-side staging API:
 This avoids "mutable blobs" and keeps CAS immutable. We do not need a provisional
 hash if the staging unit is a complete Arrow chunk.
 
+The producer-side handshake is strict: upload chunk N, get its content hash
+from the daemon, only then publish the next manifest revision listing chunk N.
+A failed upload means the manifest revision is not emitted, so renderers
+never see a chunk reference whose bytes the daemon did not store.
+
+### Save Resolution
+
+When the daemon writes the notebook to disk, it walks the manifest:
+
+1. For each `chunks[].hash`, ensure the blob is in CAS, and rewrite the entry
+   to a blob-ref form the on-disk loader can resolve back into bytes.
+2. Apply the same to `schema.hash`.
+3. Write the rest of the manifest (chunk metadata, summary, table hints)
+   inline in the saved output JSON.
+
+Load reverses the walk: blob refs in chunk and schema slots are resolved back
+into hash + content_type before the manifest is handed to renderers. This
+keeps `.ipynb` files small without inlining base64 chunk bytes.
+
+### Coalesced Artifacts
+
+After the progressive manifest reaches `complete: true`, the runtime may write a
+derived coalesced artifact for efficient reopen, export, and full-table scans.
+This is best-effort and must never block first render or progressive chunk
+availability.
+
+If the complete Arrow IPC stream is below `BlobStore::MAX_BLOB_SIZE`, the
+coalesced artifact is a single CAS blob:
+
+```json
+{
+  "kind": "single_blob",
+  "hash": "sha256...",
+  "content_type": "application/vnd.apache.arrow.stream",
+  "size": 12345678
+}
+```
+
+If the complete stream would exceed the blob limit, the coalesced artifact is a
+segment manifest:
+
+```json
+{
+  "kind": "segment_manifest",
+  "content_type": "application/vnd.nteract.arrow-coalesced-segments+json",
+  "segments": [
+    {
+      "index": 0,
+      "hash": "sha256...",
+      "content_type": "application/vnd.apache.arrow.stream",
+      "size": 67108864,
+      "row_count": 250000
+    }
+  ]
+}
+```
+
+The progressive manifest remains the source of truth while output is still
+growing. The coalesced artifact is derived and can be regenerated or omitted.
+
 For kernel transport, there are two viable paths:
 
 - **Near-term:** keep using attached Jupyter buffers and blob-ref preflight for
@@ -272,6 +393,21 @@ For kernel transport, there are two viable paths:
 The durable path is better because it removes large binary payloads from the
 IOPub message stream and can be reused by other large-output producers.
 
+### First Paint Strategy
+
+Small tables should serialize once to Arrow IPC and emit a complete one-chunk
+manifest. Large eager dataframes should emit `df.head(n)` as the first Arrow IPC
+chunk, where `n` is chosen by byte budget, then continue producing chunks after
+the first display is visible. Arrow-native and streaming sources should publish
+the first available record batch or head chunk, then append later chunks as they
+arrive.
+
+The sub-200 ms first-render target applies after the dataframe/source object is
+available and only to the head-sample path. pandas/polars cannot render before
+an already-blocking dataframe conversion completes. The complete progressive
+manifest and any coalesced artifact are follow-on work and must not block the
+initial display.
+
 ### Display Update Flow
 
 Use Jupyter-compatible display updates:
@@ -282,7 +418,10 @@ Use Jupyter-compatible display updates:
    - `text/plain` and/or `text/html` fallback
    - `transient.display_id`
 2. As later chunks complete, Python emits `update_display_data` with the same
-   display id and a manifest containing the appended chunk list.
+   display id and the full manifest revision, including every chunk emitted
+   to date in order. Updates carry full state, not deltas. Renderers diff
+   `chunks[].hash` against chunks they already loaded and fetch only the
+   missing tail.
 3. Daemon updates all matching output manifests through the existing
    `display_index` path.
 4. Frontend sees the manifest revision and appends only new chunks.
@@ -290,6 +429,20 @@ Use Jupyter-compatible display updates:
 
 Plain Jupyter frontends will render the fallback MIME. nteract frontends will
 prefer the manifest MIME.
+
+Abort and recovery:
+
+- A producer that cannot continue (kernel restart caught by the launcher,
+  unrecoverable serialization error) emits a final `update_display_data`
+  with `complete: true` plus an `aborted: { reason: "..." }` field.
+  Renderers leave already-loaded rows intact and surface the reason instead
+  of pretending the table is whole.
+- An `update_display_data` whose `display_id` no longer maps to a live
+  output (cell cleared, kernel restarted before the update lands) is
+  dropped on the daemon side. This matches today's behavior and avoids
+  resurrecting orphaned manifests.
+- The daemon does not garbage-collect chunk blobs from CAS when a manifest
+  is dropped; CAS retention is decided independently of display lifetime.
 
 ## Sift/WASM Runtime Plan
 
@@ -316,28 +469,49 @@ Rust/WASM responsibilities:
 
 Frontend responsibilities:
 
+- fetch the first chunk immediately
+- fetch more chunks as viewport scrolling or table operations need them
 - fetch only chunks not already loaded
 - preserve Sift engine state across manifest revisions
 - avoid reloading the whole table when `chunks.length` grows
+- use a coalesced artifact for full-table operations when present
 - mark the table complete only when `complete: true`
 - keep `text/plain` fallback available when the plugin fails
 
 ## Phased Implementation
 
+Each phase below should land as an individual commit in this PR so the work can
+be reviewed and tested incrementally.
+
 ### Phase 1: Canonical Arrow For DataFrames
 
 Goal: all new dataframe display outputs use Arrow IPC stream by default.
 
-Changes:
+Changes (all in `python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py`
+unless noted):
 
-- Change pandas `_serialize_pandas` to `pa.Table.from_pandas(df)` plus
-  `pa.ipc.new_stream`.
-- Change polars `_serialize_polars` to `df.write_ipc_stream`.
-- Rename Python helpers from parquet-specific names to table/Arrow names where
-  the behavior is now generic.
+- `_serialize_pandas` switches to `pa.Table.from_pandas(df)` (drop
+  `preserve_index=False`) plus `pa.ipc.new_stream` writing into a
+  `pa.BufferOutputStream`.
+- `_serialize_polars` switches to `df.write_ipc_stream(buf)`.
+- `serialize_dataframe` returns `ARROW_STREAM_MIME` instead of `PARQUET_MIME`.
+  Drop `PARQUET_MIME` from the dataframe return path; keep the constant for
+  parsing old fixtures only.
+- Audit `_bootstrap.py` formatter registrations and tests in
+  `python/nteract-kernel-launcher/tests/` for any callers that branch on
+  `PARQUET_MIME` for pandas/polars output and update them.
+- Rename helpers from parquet-specific names to Arrow/table names where the
+  behavior is now generic. A single `serialize_table` codepath shared by
+  pandas/polars/pyarrow is fine.
+- For narwhals, dispatch on backend: prefer `nw.to_native().to_arrow()` (or
+  the backend's native Arrow export), fall back to pandas conversion only if
+  no Arrow export is available.
+- Hugging Face: keep the Arrow-table-backed path. `IterableDataset` and other
+  streaming HF objects materialize a head sample then fall through to
+  `text/llm+plain`; do not silently consume the stream.
 - Keep parquet deserialization/rendering paths untouched.
-- Extend tests to assert pandas schema metadata survives and pandas index hints
-  are promoted through `nteract-predicate`.
+- Extend tests to assert pandas schema metadata survives and pandas index
+  hints are promoted through `nteract-predicate`.
 - Add polars IPC test coverage when polars is installed.
 
 Acceptance:
@@ -350,14 +524,20 @@ Acceptance:
 
 ### Phase 2: Manifest MIME Without Streaming
 
-Goal: introduce the manifest shape without changing producer timing.
+Goal: introduce the manifest shape without changing producer timing. Launcher
+formatters from Phase 1 switch to emitting the manifest MIME with
+`chunks: [single_chunk]` and `complete: true`. The raw
+`application/vnd.apache.arrow.stream` MIME stays valid for direct producers
+(external tools, tests, and old fixtures), but the launcher always wraps in a
+manifest from Phase 2 onward.
 
 Changes:
 
 - Add `application/vnd.nteract.arrow-stream-manifest+json` to MIME priority and
   Sift routing.
-- Allow a manifest with exactly one complete Arrow IPC chunk.
-- Teach runtime save/load to externalize manifest chunk blobs.
+- Switch launcher producers to emit one-chunk manifests by default.
+- Teach runtime save/load to externalize manifest chunk and schema blobs by
+  walking `chunks[].hash` and `schema.hash` (see "Save Resolution").
 - Teach Sift to load a single manifest chunk into the existing `load_ipc` path.
 
 Acceptance:
@@ -393,19 +573,45 @@ Changes:
 
 - Add a chunk writer abstraction in `nteract_kernel_launcher`.
 - Use `display_id` and `update_display_data` for progressive manifest updates.
-- For pandas/polars eager dataframes, chunk rows after conversion.
-- For Arrow-native sources, write record batches directly.
+- For pandas/polars eager dataframes, emit `df.head(n)` first, then chunk rows
+  after conversion for the remaining data.
+- For Arrow-native sources, write the first record batch/head chunk directly.
 - For large or lazy sources, publish batches as they are produced.
 
 Acceptance:
 
 - A large Arrow table displays first rows before the whole table is serialized.
+- For a table where full serialization takes more than 1 second, the head chunk
+  renders within 200 ms after the dataframe/source object is available when the
+  head-sample path can produce `df.head(n)` without forcing full conversion.
 - Final manifest is complete and durable.
 - Vanilla notebook fallback remains simple and stable.
 
-### Phase 5: Direct Daemon Blob Upload
+### Phase 5: Viewport-Driven Fetch
 
-Goal: avoid pushing large binary chunks through Jupyter IOPub buffers.
+Goal: Sift renders the first chunk immediately and fetches more data only as the
+user or operation needs it.
+
+Changes:
+
+- Load chunk 0 immediately when the manifest arrives.
+- Fetch additional chunks as the viewport nears unloaded rows.
+- For full-table sort/filter/search/export, request all missing chunks unless a
+  coalesced artifact is already available.
+- Preserve loaded table state while new chunks append.
+
+Acceptance:
+
+- Scrolling beyond loaded rows fetches the next chunk without reloading chunk 0.
+- Full-table operations either load all chunks or use the coalesced artifact.
+- A missing later chunk surfaces a recoverable table error and keeps loaded rows.
+
+### Phase 6: Direct Daemon Blob Upload
+
+Goal: avoid pushing large binary chunks through Jupyter IOPub buffers. This is
+a performance and scaling optimization, not a prerequisite for Phase 4.
+Progressive output ships first on the existing attached-buffer path; Phase 6
+swaps the transport without changing the manifest format.
 
 Changes:
 
@@ -420,17 +626,45 @@ Acceptance:
 - Hash mismatch, missing blob, and upload failure are explicit errors.
 - The manifest never references bytes that the daemon failed to store.
 
+### Phase 7: Coalesced Artifacts
+
+Goal: write a derived full-table artifact after completion without changing the
+progressive manifest contract.
+
+Changes:
+
+- If the full Arrow IPC stream fits under `BlobStore::MAX_BLOB_SIZE`, write one
+  coalesced Arrow IPC blob and reference it from `coalesced`.
+- If the full stream is too large, write larger ordered segment blobs and attach
+  a `segment_manifest` coalesced artifact.
+- Keep the progressive chunk manifest authoritative if coalescing fails.
+
+Acceptance:
+
+- Small completed tables get a single coalesced blob.
+- Too-large completed tables get a coalesced segment manifest.
+- Coalescing failure does not affect display, save, or reopen from progressive
+  chunks.
+
 ## Backward Compatibility
+
+Desktop client and runtime daemon ship together. There is no supported
+configuration where a release-N client talks to a release-M daemon, so the
+manifest MIME, blob-ref shape, attached-buffer protocol, and output store
+schema can change in a single release without compatibility shims. The only
+durable compatibility surface is saved `.ipynb` files on disk and the old
+parquet/Arrow IPC blob payloads users may still have in CAS.
 
 - Existing `.ipynb` files with parquet blob refs continue to load and render.
 - Existing `.ipynb` files with direct Arrow IPC blob refs continue to load and
   render.
-- New manifest outputs must save as ordinary JSON plus nteract blob refs, with
-  fallback text/html MIME for non-nteract frontends.
-- The old parquet MIME stays in Sift and MIME priority, but new Python producers
-  stop choosing it by default.
-- `update_display_data` without a matching display id should keep current
-  behavior: no destructive append, no new orphaned manifest.
+- New manifest outputs save as ordinary JSON plus nteract blob refs (chunks
+  and schema, plus coalesced artifacts when present), with `text/plain` /
+  `text/html` fallbacks for non-nteract frontends.
+- The old parquet MIME stays in Sift and MIME priority for old fixtures, but
+  new launcher producers do not choose it.
+- `update_display_data` without a matching display id keeps current behavior:
+  no destructive append, no new orphaned manifest.
 
 ## Testing Strategy
 
@@ -451,13 +685,18 @@ Rust:
   chunks.
 - update-display-data preserves metadata hints for manifest revisions.
 - blob upload rejects hash mismatches and missing chunks.
+- coalesced artifact generation chooses a single blob below
+  `BlobStore::MAX_BLOB_SIZE` and a segment manifest above it.
 
 WASM/Sift:
 
 - direct Arrow IPC renders.
 - one-chunk manifest renders.
 - multi-chunk manifest appends without full reload.
+- viewport-driven fetch loads later chunks only when needed.
 - filters/sorts survive append or are explicitly invalidated.
+- full-table operations use the coalesced artifact when present or fetch all
+  chunks when absent.
 - schema mismatch produces a visible table error with already-loaded rows left
   intact.
 
@@ -466,18 +705,26 @@ Notebook/E2E:
 - plain pandas display renders in nteract and saves with fallback MIME.
 - old parquet notebook fixture renders.
 - progressive output displays first chunk, then final row count after updates.
-- reopened notebook resolves manifest chunk blobs from CAS.
+- reopened notebook resolves manifest chunk blobs and coalesced artifacts from
+  CAS.
 
 ## Open Decisions
 
-- Compression: use uncompressed Arrow IPC first for simpler chunk validation, or
-  enable lz4/zstd once reader support is confirmed across Rust/WASM.
-- Chunk unit: start with self-contained Arrow IPC streams per chunk, then
-  optimize to lower-level IPC message fragments later if needed.
-- Index display: preserve pandas metadata by default, but decide whether
-  non-range index columns should be hidden, pinned, or visibly labeled in Sift.
-- Upload API: attached Jupyter buffers are enough for Phase 2/3; direct daemon
-  blob upload should be the durable design before large streaming ships.
-- Maximum chunk size: choose a target well below `BlobStore::MAX_BLOB_SIZE`
-  (for example 4-16 MiB) to balance CAS overhead, first paint, and WASM append
-  cost.
+- Compression: ship uncompressed Arrow IPC in Phase 2/3 for simpler chunk
+  validation. Phase 4 revisits lz4/zstd once Rust/WASM reader support is
+  confirmed end-to-end.
+- Chunk unit: Phase 2/3 use self-contained Arrow IPC streams per chunk.
+  Lower-level IPC message-fragment encoding stays deferred until measured
+  chunk bloat justifies the complexity.
+- Index display: pandas metadata is preserved by default starting in Phase 1.
+  Sift's presentation of non-range index columns (hidden, pinned, or visibly
+  labeled) is a Phase 3 UX decision, not a serialization decision.
+- Upload API: attached Jupyter buffers carry through Phase 4. Phase 6 swaps to
+  a direct daemon blob upload path; the manifest format does not change.
+- Maximum chunk size: `BlobStore::MAX_BLOB_SIZE` is 100 MiB
+  (`crates/runtimed/src/blob_store.rs:25`). Default to 8 MiB per chunk in
+  Phase 4 to balance CAS overhead, first paint, and WASM append cost.
+- Categoricals: pandas `Categorical` and polars `Categorical`/`Enum` columns
+  emit dictionary batches inside each self-contained chunk. The bloat from
+  recomputing dictionaries per chunk is the explicit tradeoff for chunk
+  independence in Phase 2/3 and is revisited only if it shows up in profiles.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -616,8 +616,16 @@ for the staged implementation.
   - the isolated renderer now passes manifest objects to Sift instead of
     collapsing them back to a direct URL.
 - Review rerun: `pr-reviewer` reported `verdict: clear` for `f62da4f6`.
-- Next: start producer-side progressive chunks with a narrow Python manifest
-  update path; preserve one-shot behavior until chunk publication is verified.
+- Done: `feat(outputs): add arrow stream chunk writer`
+  - Python can drain an Arrow PyCapsule-compatible source once as a
+    `RecordBatchReader` and yield independently decodable Arrow IPC mini-stream
+    chunks on record-batch boundaries.
+  - the existing dataframe/table display formatter still emits one complete
+    chunk; the chunk writer is the Phase 4 producer seam before display-id
+    updates are wired into the formatter path.
+- Next: wire a Jupyter-compatible `display_id` / `update_display_data` path
+  that can publish the first chunk and then manifest revisions without changing
+  the existing one-shot fallback.
 
 ### Phase 1: Canonical Arrow For DataFrames
 

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -638,6 +638,13 @@ for the staged implementation.
   - confirmed-fix: keep all React hooks in `SiftRenderer` before the invalid
     manifest fallback return.
 - Review rerun: `pr-reviewer` reported `verdict: clear` for `a2944dd0`.
+- Review rerun found two progressive-helper performance concerns. Disposition:
+  - confirmed-fix: single-chunk sources publish one complete `display_data`
+    bundle instead of an incomplete display followed by a duplicate completion
+    update.
+  - confirmed-fix: completion-only manifest updates do not resend chunk bytes,
+    and progressive manifest construction reuses the first chunk schema instead
+    of reparsing it for every revision.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -632,6 +632,11 @@ for the staged implementation.
     formatter/displayhook boundary can own display ids without surprising bare
     expression output.
 - Review rerun: `pr-reviewer` reported `verdict: clear` for `1bb09116`.
+- Post-rebase review found one Sift renderer hook-order regression introduced
+  while merging the manifest source path with `origin/main`'s notebook-aware
+  sizing/focus renderer. Disposition:
+  - confirmed-fix: keep all React hooks in `SiftRenderer` before the invalid
+    manifest fallback return.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -548,6 +548,32 @@ Frontend responsibilities:
 Each phase below should land as an individual commit in this PR so the work can
 be reviewed and tested incrementally.
 
+## Implementation Progress
+
+Keep this section current as the PR evolves. It is the durable working memory
+for the staged implementation.
+
+- Done: `6166a6a8 feat(outputs): emit dataframe arrow streams`
+  - pandas, polars, pyarrow tables, record batches, and PyCapsule-compatible
+    dataframe objects now emit `application/vnd.apache.arrow.stream` through the
+    launcher.
+  - `serialize_dataframe` prefers `__arrow_c_stream__()` and falls back to
+    pandas/polars-specific Arrow IPC writers for older library versions.
+  - Tests cover pandas IPC output, pandas index metadata, polars IPC output, and
+    a protocol-only PyCapsule stream object.
+- Done: `f039cd2b docs(outputs): clarify arrow stream chunking`
+  - researched current PyCapsule producers/consumers and documented the
+    `RecordBatchReader` chunking model.
+  - chunking must happen at record-batch boundaries by writing self-contained
+    IPC mini-streams; do not split already-serialized IPC bytes.
+- Done: `feat(outputs): emit arrow stream manifest sidecars`
+  - add `application/vnd.nteract.arrow-stream-manifest+json` as an emitted
+    sidecar while keeping direct Arrow IPC selected for rendering.
+  - this commit should not change the UI path yet; Sift manifest routing comes
+    in a later Phase 2 commit.
+- Next: run the repo-local `pr-reviewer` for this commit, then add manifest
+  routing/rendering only after accepted findings are resolved or deferred here.
+
 ### Phase 1: Canonical Arrow For DataFrames
 
 Goal: all new dataframe display outputs use Arrow IPC stream by default.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -631,6 +631,7 @@ for the staged implementation.
   - the helper is explicit; automatic dataframe reprs remain one-shot until the
     formatter/displayhook boundary can own display ids without surprising bare
     expression output.
+- Review rerun: `pr-reviewer` reported `verdict: clear` for `1bb09116`.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
@@ -13,6 +13,7 @@ The daemon invokes this module in place of ``ipykernel_launcher`` when the
 on. See ``docs/superpowers/specs/2026-04-24-launcher-hosted-display-bootstrap.md``.
 """
 
+from nteract_kernel_launcher._progressive import display_arrow_stream
 from nteract_kernel_launcher.app import (
     NteractKernel,
     NteractKernelApp,
@@ -31,5 +32,6 @@ __all__ = [
     "NteractKernelApp",
     "NteractShell",
     "NteractShellDisplayHook",
+    "display_arrow_stream",
     "main",
 ]

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -46,11 +46,19 @@ from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import (
     ARROW_STREAM_MANIFEST_MIME,
     ARROW_STREAM_MIME,
+    DEFAULT_ARROW_CHUNK_BYTES,
     build_arrow_stream_manifest,
+    build_arrow_stream_manifest_from_chunks,
+    iter_arrow_table_chunks,
     serialize_arrow_table,
     serialize_dataframe,
 )
-from nteract_kernel_launcher._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
+from nteract_kernel_launcher._refs import (
+    BLOB_REF_MIME,
+    BlobRef,
+    build_multi_ref_bundle,
+    build_ref_bundle,
+)
 from nteract_kernel_launcher._summary import summarize_dataframe, summarize_dataset
 
 log = logging.getLogger("nteract_kernel_launcher")
@@ -230,6 +238,16 @@ def _emit_arrow_table(
             table, total_rows=total_rows, included_rows=included, sampled=sampled
         )
 
+    if content_type == ARROW_STREAM_MIME and included_rows != total_rows:
+        try:
+            return _emit_arrow_table_chunks(
+                table,
+                total_rows=total_rows,
+                summary_fn=_summary,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug("arrow chunked emit failed: %s — keeping sampled bundle", exc)
+
     return _emit_table_bytes(
         data,
         content_type=content_type,
@@ -237,6 +255,52 @@ def _emit_arrow_table(
         included_rows=included_rows,
         summary_fn=_summary,
     )
+
+
+def _emit_arrow_table_chunks(
+    table: Any,
+    *,
+    total_rows: int,
+    summary_fn: Callable[[int, bool], str],
+) -> dict:
+    """Emit a complete multi-chunk Arrow stream manifest for a pyarrow Table."""
+    chunks = list(
+        iter_arrow_table_chunks(
+            table,
+            max_chunk_bytes=min(DEFAULT_ARROW_CHUNK_BYTES, _MAX_PAYLOAD_BYTES),
+        )
+    )
+    included_rows = sum(chunk.row_count for chunk in chunks)
+    sampled = included_rows != total_rows
+    summary_hints = {
+        "total_rows": total_rows,
+        "included_rows": included_rows,
+        "sampled": sampled,
+        "sample_strategy": "head" if sampled else "none",
+    }
+    refs = [BlobRef(hash=chunk.content_hash, size=chunk.size) for chunk in chunks]
+    bundle: dict[str, Any] = {
+        BLOB_REF_MIME: build_multi_ref_bundle(
+            refs,
+            content_type=ARROW_STREAM_MIME,
+            summary=summary_hints,
+        ),
+        ARROW_STREAM_MANIFEST_MIME: build_arrow_stream_manifest_from_chunks(
+            chunks,
+            complete=True,
+            summary=summary_hints,
+            schema=table.schema,
+        ),
+    }
+    try:
+        bundle["text/llm+plain"] = summary_fn(included_rows, sampled)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("summary build failed: %s", exc)
+
+    pending = pending_buffers()
+    for chunk in chunks:
+        pending[chunk.content_hash] = chunk.data
+    return bundle
 
 
 def _summarize_arrow_table(

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -43,7 +43,13 @@ from traitlets import ObjectName, Unicode
 
 from nteract_kernel_launcher import _buffer_hook, _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
-from nteract_kernel_launcher._format import serialize_arrow_table, serialize_dataframe
+from nteract_kernel_launcher._format import (
+    ARROW_STREAM_MANIFEST_MIME,
+    ARROW_STREAM_MIME,
+    build_arrow_stream_manifest,
+    serialize_arrow_table,
+    serialize_dataframe,
+)
 from nteract_kernel_launcher._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
 from nteract_kernel_launcher._summary import summarize_dataframe, summarize_dataset
 
@@ -275,6 +281,17 @@ def _emit_table_bytes(
     ref_bundle["buffer_index"] = 0
 
     bundle: dict[str, Any] = {BLOB_REF_MIME: ref_bundle}
+    if content_type == ARROW_STREAM_MIME:
+        try:
+            bundle[ARROW_STREAM_MANIFEST_MIME] = build_arrow_stream_manifest(
+                data,
+                content_hash=h,
+                content_size=len(data),
+                row_count=included_rows,
+                summary=summary_hints,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug("arrow manifest build failed: %s", exc)
     try:
         bundle["text/llm+plain"] = summary_fn(included_rows, sampled)
     except Exception as exc:  # noqa: BLE001

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -160,7 +160,7 @@ def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
 def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
     """Serialize → stash bytes keyed by sha256 → return ref-mime bundle.
 
-    When parquet serialization fails (e.g. pyarrow missing), fall back to
+    When Arrow IPC serialization fails (e.g. pyarrow missing), fall back to
     a summary-only ``text/llm+plain`` bundle so agents still get column
     stats instead of a raw repr. IPython's default formatter chain merges
     pandas' ``text/html`` / ``text/plain`` on top for host-side fallback.
@@ -197,9 +197,8 @@ def _emit_arrow_table(
     """Serialize a ``pa.Table`` to Arrow IPC, preserving schema KV metadata.
 
     Distinct from :func:`_emit_dataframe` because the dataframe path runs
-    bytes through ``pa.Table.from_pandas`` / ``pl.write_parquet``, which drop
-    arbitrary schema KV metadata. The table path writes Arrow IPC directly, so
-    the ``huggingface`` key survives for Sift's rich-type detection.
+    bytes through the Arrow PyCapsule stream protocol or a ``pa.Table`` fallback,
+    so the ``huggingface`` key survives for Sift's rich-type detection.
 
     ``summary_fn`` lets callers (notably ``_dataset_mimebundle``) provide
     a richer per-domain summary (HF features) instead of the generic

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
@@ -61,6 +61,15 @@ def _pub_for_msg_type(msg_type: str) -> Any | None:
     return ip.display_pub
 
 
+def _ref_entries(ref: dict) -> list[dict]:
+    refs = ref.get("refs")
+    if isinstance(refs, list):
+        return [entry for entry in refs if isinstance(entry, dict)]
+    if isinstance(ref.get("hash"), str):
+        return [ref]
+    return []
+
+
 def buffer_hook(msg: dict) -> dict | None:
     """Attach ``buffers=[bytes]`` to outgoing messages that reference a
     blob we previously stashed. Return ``None`` if we sent it ourselves.
@@ -90,17 +99,24 @@ def buffer_hook(msg: dict) -> dict | None:
         if not isinstance(ref, dict):
             return msg
 
-        h = ref.get("hash")
-        if not isinstance(h, str):
+        entries = _ref_entries(ref)
+        if not entries:
             return msg
 
-        buffers = pending_buffers().pop(h, None)
-        if buffers is None:
+        hashes = [entry.get("hash") for entry in entries]
+        if not all(isinstance(h, str) for h in hashes):
+            return msg
+
+        pending = pending_buffers()
+        if not all(h in pending for h in hashes):
             # No stashed payload for this hash — maybe a re-publish of a
             # historical message, or a ref emitted outside our formatter.
             # Pass through unchanged; the daemon can still resolve via the
             # blob store if it already has the hash.
             return msg
+        buffers = [pending.pop(h) for h in hashes if isinstance(h, str)]
+        for index, entry in enumerate(entries):
+            entry["buffer_index"] = index
 
         pub = _pub_for_msg_type(msg_type)
         if pub is None:
@@ -110,7 +126,7 @@ def buffer_hook(msg: dict) -> dict | None:
             pub.pub_socket,
             msg,
             ident=pub.topic,
-            buffers=[buffers],
+            buffers=buffers,
         )
         return None
     except Exception as exc:  # noqa: BLE001

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -212,8 +212,17 @@ def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
         encoder = _serialize_pandas
         n = len(df)
     elif hasattr(df, "__arrow_c_stream__"):
-        encoder = _serialize_arrow_stream_exportable
         n = _row_count(df)
+        if n is None:
+            raise ValueError(
+                f"unsupported row count for: {type(df).__module__}.{type(df).__name__}"
+            )
+        data = _serialize_arrow_stream_exportable(df)
+        if len(data) > max_bytes:
+            raise ValueError(
+                "generic Arrow PyCapsule stream exceeds max_bytes; progressive chunking is required"
+            )
+        return data, ARROW_STREAM_MIME, n
     else:
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -64,6 +64,10 @@ def _record_batch_reader_from_stream(source: Any) -> Any:
     if callable(from_stream):
         return from_stream(source)
 
+    # PyArrow 14/15 expose producer-side `__arrow_c_stream__()` before the
+    # public `RecordBatchReader.from_stream()` consumer. Keep this fallback
+    # narrowly scoped to generic PyCapsule sources; known pyarrow.Table paths
+    # write IPC directly and do not depend on this private bridge.
     import_capsule = getattr(pa.RecordBatchReader, "_import_from_c_capsule", None)
     if callable(import_capsule) and hasattr(source, "__arrow_c_stream__"):
         return import_capsule(source.__arrow_c_stream__())
@@ -88,13 +92,22 @@ def _serialize_arrow_stream_exportable(source: Any, rows: int | None = None) -> 
     return _serialize_record_batch_reader(reader)
 
 
+def _serialize_arrow_table_direct(table: Any) -> bytes:
+    import pyarrow as pa
+
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
 def _serialize_pandas(df: Any, rows: int | None = None) -> bytes:
     import pyarrow as pa
 
     if rows is not None:
         df = df.head(rows)
     table = pa.Table.from_pandas(df)
-    return _serialize_arrow_stream_exportable(table)
+    return _serialize_arrow_table_direct(table)
 
 
 def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
@@ -108,7 +121,7 @@ def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
 def _serialize_arrow_stream_table(table: Any, rows: int | None = None) -> bytes:
     if rows is not None:
         table = table.slice(0, rows)
-    return _serialize_arrow_stream_exportable(table)
+    return _serialize_arrow_table_direct(table)
 
 
 def build_arrow_stream_manifest(

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -12,12 +12,36 @@ from __future__ import annotations
 
 import hashlib
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from typing import Any
 
 PARQUET_MIME = "application/vnd.apache.parquet"
 ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
 ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
+DEFAULT_ARROW_CHUNK_BYTES = 8 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ArrowStreamChunk:
+    """A self-contained Arrow IPC mini-stream chunk."""
+
+    index: int
+    data: bytes
+    content_hash: str
+    size: int
+    row_count: int
+    record_batch_count: int
+
+    def manifest_entry(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "hash": self.content_hash,
+            "size": self.size,
+            "row_count": self.row_count,
+            "record_batch_count": self.record_batch_count,
+            "encoding": "arrow-ipc-stream",
+        }
 
 
 def _detect_flavor(df: Any) -> str:
@@ -83,6 +107,95 @@ def _serialize_record_batch_reader(reader: Any) -> bytes:
         for batch in reader:
             writer.write_batch(batch)
     return sink.getvalue().to_pybytes()
+
+
+def _serialize_record_batches(schema: Any, batches: list[Any]) -> bytes:
+    import pyarrow as pa
+
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, schema) as writer:
+        for batch in batches:
+            writer.write_batch(batch)
+    return sink.getvalue().to_pybytes()
+
+
+def _record_batch_estimated_bytes(batch: Any) -> int:
+    nbytes = getattr(batch, "nbytes", None)
+    if isinstance(nbytes, int):
+        return nbytes
+    get_total_buffer_size = getattr(batch, "get_total_buffer_size", None)
+    if callable(get_total_buffer_size):
+        size = get_total_buffer_size()
+        if isinstance(size, int):
+            return size
+    return 0
+
+
+def _make_arrow_stream_chunk(
+    *,
+    index: int,
+    schema: Any,
+    batches: list[Any],
+    row_count: int,
+) -> ArrowStreamChunk:
+    data = _serialize_record_batches(schema, batches)
+    return ArrowStreamChunk(
+        index=index,
+        data=data,
+        content_hash=hashlib.sha256(data).hexdigest(),
+        size=len(data),
+        row_count=row_count,
+        record_batch_count=len(batches),
+    )
+
+
+def iter_arrow_stream_chunks(
+    source: Any,
+    *,
+    max_chunk_bytes: int = DEFAULT_ARROW_CHUNK_BYTES,
+) -> Iterator[ArrowStreamChunk]:
+    """Yield independently decodable Arrow IPC stream chunks from ``source``.
+
+    The source is consumed once as a ``RecordBatchReader``. Chunk boundaries are
+    record-batch boundaries; this intentionally avoids splitting serialized IPC
+    bytes after the fact.
+    """
+    if max_chunk_bytes <= 0:
+        raise ValueError("max_chunk_bytes must be positive")
+
+    reader = _record_batch_reader_from_stream(source)
+    schema = reader.schema
+    chunk_index = 0
+    batches: list[Any] = []
+    row_count = 0
+    estimated_bytes = 0
+
+    for batch in reader:
+        batch_rows = getattr(batch, "num_rows", 0)
+        batch_bytes = _record_batch_estimated_bytes(batch)
+        if batches and estimated_bytes + batch_bytes > max_chunk_bytes:
+            yield _make_arrow_stream_chunk(
+                index=chunk_index,
+                schema=schema,
+                batches=batches,
+                row_count=row_count,
+            )
+            chunk_index += 1
+            batches = []
+            row_count = 0
+            estimated_bytes = 0
+
+        batches.append(batch)
+        row_count += batch_rows
+        estimated_bytes += batch_bytes
+
+    if batches or chunk_index == 0:
+        yield _make_arrow_stream_chunk(
+            index=chunk_index,
+            schema=schema,
+            batches=batches,
+            row_count=row_count,
+        )
 
 
 def _serialize_arrow_stream_exportable(source: Any, rows: int | None = None) -> bytes:

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -198,6 +198,30 @@ def iter_arrow_stream_chunks(
         )
 
 
+def iter_arrow_table_chunks(
+    table: Any,
+    *,
+    max_chunk_bytes: int = DEFAULT_ARROW_CHUNK_BYTES,
+) -> Iterator[ArrowStreamChunk]:
+    """Yield bounded Arrow IPC stream chunks from a pyarrow Table."""
+    if max_chunk_bytes <= 0:
+        raise ValueError("max_chunk_bytes must be positive")
+    if table.num_rows == 0:
+        yield from iter_arrow_stream_chunks(table, max_chunk_bytes=max_chunk_bytes)
+        return
+
+    table_bytes = getattr(table, "nbytes", 0)
+    bytes_per_row = max(1, table_bytes // table.num_rows)
+    rows_per_chunk = max(1, max_chunk_bytes // bytes_per_row)
+    for index, batch in enumerate(table.to_batches(max_chunksize=rows_per_chunk)):
+        yield _make_arrow_stream_chunk(
+            index=index,
+            schema=table.schema,
+            batches=[batch],
+            row_count=batch.num_rows,
+        )
+
+
 def _serialize_arrow_stream_exportable(source: Any, rows: int | None = None) -> bytes:
     if rows is not None:
         source = _limit_rows(source, rows)

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -1,10 +1,9 @@
 """DataFrame / Arrow serialization (best-available encoder).
 
-Pandas uses pyarrow. Polars uses its native parquet writer.
-``pyarrow.Table`` and ``pyarrow.RecordBatch`` emit Arrow IPC
-streams, which preserve schema KV metadata (the ``huggingface`` key Sift uses
-for rich-type detection is the load-bearing case). If the serialized payload
-would exceed ``max_bytes``, the serializer downsamples via ``head(n)`` /
+Arrow IPC stream is the canonical rich table payload. Producers that implement
+the Arrow PyCapsule stream protocol are imported through ``__arrow_c_stream__``;
+pandas and polars keep direct fallbacks for older versions. If the serialized
+payload would exceed ``max_bytes``, the serializer downsamples via ``head(n)`` /
 ``slice(0, n)`` with a halving loop and the caller advertises the partial-data
 state in the ``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
 """
@@ -24,35 +23,90 @@ def _detect_flavor(df: Any) -> str:
     return mod if mod in ("pandas", "polars") else "unknown"
 
 
+def _row_count(obj: Any) -> int | None:
+    for attr in ("num_rows", "height"):
+        value = getattr(obj, attr, None)
+        if isinstance(value, int):
+            return value
+
+    shape = getattr(obj, "shape", None)
+    if isinstance(shape, tuple) and shape and isinstance(shape[0], int):
+        return shape[0]
+
+    try:
+        return len(obj)
+    except TypeError:
+        return None
+
+
+def _limit_rows(obj: Any, rows: int) -> Any:
+    head = getattr(obj, "head", None)
+    if callable(head):
+        return head(rows)
+
+    slice_ = getattr(obj, "slice", None)
+    if callable(slice_):
+        return slice_(0, rows)
+
+    limit = getattr(obj, "limit", None)
+    if callable(limit):
+        return limit(rows)
+
+    raise TypeError(f"{type(obj).__module__}.{type(obj).__name__} cannot be row-limited")
+
+
+def _record_batch_reader_from_stream(source: Any) -> Any:
+    import pyarrow as pa
+
+    from_stream = getattr(pa.RecordBatchReader, "from_stream", None)
+    if callable(from_stream):
+        return from_stream(source)
+
+    import_capsule = getattr(pa.RecordBatchReader, "_import_from_c_capsule", None)
+    if callable(import_capsule) and hasattr(source, "__arrow_c_stream__"):
+        return import_capsule(source.__arrow_c_stream__())
+
+    raise TypeError("pyarrow does not support Arrow PyCapsule stream import")
+
+
+def _serialize_record_batch_reader(reader: Any) -> bytes:
+    import pyarrow as pa
+
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, reader.schema) as writer:
+        for batch in reader:
+            writer.write_batch(batch)
+    return sink.getvalue().to_pybytes()
+
+
+def _serialize_arrow_stream_exportable(source: Any, rows: int | None = None) -> bytes:
+    if rows is not None:
+        source = _limit_rows(source, rows)
+    reader = _record_batch_reader_from_stream(source)
+    return _serialize_record_batch_reader(reader)
+
+
 def _serialize_pandas(df: Any, rows: int | None = None) -> bytes:
     import pyarrow as pa
-    import pyarrow.parquet as pq
 
     if rows is not None:
         df = df.head(rows)
-    table = pa.Table.from_pandas(df, preserve_index=False)
-    buf = io.BytesIO()
-    pq.write_table(table, buf, compression="snappy")
-    return buf.getvalue()
+    table = pa.Table.from_pandas(df)
+    return _serialize_arrow_stream_exportable(table)
 
 
 def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
     if rows is not None:
         df = df.head(rows)
     buf = io.BytesIO()
-    df.write_parquet(buf, compression="snappy")
+    df.write_ipc_stream(buf)
     return buf.getvalue()
 
 
 def _serialize_arrow_stream_table(table: Any, rows: int | None = None) -> bytes:
-    import pyarrow as pa
-
     if rows is not None:
         table = table.slice(0, rows)
-    sink = pa.BufferOutputStream()
-    with pa.ipc.new_stream(sink, table.schema) as writer:
-        writer.write_table(table)
-    return sink.getvalue().to_pybytes()
+    return _serialize_arrow_stream_exportable(table)
 
 
 def _downsample_loop(
@@ -80,13 +134,16 @@ def _downsample_loop(
 
 
 def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
-    """Serialize ``df`` to parquet; downsample if it would exceed ``max_bytes``.
+    """Serialize ``df`` to Arrow IPC; downsample if it would exceed ``max_bytes``.
 
     Returns ``(bytes, content_type, included_rows)``. Raises ``ValueError`` for
     unsupported DataFrame types.
     """
     flavor = _detect_flavor(df)
-    if flavor == "pandas":
+    if hasattr(df, "__arrow_c_stream__"):
+        encoder = _serialize_arrow_stream_exportable
+        n = _row_count(df)
+    elif flavor == "pandas":
         encoder = _serialize_pandas
         n = len(df)
     elif flavor == "polars":
@@ -95,10 +152,13 @@ def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
     else:
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
 
+    if n is None:
+        raise ValueError(f"unsupported row count for: {type(df).__module__}.{type(df).__name__}")
+
     data, included_rows = _downsample_loop(
         lambda rows=None: encoder(df, rows=rows), n, max_bytes=max_bytes
     )
-    return data, PARQUET_MIME, included_rows
+    return data, ARROW_STREAM_MIME, included_rows
 
 
 def serialize_arrow_table(table: Any, *, max_bytes: int) -> tuple[bytes, str, int]:

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -276,6 +276,7 @@ def build_arrow_stream_manifest_from_chunks(
     *,
     complete: bool,
     summary: dict[str, Any] | None = None,
+    schema: Any | None = None,
 ) -> dict[str, Any]:
     """Build an Arrow stream manifest for ordered IPC mini-stream chunks."""
     import pyarrow as pa
@@ -283,8 +284,8 @@ def build_arrow_stream_manifest_from_chunks(
     if not chunks:
         raise ValueError("at least one Arrow stream chunk is required")
 
-    reader = pa.ipc.open_stream(pa.BufferReader(chunks[0].data))
-    schema = reader.schema
+    if schema is None:
+        schema = pa.ipc.open_stream(pa.BufferReader(chunks[0].data)).schema
     schema_bytes = schema.serialize().to_pybytes()
     metadata = schema.metadata or {}
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -132,9 +132,16 @@ def build_arrow_stream_manifest(
     reader = pa.ipc.open_stream(pa.BufferReader(data))
     schema = reader.schema
     schema_bytes = schema.serialize().to_pybytes()
-    if record_batch_count is None:
-        record_batch_count = sum(1 for _ in reader)
     metadata = schema.metadata or {}
+    chunk: dict[str, Any] = {
+        "index": 0,
+        "hash": content_hash,
+        "size": content_size,
+        "row_count": row_count,
+        "encoding": "arrow-ipc-stream",
+    }
+    if record_batch_count is not None:
+        chunk["record_batch_count"] = record_batch_count
 
     return {
         "version": 1,
@@ -148,16 +155,7 @@ def build_arrow_stream_manifest(
                 "huggingface": b"huggingface" in metadata,
             },
         },
-        "chunks": [
-            {
-                "index": 0,
-                "hash": content_hash,
-                "size": content_size,
-                "row_count": row_count,
-                "record_batch_count": record_batch_count,
-                "encoding": "arrow-ipc-stream",
-            }
-        ],
+        "chunks": [chunk],
         "complete": True,
         "summary": summary or {},
     }
@@ -194,15 +192,15 @@ def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
     unsupported DataFrame types.
     """
     flavor = _detect_flavor(df)
-    if hasattr(df, "__arrow_c_stream__"):
-        encoder = _serialize_arrow_stream_exportable
-        n = _row_count(df)
+    if flavor == "polars":
+        encoder = _serialize_polars
+        n = df.height
     elif flavor == "pandas":
         encoder = _serialize_pandas
         n = len(df)
-    elif flavor == "polars":
-        encoder = _serialize_polars
-        n = df.height
+    elif hasattr(df, "__arrow_c_stream__"):
+        encoder = _serialize_arrow_stream_exportable
+        n = _row_count(df)
     else:
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -10,12 +10,14 @@ state in the ``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
 
 from __future__ import annotations
 
+import hashlib
 import io
 from collections.abc import Callable
 from typing import Any
 
 PARQUET_MIME = "application/vnd.apache.parquet"
 ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
+ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
 
 
 def _detect_flavor(df: Any) -> str:
@@ -107,6 +109,58 @@ def _serialize_arrow_stream_table(table: Any, rows: int | None = None) -> bytes:
     if rows is not None:
         table = table.slice(0, rows)
     return _serialize_arrow_stream_exportable(table)
+
+
+def build_arrow_stream_manifest(
+    data: bytes,
+    *,
+    content_hash: str,
+    content_size: int,
+    row_count: int,
+    record_batch_count: int | None = None,
+    summary: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a one-chunk Arrow stream manifest for ``data``.
+
+    Phase 2 keeps the direct Arrow IPC stream MIME in the bundle for existing
+    renderers. The manifest is a structured sidecar describing that same blob
+    so runtime/frontends can learn the durable shape before progressive chunks
+    become the selected render path.
+    """
+    import pyarrow as pa
+
+    reader = pa.ipc.open_stream(pa.BufferReader(data))
+    schema = reader.schema
+    schema_bytes = schema.serialize().to_pybytes()
+    if record_batch_count is None:
+        record_batch_count = sum(1 for _ in reader)
+    metadata = schema.metadata or {}
+
+    return {
+        "version": 1,
+        "content_type": ARROW_STREAM_MIME,
+        "schema": {
+            "hash": hashlib.sha256(schema_bytes).hexdigest(),
+            "content_type": "application/vnd.apache.arrow.schema",
+            "fields": len(schema),
+            "metadata": {
+                "pandas": b"pandas" in metadata,
+                "huggingface": b"huggingface" in metadata,
+            },
+        },
+        "chunks": [
+            {
+                "index": 0,
+                "hash": content_hash,
+                "size": content_size,
+                "row_count": row_count,
+                "record_batch_count": record_batch_count,
+                "encoding": "arrow-ipc-stream",
+            }
+        ],
+        "complete": True,
+        "summary": summary or {},
+    }
 
 
 def _downsample_loop(

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -253,21 +253,40 @@ def build_arrow_stream_manifest(
     so runtime/frontends can learn the durable shape before progressive chunks
     become the selected render path.
     """
+    chunk = ArrowStreamChunk(
+        index=0,
+        data=data,
+        content_hash=content_hash,
+        size=content_size,
+        row_count=row_count,
+        record_batch_count=record_batch_count or 0,
+    )
+    manifest = build_arrow_stream_manifest_from_chunks(
+        [chunk],
+        complete=True,
+        summary=summary,
+    )
+    if record_batch_count is None:
+        manifest["chunks"][0].pop("record_batch_count", None)
+    return manifest
+
+
+def build_arrow_stream_manifest_from_chunks(
+    chunks: list[ArrowStreamChunk],
+    *,
+    complete: bool,
+    summary: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an Arrow stream manifest for ordered IPC mini-stream chunks."""
     import pyarrow as pa
 
-    reader = pa.ipc.open_stream(pa.BufferReader(data))
+    if not chunks:
+        raise ValueError("at least one Arrow stream chunk is required")
+
+    reader = pa.ipc.open_stream(pa.BufferReader(chunks[0].data))
     schema = reader.schema
     schema_bytes = schema.serialize().to_pybytes()
     metadata = schema.metadata or {}
-    chunk: dict[str, Any] = {
-        "index": 0,
-        "hash": content_hash,
-        "size": content_size,
-        "row_count": row_count,
-        "encoding": "arrow-ipc-stream",
-    }
-    if record_batch_count is not None:
-        chunk["record_batch_count"] = record_batch_count
 
     return {
         "version": 1,
@@ -281,8 +300,8 @@ def build_arrow_stream_manifest(
                 "huggingface": b"huggingface" in metadata,
             },
         },
-        "chunks": [chunk],
-        "complete": True,
+        "chunks": [chunk.manifest_entry() for chunk in chunks],
+        "complete": complete,
         "summary": summary or {},
     }
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from itertools import chain
 from typing import Any
 
 from nteract_kernel_launcher._buffer_hook import pending_buffers
@@ -42,10 +43,12 @@ def _summary_text(summary: dict[str, Any], *, complete: bool) -> str:
 
 def _bundle_for_progressive_chunk(
     *,
-    current_chunk: ArrowStreamChunk,
+    current_chunk: ArrowStreamChunk | None,
     chunks: list[ArrowStreamChunk],
     complete: bool,
     total_rows: int | None,
+    schema: Any,
+    include_blob_ref: bool,
 ) -> dict[str, Any]:
     included_rows = sum(chunk.row_count for chunk in chunks)
     summary = _summary_hints(
@@ -54,20 +57,30 @@ def _bundle_for_progressive_chunk(
         complete=complete,
     )
 
-    ref = BlobRef(hash=current_chunk.content_hash, size=current_chunk.size)
-    ref_bundle = build_ref_bundle(ref, content_type=ARROW_STREAM_MIME, summary=summary)
-    ref_bundle["buffer_index"] = 0
-
-    pending_buffers()[current_chunk.content_hash] = current_chunk.data
-    return {
-        BLOB_REF_MIME: ref_bundle,
+    bundle: dict[str, Any] = {
         ARROW_STREAM_MANIFEST_MIME: build_arrow_stream_manifest_from_chunks(
             chunks,
             complete=complete,
             summary=summary,
+            schema=schema,
         ),
         "text/llm+plain": _summary_text(summary, complete=complete),
     }
+    if include_blob_ref:
+        if current_chunk is None:
+            raise ValueError("current_chunk is required when include_blob_ref=True")
+        ref = BlobRef(hash=current_chunk.content_hash, size=current_chunk.size)
+        ref_bundle = build_ref_bundle(ref, content_type=ARROW_STREAM_MIME, summary=summary)
+        ref_bundle["buffer_index"] = 0
+        pending_buffers()[current_chunk.content_hash] = current_chunk.data
+        bundle[BLOB_REF_MIME] = ref_bundle
+    return bundle
+
+
+def _schema_for_chunk(chunk: ArrowStreamChunk) -> Any:
+    import pyarrow as pa
+
+    return pa.ipc.open_stream(pa.BufferReader(chunk.data)).schema
 
 
 def display_arrow_stream(
@@ -87,28 +100,58 @@ def display_arrow_stream(
     if display_fn is None:
         from IPython.display import display as display_fn
 
-    chunks: list[ArrowStreamChunk] = []
-    handle = None
-    for chunk in iter_arrow_stream_chunks(source, max_chunk_bytes=max_chunk_bytes):
+    iterator = iter(iter_arrow_stream_chunks(source, max_chunk_bytes=max_chunk_bytes))
+    try:
+        first_chunk = next(iterator)
+    except StopIteration:
+        return None
+
+    schema = _schema_for_chunk(first_chunk)
+    chunks: list[ArrowStreamChunk] = [first_chunk]
+
+    try:
+        second_chunk = next(iterator)
+    except StopIteration:
+        bundle = _bundle_for_progressive_chunk(
+            current_chunk=first_chunk,
+            chunks=chunks,
+            complete=True,
+            total_rows=total_rows,
+            schema=schema,
+            include_blob_ref=True,
+        )
+        return display_fn(bundle, raw=True, display_id=display_id)
+
+    first_bundle = _bundle_for_progressive_chunk(
+        current_chunk=first_chunk,
+        chunks=chunks,
+        complete=False,
+        total_rows=total_rows,
+        schema=schema,
+        include_blob_ref=True,
+    )
+    handle = display_fn(first_bundle, raw=True, display_id=display_id)
+
+    for chunk in chain([second_chunk], iterator):
         chunks.append(chunk)
         bundle = _bundle_for_progressive_chunk(
             current_chunk=chunk,
             chunks=chunks,
             complete=False,
             total_rows=total_rows,
+            schema=schema,
+            include_blob_ref=True,
         )
-        if handle is None:
-            handle = display_fn(bundle, raw=True, display_id=display_id)
-        else:
-            handle.update(bundle, raw=True)
+        handle.update(bundle, raw=True)
 
-    if chunks and handle is not None:
-        final_bundle = _bundle_for_progressive_chunk(
-            current_chunk=chunks[-1],
-            chunks=chunks,
-            complete=True,
-            total_rows=total_rows,
-        )
-        handle.update(final_bundle, raw=True)
+    final_bundle = _bundle_for_progressive_chunk(
+        current_chunk=None,
+        chunks=chunks,
+        complete=True,
+        total_rows=total_rows,
+        schema=schema,
+        include_blob_ref=False,
+    )
+    handle.update(final_bundle, raw=True)
 
     return handle

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py
@@ -1,0 +1,114 @@
+"""Progressive Arrow stream display helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from nteract_kernel_launcher._buffer_hook import pending_buffers
+from nteract_kernel_launcher._format import (
+    ARROW_STREAM_MANIFEST_MIME,
+    ARROW_STREAM_MIME,
+    DEFAULT_ARROW_CHUNK_BYTES,
+    ArrowStreamChunk,
+    build_arrow_stream_manifest_from_chunks,
+    iter_arrow_stream_chunks,
+)
+from nteract_kernel_launcher._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
+
+
+def _summary_hints(
+    *,
+    total_rows: int | None,
+    included_rows: int,
+    complete: bool,
+) -> dict[str, Any]:
+    sampled = total_rows is not None and included_rows != total_rows
+    return {
+        "total_rows": total_rows if total_rows is not None else included_rows,
+        "included_rows": included_rows,
+        "sampled": sampled or not complete,
+        "sample_strategy": "none" if complete and not sampled else "head",
+    }
+
+
+def _summary_text(summary: dict[str, Any], *, complete: bool) -> str:
+    included_rows = summary["included_rows"]
+    total_rows = summary["total_rows"]
+    if complete:
+        return f"Arrow stream table: {included_rows} rows"
+    return f"Arrow stream table: {included_rows} of {total_rows} rows loaded"
+
+
+def _bundle_for_progressive_chunk(
+    *,
+    current_chunk: ArrowStreamChunk,
+    chunks: list[ArrowStreamChunk],
+    complete: bool,
+    total_rows: int | None,
+) -> dict[str, Any]:
+    included_rows = sum(chunk.row_count for chunk in chunks)
+    summary = _summary_hints(
+        total_rows=total_rows,
+        included_rows=included_rows,
+        complete=complete,
+    )
+
+    ref = BlobRef(hash=current_chunk.content_hash, size=current_chunk.size)
+    ref_bundle = build_ref_bundle(ref, content_type=ARROW_STREAM_MIME, summary=summary)
+    ref_bundle["buffer_index"] = 0
+
+    pending_buffers()[current_chunk.content_hash] = current_chunk.data
+    return {
+        BLOB_REF_MIME: ref_bundle,
+        ARROW_STREAM_MANIFEST_MIME: build_arrow_stream_manifest_from_chunks(
+            chunks,
+            complete=complete,
+            summary=summary,
+        ),
+        "text/llm+plain": _summary_text(summary, complete=complete),
+    }
+
+
+def display_arrow_stream(
+    source: Any,
+    *,
+    display_id: bool | str = True,
+    max_chunk_bytes: int = DEFAULT_ARROW_CHUNK_BYTES,
+    total_rows: int | None = None,
+    display_fn: Callable[..., Any] | None = None,
+) -> Any:
+    """Display ``source`` progressively as Arrow IPC stream manifest chunks.
+
+    This explicit helper owns the Jupyter ``display_id`` / ``update_display_data``
+    path. Automatic dataframe reprs still use the one-shot formatter because
+    IPython MIME formatters cannot create their own transient display ids.
+    """
+    if display_fn is None:
+        from IPython.display import display as display_fn
+
+    chunks: list[ArrowStreamChunk] = []
+    handle = None
+    for chunk in iter_arrow_stream_chunks(source, max_chunk_bytes=max_chunk_bytes):
+        chunks.append(chunk)
+        bundle = _bundle_for_progressive_chunk(
+            current_chunk=chunk,
+            chunks=chunks,
+            complete=False,
+            total_rows=total_rows,
+        )
+        if handle is None:
+            handle = display_fn(bundle, raw=True, display_id=display_id)
+        else:
+            handle.update(bundle, raw=True)
+
+    if chunks and handle is not None:
+        final_bundle = _bundle_for_progressive_chunk(
+            current_chunk=chunks[-1],
+            chunks=chunks,
+            complete=True,
+            total_rows=total_rows,
+        )
+        handle.update(final_bundle, raw=True)
+
+    return handle

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 BLOB_REF_MIME = "application/vnd.nteract.blob-ref+json"
 
@@ -48,6 +49,33 @@ def build_ref_bundle(
         "content_type": content_type,
         "size": ref.size,
         "query": query,
+    }
+    if summary is not None:
+        bundle["summary"] = summary
+    return bundle
+
+
+def build_multi_ref_bundle(
+    refs: list[BlobRef],
+    *,
+    content_type: str,
+    summary: dict | None = None,
+    query: dict | None = None,
+) -> dict[str, Any]:
+    """Build a transport envelope for multiple attached blob buffers."""
+    bundle: dict[str, Any] = {
+        "content_type": content_type,
+        "refs": [
+            {
+                "hash": ref.hash,
+                "content_type": content_type,
+                "size": ref.size,
+                "buffer_index": index,
+            }
+            for index, ref in enumerate(refs)
+        ],
+        "query": query,
+        "size": sum(ref.size for ref in refs),
     }
     if summary is not None:
         bundle["summary"] = summary

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -168,6 +168,39 @@ def test_buffer_hook_routes_display_data_via_display_pub(monkeypatch):
     assert sent[0]["buffers"] == [data]
 
 
+def test_buffer_hook_attaches_multiple_ref_buffers(monkeypatch):
+    from nteract_kernel_launcher import _buffer_hook
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    ip, sent, pub, dh = _fake_ip_with_pubs()
+    monkeypatch.setattr(_buffer_hook, "_get_ipython", lambda: ip)
+
+    chunks = [b"chunk-one", b"chunk-two"]
+    refs = []
+    for chunk in chunks:
+        h = hashlib.sha256(chunk).hexdigest()
+        _buffer_hook.pending_buffers()[h] = chunk
+        refs.append(
+            {
+                "hash": h,
+                "size": len(chunk),
+                "content_type": "application/vnd.apache.arrow.stream",
+            }
+        )
+
+    msg = {
+        "header": {"msg_type": "display_data"},
+        "content": {"data": {BLOB_REF_MIME: {"refs": refs}}},
+    }
+    result = _buffer_hook.buffer_hook(msg)
+
+    assert result is None
+    assert sent[0]["socket"] == "PUB"
+    assert sent[0]["buffers"] == chunks
+    assert refs[0]["buffer_index"] == 0
+    assert refs[1]["buffer_index"] == 1
+
+
 def test_buffer_hook_passthrough_when_no_pending_bytes(monkeypatch):
     from nteract_kernel_launcher import _buffer_hook
     from nteract_kernel_launcher._refs import BLOB_REF_MIME
@@ -413,6 +446,36 @@ def test_emit_pyarrow_table_preserves_huggingface_kv_metadata():
     md = pa.ipc.open_stream(io.BytesIO(data)).read_all().schema.metadata or {}
     assert b"huggingface" in md, f"missing huggingface KV; got keys: {[k.decode() for k in md]}"
     assert b'"_type": "Image"' in md[b"huggingface"]
+
+
+def test_emit_pyarrow_table_chunks_when_full_stream_exceeds_limit(monkeypatch):
+    pytest.importorskip("pyarrow")
+
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    _buffer_hook.pending_buffers().clear()
+    monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 1)
+    table = _pa_table_with_hf_metadata()
+
+    bundle = _bootstrap._pyarrow_table_mimebundle(table)
+
+    assert bundle is not None
+    manifest = bundle[ARROW_STREAM_MANIFEST_MIME]
+    assert manifest["complete"] is True
+    assert manifest["summary"] == {
+        "total_rows": table.num_rows,
+        "included_rows": table.num_rows,
+        "sampled": False,
+        "sample_strategy": "none",
+    }
+    assert len(manifest["chunks"]) > 1
+    refs = bundle[BLOB_REF_MIME]["refs"]
+    assert len(refs) == len(manifest["chunks"])
+    assert [ref["hash"] for ref in refs] == [chunk["hash"] for chunk in manifest["chunks"]]
+    for ref in refs:
+        assert ref["hash"] in _buffer_hook.pending_buffers()
 
 
 def test_emit_pyarrow_record_batch_promotes_to_table():

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -337,6 +337,7 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
     pytest.importorskip("pyarrow")
 
     from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
     from nteract_kernel_launcher._refs import BLOB_REF_MIME
 
     _buffer_hook.pending_buffers().clear()
@@ -349,6 +350,8 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
     h = bundle[BLOB_REF_MIME]["hash"]
     assert h in _buffer_hook.pending_buffers()
     assert isinstance(_buffer_hook.pending_buffers()[h], bytes)
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["chunks"][0]["hash"] == h
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"]["included_rows"] == 3
 
 
 # ─── pyarrow.Table path — preserves schema KV metadata ───────────────────
@@ -391,6 +394,7 @@ def test_emit_pyarrow_table_preserves_huggingface_kv_metadata():
     pa = pytest.importorskip("pyarrow")
 
     from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
     from nteract_kernel_launcher._refs import BLOB_REF_MIME
 
     _buffer_hook.pending_buffers().clear()
@@ -404,6 +408,7 @@ def test_emit_pyarrow_table_preserves_huggingface_kv_metadata():
 
     h = bundle[BLOB_REF_MIME]["hash"]
     assert bundle[BLOB_REF_MIME]["content_type"] == "application/vnd.apache.arrow.stream"
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["schema"]["metadata"]["huggingface"] is True
     data = _buffer_hook.pending_buffers()[h]
     md = pa.ipc.open_stream(io.BytesIO(data)).read_all().schema.metadata or {}
     assert b"huggingface" in md, f"missing huggingface KV; got keys: {[k.decode() for k in md]}"

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -68,15 +68,34 @@ def test_serialize_dataframe_pandas_round_trips_data():
 def test_serialize_dataframe_pandas_preserves_index_metadata():
     pd = pytest.importorskip("pandas")
     pa = pytest.importorskip("pyarrow")
-    from nteract_kernel_launcher._format import serialize_dataframe
+    import nteract_kernel_launcher._format as fmt
 
     df = pd.DataFrame({"value": [1, 2]}, index=pd.Index(["x", "y"], name="label"))
-    data, _, _ = serialize_dataframe(df, max_bytes=10_000_000)
+    data, _, _ = fmt.serialize_dataframe(df, max_bytes=10_000_000)
 
     table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
     md = table.schema.metadata or {}
     assert b"pandas" in md
     assert "label" in table.column_names
+
+
+def test_serialize_dataframe_pandas_uses_direct_table_writer(monkeypatch):
+    pd = pytest.importorskip("pandas")
+    import nteract_kernel_launcher._format as fmt
+
+    def fail_pycapsule_path(*_args, **_kwargs):
+        raise AssertionError("pandas should write its pa.Table directly")
+
+    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", fail_pycapsule_path)
+
+    data, ct, included_rows = fmt.serialize_dataframe(
+        pd.DataFrame({"a": [1, 2, 3]}),
+        max_bytes=10_000_000,
+    )
+
+    assert ct == fmt.ARROW_STREAM_MIME
+    assert included_rows == 3
+    assert data
 
 
 def test_serialize_dataframe_polars_emits_arrow_stream():
@@ -138,6 +157,26 @@ def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
     assert included_rows == 10
     assert table.column_names == ["a"]
     assert table.num_rows == 10
+
+
+def test_serialize_arrow_table_uses_direct_writer(monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+    import nteract_kernel_launcher._format as fmt
+
+    def fail_pycapsule_path(*_args, **_kwargs):
+        raise AssertionError("pyarrow.Table should use direct IPC writer")
+
+    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", fail_pycapsule_path)
+
+    data, ct, included_rows = fmt.serialize_arrow_table(
+        pa.table({"a": [1, 2, 3]}),
+        max_bytes=10_000_000,
+    )
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert ct == fmt.ARROW_STREAM_MIME
+    assert included_rows == 3
+    assert table.num_rows == 3
 
 
 def test_build_arrow_stream_manifest_describes_one_chunk():

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -94,6 +94,25 @@ def test_serialize_dataframe_polars_emits_arrow_stream():
     assert table.num_rows == 3
 
 
+def test_serialize_dataframe_polars_uses_native_writer(monkeypatch):
+    pl = pytest.importorskip("polars")
+    import nteract_kernel_launcher._format as fmt
+
+    def fail_pycapsule_path(*_args, **_kwargs):
+        raise AssertionError("polars should use its native IPC writer")
+
+    monkeypatch.setattr(fmt, "_serialize_arrow_stream_exportable", fail_pycapsule_path)
+
+    data, ct, included_rows = fmt.serialize_dataframe(
+        pl.DataFrame({"a": [1, 2, 3]}),
+        max_bytes=10_000_000,
+    )
+
+    assert ct == fmt.ARROW_STREAM_MIME
+    assert included_rows == 3
+    assert data
+
+
 def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
     pa = pytest.importorskip("pyarrow")
     from nteract_kernel_launcher._format import ARROW_STREAM_MIME, serialize_dataframe
@@ -140,6 +159,7 @@ def test_build_arrow_stream_manifest_describes_one_chunk():
         content_hash="abc123",
         content_size=len(data),
         row_count=3,
+        record_batch_count=1,
         summary={"total_rows": 3, "included_rows": 3},
     )
 

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -239,3 +239,80 @@ def test_build_arrow_stream_manifest_describes_one_chunk():
             "encoding": "arrow-ipc-stream",
         }
     ]
+
+
+def test_iter_arrow_stream_chunks_yields_decodable_mini_streams():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import iter_arrow_stream_chunks
+
+    table = pa.table({"a": list(range(6)), "b": [f"row-{i}" for i in range(6)]})
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=2))
+
+    chunks = list(iter_arrow_stream_chunks(reader, max_chunk_bytes=1))
+
+    assert [chunk.index for chunk in chunks] == [0, 1, 2]
+    assert [chunk.row_count for chunk in chunks] == [2, 2, 2]
+    assert [chunk.record_batch_count for chunk in chunks] == [1, 1, 1]
+    decoded = [pa.ipc.open_stream(io.BytesIO(chunk.data)).read_all() for chunk in chunks]
+    assert [part.num_rows for part in decoded] == [2, 2, 2]
+    assert [part.column_names for part in decoded] == [["a", "b"], ["a", "b"], ["a", "b"]]
+    assert [chunk.manifest_entry()["hash"] for chunk in chunks] == [
+        chunk.content_hash for chunk in chunks
+    ]
+
+
+def test_iter_arrow_stream_chunks_preserves_schema_metadata():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import iter_arrow_stream_chunks
+
+    table = _pa_table_with_hf_metadata()
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=500))
+
+    chunks = list(iter_arrow_stream_chunks(reader, max_chunk_bytes=1))
+
+    assert len(chunks) == 2
+    for chunk in chunks:
+        decoded = pa.ipc.open_stream(io.BytesIO(chunk.data)).read_all()
+        md = decoded.schema.metadata or {}
+        assert b"huggingface" in md
+        assert md[b"custom"] == b"value"
+
+
+def test_iter_arrow_stream_chunks_consumes_pycapsule_stream_once():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import iter_arrow_stream_chunks
+
+    class SinglePassStream:
+        def __init__(self):
+            self._used = False
+            self._table = pa.table({"a": list(range(4))})
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            if self._used:
+                raise RuntimeError("stream already consumed")
+            self._used = True
+            return self._table.__arrow_c_stream__(requested_schema)
+
+    source = SinglePassStream()
+    chunks = list(iter_arrow_stream_chunks(source, max_chunk_bytes=1))
+
+    assert len(chunks) == 1
+    assert chunks[0].row_count == 4
+    assert source._used is True
+
+
+def test_iter_arrow_stream_chunks_emits_empty_stream_for_empty_reader():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import iter_arrow_stream_chunks
+
+    schema = pa.schema([pa.field("a", pa.int64())])
+    reader = pa.RecordBatchReader.from_batches(schema, [])
+
+    chunks = list(iter_arrow_stream_chunks(reader))
+
+    assert len(chunks) == 1
+    assert chunks[0].row_count == 0
+    assert chunks[0].record_batch_count == 0
+    decoded = pa.ipc.open_stream(io.BytesIO(chunks[0].data)).read_all()
+    assert decoded.schema == schema
+    assert decoded.num_rows == 0

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -1,8 +1,7 @@
 """Tests for the table serialization helpers in ``_format``.
 
-Coverage focus: the pa.Table path emits Arrow IPC and preserves schema KV
-metadata (the HF ``huggingface`` key Sift uses for rich-type detection) and
-the downsample loop converges for both dataframe and arrow inputs.
+Coverage focus: table-like producers emit Arrow IPC, preserve schema metadata,
+and downsample through the same bounded head/slice loop.
 """
 
 from __future__ import annotations
@@ -54,13 +53,69 @@ def test_serialize_arrow_table_downsamples_when_oversized():
 
 def test_serialize_dataframe_pandas_round_trips_data():
     pd = pytest.importorskip("pandas")
-    pq = pytest.importorskip("pyarrow.parquet")
-    from nteract_kernel_launcher._format import PARQUET_MIME, serialize_dataframe
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import ARROW_STREAM_MIME, serialize_dataframe
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
     data, ct, included_rows = serialize_dataframe(df, max_bytes=10_000_000)
-    assert ct == PARQUET_MIME
+    assert ct == ARROW_STREAM_MIME
     assert included_rows == 3
-    table = pq.read_table(io.BytesIO(data))
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
     assert table.column_names == ["a", "b"]
     assert table.num_rows == 3
+
+
+def test_serialize_dataframe_pandas_preserves_index_metadata():
+    pd = pytest.importorskip("pandas")
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import serialize_dataframe
+
+    df = pd.DataFrame({"value": [1, 2]}, index=pd.Index(["x", "y"], name="label"))
+    data, _, _ = serialize_dataframe(df, max_bytes=10_000_000)
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    md = table.schema.metadata or {}
+    assert b"pandas" in md
+    assert "label" in table.column_names
+
+
+def test_serialize_dataframe_polars_emits_arrow_stream():
+    pa = pytest.importorskip("pyarrow")
+    pl = pytest.importorskip("polars")
+    from nteract_kernel_launcher._format import ARROW_STREAM_MIME, serialize_dataframe
+
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    data, ct, included_rows = serialize_dataframe(df, max_bytes=10_000_000)
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert ct == ARROW_STREAM_MIME
+    assert included_rows == 3
+    assert table.column_names == ["a", "b"]
+    assert table.num_rows == 3
+
+
+def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import ARROW_STREAM_MIME, serialize_dataframe
+
+    class StreamOnlyTable:
+        def __init__(self, table):
+            self._table = table
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            return self._table.__arrow_c_stream__(requested_schema)
+
+        def __len__(self):
+            return self._table.num_rows
+
+        def head(self, rows):
+            return type(self)(self._table.slice(0, rows))
+
+    source = StreamOnlyTable(pa.table({"a": list(range(10))}))
+    data, ct, included_rows = serialize_dataframe(source, max_bytes=10_000_000)
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert ct == ARROW_STREAM_MIME
+    assert included_rows == 10
+    assert table.column_names == ["a"]
+    assert table.num_rows == 10

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -119,3 +119,42 @@ def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
     assert included_rows == 10
     assert table.column_names == ["a"]
     assert table.num_rows == 10
+
+
+def test_build_arrow_stream_manifest_describes_one_chunk():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import (
+        ARROW_STREAM_MANIFEST_MIME,
+        ARROW_STREAM_MIME,
+        build_arrow_stream_manifest,
+    )
+
+    table = pa.table({"a": [1, 2, 3]})
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    data = sink.getvalue().to_pybytes()
+
+    manifest = build_arrow_stream_manifest(
+        data,
+        content_hash="abc123",
+        content_size=len(data),
+        row_count=3,
+        summary={"total_rows": 3, "included_rows": 3},
+    )
+
+    assert ARROW_STREAM_MANIFEST_MIME == "application/vnd.nteract.arrow-stream-manifest+json"
+    assert manifest["content_type"] == ARROW_STREAM_MIME
+    assert manifest["complete"] is True
+    assert manifest["schema"]["fields"] == 1
+    assert manifest["schema"]["content_type"] == "application/vnd.apache.arrow.schema"
+    assert manifest["chunks"] == [
+        {
+            "index": 0,
+            "hash": "abc123",
+            "size": len(data),
+            "row_count": 3,
+            "record_batch_count": 1,
+            "encoding": "arrow-ipc-stream",
+        }
+    ]

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -159,6 +159,28 @@ def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
     assert table.num_rows == 10
 
 
+def test_serialize_dataframe_rejects_oversized_generic_pycapsule_stream():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import serialize_dataframe
+
+    class SinglePassStream:
+        def __init__(self):
+            self._used = False
+            self._table = pa.table({"a": list(range(100))})
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            if self._used:
+                raise RuntimeError("stream already consumed")
+            self._used = True
+            return self._table.__arrow_c_stream__(requested_schema)
+
+        def __len__(self):
+            return self._table.num_rows
+
+    with pytest.raises(ValueError, match="progressive chunking is required"):
+        serialize_dataframe(SinglePassStream(), max_bytes=1)
+
+
 def test_serialize_arrow_table_uses_direct_writer(monkeypatch):
     pa = pytest.importorskip("pyarrow")
     import nteract_kernel_launcher._format as fmt

--- a/python/nteract-kernel-launcher/tests/test_progressive.py
+++ b/python/nteract-kernel-launcher/tests/test_progressive.py
@@ -1,0 +1,62 @@
+"""Tests for progressive Arrow stream display helpers."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+
+def test_display_arrow_stream_publishes_manifest_revisions():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher import _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._progressive import display_arrow_stream
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    messages = []
+
+    class Handle:
+        def update(self, obj, **kwargs):
+            messages.append(("update", obj, kwargs))
+
+    def fake_display(obj, **kwargs):
+        messages.append(("display", obj, kwargs))
+        return Handle()
+
+    _buffer_hook.pending_buffers().clear()
+    table = pa.table({"a": list(range(6))})
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=2))
+
+    handle = display_arrow_stream(
+        reader,
+        display_fn=fake_display,
+        max_chunk_bytes=1,
+        total_rows=table.num_rows,
+    )
+
+    assert isinstance(handle, Handle)
+    assert [kind for kind, _, _ in messages] == ["display", "update", "update", "update"]
+    assert messages[0][2] == {"raw": True, "display_id": True}
+    assert messages[1][2] == {"raw": True}
+
+    manifests = [message[1][ARROW_STREAM_MANIFEST_MIME] for message in messages]
+    assert [len(manifest["chunks"]) for manifest in manifests] == [1, 2, 3, 3]
+    assert [manifest["complete"] for manifest in manifests] == [False, False, False, True]
+    assert manifests[-1]["summary"] == {
+        "total_rows": 6,
+        "included_rows": 6,
+        "sampled": False,
+        "sample_strategy": "none",
+    }
+
+    first_hash = messages[0][1][BLOB_REF_MIME]["hash"]
+    assert first_hash in _buffer_hook.pending_buffers()
+    decoded = pa.ipc.open_stream(io.BytesIO(_buffer_hook.pending_buffers()[first_hash])).read_all()
+    assert decoded.num_rows == 2
+
+
+def test_display_arrow_stream_is_exported_from_package():
+    import nteract_kernel_launcher
+
+    assert callable(nteract_kernel_launcher.display_arrow_stream)

--- a/python/nteract-kernel-launcher/tests/test_progressive.py
+++ b/python/nteract-kernel-launcher/tests/test_progressive.py
@@ -43,6 +43,7 @@ def test_display_arrow_stream_publishes_manifest_revisions():
     manifests = [message[1][ARROW_STREAM_MANIFEST_MIME] for message in messages]
     assert [len(manifest["chunks"]) for manifest in manifests] == [1, 2, 3, 3]
     assert [manifest["complete"] for manifest in manifests] == [False, False, False, True]
+    assert BLOB_REF_MIME not in messages[-1][1]
     assert manifests[-1]["summary"] == {
         "total_rows": 6,
         "included_rows": 6,
@@ -54,6 +55,40 @@ def test_display_arrow_stream_publishes_manifest_revisions():
     assert first_hash in _buffer_hook.pending_buffers()
     decoded = pa.ipc.open_stream(io.BytesIO(_buffer_hook.pending_buffers()[first_hash])).read_all()
     assert decoded.num_rows == 2
+
+
+def test_display_arrow_stream_single_chunk_publishes_complete_once():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._progressive import display_arrow_stream
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    messages = []
+
+    class Handle:
+        def update(self, obj, **kwargs):
+            messages.append(("update", obj, kwargs))
+
+    def fake_display(obj, **kwargs):
+        messages.append(("display", obj, kwargs))
+        return Handle()
+
+    table = pa.table({"a": list(range(3))})
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches())
+
+    display_arrow_stream(reader, display_fn=fake_display, max_chunk_bytes=1, total_rows=3)
+
+    assert [kind for kind, _, _ in messages] == ["display"]
+    assert BLOB_REF_MIME in messages[0][1]
+    manifest = messages[0][1][ARROW_STREAM_MANIFEST_MIME]
+    assert manifest["complete"] is True
+    assert len(manifest["chunks"]) == 1
+    assert manifest["summary"] == {
+        "total_rows": 3,
+        "included_rows": 3,
+        "sampled": False,
+        "sample_strategy": "none",
+    }
 
 
 def test_display_arrow_stream_is_exported_from_package():

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -40,6 +40,8 @@ const PLUGIN_MIME_TYPES: Record<string, () => Promise<PluginModule>> = {
   "application/vnd.apache.parquet": () => import("virtual:renderer-plugin/sift").then(normalize),
   "application/vnd.apache.arrow.stream": () =>
     import("virtual:renderer-plugin/sift").then(normalize),
+  "application/vnd.nteract.arrow-stream-manifest+json": () =>
+    import("virtual:renderer-plugin/sift").then(normalize),
 };
 
 /** Lazy loader for all Vega/Vega-Lite MIME variants. */

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -170,6 +170,17 @@ describe("getSelectedMimeType", () => {
       expect(getSelectedMimeType(data)).toBe("application/geo+json");
     });
 
+    it("selects Arrow stream manifest over direct Arrow IPC and HTML fallback", () => {
+      const data = {
+        "text/html": "<table><tr><td>fallback</td></tr></table>",
+        "application/vnd.apache.arrow.stream": "http://127.0.0.1:9999/blob/arrow",
+        "application/vnd.nteract.arrow-stream-manifest+json": {
+          chunks: [{ url: "http://127.0.0.1:9999/blob/arrow" }],
+        },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/vnd.nteract.arrow-stream-manifest+json");
+    });
+
     it("handles image/gif", () => {
       const data = {
         "text/plain": "<animation>",
@@ -222,6 +233,12 @@ describe("getSelectedMimeType", () => {
       expect(DEFAULT_PRIORITY).toContain("application/vnd.plotly.v1+json");
       expect(DEFAULT_PRIORITY).toContain("application/vnd.vegalite.v5+json");
       expect(DEFAULT_PRIORITY).toContain("application/vnd.vega.v5+json");
+    });
+
+    it("orders Arrow stream manifests before direct Arrow IPC", () => {
+      expect(DEFAULT_PRIORITY.indexOf("application/vnd.nteract.arrow-stream-manifest+json")).toBe(
+        DEFAULT_PRIORITY.indexOf("application/vnd.apache.arrow.stream") - 1,
+      );
     });
   });
 });

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -69,6 +69,7 @@ export const DEFAULT_PRIORITY = [
   // DataFrames — sift renders Arrow IPC/parquet as an interactive table. Must
   // outrank text/html so pandas's HTML fallback doesn't win when both
   // are present (dx emits table bytes + text/html for rich table outputs).
+  "application/vnd.nteract.arrow-stream-manifest+json",
   "application/vnd.apache.arrow.stream",
   "application/vnd.apache.parquet",
   // HTML, PDF, markdown, and LaTeX

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -9,7 +9,14 @@
  * parquet or Arrow IPC from blob URL → WASM decodes → table renders.
  */
 
-import { setWasmUrl, SiftFocusStatus, SiftTable, type TableEngineState } from "@nteract/sift";
+import {
+  setWasmUrl,
+  SiftFocusStatus,
+  SiftTable,
+  type ArrowStreamManifest,
+  type SiftSource,
+  type TableEngineState,
+} from "@nteract/sift";
 import "@nteract/sift/style.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -26,11 +33,12 @@ interface RendererProps {
   interactionActive?: boolean;
 }
 
-interface ArrowStreamManifestChunk {
+interface RendererArrowStreamManifestChunk {
   url?: unknown;
+  row_count?: unknown;
 }
 
-interface ArrowStreamManifest {
+interface RendererArrowStreamManifest {
   chunks?: unknown;
 }
 
@@ -103,10 +111,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function tableUrlFromManifest(data: unknown): string | undefined {
   if (!isRecord(data)) return undefined;
-  const manifest = data as ArrowStreamManifest;
+  const manifest = data as RendererArrowStreamManifest;
   if (!Array.isArray(manifest.chunks)) return undefined;
-  const [firstChunk] = manifest.chunks as ArrowStreamManifestChunk[];
+  const [firstChunk] = manifest.chunks as RendererArrowStreamManifestChunk[];
   return typeof firstChunk?.url === "string" ? firstChunk.url : undefined;
+}
+
+function tableManifestForData(data: unknown): ArrowStreamManifest | undefined {
+  if (!isRecord(data)) return undefined;
+  const manifest = data as RendererArrowStreamManifest;
+  if (!Array.isArray(manifest.chunks)) return undefined;
+  const chunks = [];
+  for (const chunk of manifest.chunks) {
+    if (!isRecord(chunk) || typeof chunk.url !== "string") return undefined;
+    chunks.push({
+      url: chunk.url,
+      row_count: typeof chunk.row_count === "number" ? chunk.row_count : undefined,
+    });
+  }
+  if (chunks.length === 0) return undefined;
+  return {
+    chunks,
+    complete: typeof data.complete === "boolean" ? data.complete : undefined,
+  };
+}
+
+function tableSourceForData(data: unknown, mimeType: string): SiftSource | undefined {
+  if (mimeType === ARROW_STREAM_MANIFEST_MIME) {
+    const manifest = tableManifestForData(data);
+    return manifest ? { kind: "arrow-stream-manifest", manifest } : undefined;
+  }
+  const url = typeof data === "string" ? data : String(data);
+  return { kind: "url", url };
 }
 
 function tableUrlForData(data: unknown, mimeType: string): string | undefined {
@@ -118,7 +154,8 @@ function tableUrlForData(data: unknown, mimeType: string): string | undefined {
 
 function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
   const url = tableUrlForData(data, mimeType);
-  if (!url) {
+  const source = tableSourceForData(data, mimeType);
+  if (!url || !source) {
     console.warn("[sift-renderer] missing table URL", { mimeType, data });
     return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;
   }
@@ -152,7 +189,7 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
   return (
     <div style={{ height: tableHeight, width: "100%" }}>
       <SiftTable
-        url={url}
+        source={source}
         onChange={handleChange}
         footerControl={
           <div className="sift-footer-control">{interactionActive && <SiftFocusStatus />}</div>

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -155,12 +155,6 @@ function tableUrlForData(data: unknown, mimeType: string): string | undefined {
 function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
   const url = tableUrlForData(data, mimeType);
   const source = useMemo(() => tableSourceForData(data, mimeType), [data, mimeType]);
-  if (!url || !source) {
-    console.warn("[sift-renderer] missing table URL", { mimeType, data });
-    return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;
-  }
-  console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
-  configureWasm(url);
 
   // Default to the cap so the table is visible while sift's WASM loads
   // and reports its first state. Once we see a totalCount we settle on
@@ -185,6 +179,13 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
     lastTotalRef.current = state.totalCount;
     setTableHeight(fitHeightForRowCount(state.totalCount));
   }, []);
+
+  if (!url || !source) {
+    console.warn("[sift-renderer] missing table URL", { mimeType, data });
+    return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;
+  }
+  console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
+  configureWasm(url);
 
   return (
     <div style={{ height: tableHeight, width: "100%" }}>

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -15,6 +15,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
 
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
 // --- Types ---
 
 interface RendererProps {
@@ -22,6 +24,14 @@ interface RendererProps {
   metadata?: Record<string, unknown>;
   mimeType: string;
   interactionActive?: boolean;
+}
+
+interface ArrowStreamManifestChunk {
+  url?: unknown;
+}
+
+interface ArrowStreamManifest {
+  chunks?: unknown;
 }
 
 // --- WASM configuration ---
@@ -87,8 +97,32 @@ function fitHeightForRowCount(rowCount: number): number {
 
 // --- SiftRenderer component ---
 
-function SiftRenderer({ data, interactionActive = false }: RendererProps) {
-  const url = String(data);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function tableUrlFromManifest(data: unknown): string | undefined {
+  if (!isRecord(data)) return undefined;
+  const manifest = data as ArrowStreamManifest;
+  if (!Array.isArray(manifest.chunks)) return undefined;
+  const [firstChunk] = manifest.chunks as ArrowStreamManifestChunk[];
+  return typeof firstChunk?.url === "string" ? firstChunk.url : undefined;
+}
+
+function tableUrlForData(data: unknown, mimeType: string): string | undefined {
+  if (mimeType === ARROW_STREAM_MANIFEST_MIME) {
+    return tableUrlFromManifest(data);
+  }
+  return typeof data === "string" ? data : String(data);
+}
+
+function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
+  const url = tableUrlForData(data, mimeType);
+  if (!url) {
+    console.warn("[sift-renderer] missing table URL", { mimeType, data });
+    return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;
+  }
+  console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
   configureWasm(url);
 
   // Default to the cap so the table is visible while sift's WASM loads
@@ -134,7 +168,11 @@ export function install(ctx: {
   register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
 }) {
   ctx.register(
-    ["application/vnd.apache.parquet", "application/vnd.apache.arrow.stream"],
+    [
+      "application/vnd.apache.parquet",
+      "application/vnd.apache.arrow.stream",
+      ARROW_STREAM_MANIFEST_MIME,
+    ],
     SiftRenderer,
   );
 }

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -18,7 +18,7 @@ import {
   type TableEngineState,
 } from "@nteract/sift";
 import "@nteract/sift/style.css";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
 
@@ -154,7 +154,7 @@ function tableUrlForData(data: unknown, mimeType: string): string | undefined {
 
 function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
   const url = tableUrlForData(data, mimeType);
-  const source = tableSourceForData(data, mimeType);
+  const source = useMemo(() => tableSourceForData(data, mimeType), [data, mimeType]);
   if (!url || !source) {
     console.warn("[sift-renderer] missing table URL", { mimeType, data });
     return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;


### PR DESCRIPTION
## Summary

- switches pandas, polars, pyarrow, and PyCapsule-compatible dataframe/table outputs from parquet to Arrow IPC stream payloads
- uses the Arrow PyCapsule stream protocol (`__arrow_c_stream__`) as the generic producer-neutral path, while keeping direct pandas/polars/pyarrow writers for compatibility and metadata preservation
- emits `application/vnd.nteract.arrow-stream-manifest+json` sidecars for Arrow table outputs and routes that manifest MIME through notebook, MCP, iframe plugin loading, and Sift
- adds an appendable Sift WASM store for self-contained Arrow IPC stream chunks, including schema mismatch and finished-store rejection
- adds a normalized `SiftTable` source API for manifest-backed tables, with stable manifest keys so equivalent source-object recreation does not reload the table
- adds Python chunk-writer and explicit `nteract_kernel_launcher.display_arrow_stream(...)` helper support for Jupyter `display_id` / `update_display_data` progressive manifest revisions
- fixes oversized automatic `pyarrow.Table` outputs so they emit complete multi-chunk Arrow stream manifests instead of silently downsampling to `head(n)`
- keeps `python/nteract-kernel-launcher/docs/arrow-native-outputs.md` as the durable phase/progress log for remaining follow-up work

## Current Transport

Automatic dataframe/table output still uses the existing nteract blob-ref / attached-buffer flow:

- Python serializes dataframe/table output into `application/vnd.apache.arrow.stream` bytes when the one-shot output fits.
- Python emits an Arrow stream manifest sidecar describing the selected blob/chunks.
- For oversized automatic `pyarrow.Table` outputs, Python chunks the original table into ordered, self-contained Arrow IPC stream chunks and sends a complete manifest with `total_rows == included_rows`.
- The daemon preflights the attached buffer refs into the blob store and resolves blob URLs for the selected manifest.
- Sift renders manifest sources by fetching chunk URLs in order, appending them through the WASM stream store, and marking the table complete when the manifest is complete.

The explicit helper path can publish multiple manifest revisions with Jupyter display updates:

```python
from nteract_kernel_launcher import display_arrow_stream

display_arrow_stream(reader_or_arrow_compatible_object)
```

That helper drains the Arrow stream once into self-contained IPC mini-stream chunks, publishes the first manifest with a display id, then sends full manifest revisions via `DisplayHandle.update(...)`.

Automatic progressive repr for bare large non-pyarrow dataframes and direct daemon blob upload remain follow-up phases. The Sift append path and explicit helper are ready for multiple chunks.

## Review Status

Repo-local `pr-reviewer` has reported `verdict: clear` after each pushed stage through:

- `f8a02ed8 feat(outputs): add arrow stream chunk writer`
- `1bb09116 feat(outputs): add progressive arrow display helper`
- `a2944dd0 fix(sift): keep manifest fallback after hooks`
- `120a73df fix(outputs): chunk oversized arrow table manifests`

## Verification

Latest local checks on `120a73df`:

- `uv run --with pyarrow --with pandas --with polars --with narwhals pytest python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_format.py python/nteract-kernel-launcher/tests/test_progressive.py -q`
- `cargo test -p runtimed output_store::tests::preflight_ref_buffers --lib`
- `cargo test -p kernel-env --test launcher_e2e`
- `cargo xtask wasm`
- `cargo xtask lint --fix`
- `git diff --check`

Previous phase checks also covered Sift package tests, Sift WASM tests, one-chunk manifest routing, media-router priority, package install state, and Python formatter fallbacks.

## Manual QA Notes

Good manual checks now:

- pandas, polars, and pyarrow table display should render as Sift tables through the Arrow stream manifest route
- a large pyarrow table that exceeds the one-shot payload cap should show all source rows in the manifest summary instead of silently rendering only the first `head(n)` rows
- old parquet table outputs should still render
- table outputs should preserve notebook-aware Sift sizing/focus behavior from `origin/main`
- explicit `display_arrow_stream(...)` should show an updating manifest-backed table for Arrow-compatible readers

Known follow-ups:

- Sift's virtual scroll spacer can still hit browser element-height limits for million-row tables, making later rows unreachable even when the data arrived
- automatic progressive rendering for bare large non-pyarrow dataframe reprs
- direct daemon blob upload before display publication
- viewport-driven fetch of later chunks only on scroll
- coalesced full-table artifacts after completion
