### PR TITLE
fix(notebook): drop App.tsx setDaemonCommSender export to restore HMR

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -92,8 +92,14 @@ function isLaunchErrorHandledByRuntimeBanner(error: string): boolean {
 /**
  * Update the daemon comm sender reference.
  * Called by AppContent when daemon kernel is initialized.
+ *
+ * Kept module-private (not exported). Exporting a non-component, non-hook
+ * function from this file would break Vite's react-plugin Fast Refresh
+ * boundary and force a full page reload on every HMR update, which strands
+ * any in-memory closures holding the previous daemon comm sender (visible
+ * in Tauri's webview as "Run does nothing" until ⌘Q + relaunch).
  */
-export function setDaemonCommSender(sender: ((message: unknown) => Promise<void>) | null): void {
+function setDaemonCommSender(sender: ((message: unknown) => Promise<void>) | null): void {
   daemonCommSender = sender;
 }
 


### PR DESCRIPTION
`apps/notebook/src/App.tsx` exported a non-component, non-hook function (`setDaemonCommSender`). Vite's react-plugin treats that as an "incompatible export" and refuses Fast Refresh on the file, forcing a full page reload on every HMR cycle. Chrome handles the reload cleanly. Tauri's WKWebView does not: under HMR-triggered reloads, in-memory closures that hold the previous `daemonCommSender` reference outlive the reload, so the React tree appears fresh but `Run` / `Shift+Enter` route execute requests to a dead WebSocket. Symptom is "kernel idle, no output." Recovery requires ⌘Q + relaunch.

The exported `setDaemonCommSender` had no consumers outside `App.tsx` itself (verified by grep). Removing the `export` keyword shrinks the export surface to a default React component plus a type alias, which Fast Refresh handles cleanly. No public API change.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `grep -rnE setDaemonCommSender apps/notebook/src` confirms only `App.tsx` references it
- [ ] Manual: start dev, edit `App.tsx`, confirm Vite logs `hmr update /src/App.tsx` (not `page reload`)
- [ ] Manual: in Tauri, execute a cell after an `App.tsx` HMR cycle and confirm output flows without a relaunch
