### PR TITLE
refactor(sync): flatten async reply handling

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -629,7 +629,7 @@ impl DocHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 
     /// Send a request with a broadcast channel for real-time progress updates.
@@ -654,7 +654,7 @@ impl DocHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 
     /// Get the current document heads as protocol hex strings.
@@ -698,7 +698,7 @@ impl DocHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 
     /// Flush pending RuntimeStateDoc sync frames from the daemon.
@@ -711,7 +711,7 @@ impl DocHandle {
             .send(SyncCommand::ConfirmStateSync { reply: reply_tx })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 
     fn readiness_error(status: &SyncStatus) -> Option<SyncError> {
@@ -888,7 +888,7 @@ impl DocHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 
     // =====================================================================

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -59,6 +59,7 @@ pub mod handle;
 pub mod presence;
 pub mod relay;
 pub mod relay_task;
+mod reply;
 mod shared;
 mod snapshot;
 pub mod status;

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -173,9 +173,8 @@ impl RelayHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        match tokio::time::timeout(timeout, reply_rx).await {
-            Ok(Ok(inner)) => inner,
-            Ok(Err(_)) => Err(SyncError::Disconnected),
+        match tokio::time::timeout(timeout, crate::reply::recv(reply_rx)).await {
+            Ok(reply) => reply,
             Err(_) => {
                 // Fire-and-forget eviction. If the relay has already shut
                 // down (cmd_tx closed), there's nothing to clean up.
@@ -200,6 +199,6 @@ impl RelayHandle {
             })
             .await
             .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+        crate::reply::recv(reply_rx).await
     }
 }

--- a/crates/notebook-sync/src/reply.rs
+++ b/crates/notebook-sync/src/reply.rs
@@ -1,0 +1,37 @@
+use tokio::sync::oneshot;
+
+use crate::error::SyncError;
+
+pub(crate) async fn recv<T>(rx: oneshot::Receiver<Result<T, SyncError>>) -> Result<T, SyncError> {
+    rx.await.map_err(|_| SyncError::Disconnected)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_success_value() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(42)).expect("receiver should be live");
+
+        assert_eq!(recv(rx).await.expect("reply should succeed"), 42);
+    }
+
+    #[tokio::test]
+    async fn returns_operation_error() {
+        let (tx, rx) = oneshot::channel::<Result<(), SyncError>>();
+        tx.send(Err(SyncError::Timeout))
+            .expect("receiver should be live");
+
+        assert!(matches!(recv(rx).await, Err(SyncError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn dropped_sender_is_disconnected() {
+        let (tx, rx) = oneshot::channel::<Result<(), SyncError>>();
+        drop(tx);
+
+        assert!(matches!(recv(rx).await, Err(SyncError::Disconnected)));
+    }
+}

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -965,23 +965,7 @@ impl Session {
             notebook_sync::presence::emit_focus(&handle, &cell_id, Some(&peer_label)).await;
         }
 
-        let result = tokio::time::timeout(timeout, async {
-            collect_outputs(&self.state, &cell_id, &execution_id).await
-        })
-        .await;
-
-        match result {
-            Ok(Ok(cell_result)) => Ok(cell_result),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Ok(CellResult {
-                cell_id,
-                execution_id,
-                execution_count: None,
-                status: "timeout".to_string(),
-                success: false,
-                outputs: vec![],
-            }),
-        }
+        collect_outputs_with_timeout(&self.state, cell_id, execution_id, timeout).await
     }
 
     /// Execute a source string as a new cell. Starts the kernel on demand.
@@ -1006,23 +990,7 @@ impl Session {
         // results still carry an execution ID that can be recovered later.
         let execution_id = queue_existing_cell(&self.state, &cell_id).await?;
 
-        let result = tokio::time::timeout(timeout, async {
-            collect_outputs(&self.state, &cell_id, &execution_id).await
-        })
-        .await;
-
-        match result {
-            Ok(Ok(cell_result)) => Ok(cell_result),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Ok(CellResult {
-                cell_id,
-                execution_id,
-                execution_count: None,
-                status: "timeout".to_string(),
-                success: false,
-                outputs: vec![],
-            }),
-        }
+        collect_outputs_with_timeout(&self.state, cell_id, execution_id, timeout).await
     }
 
     /// Queue a source string as a new cell without waiting for execution.
@@ -1147,23 +1115,7 @@ impl Session {
         let timeout = Duration::from_millis(opts.timeout_ms.unwrap_or(120_000) as u64);
         let fallback_cell_id = opts.cell_id.unwrap_or_default();
 
-        let result = tokio::time::timeout(timeout, async {
-            collect_outputs(&self.state, &fallback_cell_id, &execution_id).await
-        })
-        .await;
-
-        match result {
-            Ok(Ok(cell_result)) => Ok(cell_result),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Ok(CellResult {
-                cell_id: fallback_cell_id,
-                execution_id,
-                execution_count: None,
-                status: "timeout".to_string(),
-                success: false,
-                outputs: vec![],
-            }),
-        }
+        collect_outputs_with_timeout(&self.state, fallback_cell_id, execution_id, timeout).await
     }
 }
 
@@ -1933,6 +1885,29 @@ async fn collect_outputs(
     }
 }
 
+async fn collect_outputs_with_timeout(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: String,
+    execution_id: String,
+    timeout: Duration,
+) -> Result<CellResult> {
+    match tokio::time::timeout(timeout, collect_outputs(state, &cell_id, &execution_id)).await {
+        Ok(result) => result,
+        Err(_) => Ok(timeout_cell_result(cell_id, execution_id)),
+    }
+}
+
+fn timeout_cell_result(cell_id: String, execution_id: String) -> CellResult {
+    CellResult {
+        cell_id,
+        execution_id,
+        execution_count: None,
+        status: "timeout".to_string(),
+        success: false,
+        outputs: vec![],
+    }
+}
+
 async fn cell_result_from_record(
     socket_path: &std::path::Path,
     record: runtimed_client::execution_store::ExecutionRecord,
@@ -2254,6 +2229,18 @@ mod tests {
         assert_eq!(result.status, "done");
         assert_eq!(result.execution_count, Some(3));
         assert!(result.success);
+        assert!(result.outputs.is_empty());
+    }
+
+    #[test]
+    fn timeout_cell_result_preserves_ids_and_terminal_shape() {
+        let result = timeout_cell_result("cell-timeout".to_string(), "exec-timeout".to_string());
+
+        assert_eq!(result.cell_id, "cell-timeout");
+        assert_eq!(result.execution_id, "exec-timeout");
+        assert_eq!(result.execution_count, None);
+        assert_eq!(result.status, "timeout");
+        assert!(!result.success);
         assert!(result.outputs.is_empty());
     }
 


### PR DESCRIPTION
## Summary

- Add a small `notebook-sync` reply helper that flattens `oneshot::Receiver<Result<T, SyncError>>` into `Result<T, SyncError>`.
- Route `DocHandle` and `RelayHandle` reply waits through that helper, including the relay request timeout path.
- Centralize `runtimed-node` execution timeout handling so `execute_cell`, `run_cell`, and `wait_for_execution` no longer duplicate `Ok(Ok(...))` / `Ok(Err(...))` matching.

## Verification

- `cargo test -p notebook-sync reply::tests -- --nocapture`
- `cargo test -p notebook-sync --lib`
- `cargo check -p runtimed-node -p notebook-sync`
- `cargo clippy -p notebook-sync -p runtimed-node --all-targets -- -D warnings`
- `cargo xtask lint --fix`

## Note

`cargo test -p runtimed-node timeout_cell_result_preserves_ids_and_terminal_shape -- --nocapture` currently fails at the existing macOS N-API test link step before running tests with unresolved `napi_delete_reference` / `napi_reference_unref`. `cargo check -p runtimed-node` passes.
