### PR TITLE
refactor(sync): centralize automerge recovery retry

### DIFF
--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn recoverable_operation_returns_normal_value_without_rebuild() {
         let mut rebuilds = 0;
-        let value = recoverable_automerge_operation(
+        let result = recoverable_automerge_operation(
             "normal",
             &mut rebuilds,
             |_| Ok(42),
@@ -208,8 +208,11 @@ mod tests {
                 *rebuilds += 1;
                 Ok(())
             },
-        )
-        .expect("normal operation should succeed");
+        );
+        let value = match result {
+            Ok(value) => value,
+            Err(error) => panic!("normal operation should succeed, got {error:?}"),
+        };
 
         assert_eq!(value, 42);
         assert_eq!(rebuilds, 0);
@@ -218,7 +221,7 @@ mod tests {
     #[test]
     fn recoverable_operation_rebuilds_after_marked_error_and_retries_once() {
         let mut calls = 0;
-        let value = recoverable_automerge_operation(
+        let result = recoverable_automerge_operation(
             "recoverable-error",
             &mut calls,
             |calls| {
@@ -231,8 +234,11 @@ mod tests {
             },
             |source| matches!(source, automerge::AutomergeError::PatchLogMismatch),
             |_| Ok(()),
-        )
-        .expect("recoverable error should rebuild and retry");
+        );
+        let value = match result {
+            Ok(value) => value,
+            Err(error) => panic!("recoverable error should rebuild and retry, got {error:?}"),
+        };
 
         assert_eq!(value, "retried");
         assert_eq!(calls, 2);
@@ -241,7 +247,7 @@ mod tests {
     #[test]
     fn recoverable_operation_returns_unmarked_error_without_rebuild() {
         let mut rebuilt = false;
-        let error = recoverable_automerge_operation::<_, ()>(
+        let result = recoverable_automerge_operation::<_, ()>(
             "nonrecoverable-error",
             &mut rebuilt,
             |_| Err(automerge::AutomergeError::InvalidObjId("bad object".into())),
@@ -250,8 +256,11 @@ mod tests {
                 *rebuilt = true;
                 Ok(())
             },
-        )
-        .expect_err("unmarked error should not recover");
+        );
+        let error = match result {
+            Ok(()) => panic!("unmarked error should not recover"),
+            Err(error) => error,
+        };
 
         assert!(!rebuilt);
         assert!(matches!(error, AutomergeOperationError::Automerge { .. }));
@@ -260,7 +269,7 @@ mod tests {
     #[test]
     fn recoverable_operation_rebuilds_after_panic_and_preserves_first_repeated_panic() {
         let mut calls = 0;
-        let error = recoverable_automerge_operation::<_, ()>(
+        let result = recoverable_automerge_operation::<_, ()>(
             "repeated-panic",
             &mut calls,
             |calls| {
@@ -272,8 +281,11 @@ mod tests {
             },
             |_| false,
             |_| Ok(()),
-        )
-        .expect_err("repeated panic should fail");
+        );
+        let error = match result {
+            Ok(()) => panic!("repeated panic should fail"),
+            Err(error) => error,
+        };
 
         match error {
             AutomergeOperationError::Panic(error) => {

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -111,6 +111,23 @@ pub fn catch_automerge_panic<T>(
     }
 }
 
+enum AutomergeAttempt<T> {
+    Success(T),
+    AutomergeError(automerge::AutomergeError),
+    Panic(AutomergeRecoveryError),
+}
+
+fn catch_automerge_result<T>(
+    label: impl Into<String>,
+    f: impl FnOnce() -> Result<T, automerge::AutomergeError>,
+) -> AutomergeAttempt<T> {
+    match catch_automerge_panic(label, f) {
+        Ok(Ok(value)) => AutomergeAttempt::Success(value),
+        Ok(Err(source)) => AutomergeAttempt::AutomergeError(source),
+        Err(error) => AutomergeAttempt::Panic(error),
+    }
+}
+
 /// Run an Automerge operation and, when it panics or returns a caller-marked
 /// recoverable error, rebuild caller-owned state and retry once.
 ///
@@ -126,21 +143,27 @@ pub fn recoverable_automerge_operation<C, T>(
 ) -> Result<T, AutomergeOperationError> {
     let label = label.into();
 
-    let first_panic = match catch_automerge_panic(label.clone(), || operation(context)) {
-        Ok(Ok(value)) => return Ok(value),
-        Ok(Err(source)) if should_rebuild(&source) => None,
-        Ok(Err(source)) => return Err(AutomergeOperationError::automerge(label, source)),
-        Err(error) => Some(error),
+    let first_panic = match catch_automerge_result(label.clone(), || operation(context)) {
+        AutomergeAttempt::Success(value) => return Ok(value),
+        AutomergeAttempt::AutomergeError(source) if should_rebuild(&source) => None,
+        AutomergeAttempt::AutomergeError(source) => {
+            return Err(AutomergeOperationError::automerge(label, source));
+        }
+        AutomergeAttempt::Panic(error) => Some(error),
     };
 
     if let Err(source) = rebuild(context) {
         return Err(AutomergeOperationError::rebuild_failed(label, source));
     }
 
-    match catch_automerge_panic(label.clone(), || operation(context)) {
-        Ok(Ok(value)) => Ok(value),
-        Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-        Err(error) => Err(AutomergeOperationError::Panic(first_panic.unwrap_or(error))),
+    match catch_automerge_result(label.clone(), || operation(context)) {
+        AutomergeAttempt::Success(value) => Ok(value),
+        AutomergeAttempt::AutomergeError(source) => {
+            Err(AutomergeOperationError::automerge(label, source))
+        }
+        AutomergeAttempt::Panic(error) => {
+            Err(AutomergeOperationError::Panic(first_panic.unwrap_or(error)))
+        }
     }
 }
 

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -111,6 +111,39 @@ pub fn catch_automerge_panic<T>(
     }
 }
 
+/// Run an Automerge operation and, when it panics or returns a caller-marked
+/// recoverable error, rebuild caller-owned state and retry once.
+///
+/// The `context` is intentionally opaque to this crate. Document owners use it
+/// to keep their document, per-peer `sync::State`, and any retry frame together
+/// without making this small crate depend on higher-level document crates.
+pub fn recoverable_automerge_operation<C, T>(
+    label: impl Into<String>,
+    context: &mut C,
+    mut operation: impl FnMut(&mut C) -> Result<T, automerge::AutomergeError>,
+    should_rebuild: impl Fn(&automerge::AutomergeError) -> bool,
+    mut rebuild: impl FnMut(&mut C) -> Result<(), AutomergeRebuildError>,
+) -> Result<T, AutomergeOperationError> {
+    let label = label.into();
+
+    let first_panic = match catch_automerge_panic(label.clone(), || operation(context)) {
+        Ok(Ok(value)) => return Ok(value),
+        Ok(Err(source)) if should_rebuild(&source) => None,
+        Ok(Err(source)) => return Err(AutomergeOperationError::automerge(label, source)),
+        Err(error) => Some(error),
+    };
+
+    if let Err(source) = rebuild(context) {
+        return Err(AutomergeOperationError::rebuild_failed(label, source));
+    }
+
+    match catch_automerge_panic(label.clone(), || operation(context)) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
+        Err(error) => Err(AutomergeOperationError::Panic(first_panic.unwrap_or(error))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,6 +194,95 @@ mod tests {
 
         assert_eq!(error.label, "unknown");
         assert_eq!(error.panic_message, "unknown panic");
+    }
+
+    #[test]
+    fn recoverable_operation_returns_normal_value_without_rebuild() {
+        let mut rebuilds = 0;
+        let value = recoverable_automerge_operation(
+            "normal",
+            &mut rebuilds,
+            |_| Ok(42),
+            |_| true,
+            |rebuilds| {
+                *rebuilds += 1;
+                Ok(())
+            },
+        )
+        .expect("normal operation should succeed");
+
+        assert_eq!(value, 42);
+        assert_eq!(rebuilds, 0);
+    }
+
+    #[test]
+    fn recoverable_operation_rebuilds_after_marked_error_and_retries_once() {
+        let mut calls = 0;
+        let value = recoverable_automerge_operation(
+            "recoverable-error",
+            &mut calls,
+            |calls| {
+                *calls += 1;
+                if *calls == 1 {
+                    Err(automerge::AutomergeError::PatchLogMismatch)
+                } else {
+                    Ok("retried")
+                }
+            },
+            |source| matches!(source, automerge::AutomergeError::PatchLogMismatch),
+            |_| Ok(()),
+        )
+        .expect("recoverable error should rebuild and retry");
+
+        assert_eq!(value, "retried");
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn recoverable_operation_returns_unmarked_error_without_rebuild() {
+        let mut rebuilt = false;
+        let error = recoverable_automerge_operation::<_, ()>(
+            "nonrecoverable-error",
+            &mut rebuilt,
+            |_| Err(automerge::AutomergeError::InvalidObjId("bad object".into())),
+            |_| false,
+            |rebuilt| {
+                *rebuilt = true;
+                Ok(())
+            },
+        )
+        .expect_err("unmarked error should not recover");
+
+        assert!(!rebuilt);
+        assert!(matches!(error, AutomergeOperationError::Automerge { .. }));
+    }
+
+    #[test]
+    fn recoverable_operation_rebuilds_after_panic_and_preserves_first_repeated_panic() {
+        let mut calls = 0;
+        let error = recoverable_automerge_operation::<_, ()>(
+            "repeated-panic",
+            &mut calls,
+            |calls| {
+                *calls += 1;
+                if *calls == 1 {
+                    panic!("first panic");
+                }
+                panic!("second panic");
+            },
+            |_| false,
+            |_| Ok(()),
+        )
+        .expect_err("repeated panic should fail");
+
+        match error {
+            AutomergeOperationError::Panic(error) => {
+                assert_eq!(error.label, "repeated-panic");
+                assert_eq!(error.panic_message, "first panic");
+            }
+            other => panic!("expected panic error, got {other:?}"),
+        }
+        assert_eq!(calls, 2);
     }
 
     #[test]

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -88,7 +88,10 @@ use automerge::sync::SyncDoc;
 use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
+use automerge_recovery::{
+    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
+    AutomergeRebuildError,
+};
 
 /// Re-export so downstream crates (runtimed-wasm) can set text encoding
 /// without depending on automerge directly.
@@ -2118,17 +2121,20 @@ impl NotebookDoc {
         peer_state: &mut sync::State,
         label: &str,
     ) -> Result<Option<sync::Message>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
-            Ok(message) => Ok(message),
-            Err(_err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
-                    .map_err(AutomergeOperationError::Panic)
-            }
-        }
+        let mut context = SyncRecoveryContext {
+            doc: self,
+            peer_state,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| Ok(context.doc.generate_sync_message(context.peer_state)),
+            |_| false,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Receive and apply a sync message from a peer.
@@ -2149,42 +2155,30 @@ impl NotebookDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                *peer_state = sync::State::new();
-                if let Err(rebuild_source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = SyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context
+                    .doc
+                    .receive_sync_message(context.peer_state, message)
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     // ── Provenance queries ──────────────────────────────────────────
@@ -2506,6 +2500,18 @@ impl NotebookDoc {
 
 fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
     matches!(source, automerge::AutomergeError::PatchLogMismatch)
+}
+
+struct SyncRecoveryContext<'a> {
+    doc: &'a mut NotebookDoc,
+    peer_state: &'a mut sync::State,
+}
+
+struct SyncReceiveRecoveryContext<'a> {
+    doc: &'a mut NotebookDoc,
+    peer_state: &'a mut sync::State,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
 }
 
 // ── Free helpers ─────────────────────────────────────────────────────

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -30,7 +30,10 @@ use automerge::{
     sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjType,
     ReadDoc, Value, ROOT,
 };
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
+use automerge_recovery::{
+    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
+    AutomergeRebuildError,
+};
 use serde::{Deserialize, Serialize};
 
 // ── Snapshot types ───────────────────────────────────────────────────
@@ -304,17 +307,20 @@ impl PoolDoc {
         peer_state: &mut sync::State,
         label: &str,
     ) -> Result<Option<sync::Message>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
-            Ok(message) => Ok(message),
-            Err(_err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
-                    .map_err(AutomergeOperationError::Panic)
-            }
-        }
+        let mut context = PoolSyncRecoveryContext {
+            doc: self,
+            peer_state,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| Ok(context.doc.generate_sync_message(context.peer_state)),
+            |_| false,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Receive a sync message from a client.
@@ -345,42 +351,30 @@ impl PoolDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                *peer_state = sync::State::new();
-                if let Err(rebuild_source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = PoolSyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context
+                    .doc
+                    .receive_sync_message(context.peer_state, message)
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Round-trip save→load to rebuild internal automerge indices.
@@ -402,6 +396,18 @@ impl PoolDoc {
 
 fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
     matches!(source, automerge::AutomergeError::PatchLogMismatch)
+}
+
+struct PoolSyncRecoveryContext<'a> {
+    doc: &'a mut PoolDoc,
+    peer_state: &'a mut sync::State,
+}
+
+struct PoolSyncReceiveRecoveryContext<'a> {
+    doc: &'a mut PoolDoc,
+    peer_state: &'a mut sync::State,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
 }
 
 #[cfg(test)]

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -8,7 +8,10 @@
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::AutoCommit;
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
+use automerge_recovery::{
+    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
+    AutomergeRebuildError,
+};
 use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::RuntimeStateDoc;
@@ -91,16 +94,13 @@ impl SharedDocState {
         &mut self,
         label: &str,
     ) -> Result<Option<sync::Message>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.generate_sync_message()) {
-            Ok(message) => Ok(message),
-            Err(_err) => {
-                if let Err(source) = self.rebuild_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                catch_automerge_panic(label, || self.generate_sync_message())
-                    .map_err(AutomergeOperationError::Panic)
-            }
-        }
+        recoverable_automerge_operation(
+            label,
+            self,
+            |state| Ok(state.generate_sync_message()),
+            |_| false,
+            |state| state.rebuild_doc(),
+        )
     }
 
     pub(crate) fn receive_sync_message_recovering(
@@ -108,36 +108,24 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || self.receive_sync_message(message)) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                if let Err(rebuild_source) = self.rebuild_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || self.receive_sync_message(retry_message)) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                if let Err(source) = self.rebuild_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || self.receive_sync_message(retry_message)) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = SharedDocReceiveRecoveryContext {
+            state: self,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context.state.receive_sync_message(message)
+            },
+            is_recoverable_sync_error,
+            |context| context.state.rebuild_doc(),
+        )
     }
 
     // ── RuntimeStateDoc sync ────────────────────────────────────────
@@ -181,40 +169,24 @@ impl SharedDocState {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || self.receive_state_sync_message(message)) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                if let Err(rebuild_source) = self.rebuild_state_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_state_sync_message(retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                if let Err(source) = self.rebuild_state_doc() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_state_sync_message(retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = SharedDocReceiveRecoveryContext {
+            state: self,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context.state.receive_state_sync_message(message)
+            },
+            is_recoverable_sync_error,
+            |context| context.state.rebuild_state_doc(),
+        )
     }
 
     /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
@@ -284,6 +256,12 @@ impl SharedDocState {
     pub(crate) fn panic_on_next_state_sync_for_test(&mut self) {
         self.panic_on_next_state_sync = true;
     }
+}
+
+struct SharedDocReceiveRecoveryContext<'a> {
+    state: &'a mut SharedDocState,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
 }
 
 fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -81,7 +81,10 @@ use automerge::{
     sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjId,
     ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRebuildError};
+use automerge_recovery::{
+    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
+    AutomergeRebuildError,
+};
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use std::cell::Cell;
@@ -2657,17 +2660,20 @@ impl RuntimeStateDoc {
         peer_state: &mut sync::State,
         label: &str,
     ) -> Result<Option<sync::Message>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.generate_sync_message(peer_state)) {
-            Ok(message) => Ok(message),
-            Err(_err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                catch_automerge_panic(label, || self.generate_sync_message(peer_state))
-                    .map_err(AutomergeOperationError::Panic)
-            }
-        }
+        let mut context = RuntimeSyncRecoveryContext {
+            doc: self,
+            peer_state,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| Ok(context.doc.generate_sync_message(context.peer_state)),
+            |_| false,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Generate a sync message, compacting the doc if the encoded message
@@ -2716,21 +2722,26 @@ impl RuntimeStateDoc {
         max_encoded_bytes: usize,
         label: &str,
     ) -> Result<Option<Vec<u8>>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || {
-            self.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
-        }) {
-            Ok(message) => Ok(message),
-            Err(_err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                catch_automerge_panic(label, || {
-                    self.generate_sync_message_bounded_encoded(peer_state, max_encoded_bytes)
-                })
-                .map_err(AutomergeOperationError::Panic)
-            }
-        }
+        let mut context = RuntimeBoundedSyncRecoveryContext {
+            doc: self,
+            peer_state,
+            max_encoded_bytes,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                Ok(context.doc.generate_sync_message_bounded_encoded(
+                    context.peer_state,
+                    context.max_encoded_bytes,
+                ))
+            },
+            |_| false,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Receive a sync message with change stripping (read-only enforcement).
@@ -2773,42 +2784,30 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<(), AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || self.receive_sync_message(peer_state, message)) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                *peer_state = sync::State::new();
-                if let Err(rebuild_source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message(peer_state, retry_message)
-                }) {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = RuntimeSyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context
+                    .doc
+                    .receive_sync_message(context.peer_state, message)
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Receive a sync message accepting client writes.
@@ -2841,44 +2840,30 @@ impl RuntimeStateDoc {
         message: sync::Message,
         label: &str,
     ) -> Result<bool, AutomergeOperationError> {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || {
-            self.receive_sync_message_with_changes(peer_state, message)
-        }) {
-            Ok(Ok(changed)) => Ok(changed),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                *peer_state = sync::State::new();
-                if let Err(rebuild_source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message_with_changes(peer_state, retry_message)
-                }) {
-                    Ok(Ok(changed)) => Ok(changed),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_message_with_changes(peer_state, retry_message)
-                }) {
-                    Ok(Ok(changed)) => Ok(changed),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = RuntimeSyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context
+                    .doc
+                    .receive_sync_message_with_changes(context.peer_state, message)
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 
     /// Apply a sync message and return both the list of applied-change
@@ -3007,49 +2992,64 @@ impl RuntimeStateDoc {
     where
         F: Fn(&ActorId) -> bool,
     {
-        let retry_message = message.clone();
-        match catch_automerge_panic(label, || {
-            self.receive_sync_and_foreign_comms(peer_state, message, &is_foreign)
-        }) {
-            Ok(Ok(view)) => Ok(view),
-            Ok(Err(source)) if is_recoverable_sync_error(&source) => {
-                *peer_state = sync::State::new();
-                if let Err(rebuild_source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(
-                        label,
-                        rebuild_source,
-                    ));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_and_foreign_comms(peer_state, retry_message, is_foreign)
-                }) {
-                    Ok(Ok(view)) => Ok(view),
-                    Ok(Err(retry_source)) => {
-                        Err(AutomergeOperationError::automerge(label, retry_source))
-                    }
-                    Err(err) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
-                *peer_state = sync::State::new();
-                if let Err(source) = self.rebuild_from_save() {
-                    return Err(AutomergeOperationError::rebuild_failed(label, source));
-                }
-                match catch_automerge_panic(label, || {
-                    self.receive_sync_and_foreign_comms(peer_state, retry_message, is_foreign)
-                }) {
-                    Ok(Ok(view)) => Ok(view),
-                    Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-                    Err(_) => Err(AutomergeOperationError::Panic(err)),
-                }
-            }
-        }
+        let mut context = RuntimeForeignSyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+            is_foreign,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context.doc.receive_sync_and_foreign_comms(
+                    context.peer_state,
+                    message,
+                    &context.is_foreign,
+                )
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
     }
 }
 
 fn is_recoverable_sync_error(source: &AutomergeError) -> bool {
     matches!(source, AutomergeError::PatchLogMismatch)
+}
+
+struct RuntimeSyncRecoveryContext<'a> {
+    doc: &'a mut RuntimeStateDoc,
+    peer_state: &'a mut sync::State,
+}
+
+struct RuntimeBoundedSyncRecoveryContext<'a> {
+    doc: &'a mut RuntimeStateDoc,
+    peer_state: &'a mut sync::State,
+    max_encoded_bytes: usize,
+}
+
+struct RuntimeSyncReceiveRecoveryContext<'a> {
+    doc: &'a mut RuntimeStateDoc,
+    peer_state: &'a mut sync::State,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
+}
+
+struct RuntimeForeignSyncReceiveRecoveryContext<'a, F> {
+    doc: &'a mut RuntimeStateDoc,
+    peer_state: &'a mut sync::State,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
+    is_foreign: F,
 }
 
 /// Scaffold the `project_context` map in a fresh doc.


### PR DESCRIPTION
## Summary

- add a shared `automerge-recovery` retry helper for panic/recoverable-error -> rebuild -> retry-once flows
- route notebook, pool, runtime, and shared sync recovery through that helper while keeping each document owner responsible for peer-state reset and rebuild policy
- preserve the special case that settings sync only captures panics because it does not own a rebuild/reset policy

## Verification

- `cargo test -p automerge-recovery`
- `cargo test -p notebook-doc recovering`
- `cargo test -p runtime-doc`
- `cargo test -p notebook-sync`
- `cargo xtask lint --fix`
