### PR TITLE
fix(sync): retry recoverable automerge receive failures

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2140,24 +2140,49 @@ impl NotebookDoc {
         self.doc.sync().receive_sync_message(peer_state, message)
     }
 
-    /// Receive a sync message, recovering from Automerge panics by rebuilding
-    /// this doc and resetting peer sync state. A recovered panic is reported as
-    /// an error so callers do not treat the incoming message as applied.
+    /// Receive a sync message, recovering from recoverable Automerge failures
+    /// by rebuilding this doc, resetting peer sync state, and retrying the
+    /// original frame once.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
             Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                *peer_state = sync::State::new();
+                if let Err(rebuild_source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -2477,6 +2502,10 @@ impl NotebookDoc {
             attachments: HashMap::new(),
         })
     }
+}
+
+fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
+    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 // ── Free helpers ─────────────────────────────────────────────────────

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -336,24 +336,49 @@ impl PoolDoc {
             .map(|_| ())
     }
 
-    /// Receive a sync message, recovering from Automerge panics by rebuilding
-    /// this doc and resetting peer sync state. A recovered panic is reported as
-    /// an error so callers do not treat the incoming message as applied.
+    /// Receive a sync message, recovering from recoverable Automerge failures
+    /// by rebuilding this doc, resetting peer sync state, and retrying the
+    /// original frame once.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
             Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                *peer_state = sync::State::new();
+                if let Err(rebuild_source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -373,6 +398,10 @@ impl PoolDoc {
             }
         })?
     }
