### PR TITLE
refactor(sync): centralize automerge recovery policy

### DIFF
--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -154,6 +154,12 @@ pub fn catch_automerge_result<T, E>(
     AutomergeAttempt::from_caught_result(catch_automerge_panic(label, f))
 }
 
+/// Returns true when a sync-path Automerge error is safe to contain by
+/// rebuilding the local document and resetting the peer's `sync::State`.
+pub fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
+    matches!(source, automerge::AutomergeError::PatchLogMismatch)
+}
+
 /// Run an Automerge operation and, when it panics or returns a caller-marked
 /// recoverable error, rebuild caller-owned state and retry once.
 ///
@@ -310,7 +316,7 @@ mod tests {
                     Ok("retried")
                 }
             },
-            |source| matches!(source, automerge::AutomergeError::PatchLogMismatch),
+            is_recoverable_sync_error,
             |_| Ok(()),
         );
         let value = match result {
@@ -320,6 +326,34 @@ mod tests {
 
         assert_eq!(value, "retried");
         assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn only_patch_log_mismatch_is_recoverable_sync_error() {
+        assert!(is_recoverable_sync_error(
+            &automerge::AutomergeError::PatchLogMismatch
+        ));
+
+        let actor = ActorId::from(b"policy-actor" as &[u8]);
+        let sources = [
+            automerge::AutomergeError::DuplicateSeqNumber(1, actor.clone()),
+            automerge::AutomergeError::DuplicateActorId(actor),
+            automerge::AutomergeError::Fail,
+            automerge::AutomergeError::InvalidActorId("not-hex".into()),
+            automerge::AutomergeError::InvalidActorIndex(99),
+            automerge::AutomergeError::InvalidObjId("1@missing".into()),
+            automerge::AutomergeError::InvalidObjIdFormat("bad".into()),
+            automerge::AutomergeError::InvalidOp(ObjType::Map),
+            automerge::AutomergeError::InvalidSeq(7),
+            automerge::AutomergeError::MissingDeps,
+        ];
+
+        for source in sources {
+            assert!(
+                !is_recoverable_sync_error(&source),
+                "{source} must not trigger save/load sync recovery"
+            );
+        }
     }
 
     #[test]

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -89,8 +89,9 @@ use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
 use automerge_recovery::{
-    catch_automerge_panic, catch_automerge_result, recoverable_automerge_operation,
-    AutomergeAttempt, AutomergeOperationError, AutomergeRebuildError,
+    catch_automerge_panic, catch_automerge_result, is_recoverable_sync_error,
+    recoverable_automerge_operation, AutomergeAttempt, AutomergeOperationError,
+    AutomergeRebuildError,
 };
 
 /// Re-export so downstream crates (runtimed-wasm) can set text encoding
@@ -2500,10 +2501,6 @@ impl NotebookDoc {
             attachments: HashMap::new(),
         })
     }
-}
-
-fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
-    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 struct SyncRecoveryContext<'a> {

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -31,8 +31,8 @@ use automerge::{
     ReadDoc, Value, ROOT,
 };
 use automerge_recovery::{
-    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
-    AutomergeRebuildError,
+    catch_automerge_panic, is_recoverable_sync_error, recoverable_automerge_operation,
+    AutomergeOperationError, AutomergeRebuildError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -392,10 +392,6 @@ impl PoolDoc {
             }
         })?
     }
-}
-
-fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
-    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 struct PoolSyncRecoveryContext<'a> {

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -9,8 +9,8 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::AutoCommit;
 use automerge_recovery::{
-    catch_automerge_panic, recoverable_automerge_operation, AutomergeOperationError,
-    AutomergeRebuildError,
+    catch_automerge_panic, is_recoverable_sync_error, recoverable_automerge_operation,
+    AutomergeOperationError, AutomergeRebuildError,
 };
 use log::warn;
 use notebook_doc::presence::PresenceState;
@@ -262,10 +262,6 @@ struct SharedDocReceiveRecoveryContext<'a> {
     state: &'a mut SharedDocState,
     next_message: Option<sync::Message>,
     retry_message: sync::Message,
-}
-
-fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
-    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 #[cfg(test)]

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -82,8 +82,9 @@ use automerge::{
     ObjType, ReadDoc, ScalarValue, Value, ROOT,
 };
 use automerge_recovery::{
-    catch_automerge_panic, catch_automerge_result, recoverable_automerge_operation,
-    AutomergeAttempt, AutomergeOperationError, AutomergeRebuildError,
+    catch_automerge_panic, catch_automerge_result, is_recoverable_sync_error,
+    recoverable_automerge_operation, AutomergeAttempt, AutomergeOperationError,
+    AutomergeRebuildError,
 };
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -3022,10 +3023,6 @@ impl RuntimeStateDoc {
             },
         )
     }
