### PR TITLE
test(runt): use native absolute notebook path

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -5581,7 +5581,7 @@ mod tests {
 
     #[test]
     fn open_notebook_absolute_path_stays_absolute() {
-        let path = PathBuf::from("/tmp/notebook.ipynb");
+        let path = std::env::temp_dir().join("notebook.ipynb");
 
         let args = open_notebook_launch_args(Some(path.clone()), None);
 


### PR DESCRIPTION
## Summary

- make the `runt open` absolute-path unit test use a native absolute path
- keep the production path handling unchanged

## Verification

- `cargo test -p runt --bin runt open_notebook_ -- --nocapture`
- `cargo test -p runt --bin runt -- --nocapture`
- `cargo xtask lint --fix`

## Context

Current `main` passed the top-level Build workflow after #2694, but the
non-blocking Windows matrix job failed because the test used `/tmp/notebook.ipynb`
as its absolute path fixture. On Windows that path normalizes to the current
drive root, so the test should construct a native absolute path instead.
