### PR TITLE
fix(isolated): drop atomic iframe selection

### DIFF
--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -813,6 +813,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           border: "none",
           display: "block",
           pointerEvents: scrollPassthrough ? "none" : undefined,
+          userSelect: "none",
+          WebkitUserSelect: "none",
           background: "transparent",
           colorScheme: darkMode ? "dark" : "light",
           // Hide iframe during reload to prevent white flash from blank document.


### PR DESCRIPTION
Dragging across a markdown or HTML output cell sometimes highlighted the entire iframe as a single blue rectangle instead of starting text selection. Iframes are selection boundaries from the parent document's perspective - when a drag starts adjacent to or enters the iframe element, the browser falls back to selecting it atomically as a block.

The fix is one CSS rule: `user-select: none` on the iframe element. The parent's selection range can no longer include the iframe as a block. Selection inside the iframe document is unaffected, since iframe documents have their own `user-select` cascade and don't inherit from the parent's iframe tag.

Behavior after:

| Drag path | Before | After |
|---|---|---|
| Starts inside iframe content | Selects text (browser re-hit-tests mid-drag) | Selects text (unchanged) |
| Enters iframe from outside | Selects whole iframe rectangle | Selects nothing past the boundary |
| Stays outside the iframe | Selects wrapper content | Selects wrapper content (unchanged) |

## Test plan

- [x] `cargo xtask lint --fix` clean
- [ ] Manual: drag-select inside a markdown cell - normal text selection
- [ ] Manual: drag-select starting on a sift output well - no whole-iframe highlight
- [ ] Manual: drag-select across a markdown cell boundary - selection stops at the iframe edge instead of flooding the whole block
- [ ] Manual: click into sift and drag-select inside the table - unchanged
