### PR TITLE
fix(release): bump crates/notebook/Cargo.toml to break update loop

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -347,6 +347,7 @@ jobs:
           sed -i '' "s#https://github.com/nteract/desktop/releases/download/stable-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
+          sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/notebook/Cargo.toml
 
       - name: Generate Icons
         run: |
@@ -528,6 +529,7 @@ jobs:
           sed -i '' "s#https://github.com/nteract/desktop/releases/download/stable-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
+          sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/notebook/Cargo.toml
 
       - name: Generate Icons
         run: |
@@ -693,6 +695,9 @@ jobs:
           $runtCargo = Get-Content crates/runt/Cargo.toml -Raw
           $runtCargo = $runtCargo -replace '(?m)^version = ".*"$', "version = `"$version`""
           Set-Content crates/runt/Cargo.toml $runtCargo
+          $notebookCargo = Get-Content crates/notebook/Cargo.toml -Raw
+          $notebookCargo = $notebookCargo -replace '(?m)^version = ".*"$', "version = `"$version`""
+          Set-Content crates/notebook/Cargo.toml $notebookCargo
 
       - name: Generate Icons
         shell: pwsh
@@ -856,6 +861,7 @@ jobs:
           sed -i "s#https://github.com/nteract/desktop/releases/download/stable-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/notebook/Cargo.toml
 
       - name: Generate Icons
         run: |


### PR DESCRIPTION
## Summary

- Installed nightly claims a newer version is available immediately after upgrading, forever.
- Root cause: the Tauri updater plugin compares the binary's embedded `tauri::PackageInfo::version` (baked in at compile time from `crates/notebook/Cargo.toml` via `generate_context!`) against `latest.json`'s `version`. CI only bumps `crates/runt` and `crates/runtimed`; `crates/notebook/Cargo.toml` stays at the static in-tree `2.4.7`.
- With `Swatinem/rust-cache` restoring prior artifacts, the `notebook` crate's compiled object is reused from an earlier run whose `tauri.conf.json` carried a different timestamped version. Info.plist reflects the new build (the step rewrites `tauri.conf.json`), but the in-binary PackageInfo carries a stale nightly timestamp → every check sees \"update available\".
- Verified against my installed `nteract Nightly.app`:
  - `Info.plist` `CFBundleShortVersionString` = `2.4.7-nightly.202605120953` ✅
  - `strings .../MacOS/notebook | grep -oE 'nightly\\.[0-9]+'` = `nightly.202605120146` (one release behind)

## Fix

Bump `crates/notebook/Cargo.toml` alongside `runt` and `runtimed` in every per-OS \"Set version\" step. That changes `CARGO_PKG_VERSION`, invalidates the cache for the notebook crate, and embeds the correct version in the released binary.

## Test plan

- [ ] Next nightly produces an app where the Info.plist and the binary's embedded version match.
- [ ] Installed nightly stops showing a persistent \"Update available\" banner after upgrading.

🪶 Generated with Quill Agent