### PR TITLE
fix(notebook): rebuild renderer plugins when workspace sources change

### DIFF
--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -76,9 +76,17 @@ export function isolatedRendererPlugin(options: IsolatedRendererPluginOptions = 
   let devBuildPromise: Promise<void> | null = null;
   let isDevMode = false;
 
-  // Directories to watch for changes that should trigger rebuild
+  // Directories to watch for changes that should trigger rebuild. The first
+  // two are part of Vite's normal module graph (the main app imports them
+  // transitively). The last two — packages/sift/src and the sift-wasm pkg
+  // output — are bundled into virtual:renderer-plugin/sift opaquely by the
+  // renderer-plugin builder, so Vite has no idea they're dependencies. The
+  // configureServer hook below explicitly adds them to chokidar so
+  // handleHotUpdate fires on edits + WASM rebuilds.
   const isolatedRendererDir = path.resolve(__dirname, "../../src/isolated-renderer");
   const componentsDir = path.resolve(__dirname, "../../src/components");
+  const siftPackageSrcDir = path.resolve(__dirname, "../../packages/sift/src");
+  const siftWasmPkgDir = path.resolve(__dirname, "../../crates/sift-wasm/pkg");
 
   function invalidateDevCache() {
     devBuildPromise = null;
@@ -260,6 +268,15 @@ export const css = ${JSON.stringify(css)};
     // Dev server: build from source for live development
     configureServer(devServer) {
       isDevMode = true;
+      // Workspace packages bundled into virtual:renderer-plugin/* are invisible
+      // to Vite's module graph (the plugin builder runs as a separate Rolldown
+      // pass and returns opaque code strings). Watch them explicitly so edits
+      // and WASM rebuilds reach handleHotUpdate. Also watch the on-disk
+      // pre-built output dir so external rebuilds (cargo xtask renderer-plugins)
+      // invalidate the in-memory dev cache too.
+      devServer.watcher.add(siftPackageSrcDir);
+      devServer.watcher.add(siftWasmPkgDir);
+      devServer.watcher.add(PREBUILT_DIR);
       devServer.middlewares.use(async (_req, _res, next) => {
         if (!devBuildPromise) {
           devBuildPromise = buildRendererFromSource();
@@ -289,7 +306,10 @@ export const css = ${JSON.stringify(css)};
         (file.startsWith(componentsDir) &&
           (file.includes("/outputs/") ||
             file.includes("/isolated/") ||
-            file.includes("/widgets/")));
+            file.includes("/widgets/"))) ||
+        file.startsWith(siftPackageSrcDir) ||
+        file.startsWith(siftWasmPkgDir) ||
+        file.startsWith(PREBUILT_DIR);
 
       if (!isIsolatedRendererFile) return;
 


### PR DESCRIPTION
Editing `packages/sift/src/table.ts` or running `cargo xtask wasm sift` while Vite is running didn't pick the change up in the browser/Tauri. The dev server's `vite-plugin-isolated-renderer` only fired `handleHotUpdate` for files under `src/isolated-renderer/**` or `src/components/{outputs,isolated,widgets}/**`, so workspace sources bundled into `virtual:renderer-plugin/*` went unnoticed and the in-memory `devPluginOutputs` cache kept serving stale code until you stopped Vite and restarted it. Same for sift-wasm rebuilds (`crates/sift-wasm/pkg/`) and external renderer-plugin rebuilds (`cargo xtask renderer-plugins` writing to `apps/notebook/src/renderer-plugins/`).

The plugin builder runs as a separate Rolldown pass and returns opaque code strings; Vite's module graph never sees those workspace files as dependencies, so Chokidar doesn't track them by default. The fix adds three explicit watch paths and extends the `handleHotUpdate` filter to match:

- `packages/sift/src/` — sift TypeScript sources bundled into `virtual:renderer-plugin/sift`
- `crates/sift-wasm/pkg/` — sift-wasm output that gets base64-inlined into the bundle
- `apps/notebook/src/renderer-plugins/` — pre-built output dir; covers the `cargo xtask renderer-plugins` workflow that writes there from outside Vite

All three reuse the existing rebuild path: invalidate the dev cache, rebuild via `buildRendererFromSource()`, invalidate the virtual modules in the module graph, send `full-reload` to all clients.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [ ] Manual: with Vite running, edit `packages/sift/src/table.ts` and confirm Vite logs `[isolated-renderer] Rebuilding due to change in: packages/sift/src/table.ts`
- [ ] Manual: with Vite running, run `cargo xtask renderer-plugins` and confirm Vite logs a rebuild + `full-reload`
- [ ] Manual: with Vite running and Tauri attached, edit `packages/sift/src/table.ts` and confirm the change reflects in Tauri without quitting

This addresses the same symptom that bit us during #2702 review (Tauri kept serving the pre-fix sift bundle until ⌘Q + relaunch). Won't help WKWebView's HTTP cache for `nteract-frame://`-served HTML, but the renderer plugin code path itself now invalidates cleanly.
