### PR TITLE
test(notebook): expand browser e2e peer workflows

### DIFF
--- a/apps/notebook/e2e/execute-cell-output.spec.ts
+++ b/apps/notebook/e2e/execute-cell-output.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import {
+  executeCell,
+  openNotebookRoom,
+  waitForCellCount,
+  waitForCodeCellContaining,
+  waitForKernelStatus,
+  waitForOutputContaining,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test.describe("browser execution with MCP peer", () => {
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("executes an MCP-created cell in the browser and shows output", async ({ page }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.createCell("print('browser executes MCP-created cell')");
+
+    await waitForCellCount(page, 2);
+    const cell = await waitForCodeCellContaining(page, "browser executes MCP-created cell");
+
+    await executeCell(cell);
+    const output = await waitForOutputContaining(cell, "browser executes MCP-created cell", 60_000);
+    await expect(output).toContainText("browser executes MCP-created cell");
+  });
+});

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -1,7 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-export async function waitForNotebookReady(page: Page) {
-  await page.goto("/");
+export async function waitForNotebookReady(page: Page, path = "/") {
+  await page.goto(path);
   await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
   await expect(page.locator("[data-notebook-synced]")).toHaveAttribute(
     "data-notebook-synced",
@@ -13,10 +13,22 @@ export async function waitForNotebookReady(page: Page) {
   });
 }
 
+export async function openNotebookRoom(page: Page, notebookId: string) {
+  const params = new URLSearchParams({
+    notebook_id: notebookId,
+    environment_mode: "notebook",
+  });
+  await waitForNotebookReady(page, `/?${params.toString()}`);
+}
+
 export async function waitForKernelStatus(page: Page, status: string, timeout = 60_000) {
   await expect(page.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", status, {
     timeout,
   });
+}
+
+export async function waitForCellCount(page: Page, count: number, timeout = 30_000) {
+  await expect(page.locator("[data-cell-type]")).toHaveCount(count, { timeout });
 }
 
 export async function ensureCodeCell(page: Page): Promise<Locator> {
@@ -48,6 +60,42 @@ export async function setCellSource(cell: Locator, source: string) {
       },
     });
   }, source);
