### PR TITLE
refactor(settings): flatten automerge recovery attempts

### DIFF
--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -28,7 +28,10 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::Transactable;
 use automerge::{AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
-use automerge_recovery::{catch_automerge_panic, AutomergeOperationError, AutomergeRecoveryError};
+use automerge_recovery::{
+    catch_automerge_panic, catch_automerge_result, AutomergeAttempt, AutomergeOperationError,
+    AutomergeRecoveryError,
+};
 use log::info;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -1162,14 +1165,16 @@ impl SettingsDoc {
         message: sync::Message,
     ) -> Result<(), AutomergeOperationError> {
         let label = label.into();
-        match catch_automerge_panic(label.clone(), || {
+        match catch_automerge_result(label.clone(), || {
             #[cfg(debug_assertions)]
             Self::panic_if_requested(&PANIC_ON_NEXT_RECEIVE_SYNC_CALLS, "receive sync");
             self.receive_sync_message(peer_state, message)
         }) {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(source)) => Err(AutomergeOperationError::automerge(label, source)),
-            Err(error) => Err(AutomergeOperationError::Panic(error)),
+            AutomergeAttempt::Success(()) => Ok(()),
+            AutomergeAttempt::OperationError(source) => {
+                Err(AutomergeOperationError::automerge(label, source))
+            }
+            AutomergeAttempt::Panic(error) => Err(AutomergeOperationError::Panic(error)),
         }
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -88,6 +88,12 @@ pub struct DaemonConfig {
     /// Global by default, per-test when overridden. Integration tests set this
     /// to avoid write contention under parallel boot.
     pub settings_json_path: Option<PathBuf>,
+    /// Override for the runtime agent executable path.
+    ///
+    /// Production defaults to the current daemon executable. Integration tests
+    /// set this so in-process daemon tests do not spawn the test harness binary
+    /// when launching runtime agents.
+    pub runtime_agent_exe: Option<PathBuf>,
 }
 
 impl Default for DaemonConfig {
@@ -113,6 +119,7 @@ impl Default for DaemonConfig {
             env_cache_max_count: 10,
             use_preferred_blob_port: true,
             settings_json_path: None,
+            runtime_agent_exe: None,
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3865,6 +3865,7 @@ pub(crate) async fn auto_launch_kernel(
             runtime_agent_id.clone(),
             room.blob_store.root().to_path_buf(),
             socket_path,
+            daemon.config.runtime_agent_exe.clone(),
         )
         .await
         {

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1562,6 +1562,7 @@ pub(crate) async fn handle(
             runtime_agent_id.clone(),
             room.blob_store.root().to_path_buf(),
             socket_path,
+            daemon.config.runtime_agent_exe.clone(),
         )
         .await
         {

--- a/crates/runtimed/src/runtime_agent_handle.rs
+++ b/crates/runtimed/src/runtime_agent_handle.rs
@@ -46,8 +46,12 @@ impl RuntimeAgentHandle {
         runtime_agent_id: String,
         blob_root: PathBuf,
         socket_path: PathBuf,
+        runtime_agent_exe: Option<PathBuf>,
     ) -> Result<Self> {
-        let exe = std::env::current_exe()?;
+        let exe = match runtime_agent_exe {
+            Some(path) => path,
+            None => std::env::current_exe()?,
+        };
         info!(
             "[runtime-agent-handle] Spawning runtime agent: {} runtime-agent --notebook-id {} (socket: {})",
             exe.display(),

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -95,8 +95,13 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         // Pin settings.json per-temp-dir so parallel daemons don't contend on
         // the global `~/.config/runt*/settings.json` at boot.
         settings_json_path: Some(temp_dir.path().join("settings.json")),
+        runtime_agent_exe: test_runtime_agent_exe(),
         ..Default::default()
     }
+}
+
+fn test_runtime_agent_exe() -> Option<std::path::PathBuf> {
+    option_env!("CARGO_BIN_EXE_runtimed").map(std::path::PathBuf::from)
 }
 
 /// Max time we'll wait for a test daemon's socket to accept `ping`.


### PR DESCRIPTION
## Summary

- Reuses the shared `catch_automerge_result` / `AutomergeAttempt` boundary for settings-doc sync receive recovery.
- Removes the local `Ok(Ok(()))` / `Ok(Err(source))` flattening from `runtimed-client::SettingsDoc`.
- Adds a test-only runtime-agent executable override so in-process daemon integration tests spawn the real `runtimed` binary instead of the integration-test harness.

## Verification

- `cargo fmt --check`
- `cargo test -p runtimed-client settings_doc::tests::test_recovering`
- `cargo clippy -p runtimed-client --all-targets -- -D warnings`
- `cargo test -p runtimed --test integration test_multiple_notebooks_concurrent_isolation -- --nocapture`
- `cargo test -p runtimed --test integration -- --nocapture`
- `cargo clippy -p runtimed -p runtimed-client --all-targets -- -D warnings`
- `cargo xtask lint --fix`

## Stack

Targets `main`; #2669 has been merged and this branch is now the settings recovery follow-up.
