### PR TITLE
refactor(sync): flatten async outcome handling

### DIFF
--- a/crates/runtimed/src/async_outcome.rs
+++ b/crates/runtimed/src/async_outcome.rs
@@ -1,0 +1,98 @@
+use std::time::Duration;
+
+use tokio::{sync::oneshot, task::JoinError};
+
+/// Outcome of waiting for a one-shot reply with a timeout.
+///
+/// This flattens `timeout(duration, rx).await` from
+/// `Result<Result<T, oneshot::error::RecvError>, Elapsed>` into the three
+/// states callers actually care about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TimedOneShot<T> {
+    Received(T),
+    SenderDropped,
+    TimedOut,
+}
+
+pub(crate) async fn recv_oneshot_with_timeout<T>(
+    rx: oneshot::Receiver<T>,
+    timeout: Duration,
+) -> TimedOneShot<T> {
+    match tokio::time::timeout(timeout, rx).await {
+        Ok(Ok(value)) => TimedOneShot::Received(value),
+        Ok(Err(_)) => TimedOneShot::SenderDropped,
+        Err(_) => TimedOneShot::TimedOut,
+    }
+}
+
+/// Outcome of a task whose `JoinHandle` itself returns `Result<T, E>`.
+#[derive(Debug)]
+pub(crate) enum JoinedResult<T, E> {
+    Completed(T),
+    Failed(E),
+    JoinFailed(JoinError),
+}
+
+pub(crate) fn flatten_joined_result<T, E>(
+    result: Result<Result<T, E>, JoinError>,
+) -> JoinedResult<T, E> {
+    match result {
+        Ok(Ok(value)) => JoinedResult::Completed(value),
+        Ok(Err(error)) => JoinedResult::Failed(error),
+        Err(error) => JoinedResult::JoinFailed(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn receives_value_before_timeout() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(7).expect("send value");
+
+        let outcome = recv_oneshot_with_timeout(rx, Duration::from_secs(1)).await;
+
+        assert_eq!(outcome, TimedOneShot::Received(7));
+    }
+
+    #[tokio::test]
+    async fn reports_dropped_sender() {
+        let (tx, rx) = oneshot::channel::<()>();
+        drop(tx);
+
+        let outcome = recv_oneshot_with_timeout(rx, Duration::from_secs(1)).await;
+
+        assert_eq!(outcome, TimedOneShot::SenderDropped);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reports_timeout() {
+        let (_tx, rx) = oneshot::channel::<()>();
+
+        let outcome = recv_oneshot_with_timeout(rx, Duration::from_secs(5)).await;
+
+        assert_eq!(outcome, TimedOneShot::TimedOut);
+    }
+
+    #[test]
+    fn flattens_joined_success() {
+        let result = Ok::<_, JoinError>(Ok::<_, &'static str>(7));
+
+        match flatten_joined_result(result) {
+            JoinedResult::Completed(value) => assert_eq!(value, 7),
+            other => panic!("expected completed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flattens_joined_task_error() {
+        let result = Ok::<_, JoinError>(Err::<(), _>("task error"));
+
+        match flatten_joined_result(result) {
+            JoinedResult::Failed(error) => assert_eq!(error, "task error"),
+            other => panic!("expected failed, got {other:?}"),
+        }
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -24,6 +24,7 @@ pub use runtimed_settings_sync as sync_client;
 // Server-only modules (not in runtimed-client)
 // ============================================================================
 
+pub(crate) mod async_outcome;
 pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
 use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle, TrustRuntimeState};
 
 pub struct TrustState {
@@ -3885,16 +3886,16 @@ pub(crate) async fn auto_launch_kernel(
                 }
 
                 // Wait for THIS runtime agent to establish its sync connection
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(30),
+                match recv_oneshot_with_timeout(
                     runtime_agent_connect_rx,
+                    std::time::Duration::from_secs(30),
                 )
                 .await
                 {
-                    Ok(Ok(())) => {
+                    TimedOneShot::Received(()) => {
                         info!("[notebook-sync] Agent connected, sending LaunchKernel");
                     }
-                    Ok(Err(_)) => {
+                    TimedOneShot::SenderDropped => {
                         // Oneshot sender dropped — runtime agent died or was
                         // superseded by a newer spawn before connecting.
                         warn!(
@@ -3903,7 +3904,7 @@ pub(crate) async fn auto_launch_kernel(
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return;
                     }
-                    Err(_) => {
+                    TimedOneShot::TimedOut => {
                         warn!("[notebook-sync] Agent failed to connect within 30s");
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return;

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tracing::{debug, info, warn};
 
+use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
 use crate::task_supervisor::spawn_best_effort;
 
 use super::{
@@ -97,13 +98,13 @@ pub(super) async fn handle_peer_disconnect(
                 if let Some(ref d) = room_for_eviction.persistence.debouncer {
                     let (ack_tx, ack_rx) = oneshot::channel::<bool>();
                     if d.flush_request_tx.send(ack_tx).is_ok() {
-                        match tokio::time::timeout(FLUSH_TIMEOUT, ack_rx).await {
-                            Ok(Ok(true)) => {}
-                            Ok(Ok(false)) => {
+                        match recv_oneshot_with_timeout(ack_rx, FLUSH_TIMEOUT).await {
+                            TimedOneShot::Received(true) => {}
+                            TimedOneShot::Received(false) => {
                                 flush_ok = false;
                                 flush_failure_kind = Some("write error");
                             }
-                            Ok(Err(_)) => {
+                            TimedOneShot::SenderDropped => {
                                 // Debouncer dropped the ack sender without
                                 // replying — task already exited (e.g. a
                                 // previous eviction flushed and closed). Any
@@ -113,7 +114,7 @@ pub(super) async fn handle_peer_disconnect(
                                     notebook_id_for_eviction
                                 );
                             }
-                            Err(_) => {
+                            TimedOneShot::TimedOut => {
                                 flush_ok = false;
                                 flush_failure_kind = Some("timeout");
                             }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -5,6 +5,8 @@ use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFram
 use notebook_protocol::protocol::RuntimeAgentResponse;
 use tracing::{debug, info, warn};
 
+use crate::async_outcome::{flatten_joined_result, JoinedResult};
+
 use super::peer_runtime_sync::{persist_terminal_execution_records, runtime_file_save_fingerprint};
 use super::peer_writer::spawn_peer_writer;
 use super::{NotebookRoom, RuntimeAgentMessage, STATE_SYNC_COMPACT_THRESHOLD};
@@ -166,14 +168,14 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
             biased;
 
             writer_result = &mut writer_task.handle => {
-                match writer_result {
-                    Ok(Ok(())) => {
+                match flatten_joined_result(writer_result) {
+                    JoinedResult::Completed(()) => {
                         info!("[notebook-sync] Runtime agent writer closed cleanly: {}", runtime_agent_id);
                     }
-                    Ok(Err(e)) => {
+                    JoinedResult::Failed(e) => {
                         warn!("[notebook-sync] Runtime agent writer failed for {}: {}", runtime_agent_id, e);
                     }
-                    Err(e) => {
+                    JoinedResult::JoinFailed(e) => {
                         warn!("[notebook-sync] Runtime agent writer task stopped for {}: {}", runtime_agent_id, e);
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
 
 /// Per-room identity.
 ///
@@ -235,15 +236,15 @@ impl NotebookFileBinding {
             if previous_tx.send(ack_tx).is_err() {
                 return;
             }
-            match tokio::time::timeout(std::time::Duration::from_secs(5), ack_rx).await {
-                Ok(Ok(true)) => {}
-                Ok(Ok(false)) => {
+            match recv_oneshot_with_timeout(ack_rx, std::time::Duration::from_secs(5)).await {
+                TimedOneShot::Received(true) => {}
+                TimedOneShot::Received(false) => {
                     warn!("[autosave] Replaced autosave task reported failed shutdown");
                 }
-                Ok(Err(_)) => {
+                TimedOneShot::SenderDropped => {
                     warn!("[autosave] Replaced autosave task dropped shutdown ack");
                 }
-                Err(_) => {
+                TimedOneShot::TimedOut => {
                     warn!("[autosave] Timed out waiting for replaced autosave task shutdown");
                 }
             }
@@ -265,17 +266,17 @@ impl NotebookFileBinding {
             return true;
         }
 
-        match tokio::time::timeout(timeout, ack_rx).await {
-            Ok(Ok(true)) => true,
-            Ok(Ok(false)) => false,
-            Ok(Err(_)) => {
+        match recv_oneshot_with_timeout(ack_rx, timeout).await {
+            TimedOneShot::Received(true) => true,
+            TimedOneShot::Received(false) => false,
+            TimedOneShot::SenderDropped => {
                 warn!(
                     "[autosave] Shutdown ack dropped for {} before final save completed",
                     notebook_id
                 );
                 false
             }
-            Err(_) => {
+            TimedOneShot::TimedOut => {
                 warn!(
                     "[autosave] Timed out waiting for final save during shutdown of {}",
                     notebook_id

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -14,6 +14,7 @@ use notebook_doc::presence;
 use notebook_protocol::connection::{EnvSource, LaunchSpec, PackageManager};
 use runtime_doc::{KernelActivity, KernelErrorReason, RuntimeLifecycle};
 
+use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
 use crate::daemon::Daemon;
 use crate::notebook_sync_server::{
     acquire_prewarmed_env_with_capture, build_launched_config, captured_env_for_runtime,
@@ -1581,21 +1582,21 @@ pub(crate) async fn handle(
                 }
 
                 // Wait for THIS runtime agent to connect back via socket
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(30),
+                match recv_oneshot_with_timeout(
                     runtime_agent_connect_rx,
+                    std::time::Duration::from_secs(30),
                 )
                 .await
                 {
-                    Ok(Ok(())) => {}
-                    Ok(Err(_)) => {
+                    TimedOneShot::Received(()) => {}
+                    TimedOneShot::SenderDropped => {
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return NotebookResponse::Error {
                             error: "Runtime agent connect cancelled (superseded or died)"
                                 .to_string(),
                         };
                     }
-                    Err(_) => {
+                    TimedOneShot::TimedOut => {
                         reset_starting_state(room, Some(&runtime_agent_id)).await;
                         return NotebookResponse::Error {
                             error: "Agent failed to connect within 30s".to_string(),


### PR DESCRIPTION
## Summary

- add a small `runtimed` internal helper for flattened timeout/oneshot and joined task outcomes
- replace repeated `Ok(Ok(...))` / `Ok(Err(...))` handling in runtime-agent connection, writer, autosave shutdown, and eviction-flush paths
- keep each caller's existing explicit state handling while making the states named and test-covered

## Verification

- `cargo test -p runtimed async_outcome -- --nocapture`
- `cargo test -p runtimed --test integration test_settings_json_mirror_write_does_not_feedback_loop -- --nocapture`
- `cargo test -p runtimed`
- `cargo xtask lint --fix`

## Notes

The Automerge-specific panic/result path was already flattened through `AutomergeAttempt`; this PR narrows the same style to nearby Tokio sync plumbing without changing behavior.