+}
+
+export async function getCellSource(cell: Locator): Promise<string> {
+  return await cell.locator('.cm-content[contenteditable="true"]').evaluate((node) => {
+    const content = node as HTMLElement & {
+      cmTile?: {
+        view?: {
+          state: { doc: { toString: () => string } };
+        };
+      };
+    };
+    const editor = content.cmTile?.view;
+    if (!editor) throw new Error("No CodeMirror view found");
+    return editor.state.doc.toString();
+  });
+}
+
+export async function waitForCellSourceContaining(cell: Locator, text: string, timeout = 30_000) {
+  await expect.poll(() => getCellSource(cell), { timeout }).toContain(text);
+}
+
+export async function waitForCodeCellContaining(page: Page, text: string, timeout = 30_000) {
+  const cells = page.locator('[data-cell-type="code"]');
+  const findIndex = async () => {
+    const count = await cells.count();
+    for (let i = 0; i < count; i += 1) {
+      const source = await getCellSource(cells.nth(i));
+      if (source.includes(text)) return i;
+    }
+    return -1;
+  };
+
+  await expect.poll(findIndex, { timeout }).not.toBe(-1);
+  const index = await findIndex();
+  if (index < 0) throw new Error(`No code cell contains: ${text}`);
+  return cells.nth(index);
 }
 
 export async function executeCell(cell: Locator) {

--- a/apps/notebook/e2e/mcp-peer.ts
+++ b/apps/notebook/e2e/mcp-peer.ts
@@ -1,0 +1,201 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface JsonRpcResponse {
+  id?: number;
+  result?: unknown;
+  error?: { message?: string; code?: number; data?: unknown };
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface CallToolResult {
+  content?: Array<{ type?: string; text?: string }>;
+  isError?: boolean;
+}
+
+const REQUEST_TIMEOUT_MS = 120_000;
+
+export class McpPeer {
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly pending = new Map<number, PendingRequest>();
+  private nextId = 1;
+  private stdout = "";
+  private stderr = "";
+
+  private constructor(child: ChildProcessWithoutNullStreams) {
+    this.child = child;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => this.handleStdout(String(chunk)));
+    child.stderr.on("data", (chunk) => {
+      this.stderr += String(chunk);
+    });
+    child.on("exit", (code, signal) => {
+      const reason = signal ? `signal ${signal}` : `exit code ${code}`;
+      const error = new Error(`MCP peer exited unexpectedly (${reason})${this.stderrSuffix()}`);
+      for (const [, pending] of this.pending) {
+        clearTimeout(pending.timer);
+        pending.reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  static async start(): Promise<McpPeer> {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+    const binary = path.join(repoRoot, "target", "debug", "runt");
+    const command = process.env.NTERACT_BROWSER_E2E_MCP_COMMAND;
+    const args = process.env.NTERACT_BROWSER_E2E_MCP_ARGS;
+
+    const child =
+      command !== undefined
+        ? spawn(command, args === undefined ? [] : (JSON.parse(args) as string[]), {
+            cwd: repoRoot,
+            env: process.env,
+          })
+        : fs.existsSync(binary)
+          ? spawn(binary, ["mcp", "--no-show"], { cwd: repoRoot, env: process.env })
+          : spawn("cargo", ["run", "--quiet", "-p", "runt", "--", "mcp", "--no-show"], {
+              cwd: repoRoot,
+              env: process.env,
+            });
+
+    const peer = new McpPeer(child);
+    await peer.initialize();
+    return peer;
+  }
+
+  async connectNotebook(notebookId: string): Promise<unknown> {
+    return await this.callToolJson("connect_notebook", { notebook_id: notebookId });
+  }
+
+  async createCell(source: string, cellType = "code"): Promise<string> {
+    const text = await this.callToolText("create_cell", { source, cell_type: cellType });
+    const match = text.match(/Created cell:\s*([^\s]+)/);
+    if (!match) throw new Error(`create_cell did not return a cell id: ${text}`);
+    return match[1];
+  }
+
+  async setCell(cellId: string, source: string, andRun = false): Promise<unknown> {
+    return await this.callToolJson("set_cell", {
+      cell_id: cellId,
+      source,
+      and_run: andRun,
+      timeout_secs: 120,
+    });
+  }
+
+  async close(): Promise<void> {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("MCP peer closed"));
+    }
+    this.pending.clear();
+    if (this.child.exitCode !== null) return;
+    this.child.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.child.exitCode === null) this.child.kill("SIGKILL");
+        resolve();
+      }, 1_000);
+      this.child.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  private async initialize(): Promise<void> {
+    await this.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: {
+        name: "notebook-browser-e2e",
+        version: "0.0.0",
+      },
+    });
+    this.notify("notifications/initialized", {});
+  }
+
+  private async callToolText(name: string, args: Record<string, unknown>): Promise<string> {
+    const result = (await this.request("tools/call", {
+      name,
+      arguments: args,
+    })) as CallToolResult;
+    const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+    if (result.isError) throw new Error(`MCP tool ${name} failed: ${text}`);
+    return text;
+  }
+
+  private async callToolJson(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const text = await this.callToolText(name, args);
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    const message = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`MCP request timed out: ${method}${this.stderrSuffix()}`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdout += chunk;
+    let newline = this.stdout.indexOf("\n");
+    while (newline !== -1) {
+      const line = this.stdout.slice(0, newline).trim();
+      this.stdout = this.stdout.slice(newline + 1);
+      if (line) this.handleLine(line);
+      newline = this.stdout.indexOf("\n");
+    }
+  }
+
+  private handleLine(line: string): void {
+    let response: JsonRpcResponse;
+    try {
+      response = JSON.parse(line) as JsonRpcResponse;
+    } catch {
+      return;
+    }
+    if (typeof response.id !== "number") return;
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+    this.pending.delete(response.id);
+    clearTimeout(pending.timer);
+    if (response.error) {
+      pending.reject(
+        new Error(
+          `MCP error ${response.error.code ?? ""}: ${response.error.message ?? "unknown error"}`,
+        ),
+      );
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private stderrSuffix(): string {
+    const stderr = this.stderr.trim();
+    return stderr ? `\n${stderr}` : "";
+  }
+}

--- a/apps/notebook/e2e/noisy-output-interrupt.spec.ts
+++ b/apps/notebook/e2e/noisy-output-interrupt.spec.ts
@@ -2,16 +2,31 @@ import { expect, test } from "@playwright/test";
 import {
   ensureCodeCell,
   executeCell,
+  openNotebookRoom,
   setCellSource,
+  waitForCellSourceContaining,
   waitForKernelStatus,
-  waitForNotebookReady,
   waitForOutputContaining,
 } from "./helpers";
+import { McpPeer } from "./mcp-peer";
 
 test.describe("noisy output interrupt", () => {
-  test("interrupts a stdout flood and keeps the kernel usable", async ({ page }) => {
-    await waitForNotebookReady(page);
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("interrupts a stdout flood and keeps the kernel usable from an MCP peer", async ({
+    page,
+  }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
     await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
 
     const cell = await ensureCodeCell(page);
     await setCellSource(
@@ -35,10 +50,18 @@ test.describe("noisy output interrupt", () => {
     await page.getByTestId("interrupt-kernel-button").click();
     await waitForKernelStatus(page, "idle", 60_000);
 
-    await setCellSource(cell, "print('after noisy interrupt e2e')");
+    const cellId = await cell.getAttribute("data-cell-id");
+    if (cellId === null) throw new Error("Interrupted cell is missing data-cell-id");
+
+    await mcp.setCell(cellId, "print('after noisy interrupt from MCP peer')");
+    await waitForCellSourceContaining(cell, "after noisy interrupt from MCP peer");
     await executeCell(cell);
 
-    const output = await waitForOutputContaining(cell, "after noisy interrupt e2e", 60_000);
-    await expect(output).toContainText("after noisy interrupt e2e");
+    const output = await waitForOutputContaining(
+      cell,
+      "after noisy interrupt from MCP peer",
+      60_000,
+    );
+    await expect(output).toContainText("after noisy interrupt from MCP peer");
   });
 });

--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -186,10 +186,12 @@ function relayHandshake(url: URL, repoRoot: string): Record<string, unknown> {
   const notebookId = url.searchParams.get("notebook_id");
   const runtime = url.searchParams.get("runtime") ?? "python";
   const workingDir = url.searchParams.get("working_dir") ?? repoRoot;
+  const environmentMode = url.searchParams.get("environment_mode");
   return {
     channel: "create_notebook",
     runtime,
     working_dir: workingDir,
+    ...(environmentMode ? { environment_mode: environmentMode } : {}),
     ...(notebookId ? { notebook_id: notebookId } : {}),
     ephemeral: true,
   };

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -98,8 +98,9 @@ function addToken(url: string, token: string): string {
   //   /?path=/tmp/foo.ipynb
   //   /?notebook_id=<uuid>
   //   /?runtime=deno
+  //   /?environment_mode=notebook
   const pageParams = new URLSearchParams(window.location.search);
-  for (const key of ["path", "notebook_id", "runtime", "working_dir"]) {
+  for (const key of ["path", "notebook_id", "runtime", "working_dir", "environment_mode"]) {
     const value = pageParams.get(key);
     if (value) resolved.searchParams.set(key, value);
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nteract-workspace"
 version = "0.0.0"
 description = "Development workspace for nteract Python packages"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "nteract",
     "gremlin ; sys_platform == 'darwin'",
@@ -27,6 +27,12 @@ packages = []
 
 [tool.uv.workspace]
 members = ["python/runtimed", "python/nteract", "python/gremlin", "python/prewarm", "python/dx", "python/nteract-kernel-launcher", "python/pr-reviewer", "python/safari-timeline"]
+
+[tool.uv]
+environments = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+]
 
 [tool.uv.sources]
 runtimed = { workspace = true }
@@ -67,7 +73,6 @@ dev = [
     "pyzmq>=26.0",
     "numpy>=1.26",
     "matplotlib>=3.8",
-    "pydantic-ai>=0.2.0",
     "anywidget>=0.9.21",
     "quak>=0.3.4",
     "polars>=1.39.3",


### PR DESCRIPTION
## Summary

- add a Vite/Chromium browser E2E for executing an MCP-created cell and seeing output
- harden the noisy stdout interrupt/recovery browser E2E with an MCP peer updating the same notebook
- let browser relay URLs forward `environment_mode`, and run these browser E2Es with `environment_mode=notebook`

## CI failure attribution

The completed `Browser E2E (Vite)` failure on PR #2727 was not caused by that PR diff; its diff only touched `packages/sift/src/table.test.ts`.

The browser E2E artifact showed the notebook kernel never reached idle because the dev browser relay created an untitled notebook in the repository root with the default project-first environment mode. That made the daemon select the root `pyproject.toml`, and `uv` failed to resolve the workspace for a future Python/Windows marker split involving `pydantic-ai[mistral]` and missing `mistralai`.

For these fast browser E2Es, the test notebooks do not need to inherit the repository project environment. The helper now creates deterministic test rooms with `environment_mode=notebook`, which keeps the working directory but selects a notebook-owned prewarmed environment instead of `uv:pyproject`.

## Verification

- `pnpm test:e2e:browser`
- `pnpm --dir apps/notebook exec tsc -p tsconfig.json --noEmit`
- `cargo xtask lint --fix`
