### PR TITLE
fix(runtimed): coalesce display updates off iopub path

### DIFF
--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -164,6 +164,23 @@ Principle: **reset transport state, preserve document truth.**
 | Client-initiated save | `confirm_sync` before `SaveNotebook` request |
 | Daemon-internal autosave | Neither — daemon reads its own doc directly |
 
+### RuntimeStateDoc Output Pressure
+
+RuntimeStateDoc is the durable state boundary, not the hot transport for every
+transient kernel event. Control-plane signals must stay independent of output
+work:
+
+- `KernelIdle`, `ExecutionDone`, `CellError`, and `KernelDied` use reliable
+  lifecycle/control paths, not bounded output queues.
+- stdout/stderr stream chunks may be periodically flushed through bounded,
+  droppable work, but ordering boundaries use the stream committer priority
+  path so terminal state follows the final durable stream manifest.
+- Output widget replay back to the kernel is best-effort; widget state in
+  RuntimeStateDoc is the durable truth.
+- `update_display_data` with a `display_id` is transient display churn. Coalesce
+  to the latest pending value per `display_id` off the IOPub path, then flush
+  before `ExecutionDone`.
+
 ## Protocol Design Patterns
 
 ### Architecture Comparison

--- a/.agents/skills/execution-pipeline/SKILL.md
+++ b/.agents/skills/execution-pipeline/SKILL.md
@@ -90,6 +90,12 @@ best-effort output work on a bounded queue. IOPub output arms must use
 non-blocking enqueue/drop semantics for replay and must not `.await` a bounded
 work-channel send before they can observe later status messages.
 
+**Display updates:** `update_display_data` messages with `display_id` are
+transient display churn. Coalesce them by `display_id` and commit only the
+latest pending update off the IOPub hot path. Flush pending display updates
+after `KernelIdle` and before `ExecutionDone` so terminal runtime state still
+means durable output state is available.
+
 **Stream-output committer:** stdout/stderr chunks may be coalesced and
 periodic flushes may be dropped when pressure is high. The terminal buffer
 holds the latest rendered state. Ordering-sensitive boundaries, such as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Stream output may use bounded, lossy periodic flushes, but ordering boundaries c
 
 Output widget replay is not the durable record; RuntimeStateDoc is. Kernel-facing `SendCommUpdate` replay from IOPub must be non-blocking and best-effort so a full bounded work queue cannot delay later lifecycle status.
 
