### PR TITLE
fix(widgets): improve jscatter default height

### DIFF
--- a/src/components/widgets/__tests__/anywidget-view.test.ts
+++ b/src/components/widgets/__tests__/anywidget-view.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { injectCSS } from "../anywidget-view";
+import {
+  applyAnyWidgetDisplayDefaults,
+  injectCSS,
+  NTERACT_JUPYTER_SCATTER_DEFAULT_HEIGHT,
+} from "../anywidget-view";
 
 describe("injectCSS", () => {
   afterEach(() => {
@@ -81,5 +85,39 @@ describe("injectCSS", () => {
     expect(document.head.querySelector('[data-widget-id="m4"]')).toBeNull();
     expect(document.head.querySelector('link[data-widget-id="m5"]')).not.toBeNull();
     c2.cleanup();
+  });
+});
+
+describe("applyAnyWidgetDisplayDefaults", () => {
+  it("raises jupyter-scatter's library default height for nteract output display", () => {
+    const state = {
+      _anywidget_id: "jscatter.widget.JupyterScatter",
+      width: "auto",
+      height: 240,
+    };
+
+    expect(applyAnyWidgetDisplayDefaults(state)).toEqual({
+      ...state,
+      height: NTERACT_JUPYTER_SCATTER_DEFAULT_HEIGHT,
+    });
+  });
+
+  it("honors non-default explicit jupyter-scatter heights", () => {
+    const state = {
+      _anywidget_id: "jscatter.widget.JupyterScatter",
+      width: "auto",
+      height: 520,
+    };
+
+    expect(applyAnyWidgetDisplayDefaults(state)).toBe(state);
+  });
+
+  it("does not change unrelated anywidgets", () => {
+    const state = {
+      _anywidget_id: "example.Widget",
+      height: 240,
+    };
+
+    expect(applyAnyWidgetDisplayDefaults(state)).toBe(state);
   });
 });

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -125,6 +125,26 @@ export interface InjectedCSS {
   cleanup: () => void;
 }
 
+const JUPYTER_SCATTER_ANYWIDGET_ID = "jscatter.widget.JupyterScatter";
+const JUPYTER_SCATTER_LIBRARY_DEFAULT_HEIGHT = 240;
+export const NTERACT_JUPYTER_SCATTER_DEFAULT_HEIGHT = 480;
+
+export function applyAnyWidgetDisplayDefaults(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    state._anywidget_id === JUPYTER_SCATTER_ANYWIDGET_ID &&
+    state.height === JUPYTER_SCATTER_LIBRARY_DEFAULT_HEIGHT
+  ) {
+    return {
+      ...state,
+      height: NTERACT_JUPYTER_SCATTER_DEFAULT_HEIGHT,
+    };
+  }
+
+  return state;
+}
+
 /**
  * How long to wait for a `<link rel="stylesheet">` to load before
  * letting the widget render anyway. 5s is long enough for slow
@@ -445,7 +465,7 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
 
   // Get current state for the proxy - use ref to always get fresh store
   const getCurrentState = useCallback(
-    () => storeRef.current.getModel(modelId)?.state ?? {},
+    () => applyAnyWidgetDisplayDefaults(storeRef.current.getModel(modelId)?.state ?? {}),
     [modelId],
   );
 


### PR DESCRIPTION
## Summary

- Bump jupyter-scatter's default anywidget height from its library default of 240px to a nteract display default of 480px.
- Keep non-default explicit jupyter-scatter heights untouched.
- Leave unrelated anywidgets and the existing plotly fallback alone.

Note: the widget protocol serializes an explicit `height=240` the same way as jupyter-scatter's library default, so that exact value is not distinguishable at render time.

## Verification

- `pnpm test -- src/components/widgets/__tests__/anywidget-view.test.ts src/components/widgets/__tests__/afm-model-proxy.test.ts`
- `pnpm test -- src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`
