### PR TITLE
fix(outputs): drop scroll-to-deactivate on focused sift

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -398,8 +398,6 @@ export function OutputArea({
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
   const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
-  const ignoreScrollDeactivationRef = useRef(false);
-  const ignoreScrollDeactivationTimerRef = useRef<number | null>(null);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
@@ -485,26 +483,6 @@ export function OutputArea({
   }, [hasSiftOutputs, staticFrameInteractionActive]);
 
   useEffect(() => {
-    return () => {
-      if (ignoreScrollDeactivationTimerRef.current != null) {
-        window.clearTimeout(ignoreScrollDeactivationTimerRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!staticFrameInteractionActive) return;
-
-    const handleScroll = () => {
-      if (ignoreScrollDeactivationRef.current) return;
-      setStaticFrameInteractionActive(false);
-    };
-
-    window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
-  }, [staticFrameInteractionActive]);
-
-  useEffect(() => {
     if (!staticFrameInteractionActive) return;
 
     const handlePointerDown = (event: globalThis.PointerEvent) => {
@@ -522,16 +500,7 @@ export function OutputArea({
   const activateStaticFrameInteraction = useCallback(() => {
     if (shouldUseScrollPassthroughFrame) {
       if (!staticFrameInteractionActive && hasSiftOutputs) {
-        ignoreScrollDeactivationRef.current = scrollElementIntoComfortableView(
-          staticFrameInteractionRef.current,
-        );
-        if (ignoreScrollDeactivationTimerRef.current != null) {
-          window.clearTimeout(ignoreScrollDeactivationTimerRef.current);
-        }
-        ignoreScrollDeactivationTimerRef.current = window.setTimeout(() => {
-          ignoreScrollDeactivationRef.current = false;
-          ignoreScrollDeactivationTimerRef.current = null;
-        }, 250);
+        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
       }
       setStaticFrameInteractionActive(true);
       // Move DOM focus off CodeMirror without scrolling; this wrapper owns

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -219,8 +219,8 @@ describe("OutputArea iframe theme sync", () => {
     );
 
     // Pointer out without buttons no longer drops focus; the user has to
-    // click elsewhere, scroll, or press Escape. See the dedicated
-    // outside-pointer-down and Escape tests below.
+    // click elsewhere or press Escape. See the dedicated outside-pointer-down
+    // and Escape tests below.
     pointerOutWithButtons(activationWell, 0);
 
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -813,6 +813,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           border: "none",
           display: "block",
           pointerEvents: scrollPassthrough ? "none" : undefined,
+          userSelect: "none",
+          WebkitUserSelect: "none",
           background: "transparent",
           colorScheme: darkMode ? "dark" : "light",
           // Hide iframe during reload to prevent white flash from blank document.


### PR DESCRIPTION
Scrolling at the top (or bottom) boundary of a focused sift table could silently drop focus. A capture-phase `scroll` listener on `window` was deactivating `staticFrameInteractionActive` on any scroll event, including the 1-3px page-scroll leaks WKWebView occasionally lets through past sift's `overscroll-behavior: none`. The user was wheeling inside the table, hit the boundary, and got booted back to passthrough mode.

The scroll-deactivation hook was trying to handle "user scrolled away from the table." In practice the existing pointerdown-outside and Escape paths cover that intent already, and the scroll hook was the source of the false-positive.

Removed:

- `useEffect` with the `window` scroll listener
- `ignoreScrollDeactivationRef` and `ignoreScrollDeactivationTimerRef`
- The timer cleanup `useEffect`
- The setTimeout dance in `activateStaticFrameInteraction` that was suppressing the listener against its own scrollBy

Kept:

- `scrollElementIntoComfortableView` still runs on activation, so clicking into a partially-offscreen table still centers it
- Pointerdown-outside deactivation
- Escape-to-deactivate
- Auto-deactivation when `shouldUseScrollPassthroughFrame` flips false

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `OutputArea.test.tsx` 19/19 pass
- [ ] Manual: click into a sift table, wheel to the top, keep wheeling - focus stays
- [ ] Manual: same at the bottom boundary - focus stays
- [ ] Manual: click outside the table - focus drops (unchanged)
- [ ] Manual: press Escape while focused - focus drops (unchanged)
- [ ] Manual: click a partially-offscreen table - scrolls into view as before