+`update_display_data` is transient display churn. Coalesce it by `display_id` off the IOPub hot path, but flush pending display updates after `KernelIdle` and before `ExecutionDone` so terminal runtime state still follows durable output state.
+
 ## Notebook files
 
 Use MCP tools (`create_notebook`, `manage_dependencies`) for notebooks with dependency metadata — the schema is internal. Test fixtures that need deps put them at `metadata.runt.uv.dependencies`.

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -1,0 +1,306 @@
+//! Coalesced committer for `update_display_data` output updates.
+//!
+//! Display updates are transient by design: repeated updates for the same
+//! `display_id` should collapse to the latest value. The IOPub reader should
+//! not block on blob writes or RuntimeStateDoc transactions for every progress
+//! update, but execution terminal state must still wait for pending display
+//! updates to become durable before `ExecutionDone`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use runtime_doc::RuntimeStateHandle;
+use tokio::sync::{mpsc, oneshot, Notify};
+use tracing::{debug, error, warn};
+
+use crate::blob_store::BlobStore;
+use crate::output_prep::QueueCommand;
+use crate::output_prep::{
+    apply_display_manifest_updates, build_display_manifest_updates, collect_display_update_targets,
+};
+use crate::task_supervisor::spawn_supervised;
+
+const MAX_PENDING_DISPLAY_IDS: usize = 128;
+
+#[derive(Debug)]
+struct PendingDisplayUpdate {
+    data: serde_json::Value,
+    metadata: serde_json::Map<String, serde_json::Value>,
+    buffers: Vec<Vec<u8>>,
+}
+
+struct SharedPending {
+    updates: StdMutex<HashMap<String, PendingDisplayUpdate>>,
+    notify: Notify,
+}
+
+#[derive(Debug)]
+struct PriorityDisplayRequest {
+    ack: oneshot::Sender<()>,
+}
+
+#[derive(Clone)]
+pub(crate) struct DisplayUpdateCommitterHandle {
+    pending: Arc<SharedPending>,
+    priority_tx: mpsc::UnboundedSender<PriorityDisplayRequest>,
+}
+
+impl DisplayUpdateCommitterHandle {
+    pub(crate) fn request_update(
+        &self,
+        display_id: String,
+        data: serde_json::Value,
+        metadata: serde_json::Map<String, serde_json::Value>,
+        buffers: Vec<Vec<u8>>,
+    ) {
+        let mut updates = self
+            .pending
+            .updates
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        if updates.len() >= MAX_PENDING_DISPLAY_IDS && !updates.contains_key(&display_id) {
+            debug!(
+                "[display-update-committer] Dropping display_id={} update: pending set full",
+                display_id
+            );
+            return;
+        }
+
+        updates.insert(
+            display_id,
+            PendingDisplayUpdate {
+                data,
+                metadata,
+                buffers,
+            },
+        );
+        drop(updates);
+        self.pending.notify.notify_one();
+    }
+
+    pub(crate) async fn flush_for_ordering(&self) {
+        // Pending may already be taken by the worker but not committed yet.
+        // Round-trip through the worker so terminal state waits behind any
+        // in-flight display update.
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if self
+            .priority_tx
+            .send(PriorityDisplayRequest { ack: ack_tx })
+            .is_err()
+        {
+            warn!("[display-update-committer] Failed to flush: committer closed");
+            return;
+        }
+        let _ = ack_rx.await;
+    }
+}
+
+fn take_pending(pending: &SharedPending) -> HashMap<String, PendingDisplayUpdate> {
+    let mut updates = pending
+        .updates
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    std::mem::take(&mut *updates)
+}
+
+async fn commit_pending_updates(
+    pending: &SharedPending,
+    state: &RuntimeStateHandle,
+    blob_store: &BlobStore,
+    kernel_actor_id: &str,
+) {
+    let updates = take_pending(pending);
+    for (display_id, update) in updates {
+        let preflight_wrapper = serde_json::json!({ "data": update.data });
+        crate::output_store::preflight_ref_buffers(&preflight_wrapper, &update.buffers, blob_store)
+            .await;
+
+        let targets = match state.read(|sd| collect_display_update_targets(sd, &display_id)) {
+            Ok(targets) => targets,
+            Err(e) => {
+                warn!("[runtime-state] {}", e);
+                continue;
+            }
+        };
+
+        let updates = build_display_manifest_updates(
+            targets,
+            &display_id,
+            &preflight_wrapper["data"],
+            &update.metadata,
+            blob_store,
+        )
+        .await;
+
+        match updates {
+            Ok(updates) => {
+                let updated = state.transact_at_current_heads(
+                    Some(kernel_actor_id),
+                    "runtime-state-iopub-display-update-transaction",
+                    |sd| apply_display_manifest_updates(sd, &updates),
+                );
+                match updated {
+                    Ok(true) => {
+                        debug!(
+                            "[display-update-committer] Updated display_id={}",
+                            display_id
+                        );
+                    }
+                    Ok(false) => {
+                        error!(
+                            "[display-update-committer] No output found for display_id={}",
+                            display_id
+                        );
+                    }
+                    Err(e) => {
+                        warn!("[runtime-state] {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                error!(
+                    "[display-update-committer] Failed to update display_id={}: {}",
+                    display_id, e
+                );
+            }
+        }
+    }
+}
+
+async fn run_display_update_committer(
+    pending: Arc<SharedPending>,
+    mut priority_rx: mpsc::UnboundedReceiver<PriorityDisplayRequest>,
+    state: RuntimeStateHandle,
+    blob_store: Arc<BlobStore>,
+    kernel_actor_id: String,
+) {
+    loop {
+        tokio::select! {
+            biased;
+
+            request = priority_rx.recv() => {
+                match request {
+                    Some(request) => {
+                        commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+                        let _ = request.ack.send(());
+                    }
+                    None => {
+                        commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+                        break;
+                    }
+                }
+            }
+
+            _ = pending.notify.notified() => {
+                commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
+            }
+
+            else => break,
+        }
+    }
+}
+
+pub(crate) fn start_display_update_committer(
+    state: RuntimeStateHandle,
+    blob_store: Arc<BlobStore>,
+    kernel_actor_id: String,
+    lifecycle_tx: mpsc::UnboundedSender<QueueCommand>,
+) -> DisplayUpdateCommitterHandle {
+    let pending = Arc::new(SharedPending {
+        updates: StdMutex::new(HashMap::new()),
+        notify: Notify::new(),
+    });
+    let (priority_tx, priority_rx) = mpsc::unbounded_channel();
+    let worker_pending = pending.clone();
+    spawn_supervised(
+        "display-update-committer",
+        run_display_update_committer(
+            worker_pending,
+            priority_rx,
+            state,
+            blob_store,
+            kernel_actor_id,
+        ),
+        move |_| {
+            let _ = lifecycle_tx.send(QueueCommand::KernelDied);
+        },
+    );
+    DisplayUpdateCommitterHandle {
+        pending,
+        priority_tx,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output_store::DEFAULT_INLINE_THRESHOLD;
+
+    fn runtime_state() -> RuntimeStateHandle {
+        let state_doc =
+            runtime_doc::RuntimeStateDoc::try_new_with_actor("test-runtime").expect("state doc");
+        let (state_changed_tx, _state_changed_rx) = tokio::sync::broadcast::channel(8);
+        RuntimeStateHandle::new(state_doc, state_changed_tx)
+    }
+
+    async fn insert_display_output(
+        state: &RuntimeStateHandle,
+        blob_store: &BlobStore,
+        display_id: &str,
+    ) {
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": { "text/plain": "old" },
+            "metadata": {},
+            "transient": { "display_id": display_id },
+        });
+        let manifest =
+            crate::output_store::create_manifest(&output, blob_store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .expect("manifest");
+        let manifest_json = manifest.to_json();
+        state
+            .with_doc(|sd| {
+                sd.create_execution("exec-1", "cell-1")?;
+                sd.append_output("exec-1", &manifest_json)?;
+                Ok(())
+            })
+            .expect("insert output");
+    }
+
+    #[tokio::test]
+    async fn display_updates_coalesce_to_latest_value() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(dir.path().to_path_buf()));
+        let state = runtime_state();
+        insert_display_output(&state, &blob_store, "progress").await;
+
+        let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
+        let handle = start_display_update_committer(
+            state.clone(),
+            blob_store,
+            "rt:kernel:test".to_string(),
+            lifecycle_tx,
+        );
+
+        handle.request_update(
+            "progress".to_string(),
+            serde_json::json!({ "text/plain": "first" }),
+            serde_json::Map::new(),
+            Vec::new(),
+        );
+        handle.request_update(
+            "progress".to_string(),
+            serde_json::json!({ "text/plain": "latest" }),
+            serde_json::Map::new(),
+            Vec::new(),
+        );
+        handle.flush_for_ordering().await;
+
+        let outputs = state
+            .read(|sd| sd.get_outputs("exec-1"))
+            .expect("read outputs");
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0]["data"]["text/plain"]["inline"], "latest");
+    }
+}

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -33,8 +33,7 @@ use crate::async_outcome::{
 };
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
 use crate::output_prep::{
-    apply_display_manifest_updates, blob_store_large_state_values, build_display_manifest_updates,
-    collect_display_update_targets, escape_glob_pattern, extract_buffer_paths,
+    blob_store_large_state_values, escape_glob_pattern, extract_buffer_paths,
     media_to_display_data, message_content_to_nbformat, queue_command_channels,
     store_widget_buffers, QueueCommand, QueueCommandReceivers,
 };
