### PR TITLE
feat(outputs): precompute arrow manifest llm hints

### DIFF
--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -954,10 +954,10 @@ fn synthesize_basic_arrow_manifest_summary(manifest: &Value) -> Option<String> {
         format_count(included_rows),
         format_count(field_count)
     )];
-    if total_rows.is_some_and(|total| total != included_rows) {
+    if let Some(total_rows) = total_rows.filter(|total| *total != included_rows) {
         lines[0].push_str(&format!(
             " (sampled from {} total rows)",
-            format_count(total_rows.unwrap())
+            format_count(total_rows)
         ));
     }
 

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -78,7 +78,11 @@ const SYNTHESIS_PREFIXES: &[&str] = &[
 ];
 
 /// Exact MIME matches that have dedicated synthesizers.
-const SYNTHESIS_EXACT: &[&str] = &["application/geo+json", "application/vnd.apache.parquet"];
+const SYNTHESIS_EXACT: &[&str] = &[
+    "application/geo+json",
+    "application/vnd.apache.parquet",
+    notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME,
+];
 
 /// When `text/plain` exceeds this size, synthesize a truncated `text/llm+plain`.
 const LLM_TEXT_MAX_SIZE: usize = 4 * 1024;
@@ -735,6 +739,11 @@ async fn resolve_display_for_llm(
         }
         synthesize_llm_plain_for_viz(&mut output_data);
 
+        if !output_data.contains_key("text/llm+plain") {
+            synthesize_llm_plain_for_arrow_manifest(&mut output_data);
+        }
+        output_data.remove(notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME);
+
         // Resolve parquet bytes transiently for summarization, then drop them
         // so we don't ship raw parquet bytes back through MCP. The summary
         // ends up in text/llm+plain.
@@ -859,6 +868,136 @@ async fn resolve_display_for_llm(
     } else {
         Some(Output::display_data(output_data))
     }
+}
+
+/// Synthesize `text/llm+plain` from an Arrow stream manifest's precomputed LLM
+/// hint. This consumes only the small JSON manifest, never the table chunks.
+fn synthesize_llm_plain_for_arrow_manifest(output_data: &mut HashMap<String, DataValue>) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+    let Some(manifest) = output_data.get(notebook_doc::mime::ARROW_STREAM_MANIFEST_MIME) else {
+        return;
+    };
+    let text = match manifest {
+        DataValue::Json(value) => arrow_manifest_llm_text(value),
+        DataValue::Text(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|value| arrow_manifest_llm_text(&value)),
+        DataValue::Binary(_) => None,
+    };
+    if let Some(text) = text {
+        output_data.insert("text/llm+plain".to_string(), DataValue::Text(text));
+    }
+}
+
+fn arrow_manifest_llm_text(manifest: &Value) -> Option<String> {
+    if let Some(llm) = manifest.get("llm").and_then(Value::as_object) {
+        let content_type = llm
+            .get("content_type")
+            .and_then(Value::as_str)
+            .unwrap_or("text/llm+plain");
+        if content_type == "text/llm+plain" {
+            if let Some(text) = llm
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                return Some(text.to_string());
+            }
+        }
+    }
+    synthesize_basic_arrow_manifest_summary(manifest)
+}
+
+fn synthesize_basic_arrow_manifest_summary(manifest: &Value) -> Option<String> {
+    let summary = manifest.get("summary").and_then(Value::as_object);
+    let included_rows = summary
+        .and_then(|summary| summary.get("included_rows"))
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            summary
+                .and_then(|summary| summary.get("total_rows"))
+                .and_then(Value::as_u64)
+        })
+        .or_else(|| manifest.get("row_count").and_then(Value::as_u64))
+        .or_else(|| {
+            manifest
+                .get("chunks")
+                .and_then(Value::as_array)
+                .map(|chunks| {
+                    chunks
+                        .iter()
+                        .filter_map(|chunk| chunk.get("row_count").and_then(Value::as_u64))
+                        .sum()
+                })
+        })?;
+    let total_rows = summary
+        .and_then(|summary| summary.get("total_rows"))
+        .and_then(Value::as_u64);
+    let schema = manifest.get("schema").and_then(Value::as_object);
+    let columns = schema
+        .and_then(|schema| schema.get("columns"))
+        .and_then(Value::as_array);
+    let field_count = columns.map_or_else(
+        || {
+            schema
+                .and_then(|schema| schema.get("fields"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        },
+        |columns| columns.len() as u64,
+    );
+
+    let mut lines = vec![format!(
+        "Arrow table: {} rows x {} columns",
+        format_count(included_rows),
+        format_count(field_count)
+    )];
+    if total_rows.is_some_and(|total| total != included_rows) {
+        lines[0].push_str(&format!(
+            " (sampled from {} total rows)",
+            format_count(total_rows.unwrap())
+        ));
+    }
+
+    if let Some(columns) = columns {
+        lines.push("Columns:".to_string());
+        for column in columns.iter().take(40) {
+            let name = column
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed>");
+            let ty = column
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let nullable_suffix = if column.get("nullable").and_then(Value::as_bool) == Some(false)
+            {
+                ", non-nullable"
+            } else {
+                ""
+            };
+            lines.push(format!("  - {name} ({ty}{nullable_suffix})"));
+        }
+        if columns.len() > 40 {
+            lines.push(format!("  ...[+{} more columns]", columns.len() - 40));
+        }
+    }
+
+    Some(lines.join("\n"))
+}
+
+fn format_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (idx, ch) in s.chars().enumerate() {
+        if idx > 0 && (s.len() - idx).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
 }
 
 /// Truncate text keeping head and tail, since errors and results tend to
@@ -1699,6 +1838,93 @@ mod tests {
         );
         assert!(!data.contains_key("text/plain"));
         assert!(!data.contains_key("image/png"));
+    }
+
+    #[tokio::test]
+    async fn llm_uses_arrow_manifest_precomputed_text_without_chunks() {
+        let manifest_text = serde_json::json!({
+            "version": 1,
+            "content_type": "application/vnd.apache.arrow.stream",
+            "summary": {
+                "total_rows": 2_000_000,
+                "included_rows": 2_000_000,
+                "sampled": false,
+                "sample_strategy": "none"
+            },
+            "schema": {
+                "fields": 2,
+                "columns": [
+                    {"name": "row_id", "type": "int64", "nullable": true},
+                    {"name": "event", "type": "string", "nullable": true}
+                ]
+            },
+            "chunks": [
+                {"hash": "chunk_hash_should_not_be_fetched", "size": 123456, "row_count": 2_000_000}
+            ],
+            "llm": {
+                "content_type": "text/llm+plain",
+                "text": "DataFrame (pyarrow): 2,000,000 rows x 2 columns\nColumns:\n  - row_id (int64)\n  - event (string)"
+            }
+        })
+        .to_string();
+        let manifest = make_display_manifest(json!({
+            "application/vnd.nteract.arrow-stream-manifest+json": inline_ref(&manifest_text),
+        }));
+
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
+
+        let Some(DataValue::Text(summary)) = data.get("text/llm+plain") else {
+            panic!("expected precomputed manifest llm text");
+        };
+        assert!(summary.contains("2,000,000 rows x 2 columns"));
+        assert!(summary.contains("row_id"));
+        assert!(!data.contains_key("application/vnd.nteract.arrow-stream-manifest+json"));
+    }
+
+    #[tokio::test]
+    async fn llm_synthesizes_basic_arrow_manifest_summary_from_schema() {
+        let manifest_text = serde_json::json!({
+            "version": 1,
+            "summary": {
+                "total_rows": 100,
+                "included_rows": 25,
+                "sampled": true
+            },
+            "schema": {
+                "fields": 2,
+                "columns": [
+                    {"name": "value", "type": "float64", "nullable": false},
+                    {"name": "category", "type": "large_string", "nullable": true}
+                ]
+            },
+            "chunks": [
+                {"hash": "chunk_hash_should_not_be_fetched", "size": 123456, "row_count": 25}
+            ]
+        })
+        .to_string();
+        let manifest = make_display_manifest(json!({
+            "application/vnd.nteract.arrow-stream-manifest+json": inline_ref(&manifest_text),
+        }));
+
+        let Some(output) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
+            panic!("resolve should succeed");
+        };
+        let Some(data) = output.data else {
+            panic!("output should have data");
+        };
+
+        let Some(DataValue::Text(summary)) = data.get("text/llm+plain") else {
+            panic!("expected manifest-derived llm summary");
+        };
+        assert!(summary.contains("Arrow table: 25 rows x 2 columns"));
+        assert!(summary.contains("sampled from 100 total rows"));
+        assert!(summary.contains("value (float64, non-nullable)"));
+        assert!(summary.contains("category (large_string)"));
     }
 
     #[tokio::test]

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -248,6 +248,35 @@ consumers do not need to fetch chunk blobs. Manifest metadata is the source of
 truth for row counts and shape; `text/llm+plain` is human-readable text derived
 from those facts.
 