+}
+
+fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
+    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 #[cfg(test)]

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -108,14 +108,34 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(message)) {
             Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                if let Err(rebuild_source) = self.rebuild_doc() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || self.receive_sync_message(retry_message)) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 if let Err(source) = self.rebuild_doc() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || self.receive_sync_message(retry_message)) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -161,14 +181,38 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_state_sync_message(message)) {
             Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                if let Err(rebuild_source) = self.rebuild_state_doc() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_state_sync_message(retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 if let Err(source) = self.rebuild_state_doc() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_state_sync_message(retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -240,6 +284,10 @@ impl SharedDocState {
     pub(crate) fn panic_on_next_state_sync_for_test(&mut self) {
         self.panic_on_next_state_sync = true;
     }
+}
+
+fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
+    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 #[cfg(test)]

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -83,12 +83,19 @@ use automerge::{
 };
 use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
     KernelActivity, KernelErrorReason, ProjectContext, ProjectFile, ProjectFileExtras,
     ProjectFileKind, ProjectFileParsed, RuntimeLifecycle, StreamOutputState,
 };
+
+#[cfg(test)]
+thread_local! {
+    static PATCH_LOG_MISMATCH_ON_NEXT_RECEIVE_SYNC_CALLS: Cell<usize> = const { Cell::new(0) };
+}
 
 // ── Snapshot types for reading/comparing state ──────────────────────
 
@@ -396,6 +403,23 @@ impl RuntimeStateDoc {
 
     pub fn new_empty() -> Self {
         Self::try_new_empty().unwrap_or_else(|err| panic!("seed runtime state schema: {err}"))
+    }
+
+    #[cfg(test)]
+    fn __patch_log_mismatch_on_next_receive_sync_calls_for_test(count: usize) {
+        PATCH_LOG_MISMATCH_ON_NEXT_RECEIVE_SYNC_CALLS.with(|calls| calls.set(count));
+    }
+
+    #[cfg(test)]
+    fn patch_log_mismatch_if_receive_sync_requested_for_test() -> Result<(), AutomergeError> {
+        PATCH_LOG_MISMATCH_ON_NEXT_RECEIVE_SYNC_CALLS.with(|calls| {
+            let count = calls.get();
+            if count == 0 {
+                return Ok(());
+            }
+            calls.set(count - 1);
+            Err(AutomergeError::PatchLogMismatch)
+        })
     }
 
     fn schema_seed_doc() -> Result<AutoCommit, RuntimeStateError> {
@@ -2719,6 +2743,9 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
+        #[cfg(test)]
+        Self::patch_log_mismatch_if_receive_sync_requested_for_test()?;
+
         if !message.changes.is_empty() {
             tracing::debug!(
                 "[runtime-state] Stripped {} change(s) from client RuntimeStateDoc sync message",
@@ -2746,15 +2773,40 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
             Ok(Ok(())) => Ok(()),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                *peer_state = sync::State::new();
+                if let Err(rebuild_source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message(peer_state, retry_message)
+                }) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -2772,6 +2824,9 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<bool, AutomergeError> {
+        #[cfg(test)]
+        Self::patch_log_mismatch_if_receive_sync_requested_for_test()?;
+
         let heads_before = self.doc.get_heads();
         self.doc.sync().receive_sync_message(peer_state, message)?;
         let heads_after = self.doc.get_heads();
@@ -2786,17 +2841,42 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<bool, AutomergeOperationError> {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || {
             self.receive_sync_message_with_changes(peer_state, message)
         }) {
             Ok(Ok(changed)) => Ok(changed),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                *peer_state = sync::State::new();
+                if let Err(rebuild_source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message_with_changes(peer_state, retry_message)
+                }) {
+                    Ok(Ok(changed)) => Ok(changed),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_message_with_changes(peer_state, retry_message)
+                }) {
+                    Ok(Ok(changed)) => Ok(changed),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
@@ -2830,6 +2910,9 @@ impl RuntimeStateDoc {
     where
         F: Fn(&ActorId) -> bool,
     {
+        #[cfg(test)]
+        Self::patch_log_mismatch_if_receive_sync_requested_for_test()?;
+
         let heads_before = self.doc.get_heads();
         self.doc.sync().receive_sync_message(peer_state, message)?;
 
@@ -2924,20 +3007,49 @@ impl RuntimeStateDoc {
     where
         F: Fn(&ActorId) -> bool,
     {
+        let retry_message = message.clone();
         match catch_automerge_panic(label, || {
-            self.receive_sync_and_foreign_comms(peer_state, message, is_foreign)
+            self.receive_sync_and_foreign_comms(peer_state, message, &is_foreign)
         }) {
             Ok(Ok(view)) => Ok(view),
+            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
+                *peer_state = sync::State::new();
+                if let Err(rebuild_source) = self.rebuild_from_save() {
+                    return Err(AutomergeOperationError::rebuild_failed(
+                        label,
+                        rebuild_source,
+                    ));
+                }
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_and_foreign_comms(peer_state, retry_message, is_foreign)
+                }) {
+                    Ok(Ok(view)) => Ok(view),
+                    Ok(Err(retry_source)) => {
+                        Err(AutomergeOperationError::automerge(label, retry_source))
+                    }
+                    Err(err) => Err(AutomergeOperationError::Panic(err)),
+                }
+            }
             Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
             Err(err) => {
                 *peer_state = sync::State::new();
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }
-                Err(AutomergeOperationError::Panic(err))
+                match catch_automerge_panic(label, || {
+                    self.receive_sync_and_foreign_comms(peer_state, retry_message, is_foreign)
+                }) {
+                    Ok(Ok(view)) => Ok(view),
+                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+                    Err(_) => Err(AutomergeOperationError::Panic(err)),
+                }
             }
         }
     }
+}
+
+fn is_recoverable_sync_error(source: &AutomergeError) -> bool {
+    matches!(source, AutomergeError::PatchLogMismatch)
 }
 
 /// Scaffold the `project_context` map in a fresh doc.
@@ -5236,6 +5348,97 @@ mod tests {
         // Object values are always written (no deep comparison)
         let delta = serde_json::json!({"nested": {"a": 1}});
         doc.merge_comm_state_delta("w1", &delta).unwrap();
+    }
+
+    #[test]
+    fn receive_sync_with_changes_retries_original_message_after_patch_log_mismatch() {
+        let mut receiver = RuntimeStateDoc::new_empty();
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = RuntimeStateDoc::new();
+        donor
+            .create_execution_with_source("exec-retry", "cell-retry", "x = 1", 1)
+            .unwrap();
+        let mut donor_sync = sync::State::new();
+        if let Some(handshake) = receiver.generate_sync_message(&mut receiver_sync) {
+            donor
+                .doc
+                .sync()
+                .receive_sync_message(&mut donor_sync, handshake)
+                .expect("donor receives receiver handshake");
+        }
+        let message = donor
+            .generate_sync_message(&mut donor_sync)
+            .expect("donor should advertise execution");
+
+        RuntimeStateDoc::__patch_log_mismatch_on_next_receive_sync_calls_for_test(1);
+        let changed = receiver
+            .receive_sync_message_with_changes_recovering(
+                &mut receiver_sync,
+                message,
+                "receive-sync-patch-log-mismatch-test",
+            )
+            .expect("recoverable sync error should reset state and retry the original message");
+
+        assert!(changed, "retried message should apply donor changes");
+        assert!(
+            receiver.read_state().executions.contains_key("exec-retry"),
+            "execution from the failed receive frame should not be dropped"
+        );
+    }
+
+    #[test]
+    fn receive_sync_and_foreign_comms_retries_original_message_after_patch_log_mismatch() {
+        let mut receiver = RuntimeStateDoc::new();
+        receiver.set_actor("rt:kernel:deadbeef");
+        let mut receiver_sync = sync::State::new();
+
+        let mut donor = receiver.fork();
+        donor.fork_and_merge(|f| {
+            f.set_actor("human:peer");
+            f.put_comm(
+                "human-widget",
+                "j.w",
+                "",
+                "",
+                &serde_json::json!({"value": 2}),
+                0,
+            )
+            .unwrap();
+        });
+        let mut donor_sync = sync::State::new();
+        if let Some(handshake) = receiver.generate_sync_message(&mut receiver_sync) {
+            donor
+                .doc
+                .sync()
+                .receive_sync_message(&mut donor_sync, handshake)
+                .expect("donor receives receiver handshake");
+        }
+        let message = donor
+            .generate_sync_message(&mut donor_sync)
+            .expect("donor should advertise comm change");
+
+        RuntimeStateDoc::__patch_log_mismatch_on_next_receive_sync_calls_for_test(1);
+        let view = receiver
+            .receive_sync_and_foreign_comms_recovering(
+                &mut receiver_sync,
+                message,
+                |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                "receive-sync-foreign-patch-log-mismatch-test",
+            )
+            .expect("recoverable sync error should reset state and retry the original message");
+
+        assert!(
+            view.applied_actors
+                .iter()
+                .any(|actor| actor.to_bytes().starts_with(b"human:")),
+            "retried message should report the applied frontend actor"
+        );
+        let foreign_comms = view.foreign_comms.expect("foreign comm view");
+        assert!(
+            foreign_comms.contains_key("human-widget"),
+            "foreign comm from the failed receive frame should not be dropped"
+        );
     }
 
     #[test]

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2738,11 +2738,18 @@ class TestCreateNotebook:
         """
         import uuid
 
-        env_name = f"nteract-missing-env-{uuid.uuid4().hex}"
+        suffix = uuid.uuid4().hex
+        env_name = f"nteract-missing-env-{suffix}"
+        dep_name = f"nteract-unapproved-conda-dep-{suffix}"
 
         # Create environment.yml in tmp_path
         (tmp_path / "environment.yml").write_text(
-            f"name: {env_name}\nchannels:\n  - conda-forge\ndependencies:\n  - python\n"
+            f"name: {env_name}\n"
+            "channels:\n"
+            "  - conda-forge\n"
+            "dependencies:\n"
+            "  - python\n"
+            f"  - {dep_name}\n"
         )
 
         session = await client.create_notebook(runtime="python", working_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

- Treat `AutomergeError::PatchLogMismatch` as a recoverable sync-boundary failure.
- Rebuild the owning document, reset per-peer sync state, and retry the original inbound frame once.
- Apply the same receive recovery contract to notebook, runtime-state, pool-state, and shared sync state paths.
- Add runtime-state regressions that reproduce the dropped-frame failure shape and prove the original frame is applied after recovery.

## Background

The failing CI artifact showed runtime-agent `RuntimeStateSync` receive returning:

```text
patch logs cannot be shared between documents
```

The pinned Automerge fork now returns `PatchLogMismatch` for this class instead of panicking. Desktop still treated the returned Automerge error as terminal, which meant the frame could be dropped and sync could stall. This PR makes that error an explicit protocol recovery event at our document-owner boundaries.

## Verification

- `cargo test -p runtime-doc`
- `cargo test -p notebook-doc`
- `cargo test -p notebook-sync`
- `cargo check -p notebook-doc -p notebook-sync -p runtime-doc`
- `cargo xtask lint --fix`

## Notes

I also created an Automerge fork branch, `codex/patch-log-contract-tests`, with a narrow contract test for active mismatched patch logs returning `PatchLogMismatch` without panic.
