### PR TITLE
test(mcp): make sidecar fixture assertions platform-aware

### DIFF
--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -336,22 +336,19 @@ mod tests {
     fn bundled_nightly_mcp_accepts_tauri_unsuffixed_runt_sidecar() {
         let exe = PathBuf::from("/tmp/.mount_nteract/usr/bin/nteract-mcp");
         let candidates = bundled_runt_candidates(&exe, "nightly");
+        let exe_dir = exe.parent().unwrap();
 
-        assert!(candidates.contains(&PathBuf::from("/tmp/.mount_nteract/usr/bin/runt-nightly")));
-        assert!(candidates.contains(&PathBuf::from("/tmp/.mount_nteract/usr/bin/runt")));
+        assert!(candidates.contains(&exe_dir.join(executable_name("runt-nightly"))));
+        assert!(candidates.contains(&exe_dir.join(executable_name("runt"))));
     }
 
     #[test]
     fn bundled_stable_mcp_uses_unsuffixed_runt_sidecar() {
         let exe = PathBuf::from("/Applications/nteract.app/Contents/MacOS/nteract-mcp");
         let candidates = bundled_runt_candidates(&exe, "stable");
+        let exe_dir = exe.parent().unwrap();
 
-        assert_eq!(
-            candidates,
-            vec![PathBuf::from(
-                "/Applications/nteract.app/Contents/MacOS/runt"
-            )]
-        );
+        assert_eq!(candidates, vec![exe_dir.join(executable_name("runt"))]);
     }
 
     /// `child_env_for_channel` returns the additive env map only. It does not


### PR DESCRIPTION
## Summary

- Fix the `nteract-mcp` bundled sidecar unit tests so their expected sidecar paths are platform-aware.
- Preserve the production lookup behavior: nightly still checks both `runt-nightly` and sibling `runt`; stable still checks sibling `runt`.

## Verification

- `cargo test -p nteract-mcp --bin nteract-mcp bundled_ -- --nocapture`
- `cargo test -p nteract-mcp --bin nteract-mcp`
- `cargo test --target x86_64-pc-windows-gnu -p nteract-mcp --bin nteract-mcp --no-run`
- `cargo xtask lint --fix`
- `git diff --check`