+Follow-up after PR #2712: Arrow stream manifests now carry the first bounded
+LLM hint directly on the manifest:
+
+```json
+{
+  "schema": {
+    "fields": 2,
+    "columns": [
+      { "name": "row_id", "type": "int64", "nullable": true },
+      { "name": "event", "type": "large_string", "nullable": true }
+    ]
+  },
+  "summary": { "total_rows": 2000000, "included_rows": 2000000 },
+  "llm": {
+    "content_type": "text/llm+plain",
+    "text": "DataFrame (pyarrow): 2,000,000 rows × 2 columns\n..."
+  }
+}
+```
+
+This is intentionally small. It lets MCP / runtime bindings recover a useful
+LLM table summary by reading only the manifest JSON if the sibling
+`text/llm+plain` MIME is absent, without touching Arrow chunk blobs. If
+`llm.text` is missing, the resolver can still synthesize a basic row/column/type
+summary from `summary` and `schema.columns`. The richer future research path is
+a structured `llm.columns[].stats` object derived from the existing Python-side
+dataframe stat extractors and/or `nteract-predicate`, so consumers can avoid
+parsing summary prose.
+
 ## Chunked Arrow Over CAS
 
 The right streaming unit is not "chunked parquet." It is an ordered Arrow stream
@@ -878,6 +907,8 @@ Python:
 - polars output emits Arrow IPC stream.
 - downsampled outputs carry consistent `included_rows` and `sampled` hints.
 - fallback still produces `text/llm+plain` when Arrow serialization fails.
