### PR TITLE
docs(runtimed): clarify display update wake semantics

### DIFF
--- a/.agents/skills/execution-pipeline/SKILL.md
+++ b/.agents/skills/execution-pipeline/SKILL.md
@@ -94,7 +94,9 @@ work-channel send before they can observe later status messages.
 transient display churn. Coalesce them by `display_id` and commit only the
 latest pending update off the IOPub hot path. Flush pending display updates
 after `KernelIdle` and before `ExecutionDone` so terminal runtime state still
-means durable output state is available.
+means durable output state is available. The display-update committer's
+`Notify` is only a wake hint; the pending map is the source of truth, and each
+wake or priority flush drains all currently pending display IDs.
 
 **Stream-output committer:** stdout/stderr chunks may be coalesced and
 periodic flushes may be dropped when pressure is high. The terminal buffer

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -75,6 +75,9 @@ impl DisplayUpdateCommitterHandle {
             },
         );
         drop(updates);
+        // Notify is a wake hint, not the queue. The pending map above is the
+        // source of truth and intentionally coalesces to the latest update per
+        // display_id, so bursts do not need one stored permit per update.
         self.pending.notify.notify_one();
     }
 
@@ -178,6 +181,9 @@ async fn run_display_update_committer(
         tokio::select! {
             biased;
 
+            // Priority flushes drain the same pending map as normal wakes. If
+            // a notify permit is also ready, this arm still commits every
+            // pending update before acknowledging the ordering boundary.
             request = priority_rx.recv() => {
                 match request {
                     Some(request) => {
@@ -191,6 +197,8 @@ async fn run_display_update_committer(
                 }
             }
 
+            // Individual notifications are not individual updates; each wake
+            // drains all currently pending display_ids.
             _ = pending.notify.notified() => {
                 commit_pending_updates(&pending, &state, &blob_store, &kernel_actor_id).await;
             }


### PR DESCRIPTION
## Summary

- Document that the display-update committer's `Notify` is only a wake hint
- Clarify that the pending display update map is the source of truth and each wake drains all pending IDs
- Carry the same invariant into the execution-pipeline skill for future output/backpressure work

## Verification

- `cargo fmt --check`
- `cargo test -p runtimed display_update_committer --lib`
- `cargo xtask lint --fix`
