### PR TITLE
fix(notebook): forward leaked wheel events from passthrough iframe to page

### DIFF
--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -342,6 +342,19 @@
                 handleSearchNavigate(payload);
                 break;
 
+              case "interaction_state":
+                // Mirror the parent's iframe-interaction state into a flag
+                // the bootstrap wheel handler can read. active=false means
+                // the parent is in scroll-passthrough mode (sift output not
+                // clicked into) and any wheel events that reach this
+                // document — including momentum pulses that WKWebView lets
+                // through `pointer-events: none` — should be redirected
+                // to the notebook page instead of scrolling inner content.
+                if (payload && typeof payload === "object") {
+                  scrollPassthroughActive = payload.active === false;
+                }
+                break;
+
               case "bridge_ready":
               case "comm_open":
               case "comm_msg":
@@ -717,10 +730,24 @@
           return behavior === "none" || behavior === "contain";
         }
 
+        // Tracks parent-signaled scroll-passthrough mode. The parent
+        // already sets `pointer-events: none` on the iframe element when
+        // it wants wheels to bypass the iframe; this is a defensive
+        // backstop because WKWebView occasionally delivers momentum-scroll
+        // pulses to the iframe despite that style. When the flag is set,
+        // we eat every wheel and forward its delta to the parent so the
+        // notebook page scrolls instead of the inner content.
+        var scrollPassthroughActive = false;
+
         document.addEventListener(
           "wheel",
           function (e) {
             if (!e.deltaY) return;
+            if (scrollPassthroughActive) {
+              e.preventDefault();
+              sendRpc("nteract/wheelBoundary", { deltaY: e.deltaY });
+              return;
+            }
             var scroller = nearestVerticalScroller(e.target);
             if (!isWheelAtScrollBoundary(scroller, e.deltaY)) return;
             if (scrollerOptsOutOfChaining(scroller)) {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -358,6 +358,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
     const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
+    const scrollPassthroughRef = useRef(scrollPassthrough);
 
     // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
@@ -369,6 +370,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
     allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
+    scrollPassthroughRef.current = scrollPassthrough;
 
     const applyMeasuredHeight = useCallback(
       (contentHeight: number) => {
@@ -574,7 +576,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
                 onMouseDownRef.current?.();
               });
               transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
-                if (!allowWheelBoundaryScrollRef.current) {
+                // Two forward paths: the normal boundary-chaining case, and
+                // the scroll-passthrough leak case where pointer-events: none
+                // didn't fully prevent the iframe from receiving a wheel
+                // (e.g., WKWebView momentum pulse). In both cases the wheel
+                // should scroll the parent's nearest scrollable ancestor.
+                if (!allowWheelBoundaryScrollRef.current && !scrollPassthroughRef.current) {
                   return;
                 }
                 scrollFrameWheelBoundary(iframeRef.current, params as { deltaY?: number });


### PR DESCRIPTION
Scrolling the notebook hard up/down with the cursor over a sift output iframe sometimes scrolls the inner sift table even though the user hasn't clicked into it. The parent already sets `pointer-events: none` on the iframe in passthrough mode (in `isolated-frame.tsx`), which is supposed to keep wheels on the page's native scroll path. WKWebView (and to a lesser extent Safari) occasionally lets momentum-scroll pulses pierce that, so a few wheel events land inside the iframe document and sift's `.sift-viewport` (with `overscroll-behavior: none`) absorbs them locally without chaining.

The fix is a defensive forward inside the iframe. The parent already sends an `interaction_state` message when sift focus toggles (`OutputArea.tsx:481-484`). The bootstrap script in `frame.html` now listens for that message, tracks `scrollPassthroughActive = (active === false)`, and short-circuits the wheel handler when set: every wheel event is `preventDefault`'d and forwarded to the parent as `nteract/wheelBoundary`. The parent's `NTERACT_WHEEL_BOUNDARY` handler is widened to also fire when `scrollPassthrough` is true, so the forwarded delta scrolls the notebook page exactly the way the user expected.

When the user clicks to focus the table (`active = true`), the flag flips back to `false` and the wheel handler returns to its existing "forward only at boundary" semantics — focused interaction with the table is unchanged.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `frame-html.test.ts`, `OutputArea.test.tsx`, `isolated-frame.test.ts`, `scroll-boundary.test.ts` all pass (49/49)
- [ ] Manual: 2M-row sift table in `~/big-ish-data.ipynb`, hard trackpad-scroll up and down with the cursor hovering over the table without clicking — sift table position stays put while the notebook scrolls
- [ ] Manual: click the table to focus, wheel — sift table scrolls normally (focused interaction unchanged)
- [ ] Manual: with the table focused and scrolled to its top boundary, keep wheeling up — page scrolls (existing boundary-chaining behavior preserved)

## Known WebKit quirks worth citing

- `pointer-events: none` controls hit-testing for new pointer interactions but doesn't reliably suppress in-flight momentum-scroll pulses on WKWebView; the iframe document can still receive those wheel events
- WKWebView's inner `scrollTop` updates can lag the visual position during momentum, so the boundary check at `frame.html:699` flickered between true/false on the tail end of a fling — covered by short-circuiting before the boundary check now
