### PR TITLE
fix(runtimed): keep widget replay off iopub backpressure

### DIFF
--- a/.agents/skills/execution-pipeline/SKILL.md
+++ b/.agents/skills/execution-pipeline/SKILL.md
@@ -84,6 +84,12 @@ They must not share bounded queues with stdout floods, display churn, or
 Output widget replay. If output work is pending, drain lifecycle/control
 signals first so interrupts and queue release remain responsive.
 
+**Output-widget replay:** RuntimeStateDoc is the durable source of truth for
+captured Output widget outputs. The kernel-facing `SendCommUpdate` replay is
+best-effort output work on a bounded queue. IOPub output arms must use
+non-blocking enqueue/drop semantics for replay and must not `.await` a bounded
+work-channel send before they can observe later status messages.
+
 **Stream-output committer:** stdout/stderr chunks may be coalesced and
 periodic flushes may be dropped when pressure is high. The terminal buffer
 holds the latest rendered state. Ordering-sensitive boundaries, such as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Kernel lifecycle signals (`KernelIdle`, `ExecutionDone`, `CellError`, `KernelDie
 
 Stream output may use bounded, lossy periodic flushes, but ordering boundaries cannot. Flush stdout/stderr through the stream committer priority path before clearing terminal state for display/error outputs, and route `ExecutionDone` through that same priority path so terminal runtime state remains causally after the final stream manifest.
 
+Output widget replay is not the durable record; RuntimeStateDoc is. Kernel-facing `SendCommUpdate` replay from IOPub must be non-blocking and best-effort so a full bounded work queue cannot delay later lifecycle status.
+
 ## Notebook files
 
 Use MCP tools (`create_notebook`, `manage_dependencies`) for notebooks with dependency metadata — the schema is internal. Test fixtures that need deps put them at `metadata.runt.uv.dependencies`.

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -191,6 +191,31 @@ enum IoPubStateUpdate {
     Lifecycle(RuntimeLifecycle),
 }
 
+fn try_send_comm_update(
+    work_tx: &mpsc::Sender<QueueCommand>,
+    comm_id: String,
+    state: serde_json::Value,
+) {
+    match work_tx.try_send(QueueCommand::SendCommUpdate { comm_id, state }) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(QueueCommand::SendCommUpdate { comm_id, .. })) => {
+            debug!(
+                "[jupyter-kernel] Dropping comm output replay for comm_id={} because work queue is full",
+                comm_id
+            );
+        }
+        Err(mpsc::error::TrySendError::Closed(QueueCommand::SendCommUpdate {
+            comm_id, ..
+        })) => {
+            warn!(
+                "[jupyter-kernel] Dropping comm output replay for comm_id={} because work queue is closed",
+                comm_id
+            );
+        }
+        Err(_) => unreachable!("try_send_comm_update only sends SendCommUpdate"),
+    }
+}
+
 /// Created at kernel launch time, captures connection_info and session_id.
 /// Can be used concurrently with other kernel operations since interrupt
 /// creates its own ZMQ control connection.
@@ -1448,14 +1473,13 @@ impl KernelConnection for JupyterKernel {
                                                         }
                                                     }
                                                 }
-                                                let _ = iopub_work_tx
-                                                    .send(QueueCommand::SendCommUpdate {
-                                                        comm_id: widget_comm_id.clone(),
-                                                        state: serde_json::json!({
-                                                            "outputs": resolved_outputs,
-                                                        }),
-                                                    })
-                                                    .await;
+                                                try_send_comm_update(
+                                                    &iopub_work_tx,
+                                                    widget_comm_id.clone(),
+                                                    serde_json::json!({
+                                                        "outputs": resolved_outputs,
+                                                    }),
+                                                );
                                             }
                                         }
                                         continue;
@@ -1584,14 +1608,13 @@ impl KernelConnection for JupyterKernel {
                                                             }
                                                         }
                                                     }
-                                                    let _ = iopub_work_tx
-                                                        .send(QueueCommand::SendCommUpdate {
-                                                            comm_id: widget_comm_id.clone(),
-                                                            state: serde_json::json!({
-                                                                "outputs": resolved_outputs
-                                                            }),
-                                                        })
-                                                        .await;
+                                                    try_send_comm_update(
+                                                        &iopub_work_tx,
+                                                        widget_comm_id.clone(),
+                                                        serde_json::json!({
+                                                            "outputs": resolved_outputs
+                                                        }),
+                                                    );
                                                 }
                                             }
                                         }
@@ -1864,14 +1887,13 @@ impl KernelConnection for JupyterKernel {
                                                             }
                                                         }
                                                     }
-                                                    let _ = iopub_work_tx
-                                                        .send(QueueCommand::SendCommUpdate {
-                                                            comm_id: widget_comm_id.clone(),
-                                                            state: serde_json::json!({
-                                                                "outputs": resolved_outputs
-                                                            }),
-                                                        })
-                                                        .await;
+                                                    try_send_comm_update(
+                                                        &iopub_work_tx,
+                                                        widget_comm_id.clone(),
+                                                        serde_json::json!({
+                                                            "outputs": resolved_outputs
+                                                        }),
+                                                    );
                                                 }
                                             }
                                         }
@@ -1974,12 +1996,11 @@ impl KernelConnection for JupyterKernel {
                                             }) {
                                                 warn!("[runtime-state] {}", e);
                                             }
-                                            let _ = iopub_work_tx
-                                                .send(QueueCommand::SendCommUpdate {
-                                                    comm_id: widget_comm_id.clone(),
-                                                    state: serde_json::json!({ "outputs": [] }),
-                                                })
-                                                .await;
+                                            try_send_comm_update(
+                                                &iopub_work_tx,
+                                                widget_comm_id.clone(),
+                                                serde_json::json!({ "outputs": [] }),
+                                            );
                                         }
                                     }
                                 }
@@ -3274,6 +3295,32 @@ mod tests {
             line,
             source: source.to_string(),
         }
+    }
+
+    #[test]
+    fn comm_update_replay_is_best_effort_when_work_queue_is_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+
+        try_send_comm_update(
+            &tx,
+            "comm-a".to_string(),
+            serde_json::json!({ "outputs": ["first"] }),
+        );
+        try_send_comm_update(
+            &tx,
+            "comm-b".to_string(),
+            serde_json::json!({ "outputs": ["dropped"] }),
+        );
+
+        let queued = rx.try_recv().expect("first comm update should be queued");
+        assert!(matches!(
+            queued,
+            QueueCommand::SendCommUpdate { comm_id, .. } if comm_id == "comm-a"
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "full work queue should drop comm output replay"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

This is stacked on #2731, which is stacked on #2728.

- makes IOPub Output-widget replay use `try_send` on the bounded work queue
- drops kernel-facing `SendCommUpdate` replay when the work queue is full or closed
- keeps RuntimeStateDoc as the durable source of truth for captured widget outputs
- adds a focused unit test for full-queue replay drop behavior
- documents the invariant for future agents

## Why

Output-widget replay is output transport, not a lifecycle signal. The IOPub reader should not await a bounded work-channel send before it can observe later kernel status messages. Captured outputs are already committed into RuntimeStateDoc; the kernel-facing replay is best-effort and can be dropped under pressure.

## Verification

- `cargo fmt --check`
- `cargo test -p runtimed comm_update_replay_is_best_effort_when_work_queue_is_full --lib`
- `cargo test -p runtimed lifecycle --lib`
- `cargo test -p runtimed comm_update --lib`
- `cargo test -p runtimed jupyter_kernel --lib`
- `cargo xtask lint --fix`
- `rg -n -C 2 "iopub_work_tx\\s*\\.send|\\.send\\(QueueCommand::SendCommUpdate" crates/runtimed/src/jupyter_kernel.rs` returns no matches
