### PR TITLE
fix(protocol): retry busy Windows named pipes

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -6,6 +6,7 @@
 mod env;
 mod framing;
 mod handshake;
+mod pipe;
 
 pub use env::{CreateNotebookEnvironmentMode, EnvSource, LaunchSpec, PackageManager};
 
@@ -18,6 +19,9 @@ pub use framing::{
 pub use handshake::{
     Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4, PROTOCOL_VERSION,
 };
+
+#[cfg(windows)]
+pub use pipe::{connect_named_pipe_client, is_retryable_named_pipe_connect_error, ERROR_PIPE_BUSY};
 
 #[cfg(test)]
 mod tests {

--- a/crates/notebook-protocol/src/connection/pipe.rs
+++ b/crates/notebook-protocol/src/connection/pipe.rs
@@ -1,0 +1,70 @@
+//! Platform connection helpers shared by runtimed clients.
+
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::path::Path;
+#[cfg(windows)]
+use std::time::{Duration, Instant};
+
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+
+/// Windows ERROR_PIPE_BUSY.
+///
+/// Named-pipe clients can observe this while the daemon is accepting other
+/// connections. Treat it as transient the same way a not-yet-created pipe is
+/// transient during daemon startup.
+#[cfg(windows)]
+pub const ERROR_PIPE_BUSY: i32 = 231;
+
+#[cfg(windows)]
+pub fn is_retryable_named_pipe_connect_error(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::NotFound || error.raw_os_error() == Some(ERROR_PIPE_BUSY)
+}
+
+#[cfg(windows)]
+pub async fn connect_named_pipe_client(
+    socket_path: &Path,
+    timeout: Duration,
+) -> io::Result<NamedPipeClient> {
+    let pipe_name = socket_path.to_string_lossy().to_string();
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        match ClientOptions::new().open(&pipe_name) {
+            Ok(client) => return Ok(client),
+            Err(error) if is_retryable_named_pipe_connect_error(&error) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return Err(error);
+                }
+                tokio::time::sleep(remaining.min(Duration::from_millis(50))).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_named_pipe_connect_error_includes_pipe_busy() {
+        let error = io::Error::from_raw_os_error(ERROR_PIPE_BUSY);
+        assert!(is_retryable_named_pipe_connect_error(&error));
+    }
+
+    #[test]
+    fn retryable_named_pipe_connect_error_includes_not_found() {
+        let error = io::Error::new(io::ErrorKind::NotFound, "missing pipe");
+        assert!(is_retryable_named_pipe_connect_error(&error));
+    }
+
+    #[test]
+    fn retryable_named_pipe_connect_error_excludes_permission_denied() {
+        let error = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+        assert!(!is_retryable_named_pipe_connect_error(&error));
+    }
+}

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -106,7 +106,11 @@ macro_rules! connect_stream {
             }
             #[cfg(windows)]
             {
-                tokio::net::windows::named_pipe::ClientOptions::new().open(path)
+                notebook_protocol::connection::connect_named_pipe_client(
+                    path,
+                    std::time::Duration::from_secs(2),
+                )
+                .await
             }
         };
         match result {

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -49,9 +49,6 @@ pub enum DaemonProgress {
 #[cfg(unix)]
 use tokio::net::UnixStream;
 
-#[cfg(windows)]
-use tokio::net::windows::named_pipe::ClientOptions;
-
 /// Result of inspecting a notebook's state.
 #[derive(Debug, Clone)]
 pub struct InspectResult {
@@ -463,27 +460,17 @@ impl PoolClient {
 
         #[cfg(windows)]
         let stream = {
-            let pipe_name = self.socket_path.to_string_lossy().to_string();
-            let connect_result = tokio::time::timeout(self.connect_timeout, async {
-                // Named pipes may need retry if server is between connections
-                let mut attempts = 0;
-                loop {
-                    match ClientOptions::new().open(&pipe_name) {
-                        Ok(client) => return Ok(client),
-                        Err(_) if attempts < 5 => {
-                            attempts += 1;
-                            tokio::time::sleep(Duration::from_millis(50)).await;
-                        }
-                        Err(e) => return Err(e),
-                    }
+            match notebook_protocol::connection::connect_named_pipe_client(
+                &self.socket_path,
+                self.connect_timeout,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                    return Err(ClientError::Timeout);
                 }
-            })
-            .await;
-
-            match connect_result {
-                Ok(Ok(s)) => s,
-                Ok(Err(e)) => return Err(ClientError::ConnectionFailed(e)),
-                Err(_) => return Err(ClientError::Timeout),
+                Err(e) => return Err(ClientError::ConnectionFailed(e)),
             }
         };
 

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -133,24 +133,12 @@ impl SyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
         timeout: Duration,
     ) -> Result<Self, SyncClientError> {
         let pipe_name = socket_path.to_string_lossy().to_string();
-        // ERROR_PIPE_BUSY (231): all pipe instances are in use between server rotations
-        const ERROR_PIPE_BUSY: i32 = 231;
-        let client = tokio::time::timeout(timeout, async {
-            let mut attempts = 0;
-            loop {
-                match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-                    Ok(client) => return Ok(client),
-                    Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
-                        attempts += 1;
-                        tokio::time::sleep(Duration::from_millis(50)).await;
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-        })
-        .await
-        .map_err(|_| SyncClientError::Timeout)?
-        .map_err(SyncClientError::ConnectionFailed)?;
+        let client = connection::connect_named_pipe_client(&socket_path, timeout)
+            .await
+            .map_err(|error| match error.kind() {
+                std::io::ErrorKind::TimedOut => SyncClientError::Timeout,
+                _ => SyncClientError::ConnectionFailed(error),
+            })?;
 
         info!("[sync-client] Connected to {}", pipe_name);
 
@@ -174,23 +162,15 @@ impl SyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
     ) -> Result<Self, SyncClientError> {
         let deadline = snapshot_deadline(timeout);
         let pipe_name = socket_path.to_string_lossy().to_string();
-        const ERROR_PIPE_BUSY: i32 = 231;
-        let client = tokio::time::timeout(remaining_snapshot_timeout(deadline)?, async {
-            let mut attempts = 0;
-            loop {
-                match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-                    Ok(client) => return Ok(client),
-                    Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
-                        attempts += 1;
-                        tokio::time::sleep(Duration::from_millis(50)).await;
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-        })
+        let client = connection::connect_named_pipe_client(
+            &socket_path,
+            remaining_snapshot_timeout(deadline)?,
+        )
         .await
-        .map_err(|_| SyncClientError::Timeout)?
-        .map_err(SyncClientError::ConnectionFailed)?;
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::TimedOut => SyncClientError::Timeout,
+            _ => SyncClientError::ConnectionFailed(error),
+        })?;
 
         info!("[sync-client] Connected to {}", pipe_name);
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -634,18 +634,11 @@ async fn connect_and_handshake(
 
     #[cfg(windows)]
     let stream = {
-        let pipe_name = socket_path.to_string_lossy().to_string();
-        let mut attempts = 0u32;
-        loop {
-            match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-                Ok(client) => break client,
-                Err(_) if attempts < 10 => {
-                    attempts += 1;
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
+        notebook_protocol::connection::connect_named_pipe_client(
+            socket_path,
+            std::time::Duration::from_secs(2),
+        )
+        .await?
     };
 
     let (reader, mut writer) = tokio::io::split(stream);

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -210,20 +210,8 @@ async fn connect_raw_stream(socket_path: &std::path::Path) -> Result<RawStream, 
 
 #[cfg(windows)]
 async fn connect_raw_stream(socket_path: &std::path::Path) -> Result<RawStream, std::io::Error> {
-    const ERROR_PIPE_BUSY: i32 = 231;
-    let pipe_name = socket_path.to_string_lossy().to_string();
-    let mut attempts = 0;
-
-    loop {
-        match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
-            Ok(client) => return Ok(client),
-            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY) && attempts < 5 => {
-                attempts += 1;
-                sleep(Duration::from_millis(50)).await;
-            }
-            Err(err) => return Err(err),
-        }
-    }
+    notebook_protocol::connection::connect_named_pipe_client(socket_path, Duration::from_secs(2))
+        .await
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a shared Windows named-pipe connect helper in `notebook-protocol`
- retry transient `NotFound` and `ERROR_PIPE_BUSY` while preserving the final OS error after the retry budget
- route notebook sync, pool client, settings sync, runtime agent, and raw integration-test connects through the same helper

## Verification

- `cargo test -p notebook-protocol -p runtimed-client -p runtimed-settings-sync`
- `cargo test -p notebook-sync test_connect_to_missing_socket_returns_daemon_unavailable -- --nocapture`
- `cargo test -p notebook-sync`
- `cargo test -p runtimed --test integration test_multiple_notebooks_concurrent_isolation -- --nocapture`
- `cargo xtask lint --fix`
