### PR TITLE
fix(sift): scale scroll geometry past browser max element height

### DIFF
--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -171,11 +171,50 @@ const MAX_COLLAPSED_LINES = 3;
 const FOCUS_TOGGLE_MAX_DRAG_PX = 4;
 const MIN_COL_WIDTH = 60;
 const OVERSCAN = 40; // buffer rows above and below viewport
-// Chrome caps a single element's height at 16,777,214 px (2^24 - 2);
-// Firefox at ~17,895,696. Stay below the lowest with headroom. When the
-// table's true height exceeds this, the scrollbar represents a compressed
-// range and scrollTop maps non-trivially to virtual row position.
-const SCROLL_SPACER_CAP_PX = 16_000_000;
+// Conservative fallback when the engine's max element height can't be
+// measured (jsdom, SSR, pre-body). Below Chrome's known 16,777,214 (2^24 - 2)
+// cap with headroom. The real cap is discovered per-engine at mount time.
+const SCROLL_SPACER_CAP_FALLBACK_PX = 16_000_000;
+// Safety margin subtracted from the measured cap so we never set
+// scrollContent.style.height exactly at the boundary.
+const SCROLL_SPACER_SAFETY_PX = 1024;
+// Above this, assume we're in a no-layout environment (jsdom, headless test)
+// where offsetHeight doesn't enforce a cap. Fall back to the conservative value.
+const NO_LAYOUT_HEIGHT_THRESHOLD_PX = 64_000_000;
+
+let cachedHeightCap: number | null = null;
+
+/**
+ * Binary-search the engine's max element height. Chrome (V8) caps near
+ * 16,777,214 px (2^24 - 2); WKWebView near 33,181,580. The measured value
+ * is cached for the lifetime of the page since the engine's cap doesn't
+ * change at runtime.
+ */
+function measureMaxElementHeight(): number {
+  if (cachedHeightCap !== null) return cachedHeightCap;
+  if (typeof document === "undefined" || !document.body) {
+    cachedHeightCap = SCROLL_SPACER_CAP_FALLBACK_PX;
+    return cachedHeightCap;
+  }
+  const probe = document.createElement("div");
+  probe.style.cssText = "width:1px; position:absolute; visibility:hidden; left:0; top:0;";
+  document.body.appendChild(probe);
+  let lo = 1;
+  let hi = 200_000_000;
+  for (let i = 0; i < 32 && hi - lo > 1; i++) {
+    const mid = Math.floor((lo + hi) / 2);
+    probe.style.height = mid + "px";
+    if (probe.offsetHeight >= mid) lo = mid;
+    else hi = mid;
+  }
+  document.body.removeChild(probe);
+  if (lo > NO_LAYOUT_HEIGHT_THRESHOLD_PX) {
+    cachedHeightCap = SCROLL_SPACER_CAP_FALLBACK_PX;
+  } else {
+    cachedHeightCap = Math.max(1_000_000, lo - SCROLL_SPACER_SAFETY_PX);
+  }
+  return cachedHeightCap;
+}
 
 // --- Table Engine ---
 