-}
-
-fn is_recoverable_sync_error(source: &AutomergeError) -> bool {
-    matches!(source, AutomergeError::PatchLogMismatch)
 }
 
 struct RuntimeSyncRecoveryContext<'a> {

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use automerge::sync;
-use automerge_recovery::AutomergeOperationError;
+use automerge_recovery::{is_recoverable_sync_error, AutomergeOperationError};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{info, warn};
@@ -191,9 +191,13 @@ fn apply_incoming_settings_sync_frame(
                 broadcast_changed: false,
             })
         }
-        Err(AutomergeOperationError::Automerge { source, .. })
-            if is_recoverable_settings_sync_error(&source) =>
-        {
+        Err(AutomergeOperationError::Automerge { label, source }) => {
+            let recoverable = is_recoverable_sync_error(source.as_ref());
+            let error = AutomergeOperationError::Automerge { label, source };
+            if !recoverable {
+                return Err(error.into());
+            }
+
             // Treat patch-log skew like the panic path: the durable JSON file
             // remains authoritative, and the inbound frame must not be assumed
             // to have applied.
@@ -203,7 +207,7 @@ fn apply_incoming_settings_sync_frame(
                 json_path,
                 &fallback,
                 "settings-sync-receive-recovery-generate",
-                source,
+                error,
             )?;
             Ok(IncomingSettingsSyncOutcome {
                 reply,
@@ -212,10 +216,6 @@ fn apply_incoming_settings_sync_frame(
         }
         Err(error) => Err(error.into()),
     }
-}
-
-fn is_recoverable_settings_sync_error(source: &automerge::AutomergeError) -> bool {
-    matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
 fn recover_settings_doc_reset_peer_and_retry_generate(
@@ -227,7 +227,7 @@ fn recover_settings_doc_reset_peer_and_retry_generate(
     error: impl std::fmt::Display,
 ) -> anyhow::Result<Option<Vec<u8>>> {
     warn!(
-        "[sync] Rebuilding settings doc from JSON after Automerge sync failure: {}",
+        "[sync] Rebuilding settings doc from JSON after recoverable Automerge failure: {}",
         error
     );
     recover_settings_doc_from_json_or_snapshot(doc, json_path, fallback);
@@ -237,7 +237,7 @@ fn recover_settings_doc_reset_peer_and_retry_generate(
         .map(|message| message.map(|msg| msg.encode()))
         .map_err(|retry_error| {
             anyhow::anyhow!(
-                "[sync] settings sync recovery retry failed after Automerge sync failure: {}",
+                "[sync] settings sync recovery retry failed after recoverable Automerge failure: {}",
                 retry_error
             )
         })
@@ -377,7 +377,7 @@ mod tests {
             message,
             &json_path,
         )
-        .expect("patch-log mismatch should recover to canonical settings");
+        .expect("receive PatchLogMismatch should recover to canonical settings");
 
         assert!(outcome.reply.is_some());
         assert!(!outcome.broadcast_changed);


### PR DESCRIPTION
## Summary

- Centralize the sync recovery allowlist in `automerge-recovery::is_recoverable_sync_error`.
- Keep the policy intentionally narrow: only `AutomergeError::PatchLogMismatch` triggers save/load rebuild plus peer-state reset.
- Replace duplicate private predicates in notebook, runtime-state, pool-state, and notebook-sync owners.
- Treat settings receive-side `PatchLogMismatch` like receive-side panic: rebuild from canonical JSON, reset peer state, retry outbound generation, and do not persist or broadcast the inbound client edit.

## Verification

- `cargo test -p automerge-recovery`
- `cargo test -p notebook-doc recovering_sync_generation_preserves_actor_and_resets_peer_state -- --nocapture`
- `cargo test -p notebook-doc recovering_pool_sync_generation_preserves_actor_and_resets_peer_state -- --nocapture`
- `cargo test -p runtime-doc recover -- --nocapture`
- `cargo test -p notebook-sync shared::tests -- --nocapture`
- `cargo test -p runtimed sync_server::tests -- --nocapture`
- `cargo test -p runtimed-client settings_doc -- --nocapture`
- `cargo clippy -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

This does not remove panic containment. It makes the explicit error recovery policy auditable and deny-by-default while we continue collecting post-Automerge-patch evidence.
