### PR TITLE
build(automerge): update desktop patches revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=b0e1c1ab567a8b12263ef45f4574ee16bcd039a5#b0e1c1ab567a8b12263ef45f4574ee16bcd039a5"
+source = "git+https://github.com/nteract/automerge?rev=9c62368813d91c143377953d3edb8f1b34eaefc1#9c62368813d91c143377953d3edb8f1b34eaefc1"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=b0e1c1ab567a8b12263ef45f4574ee16bcd039a5#b0e1c1ab567a8b12263ef45f4574ee16bcd039a5"
+source = "git+https://github.com/nteract/automerge?rev=9c62368813d91c143377953d3edb8f1b34eaefc1#9c62368813d91c143377953d3edb8f1b34eaefc1"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "b0e1c1ab567a8b12263ef45f4574ee16bcd039a5" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "9c62368813d91c143377953d3edb8f1b34eaefc1" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- bump the `nteract/automerge` desktop-patches revision from `b0e1c1ab567a8b12263ef45f4574ee16bcd039a5` to `9c62368813d91c143377953d3edb8f1b34eaefc1`
- pick up `fix(rust): reject invalid bundle metadata`
- keep the lockfile change limited to the Automerge and Hexane git source entries

## Verification

- `gh pr checks 1 --repo nteract/automerge --watch --fail-fast`
- `cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed`
- `cargo test -p automerge-recovery`
- `cargo test -p notebook-doc -p runtime-doc -p notebook-sync --lib`
- `cargo xtask lint --fix`
- `git diff --check`

## CI gate

Keep this as a draft until GitHub CI passes, including runtimed-py integration and E2E. If those pass cleanly, this branch is intended to merge.
