### PR TITLE
test(runtimed): fail on automerge recovery logs

### DIFF
--- a/python/runtimed/tests/log_guards.py
+++ b/python/runtimed/tests/log_guards.py
@@ -1,0 +1,61 @@
+"""Assertions over daemon logs produced by integration tests."""
+
+from __future__ import annotations
+
+import re
+
+_AUTOMERGE_RECOVERY_PATTERNS = (
+    re.compile(r"\[[^\]]+\]\s+automerge panicked:", re.IGNORECASE),
+    re.compile(r"Recovered from (?:sync|RuntimeStateSync) panic", re.IGNORECASE),
+    re.compile(r"Failed to rebuild after sync panic", re.IGNORECASE),
+    re.compile(r"settings sync recovery retry failed", re.IGNORECASE),
+)
+
+_AUTOMERGE_ERROR_PATTERN = re.compile(
+    r"\b("
+    r"PatchLogMismatch|"
+    r"InvalidChangeDepIndex|"
+    r"InvalidChangeHash(?:Slice)?|"
+    r"InvalidOp|"
+    r"InvalidSeq|"
+    r"DuplicateSeq(?:Number)?|"
+    r"DuplicateDocumentOp|"
+    r"InvalidActor|"
+    r"duplicate document op(?: id)?|"
+    r"invalid document dep index"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_SYNC_CONTEXT_PATTERN = re.compile(
+    r"\b(automerge|notebook-sync|runtime[- ]state|pool[- ]state|settings sync|sync)\b",
+    re.IGNORECASE,
+)
+
+
+def find_automerge_recovery_logs(log_text: str) -> list[str]:
+    """Return daemon log lines that indicate Automerge recovery or corruption."""
+    matches: list[str] = []
+    for line_number, line in enumerate(log_text.splitlines(), start=1):
+        if any(pattern.search(line) for pattern in _AUTOMERGE_RECOVERY_PATTERNS):
+            matches.append(f"{line_number}: {line}")
+            continue
+
+        if _AUTOMERGE_ERROR_PATTERN.search(line) and _SYNC_CONTEXT_PATTERN.search(line):
+            matches.append(f"{line_number}: {line}")
+
+    return matches
+
+
+def assert_no_automerge_recovery_logs(log_text: str) -> None:
+    """Assert that integration logs did not take an Automerge recovery path."""
+    matches = find_automerge_recovery_logs(log_text)
+    if not matches:
+        return
+
+    sample = "\n".join(matches[:20])
+    remaining = len(matches) - 20
+    suffix = f"\n... and {remaining} more matching lines" if remaining > 0 else ""
+    raise AssertionError(
+        f"daemon log contains Automerge recovery/corruption markers:\n{sample}{suffix}"
+    )

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.log_guards import assert_no_automerge_recovery_logs
+
 # Skip all tests if runtimed module not available
 pytest.importorskip("runtimed")
 
@@ -651,9 +653,10 @@ def daemon_process(request):
 
             # Print daemon logs for debugging
             if log_file.exists():
-                logs = log_file.read_text()
+                logs = log_file.read_text(encoding="utf-8")
                 if logs:
                     print(f"[test] Daemon logs:\n{logs}", file=sys.stderr)
+                    assert_no_automerge_recovery_logs(logs)
 
 
 @pytest.fixture(scope="module")

--- a/python/runtimed/tests/test_log_guards.py
+++ b/python/runtimed/tests/test_log_guards.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.log_guards import assert_no_automerge_recovery_logs, find_automerge_recovery_logs
+
+
+def test_find_automerge_recovery_logs_matches_direct_recovery_lines():
+    log_text = "\n".join(
+        [
+            "INFO daemon started",
+            "ERROR [runtime-doc-sync] automerge panicked: actor table mismatch",
+            "WARN [notebook-sync] Recovered from sync panic for receive: bad actor",
+            "WARN [notebook-sync] Failed to rebuild after sync panic for receive: label: nope",
+            "WARN [notebook-sync] Recovered from RuntimeStateSync panic for outbound: nope",
+            "ERROR [sync] settings sync recovery retry failed after Automerge panic: nope",
+        ]
+    )
+
+    matches = find_automerge_recovery_logs(log_text)
+
+    assert len(matches) == 5
+    assert all("daemon started" not in match for match in matches)
+
+
+def test_find_automerge_recovery_logs_requires_sync_context_for_error_names():
+    log_text = "\n".join(
+        [
+            "INFO user stdout: PatchLogMismatch",
+            "INFO user stdout: InvalidChangeDepIndex",
+            "WARN [notebook-sync] receive failed: PatchLogMismatch",
+            "WARN [runtime-state] load failed: InvalidChangeDepIndex",
+        ]
+    )
+
+    matches = find_automerge_recovery_logs(log_text)
+
+    assert matches == [
+        "3: WARN [notebook-sync] receive failed: PatchLogMismatch",
+        "4: WARN [runtime-state] load failed: InvalidChangeDepIndex",
+    ]
+
+
+def test_assert_no_automerge_recovery_logs_reports_sample():
+    with pytest.raises(AssertionError, match="Automerge recovery/corruption markers"):
+        assert_no_automerge_recovery_logs("WARN [notebook-sync] receive failed: DuplicateSeqNumber")


### PR DESCRIPTION
## Summary

- fail spawned daemon integration tests when daemon logs show Automerge panic/recovery markers
- keep matching narrow by requiring exact recovery phrases or Automerge error names with sync context
- add focused unit tests for the log guard, including false-positive coverage for user stdout

## Verification

- `uv run pytest python/runtimed/tests/test_log_guards.py -v`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$PWD/target/debug/runtimed" RUNTIMED_LOG_LEVEL=info RUNTIMED_INTEGRATION_LOG_DIR=/tmp/nteract-automerge-log-guard RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 uv run pytest python/runtimed/tests/test_daemon_integration.py -v --timeout=120 --tb=short --durations=15 -k "test_async_cell_created_by_one_visible_to_other"`
- `cargo xtask lint --fix`
- `git diff --check`

