### PR TITLE
fix(isolated): name iframes for dev-tools picker

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -460,6 +460,7 @@ export const CodeCell = memo(function CodeCell({
             <OutputArea
               outputs={outputs}
               cellId={cell.id}
+              executionCount={executionCount}
               preloadIframe
               searchQuery={searchQuery}
               onSearchMatchCount={onSearchMatchCount}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -551,6 +551,7 @@ export const MarkdownCell = memo(function MarkdownCell({
             >
               <IsolatedFrame
                 ref={frameRef}
+                name={`md-${cell.id}`}
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 minHeight={24}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -82,6 +82,12 @@ interface OutputAreaProps {
    */
   cellId?: string;
   /**
+   * Execution count for the cell. Used to label the isolated iframe with
+   * `code-Out[N]-{cellId}` so the dev-tools frame picker shows something
+   * meaningful instead of a stack of identical `localhost` rows.
+   */
+  executionCount?: number | null;
+  /**
    * Whether the output area is collapsed.
    */
   collapsed?: boolean;
@@ -377,6 +383,7 @@ function renderOutput(
 export function OutputArea({
   outputs,
   cellId,
+  executionCount,
   collapsed = false,
   onToggleCollapse,
   maxHeight,
@@ -441,6 +448,14 @@ export function OutputArea({
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
+
+  // Frame name for dev-tools picker. `code-Out[N]-{cellId}` mirrors the
+  // Jupyter `Out[N]` convention with the cell ID appended so the picker can
+  // distinguish reruns and concurrent cells. `*` matches Jupyter's queued /
+  // never-run indicator.
+  const frameName = cellId
+    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}`
+    : undefined;
 
   // Check if we have widgets and should set up comm bridge
   const hasWidgets = hasWidgetOutputs(outputs, priority);
@@ -848,6 +863,7 @@ export function OutputArea({
             >
               <IsolatedFrame
                 ref={frameRef}
+                name={frameName}
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 minHeight={24}

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -44,6 +44,13 @@ export interface IsolatedFrameProps {
   id?: string;
 
   /**
+   * Human-readable frame name. Surfaces in dev-tools frame pickers and
+   * `window.frames` lookups. Not rendered visually - `title` is a
+   * separate attribute that we always leave empty.
+   */
+  name?: string;
+
+  /**
    * Initial content to render when the frame is ready.
    */
   initialContent?: RenderPayload;
@@ -294,6 +301,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
   function IsolatedFrame(
     {
       id,
+      name,
       initialContent,
       darkMode = true,
       colorTheme,
@@ -799,6 +807,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       <iframe
         ref={iframeRef}
         id={id}
+        name={name}
         src={frameDocument.kind === "src" ? frameDocument.url : undefined}
         srcDoc={frameDocument.kind === "srcdoc" ? frameDocument.html : undefined}
         sandbox={SANDBOX_ATTRS}


### PR DESCRIPTION
WebKit's dev tools frame picker labels iframes by their `name` attribute and falls back to the URL host when none is set. Under our custom `nteract-frame://localhost/` protocol that means every isolated iframe shows up as "localhost". In a notebook with nine output cells the picker becomes nine identical rows and you have to inspect-from-page to figure out which is which.

Plumb a real name through:

| Cell type | Frame name |
|---|---|
| Code, executed | `code-Out[3]-{cellId}` |
| Code, queued / never run | `code-Out[*]-{cellId}` |
| Markdown | `md-{cellId}` |

The cell ID suffix disambiguates reruns and concurrent cells with the same execution count, since execution numbers are sequence-only.

`IsolatedFrame` gains an optional `name` prop that maps directly to the iframe element's `name` attribute. The `title` attribute is still empty so the name never surfaces as a hover tooltip - `name` and `title` are different attributes and only `title` renders visually.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `OutputArea.test.tsx` 19/19 pass
- [ ] Manual: open dev tools in the desktop app, check the Frames picker shows `code-Out[N]-...` and `md-...` entries instead of "localhost" repeated
- [ ] Manual: hover an isolated iframe - no tooltip surfaces
- [ ] Manual: re-execute a cell, observe `Out[N]` increments in the picker
