### PR TITLE
fix(runtimed): resolve execution results through daemon

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -49,9 +49,9 @@ runs:
 
     - name: Install wasm-pack
       if: inputs.skip-wasm != 'true'
-      uses: taiki-e/install-action@v2
+      uses: ./.github/actions/install-wasm-pack
       with:
-        tool: wasm-pack@${{ inputs.wasm-pack-version }}
+        version: ${{ inputs.wasm-pack-version }}
 
     # Apple's system clang can't target wasm32-unknown-unknown.
     # Prepend Homebrew LLVM to PATH so cc-rs finds a wasm-capable clang.

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -1,0 +1,54 @@
+name: Install wasm-pack
+description: Install wasm-pack from the official rustwasm release artifacts.
+
+inputs:
+  version:
+    description: wasm-pack version to install.
+    required: false
+    default: "0.14.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Download wasm-pack
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version="${{ inputs.version }}"
+        case "$RUNNER_OS" in
+          Linux) os="unknown-linux-musl" ;;
+          macOS) os="apple-darwin" ;;
+          Windows) os="pc-windows-msvc" ;;
+          *) echo "Unsupported runner OS: $RUNNER_OS" >&2; exit 1 ;;
+        esac
+
+        case "$RUNNER_ARCH" in
+          X64) arch="x86_64" ;;
+          ARM64) arch="aarch64" ;;
+          *) echo "Unsupported runner arch: $RUNNER_ARCH" >&2; exit 1 ;;
+        esac
+
+        asset="wasm-pack-v${version}-${arch}-${os}.tar.gz"
+        url="https://github.com/rustwasm/wasm-pack/releases/download/v${version}/${asset}"
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+
+        curl --fail --location --show-error --retry 5 --retry-delay 2 \
+          --output "$tmp/$asset" \
+          "$url"
+        tar -xzf "$tmp/$asset" -C "$tmp"
+
+        bin="$(find "$tmp" -type f \( -name wasm-pack -o -name wasm-pack.exe \) -print -quit)"
+        if [ -z "$bin" ]; then
+          echo "wasm-pack binary not found in $asset" >&2
+          exit 1
+        fi
+
+        install_dir="$HOME/.cargo/bin"
+        mkdir -p "$install_dir"
+        cp "$bin" "$install_dir/"
+        chmod +x "$install_dir/$(basename "$bin")"
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+        "$install_dir/$(basename "$bin")" --version

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Install wasm-pack
         # Pin to 0.14.0+ for `--profile <NAME>` support; see comment in
         # `.github/workflows/build.yml`.
-        uses: taiki-e/install-action@v2
+        uses: ./.github/actions/install-wasm-pack
         with:
-          tool: wasm-pack@0.14.0
+          version: 0.14.0
 
       - name: Build sift-wasm
         run: wasm-pack build crates/sift-wasm --target web --release

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -239,6 +239,25 @@ impl PoolClient {
         }
     }
 
