### PR TITLE
fix(sift): polish scroll handoff cue

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -25,6 +25,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@nteract/notebook-host": "workspace:*",
+    "@nteract/sift": "workspace:*",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@lezer/common": "^1.5.2",
     "@lezer/highlight": "^1.2.3",
     "@lezer/lr": "^1.4.8",
+    "@nteract/sift": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -6,7 +6,9 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./style.css": "./src/style.css"
+    "./handoff": "./src/handoff.tsx",
+    "./style.css": "./src/style.css",
+    "./handoff.css": "./src/handoff.css"
   },
   "publishConfig": {
     "main": "./lib/index.js",
@@ -16,7 +18,12 @@
         "import": "./lib/index.js",
         "types": "./lib/index.d.ts"
       },
-      "./style.css": "./lib/style.css"
+      "./handoff": {
+        "import": "./lib/handoff.js",
+        "types": "./lib/handoff.d.ts"
+      },
+      "./style.css": "./lib/style.css",
+      "./handoff.css": "./lib/handoff.css"
     }
   },
   "files": [
@@ -27,7 +34,7 @@
     "generate": "npx tsx src/generate-data.ts",
     "dev": "vp dev",
     "build": "tsc && vp build",
-    "build:lib": "tsc && vp build --config vite.lib.config.ts && npx @tailwindcss/cli -i src/style.css -o lib/style.css --minify",
+    "build:lib": "tsc && vp build --config vite.lib.config.ts && npx @tailwindcss/cli -i src/style.css -o lib/style.css --minify && cp src/handoff.css lib/handoff.css",
     "preview": "vp preview",
     "test": "vp test run",
     "test:watch": "vp test",

--- a/packages/sift/src/handoff.css
+++ b/packages/sift/src/handoff.css
@@ -1,0 +1,36 @@
+.sift-scroll-handoff-cue {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--sift-rule, var(--border, #e5e7eb)) 82%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--sift-panel, var(--background, #ffffff)) 94%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--sift-muted, var(--muted-foreground, #6b7280)) 92%,
+    var(--sift-ink, var(--foreground, #111827))
+  );
+  cursor: pointer;
+  font: 500 11px/1.2 var(--sift-font, Inter, ui-sans-serif, system-ui, sans-serif);
+  padding: 3px 7px;
+  white-space: nowrap;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.sift-scroll-handoff-cue:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--sift-muted, var(--muted-foreground, #6b7280)) 34%,
+    var(--sift-rule, var(--border, #e5e7eb))
+  );
+  background: var(--sift-panel, var(--background, #ffffff));
+  color: var(--sift-ink, var(--foreground, #111827));
+}
+
+.sift-scroll-handoff-cue:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--sift-accent, var(--ring, #3b82f6)) 45%, transparent);
+  outline-offset: 2px;
+}

--- a/packages/sift/src/handoff.tsx
+++ b/packages/sift/src/handoff.tsx
@@ -1,0 +1,50 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+
+const DEFAULT_SCROLL_HANDOFF_LABEL = "Click inside the table to scroll";
+const DEFAULT_FOCUS_STATUS_LABEL = "Table focused";
+const DEFAULT_FOCUS_KEY_LABEL = "Esc";
+
+function classNames(...values: Array<string | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export type SiftScrollHandoffCueProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> & {
+  children?: ReactNode;
+  label?: string;
+};
+
+export function SiftScrollHandoffCue({
+  children,
+  className,
+  label = DEFAULT_SCROLL_HANDOFF_LABEL,
+  type = "button",
+  ...props
+}: SiftScrollHandoffCueProps) {
+  return (
+    <button type={type} className={classNames("sift-scroll-handoff-cue", className)} {...props}>
+      {children ?? label}
+    </button>
+  );
+}
+
+export type SiftFocusStatusProps = HTMLAttributes<HTMLSpanElement> & {
+  label?: string;
+  keyLabel?: string;
+};
+
+export function SiftFocusStatus({
+  className,
+  label = DEFAULT_FOCUS_STATUS_LABEL,
+  keyLabel = DEFAULT_FOCUS_KEY_LABEL,
+  ...props
+}: SiftFocusStatusProps) {
+  return (
+    <span className={classNames("sift-focus-hint", className)} {...props}>
+      <span>{label}</span>
+      <kbd className="sift-focus-key">{keyLabel}</kbd>
+    </span>
+  );
+}

--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -46,6 +46,8 @@ export {
   predicateToPandas,
   predicateToSQL,
 } from "./filter-schema";
+export type { SiftFocusStatusProps, SiftScrollHandoffCueProps } from "./handoff";
+export { SiftFocusStatus, SiftScrollHandoffCue } from "./handoff";
 export type { SiftTableHandle, SiftTableProps } from "./react";
 // React component
 export { SiftTable, useSiftEngine } from "./react";

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { SiftFocusStatus, SiftScrollHandoffCue } from "./handoff";
 import { SiftTable } from "./react";
 import type { Column, TableData } from "./table";
 
@@ -165,5 +166,18 @@ describe("SiftTable", () => {
     const wrapper = container.firstElementChild as HTMLElement;
     expect(wrapper.classList.contains("my-table")).toBe(true);
     expect(wrapper.style.border).toBe("1px solid red");
+  });
+
+  it("renders the scroll handoff cue with accessible default copy", () => {
+    const { getByRole } = render(<SiftScrollHandoffCue />);
+
+    expect(getByRole("button", { name: "Click inside the table to scroll" })).not.toBeNull();
+  });
+
+  it("renders the focused status with the escape key hint", () => {
+    const { getByText } = render(<SiftFocusStatus />);
+
+    expect(getByText("Table focused")).not.toBeNull();
+    expect(getByText("Esc")).not.toBeNull();
   });
 });

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -216,6 +216,7 @@ h1 {
   display: flex;
   flex-direction: column;
   height: 100%; /* fill parent */
+  border-radius: var(--sift-radius, 6px);
   background: var(--sift-panel);
 }
 
@@ -1010,27 +1011,24 @@ h1 {
 .sift-focus-hint {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  border: 1px solid color-mix(in srgb, var(--sift-accent) 34%, var(--sift-rule));
+  gap: 7px;
+  border: 1px solid color-mix(in srgb, var(--sift-muted) 24%, var(--sift-rule));
   border-radius: 6px;
-  background: color-mix(in srgb, var(--sift-accent) 7%, var(--sift-panel));
-  color: var(--sift-accent);
-  font:
-    600 11px/1.2 "SF Mono",
-    ui-monospace,
-    monospace;
-  padding: 4px 8px;
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--sift-accent) 16%, transparent);
+  background: color-mix(in srgb, var(--sift-muted) 7%, var(--sift-panel));
+  color: color-mix(in srgb, var(--sift-muted) 88%, var(--sift-ink));
+  font: 500 11px/1.2 var(--sift-font);
+  padding: 3px 7px;
 }
 
 .sift-focus-key {
-  border: 1px solid color-mix(in srgb, var(--sift-accent) 26%, var(--sift-rule));
+  border: 1px solid color-mix(in srgb, var(--sift-muted) 28%, var(--sift-rule));
   border-radius: 4px;
-  background: color-mix(in srgb, var(--sift-accent) 11%, var(--sift-panel));
-  color: var(--sift-accent);
+  background: color-mix(in srgb, var(--sift-muted) 8%, var(--sift-panel));
+  color: color-mix(in srgb, var(--sift-muted) 92%, var(--sift-ink));
+  font-family: "SF Mono", ui-monospace, monospace;
   font-size: 10px;
   line-height: 1;
-  padding: 2px 6px;
+  padding: 2px 5px;
 }
 
 .sift-debug-btn {

--- a/packages/sift/vite.lib.config.ts
+++ b/packages/sift/vite.lib.config.ts
@@ -19,9 +19,12 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
+      entry: {
+        index: resolve(__dirname, "src/index.ts"),
+        handoff: resolve(__dirname, "src/handoff.tsx"),
+      },
       formats: ["es"],
-      fileName: "index",
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     outDir: "lib",
     rolldownOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@lezer/lr':
         specifier: ^1.4.8
         version: 1.4.8
+      '@nteract/sift':
+        specifier: workspace:*
+        version: link:packages/sift
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -362,6 +365,9 @@ importers:
       '@nteract/notebook-host':
         specifier: workspace:*
         version: link:../../packages/notebook-host
+      '@nteract/sift':
+        specifier: workspace:*
+        version: link:../../packages/sift
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,3 +1,5 @@
+import { SiftScrollHandoffCue } from "@nteract/sift/handoff";
+import "@nteract/sift/handoff.css";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   type KeyboardEvent,
@@ -842,12 +844,12 @@ export function OutputArea({
               ref={staticFrameInteractionRef}
               className={cn(
                 shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
-                hasSiftOutputs && "group/sift",
+                hasSiftOutputs && "group/sift rounded-md overflow-hidden",
                 hasSiftOutputs &&
                   shouldUseScrollPassthroughFrame &&
                   !staticFrameInteractionActive &&
-                  "rounded-md hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
-                hasSiftOutputs && staticFrameInteractionActive && "rounded-md bg-background",
+                  "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
+                hasSiftOutputs && staticFrameInteractionActive && "bg-background",
               )}
               style={siftFrameStyle}
               data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
@@ -880,10 +882,9 @@ export function OutputArea({
                 onError={handleIframeError}
               />
               {showSiftInteractionCue && (
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center rounded-b-md bg-gradient-to-t from-background via-background/85 to-transparent pb-2 pt-8 opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
-                  <button
-                    type="button"
-                    className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/70 bg-background/95 px-2.5 py-1 text-[11px] font-medium text-muted-foreground shadow-sm backdrop-blur transition-colors hover:border-sky-300 hover:text-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 dark:hover:border-sky-700 dark:hover:text-sky-300"
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
+                  <SiftScrollHandoffCue
+                    className="pointer-events-auto"
                     onPointerDown={(event) => {
                       event.stopPropagation();
                       activateStaticFrameInteraction();
@@ -892,10 +893,7 @@ export function OutputArea({
                       event.stopPropagation();
                       activateStaticFrameInteraction();
                     }}
-                  >
-                    <ChevronDown className="h-3 w-3" />
-                    <span>Focus table scrolling</span>
-                  </button>
+                  />
                 </div>
               )}
             </div>

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -286,13 +286,15 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
-    expect(screen.queryByText("Focus table scrolling")).toBeNull();
+    expect(screen.queryByText("Click inside the table to scroll")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
-    expect(screen.getByRole("button", { name: "Focus table scrolling" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Click inside the table to scroll" }),
+    ).toBeInTheDocument();
   });
 
   it("activates sift iframe scrolling from the magnetize cue", () => {
@@ -300,12 +302,12 @@ describe("OutputArea iframe theme sync", () => {
     const frame = getByTestId("isolated-frame");
     const activationWell = frame.parentElement as HTMLElement;
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Focus table scrolling" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Click inside the table to scroll" }));
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
-    expect(screen.queryByRole("button", { name: "Focus table scrolling" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
   });
 
   it("releases sift iframe scrolling on outside pointer down", () => {
@@ -322,8 +324,10 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
-    expect(screen.queryByText("Focused")).toBeNull();
-    expect(screen.getByRole("button", { name: "Focus table scrolling" })).toBeInTheDocument();
+    expect(screen.queryByText("Table focused")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Click inside the table to scroll" }),
+    ).toBeInTheDocument();
   });
 
   it("forces focused iframe outputs off scroll passthrough and wheel-boundary forwarding", () => {

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -9,7 +9,7 @@
  * parquet or Arrow IPC from blob URL → WASM decodes → table renders.
  */
 
-import { setWasmUrl, SiftTable, type TableEngineState } from "@nteract/sift";
+import { setWasmUrl, SiftFocusStatus, SiftTable, type TableEngineState } from "@nteract/sift";
 import "@nteract/sift/style.css";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -41,9 +41,7 @@ function configureWasm(blobUrl: string): void {
     const parsed = new URL(blobUrl);
     const wasmUrl = new URL("/plugins/sift_wasm.wasm", parsed.origin);
     wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
-    const wasmUrlString = wasmUrl.toString();
-    console.debug("[sift-renderer] setWasmUrl:", wasmUrlString);
-    setWasmUrl(wasmUrlString);
+    setWasmUrl(wasmUrl.toString());
     wasmConfigured = true;
   } catch (err) {
     console.warn("[sift-renderer] configureWasm failed, using defaults:", err);
@@ -89,9 +87,8 @@ function fitHeightForRowCount(rowCount: number): number {
 
 // --- SiftRenderer component ---
 
-function SiftRenderer({ data, mimeType, interactionActive = false }: RendererProps) {
+function SiftRenderer({ data, interactionActive = false }: RendererProps) {
   const url = String(data);
-  console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
   configureWasm(url);
 
   // Default to the cap so the table is visible while sift's WASM loads
@@ -124,14 +121,7 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
         url={url}
         onChange={handleChange}
         footerControl={
-          <div className="sift-footer-control">
-            {interactionActive && (
-              <span className="sift-focus-hint">
-                <span>Focused</span>
-                <span className="sift-focus-key">Esc</span>
-              </span>
-            )}
-          </div>
+          <div className="sift-footer-control">{interactionActive && <SiftFocusStatus />}</div>
         }
       />
     </div>
@@ -143,7 +133,6 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
 export function install(ctx: {
   register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
 }) {
-  console.debug("[sift-renderer] plugin installed for table MIME types");
   ctx.register(
     ["application/vnd.apache.parquet", "application/vnd.apache.arrow.stream"],
     SiftRenderer,


### PR DESCRIPTION
## Summary

- add sift-owned scroll handoff and focus status components
- use the sift handoff cue from the notebook output wrapper while preserving parent-owned iframe activation
- quiet the active focus status, align inactive/focused cue placement, fix rounded table clipping, and remove noisy sift renderer debug logs

## Verification

- `pnpm --dir packages/sift test -- src/react.test.tsx`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `pnpm --dir packages/sift build`
- `pnpm --dir apps/notebook build`
- `pnpm --dir packages/sift build:lib`
- `cargo xtask lint --fix`
