### PR TITLE
test(notebook): add browser e2e for noisy interrupts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,8 @@ crates/notebook/fixtures/**/uv.lock
 
 # E2E test screenshots
 e2e-screenshots/
+playwright-report/
+test-results/
 
 # E2E daemon PID file
 .e2e-daemon.pid

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -1,0 +1,61 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export async function waitForNotebookReady(page: Page) {
+  await page.goto("/");
+  await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("[data-notebook-synced]")).toHaveAttribute(
+    "data-notebook-synced",
+    "true",
+    { timeout: 30_000 },
+  );
+  await expect(page.locator("[data-session-ready]")).toHaveAttribute("data-session-ready", "true", {
+    timeout: 120_000,
+  });
+}
+
+export async function waitForKernelStatus(page: Page, status: string, timeout = 60_000) {
+  await expect(page.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", status, {
+    timeout,
+  });
+}
+
+export async function ensureCodeCell(page: Page): Promise<Locator> {
+  const existing = page.locator('[data-cell-type="code"]').first();
+  if ((await existing.count()) > 0) return existing;
+
+  await page.getByTestId("add-code-cell-button").click();
+  await expect(existing).toBeVisible({ timeout: 10_000 });
+  return existing;
+}
+
+export async function setCellSource(cell: Locator, source: string) {
+  await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
+    const content = node as HTMLElement & {
+      cmTile?: {
+        view?: {
+          state: { doc: { length: number } };
+          dispatch: (transaction: unknown) => void;
+        };
+      };
+    };
+    const editor = content.cmTile?.view;
+    if (!editor) throw new Error("No CodeMirror view found");
+    editor.dispatch({
+      changes: {
+        from: 0,
+        to: editor.state.doc.length,
+        insert: text,
+      },
+    });
+  }, source);
+}
+
+export async function executeCell(cell: Locator) {
+  await cell.getByTestId("execute-button").click();
+}
+
+export async function waitForOutputContaining(cell: Locator, text: string, timeout = 60_000) {
+  const output = cell.locator('[data-slot="ansi-stream-output"]');
+  await expect(output).toContainText(text, { timeout });
+  return output;
+}

--- a/apps/notebook/e2e/noisy-output-interrupt.spec.ts
+++ b/apps/notebook/e2e/noisy-output-interrupt.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import {
+  ensureCodeCell,
+  executeCell,
+  setCellSource,
+  waitForKernelStatus,
+  waitForNotebookReady,
+  waitForOutputContaining,
+} from "./helpers";
+
+test.describe("noisy output interrupt", () => {
+  test("interrupts a stdout flood and keeps the kernel usable", async ({ page }) => {
+    await waitForNotebookReady(page);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const cell = await ensureCodeCell(page);
+    await setCellSource(
+      cell,
+      [
+        "import sys",
+        "import time",
+        "",
+        "for ii in range(10_000):",
+        "    print(f'noisy-e2e-line-{ii}')",
+        "    sys.stdout.flush()",
+        "    time.sleep(0.001)",
+        "",
+        "print('noisy-e2e-finished')",
+      ].join("\n"),
+    );
+
+    await executeCell(cell);
+    await waitForOutputContaining(cell, "noisy-e2e-line-25", 60_000);
+
+    await page.getByTestId("interrupt-kernel-button").click();
+    await waitForKernelStatus(page, "idle", 60_000);
+
+    await setCellSource(cell, "print('after noisy interrupt e2e')");
+    await executeCell(cell);
+
+    const output = await waitForOutputContaining(cell, "after noisy interrupt e2e", 60_000);
+    await expect(output).toContainText("after noisy interrupt e2e");
+  });
+});

