### PR TITLE
build: bump automerge stale sync need patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
+source = "git+https://github.com/nteract/automerge?rev=345f172285641cd52a1f9227569d33d60d68d76a#345f172285641cd52a1f9227569d33d60d68d76a"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=8bf500569ff404967d1bb2370645d4f97a5f42cd#8bf500569ff404967d1bb2370645d4f97a5f42cd"
+source = "git+https://github.com/nteract/automerge?rev=345f172285641cd52a1f9227569d33d60d68d76a#345f172285641cd52a1f9227569d33d60d68d76a"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "8bf500569ff404967d1bb2370645d4f97a5f42cd" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "345f172285641cd52a1f9227569d33d60d68d76a" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

- bump `nteract/automerge` from `8bf500569ff404967d1bb2370645d4f97a5f42cd` to `345f172285641cd52a1f9227569d33d60d68d76a`
- consume the fork patch that ignores stale `sync::State.their_need` hashes during sync generation
- keep the desktop diff limited to the Automerge and Hexane git sources

## Upstream fork signal

- `nteract/automerge` PR #1 is green for `345f172285641cd52a1f9227569d33d60d68d76a`
- This supersedes the earlier dangling-sequence-key bump because it includes that head plus the stale sync `need` hardening.

## Local verification

```text
cargo check --locked -p automerge-recovery -p notebook-doc -p runtime-doc -p notebook-sync -p runtimed-client -p runtimed
cargo test --locked -p automerge-recovery
cargo test --locked -p notebook-doc -p runtime-doc -p notebook-sync --lib
cargo xtask lint --fix
git diff --check
```

## CI

- GitHub CI passed for PR #2690, including `runtimed-py Integration Tests` and the E2E fan-out.
- CI log scan for run `25661020250` found no production Automerge recovery markers for `automerge panicked`, `Recovered from sync panic`, `Recovered from RuntimeStateSync panic`, `Failed to rebuild after sync panic`, `settings sync recovery retry failed`, `PatchLogMismatch`, `InvalidChangeDepIndex`, `DuplicateDocumentOp`, `invalid document dep index`, `InvalidSeq`, `InvalidOpCounter`, `InvalidActorId`, `InvalidObjId`, or `InvalidSeqKey`.
