### PR TITLE
fix(notebook): include arrow-stream-manifest MIME in sift predicates

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -202,14 +202,16 @@ function isScrollPassthroughMimeType(mimeType: string): boolean {
     mimeType === "text/html" ||
     mimeType === "image/svg+xml" ||
     mimeType === "application/vnd.apache.parquet" ||
-    mimeType === "application/vnd.apache.arrow.stream"
+    mimeType === "application/vnd.apache.arrow.stream" ||
+    mimeType === "application/vnd.nteract.arrow-stream-manifest+json"
   );
 }
 
 function isSiftMimeType(mimeType: string): boolean {
   return (
     mimeType === "application/vnd.apache.parquet" ||
-    mimeType === "application/vnd.apache.arrow.stream"
+    mimeType === "application/vnd.apache.arrow.stream" ||
+    mimeType === "application/vnd.nteract.arrow-stream-manifest+json"
   );
 }
 


### PR DESCRIPTION
`isSiftMimeType` and `isScrollPassthroughMimeType` in `OutputArea.tsx` only matched `application/vnd.apache.parquet` and `application/vnd.apache.arrow.stream`. The new `application/vnd.nteract.arrow-stream-manifest+json` that #2705 makes the default rendered MIME for tabular outputs wasn't on either list, so:

- `hasSiftOutputs = false` — no boxShadow focus ring on the output well when activated, no `SiftScrollHandoffCue` at the bottom, `interactionActive` never reaches the iframe (so `SiftFocusStatus` never renders).
- `isScrollPassthroughMimeType = false` — the iframe traps every wheel gesture inside its 600px box; the scroll-passthrough affordance for Sift tables doesn't kick in.

Add the manifest MIME to both predicates. The renderer plugin already handles it (`iframe-libraries.ts:43`, `media-router.tsx:72`); only the sift-aware focus + scroll wiring was missing the alias.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [ ] Manual: render a polars DataFrame or pyarrow Table, click the output well, confirm blue focus ring appears and `SiftFocusStatus` shows at the bottom
- [ ] Manual: hover the output well (without clicking), confirm the `SiftScrollHandoffCue` fades in at the bottom-right
