### PR TITLE
test(mcp): fix Windows binary fingerprint fixtures

### DIFF
--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -35,7 +35,7 @@ pub enum AutomergeOperationError {
     },
     #[error(transparent)]
     Panic(#[from] AutomergeRecoveryError),
-    #[error("[{label}] failed to rebuild document after Automerge panic: {source}")]
+    #[error("[{label}] failed to rebuild document after recoverable Automerge failure: {source}")]
     RebuildFailed {
         label: String,
         #[source]
@@ -160,8 +160,12 @@ pub fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
     matches!(source, automerge::AutomergeError::PatchLogMismatch)
 }
 
-/// Run an Automerge operation and, when it panics or returns a caller-marked
-/// recoverable error, rebuild caller-owned state and retry once.
+/// Run an Automerge operation and, when it returns a caller-marked recoverable
+/// error, rebuild caller-owned state and retry once.
+///
+/// Panics are diagnostic signals, not steady-state recovery inputs. They are
+/// caught so callers can close the current boundary without poisoning shared
+/// locks, but they are returned immediately without save/load rebuild or retry.
 ///
 /// The `context` is intentionally opaque to this crate. Document owners use it
 /// to keep their document, per-peer `sync::State`, and any retry frame together
@@ -175,13 +179,13 @@ pub fn recoverable_automerge_operation<C, T>(
 ) -> Result<T, AutomergeOperationError> {
     let label = label.into();
 
-    let first_panic = match catch_automerge_result(label.clone(), || operation(context)) {
+    match catch_automerge_result(label.clone(), || operation(context)) {
         AutomergeAttempt::Success(value) => return Ok(value),
-        AutomergeAttempt::OperationError(source) if should_rebuild(&source) => None,
+        AutomergeAttempt::OperationError(source) if should_rebuild(&source) => {}
         AutomergeAttempt::OperationError(source) => {
             return Err(AutomergeOperationError::automerge(label, source));
         }
-        AutomergeAttempt::Panic(error) => Some(error),
+        AutomergeAttempt::Panic(error) => return Err(AutomergeOperationError::Panic(error)),
     };
 
     if let Err(source) = rebuild(context) {
@@ -193,9 +197,7 @@ pub fn recoverable_automerge_operation<C, T>(
         AutomergeAttempt::OperationError(source) => {
             Err(AutomergeOperationError::automerge(label, source))
         }
-        AutomergeAttempt::Panic(error) => {
-            Err(AutomergeOperationError::Panic(first_panic.unwrap_or(error)))
-        }
+        AutomergeAttempt::Panic(error) => Err(AutomergeOperationError::Panic(error)),
     }
 }
 
@@ -379,34 +381,36 @@ mod tests {
     }
 
     #[test]
-    fn recoverable_operation_rebuilds_after_panic_and_preserves_first_repeated_panic() {
+    fn recoverable_operation_returns_panic_without_rebuild_or_retry() {
         let mut calls = 0;
+        let mut rebuilt = false;
         let result = recoverable_automerge_operation::<_, ()>(
-            "repeated-panic",
+            "panic-is-diagnostic",
             &mut calls,
             |calls| {
                 *calls += 1;
-                if *calls == 1 {
-                    panic!("first panic");
-                }
-                panic!("second panic");
+                panic!("diagnostic panic");
             },
-            |_| false,
-            |_| Ok(()),
+            is_recoverable_sync_error,
+            |_| {
+                rebuilt = true;
+                Ok(())
+            },
         );
         let error = match result {
-            Ok(()) => panic!("repeated panic should fail"),
+            Ok(()) => panic!("panic should be returned"),
             Err(error) => error,
         };
 
         match error {
             AutomergeOperationError::Panic(error) => {
-                assert_eq!(error.label, "repeated-panic");
-                assert_eq!(error.panic_message, "first panic");
+                assert_eq!(error.label, "panic-is-diagnostic");
+                assert_eq!(error.panic_message, "diagnostic panic");
             }
             other => panic!("expected panic error, got {other:?}"),
         }
-        assert_eq!(calls, 2);
+        assert_eq!(calls, 1);
+        assert!(!rebuilt);
     }
 
     #[test]

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -3488,14 +3488,8 @@ mod tests {
     // binary and sensitive to size changes.
 
     fn write_bin(project_root: &Path, name: &str, bytes: &[u8]) -> PathBuf {
-        let target = project_root.join("target");
-        let subdir = target.join(if use_release_binaries() {
-            "release"
-        } else {
-            "debug"
-        });
-        std::fs::create_dir_all(&subdir).unwrap();
-        let path = subdir.join(name);
+        let path = cargo_binary(project_root, name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, bytes).unwrap();
         path
     }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2119,8 +2119,11 @@ impl NotebookDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
-    /// Generate a sync message, recovering from Automerge panics by rebuilding
-    /// this doc, resetting peer sync state, and retrying once.
+    /// Generate a sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn generate_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -300,8 +300,11 @@ impl PoolDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
-    /// Generate a sync message, recovering from Automerge panics by rebuilding
-    /// this doc, resetting peer sync state, and retrying once.
+    /// Generate a sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn generate_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -41,6 +41,8 @@ pub struct SharedDocState {
     pub(crate) state_peer_state: sync::State,
 
     #[cfg(test)]
+    panic_on_next_doc_sync: bool,
+    #[cfg(test)]
     panic_on_next_state_sync: bool,
 }
 
@@ -57,6 +59,8 @@ impl SharedDocState {
             presence: PresenceState::new(),
             state_doc: RuntimeStateDoc::try_new_empty()?,
             state_peer_state: sync::State::new(),
+            #[cfg(test)]
+            panic_on_next_doc_sync: false,
             #[cfg(test)]
             panic_on_next_state_sync: false,
         })
@@ -85,6 +89,12 @@ impl SharedDocState {
         &mut self,
         message: sync::Message,
     ) -> Result<(), automerge::AutomergeError> {
+        #[cfg(test)]
+        if self.panic_on_next_doc_sync {
+            self.panic_on_next_doc_sync = false;
+            panic!("injected AutomergeSync panic");
+        }
+
         self.doc
             .sync()
             .receive_sync_message(&mut self.peer_state, message)
@@ -250,6 +260,11 @@ impl SharedDocState {
                 Err(e.into())
             }
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn panic_on_next_doc_sync_for_test(&mut self) {
+        self.panic_on_next_doc_sync = true;
     }
 
     #[cfg(test)]

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -191,14 +191,14 @@ impl SharedDocState {
 
     /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
     ///
-    /// Used after catching an automerge panic during `RuntimeStateSync`
-    /// processing — the same recovery pattern as `rebuild_doc` for the
-    /// notebook doc, but targeting the state doc.
+    /// Used after a caller-marked recoverable Automerge failure during
+    /// `RuntimeStateSync` processing — the same recovery pattern as
+    /// `rebuild_doc` for the notebook doc, but targeting the state doc.
     pub fn rebuild_state_doc(&mut self) -> Result<(), AutomergeRebuildError> {
         let rebuilt = self.state_doc.rebuild_from_save();
         if let Err(err) = &rebuilt {
             warn!(
-                "[notebook-sync] Failed to rebuild RuntimeStateDoc after panic: {}; \
+                "[notebook-sync] Failed to rebuild RuntimeStateDoc after recoverable Automerge failure: {}; \
                  resetting state sync protocol only",
                 err
             );
@@ -231,7 +231,7 @@ impl SharedDocState {
                 }
                 Err(e) => {
                     warn!(
-                        "[notebook-sync] failed to rebuild doc after panic: {}; resetting sync state only",
+                        "[notebook-sync] failed to rebuild doc after recoverable Automerge failure: {}; resetting sync state only",
                         e
                     );
                     Err(AutomergeRebuildError::load(e))
@@ -244,7 +244,7 @@ impl SharedDocState {
             Ok(rebuilt) => rebuilt,
             Err(e) => {
                 warn!(
-                    "[notebook-sync] panic while rebuilding doc after panic: {}; resetting sync state only",
+                    "[notebook-sync] panic while rebuilding doc after recoverable Automerge failure: {}; resetting sync state only",
                     e
                 );
                 Err(e.into())

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -1410,6 +1410,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automerge_sync_panic_closes_sync_task_without_recovery() {
+        let mut reactor = test_reactor();
+        {
+            let mut state = reactor.io.doc.lock().unwrap();
+            state.panic_on_next_doc_sync_for_test();
+        }
+
+        let mut daemon_state = SharedDocState::new(
+            notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+            "test-notebook".into(),
+        );
+        let daemon_msg = daemon_state
+            .generate_sync_message()
+            .expect("daemon should generate notebook sync message");
+        let (client_reply_writer, daemon_reply_reader) = tokio::io::duplex(4096);
+        let mut writer = client_reply_writer;
+        let mut reply_reader =
+            connection::FramedReader::spawn(BufReader::new(daemon_reply_reader), 16);
+        let frame = connection::TypedNotebookFrame {
+            frame_type: NotebookFrameType::AutomergeSync,
+            payload: daemon_msg.encode(),
+        };
+
+        let error = reactor
+            .handle_incoming_frame(&frame, &mut writer)
+            .await
+            .expect_err("notebook doc panic should close sync path");
+
+        assert!(
+            error.to_string().contains("automerge sync failure"),
+            "expected automerge sync failure, got {error}"
+        );
+        assert!(
+            timeout(Duration::from_millis(10), reply_reader.recv())
+                .await
+                .is_err(),
+            "panic path should not send a notebook sync reply"
+        );
+    }
+
+    #[tokio::test]
     async fn runtime_state_sync_panic_closes_sync_task_without_recovery() {
         let mut reactor = test_reactor();
         {

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -388,7 +388,7 @@ impl SyncReactor {
         writer: &mut W,
     ) -> Result<(), SyncError> {
         self.note_frame_activity();
-        self.handle_task_frame(frame, writer).await;
+        self.handle_task_frame(frame, writer).await?;
         if frame.frame_type == NotebookFrameType::AutomergeSync {
             self.state.acked_sync_generation = self.state.sync_generation;
         }
@@ -498,7 +498,7 @@ impl SyncReactor {
         &mut self,
         frame: &connection::TypedNotebookFrame,
         writer: &mut W,
-    ) {
+    ) -> Result<(), SyncError> {
         match frame.frame_type {
             NotebookFrameType::AutomergeSync => {
                 let msg = match sync::Message::decode(&frame.payload) {
@@ -508,35 +508,37 @@ impl SyncReactor {
                             "[notebook-sync] Failed to decode sync message for {}: {}",
                             self.io.notebook_id, e
                         );
-                        return;
+                        return Ok(());
                     }
                 };
 
-                // Apply and generate ack while the mutex guard is alive so panic
-                // recovery can rebuild the document without poisoning the mutex.
+                // Apply and generate ack while the mutex guard is alive. Caught
+                // Automerge panics are fatal for this sync task; recoverable
+                // Automerge errors are retried by the document boundary.
                 let ack_bytes = {
                     let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
                     match state.receive_sync_message_recovering(msg, "notebook-sync-receive") {
                         Ok(()) => {}
-                        Err(AutomergeOperationError::Panic(e)) => {
+                        Err(e @ AutomergeOperationError::Panic(_))
+                        | Err(e @ AutomergeOperationError::RebuildFailed { .. }) => {
                             warn!(
-                                "[notebook-sync] Recovered from sync panic for {}: {}",
+                                "[notebook-sync] Closing sync task after Automerge sync failure for {}: {}",
                                 self.io.notebook_id, e
                             );
-                        }
-                        Err(AutomergeOperationError::RebuildFailed { label, source }) => {
-                            warn!(
-                                "[notebook-sync] Failed to rebuild after sync panic for {}: {}: {}",
-                                self.io.notebook_id, label, source
-                            );
-                            return;
+                            return Err(SyncError::Protocol(format!(
+                                "automerge sync failure for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                         Err(e) => {
                             warn!(
                                 "[notebook-sync] Failed to apply sync message for {}: {}",
                                 self.io.notebook_id, e
                             );
-                            return;
+                            return Err(SyncError::Protocol(format!(
+                                "automerge sync apply failed for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                     }
                     match state.generate_sync_message_recovering("notebook-sync-reply") {
@@ -546,7 +548,10 @@ impl SyncReactor {
                                 "[notebook-sync] Failed to generate sync reply for {}: {}",
                                 self.io.notebook_id, e
                             );
-                            None
+                            return Err(SyncError::Protocol(format!(
+                                "automerge sync reply failed for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                     }
                 };
@@ -569,6 +574,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             NotebookFrameType::Broadcast => {
@@ -583,6 +589,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             NotebookFrameType::Presence => {
@@ -595,7 +602,7 @@ impl SyncReactor {
                         "[notebook-sync] Dropping oversized presence frame for {}: {}",
                         self.io.notebook_id, e
                     );
-                    return;
+                    return Ok(());
                 }
 
                 match decode_message(&frame.payload) {
@@ -642,6 +649,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             NotebookFrameType::Response => {
@@ -650,6 +658,7 @@ impl SyncReactor {
                     "[notebook-sync] Unexpected Response frame for {} in background loop",
                     self.io.notebook_id
                 );
+                Ok(())
             }
 
             NotebookFrameType::Request => {
@@ -657,6 +666,7 @@ impl SyncReactor {
                     "[notebook-sync] Unexpected Request frame from daemon for {}",
                     self.io.notebook_id
                 );
+                Ok(())
             }
 
             NotebookFrameType::RuntimeStateSync => {
@@ -667,37 +677,39 @@ impl SyncReactor {
                             "[notebook-sync] Failed to decode RuntimeStateSync for {}: {}",
                             self.io.notebook_id, e
                         );
-                        return;
+                        return Ok(());
                     }
                 };
 
-                // Apply and generate reply while the mutex guard is alive so
-                // recovery can rebuild the RuntimeStateDoc without poisoning it.
+                // Apply and generate reply while the mutex guard is alive. Caught
+                // Automerge panics are fatal for this sync task; recoverable
+                // Automerge errors are retried by the document boundary.
                 let (reply_bytes, runtime_state) = {
                     let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
                     match state
                         .receive_state_sync_message_recovering(msg, "runtime-state-sync-receive")
                     {
                         Ok(()) => {}
-                        Err(AutomergeOperationError::Panic(e)) => {
+                        Err(e @ AutomergeOperationError::Panic(_))
+                        | Err(e @ AutomergeOperationError::RebuildFailed { .. }) => {
                             warn!(
-                                "[notebook-sync] Recovered from RuntimeStateSync panic for {}: {}",
+                                "[notebook-sync] Closing sync task after RuntimeStateSync failure for {}: {}",
                                 self.io.notebook_id, e
                             );
-                        }
-                        Err(AutomergeOperationError::RebuildFailed { label, source }) => {
-                            warn!(
-                                "[notebook-sync] Failed to rebuild after RuntimeStateSync panic for {}: {}: {}",
-                                self.io.notebook_id, label, source
-                            );
-                            return;
+                            return Err(SyncError::Protocol(format!(
+                                "runtime-state sync failure for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                         Err(e) => {
                             warn!(
                                 "[notebook-sync] Failed to apply RuntimeStateSync for {}: {}",
                                 self.io.notebook_id, e
                             );
-                            return;
+                            return Err(SyncError::Protocol(format!(
+                                "runtime-state sync apply failed for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                     };
                     let reply_bytes = match state
@@ -709,7 +721,10 @@ impl SyncReactor {
                                 "[notebook-sync] Failed to generate RuntimeStateSync reply for {}: {}",
                                 self.io.notebook_id, e
                             );
-                            None
+                            return Err(SyncError::Protocol(format!(
+                                "runtime-state sync reply failed for {}: {e}",
+                                self.io.notebook_id
+                            )));
                         }
                     };
                     (reply_bytes, state.state_doc.read_state())
@@ -730,6 +745,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             NotebookFrameType::PoolStateSync => {
@@ -739,6 +755,7 @@ impl SyncReactor {
                     "[notebook-sync] Ignoring PoolStateSync frame for {} (handled by frontend)",
                     self.io.notebook_id
                 );
+                Ok(())
             }
 
             NotebookFrameType::SessionControl => {
@@ -750,7 +767,7 @@ impl SyncReactor {
                             "[notebook-sync] Failed to parse SessionControl for {}: {}",
                             self.io.notebook_id, e
                         );
-                        return;
+                        return Ok(());
                     }
                 };
 
@@ -766,6 +783,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
         }
     }
@@ -818,7 +836,7 @@ impl SyncReactor {
         &mut self,
         frame: &connection::TypedNotebookFrame,
         writer: &mut W,
-    ) {
+    ) -> Result<(), SyncError> {
         match frame.frame_type {
             NotebookFrameType::Response => {
                 match serde_json::from_slice::<NotebookResponseEnvelope>(&frame.payload) {
@@ -843,6 +861,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             NotebookFrameType::Broadcast => {
@@ -862,6 +881,7 @@ impl SyncReactor {
                         );
                     }
                 }
+                Ok(())
             }
 
             _ => self.handle_incoming_frame(frame, writer).await,
@@ -1390,9 +1410,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn runtime_state_sync_panic_is_caught_and_later_updates_still_apply() {
-        // Recovery resets the runtime-state peer state. After the daemon peer
-        // also rejoins with fresh sync state, later updates still apply.
+    async fn runtime_state_sync_panic_closes_sync_task_without_recovery() {
         let mut reactor = test_reactor();
         {
             let mut state = reactor.io.doc.lock().unwrap();
@@ -1413,68 +1431,38 @@ mod tests {
         let mut writer = client_reply_writer;
         let mut reply_reader =
             connection::FramedReader::spawn(BufReader::new(daemon_reply_reader), 16);
-        let mut later_update_sent = false;
 
-        for _ in 0..8 {
-            let client_msg = {
-                let mut state = reactor.io.doc.lock().unwrap();
-                state.generate_state_sync_message()
-            };
-            if let Some(client_msg) = client_msg {
-                daemon_state
-                    .receive_state_sync_message(client_msg)
-                    .expect("daemon receives client runtime-state handshake");
-            }
-
-            if let Some(daemon_msg) = daemon_state.generate_state_sync_message() {
-                let frame = connection::TypedNotebookFrame {
-                    frame_type: NotebookFrameType::RuntimeStateSync,
-                    payload: daemon_msg.encode(),
-                };
-                reactor.handle_incoming_frame(&frame, &mut writer).await;
-
-                if !later_update_sent {
-                    let _ = daemon_state.rebuild_state_doc();
-                    daemon_state
-                        .state_doc
-                        .create_execution_with_source("exec-2", "cell-2", "y = 2", 2)
-                        .expect("daemon creates later queued execution");
-                    later_update_sent = true;
-                }
-            }
-
-            while let Ok(Some(Ok(reply))) =
-                timeout(Duration::from_millis(10), reply_reader.recv()).await
-            {
-                if reply.frame_type != NotebookFrameType::RuntimeStateSync {
-                    continue;
-                }
-                let msg = sync::Message::decode(&reply.payload)
-                    .expect("client runtime-state reply decodes");
-                daemon_state
-                    .receive_state_sync_message(msg)
-                    .expect("daemon receives client runtime-state reset reply");
-            }
-
-            let state = reactor.io.doc.lock().unwrap();
-            if state
-                .state_doc
-                .read_state()
-                .executions
-                .contains_key("exec-2")
-            {
-                return;
-            }
+        let client_msg = {
+            let mut state = reactor.io.doc.lock().unwrap();
+            state.generate_state_sync_message()
+        };
+        if let Some(client_msg) = client_msg {
+            daemon_state
+                .receive_state_sync_message(client_msg)
+                .expect("daemon receives client runtime-state handshake");
         }
 
-        let state = reactor.io.doc.lock().unwrap();
+        let daemon_msg = daemon_state
+            .generate_state_sync_message()
+            .expect("daemon should generate runtime-state sync message");
+        let frame = connection::TypedNotebookFrame {
+            frame_type: NotebookFrameType::RuntimeStateSync,
+            payload: daemon_msg.encode(),
+        };
+        let error = reactor
+            .handle_incoming_frame(&frame, &mut writer)
+            .await
+            .expect_err("runtime-state panic should close sync path");
+
         assert!(
-            state
-                .state_doc
-                .read_state()
-                .executions
-                .contains_key("exec-2"),
-            "runtime-state replica should remain usable for later updates after caught panic"
+            error.to_string().contains("runtime-state sync failure"),
+            "expected runtime-state sync failure, got {error}"
+        );
+        assert!(
+            timeout(Duration::from_millis(10), reply_reader.recv())
+                .await
+                .is_err(),
+            "panic path should not send a runtime-state sync reply"
         );
     }
 

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -2656,8 +2656,11 @@ impl RuntimeStateDoc {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
-    /// Generate a sync message, recovering from Automerge panics by rebuilding
-    /// this doc, resetting peer sync state, and retrying once.
+    /// Generate a sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn generate_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2717,8 +2720,11 @@ impl RuntimeStateDoc {
             .map(|m| m.encode())
     }
 
-    /// Generate a bounded encoded sync message, recovering from Automerge panics
-    /// by rebuilding this doc, resetting peer sync state, and retrying once.
+    /// Generate a bounded encoded sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn generate_sync_message_bounded_encoded_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2779,8 +2785,11 @@ impl RuntimeStateDoc {
         Ok(())
     }
 
-    /// Receive a read-only sync message, recovering from Automerge panics by
-    /// rebuilding this doc and resetting peer sync state.
+    /// Receive a read-only sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn receive_sync_message_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2835,8 +2844,11 @@ impl RuntimeStateDoc {
         Ok(heads_before != heads_after)
     }
 
-    /// Receive a writable sync message, recovering from Automerge panics by
-    /// rebuilding this doc and resetting peer sync state.
+    /// Receive a writable sync message through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn receive_sync_message_with_changes_recovering(
         &mut self,
         peer_state: &mut sync::State,
@@ -2982,9 +2994,12 @@ impl RuntimeStateDoc {
         })
     }
 
-    /// Receive a writable sync message and compute a foreign-actor comm view,
-    /// recovering from Automerge panics by rebuilding this doc and resetting
-    /// peer sync state.
+    /// Receive a writable sync message and compute a foreign-actor comm view
+    /// through the document-owned error boundary.
+    ///
+    /// Panics are returned to the caller as diagnostic failures. Caller-marked
+    /// recoverable Automerge errors rebuild this doc, reset peer sync state,
+    /// and retry once.
     pub fn receive_sync_and_foreign_comms_recovering<F>(
         &mut self,
         peer_state: &mut sync::State,

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -564,7 +564,7 @@ where
                 Ok(message) => message.map(|m| m.encode()),
                 Err(e) => {
                     warn!("[streaming-load] cell sync generation failed: {}", e);
-                    None
+                    return Err(format!("cell sync generation failed: {e}"));
                 }
             }
         };
@@ -603,7 +603,7 @@ where
                 Ok(message) => message.map(|m| m.encode()),
                 Err(e) => {
                     warn!("[streaming-load] metadata sync generation failed: {}", e);
-                    None
+                    return Err(format!("metadata sync generation failed: {e}"));
                 }
             }
         };

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -220,16 +220,14 @@ where
                 }
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
-                                let notebook_doc_effects = match handle_notebook_doc_frame(
+                                let NotebookDocFrameOutcome::Applied(notebook_doc_effects) =
+                                    handle_notebook_doc_frame(
                                     room,
                                     &mut peer_state,
                                     &peer_writer,
                                     &frame.payload,
                                 )
-                                .await?
-                                {
-                                    NotebookDocFrameOutcome::Applied(effects) => effects,
-                                };
+                                .await?;
 
                                 if notebook_doc_phase
                                     != notebook_protocol::protocol::NotebookDocPhaseWire::Interactive

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -229,7 +229,6 @@ where
                                 .await?
                                 {
                                     NotebookDocFrameOutcome::Applied(effects) => effects,
-                                    NotebookDocFrameOutcome::Skipped => continue,
                                 };
 
                                 if notebook_doc_phase

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -30,7 +30,7 @@ pub(super) async fn handle_notebook_doc_frame(
             Ok(()) => {}
             Err(e) => {
                 warn!("[notebook-sync] receive_sync_message error: {}", e);
-                return Ok(NotebookDocFrameOutcome::Skipped);
+                return Err(anyhow::anyhow!("doc receive_sync_message error: {e}"));
             }
         }
 
@@ -46,7 +46,7 @@ pub(super) async fn handle_notebook_doc_frame(
             Ok(message) => message.map(|reply| reply.encode()),
             Err(e) => {
                 warn!("[notebook-sync] doc sync reply failed: {}", e);
-                None
+                return Err(anyhow::anyhow!("doc sync reply failed: {e}"));
             }
         };
 
@@ -67,7 +67,6 @@ pub(super) async fn handle_notebook_doc_frame(
 
 pub(super) enum NotebookDocFrameOutcome {
     Applied(NotebookDocSideEffects),
-    Skipped,
 }
 
 pub(super) struct NotebookDocSideEffects {
@@ -102,7 +101,7 @@ pub(super) async fn forward_notebook_doc_broadcast(
             Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
                 warn!("[notebook-sync] doc broadcast failed: {}", e);
-                None
+                return Err(anyhow::anyhow!("doc broadcast failed: {e}"));
             }
         }
     };
@@ -127,7 +126,7 @@ pub(super) async fn queue_doc_sync(
             Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
                 warn!("[notebook-sync] queue doc sync failed: {}", e);
-                None
+                return Err(anyhow::anyhow!("queue doc sync failed: {e}"));
             }
         }
     };

--- a/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_pool_sync.rs
@@ -19,13 +19,7 @@ where
 {
     let initial_pool_encoded = {
         let mut pool_doc = daemon.pool_doc.write().await;
-        match pool_doc.generate_sync_message_recovering(pool_peer_state, "initial-pool-sync") {
-            Ok(message) => message.map(|msg| msg.encode()),
-            Err(e) => {
-                warn!("[notebook-sync] initial pool sync failed: {}", e);
-                None
-            }
-        }
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, "initial-pool-sync")?
     };
     if let Some(encoded) = initial_pool_encoded {
         connection::send_typed_frame(writer, NotebookFrameType::PoolStateSync, &encoded).await?;
@@ -52,11 +46,11 @@ pub(super) async fn handle_pool_state_frame(
             Ok(()) => {}
             Err(e) => {
                 warn!("[notebook-sync] pool receive_sync_message error: {}", e);
-                return Ok(false);
+                return Err(anyhow::anyhow!("pool receive_sync_message error: {e}"));
             }
         }
 
-        generate_pool_sync_message(&mut pool_doc, pool_peer_state, "pool-sync-reply")
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, "pool-sync-reply")?
     };
     if let Some(encoded) = reply_encoded {
         writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
@@ -98,7 +92,7 @@ async fn send_pool_sync_update(
 ) -> anyhow::Result<()> {
     let encoded = {
         let mut pool_doc = daemon.pool_doc.write().await;
-        generate_pool_sync_message(&mut pool_doc, pool_peer_state, label)
+        generate_pool_sync_message(&mut pool_doc, pool_peer_state, label)?
     };
     if let Some(encoded) = encoded {
         writer.send_frame(NotebookFrameType::PoolStateSync, encoded)?;
@@ -110,12 +104,12 @@ fn generate_pool_sync_message(
     pool_doc: &mut notebook_doc::pool_state::PoolDoc,
     pool_peer_state: &mut sync::State,
     label: &str,
-) -> Option<Vec<u8>> {
+) -> anyhow::Result<Option<Vec<u8>>> {
     match pool_doc.generate_sync_message_recovering(pool_peer_state, label) {
-        Ok(message) => message.map(|msg| msg.encode()),
+        Ok(message) => Ok(message.map(|msg| msg.encode())),
         Err(e) => {
             warn!("[notebook-sync] pool sync generation failed: {}", e);
-            None
+            Err(anyhow::anyhow!("pool sync generation failed: {e}"))
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -77,7 +77,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     "[notebook-sync] runtime-agent initial doc sync failed: {}",
                     e
                 );
-                None
+                return;
             }
         }
     };
@@ -93,15 +93,20 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
     // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
     // Uses bounded generation to compact if oversized (same 80 MiB threshold).
     let mut state_sync_state = automerge::sync::State::new();
-    let state_sync_msg = room
-        .state
-        .generate_sync_message_bounded_encoded_recovering(
-            &mut state_sync_state,
-            STATE_SYNC_COMPACT_THRESHOLD,
-            "peer-runtime-agent-state-init",
-        )
-        .ok()
-        .flatten();
+    let state_sync_msg = match room.state.generate_sync_message_bounded_encoded_recovering(
+        &mut state_sync_state,
+        STATE_SYNC_COMPACT_THRESHOLD,
+        "peer-runtime-agent-state-init",
+    ) {
+        Ok(message) => message,
+        Err(e) => {
+            warn!(
+                "[notebook-sync] runtime-agent initial state sync failed: {}",
+                e
+            );
+            return;
+        }
+    };
     if let Some(encoded) = state_sync_msg {
         if let Err(e) =
             send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await
@@ -202,6 +207,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 }
                                 Err(e) => {
                                     warn!("[notebook-sync] Agent doc sync receive failed: {}", e);
+                                    break;
                                 }
                             }
                             // Send sync reply
@@ -222,6 +228,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 Ok(None) => {}
                                 Err(e) => {
                                     warn!("[notebook-sync] Agent doc sync reply failed: {}", e);
+                                    break;
                                 }
                             }
                         }
@@ -248,18 +255,23 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                     }
                                     Err(e) => {
                                         warn!("[notebook-sync] Agent state sync receive failed: {}", e);
-                                        return Ok(None);
+                                        return Err(e.into());
                                     }
                                 }
-                                Ok(sd
-                                    .generate_sync_message_recovering(
+                                sd.generate_sync_message_recovering(
                                         &mut state_sync_state,
                                         "peer-runtime-agent-state-reply",
                                     )
-                                    .ok()
-                                    .flatten()
-                                    .map(|reply| reply.encode()))
-                            }).ok().flatten();
+                                    .map(|message| message.map(|reply| reply.encode()))
+                                    .map_err(Into::into)
+                            });
+                            let reply_encoded = match reply_encoded {
+                                Ok(encoded) => encoded,
+                                Err(e) => {
+                                    warn!("[notebook-sync] Agent state sync failed: {}", e);
+                                    break;
+                                }
+                            };
                             if let Some(encoded) = reply_encoded {
                                 if let Err(e) = agent_writer.send_frame(
                                     NotebookFrameType::RuntimeStateSync,
@@ -319,6 +331,7 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                     Ok(None) => {}
                     Err(e) => {
                         warn!("[notebook-sync] Agent outbound doc sync failed: {}", e);
+                        break;
                     }
                 }
             }
@@ -326,15 +339,18 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             // RuntimeStateDoc changes → sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
-                let encoded = room
+                let encoded = match room
                     .state
                     .generate_sync_message_recovering(
                         &mut state_sync_state,
                         "peer-runtime-agent-state-outbound",
-                    )
-                    .ok()
-                    .flatten()
-                    .map(|msg| msg.encode());
+                    ) {
+                        Ok(message) => message.map(|msg| msg.encode()),
+                        Err(e) => {
+                            warn!("[notebook-sync] Agent outbound state sync failed: {}", e);
+                            break;
+                        }
+                    };
                 if let Some(encoded) = encoded {
                     if let Err(e) = agent_writer.send_frame(
                         NotebookFrameType::RuntimeStateSync,

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -77,41 +77,29 @@ pub(super) async fn handle_runtime_state_frame(
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
     let mut runtime_file_dirty = false;
 
-    let reply_encoded: Option<Option<Vec<u8>>> = room
-        .state
-        .with_doc(|state_doc| {
-            let before = runtime_file_save_fingerprint(state_doc);
-            let had_changes = match state_doc.receive_sync_message_with_changes_recovering(
-                state_peer_state,
-                message,
-                "state-receive-sync",
-            ) {
-                Ok(changed) => changed,
-                Err(e) => {
-                    warn!("[notebook-sync] state receive_sync_message error: {}", e);
-                    return Ok(None);
-                }
-            };
-
-            // If the client sent changes, notification is automatic via the
-            // heads comparison in RuntimeStateDoc::with_doc.
-            if had_changes && runtime_file_save_fingerprint(state_doc) != before {
-                runtime_file_dirty = true;
+    let reply_encoded = room.state.with_doc(|state_doc| {
+        let before = runtime_file_save_fingerprint(state_doc);
+        let had_changes = match state_doc.receive_sync_message_with_changes_recovering(
+            state_peer_state,
+            message,
+            "state-receive-sync",
+        ) {
+            Ok(changed) => changed,
+            Err(e) => {
+                warn!("[notebook-sync] state receive_sync_message error: {}", e);
+                return Err(e.into());
             }
+        };
 
-            Ok(Some(generate_runtime_state_sync_message(
-                state_doc,
-                state_peer_state,
-                "state-sync-reply",
-            )))
-        })
-        .ok()
-        .flatten();
+        // If the client sent changes, notification is automatic via the
+        // heads comparison in RuntimeStateDoc::with_doc.
+        if had_changes && runtime_file_save_fingerprint(state_doc) != before {
+            runtime_file_dirty = true;
+        }
 
-    let reply_encoded = match reply_encoded {
-        Some(encoded) => encoded,
-        None => return Ok(false),
-    };
+        generate_runtime_state_sync_message(state_doc, state_peer_state, "state-sync-reply")
+    })?;
+
     if let Some(encoded) = reply_encoded {
         writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
     }
@@ -160,17 +148,9 @@ fn send_runtime_state_sync_update(
     writer: &PeerWriter,
     label: &str,
 ) -> anyhow::Result<()> {
-    let encoded = room
-        .state
-        .with_doc(|state_doc| {
-            Ok(generate_runtime_state_sync_message(
-                state_doc,
-                state_peer_state,
-                label,
-            ))
-        })
-        .ok()
-        .flatten();
+    let encoded = room.state.with_doc(|state_doc| {
+        generate_runtime_state_sync_message(state_doc, state_peer_state, label)
+    })?;
     if let Some(encoded) = encoded {
         writer.send_frame(NotebookFrameType::RuntimeStateSync, encoded)?;
     }
@@ -181,15 +161,15 @@ fn generate_runtime_state_sync_message(
     state_doc: &mut runtime_doc::RuntimeStateDoc,
     state_peer_state: &mut sync::State,
     label: &str,
-) -> Option<Vec<u8>> {
+) -> Result<Option<Vec<u8>>, runtime_doc::RuntimeStateError> {
     match state_doc.generate_sync_message_recovering(state_peer_state, label) {
-        Ok(message) => message.map(|msg| msg.encode()),
+        Ok(message) => Ok(message.map(|msg| msg.encode())),
         Err(e) => {
             warn!(
                 "[notebook-sync] runtime state sync generation failed: {}",
                 e
             );
-            None
+            Err(e.into())
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -72,7 +72,7 @@ where
             Ok(message) => message.map(|msg| msg.encode()),
             Err(e) => {
                 warn!("[notebook-sync] initial doc sync failed: {}", e);
-                None
+                return Err(anyhow::anyhow!("initial doc sync failed: {e}"));
             }
         }
     };
@@ -106,20 +106,18 @@ where
             if state_doc.compact_if_oversized(COMPACTION_THRESHOLD) {
                 info!("[notebook-sync] Compacted oversized RuntimeStateDoc before initial sync");
             }
-            match state_doc.generate_sync_message_bounded_encoded_recovering(
-                state_peer_state,
-                STATE_SYNC_COMPACT_THRESHOLD,
-                "initial-state-sync",
-            ) {
-                Ok(encoded) => Ok(encoded),
-                Err(e) => {
+            state_doc
+                .generate_sync_message_bounded_encoded_recovering(
+                    state_peer_state,
+                    STATE_SYNC_COMPACT_THRESHOLD,
+                    "initial-state-sync",
+                )
+                .map_err(|e| {
                     warn!("[notebook-sync] initial runtime state sync failed: {}", e);
-                    Ok(None)
-                }
-            }
+                    runtime_doc::RuntimeStateError::from(e)
+                })
         })
-        .ok()
-        .flatten();
+        .map_err(|e| anyhow::anyhow!("initial runtime state sync failed: {e}"))?;
     if let Some(encoded) = initial_state_encoded {
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
     }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -371,63 +371,76 @@ pub async fn run_runtime_agent(
                                                     "[runtime-agent] Failed to apply RuntimeStateSync: {}",
                                                     e
                                                 );
-                                                Ok(None)
+                                                Err(e.into())
                                             }
                                         }
                                     });
 
                                     // Async work outside the lock
-                                    if let Ok(Some((queued, comm_updates))) = sync_result {
-                                        if !comm_updates.is_empty() {
-                                            if let Some(ref mut k) = kernel {
-                                                for (comm_id, delta) in &comm_updates {
-                                                    if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
-                                                        warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
+                                    match sync_result {
+                                        Ok(Some((queued, comm_updates))) => {
+                                            if !comm_updates.is_empty() {
+                                                if let Some(ref mut k) = kernel {
+                                                    for (comm_id, delta) in &comm_updates {
+                                                        if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
+                                                            warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
+                                                        }
                                                     }
                                                 }
                                             }
-                                        }
 
-                                        // Check for new queued executions
-                                        for (eid, exec) in queued {
-                                            if seen_execution_ids.insert(eid.clone()) {
-                                                if let Some(ref source) = exec.source {
-                                                    if let Some(ref mut k) = kernel {
-                                                        match kernel_state.queue_cell(
-                                                            exec.cell_id.clone(),
-                                                            eid.clone(),
-                                                            source.clone(),
-                                                            k,
-                                                        ).await {
-                                                            Ok(_) => {
-                                                                info!(
-                                                                    "[runtime-agent] Queued cell {} (execution {})",
-                                                                    exec.cell_id, eid
-                                                                );
-                                                            }
-                                                            Err(e) => {
-                                                                warn!(
-                                                                    "[runtime-agent] Failed to queue cell {}: {}",
-                                                                    exec.cell_id, e
-                                                                );
+                                            // Check for new queued executions
+                                            for (eid, exec) in queued {
+                                                if seen_execution_ids.insert(eid.clone()) {
+                                                    if let Some(ref source) = exec.source {
+                                                        if let Some(ref mut k) = kernel {
+                                                            match kernel_state.queue_cell(
+                                                                exec.cell_id.clone(),
+                                                                eid.clone(),
+                                                                source.clone(),
+                                                                k,
+                                                            ).await {
+                                                                Ok(_) => {
+                                                                    info!(
+                                                                        "[runtime-agent] Queued cell {} (execution {})",
+                                                                        exec.cell_id, eid
+                                                                    );
+                                                                }
+                                                                Err(e) => {
+                                                                    warn!(
+                                                                        "[runtime-agent] Failed to queue cell {}: {}",
+                                                                        exec.cell_id, e
+                                                                    );
+                                                                }
                                                             }
                                                         }
                                                     }
                                                 }
                                             }
                                         }
+                                        Ok(None) => {}
+                                        Err(e) => {
+                                            warn!("[runtime-agent] Closing after RuntimeStateSync failure: {}", e);
+                                            break;
+                                        }
                                     }
 
                                     // Send sync reply
-                                    let reply_encoded = ctx
+                                    let reply_encoded = match ctx
                                         .state
                                         .generate_sync_message_recovering(
                                             &mut coordinator_sync_state,
                                             "runtime-agent-state-reply",
-                                        )
-                                        .ok()
-                                        .flatten()
-                                        .map(|reply| reply.encode());
+                                        ) {
+                                            Ok(message) => message.map(|reply| reply.encode()),
+                                            Err(e) => {
+                                                warn!(
+                                                    "[runtime-agent] Closing after RuntimeStateSync reply failure: {}",
+                                                    e
+                                                );
+                                                break;
+                                            }
+                                        };
                                     if let Some(encoded) = reply_encoded {
                                         let _ = send_typed_frame(
                                             &mut writer,
@@ -531,15 +544,21 @@ pub async fn run_runtime_agent(
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
 
-                let encoded = ctx
+                let encoded = match ctx
                     .state
                     .generate_sync_message_recovering(
                         &mut coordinator_sync_state,
                         "runtime-agent-state-outbound",
-                    )
-                    .ok()
-                    .flatten()
-                    .map(|msg| msg.encode());
+                    ) {
+                        Ok(message) => message.map(|msg| msg.encode()),
+                        Err(e) => {
+                            warn!(
+                                "[runtime-agent] Closing after outbound RuntimeStateSync failure: {}",
+                                e
+                            );
+                            break;
+                        }
+                    };
                 if let Some(encoded) = encoded {
                     if let Err(e) = send_typed_frame(
                         &mut writer,

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -133,15 +133,15 @@ struct IncomingSettingsSyncOutcome {
 fn generate_settings_sync_frame(
     doc: &mut SettingsDoc,
     peer_state: &mut sync::State,
-    json_path: &Path,
+    _json_path: &Path,
     label: &'static str,
 ) -> anyhow::Result<Option<Vec<u8>>> {
-    let fallback = doc.get_all();
     match doc.generate_sync_message_recovering(label, peer_state) {
         Ok(message) => Ok(message.map(|msg| msg.encode())),
-        Err(error) => recover_settings_doc_reset_peer_and_retry_generate(
-            doc, peer_state, json_path, &fallback, label, error,
-        ),
+        Err(error) => Err(anyhow::anyhow!(
+            "[sync] settings sync generate failed after Automerge panic: {}",
+            error
+        )),
     }
 }
 
@@ -174,23 +174,10 @@ fn apply_incoming_settings_sync_frame(
                 broadcast_changed: doc_changed,
             })
         }
-        Err(AutomergeOperationError::Panic(error)) => {
-            // We cannot prove the inbound client edit applied cleanly after a
-            // receive-side panic. Rebuild from durable JSON truth and resync
-            // instead of replaying the same message into a recovered document.
-            let reply = recover_settings_doc_reset_peer_and_retry_generate(
-                doc,
-                peer_state,
-                json_path,
-                &fallback,
-                "settings-sync-receive-recovery-generate",
-                error,
-            )?;
-            Ok(IncomingSettingsSyncOutcome {
-                reply,
-                broadcast_changed: false,
-            })
-        }
+        Err(AutomergeOperationError::Panic(error)) => Err(anyhow::anyhow!(
+            "[sync] settings sync receive failed after Automerge panic: {}",
+            error
+        )),
         Err(AutomergeOperationError::Automerge { label, source }) => {
             let recoverable = is_recoverable_sync_error(source.as_ref());
             let error = AutomergeOperationError::Automerge { label, source };
@@ -237,7 +224,7 @@ fn recover_settings_doc_reset_peer_and_retry_generate(
         .map(|message| message.map(|msg| msg.encode()))
         .map_err(|retry_error| {
             anyhow::anyhow!(
-                "[sync] settings sync recovery retry failed after recoverable Automerge failure: {}",
+                "[sync] settings sync recoverable retry failed after recoverable Automerge failure: {}",
                 retry_error
             )
         })
@@ -289,7 +276,7 @@ mod tests {
 
     #[test]
     #[serial(settings_sync_panic_hooks)]
-    fn generate_panic_rebuilds_from_canonical_json_and_retries() {
+    fn generate_panic_returns_error_without_rebuild_or_retry() {
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         let canonical = SyncedSettings {
@@ -304,21 +291,21 @@ mod tests {
         let mut peer_state = sync::State::new();
 
         SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
-        let frame = generate_settings_sync_frame(
+        let error = generate_settings_sync_frame(
             &mut doc,
             &mut peer_state,
             &json_path,
             "settings-test-generate",
         )
-        .expect("recovery should retry generate");
+        .expect_err("generate panic should close settings sync path");
 
-        assert!(frame.is_some());
-        assert_eq!(doc.get_all(), canonical);
+        assert!(error.to_string().contains("settings sync generate failed"));
+        assert_eq!(doc.get_all().theme, ThemeMode::Light);
     }
 
     #[test]
     #[serial(settings_sync_panic_hooks)]
-    fn receive_panic_does_not_persist_or_broadcast_client_edit() {
+    fn receive_panic_returns_error_without_persisting_or_broadcasting() {
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         let canonical = SyncedSettings::default();
@@ -335,16 +322,17 @@ mod tests {
             .expect("client should generate settings edit");
 
         SettingsDoc::__panic_on_next_receive_sync_calls_for_test(1);
-        let outcome = apply_incoming_settings_sync_frame(
+        let error = match apply_incoming_settings_sync_frame(
             &mut server,
             &mut server_peer_state,
             message,
             &json_path,
-        )
-        .expect("receive panic should recover to canonical settings");
+        ) {
+            Ok(_) => panic!("receive panic should close settings sync path"),
+            Err(error) => error,
+        };
 
-        assert!(outcome.reply.is_some());
-        assert!(!outcome.broadcast_changed);
+        assert!(error.to_string().contains("settings sync receive failed"));
         assert_eq!(server.get_all(), canonical);
 
         let saved = std::fs::read_to_string(&json_path).expect("settings read");
@@ -403,16 +391,20 @@ mod tests {
         let mut doc = SettingsDoc::from_synced_settings(&snapshot);
         let mut peer_state = sync::State::new();
 
-        SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
-        let frame = generate_settings_sync_frame(
-            &mut doc,
-            &mut peer_state,
-            &json_path,
-            "settings-test-generate-invalid-json",
-        )
-        .expect("invalid JSON should fall back to last-known-good snapshot");
+        let mut client = SettingsDoc::new();
+        client.put("theme", "light");
+        let mut client_state = sync::State::new();
+        let message = client
+            .generate_sync_message(&mut client_state)
+            .expect("client should generate settings edit");
 
-        assert!(frame.is_some());
+        SettingsDoc::__patch_log_mismatch_on_next_receive_sync_calls_for_test(1);
+        let outcome =
+            apply_incoming_settings_sync_frame(&mut doc, &mut peer_state, message, &json_path)
+                .expect("invalid JSON should fall back to last-known-good snapshot");
+
+        assert!(outcome.reply.is_some());
+        assert!(!outcome.broadcast_changed);
         assert_eq!(doc.get_all(), snapshot);
         assert_eq!(
             std::fs::read_to_string(&json_path).expect("settings read"),
@@ -422,7 +414,7 @@ mod tests {
 
     #[test]
     #[serial(settings_sync_panic_hooks)]
-    fn repeated_generate_panic_after_recovery_returns_error() {
+    fn repeated_generate_panic_returns_first_error_without_retry() {
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         write_settings_json(&json_path, &SyncedSettings::default());
@@ -437,8 +429,8 @@ mod tests {
             &json_path,
             "settings-test-repeated-generate",
         )
-        .expect_err("second generate panic should close this sync path");
+        .expect_err("generate panic should close this sync path");
 
-        assert!(error.to_string().contains("recovery retry failed"));
+        assert!(error.to_string().contains("settings sync generate failed"));
     }
 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -62,7 +62,6 @@ where
             generate_settings_sync_frame(
                 &mut doc,
                 &mut peer_state,
-                &json_path,
                 "settings-sync-initial-generate",
             )?
         };
@@ -113,7 +112,6 @@ where
                     generate_settings_sync_frame(
                         &mut doc,
                         &mut peer_state,
-                        &json_path,
                         "settings-sync-broadcast-generate",
                     )?
                 };
@@ -133,7 +131,6 @@ struct IncomingSettingsSyncOutcome {
 fn generate_settings_sync_frame(
     doc: &mut SettingsDoc,
     peer_state: &mut sync::State,
-    _json_path: &Path,
     label: &'static str,
 ) -> anyhow::Result<Option<Vec<u8>>> {
     match doc.generate_sync_message_recovering(label, peer_state) {
@@ -167,8 +164,7 @@ fn apply_incoming_settings_sync_frame(
                 persist_settings(doc, json_path);
             }
 
-            let reply =
-                generate_settings_sync_frame(doc, peer_state, json_path, "settings-sync-reply")?;
+            let reply = generate_settings_sync_frame(doc, peer_state, "settings-sync-reply")?;
             Ok(IncomingSettingsSyncOutcome {
                 reply,
                 broadcast_changed: doc_changed,
@@ -185,9 +181,9 @@ fn apply_incoming_settings_sync_frame(
                 return Err(error.into());
             }
 
-            // Treat patch-log skew like the panic path: the durable JSON file
-            // remains authoritative, and the inbound frame must not be assumed
-            // to have applied.
+            // Treat patch-log skew as a recoverable document-boundary failure:
+            // the durable JSON file remains authoritative, and the inbound
+            // frame must not be assumed to have applied.
             let reply = recover_settings_doc_reset_peer_and_retry_generate(
                 doc,
                 peer_state,
@@ -291,13 +287,9 @@ mod tests {
         let mut peer_state = sync::State::new();
 
         SettingsDoc::__panic_on_next_generate_sync_calls_for_test(1);
-        let error = generate_settings_sync_frame(
-            &mut doc,
-            &mut peer_state,
-            &json_path,
-            "settings-test-generate",
-        )
-        .expect_err("generate panic should close settings sync path");
+        let error =
+            generate_settings_sync_frame(&mut doc, &mut peer_state, "settings-test-generate")
+                .expect_err("generate panic should close settings sync path");
 
         assert!(error.to_string().contains("settings sync generate failed"));
         assert_eq!(doc.get_all().theme, ThemeMode::Light);
@@ -426,7 +418,6 @@ mod tests {
         let error = generate_settings_sync_frame(
             &mut doc,
             &mut peer_state,
-            &json_path,
             "settings-test-repeated-generate",
         )
         .expect_err("generate panic should close this sync path");

--- a/python/runtimed/tests/log_guards.py
+++ b/python/runtimed/tests/log_guards.py
@@ -7,7 +7,10 @@ import re
 _AUTOMERGE_RECOVERY_PATTERNS = (
     re.compile(r"\[[^\]]+\]\s+automerge panicked:", re.IGNORECASE),
     re.compile(r"after Automerge panic", re.IGNORECASE),
-    re.compile(r"Closing sync task after (?:Automerge sync|RuntimeStateSync) failure", re.IGNORECASE),
+    re.compile(
+        r"Closing (?:sync task )?after (?:(?:outbound )?RuntimeStateSync(?: reply)?|Automerge sync) failure",
+        re.IGNORECASE,
+    ),
     re.compile(r"Recovered from (?:sync|RuntimeStateSync) panic", re.IGNORECASE),
     re.compile(r"Failed to rebuild after sync panic", re.IGNORECASE),
     re.compile(r"settings sync recovery retry failed", re.IGNORECASE),

--- a/python/runtimed/tests/log_guards.py
+++ b/python/runtimed/tests/log_guards.py
@@ -8,7 +8,8 @@ _AUTOMERGE_RECOVERY_PATTERNS = (
     re.compile(r"\[[^\]]+\]\s+automerge panicked:", re.IGNORECASE),
     re.compile(r"after Automerge panic", re.IGNORECASE),
     re.compile(
-        r"Closing (?:sync task )?after (?:(?:outbound )?RuntimeStateSync(?: reply)?|Automerge sync) failure",
+        r"Closing (?:sync task )?after "
+        r"(?:(?:outbound )?RuntimeStateSync(?: reply)?|Automerge sync) failure",
         re.IGNORECASE,
     ),
     re.compile(r"Recovered from (?:sync|RuntimeStateSync) panic", re.IGNORECASE),

--- a/python/runtimed/tests/log_guards.py
+++ b/python/runtimed/tests/log_guards.py
@@ -6,6 +6,8 @@ import re
 
 _AUTOMERGE_RECOVERY_PATTERNS = (
     re.compile(r"\[[^\]]+\]\s+automerge panicked:", re.IGNORECASE),
+    re.compile(r"after Automerge panic", re.IGNORECASE),
+    re.compile(r"Closing sync task after (?:Automerge sync|RuntimeStateSync) failure", re.IGNORECASE),
     re.compile(r"Recovered from (?:sync|RuntimeStateSync) panic", re.IGNORECASE),
     re.compile(r"Failed to rebuild after sync panic", re.IGNORECASE),
     re.compile(r"settings sync recovery retry failed", re.IGNORECASE),

--- a/python/runtimed/tests/test_log_guards.py
+++ b/python/runtimed/tests/test_log_guards.py
@@ -14,12 +14,15 @@ def test_find_automerge_recovery_logs_matches_direct_recovery_lines():
             "WARN [notebook-sync] Failed to rebuild after sync panic for receive: label: nope",
             "WARN [notebook-sync] Recovered from RuntimeStateSync panic for outbound: nope",
             "ERROR [sync] settings sync recovery retry failed after Automerge panic: nope",
+            "WARN [notebook-sync] Closing sync task after Automerge sync failure for nb: nope",
+            "WARN [notebook-sync] Closing sync task after RuntimeStateSync failure for nb: nope",
+            "ERROR [sync] settings sync generate failed after Automerge panic: nope",
         ]
     )
 
     matches = find_automerge_recovery_logs(log_text)
 
-    assert len(matches) == 5
+    assert len(matches) == 8
     assert all("daemon started" not in match for match in matches)
 
 

--- a/python/runtimed/tests/test_log_guards.py
+++ b/python/runtimed/tests/test_log_guards.py
@@ -16,13 +16,16 @@ def test_find_automerge_recovery_logs_matches_direct_recovery_lines():
             "ERROR [sync] settings sync recovery retry failed after Automerge panic: nope",
             "WARN [notebook-sync] Closing sync task after Automerge sync failure for nb: nope",
             "WARN [notebook-sync] Closing sync task after RuntimeStateSync failure for nb: nope",
+            "WARN [runtime-agent] Closing after RuntimeStateSync failure: nope",
+            "WARN [runtime-agent] Closing after RuntimeStateSync reply failure: nope",
+            "WARN [runtime-agent] Closing after outbound RuntimeStateSync failure: nope",
             "ERROR [sync] settings sync generate failed after Automerge panic: nope",
         ]
     )
 
     matches = find_automerge_recovery_logs(log_text)
 
-    assert len(matches) == 8
+    assert len(matches) == 11
     assert all("daemon started" not in match for match in matches)
 
 


### PR DESCRIPTION
## Summary

- fix `mcp-supervisor` binary fingerprint tests on Windows by writing test binaries through `cargo_binary()`, matching production `.exe` resolution
- adjust an infallible Automerge sync-frame destructure so Rust 1.94 clippy stays green
- wrap a long Automerge log guard regex so `cargo xtask lint --fix` stays green locally

## Context

Post-merge `main` for Automerge bump `db4408dfa5e786d270b08aeb09fbc460735e495a` had a Windows job failure in:

```text
cargo test --workspace --exclude runtimed-node --verbose
test tests::binary_fingerprint_differs_on_size_change ... FAILED
test tests::binary_fingerprint_stable_for_unchanged_file ... FAILED
test tests::managed_binary_fingerprints_tracks_daemon_and_runt_independently ... FAILED
```

The tests wrote `target/debug/runtimed` and `target/debug/runt`, but production lookup uses `cargo_binary()`, which resolves `runtimed.exe` and `runt.exe` on Windows.

## Verification

```text
cargo test -p mcp-supervisor --bin mcp-supervisor binary_fingerprint
cargo test -p mcp-supervisor --bin mcp-supervisor
cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings
cargo clippy --target x86_64-pc-windows-gnu --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --all-targets -- -D warnings
cargo xtask lint --fix
git diff --check
```
