### PR TITLE
refactor(crdt): flatten transaction recovery attempts

### DIFF
--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -111,19 +111,38 @@ pub fn catch_automerge_panic<T>(
     }
 }
 
-enum AutomergeAttempt<T> {
+/// Flattened outcome from an Automerge operation that can either return an
+/// operation error or panic.
+#[derive(Debug)]
+pub enum AutomergeAttempt<T, E = automerge::AutomergeError> {
     Success(T),
-    AutomergeError(automerge::AutomergeError),
+    OperationError(E),
     Panic(AutomergeRecoveryError),
 }
 
-fn catch_automerge_result<T>(
+impl<T> AutomergeAttempt<T, automerge::AutomergeError> {
+    pub fn into_operation_result(
+        self,
+        label: impl Into<String>,
+    ) -> Result<T, AutomergeOperationError> {
+        let label = label.into();
+        match self {
+            Self::Success(value) => Ok(value),
+            Self::OperationError(source) => Err(AutomergeOperationError::automerge(label, source)),
+            Self::Panic(error) => Err(AutomergeOperationError::Panic(error)),
+        }
+    }
+}
+
+/// Catch an Automerge operation that returns a `Result` and flatten the
+/// operation error plus panic channels into an explicit outcome.
+pub fn catch_automerge_result<T, E>(
     label: impl Into<String>,
-    f: impl FnOnce() -> Result<T, automerge::AutomergeError>,
-) -> AutomergeAttempt<T> {
+    f: impl FnOnce() -> Result<T, E>,
+) -> AutomergeAttempt<T, E> {
     match catch_automerge_panic(label, f) {
         Ok(Ok(value)) => AutomergeAttempt::Success(value),
-        Ok(Err(source)) => AutomergeAttempt::AutomergeError(source),
+        Ok(Err(source)) => AutomergeAttempt::OperationError(source),
         Err(error) => AutomergeAttempt::Panic(error),
     }
 }
@@ -145,8 +164,8 @@ pub fn recoverable_automerge_operation<C, T>(
 
     let first_panic = match catch_automerge_result(label.clone(), || operation(context)) {
         AutomergeAttempt::Success(value) => return Ok(value),
-        AutomergeAttempt::AutomergeError(source) if should_rebuild(&source) => None,
-        AutomergeAttempt::AutomergeError(source) => {
+        AutomergeAttempt::OperationError(source) if should_rebuild(&source) => None,
+        AutomergeAttempt::OperationError(source) => {
             return Err(AutomergeOperationError::automerge(label, source));
         }
         AutomergeAttempt::Panic(error) => Some(error),
@@ -158,7 +177,7 @@ pub fn recoverable_automerge_operation<C, T>(
 
     match catch_automerge_result(label.clone(), || operation(context)) {
         AutomergeAttempt::Success(value) => Ok(value),
-        AutomergeAttempt::AutomergeError(source) => {
+        AutomergeAttempt::OperationError(source) => {
             Err(AutomergeOperationError::automerge(label, source))
         }
         AutomergeAttempt::Panic(error) => {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -89,8 +89,8 @@ use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
 use automerge_recovery::{
-    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
-    AutomergeRebuildError,
+    catch_automerge_panic, catch_automerge_result, recoverable_automerge_operation,
+    AutomergeAttempt, AutomergeOperationError, AutomergeRebuildError,
 };
 
 /// Re-export so downstream crates (runtimed-wasm) can set text encoding
@@ -357,10 +357,12 @@ impl NotebookDoc {
         other: &mut NotebookDoc,
         label: &str,
     ) -> Result<Vec<automerge::ChangeHash>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.doc.merge(&mut other.doc)) {
-            Ok(Ok(changes)) => Ok(changes),
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
+        match catch_automerge_result(label, || self.doc.merge(&mut other.doc)) {
+            AutomergeAttempt::Success(changes) => Ok(changes),
+            AutomergeAttempt::OperationError(source) => {
+                Err(AutomergeOperationError::automerge(label, source))
+            }
+            AutomergeAttempt::Panic(err) => {
                 let self_rebuilt = self.rebuild_from_save();
                 let other_rebuilt = other.rebuild_from_save();
                 if let Err(source) = self_rebuilt {
@@ -403,7 +405,7 @@ impl NotebookDoc {
         let isolated = Cell::new(false);
         let mut recovery_panic = None;
 
-        let result = catch_automerge_panic(label, || {
+        let result = catch_automerge_result(label, || {
             if let Some(actor) = actor {
                 self.doc.set_actor(ActorId::from(actor.as_bytes()));
             }
@@ -430,9 +432,11 @@ impl NotebookDoc {
         }
 
         match (result, recovery_panic) {
-            (Ok(Ok(value)), None) => Ok(value),
-            (Ok(Err(source)), None) => Err(AutomergeOperationError::automerge(label, source)),
-            (Err(err), _) | (_, Some(err)) => {
+            (AutomergeAttempt::Success(value), None) => Ok(value),
+            (AutomergeAttempt::OperationError(source), None) => {
+                Err(AutomergeOperationError::automerge(label, source))
+            }
+            (AutomergeAttempt::Panic(err), _) | (_, Some(err)) => {
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source));
                 }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -82,8 +82,8 @@ use automerge::{
     ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
 use automerge_recovery::{
-    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
-    AutomergeRebuildError,
+    catch_automerge_panic, catch_automerge_result, recoverable_automerge_operation,
+    AutomergeAttempt, AutomergeOperationError, AutomergeRebuildError,
 };
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -540,10 +540,12 @@ impl RuntimeStateDoc {
         other: &mut RuntimeStateDoc,
         label: &str,
     ) -> Result<Vec<automerge::ChangeHash>, AutomergeOperationError> {
-        match catch_automerge_panic(label, || self.doc.merge(&mut other.doc)) {
-            Ok(Ok(changes)) => Ok(changes),
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(err) => {
+        match catch_automerge_result(label, || self.doc.merge(&mut other.doc)) {
+            AutomergeAttempt::Success(changes) => Ok(changes),
+            AutomergeAttempt::OperationError(source) => {
+                Err(AutomergeOperationError::automerge(label, source))
+            }
+            AutomergeAttempt::Panic(err) => {
                 let self_rebuilt = self.rebuild_from_save();
                 let other_rebuilt = other.rebuild_from_save();
                 if let Err(source) = self_rebuilt {
@@ -586,7 +588,7 @@ impl RuntimeStateDoc {
         let isolated = Cell::new(false);
         let mut recovery_panic = None;
 
-        let result = catch_automerge_panic(label, || {
+        let result = catch_automerge_result(label, || {
             if let Some(actor) = actor {
                 self.doc.set_actor(ActorId::from(actor.as_bytes()));
             }
@@ -613,9 +615,9 @@ impl RuntimeStateDoc {
         }
 
         match (result, recovery_panic) {
-            (Ok(Ok(value)), None) => Ok(value),
-            (Ok(Err(source)), None) => Err(source),
-            (Err(err), _) | (_, Some(err)) => {
+            (AutomergeAttempt::Success(value), None) => Ok(value),
+            (AutomergeAttempt::OperationError(source), None) => Err(source),
+            (AutomergeAttempt::Panic(err), _) | (_, Some(err)) => {
                 if let Err(source) = self.rebuild_from_save() {
                     return Err(AutomergeOperationError::rebuild_failed(label, source).into());
                 }


### PR DESCRIPTION
## Summary

- expose a generic `AutomergeAttempt<T, E>` outcome in `automerge-recovery`
- use the flattened attempt boundary in notebook/runtime `merge_recovering`
- use the same boundary in notebook/runtime `transact_at_heads_recovering`, preserving runtime-doc's native `RuntimeStateError`

## Stack

- Base PR: #2668 (`codex/automerge-tokio-hardening`)
- This PR contains only the follow-up transaction/merge recovery cleanup.

## Verification

- `cargo test -p automerge-recovery`
- `cargo test -p notebook-doc isolated_transaction`
- `cargo test -p runtime-doc isolated_transaction`
- `cargo test -p runtime-doc`
- `cargo test -p notebook-doc recovering`
- `cargo clippy -p automerge-recovery -p notebook-doc -p runtime-doc --all-targets -- -D warnings`
- `cargo xtask lint --fix`
