### PR TITLE
build(automerge): update desktop patches revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
+source = "git+https://github.com/nteract/automerge?rev=0a314d0ab8892793ac274d1482b8dcb322c02ac3#0a314d0ab8892793ac274d1482b8dcb322c02ac3"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=ce631758321810a02f7f6d767e178dfb4519cb9a#ce631758321810a02f7f6d767e178dfb4519cb9a"
+source = "git+https://github.com/nteract/automerge?rev=0a314d0ab8892793ac274d1482b8dcb322c02ac3#0a314d0ab8892793ac274d1482b8dcb322c02ac3"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "ce631758321810a02f7f6d767e178dfb4519cb9a" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "0a314d0ab8892793ac274d1482b8dcb322c02ac3" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- update the nteract Automerge fork rev from `ce631758321810a02f7f6d767e178dfb4519cb9a` to `0a314d0ab8892793ac274d1482b8dcb322c02ac3`
- collapse the intermediate version-only Automerge bump PRs into one direct bump from current `main`
- keep the lockfile change limited to Automerge and Hexane git sources

## Included Automerge desktop-patches changes

- `30f8c74c2 fix(rust): reject sequence gaps during batch apply`
- `567113dce fix(rust): reject op counter overflow during apply`
- `ea0ed219a fix(rust): return op counter overflow from local transactions`
- `d42157b82 fix(rust): reject marks on non-text objects`
- `cd7b8c944 fix(rust): reject invalid document dep indexes`
- `c0ac4452b fix(rust): reject duplicate document op ids`
- `0a314d0ab fix(rust): reject invalid extra bytes metadata`

## Verification

- `cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed`
- `cargo xtask lint --fix`
- `git diff --check`

