### PR TITLE
perf(runtimed): render streams only when flushing

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -197,17 +197,22 @@ async fn flush_stream_output(
     kernel_actor_id: &str,
     flush: PendingStreamFlush,
 ) {
-    let known_state = {
+    let (known_state, rendered_text) = {
         let terminals = stream_terminals.lock().await;
-        terminals
-            .get_output_state(&flush.execution_id, &flush.stream_name)
-            .cloned()
+        (
+            terminals
+                .get_output_state(&flush.execution_id, &flush.stream_name)
+                .cloned(),
+            terminals
+                .render(&flush.execution_id, &flush.stream_name)
+                .unwrap_or_default(),
+        )
     };
 
     let nbformat_value = serde_json::json!({
         "output_type": "stream",
         "name": flush.stream_name,
-        "text": flush.rendered_text,
+        "text": rendered_text,
     });
 
     let manifest =
@@ -1537,15 +1542,14 @@ impl KernelConnection for JupyterKernel {
                                         };
                                         let eid = execution_id.clone().unwrap_or_default();
 
-                                        let rendered_text = {
+                                        {
                                             let mut terminals = iopub_stream_terminals.lock().await;
-                                            terminals.feed(&eid, stream_name, &stream.text)
-                                        };
+                                            terminals.feed_chunk(&eid, stream_name, &stream.text);
+                                        }
 
                                         if let Some(flush) = stream_flushes.record_chunk(
                                             &eid,
                                             stream_name,
-                                            rendered_text,
                                             stream.text.len(),
                                             std::time::Instant::now(),
                                         ) {

--- a/crates/runtimed/src/stream_flush.rs
+++ b/crates/runtimed/src/stream_flush.rs
@@ -18,12 +18,10 @@ pub(crate) const STREAM_FLUSH_MAX_BYTES: usize = 64 * 1024;
 pub(crate) struct PendingStreamFlush {
     pub execution_id: String,
     pub stream_name: String,
-    pub rendered_text: String,
 }
 
 #[derive(Debug, Clone)]
 struct StreamFlushEntry {
-    rendered_text: Option<String>,
     pending_bytes: usize,
     has_flushed: bool,
     last_flush: Instant,
@@ -55,18 +53,15 @@ impl StreamFlushBuffer {
         &mut self,
         execution_id: &str,
         stream_name: &str,
-        rendered_text: String,
         chunk_bytes: usize,
         now: Instant,
     ) -> Option<PendingStreamFlush> {
         let key = (execution_id.to_string(), stream_name.to_string());
         let entry = self.entries.entry(key.clone()).or_insert(StreamFlushEntry {
-            rendered_text: None,
             pending_bytes: 0,
             has_flushed: false,
             last_flush: now,
         });
-        entry.rendered_text = Some(rendered_text);
         entry.pending_bytes = entry.pending_bytes.saturating_add(chunk_bytes);
 
         let delay_elapsed =
@@ -101,14 +96,12 @@ impl StreamFlushBuffer {
 
     fn take_key(&mut self, key: &StreamKey, now: Instant) -> Option<PendingStreamFlush> {
         let entry = self.entries.get_mut(key)?;
-        let rendered_text = entry.rendered_text.take()?;
         entry.pending_bytes = 0;
         entry.has_flushed = true;
         entry.last_flush = now;
         Some(PendingStreamFlush {
             execution_id: key.0.clone(),
             stream_name: key.1.clone(),
-            rendered_text,
         })
     }
 }
@@ -127,109 +120,69 @@ mod tests {
         let mut buffer = buffer();
 
         let flush = buffer
-            .record_chunk("e1", "stdout", "hello".into(), 5, now)
+            .record_chunk("e1", "stdout", 5, now)
             .expect("first chunk should flush");
 
         assert_eq!(flush.execution_id, "e1");
         assert_eq!(flush.stream_name, "stdout");
-        assert_eq!(flush.rendered_text, "hello");
     }
 
     #[test]
     fn subsequent_small_chunks_are_coalesced_until_delay() {
         let now = Instant::now();
         let mut buffer = buffer();
+        assert!(buffer.record_chunk("e1", "stdout", 1, now).is_some());
         assert!(buffer
-            .record_chunk("e1", "stdout", "a".into(), 1, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk(
-                "e1",
-                "stdout",
-                "ab".into(),
-                1,
-                now + Duration::from_millis(10)
-            )
+            .record_chunk("e1", "stdout", 1, now + Duration::from_millis(10))
             .is_none());
 
-        let flush = buffer
-            .record_chunk(
-                "e1",
-                "stdout",
-                "abc".into(),
-                1,
-                now + Duration::from_millis(100),
-            )
-            .expect("delay should flush latest rendered text");
-
-        assert_eq!(flush.rendered_text, "abc");
+        buffer
+            .record_chunk("e1", "stdout", 1, now + Duration::from_millis(100))
+            .expect("delay should flush");
     }
 
     #[test]
-    fn byte_threshold_flushes_latest_rendered_text() {
+    fn byte_threshold_flushes() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer
-            .record_chunk("e1", "stdout", "a".into(), 1, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk("e1", "stdout", "abcdef".into(), 6, now)
-            .is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 1, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 6, now).is_none());
 
-        let flush = buffer
-            .record_chunk("e1", "stdout", "abcdefghij".into(), 4, now)
+        buffer
+            .record_chunk("e1", "stdout", 4, now)
             .expect("byte threshold should flush");
-
-        assert_eq!(flush.rendered_text, "abcdefghij");
     }
 
     #[test]
     fn flush_execution_returns_all_dirty_streams_for_execution() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer
-            .record_chunk("e1", "stdout", "out".into(), 3, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk("e1", "stdout", "out2".into(), 4, now)
-            .is_none());
-        assert!(buffer
-            .record_chunk("e1", "stderr", "err".into(), 3, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk("e1", "stderr", "err2".into(), 4, now)
-            .is_none());
-        assert!(buffer
-            .record_chunk("e2", "stdout", "other".into(), 5, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk("e2", "stdout", "other2".into(), 6, now)
-            .is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 4, now).is_none());
+        assert!(buffer.record_chunk("e1", "stderr", 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stderr", 4, now).is_none());
+        assert!(buffer.record_chunk("e2", "stdout", 5, now).is_some());
+        assert!(buffer.record_chunk("e2", "stdout", 6, now).is_none());
 
         let mut flushes = buffer.flush_execution("e1", now);
         flushes.sort_by(|a, b| a.stream_name.cmp(&b.stream_name));
 
         assert_eq!(flushes.len(), 2);
         assert_eq!(flushes[0].stream_name, "stderr");
-        assert_eq!(flushes[0].rendered_text, "err2");
         assert_eq!(flushes[1].stream_name, "stdout");
-        assert_eq!(flushes[1].rendered_text, "out2");
 
         let remaining = buffer.flush_execution("e2", now);
         assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].rendered_text, "other2");
+        assert_eq!(remaining[0].execution_id, "e2");
+        assert_eq!(remaining[0].stream_name, "stdout");
     }
 
     #[test]
     fn clear_execution_discards_dirty_streams() {
         let now = Instant::now();
         let mut buffer = buffer();
-        assert!(buffer
-            .record_chunk("e1", "stdout", "out".into(), 3, now)
-            .is_some());
-        assert!(buffer
-            .record_chunk("e1", "stdout", "out2".into(), 4, now)
-            .is_none());
+        assert!(buffer.record_chunk("e1", "stdout", 3, now).is_some());
+        assert!(buffer.record_chunk("e1", "stdout", 4, now).is_none());
 
         buffer.clear_execution("e1");
 

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -90,11 +90,7 @@ impl StreamTerminals {
     }
 
     /// Feed text to the terminal for (execution_id, stream_name).
-    ///
-    /// Returns the rendered ANSI text representation of the terminal content.
-    /// This handles escape sequences like `\r` (carriage return) and cursor
-    /// movement, so progress bars will show only their final state.
-    pub fn feed(&mut self, execution_id: &str, stream_name: &str, text: &str) -> String {
+    pub fn feed_chunk(&mut self, execution_id: &str, stream_name: &str, text: &str) {
         let key = (execution_id.to_string(), stream_name.to_string());
 
         // Get or create terminal and processor for this stream
@@ -119,9 +115,22 @@ impl StreamTerminals {
                 processor.advance(term, std::slice::from_ref(byte));
             }
         }
+    }
 
-        // Serialize terminal content back to ANSI text
-        serialize_to_ansi(term)
+    /// Render the terminal content for (execution_id, stream_name).
+    pub fn render(&self, execution_id: &str, stream_name: &str) -> Option<String> {
+        let key = (execution_id.to_string(), stream_name.to_string());
+        self.terminals.get(&key).map(serialize_to_ansi)
+    }
+
+    /// Feed text to the terminal for (execution_id, stream_name).
+    ///
+    /// Returns the rendered ANSI text representation of the terminal content.
+    /// This handles escape sequences like `\r` (carriage return) and cursor
+    /// movement, so progress bars will show only their final state.
+    pub fn feed(&mut self, execution_id: &str, stream_name: &str, text: &str) -> String {
+        self.feed_chunk(execution_id, stream_name, text);
+        self.render(execution_id, stream_name).unwrap_or_default()
     }
 
     /// Clear terminal(s) for an execution.
@@ -488,6 +497,18 @@ mod tests {
         let result = terminals.feed("cell-1", "stdout", "World!");
 
         assert!(result.contains("Hello World!"));
+    }
+
+    #[test]
+    fn test_feed_chunk_renders_later() {
+        let mut terminals = StreamTerminals::new();
+
+        terminals.feed_chunk("cell-1", "stdout", "Progress: 50%");
+        terminals.feed_chunk("cell-1", "stdout", "\rProgress: 100%");
+
+        let result = terminals.render("cell-1", "stdout").unwrap();
+        assert!(result.contains("Progress: 100%"));
+        assert!(!result.contains("Progress: 50%"));
     }
 
     #[test]

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1064,6 +1064,28 @@ print("line 3")
         expected = "line 1\nline 2\nline 3\n"
         assert result.stdout == expected
 
+    async def test_noisy_stdout_final_output_reconciles(self, session):
+        """Coalesced stdout chunks should still reconcile to the final stream text."""
+        await async_start_kernel_with_retry(session)
+
+        line_count = 2_000
+        cell_id = await async_create_cell_and_wait_for_sync(
+            session,
+            f"""
+import sys
+
+for i in range({line_count}):
+    sys.stdout.write(f"chunk-{{i}}\\n")
+    sys.stdout.flush()
+""",
+        )
+        result = await session.execute_cell(cell_id, timeout_secs=30)
+
+        assert result.success, result.stderr
+        assert "chunk-0\n" in result.stdout
+        assert f"chunk-{line_count - 1}\n" in result.stdout
+        assert result.stdout.count("chunk-") == line_count
+
     async def test_interleaved_stdout_stderr_separate(self, session):
         """Interleaved stdout and stderr should remain separate streams."""
         await async_start_kernel_with_retry(session)


### PR DESCRIPTION
## Summary
- avoid serializing full terminal stream output for every IOPub stream chunk
- make the stream flush buffer track only dirty stream keys and render latest terminal state only when a flush is due
- add integration coverage that a noisy stdout burst still reconciles to complete final output

## Verification
- `cargo test -p runtimed stream_flush -- --nocapture`
- `cargo test -p runtimed stream_terminal -- --nocapture`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=$PWD/target/debug/runtimed RUST_LOG=info uv run --active --directory python/runtimed --no-sync pytest tests/test_daemon_integration.py::TestTerminalEmulation::test_noisy_stdout_final_output_reconciles -v -s`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=$PWD/target/debug/runtimed RUST_LOG=info uv run --active --directory python/runtimed --no-sync pytest tests/test_daemon_integration.py::TestTerminalEmulation tests/test_daemon_integration.py::TestKernelLifecycle::test_interrupt_large_streaming_output_unblocks -v -s`
- `cargo xtask lint --fix`