+- Arrow stream manifests carry schema column descriptors and precomputed
+  `llm.text` when the launcher generated a table summary.
 
 Rust:
 
@@ -885,6 +916,9 @@ Rust:
   Face hints.
 - output store save/load externalizes direct Arrow IPC, parquet, and manifest
   chunks.
+- LLM-selective output resolution uses manifest-level `llm.text` before any
+  Arrow chunk fetch if the sibling `text/llm+plain` MIME is missing, then falls
+  back to a manifest-derived row/column/type summary.
 - update-display-data preserves metadata hints for manifest revisions.
 - blob upload rejects hash mismatches and missing chunks.
 - coalesced artifact generation chooses a single blob below

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -272,6 +272,12 @@ def _emit_arrow_table_chunks(
     )
     included_rows = sum(chunk.row_count for chunk in chunks)
     sampled = included_rows != total_rows
+    llm_text: str | None = None
+    try:
+        llm_text = summary_fn(included_rows, sampled)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("summary build failed: %s", exc)
+
     summary_hints = {
         "total_rows": total_rows,
         "included_rows": included_rows,
@@ -290,12 +296,11 @@ def _emit_arrow_table_chunks(
             complete=True,
             summary=summary_hints,
             schema=table.schema,
+            llm={"text": llm_text} if llm_text is not None else None,
         ),
     }
-    try:
-        bundle["text/llm+plain"] = summary_fn(included_rows, sampled)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("summary build failed: %s", exc)
+    if llm_text is not None:
+        bundle["text/llm+plain"] = llm_text
 
     pending = pending_buffers()
     for chunk in chunks:
