### PR TITLE
test(runtimed): use platform-native test paths

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -6846,6 +6846,9 @@ mod tests {
         std::fs::create_dir_all(&config.cache_dir).unwrap();
         let project_dir = config.cache_dir.join("runtimed-pixi-matching");
         let venv_path = project_dir.join(".pixi").join("envs").join("default");
+        #[cfg(target_os = "windows")]
+        let python_path = venv_path.join("python.exe");
+        #[cfg(not(target_os = "windows"))]
         let python_path = venv_path.join("bin").join("python");
         std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
         std::fs::write(&python_path, "").unwrap();

--- a/crates/runtimed/src/paths.rs
+++ b/crates/runtimed/src/paths.rs
@@ -163,14 +163,22 @@ mod tests {
 
     #[test]
     fn normalize_save_target_appends_extension() {
-        let result = normalize_save_target("/tmp/foo").unwrap();
-        assert_eq!(result, PathBuf::from("/tmp/foo.ipynb"));
+        let path = std::env::temp_dir().join("foo");
+        let target = path.to_string_lossy();
+
+        let result = normalize_save_target(&target).unwrap();
+
+        assert_eq!(result, PathBuf::from(format!("{target}.ipynb")));
     }
 
     #[test]
     fn normalize_save_target_preserves_extension() {
-        let result = normalize_save_target("/tmp/foo.ipynb").unwrap();
-        assert_eq!(result, PathBuf::from("/tmp/foo.ipynb"));
+        let path = std::env::temp_dir().join("foo.ipynb");
+        let target = path.to_string_lossy();
+
+        let result = normalize_save_target(&target).unwrap();
+
+        assert_eq!(result, path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make runtimed save-path tests use native absolute temporary paths
- make the Pixi pool recovery fixture create the platform-specific Python executable path

## Verification

- `cargo test -p runtimed normalize_save_target -- --nocapture`
- `cargo test -p runtimed find_existing_environments_recovers_pixi_matching_package_hash -- --nocapture`
- `cargo xtask lint --fix`

## Context

The final current-main Build run after #2695 still had a non-blocking Windows
matrix failure. The failing tests were Windows-only fixture shape issues:
`/tmp/...` was not accepted as an absolute save target on Windows, and the Pixi
pool recovery fixture created `bin/python` while the production Windows recovery
path expects `python.exe`.
