### PR TITLE
feat(notebook): add magnetic sift focus affordance

### DIFF
--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -13,7 +13,8 @@
  * cleaning up on unmount.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import {
   applyColumnOverrides,
   applyParquetColumnHints,
@@ -45,6 +46,8 @@ export type SiftTableProps = {
   columnOverrides?: Record<string, Partial<Column>>;
   /** Called whenever sort or filter state changes from UI interaction. */
   onChange?: (state: TableEngineState) => void;
+  /** Optional control rendered in Sift's footer before built-in buttons. */
+  footerControl?: ReactNode;
   /** CSS class name for the container div. */
   className?: string;
   /** Inline styles for the container div. */
@@ -239,13 +242,17 @@ export function SiftTable({
   typeOverrides,
   columnOverrides,
   onChange,
+  footerControl,
   className,
   style,
 }: SiftTableProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const engineRef = useRef<TableEngine | null>(null);
+  const footerControlRef = useRef<HTMLDivElement | null>(null);
+  const footerControlRootRef = useRef<Root | null>(null);
   const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const hasFooterControl = footerControl != null;
 
   // Stable callback ref to avoid re-mounting engine when onChange identity changes
   const onChangeRef = useRef(onChange);
@@ -253,6 +260,30 @@ export function SiftTable({
 
   const stableOnChange = useCallback((state: TableEngineState) => {
     onChangeRef.current?.(state);
+  }, []);
+
+  const getFooterControlElement = useCallback(() => {
+    if (!hasFooterControl) return undefined;
+    if (!footerControlRef.current) {
+      footerControlRef.current = document.createElement("div");
+      footerControlRootRef.current = createRoot(footerControlRef.current);
+    }
+    return footerControlRef.current;
+  }, [hasFooterControl]);
+
+  useEffect(() => {
+    if (hasFooterControl) {
+      getFooterControlElement();
+    }
+    footerControlRootRef.current?.render(footerControl);
+  }, [footerControl, getFooterControlElement, hasFooterControl]);
+
+  useEffect(() => {
+    return () => {
+      footerControlRootRef.current?.unmount();
+      footerControlRootRef.current = null;
+      footerControlRef.current = null;
+    };
   }, []);
 
   // Mount engine when `data` prop is provided directly
@@ -272,6 +303,7 @@ export function SiftTable({
 
     engineRef.current = createTable(engineDiv, data, {
       onChange: stableOnChange,
+      footerControl: getFooterControlElement(),
     });
     setStatus("ready");
 
@@ -280,7 +312,7 @@ export function SiftTable({
       engineRef.current = null;
       engineDiv.remove();
     };
-  }, [data, stableOnChange]);
+  }, [data, stableOnChange, getFooterControlElement]);
 
   // Load from URL when `url` prop is provided.
   // Detects format via Content-Type header + magic byte fallback:
@@ -305,6 +337,7 @@ export function SiftTable({
       container.appendChild(engineDiv);
       engineRef.current = createTable(engineDiv, tableData, {
         onChange: stableOnChange,
+        footerControl: getFooterControlElement(),
       });
     }
 
@@ -447,7 +480,7 @@ export function SiftTable({
       engineRef.current = null;
       engineDiv?.remove();
     };
-  }, [url, typeOverrides, columnOverrides, stableOnChange]);
+  }, [url, typeOverrides, columnOverrides, stableOnChange, getFooterControlElement]);
 
   return (
     <div ref={containerRef} className={className} style={{ height: "100%", ...style }}>

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1001,6 +1001,12 @@ h1 {
   display: inline;
 }
 
+.sift-footer-control {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 6px;
+}
+
 .sift-debug-btn {
   background: none;
   border: 1px solid var(--sift-rule);

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1007,6 +1007,32 @@ h1 {
   margin-right: 6px;
 }
 
+.sift-focus-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--sift-accent) 34%, var(--sift-rule));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--sift-accent) 7%, var(--sift-panel));
+  color: var(--sift-accent);
+  font:
+    600 11px/1.2 "SF Mono",
+    ui-monospace,
+    monospace;
+  padding: 4px 8px;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--sift-accent) 16%, transparent);
+}
+
+.sift-focus-key {
+  border: 1px solid color-mix(in srgb, var(--sift-accent) 26%, var(--sift-rule));
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--sift-accent) 11%, var(--sift-panel));
+  color: var(--sift-accent);
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 6px;
+}
+
 .sift-debug-btn {
   background: none;
   border: 1px solid var(--sift-rule);

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1052,7 +1052,7 @@ export function createTable(
     debugGroup,
     filterPillsEl,
     statsSpacer,
-    ...(options.footerControl ? [options.footerControl] : []),
+    ...(options?.footerControl ? [options.footerControl] : []),
     debugBtn,
     fullscreenBtn,
   );

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -118,6 +118,8 @@ export type TableEngineState = {
 export type TableEngineOptions = {
   /** Called whenever sort or filter state changes from UI interaction. */
   onChange?: (state: TableEngineState) => void;
+  /** Optional control rendered in the stats/footer bar before built-in buttons. */
+  footerControl?: HTMLElement;
 };
 
 export type TableEngine = {
@@ -1050,6 +1052,7 @@ export function createTable(
     debugGroup,
     filterPillsEl,
     statsSpacer,
+    ...(options.footerControl ? [options.footerControl] : []),
     debugBtn,
     fullscreenBtn,
   );

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -876,7 +876,7 @@ export function OutputArea({
               {showSiftFocusedAffordance && (
                 <div
                   aria-hidden="true"
-                  className="pointer-events-none absolute right-3 top-3 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
+                  className="pointer-events-none absolute bottom-3 right-20 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
                 >
                   <span>Focused</span>
                   <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -40,6 +40,13 @@ const MIN_OUTPUT_WELL_HEIGHT = 360;
 const SIFT_VIEWPORT_TOP_INSET_PX = 96;
 const SIFT_VIEWPORT_BOTTOM_INSET_PX = 32;
 
+function siftFocusAccent(isDark: boolean, colorTheme?: string): string {
+  if (colorTheme === "cream") {
+    return isDark ? "#d4896a" : "#955f3b";
+  }
+  return isDark ? "#60a5fa" : "#3b82f6";
+}
+
 function getOutputWellMaxHeight(viewportRatio: number): number {
   if (typeof window === "undefined") return 720;
   return Math.max(MIN_OUTPUT_WELL_HEIGHT, Math.floor(window.innerHeight * viewportRatio));
@@ -443,8 +450,20 @@ export function OutputArea({
     outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
   const shouldScrollPassthroughFrame =
     shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const allowWheelBoundaryScroll =
+    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
   const showSiftInteractionCue =
     hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
+  const siftFrameStyle = hasSiftOutputs
+    ? ({
+        "--notebook-sift-focus": siftFrameAccent,
+        "--notebook-sift-focus-hover": `${siftFrameAccent}66`,
+        boxShadow: staticFrameInteractionActive
+          ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
+          : undefined,
+      } as React.CSSProperties)
+    : undefined;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
 
@@ -827,11 +846,10 @@ export function OutputArea({
                 hasSiftOutputs &&
                   shouldUseScrollPassthroughFrame &&
                   !staticFrameInteractionActive &&
-                  "rounded-md hover:ring-1 hover:ring-sky-300/60",
-                hasSiftOutputs &&
-                  staticFrameInteractionActive &&
-                  "rounded-md bg-background ring-2 ring-sky-400/80 shadow-lg shadow-sky-950/10",
+                  "rounded-md hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
+                hasSiftOutputs && staticFrameInteractionActive && "rounded-md bg-background",
               )}
+              style={siftFrameStyle}
               data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
               data-sift-output={hasSiftOutputs ? "true" : undefined}
               tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
@@ -852,7 +870,7 @@ export function OutputArea({
                 minHeight={24}
                 maxHeight={isolatedOutputWellMaxHeight}
                 autoHeight={shouldIsolate && !focused}
-                allowWheelBoundaryScroll={!focused && !shouldScrollPassthroughFrame}
+                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
                 scrollPassthrough={shouldScrollPassthroughFrame}
                 onReady={handleFrameReady}
                 onLinkClick={onLinkClick}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -445,7 +445,6 @@ export function OutputArea({
     shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
   const showSiftInteractionCue =
     hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const showSiftFocusedAffordance = hasSiftOutputs && staticFrameInteractionActive;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
 
@@ -454,6 +453,14 @@ export function OutputArea({
       setStaticFrameInteractionActive(false);
     }
   }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!hasSiftOutputs) return;
+    frameRef.current?.send({
+      type: "interaction_state",
+      payload: { active: staticFrameInteractionActive },
+    });
+  }, [hasSiftOutputs, staticFrameInteractionActive]);
 
   useEffect(() => {
     return () => {
@@ -871,17 +878,6 @@ export function OutputArea({
                     <ChevronDown className="h-3 w-3" />
                     <span>Focus table scrolling</span>
                   </button>
-                </div>
-              )}
-              {showSiftFocusedAffordance && (
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute bottom-3 right-20 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
-                >
-                  <span>Focused</span>
-                  <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">
-                    Esc
-                  </span>
                 </div>
               )}
             </div>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -855,20 +855,28 @@ export function OutputArea({
                 onError={handleIframeError}
               />
               {showSiftInteractionCue && (
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center rounded-b-md bg-gradient-to-t from-background via-background/85 to-transparent pb-2 pt-8 opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100"
-                >
-                  <div className="flex items-center gap-1.5 rounded-full border border-border/70 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur">
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center rounded-b-md bg-gradient-to-t from-background via-background/85 to-transparent pb-2 pt-8 opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
+                  <button
+                    type="button"
+                    className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/70 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur transition-colors hover:border-sky-300 hover:text-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 dark:hover:border-sky-700 dark:hover:text-sky-300"
+                    onPointerDown={(event) => {
+                      event.stopPropagation();
+                      activateStaticFrameInteraction();
+                    }}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      activateStaticFrameInteraction();
+                    }}
+                  >
                     <ChevronDown className="h-3 w-3" />
-                    <span>Click table to scroll rows</span>
-                  </div>
+                    <span>Focus table scrolling</span>
+                  </button>
                 </div>
               )}
               {showSiftFocusedAffordance && (
                 <div
                   aria-hidden="true"
-                  className="pointer-events-none absolute bottom-3 right-3 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
+                  className="pointer-events-none absolute right-3 top-3 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
                 >
                   <span>Focused</span>
                   <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -443,6 +443,9 @@ export function OutputArea({
     outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
   const shouldScrollPassthroughFrame =
     shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const showSiftInteractionCue =
+    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const showSiftFocusedAffordance = hasSiftOutputs && staticFrameInteractionActive;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
 
@@ -470,6 +473,21 @@ export function OutputArea({
 
     window.addEventListener("scroll", handleScroll, true);
     return () => window.removeEventListener("scroll", handleScroll, true);
+  }, [staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!staticFrameInteractionActive) return;
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
+        return;
+      }
+      setStaticFrameInteractionActive(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
   }, [staticFrameInteractionActive]);
 
   const activateStaticFrameInteraction = useCallback(() => {
@@ -797,14 +815,15 @@ export function OutputArea({
             <div
               ref={staticFrameInteractionRef}
               className={cn(
-                shouldIsolate ? "outline-none transition-shadow" : "hidden",
+                shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
+                hasSiftOutputs && "group/sift",
                 hasSiftOutputs &&
                   shouldUseScrollPassthroughFrame &&
                   !staticFrameInteractionActive &&
-                  "rounded-sm hover:ring-1 hover:ring-sky-300/50",
+                  "rounded-md hover:ring-1 hover:ring-sky-300/60",
                 hasSiftOutputs &&
                   staticFrameInteractionActive &&
-                  "rounded-sm ring-2 ring-sky-400/70",
+                  "rounded-md bg-background ring-2 ring-sky-400/80 shadow-lg shadow-sky-950/10",
               )}
               data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
               data-sift-output={hasSiftOutputs ? "true" : undefined}
@@ -835,6 +854,28 @@ export function OutputArea({
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}
               />
+              {showSiftInteractionCue && (
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center rounded-b-md bg-gradient-to-t from-background via-background/85 to-transparent pb-2 pt-8 opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100"
+                >
+                  <div className="flex items-center gap-1.5 rounded-full border border-border/70 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur">
+                    <ChevronDown className="h-3 w-3" />
+                    <span>Click table to scroll rows</span>
+                  </div>
+                </div>
+              )}
+              {showSiftFocusedAffordance && (
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute bottom-3 right-3 z-10 flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm backdrop-blur dark:border-sky-700 dark:text-sky-300"
+                >
+                  <span>Focused</span>
+                  <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">
+                    Esc
+                  </span>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -285,6 +285,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByText("Focus table scrolling")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
@@ -303,6 +304,7 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByRole("button", { name: "Focus table scrolling" })).toBeNull();
   });
 

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -285,7 +285,6 @@ describe("OutputArea iframe theme sync", () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(screen.getByText("Focused")).toBeInTheDocument();
     expect(screen.queryByText("Focus table scrolling")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
@@ -304,7 +303,6 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(screen.getByText("Focused")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Focus table scrolling" })).toBeNull();
   });
 
@@ -317,7 +315,6 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(screen.getByText("Focused")).toBeInTheDocument();
 
     fireEvent.pointerDown(document.body);
 

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -286,13 +286,26 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(screen.getByText("Focused")).toBeInTheDocument();
-    expect(screen.queryByText("Click table to scroll rows")).toBeNull();
+    expect(screen.queryByText("Focus table scrolling")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
-    expect(screen.getByText("Click table to scroll rows")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Focus table scrolling" })).toBeInTheDocument();
+  });
+
+  it("activates sift iframe scrolling from the magnetize cue", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeParquetOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Focus table scrolling" }));
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(screen.getByText("Focused")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Focus table scrolling" })).toBeNull();
   });
 
   it("releases sift iframe scrolling on outside pointer down", () => {
@@ -311,7 +324,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
     expect(screen.queryByText("Focused")).toBeNull();
-    expect(screen.getByText("Click table to scroll rows")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Focus table scrolling" })).toBeInTheDocument();
   });
 
   it("forces focused iframe outputs off scroll passthrough and wheel-boundary forwarding", () => {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,4 +1,4 @@
-import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
@@ -285,11 +285,33 @@ describe("OutputArea iframe theme sync", () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(screen.getByText("Focused")).toBeInTheDocument();
+    expect(screen.queryByText("Click table to scroll rows")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(screen.getByText("Click table to scroll rows")).toBeInTheDocument();
+  });
+
+  it("releases sift iframe scrolling on outside pointer down", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeParquetOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(activationWell);
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(screen.getByText("Focused")).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(screen.queryByText("Focused")).toBeNull();
+    expect(screen.getByText("Click table to scroll rows")).toBeInTheDocument();
   });
 
   it("forces focused iframe outputs off scroll passthrough and wheel-boundary forwarding", () => {

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -231,6 +231,17 @@ export interface SearchNavigateMessage {
 }
 
 /**
+ * Parent-side interaction state for iframe outputs.
+ */
+export interface InteractionStateMessage {
+  type: "interaction_state";
+  payload: {
+    /** Whether the parent wrapper has handed pointer/wheel interaction to the iframe. */
+    active: boolean;
+  };
+}
+
+/**
  * All message types that can be sent from parent to iframe.
  */
 export type ParentToIframeMessage =
@@ -248,7 +259,8 @@ export type ParentToIframeMessage =
   | WidgetSnapshotMessage
   | BridgeReadyMessage
   | SearchMessage
-  | SearchNavigateMessage;
+  | SearchNavigateMessage
+  | InteractionStateMessage;
 
 // --- Message Types: Iframe → Parent ---
 

--- a/src/isolated-renderer/__tests__/layout-measure.test.ts
+++ b/src/isolated-renderer/__tests__/layout-measure.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { measureDocumentHeight } from "../layout-measure";
+
+function defineElementSize(element: HTMLElement, height: number) {
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: height,
+  });
+  Object.defineProperty(element, "offsetHeight", {
+    configurable: true,
+    value: height,
+  });
+  element.getBoundingClientRect = () =>
+    ({
+      top: 0,
+      bottom: height,
+      left: 0,
+      right: 100,
+      width: 100,
+      height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+describe("measureDocumentHeight", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("prefers root content height over viewport-sized body scroll height", () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const root = document.getElementById("root") as HTMLElement;
+
+    defineElementSize(root, 720);
+    defineElementSize(document.body, 1200);
+    defineElementSize(document.documentElement, 1200);
+
+    expect(measureDocumentHeight()).toBe(722);
+  });
+
+  it("falls back to document height when root is absent", () => {
+    defineElementSize(document.body, 900);
+    defineElementSize(document.documentElement, 1200);
+
+    expect(measureDocumentHeight()).toBe(1202);
+  });
+});

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -40,6 +40,7 @@ import { TracebackOutput } from "@/components/outputs/traceback-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
+import { measureDocumentHeight } from "./layout-measure";
 // Import widget support
 import { IframeWidgetStoreProvider } from "./widget-provider";
 
@@ -199,25 +200,7 @@ type MessageHandler = (type: string, payload: unknown) => void;
 let messageHandler: MessageHandler | null = null;
 
 const LAYOUT_PULSE_DELAYS_MS = [0, 160, 600];
-const IFRAME_HEIGHT_FUDGE_PX = 2;
 let layoutPulseTimers: number[] = [];
-
-function measureDocumentHeight(): number {
-  const doc = document.documentElement;
-  const body = document.body;
-  const root = document.getElementById("root");
-  return (
-    Math.ceil(
-      Math.max(
-        body?.scrollHeight ?? 0,
-        body?.offsetHeight ?? 0,
-        doc?.scrollHeight ?? 0,
-        doc?.offsetHeight ?? 0,
-        root?.getBoundingClientRect().bottom ?? 0,
-      ),
-    ) + IFRAME_HEIGHT_FUDGE_PX
-  );
-}
 
 function postMeasuredHeight(type: "resize" | "render_complete"): void {
   window.parent.postMessage(
@@ -591,6 +574,10 @@ export function init() {
     });
   });
   resizeObserver.observe(document.body);
+  resizeObserver.observe(rootEl);
+
+  document.addEventListener("fullscreenchange", scheduleRendererLayoutPulses);
+  document.addEventListener("webkitfullscreenchange", scheduleRendererLayoutPulses);
 
   // Note: "renderer_ready" is sent from the React component's useEffect
   // to ensure the message handler is registered before parent sends messages

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -120,6 +120,7 @@ interface OutputEntry {
 interface RendererState {
   outputs: OutputEntry[];
   isDark: boolean;
+  interactionActive: boolean;
 }
 
 // --- Theme Management ---
@@ -291,6 +292,7 @@ function IsolatedRendererApp() {
   const [state, setState] = useState<RendererState>({
     outputs: [],
     isDark: document.documentElement.classList.contains("dark"),
+    interactionActive: false,
   });
 
   // Handle messages from parent
@@ -371,6 +373,14 @@ function IsolatedRendererApp() {
         }
         break;
       }
+      case "interaction_state": {
+        const interactionPayload = payload as { active?: boolean };
+        setState((prev) => ({
+          ...prev,
+          interactionActive: interactionPayload.active ?? false,
+        }));
+        break;
+      }
     }
   }, []);
 
@@ -389,7 +399,11 @@ function IsolatedRendererApp() {
   return (
     <div className="isolated-renderer" data-theme={state.isDark ? "dark" : "light"}>
       {state.outputs.map((entry) => (
-        <OutputRenderer key={entry.id} payload={entry.payload} />
+        <OutputRenderer
+          key={entry.id}
+          payload={entry.payload}
+          interactionActive={state.interactionActive}
+        />
       ))}
     </div>
   );
@@ -399,7 +413,13 @@ function IsolatedRendererApp() {
  * Render a single output based on its MIME type.
  * Uses direct component imports (not lazy loading) for isolated iframe compatibility.
  */
-function OutputRenderer({ payload }: { payload: RenderPayload }) {
+function OutputRenderer({
+  payload,
+  interactionActive,
+}: {
+  payload: RenderPayload;
+  interactionActive: boolean;
+}) {
   const { mimeType, data, metadata } = payload;
   const content = data;
 
@@ -440,7 +460,14 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
   // Check renderer plugin registry first (exact match, then pattern matchers)
   const RegisteredRenderer = getRenderer(mimeType);
   if (RegisteredRenderer) {
-    return <RegisteredRenderer data={data} metadata={metadata} mimeType={mimeType} />;
+    return (
+      <RegisteredRenderer
+        data={data}
+        metadata={metadata}
+        mimeType={mimeType}
+        interactionActive={interactionActive}
+      />
+    );
   }
 
   // Widget view - render interactive Jupyter widget

--- a/src/isolated-renderer/layout-measure.ts
+++ b/src/isolated-renderer/layout-measure.ts
@@ -1,0 +1,26 @@
+const IFRAME_HEIGHT_FUDGE_PX = 2;
+
+function measuredElementHeight(element: HTMLElement): number {
+  const rect = element.getBoundingClientRect();
+  return Math.max(element.scrollHeight, element.offsetHeight, rect.bottom);
+}
+
+export function measureDocumentHeight(): number {
+  const root = document.getElementById("root");
+  if (root) {
+    return Math.ceil(measuredElementHeight(root)) + IFRAME_HEIGHT_FUDGE_PX;
+  }
+
+  const doc = document.documentElement;
+  const body = document.body;
+  return (
+    Math.ceil(
+      Math.max(
+        body?.scrollHeight ?? 0,
+        body?.offsetHeight ?? 0,
+        doc?.scrollHeight ?? 0,
+        doc?.offsetHeight ?? 0,
+      ),
+    ) + IFRAME_HEIGHT_FUDGE_PX
+  );
+}

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -21,6 +21,7 @@ interface RendererProps {
   data: unknown;
   metadata?: Record<string, unknown>;
   mimeType: string;
+  interactionActive?: boolean;
 }
 
 // --- WASM configuration ---
@@ -88,7 +89,7 @@ function fitHeightForRowCount(rowCount: number): number {
 
 // --- SiftRenderer component ---
 
-function SiftRenderer({ data, mimeType }: RendererProps) {
+function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
   const url = String(data);
   console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
   configureWasm(url);
@@ -119,7 +120,22 @@ function SiftRenderer({ data, mimeType }: RendererProps) {
 
   return (
     <div style={{ height: tableHeight, width: "100%" }}>
-      <SiftTable url={url} onChange={handleChange} />
+      <SiftTable
+        url={url}
+        onChange={handleChange}
+        footerControl={
+          <div className="sift-footer-control">
+            {interactionActive && (
+              <span className="inline-flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm dark:border-sky-700 dark:text-sky-300">
+                <span>Focused</span>
+                <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">
+                  Esc
+                </span>
+              </span>
+            )}
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -126,11 +126,9 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
         footerControl={
           <div className="sift-footer-control">
             {interactionActive && (
-              <span className="inline-flex items-center gap-2 rounded-md border border-sky-300 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-sky-700 shadow-sm dark:border-sky-700 dark:text-sky-300">
+              <span className="sift-focus-hint">
                 <span>Focused</span>
-                <span className="rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] text-sky-700 dark:border-sky-800 dark:bg-sky-950/50 dark:text-sky-300">
-                  Esc
-                </span>
+                <span className="sift-focus-key">Esc</span>
               </span>
             )}
           </div>

--- a/src/lib/renderer-registry.ts
+++ b/src/lib/renderer-registry.ts
@@ -15,6 +15,7 @@ export interface RendererProps {
   data: unknown;
   metadata?: Record<string, unknown>;
   mimeType: string;
+  interactionActive?: boolean;
 }
 
 const exactMatches = new Map<string, ComponentType<RendererProps>>();


### PR DESCRIPTION
## Summary

This is the follow-up to #2660 for Sift's click-to-engage behavior in notebook outputs.

- Adds a stronger focused surface for Sift iframe outputs while the table owns wheel/pointer interaction.
- Adds a small bottom magnetize button before engagement so the user can intentionally hand pointer/wheel interaction to Sift.
- Renders the active `Focused / Esc` hint inside Sift's own footer control row, immediately before settings/fullscreen.
- Matches the Sift focus frame and footer hint to Sift's active theme/accent colors.
- Releases the engaged Sift table on outside pointer-down in addition to Escape, pointer-out, and outer scroll.
- Keeps an active Sift table from forwarding top/bottom wheel-boundary gestures back to the notebook page.
- Fixes isolated iframe height shrinkage after exiting Sift fullscreen/maximize.

## Notes

This keeps the simplification from #2660: there are still no general output modes or per-output controls. The new behavior is targeted to Sift MIME outputs because they are the place where iframe scroll ownership is most likely to feel sticky.

Follow-up design space if this feels right:

- tune the cue copy/visibility after using it in the notebook
- decide whether focused Sift should subtly dim sibling notebook content
- explore a stronger raised/focused frame if the current ring/chip is too quiet

## Verification

- `pnpm --filter @nteract/sift test -- --runInBand`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/scroll-boundary.test.ts`
- `pnpm test:run src/isolated-renderer/__tests__/layout-measure.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/scroll-boundary.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
- `cargo xtask lint --fix`
- Headless browser smoke against `http://localhost:6217/?path=/Users/kylekelley/codex/mathy.ipynb&runtime=python`: cue is hidden at rest, visible on Sift hover, clicking the magnetize button engages the focused state, and outside page click releases it.
- Headless browser smoke against the same notebook: active `Focused / Esc` hint renders inside Sift's footer before the settings/fullscreen controls.
- Headless browser smoke against the same notebook: active Sift focus colors use the Sift accent, and wheel-up at the top of an active Sift table does not move the notebook scroller.
- Headless browser smoke against the same notebook: engage a Sift output, click fullscreen, click back, and verify the parent iframe returns to its pre-fullscreen height.
