### PR TITLE
fix(runtime): clear execution state on interrupt

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1277,6 +1277,17 @@ impl KernelConnection for JupyterKernel {
                                     if status.execution_state
                                         == jupyter_protocol::ExecutionState::Idle
                                     {
+                                        if let Err(e) =
+                                            iopub_cmd_tx.try_send(QueueCommand::KernelIdle {
+                                                execution_id: execution_id.clone(),
+                                            })
+                                        {
+                                            warn!(
+                                                "[jupyter-kernel] KernelIdle dropped: {} — queued work after interrupt may stall",
+                                                e
+                                            );
+                                        }
+
                                         if let (Some(cid), Some(eid)) =
                                             (cell_id.clone(), execution_id.clone())
                                         {

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -214,8 +214,40 @@ impl KernelState {
     /// Record that the current execution produced an error output.
     ///
     /// Called before `execution_done` so it can determine success/failure.
-    pub fn mark_execution_error(&mut self) {
-        self.execution_had_error = true;
+    /// Returns `false` for stale errors from an already-interrupted execution.
+    pub fn mark_execution_error(&mut self, cell_id: &str, execution_id: &str) -> bool {
+        let is_current = self
+            .executing
+            .as_ref()
+            .is_some_and(|(cid, eid)| cid == cell_id && eid == execution_id);
+        if is_current {
+            self.execution_had_error = true;
+        } else {
+            debug!(
+                "[kernel-state] Ignoring stale CellError for cell={} execution={}",
+                cell_id, execution_id
+            );
+        }
+        is_current
+    }
+
+    /// Clear local execution state after an interrupt request is accepted.
+    ///
+    /// The Jupyter kernel may still deliver late IOPub for the interrupted
+    /// request. Clearing `executing` here lets new executions proceed and makes
+    /// those late messages harmless stale events.
+    pub fn interrupt(&mut self) -> (Option<QueueEntry>, Vec<QueueEntry>) {
+        let interrupted = self
+            .executing
+            .take()
+            .map(|(cell_id, execution_id)| QueueEntry {
+                cell_id,
+                execution_id,
+            });
+        let cleared = self.clear_queue();
+        self.execution_had_error = false;
+        self.status = KernelStatus::Idle;
+        (interrupted, cleared)
     }
 
     /// Drain the execution queue.

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -55,6 +55,8 @@ pub struct KernelState {
     /// Whether the current execution produced an error output.
     /// Read by `execution_done` to record success/failure in the state doc.
     execution_had_error: bool,
+    /// Interrupted execution id awaiting a final kernel idle.
+    interrupt_pending: Option<String>,
     /// Kernel lifecycle status.
     status: KernelStatus,
 
@@ -70,6 +72,7 @@ impl KernelState {
             queue: VecDeque::new(),
             executing: None,
             execution_had_error: false,
+            interrupt_pending: None,
             status: KernelStatus::Starting,
             state,
         }
@@ -82,11 +85,13 @@ impl KernelState {
         self.queue.clear();
         self.executing = None;
         self.execution_had_error = false;
+        self.interrupt_pending = None;
         self.status = KernelStatus::Starting;
     }
 
     /// Transition to idle after kernel launch completes.
     pub fn set_idle(&mut self) {
+        self.interrupt_pending = None;
         self.status = KernelStatus::Idle;
     }
 
@@ -167,7 +172,7 @@ impl KernelState {
         let matches = self
             .executing
             .as_ref()
-            .is_some_and(|(cid, _)| cid == cell_id);
+            .is_some_and(|(cid, eid)| cid == cell_id && eid == execution_id);
         if matches {
             let success = !self.execution_had_error;
             self.executing = None;
@@ -234,8 +239,9 @@ impl KernelState {
     /// Clear local execution state after an interrupt request is accepted.
     ///
     /// The Jupyter kernel may still deliver late IOPub for the interrupted
-    /// request. Clearing `executing` here lets new executions proceed and makes
-    /// those late messages harmless stale events.
+    /// request. Clearing `executing` here makes those late messages harmless
+    /// stale events, while `interrupt_pending` prevents sending new execute
+    /// requests until the kernel reports a real idle state.
     pub fn interrupt(&mut self) -> (Option<QueueEntry>, Vec<QueueEntry>) {
         let interrupted = self
             .executing
@@ -244,10 +250,33 @@ impl KernelState {
                 cell_id,
                 execution_id,
             });
+        self.interrupt_pending = interrupted.as_ref().map(|entry| entry.execution_id.clone());
         let cleared = self.clear_queue();
         self.execution_had_error = false;
-        self.status = KernelStatus::Idle;
+        self.status = if self.interrupt_pending.is_some() {
+            KernelStatus::Busy
+        } else {
+            KernelStatus::Idle
+        };
         (interrupted, cleared)
+    }
+
+    /// Release the interrupt gate when the interrupted execution reports idle.
+    pub async fn kernel_idle(
+        &mut self,
+        execution_id: Option<&str>,
+        conn: &mut impl KernelConnection,
+    ) -> Result<()> {
+        let should_release = self
+            .interrupt_pending
+            .as_deref()
+            .is_some_and(|pending| Some(pending) == execution_id);
+        if should_release {
+            self.interrupt_pending = None;
+            self.status = KernelStatus::Idle;
+            self.process_next(conn).await?;
+        }
+        Ok(())
     }
 
     /// Drain the execution queue.
@@ -317,6 +346,9 @@ impl KernelState {
     async fn process_next(&mut self, conn: &mut impl KernelConnection) -> Result<()> {
         // Already executing?
         if self.executing.is_some() {
+            return Ok(());
+        }
+        if self.interrupt_pending.is_some() {
             return Ok(());
         }
 

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -472,6 +472,8 @@ pub enum QueueCommand {
         cell_id: String,
         execution_id: String,
     },
+    /// The kernel reported idle. Used to release execution after interrupt.
+    KernelIdle { execution_id: Option<String> },
     /// A cell produced an error (for stop-on-error behavior)
     CellError {
         cell_id: String,

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -39,8 +39,8 @@ use notebook_protocol::connection::{
     PackageManager,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
-use runtime_doc::RuntimeStateHandle;
 use runtime_doc::{CommDocEntry, RuntimeLifecycle, RuntimeStateDoc};
+use runtime_doc::{KernelActivity, RuntimeStateHandle};
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{debug, error, info, warn};
 
@@ -49,6 +49,7 @@ use crate::jupyter_kernel::JupyterKernel;
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
 use crate::kernel_state::KernelState;
 use crate::output_prep::QueueCommand;
+use crate::protocol::QueueEntry;
 
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
@@ -163,22 +164,17 @@ pub async fn run_runtime_agent(
                                     if matches!(envelope.request, RuntimeAgentRequest::InterruptExecution) {
                                         if let Some(ref handle) = interrupt_handle {
                                             let handle = handle.clone();
-                                            let cleared = kernel_state.clear_queue();
+                                            let (interrupted, cleared) = kernel_state.interrupt();
                                             // Write cleared entries AND sweep any CRDT-synced
                                             // executions that haven't reached the local queue yet.
                                             // Only the agent does this sweep - the coordinator
                                             // intentionally does NOT, so that final state is
                                             // determined by the agent regardless of timing.
-                                            if let Err(e) = state.with_doc(|sd| {
-                                                for entry in &cleared {
-                                                    sd.set_execution_done(&entry.execution_id, false)?;
-                                                }
-                                                sd.mark_inflight_executions_failed()?;
-                                                Ok(())
-                                            }) {
-                                                warn!("[runtime-state] {}", e);
-                                            }
-                                            kernel_state.write_queue_to_state_doc();
+                                            mark_interrupted_executions_failed(
+                                                &state,
+                                                interrupted.as_ref(),
+                                                &cleared,
+                                            );
                                             // Interrupt kernel in background — don't block the loop
                                             tokio::spawn(async move {
                                                 if let Err(e) = handle.interrupt().await {
@@ -942,19 +938,14 @@ async fn handle_runtime_agent_request(
             if let Some(ref mut k) = kernel {
                 match k.interrupt().await {
                     Ok(()) => {
-                        let cleared = state.clear_queue();
+                        let (interrupted, cleared) = state.interrupt();
                         // Write cleared entries AND sweep CRDT-synced executions
                         // that haven't reached the local queue yet.
-                        if let Err(e) = ctx.state.with_doc(|sd| {
-                            for entry in &cleared {
-                                sd.set_execution_done(&entry.execution_id, false)?;
-                            }
-                            sd.mark_inflight_executions_failed()?;
-                            Ok(())
-                        }) {
-                            warn!("[runtime-state] {}", e);
-                        }
-                        state.write_queue_to_state_doc();
+                        mark_interrupted_executions_failed(
+                            &ctx.state,
+                            interrupted.as_ref(),
+                            &cleared,
+                        );
                         (
                             RuntimeAgentResponse::InterruptAcknowledged { cleared },
                             None,
@@ -1265,16 +1256,17 @@ async fn handle_queue_command(
                 "[runtime-agent] CellError: cell={} execution={}",
                 cell_id, execution_id
             );
-            state.mark_execution_error();
-            let cleared = state.clear_queue();
-            if let Err(e) = ctx.state.with_doc(|sd| {
-                for entry in &cleared {
-                    sd.set_execution_done(&entry.execution_id, false)?;
+            if state.mark_execution_error(&cell_id, &execution_id) {
+                let cleared = state.clear_queue();
+                if let Err(e) = ctx.state.with_doc(|sd| {
+                    for entry in &cleared {
+                        sd.set_execution_done(&entry.execution_id, false)?;
+                    }
+                    sd.set_queue(None, &[])?;
+                    Ok(())
+                }) {
+                    warn!("[runtime-state] {}", e);
                 }
-                sd.set_queue(None, &[])?;
-                Ok(())
-            }) {
-                warn!("[runtime-state] {}", e);
             }
         }
 
@@ -1317,6 +1309,27 @@ async fn handle_queue_command(
     }
 
     Ok(())
+}
+
+fn mark_interrupted_executions_failed(
+    state: &RuntimeStateHandle,
+    interrupted: Option<&QueueEntry>,
+    cleared: &[QueueEntry],
+) {
+    if let Err(e) = state.with_doc(|sd| {
+        if let Some(entry) = interrupted {
+            sd.set_execution_done(&entry.execution_id, false)?;
+        }
+        for entry in cleared {
+            sd.set_execution_done(&entry.execution_id, false)?;
+        }
+        sd.mark_inflight_executions_failed()?;
+        sd.set_queue(None, &[])?;
+        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        Ok(())
+    }) {
+        warn!("[runtime-state] {}", e);
+    }
 }
 
 /// Diff two comm state snapshots, returning `(comm_id, changed_properties)` pairs.
@@ -1547,20 +1560,15 @@ mod tests {
         assert_eq!(eb.status, "queued");
         assert!(state.queued_entries().is_empty()); // Only cA is executing, no queue
 
-        // Simulate interrupt: clear local queue + mark_inflight_executions_failed
-        let cleared = state.clear_queue();
-        assert!(cleared.is_empty()); // clear_queue drains pending queue only, not the executing cell
-
-        handle
-            .with_doc(|sd| {
-                for entry in &cleared {
-                    sd.set_execution_done(&entry.execution_id, false)?;
-                }
-                sd.mark_inflight_executions_failed()?;
-                Ok(())
-            })
-            .unwrap();
-        state.write_queue_to_state_doc();
+        // Simulate interrupt: clear local executing/queue state and mark every
+        // in-flight CRDT execution failed.
+        let (interrupted, cleared) = state.interrupt();
+        assert_eq!(
+            interrupted.as_ref().map(|e| e.execution_id.as_str()),
+            Some("eA")
+        );
+        assert!(cleared.is_empty());
+        mark_interrupted_executions_failed(&handle, interrupted.as_ref(), &cleared);
 
         // eA (executing) should be marked failed by mark_inflight
         let ea = handle.read(|sd| sd.get_execution("eA").unwrap()).unwrap();
@@ -1571,6 +1579,14 @@ mod tests {
         let eb = handle.read(|sd| sd.get_execution("eB").unwrap()).unwrap();
         assert_eq!(eb.status, "error");
         assert_eq!(eb.success, Some(false));
+
+        let rs = handle.read(|sd| sd.read_state()).unwrap();
+        assert!(rs.queue.executing.is_none());
+        assert!(rs.queue.queued.is_empty());
+        assert_eq!(
+            rs.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
     }
 
     /// After interrupt, CellError from the interrupted cell should be a
@@ -1596,21 +1612,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Simulate interrupt: clear queue
-        let cleared = state.clear_queue();
+        // Simulate interrupt: clear executing and queued work.
+        let (interrupted, cleared) = state.interrupt();
+        assert_eq!(
+            interrupted.as_ref().map(|e| e.execution_id.as_str()),
+            Some("eA")
+        );
         assert_eq!(cleared.len(), 1); // cB
         assert_eq!(cleared[0].cell_id, "cB");
-
-        handle
-            .with_doc(|sd| {
-                for entry in &cleared {
-                    sd.set_execution_done(&entry.execution_id, false)?;
-                }
-                sd.mark_inflight_executions_failed()?;
-                Ok(())
-            })
-            .unwrap();
-        state.write_queue_to_state_doc();
+        mark_interrupted_executions_failed(&handle, interrupted.as_ref(), &cleared);
 
         // Now simulate CellError from the interrupted cell A
         handle_queue_command(
@@ -1630,5 +1640,16 @@ mod tests {
         assert_eq!(ea.status, "error");
         let eb = handle.read(|sd| sd.get_execution("eB").unwrap()).unwrap();
         assert_eq!(eb.status, "error");
+
+        // A stale CellError from eA must not poison the next execution.
+        let mut mock = MockKernel;
+        state
+            .queue_cell("cC".into(), "eC".into(), "1 + 1".into(), &mut mock)
+            .await
+            .unwrap();
+        state.execution_done("cC", "eC", &mut mock).await.unwrap();
+        let ec = handle.read(|sd| sd.get_execution("eC").unwrap()).unwrap();
+        assert_eq!(ec.status, "done");
+        assert_eq!(ec.success, Some(true));
     }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1248,6 +1248,14 @@ async fn handle_queue_command(
             }
         }
 
+        QueueCommand::KernelIdle { execution_id } => {
+            if let Some(ref mut k) = kernel {
+                if let Err(e) = state.kernel_idle(execution_id.as_deref(), k).await {
+                    warn!("[runtime-agent] kernel_idle error: {}", e);
+                }
+            }
+        }
+
         QueueCommand::CellError {
             cell_id,
             execution_id,
@@ -1647,6 +1655,9 @@ mod tests {
             .queue_cell("cC".into(), "eC".into(), "1 + 1".into(), &mut mock)
             .await
             .unwrap();
+        assert!(state.executing_cell().is_none());
+        assert_eq!(state.queued_entries().len(), 1);
+        state.kernel_idle(Some("eA"), &mut mock).await.unwrap();
         state.execution_done("cC", "eC", &mut mock).await.unwrap();
         let ec = handle.read(|sd| sd.get_execution("eC").unwrap()).unwrap();
         assert_eq!(ec.status, "done");

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2034,10 +2034,6 @@ class TestKernelLifecycle:
         assert await session.kernel_started()
         assert await session.env_source() is not None
 
-    @pytest.mark.xfail(
-        reason="Flaky on CI: daemon relay 30s timeout can expire on slow runners",
-        strict=False,
-    )
     async def test_interrupt_clears_queue_and_unblocks(self, session):
         """Interrupt clears the CRDT queue and allows new cells to execute (#1583)."""
         await async_start_kernel_with_retry(session)
@@ -2048,9 +2044,9 @@ class TestKernelLifecycle:
         queued_id = await session.create_cell("queued = True")
 
         # Execute both — blocking cell runs first, queued cell waits
-        blocking_task = asyncio.create_task(session.execute_cell(blocking_id))
+        blocking_task = asyncio.ensure_future(session.execute_cell(blocking_id))
         await asyncio.sleep(0.5)  # Let blocking cell start
-        queued_task = asyncio.create_task(session.execute_cell(queued_id))
+        queued_task = asyncio.ensure_future(session.execute_cell(queued_id))
         await asyncio.sleep(0.5)  # Let queue settle
 
         # Interrupt — should clear the queue and send SIGINT
@@ -2068,6 +2064,38 @@ class TestKernelLifecycle:
         verify_id = await session.create_cell("1 + 1")
         verify_result = await asyncio.wait_for(session.execute_cell(verify_id), timeout=10)
         assert verify_result.success, f"Post-interrupt cell should succeed: {verify_result}"
+
+    async def test_interrupt_large_streaming_output_unblocks(self, session):
+        """Interrupting heavy stdout streaming clears state and allows more execution."""
+        await async_start_kernel_with_retry(session)
+
+        streaming_id = await session.create_cell(
+            "\n".join(
+                [
+                    "import sys",
+                    "import time",
+                    "",
+                    "for i in range(10_000):",
+                    "    print(i)",
+                    "    if i % 10 == 0:",
+                    "        sys.stdout.flush()",
+                    "    time.sleep(0.0005)",
+                ]
+            )
+        )
+
+        streaming_task = asyncio.ensure_future(session.execute_cell(streaming_id, timeout_secs=30))
+        await asyncio.sleep(1.0)
+
+        await session.interrupt()
+
+        streaming_result = await asyncio.wait_for(streaming_task, timeout=10)
+        assert not streaming_result.success, "Interrupted streaming cell should report failure"
+
+        verify_id = await session.create_cell("print(21 * 2)")
+        verify_result = await asyncio.wait_for(session.execute_cell(verify_id), timeout=10)
+        assert verify_result.success, f"Post-interrupt cell should succeed: {verify_result}"
+        assert "42" in verify_result.stdout
 
     async def test_async_shutdown_kernel(self, session):
         """Can shutdown the kernel."""

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2084,12 +2084,25 @@ class TestKernelLifecycle:
             )
         )
 
-        streaming_task = asyncio.ensure_future(session.execute_cell(streaming_id, timeout_secs=30))
-        await asyncio.sleep(1.0)
+        execution_id = await session.queue_cell(streaming_id)
+
+        async def streaming_started():
+            state = await session.get_runtime_state()
+            execution = state.executions.get(execution_id)
+            return execution is not None and execution.status == "running"
+
+        await async_wait_for_sync(
+            streaming_started,
+            timeout=10.0,
+            description="streaming execution to start",
+        )
 
         await session.interrupt()
 
-        streaming_result = await asyncio.wait_for(streaming_task, timeout=10)
+        streaming_result = await asyncio.wait_for(
+            session.wait_for_execution(streaming_id, execution_id, timeout_secs=10),
+            timeout=15,
+        )
         assert not streaming_result.success, "Interrupted streaming cell should report failure"
 
         verify_id = await session.create_cell("print(21 * 2)")


### PR DESCRIPTION
## Summary

Fixes the interrupt path that can leave notebooks stuck busy after a long-running
or high-volume stdout execution is interrupted.

The nightly diagnostic archive from build `db4408dfa5e786d270b08aeb09fbc460735e495a`
did not show Automerge panic/recovery markers. The daemon accepted interrupts and
received interrupt replies, but the runtime state could still advertise running
work afterward. This PR treats an accepted interrupt as a runtime-state boundary:

- clear the local executing entry and queued work
- mark interrupted and in-flight RuntimeStateDoc executions failed
- publish an empty queue and idle lifecycle
- ignore late `CellError` messages from the interrupted execution so they cannot
  poison the next execution
- keep the local runtime-agent queue gated until the interrupted execution id
  itself reports kernel idle, so immediate follow-up executions are submitted
  after the kernel has actually finished interrupt cleanup

It also removes the XFAIL from the existing interrupt integration test and adds a
large stdout streaming regression based on the stuck-kernel report.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p runtimed`
- `cargo build -p runtimed --bin runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 ... uv run pytest tests/test_daemon_integration.py::TestKernelLifecycle::test_interrupt_clears_queue_and_unblocks tests/test_daemon_integration.py::TestKernelLifecycle::test_interrupt_large_streaming_output_unblocks -v --tb=short --durations=10`
- `PYO3_PYTHON=/Users/kyle/code/src/github.com/nteract/desktop/.venv/bin/python DYLD_LIBRARY_PATH=/Users/kyle/.local/share/uv/python/cpython-3.13.12-macos-aarch64-none/lib cargo test -p runtimed-py --lib --no-default-features`

## Follow-up

The existing checked-in notebook E2E path is still WebDriver/Tauri-centered. A
separate PR should add a dev-server Playwright harness for fast frontend coverage
of user journeys like interrupt buttons and large output rendering, without
mixing that harness work into this runtime-state fix.