+    /// Read a terminal execution record by execution ID from the daemon.
+    pub async fn get_execution_record(
+        &self,
+        execution_id: &str,
+    ) -> Result<crate::execution_store::ExecutionRecord, ClientError> {
+        let response = self
+            .send_request(Request::GetExecutionResult {
+                execution_id: execution_id.to_string(),
+            })
+            .await?;
+        match response {
+            Response::ExecutionResult { record } => Ok(record),
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError(
+                "Unexpected response".to_string(),
+            )),
+        }
+    }
+
     /// Query tokio runtime metrics (worker utilization, task counts).
     ///
     /// Returns the raw metrics snapshot as a JSON value. Daemons that

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -72,6 +72,9 @@ pub enum Request {
     /// fall back to `Ping` if they only need the version.
     GetDaemonInfo,
 
+    /// Read a terminal execution result by durable execution ID.
+    GetExecutionResult { execution_id: String },
+
     /// Get tokio runtime metrics (worker utilization, task counts, queue
     /// depths). Used by `runt daemon status --json` and diagnostic tools
     /// to measure whether the daemon's async runtime is spreading work
@@ -152,6 +155,11 @@ pub enum Response {
 
     /// Generic success acknowledgment.
     Ok,
+
+    /// Durable execution record found by execution ID.
+    ExecutionResult {
+        record: crate::execution_store::ExecutionRecord,
+    },
 
     /// An error occurred.
     Error { message: String },

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -1325,14 +1325,10 @@ pub async fn get_execution_result(
 ) -> Result<CellResult> {
     let opts = options.unwrap_or_default();
     let socket_path = resolve_socket_path(opts.socket_path);
-    let info = runtimed_client::singleton::query_daemon_info(socket_path.clone()).await;
-    let execution_store_dir = execution_store_dir_for_socket(&socket_path, info.as_ref());
-    let store = runtimed_client::execution_store::ExecutionStore::new(execution_store_dir);
-    let record = store.read_record(&execution_id).await.ok_or_else(|| {
-        Error::from_reason(format!(
-            "Execution not found in durable store: {execution_id}"
-        ))
-    })?;
+    let record = PoolClient::new(socket_path.clone())
+        .get_execution_record(&execution_id)
+        .await
+        .map_err(to_napi_err)?;
 
     cell_result_from_record(&socket_path, record).await
 }
@@ -1343,20 +1339,6 @@ fn resolve_socket_path(override_path: Option<String>) -> PathBuf {
     override_path
         .map(PathBuf::from)
         .unwrap_or_else(runt_workspace::default_socket_path)
-}
-
-fn execution_store_dir_for_socket(
-    socket_path: &std::path::Path,
-    daemon_info: Option<&runtimed_client::singleton::DaemonInfo>,
-) -> PathBuf {
-    if let Some(dir) = daemon_info.and_then(|info| info.execution_store_dir.as_ref()) {
-        return PathBuf::from(dir);
-    }
-
-    socket_path
-        .parent()
-        .map(|parent| parent.join("executions"))
-        .unwrap_or_else(runtimed_client::default_execution_store_dir)
 }
 
 async fn resolve_blob_paths(socket_path: &std::path::Path) -> (Option<String>, Option<PathBuf>) {
@@ -2198,14 +2180,6 @@ mod tests {
             dependency_package_manager(None, None, &metadata),
             PackageManager::Uv
         );
-    }
-
-    #[test]
-    fn execution_store_dir_falls_back_to_socket_namespace() {
-        let dir =
-            execution_store_dir_for_socket(Path::new("/tmp/runtimed-test/runtimed.sock"), None);
-
-        assert_eq!(dir, PathBuf::from("/tmp/runtimed-test/executions"));
     }
 
     #[tokio::test]

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -148,18 +148,10 @@ impl AsyncClient {
         let socket_path = self.socket_path.clone();
         let execution_id = execution_id.to_string();
         future_into_py(py, async move {
-            let info = runtimed::singleton::query_daemon_info(socket_path.clone()).await;
-            let execution_store_dir = info
-                .as_ref()
-                .and_then(|info| info.execution_store_dir.as_ref())
-                .map(PathBuf::from)
-                .unwrap_or_else(runtimed::default_execution_store_dir);
-            let store = runtimed::execution_store::ExecutionStore::new(execution_store_dir);
-            let record = store.read_record(&execution_id).await.ok_or_else(|| {
-                to_py_err(format!(
-                    "Execution not found in durable store: {execution_id}"
-                ))
-            })?;
+            let record = runtimed::client::PoolClient::new(socket_path.clone())
+                .get_execution_record(&execution_id)
+                .await
+                .map_err(to_py_err)?;
 
             let (blob_base_url, blob_store_path) =
                 crate::daemon_paths::get_blob_paths_async(&socket_path).await;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1440,6 +1440,68 @@ impl Daemon {
         }
     }
 
+    async fn build_execution_result(&self, execution_id: String) -> Response {
+        let store = runtimed_client::execution_store::ExecutionStore::new(
+            self.config.execution_store_dir.clone(),
+        );
+        if let Some(record) = store.read_record(&execution_id).await {
+            return Response::ExecutionResult { record };
+        }
+
+        let rooms = {
+            let rooms_guard = self.notebook_rooms.lock().await;
+            rooms_guard.values().cloned().collect::<Vec<_>>()
+        };
+
+        for room in rooms {
+            let Some(exec) = room
+                .state
+                .read(|state_doc| {
+                    state_doc
+                        .read_state()
+                        .executions
+                        .get(&execution_id)
+                        .cloned()
+                })
+                .unwrap_or_default()
+            else {
+                continue;
+            };
+            if !matches!(exec.status.as_str(), "done" | "error") {
+                continue;
+            }
+
+            let notebook_path = room
+                .file_binding
+                .path()
+                .await
+                .map(|path| path.to_string_lossy().to_string());
+            let context_id = crate::notebook_sync_server::notebook_execution_context_id(
+                &room,
+                notebook_path.as_deref(),
+            );
+            let record = runtimed_client::execution_store::ExecutionRecord::from_execution_state(
+                &execution_id,
+                "notebook",
+                context_id,
+                notebook_path,
+                &exec,
+            );
+
+            if let Err(e) = store.write_record(record.clone()).await {
+                warn!(
+                    "[execution-store] Failed to persist live execution record {}: {}",
+                    execution_id, e
+                );
+            }
+            return Response::ExecutionResult { record };
+        }
+
+        Response::Error {
+            message: format!("Execution not found in durable store: {execution_id}"),
+        }
+    }
+
     /// Snapshot tokio runtime metrics for diagnostics.
     ///
     /// Uses only stable APIs (`worker_total_busy_duration`,
@@ -3383,6 +3445,10 @@ impl Daemon {
             },
 
             Request::GetDaemonInfo => self.build_daemon_info().await,
+
+            Request::GetExecutionResult { execution_id } => {
+                self.build_execution_result(execution_id).await
+            }
 
             Request::GetRuntimeMetrics => self.build_runtime_metrics(),
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1085,6 +1085,8 @@ pub struct Daemon {
     pool_ready_pixi: Notify,
     /// Content-addressed blob store.
     pub(crate) blob_store: Arc<BlobStore>,
+    /// Durable terminal execution-result records.
+    execution_store: runtimed_client::execution_store::ExecutionStore,
     /// Local package allowlist used to auto-approve familiar dependencies.
     pub(crate) trusted_packages: TrustedPackageStore,
     /// HTTP port for the blob server (set after startup).
@@ -1349,6 +1351,9 @@ impl Daemon {
         let pool_doc = Arc::new(RwLock::new(notebook_doc::pool_state::PoolDoc::new()));
 
         let blob_store = Arc::new(BlobStore::new(config.blob_store_dir.clone()));
+        let execution_store = runtimed_client::execution_store::ExecutionStore::new(
+            config.execution_store_dir.clone(),
+        );
         let trusted_packages = match TrustedPackageStore::open(
             config.trusted_packages_db_path.clone(),
         ) {
@@ -1383,6 +1388,7 @@ impl Daemon {
             pool_doc,
             pool_doc_changed,
             blob_store,
+            execution_store,
             trusted_packages,
             blob_port: Mutex::new(None),
             started_at: chrono::Utc::now(),
@@ -1441,10 +1447,7 @@ impl Daemon {
     }
 
     async fn build_execution_result(&self, execution_id: String) -> Response {
-        let store = runtimed_client::execution_store::ExecutionStore::new(
-            self.config.execution_store_dir.clone(),
-        );
-        if let Some(record) = store.read_record(&execution_id).await {
+        if let Some(record) = self.execution_store.read_record(&execution_id).await {
             return Response::ExecutionResult { record };
         }
 
@@ -1488,7 +1491,7 @@ impl Daemon {
                 &exec,
             );
 
-            if let Err(e) = store.write_record(record.clone()).await {
+            if let Err(e) = self.execution_store.write_record(record.clone()).await {
                 warn!(
                     "[execution-store] Failed to persist live execution record {}: {}",
                     execution_id, e


### PR DESCRIPTION
## Summary

- Add a daemon RPC for `GetExecutionResult` so clients no longer infer durable execution-store paths locally.
- Make Python and Node `get_execution_result()` call the daemon over the socket.
- Have the daemon read its configured durable execution store first, then fall back to live room `RuntimeStateDoc` for terminal executions and persist the record opportunistically.
- Fix CI `wasm-pack@0.14.0` installation to download from the official `rustwasm/wasm-pack` release instead of the `taiki-e/install-action` mapping to `drager/wasm-pack`, which now returns 404.

## Context

This came from a docs-only PR seeing:

```text
FAILED tests/test_daemon_integration.py::TestExecuteCell::test_cell_execute_returns_execution_handle
assert None is not None
```

The failed execution had completed, but a fresh Python client could not recover the result by execution ID quickly enough. The first draft only removed `daemon.json` discovery from Python, but CI still reproduced the failure: the durable record may lag behind the terminal runtime-state update. This version makes the daemon the only authority for execution-result lookup, so clients do not depend on `daemon.json`, default cache paths, socket-local guesses, or background persistence timing.

## Verification

- `cargo xtask lint --fix`
- `cargo check -p runtimed -p runtimed-py -p runtimed-node`
- Local smoke of the new `wasm-pack` installer path for `RUNNER_OS=macOS`, `RUNNER_ARCH=ARM64`: installed `wasm-pack 0.14.0`.
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$PWD/target/debug/runtimed" RUNTIMED_LOG_LEVEL=debug uv run pytest python/runtimed/tests/test_daemon_integration.py::TestExecuteCell::test_cell_execute_returns_execution_handle -v --tb=short --timeout=120`
  - Result: `1 passed in 67.61s`.
- Earlier broad local run before the daemon-RPC fix:
  - The xtask filter matched broadly and ran the full daemon integration file.
  - `TestExecuteCell::test_cell_execute_returns_execution_handle` passed.
  - `TestKernelLifecycle::test_interrupt_clears_queue_and_unblocks` passed.
  - `TestKernelLifecycle::test_interrupt_large_streaming_output_unblocks` passed.
  - Overall result: `116 passed, 1 skipped, 1 failed`.
  - The one failure was unrelated trust behavior: `TestTrustApproval::test_untrusted_notebook_needs_approval` expected `needs_trust_approval is True` and got `False`.