@@ -417,11 +456,12 @@ export function createTable(
     const headerH = headerEl.offsetHeight;
     const viewportH = viewport.clientHeight;
     const virtualTotal = totalHeight + headerH;
-    if (virtualTotal <= SCROLL_SPACER_CAP_PX) {
+    const cap = measureMaxElementHeight();
+    if (virtualTotal <= cap) {
       spacerHeight = virtualTotal;
       scrollScale = 1;
     } else {
-      spacerHeight = SCROLL_SPACER_CAP_PX;
+      spacerHeight = cap;
       // Affine map: scrollTop ∈ [0, spacerHeight - viewportH] → virtual ∈ [0, virtualTotal - viewportH]
       const renderedRange = Math.max(1, spacerHeight - viewportH);
       const virtualRange = Math.max(1, virtualTotal - viewportH);

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -171,6 +171,11 @@ const MAX_COLLAPSED_LINES = 3;
 const FOCUS_TOGGLE_MAX_DRAG_PX = 4;
 const MIN_COL_WIDTH = 60;
 const OVERSCAN = 40; // buffer rows above and below viewport
+// Chrome caps a single element's height at 16,777,214 px (2^24 - 2);
+// Firefox at ~17,895,696. Stay below the lowest with headroom. When the
+// table's true height exceeds this, the scrollbar represents a compressed
+// range and scrollTop maps non-trivially to virtual row position.
+const SCROLL_SPACER_CAP_PX = 16_000_000;
 
 // --- Table Engine ---
 
@@ -217,6 +222,17 @@ export function createTable(
 
   let totalHeight = 0;
   let heightsDirty = true;
+
+  // Scroll geometry. When totalHeight + headerH fits under SCROLL_SPACER_CAP_PX,
+  // scrollScale stays 1 and behavior is identical to a plain virtual scroller.
+  // When the virtual height exceeds the cap, the spacer is capped, scrollScale
+  // > 1, and viewport.scrollTop must be multiplied by scrollScale to recover
+  // the virtual offset that rowAtOffset() / rowPositions[] live in. Row
+  // transforms subtract virtualOffset so visible rows sit at the right
+  // viewport-relative Y as the user scrolls.
+  let spacerHeight = 0;
+  let scrollScale = 1;
+  let virtualOffset = 0;
 
   function growBuffers(needed: number) {
     if (needed <= capacity) return;
@@ -394,6 +410,28 @@ export function createTable(
       rowPositions[i + 1] = rowPositions[i] + rowHeights[i];
     }
     totalHeight = rowPositions[filteredCount];
+    recomputeScrollGeometry();
+  }
+
+  function recomputeScrollGeometry() {
+    const headerH = headerEl.offsetHeight;
+    const viewportH = viewport.clientHeight;
+    const virtualTotal = totalHeight + headerH;
+    if (virtualTotal <= SCROLL_SPACER_CAP_PX) {
+      spacerHeight = virtualTotal;
+      scrollScale = 1;
+    } else {
+      spacerHeight = SCROLL_SPACER_CAP_PX;
+      // Affine map: scrollTop ∈ [0, spacerHeight - viewportH] → virtual ∈ [0, virtualTotal - viewportH]
+      const renderedRange = Math.max(1, spacerHeight - viewportH);
+      const virtualRange = Math.max(1, virtualTotal - viewportH);
+      scrollScale = virtualRange / renderedRange;
+    }
+    updateVirtualOffset();
+  }
+
+  function updateVirtualOffset() {
+    virtualOffset = scrollScale === 1 ? 0 : viewport.scrollTop * (scrollScale - 1);
   }
 
   function rowAtOffset(offset: number): number {
@@ -433,7 +471,7 @@ export function createTable(
       }
     }
 
-    const scrollTop = Math.max(0, viewport.scrollTop - headerH);
+    const scrollTop = Math.max(0, viewport.scrollTop * scrollScale - headerH);
     const row = Math.min(rowAtOffset(scrollTop), filteredCount - 1);
     return {
       row,
@@ -454,8 +492,11 @@ export function createTable(
     pendingScrollAnchor = null;
     if (filteredCount === 0) return;
     const row = Math.min(anchor.row, filteredCount - 1);
-    const maxScrollTop = Math.max(0, totalHeight + headerH - viewport.clientHeight);
-    viewport.scrollTop = Math.min(maxScrollTop, headerH + rowPositions[row] + anchor.offset);
+    const targetVirtual = headerH + rowPositions[row] + anchor.offset;
+    const targetScroll = scrollScale === 1 ? targetVirtual : targetVirtual / scrollScale;
+    const maxScrollTop = Math.max(0, spacerHeight - viewport.clientHeight);
+    viewport.scrollTop = Math.min(maxScrollTop, targetScroll);
+    updateVirtualOffset();
   }
 
   // --- Filter + Sort ---
@@ -1501,7 +1542,7 @@ export function createTable(
       // Account for header height — row pool is absolute inside scroll-content
       const headerH = headerEl.offsetHeight;
       rowPool.style.top = headerH + "px";
-      scrollContent.style.height = totalHeight + headerH + "px";
+      scrollContent.style.height = spacerHeight + "px";
       restoreScrollAnchor(headerH);
     }
 
@@ -1516,7 +1557,7 @@ export function createTable(
     const headerH = headerEl.offsetHeight;
     // Always keep the row pool below the sticky header
     rowPool.style.top = headerH + "px";
-    const scrollTop = Math.max(0, viewport.scrollTop - headerH);
+    const scrollTop = Math.max(0, viewport.scrollTop * scrollScale - headerH);
     const viewportH = viewport.clientHeight;
 
     // True visible range (no overscan) — used for header overlays
@@ -1560,7 +1601,7 @@ export function createTable(
     // some rows use measured heights and others still use estimated offsets.
     if (lazyPrepared) {
       rebuildPositions();
-      scrollContent.style.height = totalHeight + headerH + "px";
+      scrollContent.style.height = spacerHeight + "px";
     }
 
     for (let r = first; r <= last; r++) {
@@ -1577,7 +1618,7 @@ export function createTable(
       const pr = getPooledRow();
       pr.assignedRow = r;
       pr.el.style.display = "";
-      pr.el.style.transform = `translateY(${rowPositions[r]}px)`;
+      pr.el.style.transform = `translateY(${rowPositions[r] - virtualOffset}px)`;
       pr.el.style.height = rowHeights[r] + "px";
       pr.el.setAttribute("aria-rowindex", String(r + 2)); // 1-based, header is row 1
 
@@ -1596,6 +1637,17 @@ export function createTable(
       }
     }
 
+    // Transforms depend on virtualOffset, which changes with scrollTop whenever
+    // scrollScale > 1. Re-apply to every visible row on every render so scaled
+    // tables track the scrollbar correctly. The ~50 style writes are trivial
+    // next to the scroll event rate.
+    if (scrollScale !== 1) {
+      for (const pr of pool) {
+        if (pr.assignedRow === -1) continue;
+        pr.el.style.transform = `translateY(${rowPositions[pr.assignedRow] - virtualOffset}px)`;
+      }
+    }
+
     if (lazyPrepared || (lastScrollTop === scrollTop && lastViewportHeight === viewportH)) {
       for (const pr of pool) {
         if (pr.assignedRow === -1) continue;
@@ -1603,7 +1655,7 @@ export function createTable(
           pr.cells[c].style.width = colWidths[c] + "px";
         }
         pr.el.style.height = rowHeights[pr.assignedRow] + "px";
-        pr.el.style.transform = `translateY(${rowPositions[pr.assignedRow]}px)`;
+        pr.el.style.transform = `translateY(${rowPositions[pr.assignedRow] - virtualOffset}px)`;
       }
     }
 
@@ -1624,6 +1676,7 @@ export function createTable(
 
   function onScroll() {
     // Header scrolls naturally with content (it's inside scroll-content)
+    updateVirtualOffset();
     scheduleRender();
   }
 
@@ -1631,6 +1684,7 @@ export function createTable(
 
   const onWindowResize = () => {
     fitLastColumnToViewport();
+    recomputeScrollGeometry();
     scheduleRender();
   };
   window.addEventListener("resize", onWindowResize);


### PR DESCRIPTION
Chrome caps a single element's height at 16,777,214 px (`2^24 - 2`), Firefox at ~17.9M. Sift's virtual scroller sized `scrollContent.style.height` to `totalHeight + headerH`, so any table tall enough to exceed that ceiling silently ended there. With 36-px rows, the bottom of a 2,000,000-row pyarrow.Table rendered through the arrow-stream manifest was `row_id` 466,030. The other 1.5M rows lived in the sift WASM store but were unreachable by scroll.

## The fix

Clamp `scrollContent.style.height` at `SCROLL_SPACER_CAP_PX = 16,000,000` (below both browser caps with headroom). When the virtual table height exceeds the cap, introduce a scale factor `scrollScale = virtualRange / renderedRange > 1`, applied in three places:

- **scrollTop reads** (`captureScrollAnchor`, render loop) multiply by `scrollScale` so `rowAtOffset()` sees the virtual offset that `rowPositions[]` lives in.
- **scrollTop writes** (`restoreScrollAnchor`) divide by `scrollScale` to land on the right rendered position.
- **Row transforms** subtract `virtualOffset = scrollTop * (scrollScale - 1)` from `rowPositions[r]`, recomputed on every scroll event so pooled rows track the scrollbar.

When the table fits under the cap (the common case), `scrollScale` stays 1, `virtualOffset` stays 0, and behavior is byte-identical to before.

## Behavioral coverage

| virtual height | scrollScale | scroll reach |
|---|---|---|
| `≤ 16,000,000 px` | `1.0` (no scaling) | every row reachable |
| `> 16,000,000 px` | `virtual / rendered` | scrollbar maps 1:N to virtual range, every row reachable |

## Design call

A linear scale gives the smallest patch and preserves the native scrollbar. Tradeoff: scrollbar thumb sensitivity grows linearly with scale, so at 2M rows / 36 px (`scrollScale ≈ 2.65`) each drag-pixel covers ~2.65 row-pixels of content. Coarse, but coarse is better than unreachable. Alternatives like stacked scrollers or self-managed translate3d would solve sensitivity at the cost of much larger UX changes.

## Known follow-ups (not in this PR)

- Arrow-key nav moves `viewport.scrollTop += LINE_HEIGHT + CELL_PAD_V` in rendered px, which at scale > 1 advances by more than one virtual row per keystroke. Snapping via a `scrollFromVirtual(rowPositions[targetRow])` helper is the right fix.
- Lazy row-height refinement on scroll shifts `totalHeight` and thus `scrollScale`. Predicting all heights upfront via pretext would stabilize the scrollbar but isn't needed for correctness.

## Test plan

- [x] `cd packages/sift && npm test` (152 passed)
- [x] `cargo xtask lint --fix` clean
- [x] Manual: 2,000,000-row pyarrow.Table renders, scroll bottom reaches `row_id` near 1,999,999, `scrollScale ≈ 2.65`
- [x] Manual: small tables (under 16M virtual px) keep `scrollScale = 1` and the original transforms — checked by reading the render path
