### PR TITLE
fix(wasm): preserve null widget state values

### DIFF
--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -44,7 +44,9 @@ pub fn __wasm_start() {
 /// JS Objects, matching what `JSON.parse()` would produce. The returned
 /// `JsValue` can be any JS type (object, array, scalar) depending on input.
 fn serialize_to_js<T: Serialize>(value: &T) -> Result<JsValue, serde_wasm_bindgen::Error> {
-    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    let serializer = serde_wasm_bindgen::Serializer::new()
+        .serialize_maps_as_objects(true)
+        .serialize_missing_as_null(true);
     value.serialize(&serializer)
 }
 

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -163,6 +163,18 @@ Deno.test("RuntimeState: committed WASM emits the shape TS consumers expect", ()
   handle.free();
 });
 
+Deno.test("RuntimeState: committed WASM preserves JSON null values", () => {
+  const handle = new NotebookHandle("null-shape-test");
+  const state = handle.get_runtime_state();
+
+  assertEquals(state.queue.executing, null);
+  assertEquals(state.env.progress, null);
+  assertEquals(state.last_saved, null);
+  assertEquals(state.path, null);
+
+  handle.free();
+});
+
 Deno.test("NotebookHandle: add cell and read back", () => {
   const handle = new NotebookHandle("test-nb");
   handle.add_cell(0, "cell-1", "code");


### PR DESCRIPTION
## Summary

- preserve JSON nulls as `null` across the runtimed WASM JS boundary
- add a committed-WASM regression guard for null-valued runtime state fields

## Why

Anywidgets such as `jupyter-scatter` can legitimately send synced traits as `null`.
nteract was serializing those Rust/Serde nulls to JavaScript `undefined`, which made
`jscatter`'s frontend crash when it expected `annotations` to be either `null` or an
array.

## Verification

- `deno test --no-check --allow-read crates/runtimed-wasm/tests/deno_smoke_test.ts --filter "RuntimeState: committed WASM"`
- `cargo test -p runtimed-wasm`
- `cargo xtask lint --fix`
- `git diff --check`
