### PR TITLE
fix(outputs): unexport anyOutputNeedsIsolation for Fast Refresh

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -287,8 +287,12 @@ function outputNeedsIsolation(
 /**
  * Check if any outputs in the array need iframe isolation.
  * If any output needs isolation, ALL outputs should go to the iframe.
+ *
+ * Not exported: keeping every `.tsx` export limited to components and
+ * hooks lets React Fast Refresh hot-patch this module instead of bailing
+ * to a full reload on every edit.
  */
-export function anyOutputNeedsIsolation(
+function anyOutputNeedsIsolation(
   outputs: JupyterOutput[],
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {


### PR DESCRIPTION
React Fast Refresh requires `.tsx` modules to only export components and hooks. A helper-function export bails the entire module out of HMR, so every save of `OutputArea.tsx` was triggering a full Vite reload instead of a hot patch. The Vite log calls it out directly:

```
hmr invalidate OutputArea.tsx -
Could not Fast Refresh ("anyOutputNeedsIsolation" export is incompatible)
```

`anyOutputNeedsIsolation` is exported but has no real consumers - it's only referenced inside this file (line 442) and in a vitest module mock that supplies its own implementation. Dropping the `export` restores Fast Refresh. About 90 seconds of dev cycle time per save reclaimed.

Added a short comment naming the constraint so the next person who reaches for `export` on a helper here knows why not.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `OutputArea.test.tsx` + `code-cell-output-focus.test.tsx` 25/25 pass
- [ ] Manual: edit `OutputArea.tsx` while dev server runs - Vite logs an `hmr update` instead of `hmr invalidate`