@@ -1217,6 +1216,13 @@ impl KernelConnection for JupyterKernel {
             iopub_kernel_actor_id.clone(),
             iopub_lifecycle_tx.clone(),
         );
+        let display_update_committer =
+            crate::display_update_committer::start_display_update_committer(
+                state_for_iopub.clone(),
+                blob_store.clone(),
+                iopub_kernel_actor_id.clone(),
+                iopub_lifecycle_tx.clone(),
+            );
 
         // Create coalescing channel early so the IOPub task can capture the sender.
         let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
@@ -1341,6 +1347,8 @@ impl KernelConnection for JupyterKernel {
                                                 e
                                             );
                                         }
+
+                                        display_update_committer.flush_for_ordering().await;
 
                                         if let (Some(cid), Some(eid)) =
                                             (cell_id.clone(), execution_id.clone())
@@ -1726,80 +1734,14 @@ impl KernelConnection for JupyterKernel {
                                     if let Some(ref display_id) = update.transient.display_id {
                                         let data_value =
                                             serde_json::to_value(&update.data).unwrap_or_default();
-
-                                        // Preflight ZMQ buffers keyed by blob-ref MIME into
-                                        // the blob store — mirror the initial-display path.
-                                        // Without this, `DisplayHandle.update(df2)` carries
-                                        // buffers the kernel still holds but the daemon never
-                                        // persists, and the blob-ref promotion downstream
-                                        // would drop the entry on `BlobStore::exists` miss.
                                         let iopub_buffers: Vec<Vec<u8>> =
                                             message.buffers.iter().map(|b| b.to_vec()).collect();
-                                        let preflight_wrapper =
-                                            serde_json::json!({ "data": data_value });
-                                        crate::output_store::preflight_ref_buffers(
-                                            &preflight_wrapper,
-                                            &iopub_buffers,
-                                            &blob_store,
-                                        )
-                                        .await;
-
-                                        let targets = match state_for_iopub.read(|sd| {
-                                            collect_display_update_targets(sd, display_id)
-                                        }) {
-                                            Ok(targets) => targets,
-                                            Err(e) => {
-                                                warn!("[runtime-state] {}", e);
-                                                continue;
-                                            }
-                                        };
-
-                                        let updates = build_display_manifest_updates(
-                                            targets,
-                                            display_id,
-                                            &data_value,
-                                            &update.metadata,
-                                            &blob_store,
-                                        )
-                                        .await;
-
-                                        match updates {
-                                            Ok(updates) => {
-                                                let updated = state_for_iopub
-                                                    .transact_at_current_heads(
-                                                        Some(&iopub_kernel_actor_id),
-                                                        "runtime-state-iopub-display-update-transaction",
-                                                        |sd| {
-                                                            apply_display_manifest_updates(
-                                                                sd, &updates,
-                                                            )
-                                                        },
-                                                    );
-                                                match updated {
-                                                    Ok(true) => {
-                                                        debug!(
-                                                            "[jupyter-kernel] Updated display_id={}",
-                                                            display_id
-                                                        );
-                                                    }
-                                                    Ok(false) => {
-                                                        error!(
-                                                            "[jupyter-kernel] No output found for display_id={}",
-                                                            display_id
-                                                        );
-                                                    }
-                                                    Err(e) => {
-                                                        warn!("[runtime-state] {}", e);
-                                                    }
-                                                }
-                                            }
-                                            Err(e) => {
-                                                error!(
-                                                    "[jupyter-kernel] Failed to update display: {}",
-                                                    e
-                                                );
-                                            }
-                                        }
+                                        display_update_committer.request_update(
+                                            display_id.clone(),
+                                            data_value,
+                                            update.metadata.clone(),
+                                            iopub_buffers,
+                                        );
                                     }
                                 }
 

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -29,6 +29,7 @@ pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;
 pub mod daemon_telemetry;
