### PR TITLE
ci: exclude runtimed-py from native workspace tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -515,7 +515,10 @@ jobs:
 
       - name: Clippy
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        # runtimed-py is built/tested in the dedicated maturin/PyO3 job below.
+        # Testing it as a plain workspace crate links the extension-module build
+        # without Python symbols on macOS.
+        run: cargo clippy --workspace --exclude runtimed-py --all-targets -- -D warnings
 
       - name: Build
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
@@ -523,7 +526,7 @@ jobs:
 
       - name: Run tests
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        run: cargo test --workspace --exclude runtimed-node --verbose
+        run: cargo test --workspace --exclude runtimed-node --exclude runtimed-py --verbose
 
   # Build Tauri app once and share with E2E shards
   # E2E smoke test - verifies basic app functionality


### PR DESCRIPTION
## Summary

- exclude `runtimed-py` from the native platform matrix clippy/test workspace commands
- keep `runtimed-py` covered by the dedicated maturin/PyO3 integration job, which configures Python and runs Rust tests with `--no-default-features`

## Why

Current `main` fails the macOS Build lane in `cargo test --workspace --exclude runtimed-node --verbose` because `runtimed-py` defaults to the PyO3 `extension-module` feature. As a plain workspace test target on macOS, that links without Python symbols and fails on unresolved `_Py_*` symbols. Linux already excludes `runtimed-py` from the generic workspace test lane for this reason.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p runtimed-py --lib --no-default-features --no-run`
