### PR TITLE
feat(outputs): persist arrow stream manifest chunks

### DIFF
--- a/crates/notebook-doc/src/mime.rs
+++ b/crates/notebook-doc/src/mime.rs
@@ -34,6 +34,13 @@ use serde::{Deserialize, Serialize};
 /// `application/vnd.apache.parquet`.
 pub const BLOB_REF_MIME: &str = "application/vnd.nteract.blob-ref+json";
 
+/// MIME type for Arrow IPC stream bytes.
+pub const ARROW_STREAM_MIME: &str = "application/vnd.apache.arrow.stream";
+
+/// MIME type for nteract's JSON manifest that references ordered Arrow stream
+/// chunk blobs.
+pub const ARROW_STREAM_MANIFEST_MIME: &str = "application/vnd.nteract.arrow-stream-manifest+json";
+
 /// Three-way classification of a MIME type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MimeKind {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3860,9 +3860,12 @@ impl Daemon {
                         "[runtimed] GC: 0 active rooms and no room has loaded since startup; skipping blob sweep this cycle"
                     );
                 } else {
-                    let mut referenced_hashes =
-                        Self::collect_blob_refs_for_gc(&room_arcs, &self.config.notebook_docs_dir)
-                            .await;
+                    let mut referenced_hashes = Self::collect_blob_refs_for_gc(
+                        &room_arcs,
+                        &self.config.notebook_docs_dir,
+                        &self.blob_store,
+                    )
+                    .await;
                     referenced_hashes.extend(execution_store_refs);
                     Self::sweep_orphaned_blobs(&self.blob_store, &referenced_hashes, blob_max_age)
                         .await;
@@ -3886,7 +3889,10 @@ fn collect_blob_hashes(
 ) {
     // display_data / execute_result: data.{mime_type}.blob
     if let Some(data) = manifest.get("data").and_then(|d| d.as_object()) {
-        for mime_data in data.values() {
+        for (mime_type, mime_data) in data {
+            if mime_type == notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME {
+                collect_arrow_manifest_hashes(mime_data, hashes);
+            }
             if let Some(hash) = mime_data.get("blob").and_then(|b| b.as_str()) {
                 hashes.insert(hash.to_string());
             }
@@ -3908,6 +3914,98 @@ fn collect_blob_hashes(
         .and_then(|t| t.get("blob"))
         .and_then(|b| b.as_str())
     {
+        hashes.insert(hash.to_string());
+    }
+}
+
+async fn collect_blob_hashes_with_store(
+    manifest: &serde_json::Value,
+    hashes: &mut std::collections::HashSet<String>,
+    blob_store: &BlobStore,
+) {
+    collect_blob_hashes(manifest, hashes);
+
+    let Some(data) = manifest.get("data").and_then(|d| d.as_object()) else {
+        return;
+    };
+    let Some(manifest_ref) = data.get(notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME) else {
+        return;
+    };
+    let Some(hash) = manifest_ref.get("blob").and_then(|b| b.as_str()) else {
+        return;
+    };
+
+    let bytes = match blob_store.get(hash).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return,
+        Err(e) => {
+            warn!(
+                "[runtimed] GC: failed to read Arrow stream manifest blob {}: {}",
+                hash, e
+            );
+            return;
+        }
+    };
+    let content = match String::from_utf8(bytes) {
+        Ok(content) => content,
+        Err(e) => {
+            warn!(
+                "[runtimed] GC: Arrow stream manifest blob {} is not UTF-8 JSON: {}",
+                hash, e
+            );
+            return;
+        }
+    };
+    let parsed = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            warn!(
+                "[runtimed] GC: failed to parse Arrow stream manifest blob {}: {}",
+                hash, e
+            );
+            return;
+        }
+    };
+    collect_arrow_manifest_hashes(&parsed, hashes);
+}
+
+fn collect_arrow_manifest_hashes(
+    manifest: &serde_json::Value,
+    hashes: &mut std::collections::HashSet<String>,
+) {
+    if let Some(inline) = manifest.get("inline").and_then(|v| v.as_str()) {
+        match serde_json::from_str::<serde_json::Value>(inline) {
+            Ok(parsed) => {
+                collect_arrow_manifest_hashes(&parsed, hashes);
+            }
+            Err(e) => {
+                warn!(
+                    "[runtimed] GC: failed to parse inline Arrow stream manifest: {}",
+                    e
+                );
+            }
+        }
+        return;
+    }
+
+    if let Some(chunks) = manifest.get("chunks").and_then(|v| v.as_array()) {
+        for chunk in chunks {
+            collect_hash_field(chunk, hashes);
+        }
+    }
+
+    if let Some(coalesced) = manifest.get("coalesced") {
+        collect_hash_field(coalesced, hashes);
+        if let Some(segments) = coalesced.get("segments").and_then(|v| v.as_array()) {
+            for segment in segments {
+                collect_hash_field(segment, hashes);
+            }
+        }
+    }
+}
+
+fn collect_hash_field(value: &serde_json::Value, hashes: &mut std::collections::HashSet<String>) {
+    if let Some(hash) = value.get("hash").and_then(|h| h.as_str()) {
         hashes.insert(hash.to_string());
     }
 }
@@ -4062,6 +4160,7 @@ impl Daemon {
     pub(crate) async fn collect_blob_refs_for_gc(
         rooms: &[(String, Arc<crate::notebook_sync_server::NotebookRoom>)],
         notebook_docs_dir: &Path,
+        blob_store: &BlobStore,
     ) -> std::collections::HashSet<String> {
         /// Rooms are scanned in batches so the sweep yields back to other
         /// daemon tasks; keeping the constant local keeps it near the loop.
@@ -4074,20 +4173,25 @@ impl Daemon {
         // 1. In-memory: active rooms (RuntimeStateDoc + notebook doc).
         for batch in rooms.chunks(ROOM_BATCH_SIZE) {
             for (_id, room) in batch {
+                let mut outputs = Vec::new();
                 let _ = room.state.read(|sd| {
                     let state = sd.read_state();
                     for exec in state.executions.values() {
                         for output in &exec.outputs {
-                            collect_blob_hashes(output, &mut referenced_hashes);
+                            outputs.push(output.clone());
                         }
                     }
                     for comm in state.comms.values() {
                         for output in &comm.outputs {
-                            collect_blob_hashes(output, &mut referenced_hashes);
+                            outputs.push(output.clone());
                         }
                         collect_blob_hashes_recursive(&comm.state, &mut referenced_hashes);
                     }
                 });
+                for output in outputs {
+                    collect_blob_hashes_with_store(&output, &mut referenced_hashes, blob_store)
+                        .await;
+                }
                 {
                     let doc = room.doc.read().await;
                     for cell in doc.get_cells() {
@@ -6232,6 +6336,95 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_blob_hashes_arrow_stream_manifest_chunks() {
+        let arrow_manifest = serde_json::json!({
+            "version": 1,
+            "chunks": [
+                {"hash": "chunk_a", "size": 10, "row_count": 5},
+                {"hash": "chunk_b", "size": 11, "row_count": 5}
+            ],
+            "coalesced": {
+                "strategy": "segment_manifest",
+                "segments": [
+                    {"hash": "segment_a", "offset": 0, "size": 10},
+                    {"hash": "segment_b", "offset": 10, "size": 11}
+                ]
+            },
+            "schema": {"hash": "schema-fingerprint-only"}
+        });
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.nteract.arrow-stream-manifest+json": {
+                    "inline": arrow_manifest.to_string()
+                }
+            }
+        });
+        let mut hashes = std::collections::HashSet::new();
+        collect_blob_hashes(&output, &mut hashes);
+
+        assert!(hashes.contains("chunk_a"));
+        assert!(hashes.contains("chunk_b"));
+        assert!(hashes.contains("segment_a"));
+        assert!(hashes.contains("segment_b"));
+        assert!(
+            !hashes.contains("schema-fingerprint-only"),
+            "schema.hash is a fingerprint, not a blob ref"
+        );
+        assert_eq!(hashes.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_collect_blob_hashes_arrow_stream_manifest_blob_ref() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let blob_store = BlobStore::new(tmp.path().join("blobs"));
+        let arrow_manifest = serde_json::json!({
+            "version": 1,
+            "chunks": [
+                {"hash": "chunk_a", "size": 10, "row_count": 5},
+                {"hash": "chunk_b", "size": 11, "row_count": 5}
+            ],
+            "coalesced": {
+                "strategy": "segment_manifest",
+                "segments": [
+                    {"hash": "segment_a", "offset": 0, "size": 10},
+                    {"hash": "segment_b", "offset": 10, "size": 11}
+                ]
+            },
+            "schema": {"hash": "schema-fingerprint-only"}
+        });
+        let manifest_hash = blob_store
+            .put(
+                arrow_manifest.to_string().as_bytes(),
+                notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME,
+            )
+            .await
+            .unwrap();
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.nteract.arrow-stream-manifest+json": {
+                    "blob": manifest_hash,
+                    "size": arrow_manifest.to_string().len()
+                }
+            }
+        });
+        let mut hashes = std::collections::HashSet::new();
+        collect_blob_hashes_with_store(&output, &mut hashes, &blob_store).await;
+
+        assert!(hashes.contains(&manifest_hash));
+        assert!(hashes.contains("chunk_a"));
+        assert!(hashes.contains("chunk_b"));
+        assert!(hashes.contains("segment_a"));
+        assert!(hashes.contains("segment_b"));
+        assert!(
+            !hashes.contains("schema-fingerprint-only"),
+            "schema.hash is a fingerprint, not a blob ref"
+        );
+        assert_eq!(hashes.len(), 5);
+    }
+
+    #[test]
     fn test_collect_blob_hashes_stream() {
         let manifest = serde_json::json!({
             "output_type": "stream",
@@ -7115,7 +7308,8 @@ mod tests {
         write_persisted_doc_with_blob(&docs_dir, "untitled-xyz", "cafebabe", "facefeed");
 
         let rooms: Vec<(String, Arc<crate::notebook_sync_server::NotebookRoom>)> = vec![];
-        let refs = Daemon::collect_blob_refs_for_gc(&rooms, &docs_dir).await;
+        let blob_store = BlobStore::new(tmp.path().join("blobs"));
+        let refs = Daemon::collect_blob_refs_for_gc(&rooms, &docs_dir, &blob_store).await;
         assert!(
             refs.contains("cafebabe"),
             "persisted-doc blob ref should be collected, got {:?}",

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -52,7 +52,9 @@ use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use notebook_doc::mime::{is_binary_mime, BLOB_REF_MIME};
+use notebook_doc::mime::{
+    is_binary_mime, ARROW_STREAM_MANIFEST_MIME, ARROW_STREAM_MIME, BLOB_REF_MIME,
+};
 
 use crate::blob_store::BlobStore;
 
@@ -1066,6 +1068,15 @@ async fn convert_data_bundle(
             }
         }
     }
+    if let Some(manifest_value) = bundle.get_mut(ARROW_STREAM_MANIFEST_MIME) {
+        let keep_manifest = restore_arrow_manifest_refs(manifest_value, blob_store)?;
+        if !keep_manifest {
+            tracing::warn!(
+                "[output-store] dropping Arrow stream manifest because a referenced chunk blob is missing"
+            );
+            bundle.remove(ARROW_STREAM_MANIFEST_MIME);
+        }
+    }
 
     let media: jupyter_protocol::media::Media = serde_json::from_value(Value::Object(bundle))
         .map_err(|e| {
@@ -1168,7 +1179,17 @@ async fn resolve_data_bundle(
             }
         }
 
-        let value = if is_binary_mime(mime_type) {
+        let value = if mime_type == ARROW_STREAM_MANIFEST_MIME {
+            let content = content_ref.resolve(blob_store).await?;
+            let mut manifest = serde_json::from_str(&content).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to parse Arrow stream manifest: {e}"),
+                )
+            })?;
+            externalize_arrow_manifest_refs(&mut manifest, blob_store).await?;
+            manifest
+        } else if is_binary_mime(mime_type) {
             // Binary: read raw bytes from blob → base64-encode for nbformat
             let base64_str = content_ref.resolve_binary_as_base64(blob_store).await?;
             Value::String(base64_str)
@@ -1185,6 +1206,150 @@ async fn resolve_data_bundle(
     }
 
     Ok(result)
+}
+
+async fn externalize_arrow_manifest_refs(
+    manifest: &mut Value,
+    blob_store: &BlobStore,
+) -> io::Result<()> {
+    if let Some(chunks) = manifest.get_mut("chunks").and_then(|v| v.as_array_mut()) {
+        for chunk in chunks {
+            if let Some(obj) = chunk.as_object_mut() {
+                externalize_arrow_ref_object(obj, blob_store).await?;
+            }
+        }
+    }
+
+    if let Some(coalesced) = manifest
+        .get_mut("coalesced")
+        .and_then(|v| v.as_object_mut())
+    {
+        externalize_arrow_ref_object(coalesced, blob_store).await?;
+        if let Some(segments) = coalesced.get_mut("segments").and_then(|v| v.as_array_mut()) {
+            for segment in segments {
+                if let Some(obj) = segment.as_object_mut() {
+                    externalize_arrow_ref_object(obj, blob_store).await?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn externalize_arrow_ref_object(
+    obj: &mut serde_json::Map<String, Value>,
+    blob_store: &BlobStore,
+) -> io::Result<()> {
+    let Some(hash) = obj.get("hash").and_then(|v| v.as_str()).map(str::to_string) else {
+        return Ok(());
+    };
+
+    if !blob_store.exists(&hash) {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("arrow manifest references missing blob: {hash}"),
+        ));
+    }
+
+    let size = match obj.get("size").and_then(|v| v.as_u64()) {
+        Some(size) => size,
+        None => {
+            blob_store
+                .get_meta(&hash)
+                .await?
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("arrow manifest references missing blob metadata: {hash}"),
+                    )
+                })?
+                .size
+        }
+    };
+
+    obj.remove("hash");
+    obj.insert("blob".to_string(), Value::String(hash));
+    obj.insert("size".to_string(), json!(size));
+    obj.insert(
+        "content_type".to_string(),
+        Value::String(ARROW_STREAM_MIME.to_string()),
+    );
+
+    Ok(())
+}
+
+fn restore_arrow_manifest_refs(manifest: &mut Value, blob_store: &BlobStore) -> io::Result<bool> {
+    if let Value::String(content) = manifest {
+        let parsed: Value = serde_json::from_str(content).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to parse Arrow stream manifest: {e}"),
+            )
+        })?;
+        *manifest = parsed;
+    }
+
+    if let Some(chunks) = manifest.get_mut("chunks").and_then(|v| v.as_array_mut()) {
+        for chunk in chunks {
+            if let Some(obj) = chunk.as_object_mut() {
+                if !restore_arrow_ref_object(obj, blob_store)? {
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    if let Some(coalesced) = manifest
+        .get_mut("coalesced")
+        .and_then(|v| v.as_object_mut())
+    {
+        if !restore_arrow_ref_object(coalesced, blob_store)? {
+            return Ok(false);
+        }
+        if let Some(segments) = coalesced.get_mut("segments").and_then(|v| v.as_array_mut()) {
+            for segment in segments {
+                if let Some(obj) = segment.as_object_mut() {
+                    if !restore_arrow_ref_object(obj, blob_store)? {
+                        return Ok(false);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}
+
+fn restore_arrow_ref_object(
+    obj: &mut serde_json::Map<String, Value>,
+    blob_store: &BlobStore,
+) -> io::Result<bool> {
+    if obj.get("hash").and_then(|v| v.as_str()).is_some() {
+        return Ok(true);
+    }
+
+    let Some(hash) = obj.get("blob").and_then(|v| v.as_str()).map(str::to_string) else {
+        return Ok(true);
+    };
+    let Some(size) = obj.get("size").and_then(|v| v.as_u64()) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Arrow manifest blob ref missing size for blob: {hash}"),
+        ));
+    };
+
+    if !blob_store.exists(&hash) {
+        return Ok(false);
+    }
+
+    obj.remove("blob");
+    obj.insert("hash".to_string(), Value::String(hash));
+    obj.insert("size".to_string(), json!(size));
+    obj.entry("content_type".to_string())
+        .or_insert_with(|| Value::String(ARROW_STREAM_MIME.to_string()));
+
+    Ok(true)
 }
 
 /// Extract metadata from a Jupyter output, preserving as Value.
@@ -2977,6 +3142,194 @@ mod tests {
             saved_again["data"][BLOB_REF_MIME],
             saved["data"][BLOB_REF_MIME]
         );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_data_bundle_externalizes_arrow_stream_manifest_chunks() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let first = b"arrow-stream-chunk-1";
+        let second = b"arrow-stream-chunk-2";
+        let first_hash = store
+            .put(first, "application/vnd.apache.arrow.stream")
+            .await
+            .unwrap();
+        let second_hash = store
+            .put(second, "application/vnd.apache.arrow.stream")
+            .await
+            .unwrap();
+        let manifest = serde_json::json!({
+            "version": 1,
+            "kind": "arrow-stream",
+            "complete": true,
+            "row_count": 10,
+            "schema": {"hash": "schema-fingerprint-only"},
+            "chunks": [
+                {"hash": first_hash, "size": first.len(), "row_count": 5},
+                {"hash": second_hash, "size": second.len(), "row_count": 5}
+            ],
+            "summary": {"columns": 2},
+            "unknown_future_field": {"keep": true}
+        });
+
+        let mut data = HashMap::new();
+        data.insert(
+            "application/vnd.nteract.arrow-stream-manifest+json".to_string(),
+            ContentRef::Inline {
+                inline: manifest.to_string(),
+            },
+        );
+        data.insert(
+            "text/plain".to_string(),
+            ContentRef::Inline {
+                inline: "10 rows x 2 columns".to_string(),
+            },
+        );
+
+        let resolved = resolve_data_bundle(&data, &store).await.unwrap();
+        let saved_manifest = resolved
+            .get("application/vnd.nteract.arrow-stream-manifest+json")
+            .expect("manifest MIME should be preserved");
+
+        assert_eq!(saved_manifest["chunks"][0]["blob"], first_hash);
+        assert_eq!(saved_manifest["chunks"][0]["size"], first.len());
+        assert_eq!(
+            saved_manifest["chunks"][0]["content_type"],
+            "application/vnd.apache.arrow.stream"
+        );
+        assert!(saved_manifest["chunks"][0].get("hash").is_none());
+        assert_eq!(saved_manifest["chunks"][1]["blob"], second_hash);
+        assert_eq!(
+            saved_manifest["schema"]["hash"], "schema-fingerprint-only",
+            "schema.hash is a fingerprint, not a blob ref"
+        );
+        assert_eq!(saved_manifest["unknown_future_field"]["keep"], true);
+        assert_eq!(
+            resolved.get("text/plain").and_then(|v| v.as_str()),
+            Some("10 rows x 2 columns")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_restores_arrow_stream_manifest_chunk_refs() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let raw = b"arrow-stream-chunk";
+        let hash = store
+            .put(raw, "application/vnd.apache.arrow.stream")
+            .await
+            .unwrap();
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.nteract.arrow-stream-manifest+json": {
+                    "version": 1,
+                    "chunks": [
+                        {
+                            "blob": hash,
+                            "size": raw.len(),
+                            "content_type": "application/vnd.apache.arrow.stream",
+                            "row_count": 7
+                        }
+                    ],
+                    "schema": {"hash": "schema-fingerprint-only"}
+                },
+                "text/plain": "7 rows x 1 column"
+            },
+            "metadata": {}
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::DisplayData { data, .. } = manifest else {
+            panic!("expected display data manifest");
+        };
+        let content = data
+            .get("application/vnd.nteract.arrow-stream-manifest+json")
+            .expect("manifest MIME should survive load")
+            .resolve(&store)
+            .await
+            .unwrap();
+        let runtime_manifest: Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(runtime_manifest["chunks"][0]["hash"], hash);
+        assert_eq!(runtime_manifest["chunks"][0]["size"], raw.len());
+        assert_eq!(runtime_manifest["chunks"][0]["row_count"], 7);
+        assert!(runtime_manifest["chunks"][0].get("blob").is_none());
+        assert_eq!(
+            runtime_manifest["chunks"][0]["content_type"],
+            "application/vnd.apache.arrow.stream"
+        );
+        assert_eq!(
+            runtime_manifest["schema"]["hash"],
+            "schema-fingerprint-only"
+        );
+        assert!(data.contains_key("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_data_bundle_errors_for_missing_arrow_manifest_chunk_blob() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let manifest = serde_json::json!({
+            "version": 1,
+            "chunks": [{"hash": "0".repeat(64), "size": 12}]
+        });
+        let mut data = HashMap::new();
+        data.insert(
+            "application/vnd.nteract.arrow-stream-manifest+json".to_string(),
+            ContentRef::Inline {
+                inline: manifest.to_string(),
+            },
+        );
+
+        let err = resolve_data_bundle(&data, &store).await.unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(
+            err.to_string()
+                .contains("arrow manifest references missing blob"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_drops_arrow_manifest_with_missing_chunk_blob() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.nteract.arrow-stream-manifest+json": {
+                    "version": 1,
+                    "chunks": [
+                        {
+                            "blob": "0".repeat(64),
+                            "size": 12,
+                            "content_type": "application/vnd.apache.arrow.stream"
+                        }
+                    ]
+                },
+                "text/plain": "fallback survives"
+            },
+            "metadata": {}
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::DisplayData { data, .. } = manifest else {
+            panic!("expected display data manifest");
+        };
+
+        assert!(
+            !data.contains_key("application/vnd.nteract.arrow-stream-manifest+json"),
+            "unloadable manifest MIME should be dropped without removing fallback siblings"
+        );
+        assert!(data.contains_key("text/plain"));
     }
 
     #[tokio::test]

--- a/docs/superpowers/specs/2026-05-11-arrow-manifest-durable-storage-design.md
+++ b/docs/superpowers/specs/2026-05-11-arrow-manifest-durable-storage-design.md
@@ -1,0 +1,250 @@
+# Arrow Manifest Durable Storage Design
+
+## Objective
+
+PR #2658 made Arrow stream manifests renderable and added complete multi-chunk
+automatic `pyarrow.Table` output for oversized tables. This follow-up defines
+and tests the saved-notebook durability contract for those manifests.
+
+The goal is not to build direct daemon upload, coalesced artifacts, or
+viewport-driven fetch. The goal is to make it unambiguous how an Arrow stream
+manifest survives save, close, blob GC, and reopen when the chunk bytes already
+exist in the daemon blob store.
+
+## Current State
+
+Runtime output manifests store display data as `ContentRef` values. A selected
+binary table payload such as `application/vnd.apache.arrow.stream` or
+`application/vnd.apache.parquet` saves as:
+
+```json
+{
+  "application/vnd.nteract.blob-ref+json": {
+    "hash": "chunk-hash",
+    "content_type": "application/vnd.apache.arrow.stream",
+    "size": 1234
+  }
+}
+```
+
+That path works for a single selected table blob because
+`resolve_data_bundle()` rewrites the selected binary `ContentRef::Blob` to a
+top-level blob-ref MIME, and `convert_data_bundle()` reverses it on load.
+
+Arrow stream manifests are different. The selected MIME is JSON:
+
+```json
+{
+  "application/vnd.nteract.arrow-stream-manifest+json": {
+    "version": 1,
+    "content_type": "application/vnd.apache.arrow.stream",
+    "chunks": [
+      {
+        "index": 0,
+        "hash": "chunk-hash",
+        "size": 1234,
+        "row_count": 4096
+      }
+    ],
+    "complete": true
+  }
+}
+```
+
+The manifest JSON can already round-trip while the same blob store still has
+`chunks[].hash`, because the frontend resolves chunk URLs from those hashes at
+render time. That is not enough as a durability contract. Plain hash strings in
+nested JSON are not self-describing blob references, are not validated at save,
+and are easy for GC/reference walkers to miss.
+
+## Durable Shape
+
+Saved `.ipynb` output JSON should make every manifest-owned blob explicit. The
+durable form replaces hash string slots with nteract blob-ref objects in those
+slots.
+
+Runtime/render shape:
+
+```json
+{
+  "hash": "chunk-hash",
+  "size": 1234,
+  "content_type": "application/vnd.apache.arrow.stream"
+}
+```
+
+Saved shape:
+
+```json
+{
+  "blob": "chunk-hash",
+  "size": 1234,
+  "content_type": "application/vnd.apache.arrow.stream"
+}
+```
+
+This deliberately uses the existing recursive `ContentRef` sentinel keys
+`blob` and `size`. The extra `content_type` field keeps the ref
+self-describing for validation and future migration. It also lets the existing
+GC collector pattern recognize the object as a blob reference instead of
+requiring a separate manifest-only retention database.
+
+The transform applies to these manifest slots:
+
+- `chunks[].hash`, with `content_type` defaulting to the manifest
+  `content_type`
+- `coalesced.hash`, when `coalesced.kind == "single_blob"`
+- `coalesced.segments[].hash`, when `coalesced.kind == "segment_manifest"`
+
+Do not transform `schema.hash` in this PR. In #2658 it is a schema fingerprint
+computed from serialized schema bytes, but those schema bytes are not stored as
+a separate CAS blob. It should remain a string validation hash until a later
+change actually writes a schema blob.
+
+The runtime/render shape keeps `hash` as a string. The saved form is only for
+`.ipynb` JSON and only at the save/load boundary. Frontend and Sift renderer
+code should not need to handle the durable shape in normal live output state.
+
+## Save Transform
+
+`resolve_data_bundle()` should keep its existing single-blob behavior for
+direct Arrow IPC and parquet MIME entries. For
+`application/vnd.nteract.arrow-stream-manifest+json`, it should parse the
+manifest JSON and walk only the known manifest ref slots.
+
+For each slot, save should:
+
+1. Require a string `hash`.
+2. Determine the expected content type from the slot.
+3. Determine `size` from the slot when present, or from blob metadata if the
+   slot omits it.
+4. Verify the hash exists in the blob store before writing the durable ref.
+5. Replace the string hash with `{ blob, size, content_type }`.
+
+If a referenced blob is missing, save should not silently produce a durable
+manifest that looks complete. The smallest acceptable behavior for this first
+PR is to return an error from `resolve_manifest()` so the save call can surface
+the same class of "output could not be resolved" failure it already uses for
+missing blobs. A future UX pass can add a more specific user-facing diagnostic.
+
+The transform must preserve all non-ref manifest fields exactly: row counts,
+record-batch counts, summary, completion state, abort state, encoding, table
+hints, and unknown future fields.
+
+## Load Transform
+
+`convert_data_bundle()` should keep its existing top-level
+`application/vnd.nteract.blob-ref+json` handling. For
+`application/vnd.nteract.arrow-stream-manifest+json`, it should parse the JSON
+manifest and reverse only the known durable ref slots.
+
+For each durable slot, load should:
+
+1. Require `{ blob: string, size: number }`.
+2. Preserve or restore `content_type`.
+3. Check that the blob exists in the local blob store.
+4. Convert back to runtime shape with `hash: blob`, `size`, and
+   `content_type`.
+
+If the blob is missing, load should keep the manifest structurally intact but
+mark the manifest as unusable rather than pretending the table is complete. For
+the test-focused PR, use the existing safe fallback behavior: drop only the
+manifest MIME from the loaded data bundle and preserve fallback siblings such
+as `text/plain` / `text/llm+plain`. A later renderer UX pass can replace that
+with a manifest-level diagnostic field. Silent fallback to a partial table is
+not acceptable.
+
+## GC Contract
+
+The awkward part is retention. It has two separate cases:
+
+1. **Active rooms.** RuntimeStateDoc outputs exist in memory. The GC walker can
+   inspect those output manifests, but Arrow manifest chunk hashes are nested
+   inside JSON payloads rather than top-level `ContentRef::Blob` fields.
+2. **Closed file-backed rooms.** RuntimeStateDoc outputs are not persisted into
+   `NotebookDoc`. Saved `.ipynb` files contain output JSON, but the current GC
+   walker scans active rooms, comm state, notebook-doc persisted `.automerge`
+   files, and execution records. It does not generally scan arbitrary saved
+   `.ipynb` files for output blob refs.
+
+The durable JSON shape helps because `{ blob, size, content_type }` is
+self-describing and can be collected recursively once it is inside a structure
+the daemon actually scans. It does not, by itself, make closed file-backed
+notebook outputs GC-safe forever.
+
+The first implementation should therefore make two contracts explicit:
+
+- Active-room GC must be manifest-aware enough to collect live
+  `chunks[].hash` / `coalesced.*.hash` refs from selected Arrow manifest MIME
+  payloads. If the manifest JSON itself is blob-backed, the collector either
+  needs blob-store access to resolve it, or an already-derived asset list.
+- Closed-room GC needs a notebook-owned output asset index if we want stronger
+  retention than the existing orphan grace period. The index should be written
+  at save time from the resolved `.ipynb` outputs and stored in a document-owned
+  structure GC already scans, or in a new persisted sidecar with equivalent
+  retention semantics.
+
+The recommended long-term shape is a dedicated output asset index, not an
+overload of markdown `resolved_assets`. The index keys can be opaque but should
+be stable enough to replace on each successful save, for example:
+
+```text
+outputs/<cell_id>/<output_id>/<mime>/<slot>
+```
+
+The values are blob hashes. The index is for retention only; renderers should
+continue reading normal output manifests.
+
+The focused tests should cover both paths without pretending the second path is
+already solved:
+
+1. A runtime output manifest with a selected Arrow manifest MIME contributes
+   its nested chunk/coalesced blob refs to active-room GC collection.
+2. A characterization test documents that persisted NotebookDoc files do not
+   currently retain RuntimeStateDoc outputs after eviction. That test should
+   justify the output asset index rather than hiding the gap.
+3. A helper-level test proves recursive collection can find durable nested refs
+   once they are present in a scanned persisted structure.
+
+## Focused Tests
+
+Add tests before changing broad behavior:
+
+- `resolve_manifest` saves an Arrow stream manifest with two chunks using
+  durable nested refs, not plain string hashes.
+- `create_manifest` loads that saved shape back to runtime shape with string
+  `hash` fields and renderer-usable chunk metadata.
+- The transform preserves `summary`, `complete`, `row_count`,
+  `record_batch_count`, and unknown manifest fields.
+- Missing chunk blob on save is an error, not silent partial output.
+- Missing chunk blob on load drops the Arrow manifest MIME and preserves
+  fallback text siblings.
+- Recursive blob collection finds manifest `chunks` and `coalesced` refs in
+  both direct runtime shape and saved durable shape where applicable.
+- `schema.hash` stays a plain string fingerprint and is not treated as a blob
+  ref until schema bytes are actually stored.
+- A characterization test shows closed file-backed rooms need an output asset
+  index for GC-safe saved output blobs after RuntimeStateDoc outputs disappear.
+- Existing direct Arrow IPC/parquet blob-ref save/load tests keep passing.
+
+## Non-Goals
+
+- No virtual scroll cap work.
+- No direct daemon `PutBlob` / `PutBlobChunk` protocol.
+- No coalesced artifact writer.
+- No viewport-driven chunk fetching.
+- No Sift UI changes beyond what tests require.
+- No attempt to make saved notebooks portable across machines without copying
+  the nteract blob store.
+
+## PR Split
+
+The first implementation PR should land the save/load transforms, active-room
+GC collection, and characterization tests. It should not add the output asset
+index yet. That keeps the first PR focused on the manifest storage contract
+and makes the remaining closed-room retention gap explicit.
+
+The next PR should add the notebook-owned output asset index and move the
+characterization test from "documented gap" to "protected after save." No code
+path should imply closed-room output blobs are protected unless that index
+exists.

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -309,18 +309,18 @@ giving renderers enough structure to fetch and append parts.
 Hash domains:
 
 - `schema.hash` covers the Arrow IPC schema message bytes (the leading
-  message of an Arrow IPC stream), stored in CAS under the nteract-owned
-  `application/vnd.apache.arrow.schema` content type so renderers can parse it
-  once and key chunk validation off the same hash. Do not store this as JSON
-  unless the hash domain changes to canonical schema JSON at the same time.
+  message of an Arrow IPC stream) or another stable schema fingerprint chosen
+  by the manifest producer. In the current implementation it is a fingerprint
+  only, not a CAS blob reference. Save/load and GC must not rewrite it until a
+  future schema-blob design stores schema bytes separately.
 - Each `chunks[].hash` covers the bytes of the chunk blob the daemon stored
   via `BlobStore::put`. With self-contained per-chunk Arrow IPC streams (see
   "Chunk Boundaries"), `hash` covers a complete decodable mini-stream
   including the schema and any dictionary batches.
 
-For v1, "schema compatibility" between chunks means byte-equal `schema.hash`
-against the manifest's top-level schema hash. Promotable type checks are
-deferred until we have a concrete reason for them.
+For v1, "schema compatibility" between chunks means byte-equal schema
+fingerprints against the manifest's top-level schema hash. Promotable type
+checks are deferred until we have a concrete reason for them.
 
 ### Stored Forms
 
@@ -398,13 +398,18 @@ When the daemon writes the notebook to disk, it walks the manifest:
 
 1. For each `chunks[].hash`, ensure the blob is in CAS, and rewrite the entry
    to a blob-ref form the on-disk loader can resolve back into bytes.
-2. Apply the same to `schema.hash`.
-3. Write the rest of the manifest (chunk metadata, summary, table hints)
+2. Apply the same transform to `coalesced.hash` and
+   `coalesced.segments[].hash` when present.
+3. Leave `schema.hash` unchanged because it is a fingerprint, not a stored
+   schema blob.
+4. Write the rest of the manifest (chunk metadata, summary, table hints)
    inline in the saved output JSON.
 
-Load reverses the walk: blob refs in chunk and schema slots are resolved back
-into hash + content_type before the manifest is handed to renderers. This
-keeps `.ipynb` files small without inlining base64 chunk bytes.
+Load reverses the walk: blob refs in chunk/coalesced slots are resolved back
+into hash + content_type before the manifest is handed to renderers. Missing
+chunk blobs drop only the manifest MIME and preserve fallback siblings such as
+`text/plain` / `text/llm+plain`. This keeps `.ipynb` files small without
+inlining base64 chunk bytes.
 
 ### Coalesced Artifacts
 
@@ -663,6 +668,15 @@ for the staged implementation.
 - Next: decide whether automatic large dataframe reprs should opt into the
   helper by publishing their own display output, or stay one-shot while direct
   daemon blob upload and save/load manifest externalization are completed.
+- In progress: durable manifest save/load and GC collection follow-up
+  - runtime save rewrites `chunks[].hash`, `coalesced.hash`, and
+    `coalesced.segments[].hash` to nested `{blob, size, content_type}` refs
+    while preserving the manifest MIME and fallback siblings.
+  - runtime load restores those nested refs back to renderer-facing `hash`
+    entries; missing chunk blobs drop only the manifest MIME.
+  - active-room blob GC now marks Arrow manifest chunk/coalesced hashes.
+  - `schema.hash` intentionally remains a plain fingerprint until schema bytes
+    become their own stored artifact.
 
 ### Phase 1: Canonical Arrow For DataFrames
 
@@ -720,8 +734,9 @@ Changes:
 - Add `application/vnd.nteract.arrow-stream-manifest+json` to MIME priority and
   Sift routing.
 - Switch launcher producers to emit one-chunk manifests by default.
-- Teach runtime save/load to externalize manifest chunk and schema blobs by
-  walking `chunks[].hash` and `schema.hash` (see "Save Resolution").
+- Teach runtime save/load to externalize manifest chunk/coalesced blobs by
+  walking `chunks[].hash`, `coalesced.hash`, and
+  `coalesced.segments[].hash` (see "Save Resolution").
 - Teach Sift to load a single manifest chunk into the existing `load_ipc` path.
 
 Acceptance:


### PR DESCRIPTION
## Summary

- Add durable save/load transforms for `application/vnd.nteract.arrow-stream-manifest+json` chunk references.
- Rewrite known runtime refs (`chunks[].hash`, `coalesced.hash`, `coalesced.segments[].hash`) to saved `{blob, size, content_type}` objects, then restore them on load.
- Teach active-room blob GC to mark Arrow manifest chunk/coalesced hashes while leaving `schema.hash` as a fingerprint.
- Update the Arrow-native roadmap notes with the narrower durability contract.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p notebook-doc mime:: --lib`
- `cargo test -p runtimed output_store:: --lib`
- `cargo test -p runtimed collect_blob_hashes --lib`
- `cargo test -p runtimed --lib`
