### PR TITLE
fix(supervisor): probe Vite over localhost instead of 127.0.0.1

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -2541,7 +2541,11 @@ const VITE_POST_CONNECT_STABILIZE: Duration = Duration::from_millis(1500);
 /// risk of adopting a non-Vite server on a project-specific port
 /// `vite_port_for_workspace(&root)` is low in dev contexts.
 async fn vite_port_is_live(port: u16) -> bool {
-    let addr = format!("127.0.0.1:{port}");
+    // Use "localhost" so tokio resolves both ::1 and 127.0.0.1 and tries each
+    // in order. Vite-Plus binds to whichever the OS resolver returns first
+    // for "localhost", which on macOS is the IPv6 entry — probing only
+    // 127.0.0.1 here would miss the running server.
+    let addr = format!("localhost:{port}");
     tokio::time::timeout(
         Duration::from_millis(400),
         tokio::net::TcpStream::connect(&addr),
@@ -2563,7 +2567,12 @@ async fn vite_port_is_live(port: u16) -> bool {
 /// process is still alive after the stabilize window.
 async fn await_vite_ready(child: &mut std::process::Child, port: u16) -> Result<(), String> {
     let deadline = tokio::time::Instant::now() + VITE_READY_TIMEOUT;
-    let addr = format!("127.0.0.1:{port}");
+    // "localhost" resolves to ::1 and 127.0.0.1 on most systems; tokio tries
+    // each in order so this probe succeeds whether Vite-Plus bound IPv4 or
+    // IPv6. Vite-Plus's default on macOS is the IPv6 entry, so probing only
+    // 127.0.0.1 here would time out for the full VITE_READY_TIMEOUT even
+    // though the server came up cleanly.
+    let addr = format!("localhost:{port}");
 
     loop {
         match child.try_wait() {


### PR DESCRIPTION
`vite_port_is_live` and `await_vite_ready` in `crates/mcp-supervisor/src/main.rs` probed Vite via `tokio::net::TcpStream::connect("127.0.0.1:{port}")`. Vite-Plus binds to whichever address the OS resolver returns first for `localhost`. On macOS that's `::1` (IPv6), so the probe connection-refused for the full 60-second `VITE_READY_TIMEOUT` while Vite was happily serving on `[::1]:6082`. Surface symptom every session: `up vite=true` reports `vite: FAILED — Vite did not accept connections on port 6082 within 60s` even though Vite is up and Chrome can hit it.

Fix: use `"localhost:{port}"`. Tokio's `TcpStream::connect` resolves the name asynchronously and tries each returned `SocketAddr` in order, succeeding on whichever address Vite actually bound.

## Test plan

- [x] `cargo build -p mcp-supervisor`
- [x] `cargo xtask lint --fix`
- [ ] Manual: start `up vite=true` and confirm `vite: ready` instead of `vite: FAILED`. Verified by inspection: same code path that previously reported FAILED for a working server now connects via the resolver's first hit.

## Why not portless?

`vercel-labs/portless` replaces port numbers with named local URLs at the system level (hosts file / mDNS proxy). Useful for stable cross-app dev URLs but orthogonal to this bug — the supervisor probe is internal infrastructure connecting to a localhost port. Adopting portless would shift our dev URL discipline (separate, larger discussion) but wouldn't change that the supervisor needs to TCP-probe whatever address Vite-Plus chose.
