### PR TITLE
fix(runtimed): coalesce noisy stream output flushes

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -39,6 +39,7 @@ use crate::output_prep::{
 };
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
+use crate::stream_flush::{PendingStreamFlush, StreamFlushBuffer};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
@@ -187,6 +188,82 @@ fn history_cache_value_satisfies_limit(value: &HistoryCacheValue, limit: i32) ->
 enum IoPubStateUpdate {
     Activity(KernelActivity),
     Lifecycle(RuntimeLifecycle),
+}
+
+async fn flush_stream_output(
+    state: &runtime_doc::RuntimeStateHandle,
+    blob_store: &crate::blob_store::BlobStore,
+    stream_terminals: &Arc<tokio::sync::Mutex<StreamTerminals>>,
+    kernel_actor_id: &str,
+    flush: PendingStreamFlush,
+) {
+    let known_state = {
+        let terminals = stream_terminals.lock().await;
+        terminals
+            .get_output_state(&flush.execution_id, &flush.stream_name)
+            .cloned()
+    };
+
+    let nbformat_value = serde_json::json!({
+        "output_type": "stream",
+        "name": flush.stream_name,
+        "text": flush.rendered_text,
+    });
+
+    let manifest =
+        match output_store::create_manifest(&nbformat_value, blob_store, DEFAULT_INLINE_THRESHOLD)
+            .await
+        {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                warn!("[jupyter-kernel] Failed to create stream manifest: {}", e);
+                return;
+            }
+        };
+    let manifest_json = manifest.to_json();
+
+    let blob_hash = if let OutputManifest::Stream { ref text, .. } = manifest {
+        match text {
+            ContentRef::Blob { blob, .. } => blob.clone(),
+            ContentRef::Inline { inline } => inline.clone(),
+        }
+    } else {
+        String::new()
+    };
+
+    let upsert_result = match state.transact_at_current_heads(
+        Some(kernel_actor_id),
+        "runtime-state-iopub-stream-transaction",
+        |sd| match sd.upsert_stream_output(
+            &flush.execution_id,
+            &flush.stream_name,
+            &manifest_json,
+            known_state.as_ref(),
+        ) {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                warn!("[jupyter-kernel] Failed to upsert stream output: {}", e);
+                Err(e)
+            }
+        },
+    ) {
+        Ok(result) => result,
+        Err(e) => {
+            warn!("[runtime-state] {}", e);
+            return;
+        }
+    };
+
+    let (_updated, output_id) = upsert_result;
+    let mut terminals = stream_terminals.lock().await;
+    terminals.set_output_state(
+        &flush.execution_id,
+        &flush.stream_name,
+        StreamOutputState {
+            output_id,
+            blob_hash,
+        },
+    );
 }
 
 /// Created at kernel launch time, captures connection_info and session_id.
