### PR TITLE
ci(notebook): run browser e2e in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,6 +257,48 @@ jobs:
       - name: Run JS benchmarks
         run: vp test bench --run apps/notebook/src/lib/__tests__/
 
+  browser-e2e:
+    name: Browser E2E (Vite)
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-browser-e2e
+
+      # Build wasm + renderer plugins (gitignored; Vite imports them).
+      - uses: ./.github/actions/build-runtime-artifacts
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter notebook-ui exec playwright install --with-deps chromium
+
+      - name: Run browser E2E
+        run: pnpm --filter notebook-ui test:e2e:browser -- --project=chromium
+        env:
+          NTERACT_BROWSER_E2E_READY_TIMEOUT_MS: 300000
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-e2e-playwright-report
+          path: |
+            apps/notebook/playwright-report/
+            apps/notebook/test-results/
+          retention-days: 7
+
   build-linux:
     name: Linux (release artifacts)
     needs: [changes, build-ui]

--- a/apps/notebook/e2e/run-browser-e2e.mjs
+++ b/apps/notebook/e2e/run-browser-e2e.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const READY_TIMEOUT_MS = 120_000;
+const READY_TIMEOUT_MS = positiveNumberEnv("NTERACT_BROWSER_E2E_READY_TIMEOUT_MS") ?? 120_000;
 const POLL_MS = 250;
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -15,6 +15,11 @@ const port = Number(
 );
 const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
 const healthURL = `${baseURL}/__nteract_dev_relay/health`;
+
+function positiveNumberEnv(name) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
 
 function cacheDir() {
   if (process.env.XDG_CACHE_HOME) return process.env.XDG_CACHE_HOME;


### PR DESCRIPTION
## Summary

- add a `Browser E2E (Vite)` Build workflow job for the new Playwright browser lane
- install Playwright Chromium in CI and run `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium`
- make the browser E2E wrapper readiness timeout configurable so CI cold builds do not fail while `cargo xtask dev-daemon` is still compiling

## Verification

- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- --list`
- `cargo xtask lint --fix`