@@ -332,6 +337,11 @@ def _emit_table_bytes(
     summaries can name the sampling state honestly.
     """
     sampled = included_rows != total_rows
+    llm_text: str | None = None
+    try:
+        llm_text = summary_fn(included_rows, sampled)
+    except Exception as exc:  # noqa: BLE001
+        log.debug("summary build failed: %s", exc)
 
     h = hashlib.sha256(data).hexdigest()
     ref = BlobRef(hash=h, size=len(data))
@@ -353,13 +363,12 @@ def _emit_table_bytes(
                 content_size=len(data),
                 row_count=included_rows,
                 summary=summary_hints,
+                llm={"text": llm_text} if llm_text is not None else None,
             )
         except Exception as exc:  # noqa: BLE001
             log.debug("arrow manifest build failed: %s", exc)
-    try:
-        bundle["text/llm+plain"] = summary_fn(included_rows, sampled)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("summary build failed: %s", exc)
+    if llm_text is not None:
+        bundle["text/llm+plain"] = llm_text
 
     pending_buffers()[h] = data
     return bundle

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -269,6 +269,7 @@ def build_arrow_stream_manifest(
     row_count: int,
     record_batch_count: int | None = None,
     summary: dict[str, Any] | None = None,
+    llm: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a one-chunk Arrow stream manifest for ``data``.
 
@@ -289,6 +290,7 @@ def build_arrow_stream_manifest(
         [chunk],
         complete=True,
         summary=summary,
+        llm=llm,
     )
     if record_batch_count is None:
         manifest["chunks"][0].pop("record_batch_count", None)
@@ -301,6 +303,7 @@ def build_arrow_stream_manifest_from_chunks(
     complete: bool,
     summary: dict[str, Any] | None = None,
     schema: Any | None = None,
+    llm: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build an Arrow stream manifest for ordered IPC mini-stream chunks."""
     import pyarrow as pa
@@ -313,13 +316,21 @@ def build_arrow_stream_manifest_from_chunks(
     schema_bytes = schema.serialize().to_pybytes()
     metadata = schema.metadata or {}
 
-    return {
+    manifest = {
         "version": 1,
         "content_type": ARROW_STREAM_MIME,
         "schema": {
             "hash": hashlib.sha256(schema_bytes).hexdigest(),
             "content_type": "application/vnd.apache.arrow.schema",
             "fields": len(schema),
+            "columns": [
+                {
+                    "name": field.name,
+                    "type": str(field.type),
+                    "nullable": bool(field.nullable),
+                }
+                for field in schema
+            ],
             "metadata": {
                 "pandas": b"pandas" in metadata,
                 "huggingface": b"huggingface" in metadata,
@@ -328,6 +339,23 @@ def build_arrow_stream_manifest_from_chunks(
         "chunks": [chunk.manifest_entry() for chunk in chunks],
         "complete": complete,
         "summary": summary or {},
+    }
+    llm_entry = _normalize_manifest_llm(llm)
+    if llm_entry is not None:
+        manifest["llm"] = llm_entry
+    return manifest
+
+
+def _normalize_manifest_llm(llm: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the bounded LLM hint object stored on Arrow manifests."""
+    if llm is None:
+        return None
+    text = llm.get("text")
+    if not isinstance(text, str) or not text:
+        return None
+    return {
+        "content_type": str(llm.get("content_type") or "text/llm+plain"),
+        "text": text,
     }
 
 

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -385,6 +385,11 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
     assert isinstance(_buffer_hook.pending_buffers()[h], bytes)
     assert bundle[ARROW_STREAM_MANIFEST_MIME]["chunks"][0]["hash"] == h
     assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"]["included_rows"] == 3
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["llm"]["text"] == bundle["text/llm+plain"]
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["schema"]["columns"] == [
+        {"name": "a", "type": "int64", "nullable": True},
+        {"name": "b", "type": "large_string", "nullable": True},
+    ]
 
 
 # ─── pyarrow.Table path — preserves schema KV metadata ───────────────────

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -228,6 +228,7 @@ def test_build_arrow_stream_manifest_describes_one_chunk():
     assert manifest["content_type"] == ARROW_STREAM_MIME
     assert manifest["complete"] is True
     assert manifest["schema"]["fields"] == 1
+    assert manifest["schema"]["columns"] == [{"name": "a", "type": "int64", "nullable": True}]
     assert manifest["schema"]["content_type"] == "application/vnd.apache.arrow.schema"
     assert manifest["chunks"] == [
         {
@@ -239,6 +240,31 @@ def test_build_arrow_stream_manifest_describes_one_chunk():
             "encoding": "arrow-ipc-stream",
         }
     ]
+
+
+def test_build_arrow_stream_manifest_carries_precomputed_llm_text():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import build_arrow_stream_manifest
+
+    table = pa.table({"a": [1, 2, 3], "label": ["x", "y", "z"]})
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    data = sink.getvalue().to_pybytes()
+
+    manifest = build_arrow_stream_manifest(
+        data,
+        content_hash="abc123",
+        content_size=len(data),
+        row_count=3,
+        summary={"total_rows": 3, "included_rows": 3},
+        llm={"text": "DataFrame: 3 rows x 2 columns"},
+    )
+
+    assert manifest["llm"] == {
+        "content_type": "text/llm+plain",
+        "text": "DataFrame: 3 rows x 2 columns",
+    }
 
 
 def test_iter_arrow_stream_chunks_yields_decodable_mini_streams():


### PR DESCRIPTION
## Summary

- Add bounded schema column descriptors to Arrow stream manifests.
- Store precomputed manifest-level `llm.text` when the launcher already generated `text/llm+plain`.
- Let LLM-selective output resolution use manifest `llm.text`, or synthesize a basic row/column/type summary from manifest JSON, without fetching Arrow chunk blobs.
- Update the Arrow-native output plan with the current small contract and the deferred structured-stats research path.

## Verification

- `uv run pytest python/nteract-kernel-launcher/tests/test_format.py python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_progressive.py -q`
- `cargo test -p runtimed-outputs output_resolver --lib`
- `cargo test -p runtimed arrow_stream_manifest --lib`
- `cargo xtask lint --fix`

## Notes

- `cargo xtask wasm` was needed in the fresh worktree to rebuild the gitignored `sift.js` asset before `runtimed` tests could compile. The unrelated generated renderer CSS pointer diff was restored before commit.
