### PR TITLE
fix(build): pin maturin develop to active venv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -837,13 +837,14 @@ jobs:
       - name: Build runtimed-py into the workspace venv
         # `uv sync` at repo root populates .venv with the workspace
         # members (runtimed, dx, nteract, gremlin) plus their deps
-        # (pandas, polars, pyarrow). VIRTUAL_ENV pins maturin to that
-        # same .venv so the bindings land where pytest will look.
+        # (pandas, polars, pyarrow). VIRTUAL_ENV plus `uv run --active`
+        # pins maturin to that same .venv so the bindings land where
+        # pytest will look.
         run: |
           uv sync
           cd crates/runtimed-py && \
             VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
-            uv run --directory ../../python/runtimed maturin develop
+            uv run --active --directory ../../python/runtimed maturin develop
 
       - name: Run runtimed-py Rust unit tests
         run: |

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -666,10 +666,9 @@ fn run_maturin_develop_force(project_root: &Path) -> MaturinDevelopStatus {
     // our stderr (which is the supervisor's log stream).
     //
     // We run maturin from python/runtimed (where it's a dev dependency),
-    // but set VIRTUAL_ENV to .venv (the workspace root venv) so the .so
-    // is installed where the MCP server actually runs from. Without this,
-    // maturin installs into python/runtimed/.venv (the test-only venv)
-    // and the MCP server never sees the updated bindings.
+    // but activate .venv (the workspace root venv) so the .so is installed
+    // where the MCP server actually runs from. Without --active, newer uv
+    // ignores VIRTUAL_ENV when it does not match the selected project env.
     // Use a separate target directory so maturin's cdylib build doesn't
     // invalidate fingerprints in the main target/ dir. Without this,
     // concurrent or subsequent cargo builds see stale timestamps from
@@ -678,6 +677,7 @@ fn run_maturin_develop_force(project_root: &Path) -> MaturinDevelopStatus {
     let status = std::process::Command::new("uv")
         .args([
             "run",
+            "--active",
             "--directory",
             &project_root.join("python/runtimed").to_string_lossy(),
             "maturin",

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -780,6 +780,7 @@ fn ensure_maturin_develop() {
     let status = Command::new("uv")
         .args([
             "run",
+            "--active",
             "--directory",
             "python/runtimed",
             "maturin",


### PR DESCRIPTION
## Summary

- pass `--active` when `uv run` invokes `maturin develop` with `VIRTUAL_ENV` pinned
- update the CI and supervisor comments to match current uv behavior
- keep the existing root `.venv` workflow intact instead of changing Python workspace membership

## Verification

- `cargo xtask lint --fix`
- `cargo check -p xtask -p mcp-supervisor`
- `VIRTUAL_ENV=$PWD/.venv uv run --active --directory python/runtimed --no-sync python -c "import runtimed, runtimed._internals"`
