### PR TITLE
build: bump automerge dangling sequence key amend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
+source = "git+https://github.com/nteract/automerge?rev=eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9#eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
+source = "git+https://github.com/nteract/automerge?rev=eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9#eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "8bf500569ff404967d1bb2370645d4f97a5f42cd" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- bump `nteract/automerge` from `8bf500569ff404967d1bb2370645d4f97a5f42cd` to `eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9`
- track the amended fork head for the dangling sequence update key patch
- keep the desktop diff limited to the Automerge and Hexane git sources

## Upstream fork signal

- `nteract/automerge` PR #1 is green for `eb8ffc24ed1dd789bae5387d9b6f5f9a9d097cd9`

## Local verification

```text
cargo check -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed
cargo test -p automerge-recovery
cargo test -p notebook-doc -p runtime-doc -p notebook-sync --lib
cargo xtask lint --fix
git diff --check
```
