### PR TITLE
fix(notebook): keep sift focus until click-elsewhere, not pointer-out

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -3,7 +3,6 @@ import "@nteract/sift/handoff.css";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   type KeyboardEvent,
-  type PointerEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -547,21 +546,6 @@ export function OutputArea({
     onIframeMouseDown,
   ]);
 
-  const deactivateStaticFrameInteractionWhenIdle = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
-      if (
-        event.relatedTarget instanceof Node &&
-        event.currentTarget.contains(event.relatedTarget)
-      ) {
-        return;
-      }
-      if (!(event.buttons > 0)) {
-        setStaticFrameInteractionActive(false);
-      }
-    },
-    [],
-  );
-
   const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape") {
       setStaticFrameInteractionActive(false);
@@ -859,11 +843,6 @@ export function OutputArea({
               tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
               onPointerDown={
                 shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
-              }
-              onPointerOut={
-                shouldUseScrollPassthroughFrame
-                  ? deactivateStaticFrameInteractionWhenIdle
-                  : undefined
               }
               onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
             >

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -192,7 +192,7 @@ describe("OutputArea iframe theme sync", () => {
     );
   });
 
-  it("activates static iframe outputs for pointer interaction until the pointer leaves", () => {
+  it("activates static iframe outputs on pointer down and keeps them active when the pointer leaves", () => {
     const onIframeMouseDown = vi.fn();
     const { getByTestId } = render(
       <OutputArea outputs={makeMarkdownOutput()} isolated onIframeMouseDown={onIframeMouseDown} />,
@@ -209,6 +209,8 @@ describe("OutputArea iframe theme sync", () => {
       "true",
     );
 
+    // Pointer out while a button is held used to be a no-op and remains so —
+    // active drags keep the frame focused.
     pointerOutWithButtons(activationWell, 1);
 
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
@@ -216,11 +218,14 @@ describe("OutputArea iframe theme sync", () => {
       "true",
     );
 
+    // Pointer out without buttons no longer drops focus; the user has to
+    // click elsewhere, scroll, or press Escape. See the dedicated
+    // outside-pointer-down and Escape tests below.
     pointerOutWithButtons(activationWell, 0);
 
-    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
-      "false",
+      "true",
     );
   });
 


### PR DESCRIPTION
Click-to-focus on a Sift output well also auto-unfocused as soon as the cursor left the wrapper. Edge cases on the right side of the frame (scrollbar, table border, sub-pixel overshoot) flipped focus off and on as the cursor wobbled, even with an active interaction in progress.

The hover-out path was there to mirror the way the focus ring fades on plain hover, but it conflicted with the established "I clicked into this, leave it focused until I click away" model. The other deactivation paths are already in place:

- pointerdown outside the wrapper (existing document listener)
- window scroll (existing scroll listener)
- Escape key (existing keydown handler)
- `shouldUseScrollPassthroughFrame` flipping to false (existing effect)

Remove the `onPointerOut`-driven `deactivateStaticFrameInteractionWhenIdle` and its callback. The remaining paths give the expected behavior: click in to grab focus, leave it until you click elsewhere, scroll the page, or press Escape.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] Manual: render a Sift table, click into it, drag the cursor outside the wrapper (especially the right edge), confirm focus ring + handoff cue + `SiftFocusStatus` stay put
- [x] Manual: click outside, confirm focus drops
- [x] Manual: scroll the page while focused, confirm focus drops (unchanged)
- [x] Manual: press Escape while focused, confirm focus drops (unchanged)
