### PR TITLE
build(automerge): update desktop patches revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
+source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
+source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "c24f070ca171ece9b67021483ffc518f5340e841" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "ce631758321810a02f7f6d767e178dfb4519cb9a" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- update the workspace `automerge` dependency from `c24f070ca171ece9b67021483ffc518f5340e841` to `ce631758321810a02f7f6d767e178dfb4519cb9a`
- pull in the latest green `nteract/automerge` `desktop-patches` fixes for patch-log mismatch and invalid actor/object batch-apply paths
- keep the `Cargo.lock` diff scoped to the Automerge and Hexane git source revisions

## Verification

- `cargo test -p automerge-recovery --lib -- --nocapture`
- `cargo test -p notebook-doc --lib -- --nocapture`
- `cargo test -p runtime-doc --lib -- --nocapture`
- `cargo test -p runtimed-client --lib -- --nocapture`
- `cargo test -p notebook-sync --lib -- --nocapture`
- `cargo test -p runtimed-settings-sync -- --nocapture`
- `cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p runtimed-client -p notebook-sync -p runtimed-settings-sync`
- `cargo xtask lint --fix`

## Notes

The target Automerge fork revision is the head of `nteract/automerge` `desktop-patches` after its CI passed for the patch-log mismatch and invalid actor/object fixes.