+pub(crate) mod display_update_committer;
 pub mod dx_blob_comm;
 pub mod embedded_plugins;
 pub mod inline_env;

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1272,6 +1272,28 @@ class TestOutputHandling:
         # The display_data should contain the displayed value
         # Exact structure depends on Python bindings, but data should be present
 
+    async def test_display_handle_update_reconciles_latest_output(self, session):
+        """DisplayHandle.update should resolve to the latest display value."""
+        await async_start_kernel_with_retry(session)
+
+        cell_id = await async_create_cell_and_wait_for_sync(
+            session,
+            "\n".join(
+                [
+                    "from IPython.display import display",
+                    "handle = display('old', display_id=True)",
+                    "handle.update('latest')",
+                ]
+            ),
+        )
+        result = await session.execute_cell(cell_id)
+
+        assert result.success, result.error
+        assert len(result.display_data) == 1
+        text = str(result.display_data[0].data.get("text/plain", ""))
+        assert "latest" in text
+        assert "old" not in text
+
     async def test_error_traceback_captured(self, session):
         """Test that full traceback is captured on error."""
         await async_start_kernel_with_retry(session)


### PR DESCRIPTION
## Summary

- move `update_display_data` RuntimeStateDoc mutations out of the IOPub reader into a coalescing display-update committer
- keep only the latest pending update per `display_id`, with a bounded pending display-id set
- flush pending display updates after `KernelIdle` and before `ExecutionDone` so terminal execution state still follows durable output state
- document the output-pressure invariant in `AGENTS.md`, `execution-pipeline`, and `automerge-sync`

## Stack

Stacked on #2733 (`codex/nonblocking-widget-output-replay`), which is stacked on #2731 and #2728.

## Verification

- `cargo fmt --check`
- `cargo test -p runtimed display_update_committer --lib`
- `cargo test -p runtimed stream_committer --lib`
- `cargo test -p runtimed lifecycle --lib`
- `cargo build -p runtimed`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_WORKSPACE_PATH=$PWD RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUST_LOG=info .venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py -k 'display_handle_update_reconciles_latest_output' -v`
- `cargo xtask lint --fix`
