### PR TITLE
build(automerge): update invalid-change desktop patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
+source = "git+https://github.com/nteract/automerge?rev=d42157b82ba38a27a6b19680eaa611bc8e38b3f2#d42157b82ba38a27a6b19680eaa611bc8e38b3f2"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
+source = "git+https://github.com/nteract/automerge?rev=d42157b82ba38a27a6b19680eaa611bc8e38b3f2#d42157b82ba38a27a6b19680eaa611bc8e38b3f2"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
+source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=c24f070ca171ece9b67021483ffc518f5340e841#c24f070ca171ece9b67021483ffc518f5340e841"
+source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "c24f070ca171ece9b67021483ffc518f5340e841" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "ce631758321810a02f7f6d767e178dfb4519cb9a" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "ce631758321810a02f7f6d767e178dfb4519cb9a" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "d42157b82ba38a27a6b19680eaa611bc8e38b3f2" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- stack on #2676 and update desktop's pinned `nteract/automerge` revision from `ce631758321810a02f7f6d767e178dfb4519cb9a` to `d42157b82ba38a27a6b19680eaa611bc8e38b3f2`
- consume the now-green `desktop-patches` fixes for sequence gaps, op-counter overflow, local transaction op-counter overflow, and marks on non-text objects
- keep the `Cargo.lock` diff scoped to the Automerge and Hexane git source revisions

## Verification

- `cargo check --locked -p automerge-recovery -p notebook-doc -p runtime-doc -p runtimed-client -p notebook-sync -p runtimed-settings-sync`
- `cargo test -p automerge-recovery -p notebook-doc -p runtime-doc -p runtimed-client -p notebook-sync -p runtimed-settings-sync --lib`
- `cargo xtask lint --fix`

## Notes

`nteract/automerge` PR #1 CI is green for head `d42157b82` on both push and pull_request workflow runs.
