### PR TITLE
refactor(sync): flatten remaining async outcomes

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -34,6 +34,24 @@ const DEFAULT_ACTOR_LABEL: &str = "runtimed-py";
 /// Remote cursor info: (peer_id, peer_label, cell_id, line, column).
 pub(crate) type RemoteCursor = (String, String, String, u32, u32);
 
+#[derive(Debug)]
+enum TimedExecution<T> {
+    Completed(T),
+    Failed(PyErr),
+    TimedOut,
+}
+
+async fn execute_with_timeout<T, F>(future: F, timeout: std::time::Duration) -> TimedExecution<T>
+where
+    F: std::future::Future<Output = PyResult<T>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(value)) => TimedExecution::Completed(value),
+        Ok(Err(error)) => TimedExecution::Failed(error),
+        Err(_) => TimedExecution::TimedOut,
+    }
+}
+
 // =========================================================================
 // Shared state
 // =========================================================================
@@ -1300,19 +1318,22 @@ pub(crate) async fn execute_cell(
     timeout_secs: f64,
 ) -> PyResult<ExecutionResult> {
     let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-    let result = tokio::time::timeout(timeout, async {
-        // queue_cell is the single primitive: auto-starts kernel, confirms
-        // sync, sends ExecuteCell request, emits focus presence.
-        let execution_id = queue_cell(state, notebook_id, cell_id).await?;
+    let execution = execute_with_timeout(
+        async {
+            // queue_cell is the single primitive: auto-starts kernel, confirms
+            // sync, sends ExecuteCell request, emits focus presence.
+            let execution_id = queue_cell(state, notebook_id, cell_id).await?;
 
-        wait_for_execution(state, cell_id, &execution_id, timeout_secs).await
-    })
+            wait_for_execution(state, cell_id, &execution_id, timeout_secs).await
+        },
+        timeout,
+    )
     .await;
 
-    match result {
-        Ok(Ok(exec_result)) => Ok(exec_result),
-        Ok(Err(e)) => Err(e),
-        Err(_) => Err(to_py_err(format!(
+    match execution {
+        TimedExecution::Completed(exec_result) => Ok(exec_result),
+        TimedExecution::Failed(e) => Err(e),
+        TimedExecution::TimedOut => Err(to_py_err(format!(
             "Execution timed out after {} seconds",
             timeout_secs
         ))),
@@ -2401,6 +2422,52 @@ mod tests {
         let a = make_actor_label("Claude");
         let b = make_actor_label("Claude");
         assert_ne!(a, b, "each call should produce a unique session suffix");
+    }
+
+    #[tokio::test]
+    async fn execute_with_timeout_reports_success() {
+        let result = execute_with_timeout(
+            async { Ok::<_, PyErr>(7) },
+            std::time::Duration::from_secs(1),
+        )
+        .await;
+
+        match result {
+            TimedExecution::Completed(value) => assert_eq!(value, 7),
+            other => panic!("expected completed execution, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_with_timeout_reports_error() {
+        Python::initialize();
+
+        let result = execute_with_timeout(
+            async { Err::<(), _>(to_py_err("execution failed")) },
+            std::time::Duration::from_secs(1),
+        )
+        .await;
+
+        match result {
+            TimedExecution::Failed(error) => {
+                assert!(error.to_string().contains("execution failed"));
+            }
+            other => panic!("expected failed execution, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_with_timeout_reports_timeout() {
+        let result = execute_with_timeout(
+            std::future::pending::<PyResult<()>>(),
+            std::time::Duration::ZERO,
+        )
+        .await;
+
+        match result {
+            TimedExecution::TimedOut => {}
+            other => panic!("expected timed out execution, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/async_outcome.rs
+++ b/crates/runtimed/src/async_outcome.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 use tokio::{sync::oneshot, task::JoinError};
 
@@ -22,6 +22,32 @@ pub(crate) async fn recv_oneshot_with_timeout<T>(
         Ok(Ok(value)) => TimedOneShot::Received(value),
         Ok(Err(_)) => TimedOneShot::SenderDropped,
         Err(_) => TimedOneShot::TimedOut,
+    }
+}
+
+/// Outcome of waiting for a fallible future with a timeout.
+///
+/// This flattens `timeout(duration, future_returning_result).await` from
+/// `Result<Result<T, E>, Elapsed>` into the three states callers actually
+/// care about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TimedResult<T, E> {
+    Completed(T),
+    Failed(E),
+    TimedOut,
+}
+
+pub(crate) async fn await_result_with_timeout<T, E, F>(
+    future: F,
+    timeout: Duration,
+) -> TimedResult<T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(value)) => TimedResult::Completed(value),
+        Ok(Err(error)) => TimedResult::Failed(error),
+        Err(_) => TimedResult::TimedOut,
     }
 }
 
@@ -74,6 +100,38 @@ mod tests {
         let outcome = recv_oneshot_with_timeout(rx, Duration::from_secs(5)).await;
 
         assert_eq!(outcome, TimedOneShot::TimedOut);
+    }
+
+    #[tokio::test]
+    async fn awaits_fallible_future_success() {
+        let outcome =
+            await_result_with_timeout(async { Ok::<_, &'static str>(7) }, Duration::from_secs(1))
+                .await;
+
+        assert_eq!(outcome, TimedResult::Completed(7));
+    }
+
+    #[tokio::test]
+    async fn awaits_fallible_future_error() {
+        let outcome =
+            await_result_with_timeout(async { Err::<(), _>("failed") }, Duration::from_secs(1))
+                .await;
+
+        assert_eq!(outcome, TimedResult::Failed("failed"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn awaits_fallible_future_timeout() {
+        let outcome = await_result_with_timeout(
+            async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Ok::<_, &'static str>(())
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert_eq!(outcome, TimedResult::TimedOut);
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -24,6 +24,7 @@ use tokio::net::windows::named_pipe::ServerOptions;
 
 use tokio::sync::RwLock;
 
+use crate::async_outcome::{await_result_with_timeout, TimedResult};
 use crate::blob_server;
 use crate::blob_store::BlobStore;
 use crate::notebook_sync_server::{NotebookRooms, PathIndex};
@@ -530,7 +531,7 @@ async fn absorb_rapid_settings_signals(
     rx: &mut tokio::sync::broadcast::Receiver<()>,
     quiet: std::time::Duration,
 ) {
-    while let Ok(Ok(())) = tokio::time::timeout(quiet, rx.recv()).await {}
+    while let TimedResult::Completed(()) = await_result_with_timeout(rx.recv(), quiet).await {}
 }
 
 impl Pool {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -28,6 +28,9 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+use crate::async_outcome::{
+    await_result_with_timeout, recv_oneshot_with_timeout, TimedOneShot, TimedResult,
+};
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
 use crate::output_prep::{
     apply_display_manifest_updates, blob_store_large_state_values, build_display_manifest_updates,
@@ -208,14 +211,14 @@ impl InterruptHandle {
 
         info!("[jupyter-kernel] Sent interrupt_request (via handle)");
 
-        match tokio::time::timeout(std::time::Duration::from_secs(5), control.read()).await {
-            Ok(Ok(_reply)) => {
+        match await_result_with_timeout(control.read(), std::time::Duration::from_secs(5)).await {
+            TimedResult::Completed(_reply) => {
                 info!("[jupyter-kernel] Received interrupt_reply");
             }
-            Ok(Err(e)) => {
+            TimedResult::Failed(e) => {
                 warn!("[jupyter-kernel] Error receiving interrupt_reply: {}", e);
             }
-            Err(_) => {
+            TimedResult::TimedOut => {
                 warn!("[jupyter-kernel] Timed out waiting for interrupt_reply (5s)");
             }
         }
@@ -2369,11 +2372,11 @@ impl KernelConnection for JupyterKernel {
         }
 
         let reply = tokio::select! {
-            result = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()) => {
+            result = await_result_with_timeout(shell.read(), std::time::Duration::from_secs(30)) => {
                 match result {
-                    Ok(Ok(msg)) => Ok(msg),
-                    Ok(Err(e)) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
-                    Err(_) => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
+                    TimedResult::Completed(msg) => Ok(msg),
+                    TimedResult::Failed(e) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
+                    TimedResult::TimedOut => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
                 }
             }
             died_msg = died_rx => {
@@ -2619,8 +2622,8 @@ impl KernelConnection for JupyterKernel {
                         hb.single_heartbeat().await
                     };
 
-                    let failure = match tokio::time::timeout(HEARTBEAT_TIMEOUT, check).await {
-                        Ok(Ok(())) => {
+                    let failure = match await_result_with_timeout(check, HEARTBEAT_TIMEOUT).await {
+                        TimedResult::Completed(()) => {
                             if consecutive_failures > 0 {
                                 info!(
                                     "[jupyter-kernel] Heartbeat recovered: kernel_id={} kernel_type={} env_source={} pid={:?} previous_failures={} launch_elapsed_ms={}",
@@ -2635,10 +2638,10 @@ impl KernelConnection for JupyterKernel {
                             consecutive_failures = 0;
                             continue;
                         }
-                        Ok(Err(e)) => {
+                        TimedResult::Failed(e) => {
                             format!("connection error: {e}")
                         }
-                        Err(_) => {
+                        TimedResult::TimedOut => {
                             format!("timeout after {}ms", HEARTBEAT_TIMEOUT.as_millis())
                         }
                     };
@@ -2864,14 +2867,14 @@ impl KernelConnection for JupyterKernel {
         info!("[jupyter-kernel] Sent interrupt_request");
 
         // Wait for acknowledgement with timeout
-        match tokio::time::timeout(std::time::Duration::from_secs(5), control.read()).await {
-            Ok(Ok(_reply)) => {
+        match await_result_with_timeout(control.read(), std::time::Duration::from_secs(5)).await {
+            TimedResult::Completed(_reply) => {
                 info!("[jupyter-kernel] Received interrupt_reply");
             }
-            Ok(Err(e)) => {
+            TimedResult::Failed(e) => {
                 warn!("[jupyter-kernel] Error receiving interrupt_reply: {}", e);
             }
-            Err(_) => {
+            TimedResult::TimedOut => {
                 warn!("[jupyter-kernel] Timed out waiting for interrupt_reply (5s)");
             }
         }
@@ -3106,10 +3109,10 @@ impl KernelConnection for JupyterKernel {
         debug!("[jupyter-kernel] Sent complete_request: msg_id={}", msg_id);
 
         // Wait for response with timeout (shell reader task will resolve via pending_completions)
-        match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-            Ok(Ok(result)) => Ok(result),
-            Ok(Err(_)) => Err(anyhow::anyhow!("Completion request cancelled")),
-            Err(_) => {
+        match recv_oneshot_with_timeout(rx, std::time::Duration::from_secs(5)).await {
+            TimedOneShot::Received(result) => Ok(result),
+            TimedOneShot::SenderDropped => Err(anyhow::anyhow!("Completion request cancelled")),
+            TimedOneShot::TimedOut => {
                 if let Ok(mut guard) = pending.lock() {
                     guard.remove(&msg_id);
                 }
@@ -3171,13 +3174,13 @@ impl KernelConnection for JupyterKernel {
         shell.send(message).await?;
         debug!("[jupyter-kernel] Sent history_request: msg_id={}", msg_id);
 
-        match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
-            Ok(Ok(entries)) => {
+        match recv_oneshot_with_timeout(rx, std::time::Duration::from_secs(5)).await {
+            TimedOneShot::Received(entries) => {
                 self.history_cache.insert(cache_key, n, entries.clone());
                 Ok(entries)
             }
-            Ok(Err(_)) => Err(anyhow::anyhow!("History request cancelled")),
-            Err(_) => {
+            TimedOneShot::SenderDropped => Err(anyhow::anyhow!("History request cancelled")),
+            TimedOneShot::TimedOut => {
                 if let Ok(mut guard) = pending.lock() {
                     guard.remove(&msg_id);
                 }

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -11,6 +11,7 @@ use std::process::Stdio;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
+use crate::async_outcome::{await_result_with_timeout, TimedResult};
 use crate::EnvType;
 
 // -- IPC protocol --------------------------------------------------------
@@ -205,10 +206,10 @@ async fn run_uv_pip_install(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    match tokio::time::timeout(timeout, command.output()).await {
-        Ok(Ok(output)) => UvInstallAttempt::Completed(output),
-        Ok(Err(e)) => UvInstallAttempt::SpawnError(e),
-        Err(_) => UvInstallAttempt::Timeout,
+    match await_result_with_timeout(command.output(), timeout).await {
+        TimedResult::Completed(output) => UvInstallAttempt::Completed(output),
+        TimedResult::Failed(e) => UvInstallAttempt::SpawnError(e),
+        TimedResult::TimedOut => UvInstallAttempt::Timeout,
     }
 }
 
@@ -278,8 +279,7 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
 
     // Create venv
     progress("venv", "creating virtual environment");
-    let venv_result = tokio::time::timeout(
-        std::time::Duration::from_secs(60),
+    let venv_result = await_result_with_timeout(
         tokio::process::Command::new(&uv_path)
             .arg("venv")
             .arg(env_dir)
@@ -288,12 +288,13 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output(),
+        std::time::Duration::from_secs(60),
     )
     .await;
 
     match venv_result {
-        Ok(Ok(output)) if output.status.success() => {}
-        Ok(Ok(output)) => {
+        TimedResult::Completed(output) if output.status.success() => {}
+        TimedResult::Completed(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             emit_failure(
                 format!("Failed to create venv: {stderr}"),
@@ -302,11 +303,11 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
             );
             return;
         }
-        Ok(Err(e)) => {
+        TimedResult::Failed(e) => {
             emit_failure(format!("Failed to create venv: {e}"), "setup_failed", None);
             return;
         }
-        Err(_) => {
+        TimedResult::TimedOut => {
             emit_failure(
                 "Timeout creating venv after 60 seconds".into(),
                 "timeout",
@@ -373,21 +374,21 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
     let warmup_script =
         kernel_env::warmup::build_warmup_command(packages, false, site_packages.as_deref());
 
-    let warmup_result = tokio::time::timeout(
-        std::time::Duration::from_secs(180),
+    let warmup_result = await_result_with_timeout(
         tokio::process::Command::new(&python_path)
             .args(["-c", &warmup_script])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output(),
+        std::time::Duration::from_secs(180),
     )
     .await;
 
     match warmup_result {
-        Ok(Ok(output)) if output.status.success() => {
+        TimedResult::Completed(output) if output.status.success() => {
             tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
         }
-        Ok(Ok(output)) => {
+        TimedResult::Completed(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             cleanup_and_fail(
                 env_dir,
@@ -401,7 +402,7 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
             .await;
             return;
         }
-        Ok(Err(e)) => {
+        TimedResult::Failed(e) => {
             cleanup_and_fail(
                 env_dir,
                 format!("UV warmup failed: {e}"),
@@ -411,7 +412,7 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
             .await;
             return;
         }
-        Err(_) => {
+        TimedResult::TimedOut => {
             cleanup_and_fail(env_dir, "UV warmup timed out".into(), "timeout", None).await;
             return;
         }
@@ -648,21 +649,21 @@ async fn create_conda(env_dir: &Path, packages: &[String], channels: &[String]) 
     let warmup_script =
         kernel_env::warmup::build_warmup_command(packages, true, site_packages.as_deref());
 
-    let warmup_result = tokio::time::timeout(
-        std::time::Duration::from_secs(180),
+    let warmup_result = await_result_with_timeout(
         tokio::process::Command::new(&python_path)
             .args(["-c", &warmup_script])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output(),
+        std::time::Duration::from_secs(180),
     )
     .await;
 
     match warmup_result {
-        Ok(Ok(output)) if output.status.success() => {
+        TimedResult::Completed(output) if output.status.success() => {
             tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
         }
-        Ok(Ok(output)) => {
+        TimedResult::Completed(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             cleanup_and_fail(
                 env_dir,
@@ -676,7 +677,7 @@ async fn create_conda(env_dir: &Path, packages: &[String], channels: &[String]) 
             .await;
             return;
         }
-        Ok(Err(e)) => {
+        TimedResult::Failed(e) => {
             cleanup_and_fail(
                 env_dir,
                 format!("Conda warmup failed: {e}"),
@@ -686,7 +687,7 @@ async fn create_conda(env_dir: &Path, packages: &[String], channels: &[String]) 
             .await;
             return;
         }
-        Err(_) => {
+        TimedResult::TimedOut => {
             cleanup_and_fail(env_dir, "Conda warmup timed out".into(), "timeout", None).await;
             return;
         }


### PR DESCRIPTION
## Summary

Flatten the remaining production `timeout(...).await` nested-result handling in the daemon/runtime paths into named outcomes:

- add `TimedResult::{Completed, Failed, TimedOut}` beside the existing async outcome helpers
- apply it to Jupyter interrupt, kernel-info, heartbeat, warm-env subprocess timeout, and settings debounce paths
- keep completion/history oneshot cleanup explicit through `TimedOneShot`
- flatten the Python binding execution timeout path with local `TimedExecution` states

The intent is to keep explicit error/timeout handling while removing call-site `Ok(Ok(value))` / `Ok(Err(source))` plucks from the steady-state code.

## Verification

- `cargo check -p runtimed`
- `cargo check -p runtimed-py`
- `cargo test -p runtimed --lib async_outcome -- --nocapture`
- `cargo test -p runtimed`
- `cargo fmt --check`
- `git diff --check`
- `cargo xtask lint --fix`
- Bedrock branch-diff audit: clear, no actionable findings

Note: `cargo test -p runtimed-py execute_with_timeout -- --nocapture` is blocked locally by the existing macOS PyO3 linker setup (`Py_DecRef` and related Python API symbols unresolved). `cargo check -p runtimed-py` passes, and CI's Python binding jobs should be the meaningful full signal for this path.