@@ -1203,6 +1280,7 @@ impl KernelConnection for JupyterKernel {
                     std::collections::HashMap::new();
 
                 let comm_coalesce_tx = comm_coalesce_tx_for_iopub;
+                let mut stream_flushes = StreamFlushBuffer::default();
 
                 loop {
                     match iopub.read().await {
@@ -1280,6 +1358,22 @@ impl KernelConnection for JupyterKernel {
                                     if status.execution_state
                                         == jupyter_protocol::ExecutionState::Idle
                                     {
+                                        if let Some(eid) = execution_id.as_ref() {
+                                            for flush in stream_flushes
+                                                .flush_execution(eid, std::time::Instant::now())
+                                            {
+                                                flush_stream_output(
+                                                    &state_for_iopub,
+                                                    &blob_store,
+                                                    &iopub_stream_terminals,
+                                                    &iopub_kernel_actor_id,
+                                                    flush,
+                                                )
+                                                .await;
+                                            }
+                                            stream_flushes.clear_execution(eid);
+                                        }
+
                                         if let Err(e) =
                                             iopub_cmd_tx.try_send(QueueCommand::KernelIdle {
                                                 execution_id: execution_id.clone(),
@@ -1443,91 +1537,27 @@ impl KernelConnection for JupyterKernel {
                                         };
                                         let eid = execution_id.clone().unwrap_or_default();
 
-                                        let (rendered_text, known_state) = {
+                                        let rendered_text = {
                                             let mut terminals = iopub_stream_terminals.lock().await;
-                                            let text =
-                                                terminals.feed(&eid, stream_name, &stream.text);
-                                            let state = terminals
-                                                .get_output_state(&eid, stream_name)
-                                                .cloned();
-                                            (text, state)
+                                            terminals.feed(&eid, stream_name, &stream.text)
                                         };
 
-                                        let nbformat_value = serde_json::json!({
-                                            "output_type": "stream",
-                                            "name": stream_name,
-                                            "text": rendered_text
-                                        });
-
-                                        let manifest = match output_store::create_manifest(
-                                            &nbformat_value,
-                                            &blob_store,
-                                            DEFAULT_INLINE_THRESHOLD,
-                                        )
-                                        .await
-                                        {
-                                            Ok(m) => m,
-                                            Err(e) => {
-                                                warn!(
-                                                "[jupyter-kernel] Failed to create stream manifest: {}",
-                                                e
-                                            );
-                                                continue;
-                                            }
-                                        };
-                                        let manifest_json = manifest.to_json();
-
-                                        let blob_hash =
-                                            if let OutputManifest::Stream { ref text, .. } =
-                                                manifest
-                                            {
-                                                match text {
-                                                    ContentRef::Blob { blob, .. } => blob.clone(),
-                                                    ContentRef::Inline { inline } => inline.clone(),
-                                                }
-                                            } else {
-                                                String::new()
-                                            };
-
-                                        let upsert_result = match state_for_iopub
-                                            .transact_at_current_heads(
-                                                Some(&iopub_kernel_actor_id),
-                                                "runtime-state-iopub-stream-transaction",
-                                                |sd| {
-                                                    match sd.upsert_stream_output(
-                                                        &eid,
-                                                        stream_name,
-                                                        &manifest_json,
-                                                        known_state.as_ref(),
-                                                    ) {
-                                                        Ok(result) => Ok(result),
-                                                        Err(e) => {
-                                                            warn!(
-                                                                "[jupyter-kernel] Failed to upsert stream output: {}",
-                                                                e
-                                                            );
-                                                            Err(e)
-                                                        }
-                                                    }
-                                                },
-                                            ) {
-                                            Ok(result) => result,
-                                            Err(e) => {
-                                                warn!("[runtime-state] {}", e);
-                                                continue;
-                                            }
-                                        };
-
-                                        let (_updated, output_id) = upsert_result;
-                                        let mut terminals = iopub_stream_terminals.lock().await;
-                                        terminals.set_output_state(
+                                        if let Some(flush) = stream_flushes.record_chunk(
                                             &eid,
                                             stream_name,
-                                            StreamOutputState {
-                                                output_id,
-                                                blob_hash: blob_hash.clone(),
-                                            },
-                                        );
+                                            rendered_text,
+                                            stream.text.len(),
+                                            std::time::Instant::now(),
+                                        ) {
+                                            flush_stream_output(
+                                                &state_for_iopub,
+                                                &blob_store,
+                                                &iopub_stream_terminals,
+                                                &iopub_kernel_actor_id,
+                                                flush,
+                                            )
+                                            .await;
+                                        }
                                     }
                                 }
 
@@ -1654,6 +1684,20 @@ impl KernelConnection for JupyterKernel {
                                             _ => "unknown",
                                         };
                                         let eid = execution_id.clone().unwrap_or_default();
+
+                                        for flush in stream_flushes
+                                            .flush_execution(&eid, std::time::Instant::now())
+                                        {
+                                            flush_stream_output(
+                                                &state_for_iopub,
+                                                &blob_store,
+                                                &iopub_stream_terminals,
+                                                &iopub_kernel_actor_id,
+                                                flush,
+                                            )
+                                            .await;
+                                        }
+                                        stream_flushes.clear_execution(&eid);
 
                                         {
                                             let mut terminals = iopub_stream_terminals.lock().await;
@@ -1922,6 +1966,20 @@ impl KernelConnection for JupyterKernel {
 
                                     if let Some(ref cid) = cell_id {
                                         let eid = execution_id.clone().unwrap_or_default();
+
+                                        for flush in stream_flushes
+                                            .flush_execution(&eid, std::time::Instant::now())
+                                        {
+                                            flush_stream_output(
+                                                &state_for_iopub,
+                                                &blob_store,
+                                                &iopub_stream_terminals,
+                                                &iopub_kernel_actor_id,
+                                                flush,
+                                            )
+                                            .await;
+                                        }
+                                        stream_flushes.clear_execution(&eid);
 
                                         {
                                             let mut terminals = iopub_stream_terminals.lock().await;

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -50,6 +50,7 @@ pub mod runtime_agent;
 pub mod runtime_agent_handle;
 pub(crate) mod runtime_agent_manifest;
 pub mod singleton;
+pub(crate) mod stream_flush;
 pub mod stream_terminal;
 pub mod sync_server;
 pub mod task_supervisor;

--- a/crates/runtimed/src/stream_flush.rs
+++ b/crates/runtimed/src/stream_flush.rs
@@ -1,0 +1,238 @@
+//! Coalescing policy for noisy stdout/stderr IOPub streams.
+//!
+//! The Jupyter IOPub reader must stay responsive enough to observe status
+//! messages such as `idle` after an interrupt. Writing every tiny stream chunk
+//! through blob storage and Automerge makes that reader do too much work per
+//! frame, so stream writes are flushed early once, then coalesced within bounded
+//! byte/time thresholds.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+type StreamKey = (String, String);
+
+pub(crate) const STREAM_FLUSH_MAX_DELAY: Duration = Duration::from_millis(75);
+pub(crate) const STREAM_FLUSH_MAX_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingStreamFlush {
+    pub execution_id: String,
+    pub stream_name: String,
+    pub rendered_text: String,
+}
+
+#[derive(Debug, Clone)]
+struct StreamFlushEntry {
+    rendered_text: Option<String>,
+    pending_bytes: usize,
+    has_flushed: bool,
+    last_flush: Instant,
+}
+
+#[derive(Debug)]
+pub(crate) struct StreamFlushBuffer {
+    max_delay: Duration,
+    max_bytes: usize,
+    entries: HashMap<StreamKey, StreamFlushEntry>,
+}
+
+impl Default for StreamFlushBuffer {
+    fn default() -> Self {
+        Self::new(STREAM_FLUSH_MAX_DELAY, STREAM_FLUSH_MAX_BYTES)
+    }
+}
+
+impl StreamFlushBuffer {
+    pub(crate) fn new(max_delay: Duration, max_bytes: usize) -> Self {
+        Self {
+            max_delay,
+            max_bytes,
+            entries: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn record_chunk(
+        &mut self,
+        execution_id: &str,
+        stream_name: &str,
+        rendered_text: String,
+        chunk_bytes: usize,
+        now: Instant,
+    ) -> Option<PendingStreamFlush> {
+        let key = (execution_id.to_string(), stream_name.to_string());
+        let entry = self.entries.entry(key.clone()).or_insert(StreamFlushEntry {
+            rendered_text: None,
+            pending_bytes: 0,
+            has_flushed: false,
+            last_flush: now,
+        });
+        entry.rendered_text = Some(rendered_text);
+        entry.pending_bytes = entry.pending_bytes.saturating_add(chunk_bytes);
+
+        let delay_elapsed =
+            entry.has_flushed && now.duration_since(entry.last_flush) >= self.max_delay;
+        let bytes_exceeded = entry.pending_bytes >= self.max_bytes;
+        if !entry.has_flushed || delay_elapsed || bytes_exceeded {
+            return self.take_key(&key, now);
+        }
+
+        None
+    }
+
+    pub(crate) fn flush_execution(
+        &mut self,
+        execution_id: &str,
+        now: Instant,
+    ) -> Vec<PendingStreamFlush> {
+        let keys: Vec<_> = self
+            .entries
+            .keys()
+            .filter(|(eid, _)| eid == execution_id)
+            .cloned()
+            .collect();
+        keys.into_iter()
+            .filter_map(|key| self.take_key(&key, now))
+            .collect()
+    }
+
+    pub(crate) fn clear_execution(&mut self, execution_id: &str) {
+        self.entries.retain(|(eid, _), _| eid != execution_id);
+    }
+
+    fn take_key(&mut self, key: &StreamKey, now: Instant) -> Option<PendingStreamFlush> {
+        let entry = self.entries.get_mut(key)?;
+        let rendered_text = entry.rendered_text.take()?;
+        entry.pending_bytes = 0;
+        entry.has_flushed = true;
+        entry.last_flush = now;
+        Some(PendingStreamFlush {
+            execution_id: key.0.clone(),
+            stream_name: key.1.clone(),
+            rendered_text,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer() -> StreamFlushBuffer {
+        StreamFlushBuffer::new(Duration::from_millis(100), 10)
+    }
+
+    #[test]
+    fn first_chunk_flushes_immediately() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+
+        let flush = buffer
+            .record_chunk("e1", "stdout", "hello".into(), 5, now)
+            .expect("first chunk should flush");
+
+        assert_eq!(flush.execution_id, "e1");
+        assert_eq!(flush.stream_name, "stdout");
+        assert_eq!(flush.rendered_text, "hello");
+    }
+
+    #[test]
+    fn subsequent_small_chunks_are_coalesced_until_delay() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        assert!(buffer
+            .record_chunk("e1", "stdout", "a".into(), 1, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk(
+                "e1",
+                "stdout",
+                "ab".into(),
+                1,
+                now + Duration::from_millis(10)
+            )
+            .is_none());
+
+        let flush = buffer
+            .record_chunk(
+                "e1",
+                "stdout",
+                "abc".into(),
+                1,
+                now + Duration::from_millis(100),
+            )
+            .expect("delay should flush latest rendered text");
+
+        assert_eq!(flush.rendered_text, "abc");
+    }
+
+    #[test]
+    fn byte_threshold_flushes_latest_rendered_text() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        assert!(buffer
+            .record_chunk("e1", "stdout", "a".into(), 1, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk("e1", "stdout", "abcdef".into(), 6, now)
+            .is_none());
+
+        let flush = buffer
+            .record_chunk("e1", "stdout", "abcdefghij".into(), 4, now)
+            .expect("byte threshold should flush");
+
+        assert_eq!(flush.rendered_text, "abcdefghij");
+    }
+
+    #[test]
+    fn flush_execution_returns_all_dirty_streams_for_execution() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        assert!(buffer
+            .record_chunk("e1", "stdout", "out".into(), 3, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk("e1", "stdout", "out2".into(), 4, now)
+            .is_none());
+        assert!(buffer
+            .record_chunk("e1", "stderr", "err".into(), 3, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk("e1", "stderr", "err2".into(), 4, now)
+            .is_none());
+        assert!(buffer
+            .record_chunk("e2", "stdout", "other".into(), 5, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk("e2", "stdout", "other2".into(), 6, now)
+            .is_none());
+
+        let mut flushes = buffer.flush_execution("e1", now);
+        flushes.sort_by(|a, b| a.stream_name.cmp(&b.stream_name));
+
+        assert_eq!(flushes.len(), 2);
+        assert_eq!(flushes[0].stream_name, "stderr");
+        assert_eq!(flushes[0].rendered_text, "err2");
+        assert_eq!(flushes[1].stream_name, "stdout");
+        assert_eq!(flushes[1].rendered_text, "out2");
+
+        let remaining = buffer.flush_execution("e2", now);
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].rendered_text, "other2");
+    }
+
+    #[test]
+    fn clear_execution_discards_dirty_streams() {
+        let now = Instant::now();
+        let mut buffer = buffer();
+        assert!(buffer
+            .record_chunk("e1", "stdout", "out".into(), 3, now)
+            .is_some());
+        assert!(buffer
+            .record_chunk("e1", "stdout", "out2".into(), 4, now)
+            .is_none());
+
+        buffer.clear_execution("e1");
+
+        assert!(buffer.flush_execution("e1", now).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- coalesce hot-path stdout/stderr IOPub stream writes after the first chunk
- force-flush any dirty stream output before `ExecutionDone`, rich output append, or error append
- keep the existing output manifest / blob store / RuntimeStateDoc schema intact

## Why

Nightly diagnostics from a stuck noisy stdout run showed the control-channel interrupt completing quickly, but the execution never reached the visible post-interrupt recovery state. The likely pressure point was the IOPub loop doing blob-store and Automerge writes for every tiny stream frame before it could observe and propagate later IOPub status messages.

This keeps early feedback by flushing the first stream chunk immediately, then stores only the latest rendered terminal state until either a time threshold, a byte threshold, or an execution boundary requires a flush.

## Verification

- `cargo test -p runtimed stream_flush -- --nocapture`
- `cargo check -p runtimed`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kyle/codex/desktop/target/debug/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/Users/kyle/codex/desktop RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR=/Users/kyle/codex/desktop/python/runtimed/integration-logs RUNTIMED_PYTEST_WORKERS=1 VIRTUAL_ENV=/Users/kyle/codex/desktop/.venv uv run pytest tests/test_daemon_integration.py::TestKernelLifecycle::test_interrupt_large_streaming_output_unblocks -v --tb=short`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kyle/codex/desktop/target/debug/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/Users/kyle/codex/desktop RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR=/Users/kyle/codex/desktop/python/runtimed/integration-logs RUNTIMED_PYTEST_WORKERS=1 VIRTUAL_ENV=/Users/kyle/codex/desktop/.venv uv run pytest tests/test_daemon_integration.py::TestKernelLifecycle::test_interrupt_clears_queue_and_unblocks -v --tb=short`
- `cargo xtask lint --fix`
- `cargo test -p runtimed`
- `cargo xtask integration interrupt` accidentally ran the full `test_daemon_integration.py` suite because the current xtask filter parser selects the subcommand name as the filter. Result: `116 passed, 1 skipped, 1 failed`; both interrupt tests and all stream-output/terminal-emulation tests passed. The one failure was `TestTrustApproval::test_untrusted_notebook_needs_approval`.
- Reran `TestTrustApproval::test_untrusted_notebook_needs_approval` directly twice after the full-suite failure; it passed, with the clean rerun command exiting 0.

Note: the first full `cargo test -p runtimed` run hit a one-off failure in `sync_server::tests::receive_patch_log_mismatch_does_not_persist_or_broadcast_client_edit`; rerunning that exact test passed, and a second full `cargo test -p runtimed` passed.
