### PR TITLE
build(automerge): update document-load desktop patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=d42157b82ba38a27a6b19680eaa611bc8e38b3f2#d42157b82ba38a27a6b19680eaa611bc8e38b3f2"
+source = "git+https://github.com/nteract/automerge?rev=99eb88b9984323da93dcfc835122232b00534f76#99eb88b9984323da93dcfc835122232b00534f76"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=d42157b82ba38a27a6b19680eaa611bc8e38b3f2#d42157b82ba38a27a6b19680eaa611bc8e38b3f2"
+source = "git+https://github.com/nteract/automerge?rev=99eb88b9984323da93dcfc835122232b00534f76#99eb88b9984323da93dcfc835122232b00534f76"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "d42157b82ba38a27a6b19680eaa611bc8e38b3f2" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "99eb88b9984323da93dcfc835122232b00534f76" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- Advance the desktop Automerge fork revision from `d42157b82...` to `99eb88b9984323da93dcfc835122232b00534f76`.
- Consume the newer malformed saved-document/load-path fixes:
  - `cd7b8c944 fix(rust): reject invalid document dep indexes`
  - `99eb88b99 fix(rust): reject duplicate document op ids`
- Keep this as a pure dependency bump on top of #2678.

## Verification

Desktop:

- `cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed`
- `cargo test -p automerge-recovery`
- `cargo test -p notebook-doc -p runtime-doc -p notebook-sync --lib`
- `cargo clippy -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- `git diff --check`

Automerge fork:

- `cargo test --manifest-path rust/Cargo.toml -p automerge --lib`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`

## Notes

These Automerge fixes convert additional malformed document/load panic classes into explicit errors. They are not new desktop recovery allowlist cases.
