### PR TITLE
ci(publish): use github-hosted windows runner for npm provenance

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,7 +51,10 @@ jobs:
           - target: linux-x64-gnu
             runner: ubuntu-latest
           - target: win32-x64-msvc
-            runner: blacksmith-4vcpu-windows-2025
+            # npm provenance / sigstore requires GitHub-hosted runners.
+            # Publishing from a self-hosted (Blacksmith) Windows runner fails
+            # with: "Unsupported GitHub Actions runner environment: self-hosted".
+            runner: windows-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Switch the Windows leg of `publish-npm.yml` from `blacksmith-4vcpu-windows-2025` to `windows-latest`.
- npm trusted publishing / sigstore provenance rejects self-hosted runners; Blacksmith runners identify as `self-hosted`, so `@runtimed/node-win32-x64-msvc` fails to publish with:
  > Unsupported GitHub Actions runner environment: \"self-hosted\". Only \"github-hosted\" runners are supported when publishing with provenance.
- macOS and Linux legs already use github-hosted runners; no change needed there.
- PyPI publish already happens on the ubuntu `prerelease` job (github-hosted), so no Python-side change required — the Windows wheel is built on Blacksmith but uploaded as an artifact and OIDC-published from ubuntu.

Failing run: https://github.com/nteract/desktop/actions/runs/25709953304/job/75487897154

## Test plan

- [ ] Next stable release triggers `publish-npm.yml` and the Windows publish step succeeds with provenance.

🪶 Generated with Quill Agent