--- a/apps/notebook/e2e/run-browser-e2e.mjs
+++ b/apps/notebook/e2e/run-browser-e2e.mjs
@@ -1,0 +1,175 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const READY_TIMEOUT_MS = 120_000;
+const POLL_MS = 250;
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(appRoot, "../..");
+const port = Number(
+  process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? vitePort(repoRoot),
+);
+const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
+const healthURL = `${baseURL}/__nteract_dev_relay/health`;
+
+function cacheDir() {
+  if (process.env.XDG_CACHE_HOME) return process.env.XDG_CACHE_HOME;
+  if (process.platform === "darwin") return path.join(os.homedir(), "Library", "Caches");
+  if (process.platform === "win32") {
+    return process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+  }
+  return path.join(os.homedir(), ".cache");
+}
+
+function worktreeHash(workspace) {
+  return crypto.createHash("sha256").update(workspace).digest("hex").slice(0, 12);
+}
+
+function vitePort(workspace) {
+  const hash = worktreeHash(workspace);
+  return 5100 + (Number.parseInt(hash.slice(0, 4), 16) % 4900);
+}
+
+function daemonJsonPath(workspace) {
+  const namespace = process.env.RUNTIMED_CACHE_NAMESPACE ?? "runt-nightly";
+  return path.join(cacheDir(), namespace, "worktrees", worktreeHash(workspace), "daemon.json");
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readDaemonState(workspace) {
+  try {
+    return JSON.parse(fs.readFileSync(daemonJsonPath(workspace), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function socketExists(state) {
+  const socketPath = state?.socket_path ?? state?.endpoint;
+  if (!socketPath) return false;
+  try {
+    return fs.statSync(socketPath).isSocket();
+  } catch {
+    return false;
+  }
+}
+
+function daemonRunning(workspace) {
+  const state = readDaemonState(workspace);
+  if (!socketExists(state)) return false;
+  return state?.pid === undefined || processIsRunning(state.pid);
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(label, predicate, timeoutMs = READY_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await delay(POLL_MS);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function relayHealthy() {
+  try {
+    const response = await fetch(healthURL, { headers: { Accept: "application/json" } });
+    if (!response.ok) return false;
+    const json = await response.json();
+    return json?.relay === "ok" && json?.daemon?.socket_exists === true;
+  } catch {
+    return false;
+  }
+}
+
+function spawnManaged(command, args, options) {
+  return spawn(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      RUNTIMED_DEV: "1",
+      RUNTIMED_WORKSPACE_PATH: repoRoot,
+      RUNTIMED_VITE_PORT: String(port),
+      VITE_E2E: "1",
+    },
+    ...options,
+  });
+}
+
+function playwrightArgs() {
+  return [
+    "--filter",
+    "notebook-ui",
+    "exec",
+    "playwright",
+    "test",
+    "-c",
+    "playwright.config.ts",
+    ...process.argv.slice(2).filter((arg) => arg !== "--"),
+  ];
+}
+
+async function waitForExit(child) {
+  return await new Promise((resolve) => {
+    child.on("exit", (code, signal) => {
+      resolve(code ?? (signal ? 1 : 0));
+    });
+  });
+}
+
+async function stop(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await delay(500);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+async function main() {
+  let daemon = null;
+  let vite = null;
+
+  try {
+    const args = playwrightArgs();
+    if (args.includes("--list")) {
+      process.exitCode = await waitForExit(spawnManaged("pnpm", args, { cwd: appRoot }));
+      return;
+    }
+
+    if (!daemonRunning(repoRoot)) {
+      daemon = spawnManaged("cargo", ["xtask", "dev-daemon"]);
+      await waitUntil("dev daemon", () => daemonRunning(repoRoot));
+    }
+
+    if (!(await relayHealthy())) {
+      vite = spawnManaged("pnpm", ["--filter", "notebook-ui", "dev"]);
+      await waitUntil("Vite browser relay", relayHealthy);
+    }
+
+    const result = spawnManaged("pnpm", args, { cwd: appRoot });
+
+    process.exitCode = await waitForExit(result);
+  } finally {
+    await stop(vite);
+    await stop(daemon);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vp dev",
     "build": "tsc -b && vp build",
-    "preview": "vp preview"
+    "preview": "vp preview",
+    "test:e2e:browser": "node e2e/run-browser-e2e.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
@@ -52,6 +53,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.8",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",

--- a/apps/notebook/playwright.config.ts
+++ b/apps/notebook/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "@playwright/test";
+import crypto from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function worktreeVitePort() {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const hash = crypto.createHash("sha256").update(repoRoot).digest("hex");
+  return 5100 + (Number.parseInt(hash.slice(0, 4), 16) % 4900);
+}
+
+const port = Number(
+  process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? worktreeVitePort(),
+);
+const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 120_000,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        ...(process.env.NTERACT_BROWSER_E2E_CHANNEL
+          ? { channel: process.env.NTERACT_BROWSER_E2E_CHANNEL }
+          : {}),
+      },
+    },
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "notebook:dev": "pnpm --dir apps/notebook dev",
     "test": "vp test",
     "test:run": "vp test run",
+    "test:e2e:browser": "pnpm --filter notebook-ui test:e2e:browser",
     "test:e2e": "wdio run e2e/wdio.conf.js",
     "test:e2e:native": "wdio run e2e/wdio.conf.js"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))


### PR DESCRIPTION
## Summary

- add a notebook browser E2E lane that runs the Vite browser host against the real dev daemon relay
- add a Chromium workflow test for noisy stdout followed by toolbar interrupt and follow-up execution
- ignore Playwright output directories so failed local runs do not leave tracked noise

## Notes

This keeps the existing Tauri/WebDriver E2E lane intact. The new lane is meant for cheaper Chrome-centric workflow coverage through Vite. Portless/HTTPS integration is intentionally left as a follow-up task.

Local runs use the worktree-derived Vite port by default. On machines without Playwright-managed Chromium installed, the lane can use system Chrome:

```bash
NTERACT_BROWSER_E2E_CHANNEL=chrome pnpm --filter notebook-ui test:e2e:browser -- --project=chromium
```

## Verification

- `pnpm --filter notebook-ui test:e2e:browser -- --list`
- `NTERACT_BROWSER_E2E_CHANNEL=chrome pnpm --filter notebook-ui test:e2e:browser -- --project=chromium`
- `pnpm --filter notebook-ui build`
- `cargo xtask lint --fix`
- main Build run 25700362675: success
- main Smoke run 25700362617: success
