### PR TITLE
build: bump automerge fork sequence key patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=9c62368813d91c143377953d3edb8f1b34eaefc1#9c62368813d91c143377953d3edb8f1b34eaefc1"
+source = "git+https://github.com/nteract/automerge?rev=286937778b7d04e25049e70918a9a9a943e8e9ca#286937778b7d04e25049e70918a9a9a943e8e9ca"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=9c62368813d91c143377953d3edb8f1b34eaefc1#9c62368813d91c143377953d3edb8f1b34eaefc1"
+source = "git+https://github.com/nteract/automerge?rev=286937778b7d04e25049e70918a9a9a943e8e9ca#286937778b7d04e25049e70918a9a9a943e8e9ca"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "9c62368813d91c143377953d3edb8f1b34eaefc1" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "286937778b7d04e25049e70918a9a9a943e8e9ca" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- bump `nteract/automerge` from `9c62368813d91c143377953d3edb8f1b34eaefc1` to `286937778b7d04e25049e70918a9a9a943e8e9ca`
- consume the fork patch that turns malformed imported sequence insert keys into `AutomergeError::InvalidSeqKey` instead of an `Untangler` panic
- keep the desktop diff limited to the Automerge and Hexane git sources

## Upstream fork signal

- `nteract/automerge` PR #1 is green for `286937778b7d04e25049e70918a9a9a943e8e9ca`

## Local verification

```text
cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed
cargo test -p automerge-recovery
cargo test -p notebook-doc -p runtime-doc -p notebook-sync --lib
cargo xtask lint --fix
git diff --check
```
