### PR TITLE
build: bump automerge dangling sequence key patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=286937778b7d04e25049e70918a9a9a943e8e9ca#286937778b7d04e25049e70918a9a9a943e8e9ca"
+source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=286937778b7d04e25049e70918a9a9a943e8e9ca#286937778b7d04e25049e70918a9a9a943e8e9ca"
+source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "286937778b7d04e25049e70918a9a9a943e8e9ca" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "8bf500569ff404967d1bb2370645d4f97a5f42cd" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- bump `nteract/automerge` from `286937778b7d04e25049e70918a9a9a943e8e9ca` to `8bf500569ff404967d1bb2370645d4f97a5f42cd`
- consume the fork patch that rejects dangling sequence update keys instead of letting malformed imported updates reach panic-prone paths
- keep the desktop diff limited to the Automerge and Hexane git sources

## Upstream fork signal

- `nteract/automerge` PR #1 is green for `8bf500569ff404967d1bb2370645d4f97a5f42cd`

## Local verification

```text
cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed
cargo test -p automerge-recovery
cargo test -p notebook-doc -p runtime-doc -p notebook-sync --lib
cargo xtask lint --fix
git diff --check
```
