### PR TITLE
test(notebook): support portless browser e2e

### DIFF
--- a/apps/notebook/e2e/run-browser-e2e.mjs
+++ b/apps/notebook/e2e/run-browser-e2e.mjs
@@ -1,10 +1,23 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+function truthyEnv(name) {
+  const value = String(process.env[name] ?? "").toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+function positiveNumberEnv(name) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+const scriptArgs = process.argv.slice(2).filter((arg) => arg !== "--");
 const READY_TIMEOUT_MS = positiveNumberEnv("NTERACT_BROWSER_E2E_READY_TIMEOUT_MS") ?? 120_000;
 const POLL_MS = 250;
 
@@ -13,12 +26,51 @@ const repoRoot = path.resolve(appRoot, "../..");
 const port = Number(
   process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? vitePort(repoRoot),
 );
-const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
+const usePortless =
+  (scriptArgs.includes("--portless") || truthyEnv("NTERACT_BROWSER_E2E_PORTLESS")) &&
+  !scriptArgs.includes("--no-portless") &&
+  process.env.PORTLESS !== "0";
+const portlessName = process.env.NTERACT_BROWSER_E2E_PORTLESS_NAME ?? "nteract-notebook";
+const baseURL =
+  process.env.NTERACT_BROWSER_E2E_BASE_URL ??
+  (usePortless ? portlessUrl(portlessName) : `http://localhost:${port}`);
 const healthURL = `${baseURL}/__nteract_dev_relay/health`;
+const ignoreHTTPSErrors =
+  process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS === "1" ||
+  (usePortless &&
+    baseURL.startsWith("https://") &&
+    process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS !== "0");
 
-function positiveNumberEnv(name) {
-  const value = Number(process.env[name]);
-  return Number.isFinite(value) && value > 0 ? value : null;
+function portlessUrl(name) {
+  const result = spawnSync("pnpm", ["exec", "portless", "get", name], {
+    cwd: appRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.status === 0) return normalizePortlessUrl(extractUrl(result.stdout));
+
+  const stderr = result.stderr.trim();
+  const details = stderr ? `\n${stderr}` : "";
+  throw new Error(`failed to resolve Portless URL for ${name}${details}`);
+}
+
+function extractUrl(output) {
+  const lines = output.trim().split(/\r?\n/).reverse();
+  const url = lines.find((line) => line.startsWith("http://") || line.startsWith("https://"));
+  if (!url) throw new Error(`failed to find Portless URL in output:\n${output.trim()}`);
+  return url;
+}
+
+function normalizePortlessUrl(url) {
+  const parsed = new URL(url);
+  if (process.env.PORTLESS_HTTPS !== undefined) {
+    parsed.protocol =
+      process.env.PORTLESS_HTTPS === "0" || process.env.PORTLESS_HTTPS === "false"
+        ? "http:"
+        : "https:";
+  }
+  if (process.env.PORTLESS_PORT) parsed.port = process.env.PORTLESS_PORT;
+  return parsed.toString().replace(/\/$/, "");
 }
 
 function cacheDir() {
@@ -81,9 +133,17 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function waitUntil(label, predicate, timeoutMs = READY_TIMEOUT_MS) {
+function childExitDescription(child) {
+  if (!child) return null;
+  if (child.exitCode !== null) return `exit code ${child.exitCode}`;
+  return child.signalCode ? `signal ${child.signalCode}` : null;
+}
+
+async function waitUntil(label, predicate, timeoutMs = READY_TIMEOUT_MS, child = null) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    const exit = childExitDescription(child);
+    if (exit) throw new Error(`${label} process exited before readiness (${exit})`);
     if (await predicate()) return;
     await delay(POLL_MS);
   }
@@ -92,28 +152,97 @@ async function waitUntil(label, predicate, timeoutMs = READY_TIMEOUT_MS) {
 
 async function relayHealthy() {
   try {
-    const response = await fetch(healthURL, { headers: { Accept: "application/json" } });
-    if (!response.ok) return false;
-    const json = await response.json();
+    const json = await getJson(healthURL);
     return json?.relay === "ok" && json?.daemon?.socket_exists === true;
   } catch {
     return false;
   }
 }
 
-function spawnManaged(command, args, options) {
+function getJson(url) {
+  const parsed = new URL(url);
+  const client = parsed.protocol === "https:" ? https : http;
+  const rejectUnauthorized = !ignoreHTTPSErrors && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0";
+
+  return new Promise((resolve, reject) => {
+    const request = client.get(
+      parsed,
+      {
+        headers: { Accept: "application/json" },
+        ...(parsed.protocol === "https:" ? { rejectUnauthorized } : {}),
+      },
+      (response) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+            reject(new Error(`GET ${url} failed with status ${response.statusCode}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+    request.on("error", reject);
+    request.setTimeout(5_000, () => {
+      request.destroy(new Error(`GET ${url} timed out`));
+    });
+  });
+}
+
+function spawnManaged(command, args, options = {}) {
+  const { env: extraEnv, ...spawnOptions } = options;
+
   return spawn(command, args, {
     cwd: repoRoot,
     stdio: "inherit",
     env: {
       ...process.env,
+      ...extraEnv,
       RUNTIMED_DEV: "1",
       RUNTIMED_WORKSPACE_PATH: repoRoot,
       RUNTIMED_VITE_PORT: String(port),
+      NTERACT_BROWSER_E2E_BASE_URL: baseURL,
+      ...(ignoreHTTPSErrors ? { NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS: "1" } : {}),
       VITE_E2E: "1",
     },
-    ...options,
+    ...spawnOptions,
   });
+}
+
+function viteProcess() {
+  if (!usePortless) {
+    return { command: "pnpm", args: ["--filter", "notebook-ui", "dev"], cwd: repoRoot };
+  }
+
+  return {
+    command: "pnpm",
+    args: [
+      "exec",
+      "portless",
+      "run",
+      "--name",
+      portlessName,
+      "--app-port",
+      String(port),
+      "pnpm",
+      "exec",
+      "vp",
+      "dev",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+    ],
+    cwd: appRoot,
+  };
 }
 
 function playwrightArgs() {
@@ -125,7 +254,7 @@ function playwrightArgs() {
     "test",
     "-c",
     "playwright.config.ts",
-    ...process.argv.slice(2).filter((arg) => arg !== "--"),
+    ...scriptArgs.filter((arg) => arg !== "--portless" && arg !== "--no-portless"),
   ];
 }
 
@@ -157,12 +286,13 @@ async function main() {
 
     if (!daemonRunning(repoRoot)) {
       daemon = spawnManaged("cargo", ["xtask", "dev-daemon"]);
-      await waitUntil("dev daemon", () => daemonRunning(repoRoot));
+      await waitUntil("dev daemon", () => daemonRunning(repoRoot), READY_TIMEOUT_MS, daemon);
     }
 
     if (!(await relayHealthy())) {
-      vite = spawnManaged("pnpm", ["--filter", "notebook-ui", "dev"]);
-      await waitUntil("Vite browser relay", relayHealthy);
+      const viteCommand = viteProcess();
+      vite = spawnManaged(viteCommand.command, viteCommand.args, { cwd: viteCommand.cwd });
+      await waitUntil("Vite browser relay", relayHealthy, READY_TIMEOUT_MS, vite);
     }
 
     const result = spawnManaged("pnpm", args, { cwd: appRoot });

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -7,7 +7,8 @@
     "dev": "vp dev",
     "build": "tsc -b && vp build",
     "preview": "vp preview",
-    "test:e2e:browser": "node e2e/run-browser-e2e.mjs"
+    "test:e2e:browser": "node e2e/run-browser-e2e.mjs",
+    "test:e2e:browser:portless": "node e2e/run-browser-e2e.mjs --portless"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
@@ -59,6 +60,7 @@
     "@types/react-dom": "^19.1.5",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "portless": "^0.13.0",
     "tailwindcss": "^4.1.8",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",

--- a/apps/notebook/playwright.config.ts
+++ b/apps/notebook/playwright.config.ts
@@ -13,6 +13,11 @@ const port = Number(
   process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? worktreeVitePort(),
 );
 const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
+const ignoreHTTPSErrors =
+  process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS === "1" ||
+  (baseURL.startsWith("https://") &&
+    process.env.NTERACT_BROWSER_E2E_PORTLESS === "1" &&
+    process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS !== "0");
 
 export default defineConfig({
   testDir: "./e2e",
@@ -20,6 +25,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   use: {
     baseURL,
+    ignoreHTTPSErrors,
     headless: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",

--- a/apps/notebook/playwright.config.ts
+++ b/apps/notebook/playwright.config.ts
@@ -9,14 +9,19 @@ function worktreeVitePort() {
   return 5100 + (Number.parseInt(hash.slice(0, 4), 16) % 4900);
 }
 
+function truthyEnv(name: string) {
+  const value = String(process.env[name] ?? "").toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
 const port = Number(
   process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? worktreeVitePort(),
 );
 const baseURL = process.env.NTERACT_BROWSER_E2E_BASE_URL ?? `http://localhost:${port}`;
 const ignoreHTTPSErrors =
-  process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS === "1" ||
+  truthyEnv("NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS") ||
   (baseURL.startsWith("https://") &&
-    process.env.NTERACT_BROWSER_E2E_PORTLESS === "1" &&
+    truthyEnv("NTERACT_BROWSER_E2E_PORTLESS") &&
     process.env.NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS !== "0");
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vp test",
     "test:run": "vp test run",
     "test:e2e:browser": "pnpm --filter notebook-ui test:e2e:browser",
+    "test:e2e:browser:portless": "pnpm --filter notebook-ui test:e2e:browser:portless",
     "test:e2e": "wdio run e2e/wdio.conf.js",
     "test:e2e:native": "wdio run e2e/wdio.conf.js"
   },

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -108,7 +108,8 @@ function addToken(url: string, token: string): string {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  const normalized = hostname.replace(/^\[(.*)\]$/, "$1");
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
 }
 
 function normalizeRelayWebSocketUrl(url: URL): URL {

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -91,7 +91,7 @@ function createHttpBlobResolver(port: number, fetchImpl: typeof fetch): HostBlob
 }
 
 function addToken(url: string, token: string): string {
-  const resolved = new URL(url, window.location.href);
+  const resolved = normalizeRelayWebSocketUrl(new URL(url, window.location.href));
   resolved.searchParams.set("token", token);
 
   // Convenience for manual local debugging:
@@ -105,6 +105,21 @@ function addToken(url: string, token: string): string {
   }
 
   return resolved.toString();
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function normalizeRelayWebSocketUrl(url: URL): URL {
+  if (!url.pathname.startsWith("/__nteract_dev_relay/")) return url;
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") return url;
+  if (!isLoopbackHost(url.hostname)) return url;
+  if (isLoopbackHost(window.location.hostname)) return url;
+
+  const normalized = new URL(url.pathname + url.search + url.hash, window.location.href);
+  normalized.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return normalized;
 }
 
 async function loadConfig(configUrl: string, fetchImpl: typeof fetch): Promise<BrowserRelayConfig> {

--- a/packages/notebook-host/tests/browser-host-portless.test.ts
+++ b/packages/notebook-host/tests/browser-host-portless.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://nteract-notebook.localhost:8443/"}
+import { describe, expect, it, vi } from "vite-plus/test";
+import { createBrowserHost } from "../src/browser";
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send() {}
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+const config = {
+  websocket_url: "ws://127.0.0.1:5174/__nteract_dev_relay/ws",
+  token: "dev-token",
+  blob_port: 48123,
+  daemon: {
+    version: "dev",
+    socket_path: "/tmp/runtimed.sock",
+    is_dev_mode: true,
+  },
+};
+
+function fetchConfig() {
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => config,
+  })) as unknown as typeof fetch;
+}
+
+describe("createBrowserHost() with Portless", () => {
+  it("uses the current HTTPS origin for loopback relay WebSockets", async () => {
+    FakeWebSocket.instances = [];
+
+    await createBrowserHost({
+      fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toContain("wss://nteract-notebook.localhost:8443/__nteract_dev_relay/ws");
+    expect(ws.url).toContain("token=dev-token");
+  });
+});

--- a/packages/notebook-host/tests/browser-host-portless.test.ts
+++ b/packages/notebook-host/tests/browser-host-portless.test.ts
@@ -42,10 +42,10 @@ const config = {
   },
 };
 
-function fetchConfig() {
+function fetchConfig(websocket_url = config.websocket_url) {
   return vi.fn(async () => ({
     ok: true,
-    json: async () => config,
+    json: async () => ({ ...config, websocket_url }),
   })) as unknown as typeof fetch;
 }
 
@@ -55,6 +55,19 @@ describe("createBrowserHost() with Portless", () => {
 
     await createBrowserHost({
       fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toContain("wss://nteract-notebook.localhost:8443/__nteract_dev_relay/ws");
+    expect(ws.url).toContain("token=dev-token");
+  });
+
+  it("normalizes IPv6 loopback relay WebSockets", async () => {
+    FakeWebSocket.instances = [];
+
+    await createBrowserHost({
+      fetchImpl: fetchConfig("ws://[::1]:5174/__nteract_dev_relay/ws"),
       WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
     });
 

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://nteract-notebook.localhost:8443/"}
 import { describe, expect, it, vi } from "vite-plus/test";
 import { createBrowserHost } from "../src/browser";
 
@@ -69,6 +70,19 @@ function textFrame(value: unknown): Uint8Array {
 }
 
 describe("createBrowserHost()", () => {
+  it("uses the current HTTPS origin for loopback relay WebSockets", async () => {
+    FakeWebSocket.instances = [];
+
+    await createBrowserHost({
+      fetchImpl: fetchConfig(),
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toContain("wss://nteract-notebook.localhost:8443/__nteract_dev_relay/ws");
+    expect(ws.url).toContain("token=dev-token");
+  });
+
   it("connects to the dev relay with a token and emits ready", async () => {
     FakeWebSocket.instances = [];
     const host = await createBrowserHost({

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-// @vitest-environment-options {"url":"https://nteract-notebook.localhost:8443/"}
 import { describe, expect, it, vi } from "vite-plus/test";
 import { createBrowserHost } from "../src/browser";
 
@@ -70,19 +69,6 @@ function textFrame(value: unknown): Uint8Array {
 }
 
 describe("createBrowserHost()", () => {
-  it("uses the current HTTPS origin for loopback relay WebSockets", async () => {
-    FakeWebSocket.instances = [];
-
-    await createBrowserHost({
-      fetchImpl: fetchConfig(),
-      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket,
-    });
-
-    const ws = FakeWebSocket.instances[0];
-    expect(ws.url).toContain("wss://nteract-notebook.localhost:8443/__nteract_dev_relay/ws");
-    expect(ws.url).toContain("token=dev-token");
-  });
-
   it("connects to the dev relay with a token and emits ready", async () => {
     FakeWebSocket.instances = [];
     const host = await createBrowserHost({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+      portless:
+        specifier: ^0.13.0
+        version: 0.13.0
       tailwindcss:
         specifier: ^4.1.8
         version: 4.2.2
@@ -7835,6 +7838,12 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  portless@0.13.0:
+    resolution: {integrity: sha512-PxMZ5BHH+ZZi9rTq4T8m003aZxh56qI0aBdNsxLn7jrTtvNJYBWYD3lc5PuQrom/aVh6z8iLb+tKUI6b7QNYQw==}
+    engines: {node: '>=20'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -17688,6 +17697,8 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  portless@0.13.0: {}
 
   postcss@8.5.9:
     dependencies:


### PR DESCRIPTION
## Summary

- add an opt-in Portless runner mode for the browser E2E harness
- add root and notebook scripts for `test:e2e:browser:portless`
- normalize loopback dev-relay WebSocket URLs to the current page origin so HTTPS Portless runs can use `wss://.../__nteract_dev_relay/ws`

## Notes

The default localhost browser E2E path is unchanged. Portless mode is opt-in with `--portless`, `NTERACT_BROWSER_E2E_PORTLESS=1`, or the new package script.

The runner now also supports `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS`, passes the resolved base URL into Playwright, and tolerates Portless HTTPS certificates without weakening the default non-Portless path.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run packages/notebook-host/tests/browser-host.test.ts packages/notebook-host/tests/browser-host-portless.test.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --list`
- `PORTLESS_PORT=8443 PORTLESS_HTTPS=1 PORTLESS_SYNC_HOSTS=0 pnpm --filter notebook-ui test:e2e:browser:portless -- --list`
- `PORTLESS_PORT=8443 PORTLESS_HTTPS=1 PORTLESS_SYNC_HOSTS=0 NTERACT_BROWSER_E2E_CHANNEL=chrome pnpm --filter notebook-ui test:e2e:browser:portless -- --project=chromium`
